### PR TITLE
improve phase transition handling and update deprecated API usage

### DIFF
--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -160,7 +160,10 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			utils.SetSandboxCondition(newStatus, *cond)
 		}
 		// If it is paused, first set the sandbox to the Paused state.
+		// To prevent loss of state information, the state immediately before Paused must currently be Running.
 	} else if box.Spec.Paused && box.Status.Phase == agentsv1alpha1.SandboxRunning {
+		// The paused and resumed condition are exclusive
+		utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionResumed))
 		newStatus.Phase = agentsv1alpha1.SandboxPaused
 		// enter resume phase
 	} else if !box.Spec.Paused && newStatus.Phase == agentsv1alpha1.SandboxPaused {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
- **Update deprecated API**: Replace `k8s.io/utils/pointer` with `k8s.io/utils/ptr` for pointer utilities
- **Fix phase transition conditions**: 
  - Clear `Paused` condition when transitioning to `Running` phase
  - Clear `Resumed` condition when transitioning to `Paused` phase  
  - Add nil check for `Ready` condition before updating
  - Add additional validation for `Paused` condition status
- **Improve resuming logic**:
  - Add safeguard to detect pods in `Terminating` state during resume
  - Clear `Paused` condition when entering `Resuming` phase
- **Expand pause trigger**: Allow pausing from both `Running` and `Pending` phases

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

