### PR TITLE
fix: correct keyword casing in `sandbox-manager.Dockerfile`

### DIFF
--- a/dockerfiles/sandbox-manager.Dockerfile
+++ b/dockerfiles/sandbox-manager.Dockerfile
@@ -16,7 +16,7 @@ COPY ../proto ./proto
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o sandbox-manager ./cmd/sandbox-manager
 
 # Final stage
-FROM alpine:3.20 as runtime
+FROM alpine:3.20 AS runtime
 
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories && \
     apk --no-cache add ca-certificates && \


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR fixes a Docker linting warning in the `sandbox-manager.Dockerfile` by changing the `as` keyword to uppercase `AS` to match the `FROM` keyword casing.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fixes #125 

### Ⅲ. Describe how to verify it
Build the sandbox-manager image and verify no linting warnings appear:
```bash
make docker-build-manager
```

<details>
<summary>Docker build logs</summary>

```
docker build -f dockerfiles/sandbox-manager.Dockerfile -t sandbox-manager:latest .
[+] Building 2.2s (18/18) FINISHED                                                                                                                    docker:default
 => [internal] load build definition from sandbox-manager.Dockerfile                                                                                            0.0s
 => => transferring dockerfile: 958B                                                                                                                            0.0s 
 => [internal] load metadata for docker.io/library/alpine:3.20                                                                                                  0.7s 
 => [internal] load metadata for docker.io/library/golang:1.24                                                                                                  0.8s 
 => [internal] load .dockerignore                                                                                                                               0.1s
 => => transferring context: 78B                                                                                                                                0.0s 
 => [builder 1/9] FROM docker.io/library/golang:1.24@sha256:c2131140c7c29ff277b1c412d524b7f56289513f49672c57a3d992247dd146f8                                    0.0s
 => => resolve docker.io/library/golang:1.24@sha256:c2131140c7c29ff277b1c412d524b7f56289513f49672c57a3d992247dd146f8                                            0.0s 
 => [internal] load build context                                                                                                                               0.9s
 => => transferring context: 14.07kB                                                                                                                            0.9s 
 => [runtime 1/4] FROM docker.io/library/alpine:3.20@sha256:a4f4213abb84c497377b8544c81b3564f313746700372ec4fe84653e4fb03805                                    0.0s 
 => => resolve docker.io/library/alpine:3.20@sha256:a4f4213abb84c497377b8544c81b3564f313746700372ec4fe84653e4fb03805                                            0.0s 
 => CACHED [runtime 2/4] RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories &&     apk --no-cache add ca-certificates &&     rm   0.0s 
 => CACHED [builder 2/9] WORKDIR /app                                                                                                                           0.0s 
 => CACHED [builder 3/9] COPY ../go.mod go.sum ./                                                                                                               0.0s 
 => CACHED [builder 4/9] COPY ../cmd/sandbox-manager ./cmd/sandbox-manager                                                                                      0.0s
 => CACHED [builder 5/9] COPY ../pkg ./pkg                                                                                                                      0.0s 
 => CACHED [builder 6/9] COPY ../api  ./api                                                                                                                     0.0s 
 => CACHED [builder 7/9] COPY ../client ./client                                                                                                                0.0s 
 => CACHED [builder 8/9] COPY ../proto ./proto                                                                                                                  0.0s 
 => CACHED [builder 9/9] RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o sandbox-manager ./cmd/sandbox-manager                                   0.0s 
 => CACHED [runtime 3/4] COPY --from=builder /app/sandbox-manager .                                                                                             0.0s 
 => exporting to image                                                                                                                                          0.1s 
 => => exporting layers                                                                                                                                         0.0s 
 => => exporting manifest sha256:38f398e4788a5db467c9cd4ebce1fd833e66c56a3c2b1295aca8114ea7d62d82                                                               0.0s 
 => => exporting config sha256:9cf2f4cba93c97ea264f876616f15af786ccce815f874b083fcb8032a6252eab                                                                 0.0s 
 => => exporting attestation manifest sha256:5ecd6431b5771a71383f37c49e3c53273b5363496ff601a748f30ccac4930055                                                   0.0s 
 => => exporting manifest list sha256:89c3d968bea849edfddbd65559614276e082a6a33ed34867c569e920f7ec219a                                                          0.0s 
 => => naming to docker.io/library/sandbox-manager:latest                                                                                                       0.0s 
 => => unpacking to docker.io/library/sandbox-manager:latest  
```

</details>


### Ⅳ. Special notes for reviews

