### PR TITLE
fix: resolve NPE when using built-in API key

### DIFF
--- a/pkg/servers/e2b/keys/keys.go
+++ b/pkg/servers/e2b/keys/keys.go
@@ -233,7 +233,7 @@ func (k *SecretKeyStorage) ListByOwner(owner uuid.UUID) []*models.TeamAPIKey {
 	var result []*models.TeamAPIKey
 	k.idxByID.Range(func(_, value any) bool {
 		apikey := value.(*models.CreatedTeamAPIKey)
-		if apikey.ID == owner || apikey.CreatedBy.ID == owner {
+		if apikey.ID == owner || (apikey.CreatedBy != nil && apikey.CreatedBy.ID == owner) {
 			result = append(result, &models.TeamAPIKey{
 				CreatedAt: apikey.CreatedAt,
 				ID:        apikey.ID,


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR fixes a **NullPointerException** that occurs when calling the `ListByOwner` API to list API keys for a given owner.

The issue happens when returning a list of API keys that includes the `system built-in admin API key` (e.g., some-api-key created during deployment). The built-in key has its `CreatedBy`field set to null:
```json
{
  "createdAt": "2026-02-12T12:37:10.131568431Z",
  "id": "xxxxxx",
  "key": "some-api-key",
  "name": "admin",
  "createdBy": null
}
```
In the code: `pkg/servers/e2b/keys/keys.go#236`

```if apikey.ID == owner || apikey.CreatedBy.ID == owner { ... }```

the `apikey.CreatedBy.ID` dereference causes a **panic** when `CreatedBy` is nil.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

