### PR TITLE
test(e2b): update E2B tests and patch_e2b

### DIFF
--- a/.github/workflows/e2e-e2b-2.4.1.yaml
+++ b/.github/workflows/e2e-e2b-2.4.1.yaml
@@ -102,5 +102,8 @@ jobs:
           export E2B_DOMAIN=localhost
           export E2B_API_KEY=some-api-key
           sudo -E kubectl port-forward services/sandbox-manager 80:7788 -n sandbox-system &
-          bash hack/run-e2b-e2e-test.sh --e2b-version 2.8.1 --sdk-version 2.4.1
+          bash hack/run-e2b-e2e-test.sh \
+            --e2b-version 2.8.1 --sdk-version 2.4.1 \
+            --runtime-image "${RUNTIME_IMG}" \
+            --code-interpreter-image "${CODE_INTERPRETER_IMG}"
 

--- a/.github/workflows/e2e-e2b-latest.yaml
+++ b/.github/workflows/e2e-e2b-latest.yaml
@@ -103,5 +103,7 @@ jobs:
           export E2B_DOMAIN=localhost
           export E2B_API_KEY=some-api-key
           sudo -E kubectl port-forward services/sandbox-manager 80:7788 -n sandbox-system &
-          bash hack/run-e2b-e2e-test.sh
+          bash hack/run-e2b-e2e-test.sh \
+            --runtime-image "${RUNTIME_IMG}" \
+            --code-interpreter-image "${CODE_INTERPRETER_IMG}"
 

--- a/sdk/customized_e2b/kruise_agents/patch_e2b.py
+++ b/sdk/customized_e2b/kruise_agents/patch_e2b.py
@@ -7,11 +7,13 @@ from e2b_code_interpreter.code_interpreter_sync import JUPYTER_PORT
 
 
 def __sandbox_get_host(self, port: int) -> str:
-    return f"{self.sandbox_domain}/kruise/{self.sandbox_id}/{port}"
+    domain = os.environ.get("E2B_DOMAIN") or self.sandbox_domain
+    return f"{domain}/kruise/{self.sandbox_id}/{port}"
 
 
 def __connection_config_get_host(_, sandbox_id: str, sandbox_domain: str, port: int) -> str:
-    return f"{sandbox_domain}/kruise/{sandbox_id}/{port}"
+    domain = os.environ.get("E2B_DOMAIN") or sandbox_domain
+    return f"{domain}/kruise/{sandbox_id}/{port}"
 
 
 def __get_api_url(https: bool):

--- a/test/e2b/assets/sandboxset-code-interpreter.yaml
+++ b/test/e2b/assets/sandboxset-code-interpreter.yaml
@@ -11,9 +11,9 @@ spec:
     spec:
       initContainers:
         - name: runtime
-          image: agent-runtime:latest
+          image: ${RUNTIME_IMAGE}
           imagePullPolicy: IfNotPresent
-          command: [ "sh", "/workspace/entrypoint.sh" ]
+          command: [ "sh", "${RUNTIME_ENTRYPOINT}" ]
           volumeMounts:
             - name: envd-volume
               mountPath: /mnt/envd
@@ -23,7 +23,7 @@ spec:
           restartPolicy: Always
       containers:
         - name: sandbox
-          image: registry-ap-southeast-1.ack.aliyuncs.com/acs/code-interpreter:v1.6
+          image: ${CODE_INTERPRETER_IMAGE}
           imagePullPolicy: IfNotPresent
           env:
             - name: ENVD_DIR

--- a/test/e2b/requirements.txt
+++ b/test/e2b/requirements.txt
@@ -1,2 +1,3 @@
 python-dotenv
 pytest==9.0.1
+requests

--- a/test/e2b/utils.py
+++ b/test/e2b/utils.py
@@ -127,7 +127,7 @@ def wait_for_sandbox():
     while time.time() - ready_start_time < timeout:
         try:
             result = subprocess.run(
-                ["kubectl", "get", "sbx", "-o", "json"],
+                ["kubectl", "get", "sbx", "-n", "default", "-o", "json"],
                 capture_output=True,
                 text=True,
                 check=True
@@ -161,7 +161,7 @@ def wait_for_sandbox():
         # Get final state and describe not-ready sandboxes
         try:
             result = subprocess.run(
-                ["kubectl", "get", "sbx", "-o", "json"],
+                ["kubectl", "get", "sbx", "-n", "default", "-o", "json"],
                 capture_output=True,
                 text=True,
                 check=True
@@ -192,9 +192,9 @@ def wait_for_sandbox():
 
             for sbx_name in not_ready_sandboxes:
                 print(f"\n=== Describing not-ready sandbox: {sbx_name} ===")
-                kubectl("describe", "pod", sbx_name)
-                kubectl("logs", sbx_name, "-c", "runtime")
-                kubectl("logs", sbx_name, "-c", "sandbox")
+                kubectl("describe", "pod", "-n", "default", sbx_name)
+                kubectl("logs", "-n", "default", sbx_name, "-c", "runtime")
+                kubectl("logs", "-n", "default", sbx_name, "-c", "sandbox")
 
             raise TimeoutError(
                 f"Timeout waiting for Ready sandboxes: found {len(ready_sandboxes)}/2 after {timeout}s. "


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

- Makes test SandboxSet images (runtime image and code interpreter image) and runtime image entrypoint configurable
- Adds `requests` dependency and `-n default` to resolve CI issues
- Removes `-x` flag from pytest invocation for complete test suite execution
- Updates `patch_e2b` to use client-side environment variable `E2B_DOMAIN` and ignore server-side configured domain when possible

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

