### PR TITLE
feat: Add sandbox claim label synchronization between Pod and Sandbox

### DIFF
--- a/api/v1alpha1/sandboxset_types.go
+++ b/api/v1alpha1/sandboxset_types.go
@@ -23,8 +23,11 @@ import (
 const (
 	InternalPrefix = "agents.kruise.io/"
 
-	LabelSandboxPool  = InternalPrefix + "sandbox-pool"
-	LabelTemplateHash = InternalPrefix + "template-hash"
+	// LabelSandboxPool identifies which SandboxSet generated the sandbox
+	LabelSandboxPool = InternalPrefix + "sandbox-pool"
+	// LabelSandboxIsClaimed indicates whether the sandbox has been claimed by user
+	LabelSandboxIsClaimed = InternalPrefix + "sandbox-claimed"
+	LabelTemplateHash     = InternalPrefix + "template-hash"
 
 	AnnotationLock      = InternalPrefix + "lock"
 	AnnotationOwner     = InternalPrefix + "owner"

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.27.3
 	github.com/onsi/gomega v1.38.2
+	github.com/prometheus/client_golang v1.22.0
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.75.1
@@ -68,7 +69,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.16.0 // indirect

--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -135,7 +135,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if newStatus.Selector == "" {
 		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				agentsv1alpha1.LabelSandboxPool: sbs.Name,
+				agentsv1alpha1.LabelSandboxPool:      sbs.Name,
+				agentsv1alpha1.LabelSandboxIsClaimed: "false",
 			},
 		})
 		if err != nil {
@@ -253,6 +254,7 @@ func (r *Reconciler) createSandbox(ctx context.Context, sbs *agentsv1alpha1.Sand
 	sbx.Annotations = clearAndInitInnerKeys(sbx.Annotations)
 	sbx.Labels = clearAndInitInnerKeys(sbx.Labels)
 	sbx.Labels[agentsv1alpha1.LabelSandboxPool] = sbs.Name
+	sbx.Labels[agentsv1alpha1.LabelSandboxIsClaimed] = "false"
 	sbx.Labels[agentsv1alpha1.LabelTemplateHash] = revision
 	if err := ctrl.SetControllerReference(sbs, sbx, r.Scheme); err != nil {
 		return nil, err

--- a/pkg/controller/sandboxset/sandboxset_controller_test.go
+++ b/pkg/controller/sandboxset/sandboxset_controller_test.go
@@ -75,8 +75,9 @@ func getBaseSandbox(idx int32, prefix, templateHash string) *v1alpha1.Sandbox {
 			Name:      prefix + strconv.Itoa(int(idx)),
 			Namespace: "default",
 			Labels: map[string]string{
-				v1alpha1.LabelTemplateHash: templateHash,
-				v1alpha1.LabelSandboxPool:  "test",
+				v1alpha1.LabelTemplateHash:     templateHash,
+				v1alpha1.LabelSandboxPool:      "test",
+				v1alpha1.LabelSandboxIsClaimed: "false",
 			},
 			Annotations: map[string]string{},
 		},

--- a/pkg/sandbox-manager/infra/sandboxcr/pool.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/pool.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/openkruise/agents/api/v1alpha1"
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	sandboxclient "github.com/openkruise/agents/client/clientset/versioned"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
@@ -155,7 +156,15 @@ func (p *Pool) modifyPickedSandbox(sbx *Sandbox, opts infra.ClaimSandboxOptions)
 		// should perform an inplace update
 		sbx.SetImage(opts.Image)
 	}
+	// claim sandbox
 	sbx.SetOwnerReferences([]metav1.OwnerReference{}) // make SandboxSet scale up
+	labels := sbx.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string, 1)
+	}
+	labels[agentsv1alpha1.LabelSandboxIsClaimed] = "true"
+	sbx.SetLabels(labels)
+
 	sbx.Annotations[v1alpha1.AnnotationClaimTime] = time.Now().Format(time.RFC3339)
 	return nil
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR introduces a new label `LabelSandboxIsClaimed` to track sandbox claim status and implements label synchronization between Sandbox and Pod resources.

## Changes

### 1. Core Controller Enhancement
- Implement `handleClaimSandbox()` function to synchronize labels between Sandbox and Pod
  - Add missing labels from Sandbox to Pod
  - Remove labels from Pod that don't exist in Sandbox
  - Update Pod labels when values differ from Sandbox
- Use Strategic Merge Patch with `null` values for safe label deletion (avoids conflicts with other controllers)

### 2. SandboxSet Controller Updates
- Set `LabelSandboxIsClaimed: "false"` when creating new sandboxes
- Update label selector to include `LabelSandboxIsClaimed: "false"` for better sandbox filtering

### 3. Sandbox Manager Integration
- Set `LabelSandboxIsClaimed: "true"` when a sandbox is claimed by a user


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #46

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews
HPA requires the `scale` subresource to expose a `selector` field, and it uses that selector to isolate different HPAs from each other, preventing them from targeting/claiming the same Pods.
https://github.com/kubernetes/kubernetes/blob/v1.35.0/pkg/controller/podautoscaler/horizontal.go#L397
```go
func (a *HorizontalController) validateAndParseSelector(hpa *autoscalingv2.HorizontalPodAutoscaler, selector string) (labels.Selector, error) {
	if selector == "" {
		errMsg := "selector is required"
		a.eventRecorder.Event(hpa, v1.EventTypeWarning, "SelectorRequired", errMsg)
		setCondition(hpa, autoscalingv2.ScalingActive, v1.ConditionFalse, "InvalidSelector", "the HPA target's scale is missing a selector")
		return nil, errors.New(errMsg)
	}
        ...
	selectingHpas := a.hpasControllingPodsUnderSelector(pods)
	if len(selectingHpas) > 1 {
		errMsg := fmt.Sprintf("pods by selector %v are controlled by multiple HPAs: %v", selector, selectingHpas)
		a.eventRecorder.Event(hpa, v1.EventTypeWarning, "AmbiguousSelector", errMsg)
		setCondition(hpa, autoscalingv2.ScalingActive, v1.ConditionFalse, "AmbiguousSelector", "%s", errMsg)
		return nil, errors.New(errMsg)
	}
}
```
KEDA relies on HPA under the hood for autoscaling.
![keda-arch](https://raw.githubusercontent.com/kedacore/keda/main/images/keda-arch.png)


