### PR TITLE
docs(cert): update instructions for single domain access with SDK

### DIFF
--- a/config/sandbox-manager/ingress_patch.yaml
+++ b/config/sandbox-manager/ingress_patch.yaml
@@ -3,5 +3,13 @@
   value: "*.replace.with.your.domain"
 
 - op: replace
+  path: /spec/rules/1/host
+  value: "replace.with.your.domain"
+
+- op: replace
   path: /spec/tls/0/hosts/0
   value: "*.replace.with.your.domain"
+
+- op: replace
+  path: /spec/tls/0/hosts/1
+  value: "replace.with.your.domain"

--- a/docs/best-practices/cert-manager-zh_CN.md
+++ b/docs/best-practices/cert-manager-zh_CN.md
@@ -49,6 +49,7 @@ kubectl get secret sandbox-ca-key-pair -n sandbox-system -o jsonpath='{.data.tls
 
 ```bash
 export SSL_CERT_FILE=/path/to/ca.crt
-```
 
-或者将 CA 证书添加到系统的信任存储中。
+# 如果你需要通过定制 SDK 的方式使用单域名接入，还需要配置以下环境变量
+$ export REQUESTS_CA_BUNDLE=/path/to/ca.crt
+```

--- a/docs/best-practices/cert-manager.md
+++ b/docs/best-practices/cert-manager.md
@@ -51,6 +51,7 @@ Clients need to set the environment variable `SSL_CERT_FILE` to the path of the 
 
 ```bash
 export SSL_CERT_FILE=/path/to/ca.crt
-```
 
-Or add the CA certificate to the system's trust store.
+# If you need to access via single domain using the customized SDK, you also need to configure the following environment variable
+$ export REQUESTS_CA_BUNDLE=/path/to/ca.crt
+```

--- a/docs/best-practices/use-self-signed-cert-zh_CN.md
+++ b/docs/best-practices/use-self-signed-cert-zh_CN.md
@@ -59,4 +59,7 @@ $ kubectl create secret tls sandbox-manager-tls \
 
 ```shell
 $ export SSL_CERT_FILE=/path/to/ca-fullchain.pem
+
+# 如果你需要通过定制 SDK 的方式使用单域名接入，还需要配置以下环境变量
+$ export REQUESTS_CA_BUNDLE=/path/to/ca-fullchain.pem
 ```

--- a/docs/best-practices/use-self-signed-cert.md
+++ b/docs/best-practices/use-self-signed-cert.md
@@ -64,4 +64,7 @@ ca-fullchain.pem) generated in Step 1:
 
 ```shell
 $ export SSL_CERT_FILE=/path/to/ca-fullchain.pem
+
+# If you need to access via single domain using the customized SDK, you also need to configure the following environment variable
+$ export REQUESTS_CA_BUNDLE=/path/to/ca-fullchain.pem
 ```


### PR DESCRIPTION
- Add note about setting REQUESTS_CA_BUNDLE environment variable for customized SDK
- Include instructions in both English and Chinese documentation files
- Update best-practices docs related to cert-manager and self-signed certificates
- Modify ingress patch YAML to fix host replacement paths for multiple hosts in TLS and rules sections

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

