### PR TITLE
[Feature] Add MCP Protocol API as Alternative Interface to E2B

### DIFF
--- a/api/v1alpha1/sandboxset_types.go
+++ b/api/v1alpha1/sandboxset_types.go
@@ -36,6 +36,7 @@ const (
 
 	AnnotationLock               = InternalPrefix + "lock"
 	AnnotationOwner              = InternalPrefix + "owner"
+	AnnotationMCPSessionID       = InternalPrefix + "mcp-session-id"
 	AnnotationClaimTime          = InternalPrefix + "claim-timestamp"
 	AnnotationRestoreFrom        = InternalPrefix + "restore-from"
 	AnnotationInitRuntimeRequest = InternalPrefix + "init-runtime-request"

--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -17,11 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"net/http"         // Added for pprof server
 	_ "net/http/pprof" // Added to register pprof handlers
 	"os"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/spf13/pflag"
@@ -35,6 +37,7 @@ import (
 	"github.com/openkruise/agents/pkg/servers/e2b"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/openkruise/agents/pkg/servers/mcp"
 	"github.com/openkruise/agents/pkg/utils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 )
@@ -68,6 +71,12 @@ func main() {
 	var e2bKeyStorage string
 	var e2bKeyStorageDisableAutoMigrate bool
 
+	// Define variables for MCP server configuration
+	var mcpEnabled bool
+	var mcpPort int
+	var mcpSandboxTTL int
+	var mcpSessionSyncPort int
+
 	utilfeature.DefaultMutableFeatureGate.AddFlag(pflag.CommandLine)
 
 	// Register the new pprof flags
@@ -95,6 +104,12 @@ func main() {
 			"When --e2b-key-storage=mysql and auth is enabled, set MySQL DSN via environment variable "+E2BKeyStorageDSNEnvVar)
 	pflag.BoolVar(&e2bKeyStorageDisableAutoMigrate, "e2b-key-storage-disable-schema-auto-update", false,
 		"Disable schema auto-migration for DB-Based key storage like mysql; when enabled, schema changes are skipped but admin team/key bootstrap still runs")
+
+	// Register MCP server configuration flags
+	pflag.BoolVar(&mcpEnabled, "mcp-enabled", false, "Enable MCP server")
+	pflag.IntVar(&mcpPort, "mcp-port", 8082, "MCP server port")
+	pflag.IntVar(&mcpSandboxTTL, "mcp-sandbox-ttl", 300, "MCP sandbox TTL in seconds")
+	pflag.IntVar(&mcpSessionSyncPort, "mcp-session-sync-port", 7790, "MCP session sync port")
 
 	opts := zap.Options{
 		Development: false,
@@ -176,6 +191,18 @@ func main() {
 			klog.Fatalf("--e2b-key-storage must be 'secret' or 'mysql'")
 		}
 	}
+	// Validate MCP server configuration
+	if mcpPort <= 0 || mcpPort > 65535 {
+		klog.Fatalf("--mcp-port must be between 1 and 65535")
+	}
+
+	if mcpSandboxTTL <= 0 {
+		klog.Fatalf("--mcp-sandbox-ttl must be greater than 0")
+	}
+
+	if mcpSessionSyncPort <= 0 || mcpSessionSyncPort > 65535 {
+		klog.Fatalf("--mcp-session-sync-port must be between 1 and 65535")
+	}
 
 	// Initialize Kubernetes client and config
 	clientConfig, err := clients.NewRestConfig(float32(kubeClientQPS), kubeClientBurst)
@@ -206,6 +233,44 @@ func main() {
 	if err != nil {
 		klog.Fatalf("Failed to start sandbox controller: %v", err)
 	}
+
+	// Create MCP Server before Run() to register SessionEventHandler before Informer starts
+	var mcpServer *mcp.MCPServer
+	if mcpEnabled {
+		klog.Info("MCP Server enabled, creating...")
+		mcpConfig := mcp.DefaultServerConfig()
+		mcpConfig.Port = mcpPort
+		mcpConfig.SandboxTTL = time.Second * time.Duration(mcpSandboxTTL)
+		mcpConfig.SessionSyncPort = mcpSessionSyncPort
+
+		mcpServer = mcp.NewMCPServer(
+			mcpConfig,
+			sandboxController.GetManager(),
+			sandboxController.GetKeys(),
+			sandboxController.GetManager().GetPeersManager(),
+		)
+		klog.Info("MCP Server created, SessionEventHandler registered")
+	}
+
+	// Start MCP Server HTTP service
+	if mcpServer != nil {
+		if err := mcpServer.Run(sandboxCtx); err != nil {
+			klog.Fatalf("Failed to run MCP server: %v", err)
+		}
+		klog.InfoS("MCP server started successfully", "port", mcpPort, "sandboxTTL", time.Second*time.Duration(mcpSandboxTTL))
+	}
+
 	<-sandboxCtx.Done()
+
+	// Stop MCP Server if running
+	if mcpServer != nil {
+		klog.Info("Stopping MCP server...")
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		if err := mcpServer.Stop(stopCtx); err != nil {
+			klog.ErrorS(err, "Failed to stop MCP server gracefully")
+		}
+	}
+
 	klog.Info("Sandbox controller stopped")
 }

--- a/docs/best-practices/use-mcp.md
+++ b/docs/best-practices/use-mcp.md
@@ -1,0 +1,243 @@
+# Using OpenKruise Agents Sandbox via MCP Protocol
+
+The sandbox-manager component of OpenKruise Agents supports MCP (Model Context Protocol) as an alternative interface to E2B protocol for AI agent integrations.
+
+## Overview
+
+MCP Server provides a standardized protocol interface for AI agents to execute code and commands in sandbox environments. It runs alongside the E2B API server and shares the same authentication and sandbox management infrastructure.
+
+```text
+┌─────────────┐    ┌─────────────┐
+│   E2B API   │    │   MCP API   │   <-- External Protocol Interfaces
+└──────┬──────┘    └──────┬──────┘
+       │                  │
+       └────────┬─────────┘
+                ▼
+        ┌───────────────┐
+        │ SandboxManager│              <-- Unified Management Layer
+        └───────┬───────┘
+                ▼
+        ┌───────────────┐
+        │  Sandbox CRs  │              <-- Kubernetes Resources
+        └───────────────┘
+```
+
+### Available Tools
+
+| Tool Name      | Description                                                                |
+|----------------|----------------------------------------------------------------------------|
+| `run_code`     | Execute code in a persistent sandbox with Jupyter Notebook semantics       |
+| `run_code_once`| Execute code in a one-time sandbox (auto-cleanup after execution)          |
+| `run_command`  | Execute shell commands in the sandbox environment                          |
+
+## Enabling MCP Server
+
+MCP Server is disabled by default. To enable it, configure the following flags in sandbox-manager:
+
+| Flag                      | Description                              | Default Value |
+|---------------------------|------------------------------------------|---------------|
+| `--mcp-enabled`           | Enable MCP Server                        | `false`       |
+| `--mcp-port`              | Port for MCP HTTP endpoint               | `8082`        |
+| `--mcp-sandbox-ttl`       | Sandbox TTL in seconds                   | `300`         |
+| `--mcp-session-sync-port` | Port for session peer synchronization    | `7790`        |
+
+### Configuration Example
+
+1. Add flags to sandbox-manager Deployment args:
+
+```yaml
+args:
+  - --mcp-enabled=true
+  - --mcp-port=8082
+  - --mcp-sandbox-ttl=300
+  - --mcp-session-sync-port=7790
+```
+
+2. Add container port to sandbox-manager Deployment:
+
+```yaml
+ports:
+  - containerPort: 8082
+    name: http-mcp
+```
+
+3. Add service port to sandbox-manager Service (required for Service-based access):
+
+```yaml
+ports:
+  - port: 8082
+    targetPort: 8082
+    protocol: TCP
+    name: http-mcp
+```
+
+## Authentication
+
+MCP Server uses HTTP header authentication, sharing the same API key system with E2B:
+
+- **Header**: `E2B-API-KEY`
+- **Value**: Same API key used for E2B API (`E2B_API_KEY`)
+
+If `E2B_ENABLE_AUTH` is set to `false`, authentication is disabled and anonymous access is allowed.
+
+## Session Configuration Headers
+
+MCP Server supports optional HTTP headers for per-request session configuration:
+
+| Header                 | Description                                      | Default Value                  |
+|------------------------|--------------------------------------------------|--------------------------------|
+| `X-Template`           | Sandbox template name (SandboxSet name)          | Server default                 |
+| `X-Sandbox-TTL`        | Sandbox TTL in seconds                           | `--mcp-sandbox-ttl` value      |
+| `X-Execution-Timeout`  | Code/command execution timeout in seconds        | 60                             |
+
+### Usage Example
+
+```python
+headers = {
+    "E2B-API-KEY": "<your-api-key>",
+    "X-Template": "code-interpreter",      # Use specific SandboxSet
+    "X-Sandbox-TTL": "600",                 # 10 minutes TTL
+    "X-Execution-Timeout": "120"            # 2 minutes timeout
+}
+```
+
+## Endpoint
+
+The default MCP endpoint path is `/mcp`. Full endpoint URL:
+
+```
+http://<sandbox-manager-host>:<MCP_SERVER_PORT>/mcp
+```
+
+## Client Integration Methods
+
+### 1. Direct HTTP Access (In-Cluster)
+
+For clients running in the same Kubernetes cluster:
+
+```python
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+async def run_code_in_sandbox():
+    # Configure MCP client
+    mcp_url = "http://sandbox-manager.sandbox-system.svc.cluster.local:8082/mcp"
+    headers = {"E2B-API-KEY": "<your-api-key>"}
+    
+    async with streamablehttp_client(mcp_url, headers=headers) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            
+            # Call run_code tool
+            result = await session.call_tool("run_code", {
+                "code": "print('Hello from sandbox!')",
+                "language": "python"
+            })
+            print(result)
+```
+
+### 2. Port Forward to Local Machine
+
+1. Port forward MCP server:
+   ```shell
+   kubectl port-forward services/sandbox-manager 8082:8082 -n sandbox-system
+   ```
+
+2. Connect from local client:
+   ```python
+   mcp_url = "http://localhost:8082/mcp"
+   headers = {"E2B-API-KEY": "<your-api-key>"}
+   ```
+
+### 3. External Access via Ingress
+
+Configure Ingress to expose MCP endpoint externally. Ensure proper TLS and authentication.
+
+## Tool Usage Examples
+
+### run_code
+
+Execute code with persistent session state:
+
+```json
+{
+  "code": "x = 10\nprint(f'x = {x}')",
+  "language": "python"
+}
+```
+
+Response:
+```json
+{
+  "logs": {
+    "stdout": [
+      "x = 10\n"
+    ],
+    "stderr": []
+  },
+  "results": [],
+  "sandbox_id": "default--sandbox-abc123",
+  "execution_count": 3
+}
+```
+
+### run_code_once
+
+Execute code in a disposable sandbox:
+
+```json
+{
+  "code": "import os\nprint(os.getcwd())",
+  "language": "python"
+}
+```
+
+### run_command
+
+Execute shell commands:
+
+```json
+{
+  "cmd": "ls -la /workspace"
+}
+
+```
+
+Response:
+```json
+{
+  "stdout": "...",
+  "stderr": "",
+  "exit_code": 0,
+  "sandbox_id": "default--sandbox-abc123"
+}
+```
+
+## Session Management
+
+MCP Server automatically manages sandbox lifecycle:
+
+- **Session Binding**: Each MCP session is bound to a dedicated sandbox
+- **Auto-Provisioning**: Sandbox is claimed from SandboxSet pool on first tool call
+- **TTL Management**: Sandbox is automatically released after `--mcp-sandbox-ttl` idle time
+- **Peer Sync**: Sessions are synchronized across sandbox-manager replicas
+
+## Comparison with E2B API
+
+| Feature              | E2B API                        | MCP Protocol                   |
+|----------------------|--------------------------------|--------------------------------|
+| Protocol             | REST HTTP                      | MCP over HTTP (Streamable)     |
+| Session State        | Manual sandbox management      | Automatic session-sandbox binding |
+| Authentication       | `E2B-API-KEY` header           | `E2B-API-KEY` header           |
+| Use Case             | Direct sandbox control         | AI agent tool integration      |
+| Sandbox Lifecycle    | Explicit create/delete         | Auto-provisioned per session   |
+
+## Health Check
+
+MCP Server provides a health check endpoint:
+
+```shell
+curl http://<sandbox-manager-host>:8082/health
+# Response: OK
+```

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/memberlist v0.5.4
 	github.com/jellydator/ttlcache/v3 v3.4.0
+	github.com/mark3labs/mcp-go v0.43.2
 	github.com/onsi/ginkgo/v2 v2.27.3
 	github.com/onsi/gomega v1.38.2
 	github.com/prometheus/client_golang v1.23.2
@@ -46,8 +47,10 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -78,6 +81,7 @@ require (
 	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -95,9 +99,12 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/cobra v1.10.0 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,12 +19,16 @@ github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -57,6 +61,8 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
@@ -151,6 +157,8 @@ github.com/hashicorp/memberlist v0.5.4 h1:40YY+3qq2tAUhZIMEK8kqusKZBBjdwJ3NUjvYk
 github.com/hashicorp/memberlist v0.5.4/go.mod h1:OgN6xiIo6RlHUWk+ALjP9e32xWCoQrsOCmHrWCm2MWA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
+github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP4mnWdTY=
 github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
@@ -187,6 +195,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mark3labs/mcp-go v0.43.2 h1:21PUSlWWiSbUPQwXIJ5WKlETixpFpq+WBpbMGDSVy/I=
+github.com/mark3labs/mcp-go v0.43.2/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -258,6 +268,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
+github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.10.0 h1:a5/WeUlSDCvV5a45ljW2ZFtV0bTDpkfSAj3uqB6Sc+0=
 github.com/spf13/cobra v1.10.0/go.mod h1:9dhySC7dnTtEiqzmqfkLj47BslqLCUPMXjG2lj/NgoE=
 github.com/spf13/pflag v1.0.8/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -288,8 +300,12 @@ github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhso
 github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
+github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 h1:RbKq8BG0FI8OiXhBfcRtqqHcZcka+gU3cskNuf05R18=

--- a/pkg/sandbox-manager/consts/consts.go
+++ b/pkg/sandbox-manager/consts/consts.go
@@ -32,6 +32,7 @@ const (
 	ExtProcPort               = 9002
 	DefaultExtProcConcurrency = 1000
 	RuntimePort               = 49983
+	RuntimeCodeExecPort       = 49999
 	ShutdownTimeout           = 90 * time.Second
 	RequestPeerTimeout        = 100 * time.Millisecond
 )

--- a/pkg/sandbox-manager/core.go
+++ b/pkg/sandbox-manager/core.go
@@ -190,6 +190,22 @@ func (m *SandboxManager) Stop(ctx context.Context) {
 	}
 }
 
+// ListPeers returns peer IPs discovered by proxy
+func (m *SandboxManager) ListPeers() []string {
+	peers := m.proxy.ListPeers()
+	ips := make([]string, 0, len(peers))
+	for _, p := range peers {
+		if p.IP != "" {
+			ips = append(ips, p.IP)
+		}
+	}
+	return ips
+}
+
+func (m *SandboxManager) GetPeersManager() peers.Peers {
+	return m.peersManager
+}
+
 func (m *SandboxManager) GetInfra() infra.Infrastructure {
 	return m.infra
 }

--- a/pkg/sandbox-manager/infra/interface.go
+++ b/pkg/sandbox-manager/infra/interface.go
@@ -48,6 +48,13 @@ type Builder interface {
 	Build() Infrastructure
 }
 
+// SandboxEventHandler defines the interface for handling sandbox lifecycle events
+type SandboxEventHandler interface {
+	OnSandboxAdd(sessionID, sandboxID, userID, accessToken, state string)
+	OnSandboxDelete(sessionID string)
+	OnSandboxUpdate(sessionID, sandboxID, userID, accessToken, state string)
+}
+
 type Infrastructure interface {
 	Run(ctx context.Context) error // Starts the infrastructure
 	Stop(ctx context.Context)      // Stops the infrastructure
@@ -61,6 +68,7 @@ type Infrastructure interface {
 	ClaimSandbox(ctx context.Context, opts ClaimSandboxOptions) (Sandbox, ClaimMetrics, error)
 	CloneSandbox(ctx context.Context, opts CloneSandboxOptions) (Sandbox, CloneMetrics, error)
 	DeleteCheckpoint(ctx context.Context, user string, checkpointID string) error
+	SetSandboxEventHandler(handler SandboxEventHandler)
 }
 
 type Sandbox interface {
@@ -80,10 +88,10 @@ type Sandbox interface {
 	SaveTimeout(ctx context.Context, opts TimeoutOptions) error
 	GetTimeout() TimeoutOptions
 	GetClaimTime() (time.Time, error)
-	Kill(ctx context.Context) error                                                                     // Delete the Sandbox resource
-	InplaceRefresh(ctx context.Context, deepcopy bool) error                                            // Update the Sandbox resource object to the latest
-	Request(ctx context.Context, method, path string, port int, body io.Reader) (*http.Response, error) // Make a request to the Sandbox
-	CSIMount(ctx context.Context, driver string, request string) error                                  // request is string config for csi.NodePublishVolumeRequest
+	Kill(ctx context.Context) error                                                                                          // Delete the Sandbox resource
+	InplaceRefresh(ctx context.Context, deepcopy bool) error                                                                 // Update the Sandbox resource object to the latest
+	Request(ctx context.Context, method, path string, port int, body io.Reader, headers http.Header) (*http.Response, error) // Make a request to the Sandbox
+	CSIMount(ctx context.Context, driver string, request string) error                                                       // request is string config for csi.NodePublishVolumeRequest
 	CreateCheckpoint(ctx context.Context, opts CreateCheckpointOptions) (string, error)
 }
 

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -112,6 +112,17 @@ type Infra struct {
 	createLimiter    *rate.Limiter
 
 	reconcileRouteStopCh chan struct{}
+
+	// SandboxEventHandler handles sandbox lifecycle events
+	SandboxEventHandler infra.SandboxEventHandler
+}
+
+// SetSandboxEventHandler sets the sandbox event handler for handling sandbox lifecycle events
+func (i *Infra) SetSandboxEventHandler(handler infra.SandboxEventHandler) {
+	if i.SandboxEventHandler != nil {
+		panic("SandboxEventHandler already set, cannot register twice")
+	}
+	i.SandboxEventHandler = handler
 }
 
 func (i *Infra) Run(ctx context.Context) error {
@@ -307,6 +318,9 @@ func (i *Infra) GetClaimedSandbox(ctx context.Context, sandboxID string) (infra.
 	return AsSandbox(sandbox, i.Cache), nil
 }
 
+// reconcileSandbox is a unified reconcile handler registered with the Sandbox
+// CustomReconciler. It refreshes the proxy route for the sandbox and
+// forwards sandbox lifecycle events to the MCP SandboxEventHandler (if set).
 func (i *Infra) reconcileSandbox(ctx context.Context, sbx *v1alpha1.Sandbox, notFound bool) (ctrl.Result, error) {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
 
@@ -315,12 +329,39 @@ func (i *Infra) reconcileSandbox(ctx context.Context, sbx *v1alpha1.Sandbox, not
 		sandboxID := stateutils.GetSandboxID(sbx)
 		i.Proxy.DeleteRoute(sandboxID)
 		log.Info("sandbox route deleted during reconciliation", "sandboxID", sandboxID)
+
+		// Forward delete event to MCP session handler
+		if i.SandboxEventHandler != nil {
+			sessionID := sbx.GetAnnotations()[v1alpha1.AnnotationMCPSessionID]
+			if sessionID != "" {
+				i.SandboxEventHandler.OnSandboxDelete(sessionID)
+			}
+		}
 		return ctrl.Result{}, nil
 	}
 
-	// Sandbox exists, refresh route
+	// Sandbox exists, refresh route. Use the existence of an old route to
+	// distinguish between a newly observed sandbox (Add) and an update.
+	_, hadRoute := i.Proxy.LoadRoute(sbx.GetName())
 	i.refreshRoute(sbx)
 	log.V(consts.DebugLogLevel).Info("sandbox route refreshed during reconciliation")
+
+	// Forward add/update event to MCP session handler
+	if i.SandboxEventHandler != nil {
+		annotations := sbx.GetAnnotations()
+		sessionID := annotations[v1alpha1.AnnotationMCPSessionID]
+		if sessionID != "" {
+			state, _ := stateutils.GetSandboxState(sbx)
+			sandboxID := stateutils.GetSandboxID(sbx)
+			owner := annotations[v1alpha1.AnnotationOwner]
+			token := annotations[v1alpha1.AnnotationRuntimeAccessToken]
+			if hadRoute {
+				i.SandboxEventHandler.OnSandboxUpdate(sessionID, sandboxID, owner, token, state)
+			} else {
+				i.SandboxEventHandler.OnSandboxAdd(sessionID, sandboxID, owner, token, state)
+			}
+		}
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -217,8 +217,8 @@ func (s *Sandbox) GetResource() infra.SandboxResource {
 	return sandboxManagerUtils.CalculateResourceFromContainers(s.Spec.Template.Spec.Containers)
 }
 
-func (s *Sandbox) Request(ctx context.Context, method, path string, port int, body io.Reader) (*http.Response, error) {
-	return proxyutils.DefaultRequestFunc(ctx, s.Sandbox, method, path, port, body)
+func (s *Sandbox) Request(ctx context.Context, method, path string, port int, body io.Reader, headers http.Header) (*http.Response, error) {
+	return proxyutils.DefaultRequestFunc(ctx, s.Sandbox, method, path, port, body, headers)
 }
 
 func (s *Sandbox) Pause(ctx context.Context, opts infra.PauseOptions) error {

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
@@ -437,7 +437,7 @@ func TestSandbox_Request(t *testing.T) {
 		proxyutils.DefaultRequestFunc = orig
 	})
 
-	proxyutils.DefaultRequestFunc = func(ctx context.Context, sbx *v1alpha1.Sandbox, method, path string, port int, body io.Reader) (*http.Response, error) {
+	proxyutils.DefaultRequestFunc = func(ctx context.Context, sbx *v1alpha1.Sandbox, method, path string, port int, body io.Reader, headers http.Header) (*http.Response, error) {
 		assert.Equal(t, "GET", method)
 		assert.Equal(t, "/healthz", path)
 		assert.Equal(t, 8080, port)
@@ -454,7 +454,7 @@ func TestSandbox_Request(t *testing.T) {
 			},
 		},
 	}
-	resp, err := s.Request(context.Background(), "GET", "/healthz", 8080, nil)
+	resp, err := s.Request(context.Background(), "GET", "/healthz", 8080, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -195,3 +195,13 @@ func (sc *Controller) Run() (context.Context, error) {
 	}
 	return ctx, nil
 }
+
+// GetManager returns the sandbox manager
+func (sc *Controller) GetManager() *sandboxmanager.SandboxManager {
+	return sc.manager
+}
+
+// GetKeys returns the key storage
+func (sc *Controller) GetKeys() keys.KeyStorage {
+	return sc.keys
+}

--- a/pkg/servers/e2b/services.go
+++ b/pkg/servers/e2b/services.go
@@ -118,7 +118,8 @@ func (sc *Controller) BrowserUse(r *http.Request) (web.ApiResponse[*browserHandS
 		return web.ApiResponse[*browserHandShake]{}, apiErr
 	}
 
-	resp, err := sbx.Request(r.Context(), r.Method, "/json/version", cdpPort, r.Body)
+	resp, err := sbx.Request(r.Context(), r.Method, "/json/version", cdpPort, r.Body, nil)
+
 	if err != nil {
 		return web.ApiResponse[*browserHandShake]{}, &web.ApiError{
 			Message: fmt.Sprintf("Failed to proxy request to sandbox port %d: %v", cdpPort, err),

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -1463,7 +1463,7 @@ func TestBrowserUseCDPPort(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			proxyutils.DefaultRequestFunc = func(ctx context.Context, sbx *v1alpha1.Sandbox, method, path string, port int, body io.Reader) (*http.Response, error) {
+			proxyutils.DefaultRequestFunc = func(ctx context.Context, sbx *v1alpha1.Sandbox, method, path string, port int, body io.Reader, headers http.Header) (*http.Response, error) {
 				assert.Equal(t, "/json/version", path)
 				assert.Equal(t, tt.expectedPort, port)
 				return &http.Response{

--- a/pkg/servers/mcp/auth.go
+++ b/pkg/servers/mcp/auth.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"net/http"
+
+	"k8s.io/klog/v2"
+
+	"github.com/openkruise/agents/pkg/servers/e2b/keys"
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+)
+
+// KeyStorage defines the interface for API key validation
+type KeyStorage interface {
+	LoadByKey(ctx context.Context, key string) (*models.CreatedTeamAPIKey, bool)
+}
+
+// Auth handles authentication for MCP server
+type Auth struct {
+	keys KeyStorage
+}
+
+func NewAuth(keys KeyStorage) *Auth {
+	a := &Auth{}
+	if keys != nil {
+		a.keys = keys
+	}
+	return a
+}
+
+// ValidateAPIKey validates the API key and returns user information
+func (a *Auth) ValidateAPIKey(ctx context.Context, apiKey string) (*models.CreatedTeamAPIKey, error) {
+	if a.keys == nil {
+		// If authentication is disabled, return anonymous user
+		return &models.CreatedTeamAPIKey{
+			ID:   keys.AdminKeyID,
+			Name: "auth-disabled",
+		}, nil
+	}
+
+	if apiKey == "" {
+		return nil, NewMCPError(ErrorCodeAuthFailed, "API key is required", nil)
+	}
+
+	user, ok := a.keys.LoadByKey(ctx, apiKey)
+	if !ok {
+		return nil, NewMCPError(ErrorCodeAuthFailed, "Invalid API key", nil)
+	}
+
+	return user, nil
+}
+
+// HTTPAuthMiddleware creates an HTTP middleware for E2B-API-KEY authentication
+func (a *Auth) HTTPAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		// Extract E2B-API-KEY from header
+		apiKey := r.Header.Get("E2B-API-KEY")
+
+		// Validate API key
+		user, err := a.ValidateAPIKey(ctx, apiKey)
+		if err != nil {
+			// Security audit log: authentication failed
+			klog.FromContext(ctx).Error(err, "HTTP authentication failed",
+				"apiKeyHint", MaskAPIKey(apiKey),
+				"path", r.URL.Path,
+				"remoteAddr", r.RemoteAddr)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"Unauthorized","message":"Invalid or missing API key"}`))
+			return
+		}
+
+		// Set user in context and proceed
+		ctx = SetUserContext(ctx, user)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/pkg/servers/mcp/auth_test.go
+++ b/pkg/servers/mcp/auth_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/openkruise/agents/pkg/servers/e2b/keys"
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockKeyStorage provides a simple mock for SecretKeyStorage
+type mockKeyStorage struct {
+	keys map[string]*models.CreatedTeamAPIKey
+}
+
+func newMockKeyStorage() *mockKeyStorage {
+	return &mockKeyStorage{
+		keys: make(map[string]*models.CreatedTeamAPIKey),
+	}
+}
+
+func (m *mockKeyStorage) addKey(key string, user *models.CreatedTeamAPIKey) {
+	m.keys[key] = user
+}
+
+func (m *mockKeyStorage) LoadByKey(_ context.Context, key string) (*models.CreatedTeamAPIKey, bool) {
+	user, ok := m.keys[key]
+	return user, ok
+}
+
+func TestNewAuth(t *testing.T) {
+	t.Run("with key storage", func(t *testing.T) {
+		storage := newMockKeyStorage()
+		auth := NewAuth(storage)
+
+		assert.NotNil(t, auth)
+		assert.Equal(t, storage, auth.keys)
+	})
+
+	t.Run("with nil key storage", func(t *testing.T) {
+		auth := NewAuth(nil)
+
+		assert.NotNil(t, auth)
+		assert.Nil(t, auth.keys)
+	})
+}
+
+func TestAuth_ValidateAPIKey(t *testing.T) {
+	t.Run("auth disabled (nil keys) returns anonymous user", func(t *testing.T) {
+		auth := &Auth{keys: nil}
+		ctx := context.Background()
+
+		user, err := auth.ValidateAPIKey(ctx, "any-key")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, user)
+		assert.Equal(t, keys.AdminKeyID, user.ID)
+		assert.Equal(t, "auth-disabled", user.Name)
+	})
+
+	t.Run("auth disabled with empty key returns anonymous user", func(t *testing.T) {
+		auth := &Auth{keys: nil}
+		ctx := context.Background()
+
+		user, err := auth.ValidateAPIKey(ctx, "")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, user)
+		assert.Equal(t, "auth-disabled", user.Name)
+	})
+}
+
+func TestAuth_HTTPAuthMiddleware(t *testing.T) {
+	t.Run("auth disabled passes through", func(t *testing.T) {
+		auth := &Auth{keys: nil}
+		called := false
+		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			// Verify user is set in context
+			user, err := GetUserFromContext(r.Context())
+			assert.NoError(t, err)
+			assert.NotNil(t, user)
+			assert.Equal(t, "auth-disabled", user.Name)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := auth.HTTPAuthMiddleware(nextHandler)
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		assert.True(t, called)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("valid API key passes through", func(t *testing.T) {
+		mockStorage := newMockKeyStorage()
+		testUser := &models.CreatedTeamAPIKey{
+			ID:   uuid.New(),
+			Name: "test-user",
+			Key:  "valid-key",
+		}
+		mockStorage.addKey("valid-key", testUser)
+
+		// Create auth with mock storage (now works because Auth.keys is KeyStorage interface)
+		auth := &Auth{keys: mockStorage}
+
+		called := false
+		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			// Verify user is set in context
+			user, err := GetUserFromContext(r.Context())
+			assert.NoError(t, err)
+			assert.Equal(t, testUser.ID, user.ID)
+			assert.Equal(t, "test-user", user.Name)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := auth.HTTPAuthMiddleware(nextHandler)
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("E2B-API-KEY", "valid-key")
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		assert.True(t, called)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("invalid API key returns 401", func(t *testing.T) {
+		mockStorage := newMockKeyStorage()
+		// Storage is empty, no valid keys
+		auth := &Auth{keys: mockStorage}
+
+		called := false
+		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		})
+
+		handler := auth.HTTPAuthMiddleware(nextHandler)
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("E2B-API-KEY", "invalid-key")
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		assert.False(t, called)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	})
+
+	t.Run("missing API key with auth enabled returns 401", func(t *testing.T) {
+		mockStorage := newMockKeyStorage()
+		auth := &Auth{keys: mockStorage}
+
+		called := false
+		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		})
+
+		handler := auth.HTTPAuthMiddleware(nextHandler)
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		// No E2B-API-KEY header
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		assert.False(t, called)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Contains(t, rec.Body.String(), "Unauthorized")
+	})
+}

--- a/pkg/servers/mcp/handler.go
+++ b/pkg/servers/mcp/handler.go
@@ -1,0 +1,416 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"k8s.io/klog/v2"
+
+	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
+)
+
+// Handler handles MCP tool calls
+type Handler struct {
+	sessionManager *SessionManager
+	operator       SandboxOperator
+	config         *ServerConfig
+}
+
+func NewHandler(sessionManager *SessionManager, operator SandboxOperator, config *ServerConfig) *Handler {
+	return &Handler{
+		sessionManager: sessionManager,
+		operator:       operator,
+		config:         config,
+	}
+}
+
+// HandleRunCode handles the run_code tool
+func (h *Handler) HandleRunCode(ctx context.Context, req mcpgo.CallToolRequest, args RunCodeRequest) (RunCodeResponse, error) {
+	log := klog.FromContext(ctx).WithValues("tool", ToolRunCode)
+
+	// Get user from context
+	user, err := GetUserFromContext(ctx)
+	if err != nil {
+		return RunCodeResponse{}, err
+	}
+
+	// Get or determine session ID
+	sessionID, err := GetSessionID(ctx)
+	if err != nil {
+		return RunCodeResponse{}, err
+	}
+	log = log.WithValues("sessionID", sessionID, "userID", user.ID.String())
+
+	// Get user session configuration (with fallback to defaults)
+	userConfig := GetUserSessionConfig(ctx)
+	template := h.config.DefaultTemplate
+	if userConfig != nil && userConfig.Template != "" {
+		template = userConfig.Template
+	}
+
+	// Determine sandbox TTL (user config or default)
+	sandboxTTL := h.config.SandboxTTL
+	if userConfig != nil && userConfig.SandboxTTL != nil {
+		sandboxTTL = *userConfig.SandboxTTL
+	}
+
+	// Get or create session
+	sessionStart := time.Now()
+	session, err := h.sessionManager.GetOrCreateSession(ctx, sessionID, user.ID.String(), template, sandboxTTL)
+	if err != nil {
+		return RunCodeResponse{}, err
+	}
+	log.Info("session loaded", "sandboxID", session.SandboxID, "cost", time.Since(sessionStart))
+
+	log.Info("executing code", "sandboxID", session.SandboxID, "codeLength", len(args.Code))
+
+	// Determine code execution timeout (user config or default)
+	execTimeout := h.config.ExecutionTimeout
+	if userConfig != nil && userConfig.ExecutionTimeout != nil {
+		execTimeout = *userConfig.ExecutionTimeout
+	}
+
+	// Execute code through sandbox
+	ctx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+
+	execStart := time.Now()
+	result, err := h.executeCodeInSandbox(ctx, session, args.Code, args.Language)
+	if err != nil {
+		log.Error(err, "code execution failed", "cost", time.Since(execStart))
+		return RunCodeResponse{}, fmt.Errorf("code execution failed: %w", err)
+	}
+	resTmp, _ := json.Marshal(result)
+	log.Info("code executed successfully", "sandboxID", session.SandboxID, "resultLength", len(resTmp), "cost", time.Since(execStart))
+
+	return *result, nil
+}
+
+// HandleRunCodeOnce handles the run_code_once tool
+// This creates a new sandbox for each call and cleans it up after execution
+func (h *Handler) HandleRunCodeOnce(ctx context.Context, req mcpgo.CallToolRequest, args RunCodeOnceRequest) (RunCodeResponse, error) {
+	log := klog.FromContext(ctx).WithValues("tool", ToolRunCodeOnce)
+
+	// Get user from context
+	user, err := GetUserFromContext(ctx)
+	if err != nil {
+		return RunCodeResponse{}, err
+	}
+
+	// Get or determine session ID
+	sessionID, err := GetSessionID(ctx)
+	if err != nil {
+		return RunCodeResponse{}, err
+	}
+	log = log.WithValues("sessionID", sessionID, "userID", user.ID.String())
+
+	// Get user session configuration (with fallback to defaults)
+	userConfig := GetUserSessionConfig(ctx)
+	template := h.config.DefaultTemplate
+	if userConfig != nil && userConfig.Template != "" {
+		template = userConfig.Template
+	}
+
+	// Determine sandbox TTL (user config or default)
+	sandboxTTL := h.config.SandboxTTL
+	if userConfig != nil && userConfig.SandboxTTL != nil {
+		sandboxTTL = *userConfig.SandboxTTL
+	}
+
+	log.Info("creating one-time sandbox for code execution", "codeLength", len(args.Code))
+	// Create a new sandbox for this one-time execution
+	createStart := time.Now()
+	sandboxInfo, err := CreateSandbox(ctx, h.operator, user.ID.String(), sessionID, template, sandboxTTL)
+	if err != nil {
+		log.Error(err, "failed to create one-time sandbox", "cost", time.Since(createStart))
+		return RunCodeResponse{}, NewMCPError(ErrorCodeSandboxCreation, fmt.Sprintf("Failed to create sandbox: %v", err), nil)
+	}
+
+	log = log.WithValues("sandboxID", sandboxInfo.SandboxID)
+	log.Info("one-time sandbox created successfully", "cost", time.Since(createStart))
+
+	// Ensure sandbox is cleaned up after execution, regardless of success or failure
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		deleteStart := time.Now()
+		if cleanupErr := DeleteSandbox(cleanupCtx, h.operator, user.ID.String(), sandboxInfo.SandboxID); cleanupErr != nil {
+			log.Error(cleanupErr, "failed to cleanup one-time sandbox", "cost", time.Since(deleteStart))
+		} else {
+			log.Info("one-time sandbox cleaned up successfully", "cost", time.Since(deleteStart))
+		}
+	}()
+
+	// Create a temporary session for execution
+	tempSession := &UserSession{
+		UserID:      user.ID.String(),
+		SandboxID:   sandboxInfo.SandboxID,
+		AccessToken: sandboxInfo.AccessToken,
+	}
+
+	// Determine code execution timeout (user config or default)
+	execTimeout := h.config.ExecutionTimeout
+	if userConfig != nil && userConfig.ExecutionTimeout != nil {
+		execTimeout = *userConfig.ExecutionTimeout
+	}
+
+	// Execute code through sandbox with timeout
+	execCtx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+
+	execStart := time.Now()
+	result, err := h.executeCodeInSandbox(execCtx, tempSession, args.Code, args.Language)
+	if err != nil {
+		log.Error(err, "code execution failed in one-time sandbox", "cost", time.Since(execStart))
+		return RunCodeResponse{}, fmt.Errorf("code execution failed: %w", err)
+	}
+
+	resTmp, _ := json.Marshal(result)
+	log.Info("code executed successfully in one-time sandbox", "resultLength", len(resTmp), "cost", time.Since(execStart))
+
+	return *result, nil
+}
+
+// HandleRunCommand handles the run_command tool
+func (h *Handler) HandleRunCommand(ctx context.Context, req mcpgo.CallToolRequest, args RunCommandRequest) (RunCommandResponse, error) {
+	log := klog.FromContext(ctx).WithValues("tool", ToolRunCommand)
+
+	// Get user from context
+	user, err := GetUserFromContext(ctx)
+	if err != nil {
+		return RunCommandResponse{}, err
+	}
+
+	// Get or determine session ID
+	sessionID, err := GetSessionID(ctx)
+	if err != nil {
+		return RunCommandResponse{}, err
+	}
+	log = log.WithValues("sessionID", sessionID, "userID", user.ID.String())
+
+	// Get user session configuration (with fallback to defaults)
+	userConfig := GetUserSessionConfig(ctx)
+	template := h.config.DefaultTemplate
+	if userConfig != nil && userConfig.Template != "" {
+		template = userConfig.Template
+	}
+
+	// Get or create session
+	// NOTE: sandbox TTL is determined by the first request that creates the session.
+	sandboxTTL := h.config.SandboxTTL
+	if userConfig != nil && userConfig.SandboxTTL != nil {
+		sandboxTTL = *userConfig.SandboxTTL
+	}
+
+	sessionStart := time.Now()
+	session, err := h.sessionManager.GetOrCreateSession(ctx, sessionID, user.ID.String(), template, sandboxTTL)
+	if err != nil {
+		return RunCommandResponse{}, err
+	}
+	log.Info("session loaded", "sandboxID", session.SandboxID, "cost", time.Since(sessionStart))
+
+	log.Info("executing command", "cmd", args.Cmd)
+
+	// Determine timeout (user config or default)
+	execTimeout := h.config.ExecutionTimeout
+	if userConfig != nil && userConfig.ExecutionTimeout != nil {
+		execTimeout = *userConfig.ExecutionTimeout
+	}
+
+	execStart := time.Now()
+	result, err := ExecuteCommand(
+		ctx,
+		h.operator,
+		user.ID.String(),
+		session.SandboxID,
+		args.Cmd,
+		args.Envs,
+		args.Cwd,
+		execTimeout,
+	)
+	if err != nil {
+		log.Error(err, "command execution failed", "cost", time.Since(execStart))
+		return RunCommandResponse{
+			SandboxID: session.SandboxID,
+			Error:     err.Error(),
+			ExitCode:  -1,
+		}, nil // Return response with error info, not error
+	}
+
+	resTmp, _ := json.Marshal(result)
+	log.V(consts.DebugLogLevel).Info("command res", "result", string(resTmp))
+
+	response := RunCommandResponse{
+		Stdout:    strings.Join(result.Stdout, ""),
+		Stderr:    strings.Join(result.Stderr, ""),
+		ExitCode:  int(result.ExitCode),
+		SandboxID: session.SandboxID,
+	}
+
+	if result.Error != nil {
+		response.Error = result.Error.Error()
+	}
+
+	log.Info("command executed successfully", "exitCode", response.ExitCode, "cost", time.Since(execStart))
+	return response, nil
+}
+
+// Helper functions
+
+func (h *Handler) executeCodeInSandbox(ctx context.Context, session *UserSession, code string, language string) (*RunCodeResponse, error) {
+	log := klog.FromContext(ctx)
+
+	if language == "" {
+		language = "python"
+	}
+	language = strings.ToLower(strings.TrimSpace(language))
+
+	// Validate language is supported
+	if language != "python" && language != "javascript" {
+		msg := fmt.Sprintf("unsupported language: %s, only python and javascript are supported", language)
+		log.Error(nil, msg, "language", language)
+		return nil, NewMCPError(ErrorCodeCodeExecution, msg, nil)
+	}
+
+	// Prepare E2B compliant request body with all required fields
+	requestBody, err := json.Marshal(map[string]interface{}{
+		"code":       code,
+		"context_id": nil,      // Reserved for future multi-context support
+		"language":   language, // User-specified or default: python or javascript
+		"env_vars":   nil,      // Reserved for future environment variable support
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Send request to sandbox /execute endpoint with authentication headers
+	// Following E2B Python client format: X-Access-Token for envd authentication
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
+	if session.AccessToken != "" {
+		headers.Set("X-Access-Token", session.AccessToken)
+	}
+
+	resp, err := RequestToSandbox(ctx, h.operator, session.UserID, session.SandboxID, http.MethodPost, "/execute", consts.RuntimeCodeExecPort, bytes.NewReader(requestBody), headers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request to sandbox: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("sandbox returned error: status=%d, body=%s", resp.StatusCode, string(body))
+	}
+
+	// Initialize execution result structure
+	execution := &RunCodeResponse{
+		Logs: ExecutionLogs{
+			Stdout: []string{},
+			Stderr: []string{},
+		},
+		Results:   []ExecutionResult{},
+		SandboxID: session.SandboxID,
+	}
+
+	// Parse streaming SSE response line by line
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue // Skip empty lines
+		}
+
+		// Parse each line as JSON
+		var data map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &data); err != nil {
+			log.V(1).Info("failed to parse JSON line, skipping", "line", line, "error", err)
+			continue
+		}
+
+		// Extract type field to determine message type
+		msgType, ok := data["type"].(string)
+		if !ok {
+			log.V(1).Info("missing or invalid type field, skipping", "data", data)
+			continue
+		}
+
+		// Process different message types according to E2B specification
+		switch msgType {
+		case "stdout":
+			if text, ok := data["text"].(string); ok {
+				execution.Logs.Stdout = append(execution.Logs.Stdout, text)
+			}
+		case "stderr":
+			if text, ok := data["text"].(string); ok {
+				execution.Logs.Stderr = append(execution.Logs.Stderr, text)
+			}
+		case "result":
+			// Parse complete result object with all MIME types
+			var result ExecutionResult
+			if resultBytes, err := json.Marshal(data); err == nil {
+				if err := json.Unmarshal(resultBytes, &result); err == nil {
+					execution.Results = append(execution.Results, result)
+				} else {
+					log.V(1).Info("failed to parse result object", "error", err)
+				}
+			}
+		case "error":
+			// Parse execution error with name, value, and traceback
+			execution.Error = &ExecutionError{
+				Name:      getStringField(data, "name"),
+				Value:     getStringField(data, "value"),
+				Traceback: getStringField(data, "traceback"),
+			}
+		case "number_of_executions":
+			// Extract execution count
+			if count, ok := data["execution_count"].(float64); ok {
+				intCount := int(count)
+				execution.ExecutionCount = &intCount
+			}
+		default:
+			log.V(2).Info("unknown message type, ignoring", "type", msgType, "data", data)
+		}
+	}
+
+	// Check for scanner errors (I/O issues during streaming)
+	if err := scanner.Err(); err != nil {
+		log.Error(err, "error reading streaming response", "sandboxID", session.SandboxID)
+		// Return partial results even if streaming was interrupted
+		return execution, fmt.Errorf("streaming interrupted: %w", err)
+	}
+
+	return execution, nil
+}
+
+// getStringField safely extracts a string field from a map
+func getStringField(data map[string]interface{}, key string) string {
+	if val, ok := data[key].(string); ok {
+		return val
+	}
+	return ""
+}

--- a/pkg/servers/mcp/handler_test.go
+++ b/pkg/servers/mcp/handler_test.go
@@ -1,0 +1,1111 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestHandler creates a Handler for testing without real dependencies
+func createTestHandler() (*Handler, *SessionManager, *server.MCPServer) {
+	config := DefaultServerConfig()
+	operator := &mockSandboxOperator{}
+	sm := createTestSessionManager(operator, nil)
+	mcpSrv := server.NewMCPServer("test-server", "0.0.1")
+
+	h := &Handler{
+		sessionManager: sm,
+		operator:       operator,
+		config:         config,
+	}
+
+	return h, sm, mcpSrv
+}
+
+// createTestHandlerWithOperator creates a Handler for testing with custom SandboxOperator
+func createTestHandlerWithOperator(operator *mockSandboxOperator) (*Handler, *SessionManager, *server.MCPServer) {
+	config := DefaultServerConfig()
+	sm := createTestSessionManager(operator, nil)
+	mcpSrv := server.NewMCPServer("test-server", "0.0.1")
+
+	h := &Handler{
+		sessionManager: sm,
+		operator:       operator,
+		config:         config,
+	}
+
+	return h, sm, mcpSrv
+}
+
+// createTestContext creates a context with user and session for testing
+func createTestContext(mcpSrv *server.MCPServer, userID uuid.UUID, sessionID string) context.Context {
+	ctx := context.Background()
+
+	// Set user in context
+	testUser := &models.CreatedTeamAPIKey{
+		ID:   userID,
+		Name: "test-user",
+	}
+	ctx = SetUserContext(ctx, testUser)
+
+	// Set mock client session
+	mockSession := newMockClientSession(sessionID)
+	ctx = mcpSrv.WithContext(ctx, mockSession)
+
+	return ctx
+}
+
+// mockSandboxWithRequest is a mock sandbox that supports custom HTTP request responses
+type mockSandboxWithRequest struct {
+	*mockSandbox
+	response        *http.Response
+	requestErr      error
+	capturedHeaders *http.Header
+}
+
+// newMockSandboxWithRequest creates a mock sandbox with custom request response
+func newMockSandboxWithRequest(sandboxID string, response *http.Response, requestErr error) *mockSandboxWithRequest {
+	return &mockSandboxWithRequest{
+		mockSandbox: newMockSandbox(sandboxID),
+		response:    response,
+		requestErr:  requestErr,
+	}
+}
+
+// newMockSandboxWithRequestCapture creates a mock sandbox that captures request headers
+func newMockSandboxWithRequestCapture(sandboxID string, capturedHeaders *http.Header) *mockSandboxWithRequest {
+	// Return a response that will trigger error but allow header capture
+	resp := newMockHTTPResponse(http.StatusOK, ``)
+	return &mockSandboxWithRequest{
+		mockSandbox:     newMockSandbox(sandboxID),
+		response:        resp,
+		requestErr:      nil,
+		capturedHeaders: capturedHeaders,
+	}
+}
+
+func (m *mockSandboxWithRequest) Request(ctx context.Context, method, path string, port int, body io.Reader, headers http.Header) (*http.Response, error) {
+	if m.capturedHeaders != nil {
+		*m.capturedHeaders = headers.Clone()
+	}
+	if m.requestErr != nil {
+		return nil, m.requestErr
+	}
+	return m.response, nil
+}
+
+// newMockHTTPResponse creates a mock HTTP response with given status and body
+func newMockHTTPResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func TestHandleRunCode(t *testing.T) {
+	t.Run("returns error when user not in context", func(t *testing.T) {
+		operator := newMockOperatorWithSandbox("sandbox-abc", nil)
+		h, _, mcpSrv := createTestHandlerWithOperator(operator)
+		sessionID := "session-123"
+
+		// Create context WITHOUT user
+		mockSession := newMockClientSession(sessionID)
+		ctx := mcpSrv.WithContext(context.Background(), mockSession)
+
+		args := RunCodeRequest{
+			Code:     "print('test')",
+			Language: "python",
+		}
+
+		result, err := h.HandleRunCode(ctx, mcpgo.CallToolRequest{}, args)
+
+		assert.Error(t, err)
+		assert.IsType(t, &MCPError{}, err)
+		assert.Equal(t, ErrorCodeAuthFailed, err.(*MCPError).Code)
+		assert.Equal(t, RunCodeResponse{}, result)
+	})
+
+	t.Run("returns error when session ID not in context", func(t *testing.T) {
+		operator := newMockOperatorWithSandbox("sandbox-abc", nil)
+		h, _, _ := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+
+		// Create context WITHOUT session
+		ctx := context.Background()
+		testUser := &models.CreatedTeamAPIKey{
+			ID:   userID,
+			Name: "test-user",
+		}
+		ctx = SetUserContext(ctx, testUser)
+
+		args := RunCodeRequest{
+			Code:     "print('test')",
+			Language: "python",
+		}
+
+		result, err := h.HandleRunCode(ctx, mcpgo.CallToolRequest{}, args)
+
+		assert.Error(t, err)
+		assert.IsType(t, &MCPError{}, err)
+		assert.Equal(t, ErrorCodeInternalError, err.(*MCPError).Code)
+		assert.Equal(t, RunCodeResponse{}, result)
+	})
+
+	t.Run("returns error when session creation fails", func(t *testing.T) {
+		operator := newMockOperatorWithSandbox("", errors.New("sandbox creation failed"))
+		h, _, mcpSrv := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+		sessionID := "session-fail"
+
+		ctx := createTestContext(mcpSrv, userID, sessionID)
+		args := RunCodeRequest{
+			Code:     "print('test')",
+			Language: "python",
+		}
+
+		result, err := h.HandleRunCode(ctx, mcpgo.CallToolRequest{}, args)
+
+		assert.Error(t, err)
+		assert.IsType(t, &MCPError{}, err)
+		assert.Equal(t, ErrorCodeSandboxCreation, err.(*MCPError).Code)
+		assert.Equal(t, RunCodeResponse{}, result)
+	})
+
+	t.Run("reuses existing session and does not call sandbox creator", func(t *testing.T) {
+		creatorCallCount := 0
+		operator := &mockSandboxOperator{
+			claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+				creatorCallCount++
+				return newMockSandbox("new-sandbox"), nil
+			},
+		}
+		_, sm, mcpSrv := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+		sessionID := "session-reuse"
+
+		// Pre-store a session
+		existingSession := &UserSession{
+			SessionID:   sessionID,
+			UserID:      userID.String(),
+			SandboxID:   "sandbox-existing",
+			TemplateID:  "template-1",
+			State:       "Running",
+			AccessToken: "existing-token",
+		}
+		sm.sessions.Store(sessionID, existingSession)
+
+		ctx := createTestContext(mcpSrv, userID, sessionID)
+
+		// Test through SessionManager directly to verify session reuse
+		session, err := sm.GetOrCreateSession(ctx, sessionID, userID.String(), "template-1", 10*time.Minute)
+
+		require.NoError(t, err)
+		assert.Equal(t, "sandbox-existing", session.SandboxID)
+		assert.Equal(t, 0, creatorCallCount) // Creator should not be called
+	})
+}
+
+func TestHandleRunCodeOnce(t *testing.T) {
+	t.Run("returns error when user not in context", func(t *testing.T) {
+		h, _, mcpSrv := createTestHandler()
+		sessionID := "session-once-123"
+
+		// Create context WITHOUT user
+		mockSession := newMockClientSession(sessionID)
+		ctx := mcpSrv.WithContext(context.Background(), mockSession)
+
+		args := RunCodeOnceRequest{
+			Code:     "print('test')",
+			Language: "python",
+		}
+
+		result, err := h.HandleRunCodeOnce(ctx, mcpgo.CallToolRequest{}, args)
+
+		assert.Error(t, err)
+		assert.IsType(t, &MCPError{}, err)
+		assert.Equal(t, ErrorCodeAuthFailed, err.(*MCPError).Code)
+		assert.Equal(t, RunCodeResponse{}, result)
+	})
+}
+
+func TestHandleRunCommand(t *testing.T) {
+	t.Run("returns error when user not in context", func(t *testing.T) {
+		operator := newMockOperatorWithSandbox("sandbox-cmd-abc", nil)
+		h, _, mcpSrv := createTestHandlerWithOperator(operator)
+		sessionID := "session-cmd-123"
+
+		// Create context WITHOUT user
+		mockSession := newMockClientSession(sessionID)
+		ctx := mcpSrv.WithContext(context.Background(), mockSession)
+
+		args := RunCommandRequest{
+			Cmd: "ls -la",
+		}
+
+		result, err := h.HandleRunCommand(ctx, mcpgo.CallToolRequest{}, args)
+
+		assert.Error(t, err)
+		assert.IsType(t, &MCPError{}, err)
+		assert.Equal(t, ErrorCodeAuthFailed, err.(*MCPError).Code)
+		assert.Equal(t, RunCommandResponse{}, result)
+	})
+
+	t.Run("returns error when session creation fails", func(t *testing.T) {
+		operator := newMockOperatorWithSandbox("", errors.New("sandbox creation failed"))
+		h, _, mcpSrv := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+		sessionID := "session-cmd-fail"
+
+		ctx := createTestContext(mcpSrv, userID, sessionID)
+		args := RunCommandRequest{
+			Cmd: "ls -la",
+		}
+
+		result, err := h.HandleRunCommand(ctx, mcpgo.CallToolRequest{}, args)
+
+		assert.Error(t, err)
+		assert.IsType(t, &MCPError{}, err)
+		assert.Equal(t, ErrorCodeSandboxCreation, err.(*MCPError).Code)
+		assert.Equal(t, RunCommandResponse{}, result)
+	})
+
+	t.Run("reuses existing session and does not call sandbox creator", func(t *testing.T) {
+		creatorCallCount := 0
+		operator := &mockSandboxOperator{
+			claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+				creatorCallCount++
+				return newMockSandbox("new-sandbox"), nil
+			},
+		}
+		_, sm, mcpSrv := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+		sessionID := "session-cmd-reuse"
+
+		// Pre-store a session
+		existingSession := &UserSession{
+			SessionID:   sessionID,
+			UserID:      userID.String(),
+			SandboxID:   "sandbox-existing-cmd",
+			TemplateID:  "template-1",
+			State:       "Running",
+			AccessToken: "existing-token",
+		}
+		sm.sessions.Store(sessionID, existingSession)
+
+		ctx := createTestContext(mcpSrv, userID, sessionID)
+
+		// Test through SessionManager directly to verify session reuse
+		session, err := sm.GetOrCreateSession(ctx, sessionID, userID.String(), "template-1", 10*time.Minute)
+
+		require.NoError(t, err)
+		assert.Equal(t, "sandbox-existing-cmd", session.SandboxID)
+		assert.Equal(t, 0, creatorCallCount) // Creator should not be called
+	})
+}
+
+func TestHandleRunCode_UserConfig(t *testing.T) {
+	t.Run("uses user-configured template", func(t *testing.T) {
+		var capturedTemplate string
+		operator := &mockSandboxOperator{
+			claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+				capturedTemplate = opts.Template
+				return newMockSandbox("sandbox-config"), nil
+			},
+		}
+		h, _, mcpSrv := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+		sessionID := "session-config"
+
+		ctx := createTestContext(mcpSrv, userID, sessionID)
+		// Set user config with custom template
+		customTTL := 30 * time.Minute
+		customTimeout := 120 * time.Second
+		ctx = SetUserSessionConfig(ctx, &UserSessionConfig{
+			Template:         "custom-template",
+			SandboxTTL:       &customTTL,
+			ExecutionTimeout: &customTimeout,
+		})
+
+		args := RunCodeRequest{
+			Code:     "print('test')",
+			Language: "python",
+		}
+
+		// This will fail at executeCodeInSandbox but we can verify template was used
+		_, _ = h.HandleRunCode(ctx, mcpgo.CallToolRequest{}, args)
+
+		assert.Equal(t, "custom-template", capturedTemplate)
+	})
+
+	t.Run("uses default template when userConfig is nil", func(t *testing.T) {
+		var capturedTemplate string
+		operator := &mockSandboxOperator{
+			claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+				capturedTemplate = opts.Template
+				return newMockSandbox("sandbox-default"), nil
+			},
+		}
+		h, _, mcpSrv := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+		sessionID := "session-default"
+
+		ctx := createTestContext(mcpSrv, userID, sessionID)
+		// No user config set
+
+		args := RunCodeRequest{
+			Code:     "print('test')",
+			Language: "python",
+		}
+
+		_, _ = h.HandleRunCode(ctx, mcpgo.CallToolRequest{}, args)
+
+		assert.Equal(t, h.config.DefaultTemplate, capturedTemplate)
+	})
+
+	t.Run("uses default template when userConfig.Template is empty", func(t *testing.T) {
+		var capturedTemplate string
+		operator := &mockSandboxOperator{
+			claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+				capturedTemplate = opts.Template
+				return newMockSandbox("sandbox-empty-config"), nil
+			},
+		}
+		h, _, mcpSrv := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+		sessionID := "session-empty-config"
+
+		ctx := createTestContext(mcpSrv, userID, sessionID)
+		// Set empty user config
+		ctx = SetUserSessionConfig(ctx, &UserSessionConfig{
+			Template: "", // empty
+		})
+
+		args := RunCodeRequest{
+			Code:     "print('test')",
+			Language: "python",
+		}
+
+		_, _ = h.HandleRunCode(ctx, mcpgo.CallToolRequest{}, args)
+
+		assert.Equal(t, h.config.DefaultTemplate, capturedTemplate)
+	})
+}
+
+func TestHandleRunCodeOnce_MoreBranches(t *testing.T) {
+	t.Run("returns error when session ID not in context", func(t *testing.T) {
+		operator := newMockOperatorWithSandbox("sandbox-abc", nil)
+		h, _, _ := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+
+		// Create context WITHOUT session
+		ctx := context.Background()
+		testUser := &models.CreatedTeamAPIKey{
+			ID:   userID,
+			Name: "test-user",
+		}
+		ctx = SetUserContext(ctx, testUser)
+
+		args := RunCodeOnceRequest{
+			Code:     "print('test')",
+			Language: "python",
+		}
+
+		result, err := h.HandleRunCodeOnce(ctx, mcpgo.CallToolRequest{}, args)
+
+		assert.Error(t, err)
+		assert.IsType(t, &MCPError{}, err)
+		assert.Equal(t, ErrorCodeInternalError, err.(*MCPError).Code)
+		assert.Equal(t, RunCodeResponse{}, result)
+	})
+
+	t.Run("returns error when sandbox creation fails", func(t *testing.T) {
+		operator := newMockOperatorWithSandbox("", errors.New("no available sandbox"))
+		h, _, mcpSrv := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+		sessionID := "session-once-fail"
+
+		ctx := createTestContext(mcpSrv, userID, sessionID)
+		args := RunCodeOnceRequest{
+			Code:     "print('test')",
+			Language: "python",
+		}
+
+		result, err := h.HandleRunCodeOnce(ctx, mcpgo.CallToolRequest{}, args)
+
+		assert.Error(t, err)
+		assert.IsType(t, &MCPError{}, err)
+		assert.Equal(t, ErrorCodeSandboxCreation, err.(*MCPError).Code)
+		assert.Equal(t, RunCodeResponse{}, result)
+	})
+
+	t.Run("uses user-configured template", func(t *testing.T) {
+		var capturedTemplate string
+		operator := &mockSandboxOperator{
+			claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+				capturedTemplate = opts.Template
+				return newMockSandboxWithRequest("sandbox-once-config", nil, errors.New("expected error")), nil
+			},
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return newMockSandboxWithRequest(sandboxID, nil, errors.New("expected error")), nil
+			},
+		}
+		h, _, mcpSrv := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+		sessionID := "session-once-config"
+
+		ctx := createTestContext(mcpSrv, userID, sessionID)
+		// Set user config with custom template
+		ctx = SetUserSessionConfig(ctx, &UserSessionConfig{
+			Template: "custom-once-template",
+		})
+
+		args := RunCodeOnceRequest{
+			Code:     "print('test')",
+			Language: "python",
+		}
+
+		// Will fail at executeCodeInSandbox but we can verify template was used
+		_, _ = h.HandleRunCodeOnce(ctx, mcpgo.CallToolRequest{}, args)
+
+		assert.Equal(t, "custom-once-template", capturedTemplate)
+	})
+
+	t.Run("uses user-configured SandboxTTL and ExecutionTimeout", func(t *testing.T) {
+		operator := &mockSandboxOperator{
+			claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+				return newMockSandboxWithRequest("sandbox-once-ttl", nil, errors.New("expected error")), nil
+			},
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return newMockSandboxWithRequest(sandboxID, nil, errors.New("expected error")), nil
+			},
+		}
+		h, _, mcpSrv := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+		sessionID := "session-once-ttl"
+
+		ctx := createTestContext(mcpSrv, userID, sessionID)
+		// Set user config with custom TTL and timeout
+		customTTL := 15 * time.Minute
+		customTimeout := 90 * time.Second
+		ctx = SetUserSessionConfig(ctx, &UserSessionConfig{
+			SandboxTTL:       &customTTL,
+			ExecutionTimeout: &customTimeout,
+		})
+
+		args := RunCodeOnceRequest{
+			Code:     "print('test')",
+			Language: "python",
+		}
+
+		// Will fail at executeCodeInSandbox but config is processed
+		_, _ = h.HandleRunCodeOnce(ctx, mcpgo.CallToolRequest{}, args)
+
+		// Test passes if no panic - config values are used in the handler
+	})
+
+	t.Run("cleanup is called even if code execution fails", func(t *testing.T) {
+		cleanupCalled := false
+		operator := &mockSandboxOperator{
+			claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+				return newMockSandboxWithRequest("sandbox-cleanup", nil, errors.New("expected error")), nil
+			},
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				sbx := newMockSandboxWithRequest(sandboxID, nil, errors.New("expected error"))
+				sbx.killErr = nil
+				cleanupCalled = true
+				return sbx, nil
+			},
+		}
+		h, _, mcpSrv := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+		sessionID := "session-cleanup"
+
+		ctx := createTestContext(mcpSrv, userID, sessionID)
+		args := RunCodeOnceRequest{
+			Code:     "print('test')",
+			Language: "python",
+		}
+
+		// Code execution will fail but cleanup should still be called
+		_, _ = h.HandleRunCodeOnce(ctx, mcpgo.CallToolRequest{}, args)
+
+		// Cleanup is called via defer in HandleRunCodeOnce
+		assert.True(t, cleanupCalled, "cleanup should be called even if code execution fails")
+	})
+}
+
+func TestHandleRunCommand_MoreBranches(t *testing.T) {
+	t.Run("returns error when session ID not in context", func(t *testing.T) {
+		operator := newMockOperatorWithSandbox("sandbox-cmd-abc", nil)
+		h, _, _ := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+
+		// Create context WITHOUT session
+		ctx := context.Background()
+		testUser := &models.CreatedTeamAPIKey{
+			ID:   userID,
+			Name: "test-user",
+		}
+		ctx = SetUserContext(ctx, testUser)
+
+		args := RunCommandRequest{
+			Cmd: "ls -la",
+		}
+
+		result, err := h.HandleRunCommand(ctx, mcpgo.CallToolRequest{}, args)
+
+		assert.Error(t, err)
+		assert.IsType(t, &MCPError{}, err)
+		assert.Equal(t, ErrorCodeInternalError, err.(*MCPError).Code)
+		assert.Equal(t, RunCommandResponse{}, result)
+	})
+
+	t.Run("uses user-configured template", func(t *testing.T) {
+		var capturedTemplate string
+		operator := &mockSandboxOperator{
+			claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+				capturedTemplate = opts.Template
+				return newMockSandbox("sandbox-cmd-config"), nil
+			},
+		}
+		h, _, mcpSrv := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+		sessionID := "session-cmd-config"
+
+		ctx := createTestContext(mcpSrv, userID, sessionID)
+		// Set user config with custom template
+		ctx = SetUserSessionConfig(ctx, &UserSessionConfig{
+			Template: "custom-cmd-template",
+		})
+
+		args := RunCommandRequest{
+			Cmd: "ls -la",
+		}
+
+		// Will fail at ExecuteCommand but we can verify template was used
+		_, _ = h.HandleRunCommand(ctx, mcpgo.CallToolRequest{}, args)
+
+		assert.Equal(t, "custom-cmd-template", capturedTemplate)
+	})
+
+	t.Run("uses user-configured SandboxTTL and ExecutionTimeout", func(t *testing.T) {
+		operator := &mockSandboxOperator{
+			claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+				return newMockSandbox("sandbox-cmd-ttl"), nil
+			},
+		}
+		h, _, mcpSrv := createTestHandlerWithOperator(operator)
+		userID := uuid.New()
+		sessionID := "session-cmd-ttl"
+
+		ctx := createTestContext(mcpSrv, userID, sessionID)
+		// Set user config with custom TTL and timeout
+		customTTL := 20 * time.Minute
+		customTimeout := 180 * time.Second
+		ctx = SetUserSessionConfig(ctx, &UserSessionConfig{
+			SandboxTTL:       &customTTL,
+			ExecutionTimeout: &customTimeout,
+		})
+
+		args := RunCommandRequest{
+			Cmd: "echo hello",
+		}
+
+		// Will fail at ExecuteCommand but config is processed
+		_, _ = h.HandleRunCommand(ctx, mcpgo.CallToolRequest{}, args)
+
+		// Test passes if no panic - config values are used in the handler
+	})
+}
+
+func TestExecuteCodeInSandbox(t *testing.T) {
+	t.Run("returns error for unsupported language", func(t *testing.T) {
+		h, _, _ := createTestHandler()
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox", AccessToken: "token"}
+
+		result, err := h.executeCodeInSandbox(context.Background(), session, "code", "go")
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.IsType(t, &MCPError{}, err)
+		assert.Equal(t, ErrorCodeCodeExecution, err.(*MCPError).Code)
+		assert.Contains(t, err.Error(), "unsupported language")
+	})
+
+	t.Run("returns error for ruby language", func(t *testing.T) {
+		h, _, _ := createTestHandler()
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox", AccessToken: "token"}
+
+		result, err := h.executeCodeInSandbox(context.Background(), session, "code", "ruby")
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.IsType(t, &MCPError{}, err)
+		assert.Equal(t, ErrorCodeCodeExecution, err.(*MCPError).Code)
+		assert.Contains(t, err.Error(), "unsupported language")
+	})
+
+	t.Run("defaults to python when language is empty", func(t *testing.T) {
+		// Create operator with mock sandbox that returns request error
+		mockSbx := newMockSandboxWithRequest("sandbox-default-lang", nil, errors.New("request error"))
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-default-lang", AccessToken: "token"}
+
+		// Should not fail language validation when empty
+		_, err := h.executeCodeInSandbox(context.Background(), session, "print('hello')", "")
+
+		// Error should be from request, not language validation
+		assert.Error(t, err)
+		assert.NotContains(t, err.Error(), "unsupported language")
+		assert.Contains(t, err.Error(), "request")
+	})
+
+	t.Run("accepts javascript language", func(t *testing.T) {
+		mockSbx := newMockSandboxWithRequest("sandbox-js", nil, errors.New("request error"))
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-js", AccessToken: "token"}
+
+		_, err := h.executeCodeInSandbox(context.Background(), session, "console.log('hello')", "javascript")
+
+		// Error should be from request, not language validation
+		assert.Error(t, err)
+		assert.NotContains(t, err.Error(), "unsupported language")
+	})
+
+	t.Run("accepts JavaScript with different casing", func(t *testing.T) {
+		mockSbx := newMockSandboxWithRequest("sandbox-js-case", nil, errors.New("request error"))
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-js-case", AccessToken: "token"}
+
+		_, err := h.executeCodeInSandbox(context.Background(), session, "console.log('hello')", "  JavaScript  ")
+
+		// Error should be from request, not language validation
+		assert.Error(t, err)
+		assert.NotContains(t, err.Error(), "unsupported language")
+	})
+
+	t.Run("returns error when sandbox request fails", func(t *testing.T) {
+		mockSbx := newMockSandboxWithRequest("sandbox-req-fail", nil, errors.New("sandbox unreachable"))
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-req-fail", AccessToken: "token"}
+
+		result, err := h.executeCodeInSandbox(context.Background(), session, "print('hello')", "python")
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to send request to sandbox")
+	})
+
+	t.Run("returns error when sandbox returns non-200 status", func(t *testing.T) {
+		resp := newMockHTTPResponse(http.StatusInternalServerError, `{"error": "internal error"}`)
+		mockSbx := newMockSandboxWithRequest("sandbox-500", resp, nil)
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-500", AccessToken: "token"}
+
+		result, err := h.executeCodeInSandbox(context.Background(), session, "print('hello')", "python")
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "sandbox returned error")
+		assert.Contains(t, err.Error(), "status=500")
+	})
+
+	t.Run("parses SSE response with stdout", func(t *testing.T) {
+		sseData := `{"type": "stdout", "text": "Hello World\n"}
+{"type": "stdout", "text": "Line 2\n"}`
+		resp := newMockHTTPResponse(http.StatusOK, sseData)
+		mockSbx := newMockSandboxWithRequest("sandbox-stdout", resp, nil)
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-stdout", AccessToken: "token"}
+
+		result, err := h.executeCodeInSandbox(context.Background(), session, "print('Hello World')", "python")
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Logs.Stdout, 2)
+		assert.Equal(t, "Hello World\n", result.Logs.Stdout[0])
+		assert.Equal(t, "Line 2\n", result.Logs.Stdout[1])
+	})
+
+	t.Run("parses SSE response with stderr", func(t *testing.T) {
+		sseData := `{"type": "stderr", "text": "Error: something went wrong\n"}`
+		resp := newMockHTTPResponse(http.StatusOK, sseData)
+		mockSbx := newMockSandboxWithRequest("sandbox-stderr", resp, nil)
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-stderr", AccessToken: "token"}
+
+		result, err := h.executeCodeInSandbox(context.Background(), session, "import sys; sys.stderr.write('error')", "python")
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Logs.Stderr, 1)
+		assert.Equal(t, "Error: something went wrong\n", result.Logs.Stderr[0])
+	})
+
+	t.Run("parses SSE response with error", func(t *testing.T) {
+		sseData := `{"type": "error", "name": "NameError", "value": "name 'undefined' is not defined", "traceback": "Traceback...\n"}`
+		resp := newMockHTTPResponse(http.StatusOK, sseData)
+		mockSbx := newMockSandboxWithRequest("sandbox-error", resp, nil)
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-error", AccessToken: "token"}
+
+		result, err := h.executeCodeInSandbox(context.Background(), session, "print(undefined)", "python")
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.NotNil(t, result.Error)
+		assert.Equal(t, "NameError", result.Error.Name)
+		assert.Equal(t, "name 'undefined' is not defined", result.Error.Value)
+		assert.Contains(t, result.Error.Traceback, "Traceback")
+	})
+
+	t.Run("parses SSE response with result", func(t *testing.T) {
+		sseData := `{"type": "result", "text": "42", "is_main_result": true}`
+		resp := newMockHTTPResponse(http.StatusOK, sseData)
+		mockSbx := newMockSandboxWithRequest("sandbox-result", resp, nil)
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-result", AccessToken: "token"}
+
+		result, err := h.executeCodeInSandbox(context.Background(), session, "40 + 2", "python")
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Results, 1)
+		assert.Equal(t, "42", result.Results[0].Text)
+		assert.True(t, result.Results[0].IsMainResult)
+	})
+
+	t.Run("parses SSE response with number_of_executions", func(t *testing.T) {
+		sseData := `{"type": "number_of_executions", "execution_count": 5}`
+		resp := newMockHTTPResponse(http.StatusOK, sseData)
+		mockSbx := newMockSandboxWithRequest("sandbox-exec-count", resp, nil)
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-exec-count", AccessToken: "token"}
+
+		result, err := h.executeCodeInSandbox(context.Background(), session, "1+1", "python")
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.NotNil(t, result.ExecutionCount)
+		assert.Equal(t, 5, *result.ExecutionCount)
+	})
+
+	t.Run("handles mixed SSE response types", func(t *testing.T) {
+		sseData := `{"type": "stdout", "text": "output\n"}
+{"type": "stderr", "text": "warning\n"}
+{"type": "result", "text": "100"}
+{"type": "number_of_executions", "execution_count": 3}`
+		resp := newMockHTTPResponse(http.StatusOK, sseData)
+		mockSbx := newMockSandboxWithRequest("sandbox-mixed", resp, nil)
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-mixed", AccessToken: "token"}
+
+		result, err := h.executeCodeInSandbox(context.Background(), session, "print('test')", "python")
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Logs.Stdout, 1)
+		assert.Len(t, result.Logs.Stderr, 1)
+		assert.Len(t, result.Results, 1)
+		assert.NotNil(t, result.ExecutionCount)
+		assert.Equal(t, 3, *result.ExecutionCount)
+	})
+
+	t.Run("skips empty lines in SSE response", func(t *testing.T) {
+		sseData := `{"type": "stdout", "text": "line1\n"}
+
+{"type": "stdout", "text": "line2\n"}
+`
+		resp := newMockHTTPResponse(http.StatusOK, sseData)
+		mockSbx := newMockSandboxWithRequest("sandbox-empty-lines", resp, nil)
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-empty-lines", AccessToken: "token"}
+
+		result, err := h.executeCodeInSandbox(context.Background(), session, "print('test')", "python")
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Logs.Stdout, 2)
+	})
+
+	t.Run("skips invalid JSON lines", func(t *testing.T) {
+		sseData := `{"type": "stdout", "text": "valid\n"}
+not valid json
+{"type": "stdout", "text": "also valid\n"}`
+		resp := newMockHTTPResponse(http.StatusOK, sseData)
+		mockSbx := newMockSandboxWithRequest("sandbox-invalid-json", resp, nil)
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-invalid-json", AccessToken: "token"}
+
+		result, err := h.executeCodeInSandbox(context.Background(), session, "print('test')", "python")
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Logs.Stdout, 2)
+	})
+
+	t.Run("skips lines without type field", func(t *testing.T) {
+		sseData := `{"type": "stdout", "text": "valid\n"}
+{"text": "no type field"}
+{"type": "stdout", "text": "also valid\n"}`
+		resp := newMockHTTPResponse(http.StatusOK, sseData)
+		mockSbx := newMockSandboxWithRequest("sandbox-no-type", resp, nil)
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-no-type", AccessToken: "token"}
+
+		result, err := h.executeCodeInSandbox(context.Background(), session, "print('test')", "python")
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Logs.Stdout, 2)
+	})
+
+	t.Run("ignores unknown message types", func(t *testing.T) {
+		sseData := `{"type": "stdout", "text": "valid\n"}
+{"type": "unknown_type", "data": "some data"}
+{"type": "stdout", "text": "also valid\n"}`
+		resp := newMockHTTPResponse(http.StatusOK, sseData)
+		mockSbx := newMockSandboxWithRequest("sandbox-unknown-type", resp, nil)
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-unknown-type", AccessToken: "token"}
+
+		result, err := h.executeCodeInSandbox(context.Background(), session, "print('test')", "python")
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result.Logs.Stdout, 2)
+	})
+
+	t.Run("sets access token in request header", func(t *testing.T) {
+		var capturedHeaders http.Header
+		mockSbx := newMockSandboxWithRequestCapture("sandbox-header", &capturedHeaders)
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-header", AccessToken: "my-secret-token"}
+
+		_, _ = h.executeCodeInSandbox(context.Background(), session, "print('test')", "python")
+
+		assert.Equal(t, "my-secret-token", capturedHeaders.Get("X-Access-Token"))
+		assert.Equal(t, "application/json", capturedHeaders.Get("Content-Type"))
+	})
+
+	t.Run("does not set access token header when empty", func(t *testing.T) {
+		var capturedHeaders http.Header
+		mockSbx := newMockSandboxWithRequestCapture("sandbox-no-token", &capturedHeaders)
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		config := DefaultServerConfig()
+		h := &Handler{operator: operator, config: config}
+
+		session := &UserSession{UserID: "user", SandboxID: "sandbox-no-token", AccessToken: ""}
+
+		_, _ = h.executeCodeInSandbox(context.Background(), session, "print('test')", "python")
+
+		assert.Equal(t, "", capturedHeaders.Get("X-Access-Token"))
+	})
+}
+
+func TestGetStringField(t *testing.T) {
+	t.Run("returns string value when key exists", func(t *testing.T) {
+		data := map[string]interface{}{
+			"name":  "test-value",
+			"count": 42,
+		}
+
+		result := getStringField(data, "name")
+
+		assert.Equal(t, "test-value", result)
+	})
+
+	t.Run("returns empty string when key does not exist", func(t *testing.T) {
+		data := map[string]interface{}{
+			"name": "test-value",
+		}
+
+		result := getStringField(data, "nonexistent")
+
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("returns empty string when value is not a string", func(t *testing.T) {
+		data := map[string]interface{}{
+			"count": 42,
+			"flag":  true,
+			"obj":   map[string]interface{}{"nested": "value"},
+		}
+
+		assert.Equal(t, "", getStringField(data, "count"))
+		assert.Equal(t, "", getStringField(data, "flag"))
+		assert.Equal(t, "", getStringField(data, "obj"))
+	})
+
+	t.Run("returns empty string for nil map", func(t *testing.T) {
+		var data map[string]interface{} = nil
+
+		result := getStringField(data, "key")
+
+		assert.Equal(t, "", result)
+	})
+}

--- a/pkg/servers/mcp/middleware.go
+++ b/pkg/servers/mcp/middleware.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"k8s.io/klog/v2"
+)
+
+// SessionManagementMiddleware creates middleware for session management
+func (s *MCPServer) SessionManagementMiddleware(next server.ToolHandlerFunc) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		// Extract session ID from MCP client session
+		var sessionID string
+		if clientSession := server.ClientSessionFromContext(ctx); clientSession != nil {
+			sessionID = clientSession.SessionID()
+		}
+
+		// Session ID is required
+		if sessionID == "" {
+			klog.FromContext(ctx).Error(nil, "session ID is required but not found")
+			return nil, NewMCPError(ErrorCodeAuthFailed, "Session ID is required", nil)
+		}
+
+		// Call next handler
+		return next(ctx, req)
+	}
+}
+
+// LoggingMiddleware creates middleware for logging tool calls
+func (s *MCPServer) LoggingMiddleware(next server.ToolHandlerFunc) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		log := klog.FromContext(ctx).WithValues("middleware", "Logging", "tool", req.Params.Name)
+
+		// Get user info if available
+		userID := "unknown"
+		if user, err := GetUserFromContext(ctx); err == nil {
+			userID = user.ID.String()
+		}
+
+		// Get session ID if available
+		sessionID := "unknown"
+		if clientSession := server.ClientSessionFromContext(ctx); clientSession != nil {
+			if sid := clientSession.SessionID(); sid != "" {
+				sessionID = sid
+			}
+		}
+
+		log.Info("tool call started", "userID", userID, "sessionID", sessionID, "arguments", req.Params.Arguments)
+		start := time.Now()
+
+		// Call next handler
+		result, err := next(ctx, req)
+
+		// Log completion
+		duration := time.Since(start)
+		if err != nil {
+			log.Error(err, "tool call failed", "duration", duration, "userID", userID, "sessionID", sessionID)
+		} else {
+			log.Info("tool call completed", "duration", duration, "userID", userID, "sessionID", sessionID)
+		}
+
+		return result, err
+	}
+}
+
+// ConfigMiddleware parses user session configuration from HTTP headers
+func (s *MCPServer) ConfigMiddleware(next server.ToolHandlerFunc) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		// Extract configuration from HTTP headers
+		config := &UserSessionConfig{}
+
+		// Parse Template
+		if template := req.Header.Get("X-Template"); template != "" {
+			config.Template = template
+		}
+
+		// Parse SandboxTTL (in seconds)
+		if ttlStr := req.Header.Get("X-Sandbox-TTL"); ttlStr != "" {
+			if ttlSec, err := strconv.ParseInt(ttlStr, 10, 64); err == nil && ttlSec >= 0 {
+				ttl := time.Duration(ttlSec) * time.Second
+				config.SandboxTTL = &ttl
+			}
+		}
+
+		// Parse ExecutionTimeout (in seconds)
+		if timeoutStr := req.Header.Get("X-Execution-Timeout"); timeoutStr != "" {
+			if timeoutSec, err := strconv.ParseInt(timeoutStr, 10, 64); err == nil && timeoutSec > 0 {
+				timeout := time.Duration(timeoutSec) * time.Second
+				config.ExecutionTimeout = &timeout
+			}
+		}
+
+		// Set config in context
+		ctx = SetUserSessionConfig(ctx, config)
+
+		// Call next handler
+		return next(ctx, req)
+	}
+}
+
+// applyMiddlewares applies all middlewares to a tool handler
+func (s *MCPServer) applyMiddlewares(handler server.ToolHandlerFunc) server.ToolHandlerFunc {
+	// Execution order: Config -> Session -> Logging -> Tool Handler
+	handler = s.LoggingMiddleware(handler)
+	handler = s.SessionManagementMiddleware(handler)
+	handler = s.ConfigMiddleware(handler)
+
+	return handler
+}

--- a/pkg/servers/mcp/middleware_test.go
+++ b/pkg/servers/mcp/middleware_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockClientSession is a mock implementation of server.ClientSession for testing
+type mockClientSession struct {
+	sessionID           string
+	initialized         bool
+	notificationChannel chan mcpgo.JSONRPCNotification
+}
+
+func newMockClientSession(sessionID string) *mockClientSession {
+	return &mockClientSession{
+		sessionID:           sessionID,
+		initialized:         true,
+		notificationChannel: make(chan mcpgo.JSONRPCNotification, 10),
+	}
+}
+
+func (m *mockClientSession) Initialize() {
+	m.initialized = true
+}
+
+func (m *mockClientSession) Initialized() bool {
+	return m.initialized
+}
+
+func (m *mockClientSession) NotificationChannel() chan<- mcpgo.JSONRPCNotification {
+	return m.notificationChannel
+}
+
+func (m *mockClientSession) SessionID() string {
+	return m.sessionID
+}
+
+// createTestMCPServer creates a minimal MCPServer for testing middlewares
+func createTestMCPServer() *MCPServer {
+	config := DefaultServerConfig()
+	return &MCPServer{
+		config:    config,
+		mcpServer: server.NewMCPServer("test-server", "0.0.1"),
+	}
+}
+
+// setClientSessionInContext uses the mcp-go server's WithContext to set a ClientSession
+func setClientSessionInContext(ctx context.Context, mcpSrv *server.MCPServer, session server.ClientSession) context.Context {
+	return mcpSrv.WithContext(ctx, session)
+}
+
+// TestSessionManagementMiddleware tests the session management middleware
+func TestSessionManagementMiddleware(t *testing.T) {
+	mcpServer := createTestMCPServer()
+
+	t.Run("with valid session ID", func(t *testing.T) {
+		mockSession := newMockClientSession("test-session-123")
+		ctx := setClientSessionInContext(context.Background(), mcpServer.mcpServer, mockSession)
+
+		handlerCalled := false
+		expectedResult := &mcpgo.CallToolResult{
+			Content: []mcpgo.Content{mcpgo.NewTextContent("success")},
+		}
+
+		handler := func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			handlerCalled = true
+			return expectedResult, nil
+		}
+
+		wrappedHandler := mcpServer.SessionManagementMiddleware(handler)
+		result, err := wrappedHandler(ctx, mcpgo.CallToolRequest{
+			Params: mcpgo.CallToolParams{Name: "test_tool"},
+		})
+
+		assert.NoError(t, err)
+		assert.True(t, handlerCalled)
+		assert.Equal(t, expectedResult, result)
+	})
+
+	t.Run("with empty session ID", func(t *testing.T) {
+		// Create mock session with empty session ID
+		mockSession := newMockClientSession("")
+		ctx := setClientSessionInContext(context.Background(), mcpServer.mcpServer, mockSession)
+
+		handlerCalled := false
+		handler := func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			handlerCalled = true
+			return nil, nil
+		}
+
+		wrappedHandler := mcpServer.SessionManagementMiddleware(handler)
+		result, err := wrappedHandler(ctx, mcpgo.CallToolRequest{
+			Params: mcpgo.CallToolParams{Name: "test_tool"},
+		})
+
+		assert.Error(t, err)
+		assert.False(t, handlerCalled)
+		assert.Nil(t, result)
+		assert.IsType(t, &MCPError{}, err)
+		assert.Equal(t, ErrorCodeAuthFailed, err.(*MCPError).Code)
+		assert.Contains(t, err.Error(), "Session ID is required")
+	})
+}
+
+// TestLoggingMiddleware tests the logging middleware
+func TestLoggingMiddleware(t *testing.T) {
+	mcpServer := createTestMCPServer()
+
+	t.Run("logs successful tool call", func(t *testing.T) {
+		mockSession := newMockClientSession("test-session-123")
+		ctx := setClientSessionInContext(context.Background(), mcpServer.mcpServer, mockSession)
+
+		// Set user in context
+		testUser := &models.CreatedTeamAPIKey{
+			ID:   uuid.New(),
+			Name: "test-user",
+		}
+		ctx = SetUserContext(ctx, testUser)
+
+		expectedResult := &mcpgo.CallToolResult{
+			Content: []mcpgo.Content{mcpgo.NewTextContent("success")},
+		}
+
+		handler := func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			return expectedResult, nil
+		}
+
+		wrappedHandler := mcpServer.LoggingMiddleware(handler)
+		result, err := wrappedHandler(ctx, mcpgo.CallToolRequest{
+			Params: mcpgo.CallToolParams{
+				Name:      "test_tool",
+				Arguments: map[string]any{"arg1": "value1"},
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedResult, result)
+	})
+}
+
+// TestConfigMiddleware tests the config middleware
+func TestConfigMiddleware(t *testing.T) {
+	mcpServer := createTestMCPServer()
+
+	t.Run("parses all headers correctly", func(t *testing.T) {
+		ctx := context.Background()
+
+		var capturedConfig *UserSessionConfig
+		handler := func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			capturedConfig = GetUserSessionConfig(ctx)
+			return &mcpgo.CallToolResult{}, nil
+		}
+
+		headers := http.Header{}
+		headers.Set("X-Template", "custom-template")
+		headers.Set("X-Sandbox-TTL", "300")       // 300 seconds = 5 minutes
+		headers.Set("X-Execution-Timeout", "120") // 120 seconds = 2 minutes
+
+		wrappedHandler := mcpServer.ConfigMiddleware(handler)
+		_, err := wrappedHandler(ctx, mcpgo.CallToolRequest{
+			Header: headers,
+			Params: mcpgo.CallToolParams{Name: "test_tool"},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, capturedConfig)
+		assert.Equal(t, "custom-template", capturedConfig.Template)
+		assert.NotNil(t, capturedConfig.SandboxTTL)
+		assert.Equal(t, 5*time.Minute, *capturedConfig.SandboxTTL)
+		assert.NotNil(t, capturedConfig.ExecutionTimeout)
+		assert.Equal(t, 2*time.Minute, *capturedConfig.ExecutionTimeout)
+	})
+
+	t.Run("handles empty headers", func(t *testing.T) {
+		ctx := context.Background()
+
+		var capturedConfig *UserSessionConfig
+		handler := func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			capturedConfig = GetUserSessionConfig(ctx)
+			return &mcpgo.CallToolResult{}, nil
+		}
+
+		wrappedHandler := mcpServer.ConfigMiddleware(handler)
+		_, err := wrappedHandler(ctx, mcpgo.CallToolRequest{
+			Header: http.Header{},
+			Params: mcpgo.CallToolParams{Name: "test_tool"},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, capturedConfig)
+		assert.Empty(t, capturedConfig.Template)
+		assert.Nil(t, capturedConfig.SandboxTTL)
+		assert.Nil(t, capturedConfig.ExecutionTimeout)
+	})
+}
+
+// TestApplyMiddlewares tests the middleware chain
+func TestApplyMiddlewares(t *testing.T) {
+	mcpServer := createTestMCPServer()
+	t.Run("session validation fails before handler is called", func(t *testing.T) {
+		// Context without session
+		ctx := context.Background()
+
+		handlerCalled := false
+		handler := func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+			handlerCalled = true
+			return &mcpgo.CallToolResult{}, nil
+		}
+
+		wrappedHandler := mcpServer.applyMiddlewares(handler)
+		result, err := wrappedHandler(ctx, mcpgo.CallToolRequest{
+			Params: mcpgo.CallToolParams{Name: "test_tool"},
+		})
+
+		assert.Error(t, err)
+		assert.False(t, handlerCalled)
+		assert.Nil(t, result)
+	})
+}

--- a/pkg/servers/mcp/peer.go
+++ b/pkg/servers/mcp/peer.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkruise/agents/pkg/servers/web"
+	"k8s.io/klog/v2"
+)
+
+const (
+	SessionSyncAPI = "/session/sync"
+)
+
+// SessionSyncMessage represents a session sync message between peers
+type SessionSyncMessage struct {
+	Session *UserSession `json:"session"`
+	Deleted bool         `json:"deleted"`
+}
+
+// startPeerSync starts the peer synchronization HTTP server
+func (sm *SessionManager) startPeerSync() error {
+	mux := http.NewServeMux()
+	web.RegisterRoute(mux, http.MethodPost, SessionSyncAPI, sm.handleSessionSync)
+
+	sm.httpSrv = &http.Server{
+		Addr:              fmt.Sprintf(":%d", sm.config.SessionSyncPort),
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	// Start HTTP server
+	go func() {
+		klog.InfoS("Starting session sync server", "address", sm.httpSrv.Addr)
+		if err := sm.httpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			klog.Errorf("Session sync HTTP server failed: %v", err)
+		}
+	}()
+
+	return nil
+}
+
+// stopPeerSync stops the peer synchronization
+func (sm *SessionManager) stopPeerSync() {
+	sm.stopOnce.Do(func() {
+		if sm.httpSrv != nil {
+			_ = sm.httpSrv.Shutdown(context.Background())
+		}
+	})
+}
+
+// SyncSessionWithPeers syncs a session change to all peers
+func (sm *SessionManager) SyncSessionWithPeers(ctx context.Context, session *UserSession, deleted bool) error {
+	if sm.peersManager == nil {
+		return nil
+	}
+
+	peerList := sm.peersManager.GetPeers()
+	if len(peerList) == 0 {
+		return nil
+	}
+
+	msg := SessionSyncMessage{
+		Session: session,
+		Deleted: deleted,
+	}
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	var (
+		wg         sync.WaitGroup
+		mu         sync.Mutex
+		errStrings []string
+	)
+
+	for _, p := range peerList {
+		wg.Add(1)
+		go func(peerIP string) {
+			defer wg.Done()
+			if err := sm.requestPeer(ctx, http.MethodPost, peerIP, SessionSyncAPI, body); err != nil {
+				mu.Lock()
+				errStrings = append(errStrings, err.Error())
+				mu.Unlock()
+			}
+		}(p.IP)
+	}
+	wg.Wait()
+
+	if len(errStrings) == 0 {
+		return nil
+	}
+	return errors.New(strings.Join(errStrings, ";"))
+}
+
+// handleSessionSync handles session sync requests from peers
+func (sm *SessionManager) handleSessionSync(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
+	log := klog.FromContext(r.Context())
+
+	var msg SessionSyncMessage
+	if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+		return web.ApiResponse[struct{}]{}, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: fmt.Sprintf("failed to unmarshal body: %s", err.Error()),
+		}
+	}
+
+	if msg.Session == nil {
+		return web.ApiResponse[struct{}]{}, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: "session is nil",
+		}
+	}
+
+	if msg.Deleted {
+		sm.sessions.Delete(msg.Session.SessionID)
+		log.Info("session deleted from peer sync", "sessionID", msg.Session.SessionID)
+	} else {
+		sm.sessions.Store(msg.Session.SessionID, msg.Session)
+		log.Info("session synced from peer", "sessionID", msg.Session.SessionID, "sandboxID", msg.Session.SandboxID)
+	}
+
+	return web.ApiResponse[struct{}]{
+		Code: http.StatusNoContent,
+	}, nil
+}

--- a/pkg/servers/mcp/peer_test.go
+++ b/pkg/servers/mcp/peer_test.go
@@ -1,0 +1,354 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openkruise/agents/pkg/peers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockPeers is a simple in-memory Peers implementation for testing
+type mockPeers struct {
+	mu      sync.RWMutex
+	members []peers.Peer
+}
+
+func newMockPeers(members ...peers.Peer) *mockPeers {
+	return &mockPeers{members: members}
+}
+
+func (m *mockPeers) Start(_ context.Context, _ int) error { return nil }
+func (m *mockPeers) Stop() error                          { return nil }
+func (m *mockPeers) GetPeers() []peers.Peer {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]peers.Peer, len(m.members))
+	copy(result, m.members)
+	return result
+}
+func (m *mockPeers) GetAllMembers() []peers.Peer                 { return m.GetPeers() }
+func (m *mockPeers) WaitForPeers(_ context.Context, _ int) error { return nil }
+func (m *mockPeers) LocalAddr() net.IP                           { return net.ParseIP("127.0.0.1") }
+func (m *mockPeers) LocalPort() int                              { return 0 }
+
+func (m *mockPeers) SetMembers(members ...peers.Peer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.members = members
+}
+
+// createPeerTestSessionManager creates a SessionManager for peer testing
+func createPeerTestSessionManager() *SessionManager {
+	config := &ServerConfig{
+		SessionSyncPort: 7090,
+	}
+	operator := &mockSandboxOperator{}
+	sm := NewSessionManager(operator, config, nil)
+	sm.SetRequestPeer(noopRequestPeer)
+	return sm
+}
+
+// createPeerTestSessionManagerWithPeers creates a SessionManager for peer testing with mockPeers and custom requestPeer
+func createPeerTestSessionManagerWithPeers(mp *mockPeers, requestPeer RequestPeerFunc) *SessionManager {
+	config := &ServerConfig{
+		SessionSyncPort: 7090,
+	}
+	operator := &mockSandboxOperator{}
+	sm := NewSessionManager(operator, config, mp)
+	sm.SetRequestPeer(requestPeer)
+	return sm
+}
+
+func TestSyncSessionWithPeers(t *testing.T) {
+	t.Run("syncs session to all peers", func(t *testing.T) {
+		var mu sync.Mutex
+		requests := make(map[string][]byte)
+		requestPeer := func(ctx context.Context, method, ip, path string, body []byte) error {
+			mu.Lock()
+			requests[ip] = body
+			mu.Unlock()
+			return nil
+		}
+		mp := newMockPeers(
+			peers.Peer{IP: "1.1.1.1", Name: "node-1"},
+			peers.Peer{IP: "1.1.1.2", Name: "node-2"},
+		)
+		sm := createPeerTestSessionManagerWithPeers(mp, requestPeer)
+
+		session := &UserSession{
+			SessionID: "session-123",
+			UserID:    "user-456",
+			SandboxID: "sandbox-789",
+		}
+
+		err := sm.SyncSessionWithPeers(context.Background(), session, false)
+
+		require.NoError(t, err)
+		assert.Len(t, requests, 2)
+
+		// Verify message content
+		for _, body := range requests {
+			var msg SessionSyncMessage
+			err := json.Unmarshal(body, &msg)
+			require.NoError(t, err)
+			assert.Equal(t, "session-123", msg.Session.SessionID)
+			assert.False(t, msg.Deleted)
+		}
+	})
+
+	t.Run("aggregates errors from multiple peers", func(t *testing.T) {
+		requestPeer := func(ctx context.Context, method, ip, path string, body []byte) error {
+			return errors.New("peer error: " + ip)
+		}
+		mp := newMockPeers(
+			peers.Peer{IP: "1.1.1.1", Name: "node-1"},
+			peers.Peer{IP: "1.1.1.2", Name: "node-2"},
+		)
+		sm := createPeerTestSessionManagerWithPeers(mp, requestPeer)
+
+		session := &UserSession{SessionID: "session-123"}
+
+		err := sm.SyncSessionWithPeers(context.Background(), session, false)
+
+		assert.Error(t, err)
+		// Both errors should be aggregated
+		assert.Contains(t, err.Error(), "peer error")
+	})
+}
+
+func TestHandleSessionSync(t *testing.T) {
+	t.Run("stores session from peer", func(t *testing.T) {
+		sm := createPeerTestSessionManager()
+
+		session := &UserSession{
+			SessionID: "session-from-peer",
+			UserID:    "user-123",
+			SandboxID: "sandbox-456",
+		}
+		msg := SessionSyncMessage{Session: session, Deleted: false}
+		body, _ := json.Marshal(msg)
+
+		req := httptest.NewRequest(http.MethodPost, SessionSyncAPI, bytes.NewReader(body))
+
+		resp, apiErr := sm.handleSessionSync(req)
+
+		assert.Nil(t, apiErr)
+		assert.Equal(t, http.StatusNoContent, resp.Code)
+
+		// Verify session was stored
+		stored, ok := sm.sessions.Load("session-from-peer")
+		assert.True(t, ok)
+		assert.Equal(t, "user-123", stored.(*UserSession).UserID)
+	})
+}
+
+func TestSyncSessionWithPeers_NoPeers(t *testing.T) {
+	t.Run("returns nil when no peers", func(t *testing.T) {
+		mp := newMockPeers() // empty members
+		sm := createPeerTestSessionManagerWithPeers(mp, noopRequestPeer)
+
+		session := &UserSession{
+			SessionID: "session-123",
+			UserID:    "user-456",
+		}
+
+		err := sm.SyncSessionWithPeers(context.Background(), session, false)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns nil when peersManager is nil", func(t *testing.T) {
+		sm := createPeerTestSessionManager() // nil peersManager
+
+		session := &UserSession{
+			SessionID: "session-123",
+			UserID:    "user-456",
+		}
+
+		err := sm.SyncSessionWithPeers(context.Background(), session, false)
+
+		assert.NoError(t, err)
+	})
+}
+
+func TestSyncSessionWithPeers_Delete(t *testing.T) {
+	t.Run("syncs session deletion to peers", func(t *testing.T) {
+		var mu sync.Mutex
+		requests := make(map[string]SessionSyncMessage)
+		requestPeer := func(ctx context.Context, method, ip, path string, body []byte) error {
+			var msg SessionSyncMessage
+			if err := json.Unmarshal(body, &msg); err != nil {
+				return err
+			}
+			mu.Lock()
+			requests[ip] = msg
+			mu.Unlock()
+			return nil
+		}
+		mp := newMockPeers(peers.Peer{IP: "1.1.1.1", Name: "node-1"})
+		sm := createPeerTestSessionManagerWithPeers(mp, requestPeer)
+
+		session := &UserSession{
+			SessionID: "session-to-delete",
+			UserID:    "user-456",
+		}
+
+		err := sm.SyncSessionWithPeers(context.Background(), session, true)
+
+		require.NoError(t, err)
+		assert.Len(t, requests, 1)
+		assert.True(t, requests["1.1.1.1"].Deleted)
+		assert.Equal(t, "session-to-delete", requests["1.1.1.1"].Session.SessionID)
+	})
+}
+
+func TestHandleSessionSync_InvalidJSON(t *testing.T) {
+	t.Run("returns error for invalid JSON", func(t *testing.T) {
+		sm := createPeerTestSessionManager()
+
+		req := httptest.NewRequest(http.MethodPost, SessionSyncAPI, bytes.NewReader([]byte("invalid-json")))
+
+		_, apiErr := sm.handleSessionSync(req)
+
+		require.NotNil(t, apiErr)
+		assert.Equal(t, http.StatusBadRequest, apiErr.Code)
+		assert.Contains(t, apiErr.Message, "failed to unmarshal body")
+	})
+}
+
+func TestHandleSessionSync_NilSession(t *testing.T) {
+	t.Run("returns error for nil session", func(t *testing.T) {
+		sm := createPeerTestSessionManager()
+
+		msg := SessionSyncMessage{Session: nil, Deleted: false}
+		body, _ := json.Marshal(msg)
+
+		req := httptest.NewRequest(http.MethodPost, SessionSyncAPI, bytes.NewReader(body))
+
+		_, apiErr := sm.handleSessionSync(req)
+
+		require.NotNil(t, apiErr)
+		assert.Equal(t, http.StatusBadRequest, apiErr.Code)
+		assert.Equal(t, "session is nil", apiErr.Message)
+	})
+}
+
+func TestHandleSessionSync_DeleteSession(t *testing.T) {
+	t.Run("deletes session from peer sync", func(t *testing.T) {
+		sm := createPeerTestSessionManager()
+
+		// Pre-populate session
+		existingSession := &UserSession{
+			SessionID: "session-to-delete",
+			UserID:    "user-123",
+		}
+		sm.sessions.Store("session-to-delete", existingSession)
+
+		// Send delete message
+		msg := SessionSyncMessage{
+			Session: &UserSession{SessionID: "session-to-delete"},
+			Deleted: true,
+		}
+		body, _ := json.Marshal(msg)
+
+		req := httptest.NewRequest(http.MethodPost, SessionSyncAPI, bytes.NewReader(body))
+
+		resp, apiErr := sm.handleSessionSync(req)
+
+		assert.Nil(t, apiErr)
+		assert.Equal(t, http.StatusNoContent, resp.Code)
+
+		// Verify session was deleted
+		_, ok := sm.sessions.Load("session-to-delete")
+		assert.False(t, ok)
+	})
+}
+
+func TestStartAndStopPeerSync(t *testing.T) {
+	t.Run("starts and stops peer sync server", func(t *testing.T) {
+		config := &ServerConfig{
+			SessionSyncPort: 17091, // Use a unique port to avoid conflicts
+		}
+		operator := &mockSandboxOperator{}
+		sm := NewSessionManager(operator, config, nil)
+		sm.SetRequestPeer(noopRequestPeer)
+
+		// Start the peer sync
+		err := sm.startPeerSync()
+		require.NoError(t, err)
+
+		// Give the server time to start
+		time.Sleep(100 * time.Millisecond)
+
+		// Verify server is running
+		assert.NotNil(t, sm.httpSrv)
+
+		// Stop the peer sync
+		sm.stopPeerSync()
+
+		// Give it time to stop
+		time.Sleep(100 * time.Millisecond)
+	})
+}
+
+func TestSyncSessionWithPeers_PartialFailure(t *testing.T) {
+	t.Run("continues syncing even when some peers fail", func(t *testing.T) {
+		var mu sync.Mutex
+		successfulPeers := make([]string, 0)
+		requestPeer := func(ctx context.Context, method, ip, path string, body []byte) error {
+			if ip == "fail-peer" {
+				return errors.New("connection failed")
+			}
+			mu.Lock()
+			successfulPeers = append(successfulPeers, ip)
+			mu.Unlock()
+			return nil
+		}
+
+		mp := newMockPeers(
+			peers.Peer{IP: "success-peer-1", Name: "node-1"},
+			peers.Peer{IP: "fail-peer", Name: "node-2"},
+			peers.Peer{IP: "success-peer-2", Name: "node-3"},
+		)
+		sm := createPeerTestSessionManagerWithPeers(mp, requestPeer)
+
+		session := &UserSession{SessionID: "session-123"}
+
+		err := sm.SyncSessionWithPeers(context.Background(), session, false)
+
+		// Should return error because one peer failed
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "connection failed")
+
+		// But successful peers should have been synced
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Len(t, successfulPeers, 2)
+	})
+}

--- a/pkg/servers/mcp/sandbox.go
+++ b/pkg/servers/mcp/sandbox.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"k8s.io/klog/v2"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/openkruise/agents/pkg/utils/runtime"
+	"github.com/openkruise/agents/proto/envd/process"
+)
+
+// SandboxOperator defines the interface for sandbox operations
+// This abstraction allows for dependency injection and easier testing
+type SandboxOperator interface {
+	ClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error)
+	GetClaimedSandbox(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error)
+}
+
+// SandboxInfo contains basic sandbox information
+type SandboxInfo struct {
+	SandboxID   string
+	AccessToken string
+	State       string
+}
+
+// CommandResult represents the result of command execution
+type CommandResult struct {
+	PID      uint32
+	Stdout   []string
+	Stderr   []string
+	ExitCode int32
+	Exited   bool
+	Error    error
+}
+
+// CreateSandbox creates a new sandbox for the user using the SandboxOperator interface
+// sandboxTTL controls when the sandbox will be automatically reclaimed.
+// If sandboxTTL is zero, no timeout will be applied.
+func CreateSandbox(ctx context.Context, operator SandboxOperator, userID, sessionID, templateID string, sandboxTTL time.Duration) (*SandboxInfo, error) {
+	log := klog.FromContext(ctx).WithValues("userID", userID, "templateID", templateID)
+
+	accessToken := uuid.NewString()
+	sbx, err := operator.ClaimSandbox(ctx, infra.ClaimSandboxOptions{
+		User:     userID,
+		Template: templateID,
+		Modifier: func(sbx infra.Sandbox) {
+			// Configure sandbox shutdown time based on sandboxTTL
+			if sandboxTTL > 0 {
+				now := time.Now()
+				sbx.SetTimeout(infra.TimeoutOptions{
+					ShutdownTime: now.Add(sandboxTTL),
+				})
+			}
+
+			annotations := sbx.GetAnnotations()
+			if annotations == nil {
+				annotations = make(map[string]string)
+			}
+			annotations[v1alpha1.AnnotationMCPSessionID] = sessionID
+			annotations[v1alpha1.AnnotationRuntimeAccessToken] = accessToken
+			sbx.SetAnnotations(annotations)
+		},
+		InitRuntime: &config.InitRuntimeOptions{
+			EnvVars:     models.EnvVars{},
+			AccessToken: accessToken,
+		},
+	})
+	if err != nil {
+		log.Error(err, "failed to claim sandbox")
+		return nil, fmt.Errorf("failed to claim sandbox: %w", err)
+	}
+
+	state, _ := sbx.GetState()
+	log.Info("sandbox created", "sandboxID", sbx.GetSandboxID())
+	return &SandboxInfo{
+		SandboxID:   sbx.GetSandboxID(),
+		AccessToken: accessToken,
+		State:       state,
+	}, nil
+}
+
+// GetSandbox retrieves sandbox information using the SandboxOperator interface
+func GetSandbox(ctx context.Context, operator SandboxOperator, userID, sandboxID string) (*SandboxInfo, error) {
+	sbx, err := operator.GetClaimedSandbox(ctx, userID, sandboxID)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox not found: %w", err)
+	}
+
+	state, _ := sbx.GetState()
+	return &SandboxInfo{
+		SandboxID:   sbx.GetSandboxID(),
+		AccessToken: sbx.GetAnnotations()[v1alpha1.AnnotationRuntimeAccessToken],
+		State:       state,
+	}, nil
+}
+
+// DeleteSandbox deletes a sandbox using the SandboxOperator interface
+func DeleteSandbox(ctx context.Context, operator SandboxOperator, userID, sandboxID string) error {
+	log := klog.FromContext(ctx).WithValues("userID", userID, "sandboxID", sandboxID)
+
+	sbx, err := operator.GetClaimedSandbox(ctx, userID, sandboxID)
+	if err != nil {
+		log.Error(err, "failed to get sandbox")
+		return fmt.Errorf("sandbox not found: %w", err)
+	}
+
+	if err := sbx.Kill(ctx); err != nil {
+		log.Error(err, "failed to delete sandbox")
+		return fmt.Errorf("failed to delete sandbox: %w", err)
+	}
+
+	log.Info("sandbox deleted successfully")
+	return nil
+}
+
+// RequestToSandbox sends an HTTP request to the sandbox
+func RequestToSandbox(ctx context.Context, operator SandboxOperator, userID, sandboxID string, method, path string, port int, body io.Reader, headers http.Header) (*http.Response, error) {
+	sbx, err := operator.GetClaimedSandbox(ctx, userID, sandboxID)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox not found: %w", err)
+	}
+
+	return sbx.Request(ctx, method, path, port, body, headers)
+}
+
+// ExecuteCommand executes a shell command in the sandbox via gRPC
+// Aligned with E2B Commands.run() interface - commands are run via /bin/bash -l -c
+func ExecuteCommand(ctx context.Context, operator SandboxOperator, userID, sandboxID string, cmd string, envs map[string]string, cwd *string, timeout time.Duration) (*CommandResult, error) {
+	log := klog.FromContext(ctx).WithValues("userID", userID, "sandboxID", sandboxID, "cmd", cmd)
+
+	sbx, err := operator.GetClaimedSandbox(ctx, userID, sandboxID)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox not found: %w", err)
+	}
+
+	// Type assert to sandboxcr.Sandbox to access runCommandWithRuntime
+	sbxImpl, ok := sbx.(*sandboxcr.Sandbox)
+	if !ok {
+		return nil, fmt.Errorf("unexpected sandbox implementation type")
+	}
+
+	// Build process config following E2B pattern:
+	// Commands are run via /bin/bash -l -c "<cmd>"
+	processConfig := &process.ProcessConfig{
+		Cmd:  "/bin/bash",
+		Args: []string{"-l", "-c", cmd},
+		Envs: envs,
+		Cwd:  cwd,
+	}
+
+	log.Info("executing command in sandbox")
+
+	result, err := runtime.RunCommandWithRuntime(ctx, runtime.RunCmdFuncArgs{
+		Sbx:           sbxImpl.Sandbox,
+		ProcessConfig: processConfig,
+		Timeout:       timeout,
+	})
+	if err != nil {
+		log.Error(err, "command execution failed")
+		return nil, err
+	}
+
+	log.Info("command execution completed", "exitCode", result.ExitCode, "exited", result.Exited)
+
+	// Convert to MCP CommandResult
+	return &CommandResult{
+		PID:      result.PID,
+		Stdout:   result.Stdout,
+		Stderr:   result.Stderr,
+		ExitCode: result.ExitCode,
+		Exited:   result.Exited,
+		Error:    result.Error,
+	}, result.Error
+}

--- a/pkg/servers/mcp/sandbox_test.go
+++ b/pkg/servers/mcp/sandbox_test.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/proxy"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSandbox implements infra.Sandbox interface for testing
+type mockSandbox struct {
+	metav1.ObjectMeta
+	sandboxID   string
+	state       string
+	stateReason string
+	route       proxy.Route
+	template    string
+	image       string
+	timeout     infra.TimeoutOptions
+	claimTime   time.Time
+	killErr     error
+	annotations map[string]string
+}
+
+func newMockSandbox(sandboxID string) *mockSandbox {
+	return &mockSandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        sandboxID,
+			Namespace:   "default",
+			Annotations: make(map[string]string),
+		},
+		sandboxID:   sandboxID,
+		state:       v1alpha1.SandboxStateRunning,
+		stateReason: "",
+		route: proxy.Route{
+			ID:    sandboxID,
+			IP:    "10.0.0.1",
+			Owner: "test-user",
+		},
+		template:    "test-template",
+		claimTime:   time.Now(),
+		annotations: make(map[string]string),
+	}
+}
+
+func (m *mockSandbox) Pause(ctx context.Context, opts infra.PauseOptions) error { return nil }
+func (m *mockSandbox) Resume(ctx context.Context) error                         { return nil }
+func (m *mockSandbox) GetSandboxID() string                                     { return m.sandboxID }
+func (m *mockSandbox) GetRoute() proxy.Route                                    { return m.route }
+func (m *mockSandbox) GetState() (string, string)                               { return m.state, m.stateReason }
+func (m *mockSandbox) GetTemplate() string                                      { return m.template }
+func (m *mockSandbox) GetResource() infra.SandboxResource                       { return infra.SandboxResource{} }
+func (m *mockSandbox) SetImage(image string)                                    { m.image = image }
+func (m *mockSandbox) GetImage() string                                         { return m.image }
+func (m *mockSandbox) SetTimeout(opts infra.TimeoutOptions)                     { m.timeout = opts }
+func (m *mockSandbox) SaveTimeout(ctx context.Context, opts infra.TimeoutOptions) error {
+	m.timeout = opts
+	return nil
+}
+func (m *mockSandbox) GetTimeout() infra.TimeoutOptions                        { return m.timeout }
+func (m *mockSandbox) GetClaimTime() (time.Time, error)                        { return m.claimTime, nil }
+func (m *mockSandbox) Kill(ctx context.Context) error                          { return m.killErr }
+func (m *mockSandbox) InplaceRefresh(ctx context.Context, deepcopy bool) error { return nil }
+func (m *mockSandbox) Request(ctx context.Context, method, path string, port int, body io.Reader, headers http.Header) (*http.Response, error) {
+	return nil, nil
+}
+func (m *mockSandbox) CSIMount(ctx context.Context, driver string, request string) error { return nil }
+func (m *mockSandbox) GetRuntimeURL() string                                             { return "http://10.0.0.1:49982" }
+func (m *mockSandbox) GetAccessToken() string                                            { return "mock-token" }
+func (m *mockSandbox) GetAnnotations() map[string]string                                 { return m.annotations }
+func (m *mockSandbox) SetAnnotations(annotations map[string]string)                      { m.annotations = annotations }
+func (m *mockSandbox) SetPodLabels(labels map[string]string)                             {}
+func (m *mockSandbox) GetPodLabels() map[string]string                                   { return nil }
+func (m *mockSandbox) CreateCheckpoint(_ context.Context, _ infra.CreateCheckpointOptions) (string, error) {
+	return "", nil
+}
+
+// mockSandboxOperator implements SandboxOperator interface for testing
+type mockSandboxOperator struct {
+	claimSandboxFunc      func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error)
+	getClaimedSandboxFunc func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error)
+}
+
+func (m *mockSandboxOperator) ClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+	if m.claimSandboxFunc != nil {
+		return m.claimSandboxFunc(ctx, opts)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockSandboxOperator) GetClaimedSandbox(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+	if m.getClaimedSandboxFunc != nil {
+		return m.getClaimedSandboxFunc(ctx, userID, sandboxID)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func TestCreateSandbox(t *testing.T) {
+	t.Run("creates sandbox successfully", func(t *testing.T) {
+		mockSbx := newMockSandbox("sandbox-123")
+		mockSbx.state = v1alpha1.SandboxStateRunning
+
+		operator := &mockSandboxOperator{
+			claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+				assert.Equal(t, "user-1", opts.User)
+				assert.Equal(t, "template-1", opts.Template)
+				// Call modifier to test annotation setting
+				if opts.Modifier != nil {
+					opts.Modifier(mockSbx)
+				}
+				return mockSbx, nil
+			},
+		}
+
+		ctx := context.Background()
+		info, err := CreateSandbox(ctx, operator, "user-1", "session-1", "template-1", 5*time.Minute)
+
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "sandbox-123", info.SandboxID)
+		assert.Equal(t, v1alpha1.SandboxStateRunning, info.State)
+		assert.NotEmpty(t, info.AccessToken)
+
+		// Verify annotations were set
+		assert.Equal(t, "session-1", mockSbx.annotations[v1alpha1.AnnotationMCPSessionID])
+	})
+
+	t.Run("handles claim error", func(t *testing.T) {
+		operator := &mockSandboxOperator{
+			claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+				return nil, errors.New("no available sandbox")
+			},
+		}
+
+		ctx := context.Background()
+		info, err := CreateSandbox(ctx, operator, "user-1", "session-1", "template-1", 5*time.Minute)
+
+		assert.Error(t, err)
+		assert.Nil(t, info)
+		assert.Contains(t, err.Error(), "failed to claim sandbox")
+	})
+
+	t.Run("sets timeout when TTL > 0", func(t *testing.T) {
+		mockSbx := newMockSandbox("sandbox-ttl")
+		var capturedTimeout infra.TimeoutOptions
+
+		operator := &mockSandboxOperator{
+			claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+				if opts.Modifier != nil {
+					opts.Modifier(mockSbx)
+					capturedTimeout = mockSbx.timeout
+				}
+				return mockSbx, nil
+			},
+		}
+
+		ctx := context.Background()
+		_, err := CreateSandbox(ctx, operator, "user-1", "session-1", "template-1", 10*time.Minute)
+
+		require.NoError(t, err)
+		assert.False(t, capturedTimeout.ShutdownTime.IsZero())
+	})
+
+	t.Run("does not set timeout when TTL is 0", func(t *testing.T) {
+		mockSbx := newMockSandbox("sandbox-no-ttl")
+
+		operator := &mockSandboxOperator{
+			claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+				if opts.Modifier != nil {
+					opts.Modifier(mockSbx)
+				}
+				return mockSbx, nil
+			},
+		}
+
+		ctx := context.Background()
+		_, err := CreateSandbox(ctx, operator, "user-1", "session-1", "template-1", 0)
+
+		require.NoError(t, err)
+		assert.True(t, mockSbx.timeout.ShutdownTime.IsZero())
+	})
+}
+
+func TestGetSandbox(t *testing.T) {
+	t.Run("gets sandbox successfully", func(t *testing.T) {
+		mockSbx := newMockSandbox("sandbox-get")
+		mockSbx.state = v1alpha1.SandboxStateRunning
+		mockSbx.annotations[v1alpha1.AnnotationRuntimeAccessToken] = "access-token-123"
+
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				assert.Equal(t, "user-1", userID)
+				assert.Equal(t, "sandbox-get", sandboxID)
+				return mockSbx, nil
+			},
+		}
+
+		ctx := context.Background()
+		info, err := GetSandbox(ctx, operator, "user-1", "sandbox-get")
+
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "sandbox-get", info.SandboxID)
+		assert.Equal(t, v1alpha1.SandboxStateRunning, info.State)
+		assert.Equal(t, "access-token-123", info.AccessToken)
+	})
+
+	t.Run("returns error when sandbox not found", func(t *testing.T) {
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return nil, errors.New("sandbox not found")
+			},
+		}
+
+		ctx := context.Background()
+		info, err := GetSandbox(ctx, operator, "user-1", "non-existent")
+
+		assert.Error(t, err)
+		assert.Nil(t, info)
+		assert.Contains(t, err.Error(), "sandbox not found")
+	})
+}
+
+func TestDeleteSandbox(t *testing.T) {
+	t.Run("deletes sandbox successfully", func(t *testing.T) {
+		mockSbx := newMockSandbox("sandbox-delete")
+		mockSbx.killErr = nil
+
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		ctx := context.Background()
+		err := DeleteSandbox(ctx, operator, "user-1", "sandbox-delete")
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns error when kill fails", func(t *testing.T) {
+		mockSbx := newMockSandbox("sandbox-kill-fail")
+		mockSbx.killErr = errors.New("kill operation failed")
+
+		operator := &mockSandboxOperator{
+			getClaimedSandboxFunc: func(ctx context.Context, userID, sandboxID string) (infra.Sandbox, error) {
+				return mockSbx, nil
+			},
+		}
+
+		ctx := context.Background()
+		err := DeleteSandbox(ctx, operator, "user-1", "sandbox-kill-fail")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to delete sandbox")
+	})
+}
+
+func TestSandboxOperatorInterface(t *testing.T) {
+	t.Run("mock operator implements interface", func(t *testing.T) {
+		var operator SandboxOperator = &mockSandboxOperator{}
+		assert.NotNil(t, operator)
+	})
+}

--- a/pkg/servers/mcp/server.go
+++ b/pkg/servers/mcp/server.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/openkruise/agents/pkg/peers"
+	sandbox_manager "github.com/openkruise/agents/pkg/sandbox-manager"
+	"github.com/openkruise/agents/pkg/servers/e2b/keys"
+)
+
+// MCPServer represents the MCP server (similar to e2b.Controller)
+type MCPServer struct {
+	config    *ServerConfig
+	mcpServer *server.MCPServer
+	handler   *Handler
+	auth      *Auth
+
+	// Session manager for lifecycle and peer sync
+	sessionManager *SessionManager
+
+	// HTTP server components (similar to e2b.Controller)
+	mux        *http.ServeMux
+	httpServer *http.Server
+}
+
+// NewMCPServer creates a new MCP server (similar to e2b.NewController)
+func NewMCPServer(
+	config *ServerConfig,
+	manager *sandbox_manager.SandboxManager,
+	keyStorage keys.KeyStorage,
+	peersManager peers.Peers,
+) *MCPServer {
+	s := &MCPServer{
+		config: config,
+		mux:    http.NewServeMux(),
+	}
+
+	s.httpServer = &http.Server{
+		Addr:              fmt.Sprintf(":%d", config.Port),
+		Handler:           s.mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	// Create auth (always needed, even for anonymous users)
+	s.auth = NewAuth(keyStorage)
+
+	// Create session manager with production dependencies
+	// manager implements SandboxOperator interface, shared with Handler
+	s.sessionManager = NewSessionManager(manager, config, peersManager)
+
+	// Register session manager as event handler to receive sandbox events
+	// This must be done before Infra.Run() to avoid missing events
+	manager.GetInfra().SetSandboxEventHandler(s.sessionManager)
+
+	// Create handler
+	s.handler = NewHandler(s.sessionManager, manager, config)
+
+	// Create MCP server
+	s.mcpServer = server.NewMCPServer(
+		"kruise-agents-mcp-server",
+		"0.0.1",
+		server.WithToolCapabilities(true),
+	)
+
+	// Register tools and routes
+	s.registerTools()
+	s.registerRoutes()
+
+	return s
+}
+
+// registerRoutes registers HTTP routes (similar to e2b.Controller.registerRoutes)
+func (s *MCPServer) registerRoutes() {
+	// Health check endpoint
+	s.mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "OK")
+	})
+
+	// Create streamable HTTP handler for MCP protocol
+	var httpHandler http.Handler
+	httpHandler = server.NewStreamableHTTPServer(s.mcpServer,
+		server.WithStateLess(false),
+	)
+
+	// Apply authentication middleware (provides user context, anonymous if keys == nil)
+	httpHandler = s.auth.HTTPAuthMiddleware(httpHandler)
+
+	// Register MCP endpoint
+	s.mux.Handle(s.config.MCPEndpointPath, httpHandler)
+}
+
+// Run starts the MCP server (similar to e2b.Controller.Run)
+func (s *MCPServer) Run(ctx context.Context) error {
+	log := klog.FromContext(ctx).WithValues("component", "MCPServer")
+
+	if err := s.sessionManager.Start(); err != nil {
+		return fmt.Errorf("failed to start session manager: %w", err)
+	}
+
+	go func() {
+		log.Info("Starting MCP server", "address", s.httpServer.Addr)
+		if err := s.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Error(err, "MCP HTTP server failed")
+		}
+	}()
+
+	log.Info("MCP server started successfully")
+	return nil
+}
+
+func (s *MCPServer) Stop(ctx context.Context) error {
+	log := klog.FromContext(ctx).WithValues("component", "MCPServer")
+
+	s.sessionManager.Stop()
+
+	if err := s.httpServer.Shutdown(ctx); err != nil {
+		log.Error(err, "Failed to shutdown MCP HTTP server")
+		return err
+	}
+
+	log.Info("MCP server stopped")
+	return nil
+}
+
+func (s *MCPServer) registerTools() {
+	toolRegistry := []struct {
+		definition mcp.Tool
+		handler    server.ToolHandlerFunc
+	}{
+		{
+			definition: mcp.NewTool(
+				ToolRunCode,
+				mcp.WithDescription("Execute code in a secure sandbox environment using Jupyter Notebook semantics. "+
+					"You can reference previously defined variables, imports, and functions in the code. "+
+					"Returns structured response with error, logs (stdout/stderr arrays), and results (rich output)."),
+				mcp.WithInputSchema[RunCodeRequest](),
+				mcp.WithOutputSchema[RunCodeResponse](),
+			),
+			handler: mcp.NewStructuredToolHandler(s.handler.HandleRunCode),
+		},
+		{
+			definition: mcp.NewTool(
+				ToolRunCodeOnce,
+				mcp.WithDescription("Execute code in a one-time sandbox environment. "+
+					"Each call creates a new isolated sandbox, executes the code, and automatically cleans up the sandbox after execution. "+
+					"Ideal for stateless code execution where no session persistence is needed. "+
+					"Returns structured response with error, logs (stdout/stderr arrays), and results (rich output)."),
+				mcp.WithInputSchema[RunCodeOnceRequest](),
+				mcp.WithOutputSchema[RunCodeResponse](),
+			),
+			handler: mcp.NewStructuredToolHandler(s.handler.HandleRunCodeOnce),
+		},
+		{
+			definition: mcp.NewTool(
+				ToolRunCommand,
+				mcp.WithDescription("Execute a shell command in the sandbox environment. "+
+					"Commands are run via /bin/bash -l -c. "+
+					"Supports environment variables, working directory. "+
+					"Returns command result with stdout, stderr, and exit code."),
+				mcp.WithInputSchema[RunCommandRequest](),
+				mcp.WithOutputSchema[RunCommandResponse](),
+			),
+			handler: mcp.NewStructuredToolHandler(s.handler.HandleRunCommand),
+		},
+	}
+
+	// Register each tool with its handler (wrapped with middlewares)
+	for _, entry := range toolRegistry {
+		s.mcpServer.AddTool(entry.definition, s.applyMiddlewares(entry.handler))
+	}
+}

--- a/pkg/servers/mcp/server_test.go
+++ b/pkg/servers/mcp/server_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestMCPServerForRegisterTools creates an MCPServer for testing registerTools
+func createTestMCPServerForRegisterTools() *MCPServer {
+	config := DefaultServerConfig()
+	operator := &mockSandboxOperator{}
+	sm := NewSessionManager(operator, config, nil)
+	sm.SetRequestPeer(noopRequestPeer)
+
+	s := &MCPServer{
+		config:         config,
+		mcpServer:      server.NewMCPServer("test-server", "0.0.1", server.WithToolCapabilities(true)),
+		sessionManager: sm,
+		handler:        NewHandler(sm, nil, config),
+	}
+
+	return s
+}
+
+func TestRegisterTools(t *testing.T) {
+	t.Run("registers all expected tools", func(t *testing.T) {
+		s := createTestMCPServerForRegisterTools()
+
+		// Call registerTools
+		s.registerTools()
+
+		// Get registered tools
+		tools := s.mcpServer.ListTools()
+
+		// Verify expected tool count
+		assert.Len(t, tools, 3, "should register exactly 3 tools")
+
+		// Verify each tool is registered
+		expectedTools := []string{ToolRunCode, ToolRunCodeOnce, ToolRunCommand}
+		for _, toolName := range expectedTools {
+			tool, exists := tools[toolName]
+			require.True(t, exists, "tool %s should be registered", toolName)
+			assert.NotNil(t, tool, "tool %s should not be nil", toolName)
+		}
+	})
+}
+
+func TestRegisterRoutes(t *testing.T) {
+	t.Run("health endpoint returns OK", func(t *testing.T) {
+		s := createTestMCPServerForRegisterTools()
+		s.mux = http.NewServeMux()
+		s.auth = NewAuth(nil) // No authentication
+		s.registerRoutes()
+
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		rec := httptest.NewRecorder()
+		s.mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "OK", rec.Body.String())
+	})
+}
+
+func TestRunAndStop(t *testing.T) {
+	t.Run("server starts and stops successfully", func(t *testing.T) {
+		config := DefaultServerConfig()
+		config.Port = 0 // Use random available port
+
+		operator := &mockSandboxOperator{}
+		sm := NewSessionManager(operator, config, nil)
+		sm.SetRequestPeer(noopRequestPeer)
+
+		s := &MCPServer{
+			config:         config,
+			mux:            http.NewServeMux(),
+			mcpServer:      server.NewMCPServer("test-server", "0.0.1", server.WithToolCapabilities(true)),
+			sessionManager: sm,
+			auth:           NewAuth(nil),
+			handler:        NewHandler(sm, nil, config),
+		}
+
+		s.httpServer = &http.Server{
+			Addr:              ":0", // Use any available port
+			Handler:           s.mux,
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		s.registerRoutes()
+
+		ctx := context.Background()
+
+		// Start server
+		err := s.Run(ctx)
+		require.NoError(t, err)
+
+		// Give server time to start
+		time.Sleep(50 * time.Millisecond)
+
+		// Stop server
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		err = s.Stop(stopCtx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("stop handles shutdown timeout gracefully", func(t *testing.T) {
+		config := DefaultServerConfig()
+		config.Port = 0
+
+		operator := &mockSandboxOperator{}
+		sm := NewSessionManager(operator, config, nil)
+		sm.SetRequestPeer(noopRequestPeer)
+
+		s := &MCPServer{
+			config:         config,
+			mux:            http.NewServeMux(),
+			mcpServer:      server.NewMCPServer("test-server", "0.0.1"),
+			sessionManager: sm,
+			auth:           NewAuth(nil),
+			handler:        NewHandler(sm, nil, config),
+		}
+
+		s.httpServer = &http.Server{
+			Addr:              ":0",
+			Handler:           s.mux,
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		s.registerRoutes()
+
+		ctx := context.Background()
+
+		// Start server
+		err := s.Run(ctx)
+		require.NoError(t, err)
+
+		time.Sleep(50 * time.Millisecond)
+
+		// Stop with very short timeout
+		stopCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		// Should complete without error for a server with no active connections
+		err = s.Stop(stopCtx)
+		assert.NoError(t, err)
+	})
+}

--- a/pkg/servers/mcp/session.go
+++ b/pkg/servers/mcp/session.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/openkruise/agents/pkg/peers"
+	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
+	"k8s.io/klog/v2"
+)
+
+// RequestPeerFunc is a function type for sending HTTP requests to peer nodes.
+type RequestPeerFunc func(ctx context.Context, method, ip, path string, body []byte) error
+
+// SessionManager manages user sessions and their associated sandboxes
+// Similar to proxy.Server, it maintains local session-sandbox mappings
+// and synchronizes changes with peer instances
+type SessionManager struct {
+	sessions sync.Map // map[sessionID]*UserSession
+	config   *ServerConfig
+
+	// operator handles sandbox operations (shared with Handler)
+	operator SandboxOperator
+
+	// requestPeer is a function for sending HTTP requests to peer nodes
+	requestPeer RequestPeerFunc
+
+	// peersManager provides peer discovery via memberlist gossip protocol
+	peersManager peers.Peers
+
+	// Peer synchronization
+	stopOnce sync.Once
+	httpSrv  *http.Server
+}
+
+// NewSessionManager creates a new session manager with the given dependencies
+func NewSessionManager(operator SandboxOperator, config *ServerConfig, peersManager peers.Peers) *SessionManager {
+	sm := &SessionManager{
+		operator:     operator,
+		config:       config,
+		peersManager: peersManager,
+	}
+	sm.requestPeer = sm.defaultRequestPeer
+	return sm
+}
+
+// SetRequestPeer sets a custom requestPeer function (for testing)
+func (sm *SessionManager) SetRequestPeer(fn RequestPeerFunc) {
+	sm.requestPeer = fn
+}
+
+// defaultRequestPeer is the default implementation for sending HTTP requests to peer nodes
+func (sm *SessionManager) defaultRequestPeer(ctx context.Context, method, ip, path string, body []byte) error {
+	var buf io.Reader
+	if len(body) > 0 {
+		buf = bytes.NewReader(body)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, consts.RequestPeerTimeout)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, method, fmt.Sprintf("http://%s:%d%s", ip, sm.config.SessionSyncPort, path), buf)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
+
+	return nil
+}
+
+// Start starts the session manager background tasks and peer sync server
+func (sm *SessionManager) Start() error {
+	return sm.startPeerSync()
+}
+
+// Stop stops the session manager
+func (sm *SessionManager) Stop() {
+	sm.stopPeerSync()
+}
+
+// GetOrCreateSession gets an existing session or creates a new one.
+// Parameters:
+//   - sessionID: the MCP protocol session identifier
+//   - userID: the authenticated user identifier
+//   - templateID: the sandbox template to use
+//   - sandboxTTL: the TTL (time-to-live) for sandbox shutdownTime
+func (sm *SessionManager) GetOrCreateSession(ctx context.Context, sessionID, userID, templateID string, sandboxTTL time.Duration) (*UserSession, error) {
+	log := klog.FromContext(ctx).WithValues("sessionID", sessionID, "userID", userID, "templateID", templateID)
+
+	// Check if session already exists
+	if value, ok := sm.sessions.Load(sessionID); ok {
+		session := value.(*UserSession)
+
+		// Verify session belongs to the user
+		if session.UserID != userID {
+			log.Error(nil, "session does not belong to user")
+			return nil, NewMCPError(ErrorCodeAuthFailed, "Session does not belong to the authenticated user", nil)
+		}
+
+		// Session exists and belongs to user, reuse it
+		// TODO: Check sandbox status before reusing. If sandbox is in abnormal state
+		// (e.g., Failed, Terminating), should clean up the stale session and create a new one
+		log.Info("reusing existing sandbox", "sandboxID", session.SandboxID)
+		return session, nil
+	}
+
+	// Create new sandbox
+	log.Info("creating new sandbox")
+	sandboxInfo, err := CreateSandbox(ctx, sm.operator, userID, sessionID, templateID, sandboxTTL)
+	if err != nil {
+		log.Error(err, "failed to create sandbox")
+		return nil, NewMCPError(ErrorCodeSandboxCreation, fmt.Sprintf("Failed to create sandbox: %v", err), nil)
+	}
+
+	// Create new session
+	session := &UserSession{
+		SessionID:   sessionID,
+		UserID:      userID,
+		SandboxID:   sandboxInfo.SandboxID,
+		TemplateID:  templateID,
+		State:       sandboxInfo.State,
+		AccessToken: sandboxInfo.AccessToken,
+	}
+
+	sm.sessions.Store(sessionID, session)
+	log.Info("sandbox created successfully", "sandboxID", session.SandboxID)
+
+	// Sync new session to peers
+	if err := sm.SyncSessionWithPeers(ctx, session, false); err != nil {
+		log.Error(err, "failed to sync session with peers")
+	}
+
+	return session, nil
+}
+
+// GetSession retrieves an existing session by sessionID
+func (sm *SessionManager) GetSession(sessionID string) (*UserSession, bool) {
+	value, ok := sm.sessions.Load(sessionID)
+	if !ok {
+		return nil, false
+	}
+	return value.(*UserSession), true
+}
+
+// OnSandboxAdd handles sandbox add events from cluster
+func (sm *SessionManager) OnSandboxAdd(sessionID, sandboxID, userID, accessToken, state string) {
+	if sessionID == "" {
+		return
+	}
+	session := &UserSession{
+		SessionID:   sessionID,
+		UserID:      userID,
+		SandboxID:   sandboxID,
+		State:       state,
+		AccessToken: accessToken,
+	}
+	sm.sessions.Store(sessionID, session)
+	klog.InfoS("session added from cluster event", "sessionID", sessionID, "sandboxID", sandboxID, "state", state)
+}
+
+// OnSandboxDelete handles sandbox delete events from cluster
+func (sm *SessionManager) OnSandboxDelete(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	if _, ok := sm.sessions.Load(sessionID); ok {
+		sm.sessions.Delete(sessionID)
+		klog.InfoS("session deleted from cluster event", "sessionID", sessionID)
+	}
+}
+
+// OnSandboxUpdate handles sandbox update events from cluster
+func (sm *SessionManager) OnSandboxUpdate(sessionID, sandboxID, userID, accessToken, state string) {
+	if sessionID == "" {
+		return
+	}
+	session := &UserSession{
+		SessionID:   sessionID,
+		UserID:      userID,
+		SandboxID:   sandboxID,
+		State:       state,
+		AccessToken: accessToken,
+	}
+	sm.sessions.Store(sessionID, session)
+	klog.InfoS("session updated from cluster event", "sessionID", sessionID, "sandboxID", sandboxID, "state", state)
+}

--- a/pkg/servers/mcp/session_test.go
+++ b/pkg/servers/mcp/session_test.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+)
+
+// noopRequestPeer is a no-op RequestPeerFunc for testing
+func noopRequestPeer(ctx context.Context, method, ip, path string, body []byte) error {
+	return nil
+}
+
+// createTestSessionManager creates a SessionManager for testing
+func createTestSessionManager(operator SandboxOperator, requestPeer RequestPeerFunc) *SessionManager {
+	config := DefaultServerConfig()
+	sm := NewSessionManager(operator, config, nil)
+	if requestPeer == nil {
+		requestPeer = noopRequestPeer
+	}
+	sm.SetRequestPeer(requestPeer)
+	return sm
+}
+
+// newMockOperatorWithSandbox creates a mock operator that returns a sandbox with given properties
+func newMockOperatorWithSandbox(sandboxID string, err error) *mockSandboxOperator {
+	return &mockSandboxOperator{
+		claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+			if err != nil {
+				return nil, err
+			}
+			sbx := newMockSandbox(sandboxID)
+			sbx.state = "running"
+			return sbx, nil
+		},
+	}
+}
+
+func TestNewSessionManager(t *testing.T) {
+	config := DefaultServerConfig()
+	operator := &mockSandboxOperator{}
+	sm := NewSessionManager(operator, config, nil)
+
+	assert.NotNil(t, sm)
+	assert.Equal(t, config, sm.config)
+	assert.NotNil(t, sm.requestPeer)
+	assert.NotNil(t, sm.operator)
+}
+
+func TestGetOrCreateSession(t *testing.T) {
+	t.Run("creates new session successfully", func(t *testing.T) {
+		operator := newMockOperatorWithSandbox("sandbox-123", nil)
+		sm := createTestSessionManager(operator, nil)
+
+		ctx := context.Background()
+		session, err := sm.GetOrCreateSession(ctx, "session-1", "user-1", "template-1", 5*time.Minute)
+
+		require.NoError(t, err)
+		require.NotNil(t, session)
+		assert.Equal(t, "session-1", session.SessionID)
+		assert.Equal(t, "user-1", session.UserID)
+		assert.Equal(t, "sandbox-123", session.SandboxID)
+		assert.Equal(t, "template-1", session.TemplateID)
+		assert.Equal(t, "running", session.State)
+	})
+
+	t.Run("reuses existing session for same user", func(t *testing.T) {
+		callCount := 0
+		operator := &mockSandboxOperator{
+			claimSandboxFunc: func(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
+				callCount++
+				return newMockSandbox("new-sandbox"), nil
+			},
+		}
+		sm := createTestSessionManager(operator, nil)
+
+		// Pre-store a session
+		existingSession := &UserSession{
+			SessionID:   "session-existing",
+			UserID:      "user-1",
+			SandboxID:   "sandbox-existing",
+			TemplateID:  "template-1",
+			State:       "Running",
+			AccessToken: "existing-token",
+		}
+		sm.sessions.Store("session-existing", existingSession)
+
+		ctx := context.Background()
+		session, err := sm.GetOrCreateSession(ctx, "session-existing", "user-1", "template-2", 5*time.Minute)
+
+		require.NoError(t, err)
+		require.NotNil(t, session)
+		assert.Equal(t, "sandbox-existing", session.SandboxID) // Should return existing sandbox
+		assert.Equal(t, 0, callCount)                          // Creator should not be called
+	})
+
+	t.Run("rejects session belonging to different user", func(t *testing.T) {
+		operator := &mockSandboxOperator{}
+		sm := createTestSessionManager(operator, nil)
+
+		// Pre-store a session for user-1
+		existingSession := &UserSession{
+			SessionID:   "session-1",
+			UserID:      "user-1",
+			SandboxID:   "sandbox-1",
+			TemplateID:  "template-1",
+			State:       "Running",
+			AccessToken: "token-1",
+		}
+		sm.sessions.Store("session-1", existingSession)
+
+		ctx := context.Background()
+		// Try to access with different user
+		session, err := sm.GetOrCreateSession(ctx, "session-1", "user-2", "template-1", 5*time.Minute)
+
+		assert.Error(t, err)
+		assert.Nil(t, session)
+		assert.IsType(t, &MCPError{}, err)
+		assert.Equal(t, ErrorCodeAuthFailed, err.(*MCPError).Code)
+		assert.Contains(t, err.Error(), "does not belong to")
+	})
+
+	t.Run("handles sandbox creation failure", func(t *testing.T) {
+		operator := newMockOperatorWithSandbox("", errors.New("sandbox creation failed"))
+		sm := createTestSessionManager(operator, nil)
+
+		ctx := context.Background()
+		session, err := sm.GetOrCreateSession(ctx, "session-fail", "user-1", "template-1", 5*time.Minute)
+
+		assert.Error(t, err)
+		assert.Nil(t, session)
+		assert.IsType(t, &MCPError{}, err)
+		assert.Equal(t, ErrorCodeSandboxCreation, err.(*MCPError).Code)
+	})
+}
+
+func TestGetSession(t *testing.T) {
+	t.Run("returns existing session", func(t *testing.T) {
+		operator := &mockSandboxOperator{}
+		sm := createTestSessionManager(operator, nil)
+
+		existingSession := &UserSession{
+			SessionID:   "session-get",
+			UserID:      "user-1",
+			SandboxID:   "sandbox-get",
+			TemplateID:  "template-1",
+			State:       "Running",
+			AccessToken: "token-get",
+		}
+		sm.sessions.Store("session-get", existingSession)
+
+		session, ok := sm.GetSession("session-get")
+
+		assert.True(t, ok)
+		require.NotNil(t, session)
+		assert.Equal(t, "session-get", session.SessionID)
+		assert.Equal(t, "sandbox-get", session.SandboxID)
+	})
+
+	t.Run("returns false for non-existing session", func(t *testing.T) {
+		operator := &mockSandboxOperator{}
+		sm := createTestSessionManager(operator, nil)
+
+		session, ok := sm.GetSession("non-existing")
+
+		assert.False(t, ok)
+		assert.Nil(t, session)
+	})
+}
+
+func TestOnSandboxAdd(t *testing.T) {
+	t.Run("adds session from cluster event", func(t *testing.T) {
+		operator := &mockSandboxOperator{}
+		sm := createTestSessionManager(operator, nil)
+
+		sm.OnSandboxAdd("session-add", "sandbox-add", "user-add", "token-add", "Running")
+
+		session, ok := sm.GetSession("session-add")
+		assert.True(t, ok)
+		require.NotNil(t, session)
+		assert.Equal(t, "session-add", session.SessionID)
+		assert.Equal(t, "sandbox-add", session.SandboxID)
+		assert.Equal(t, "user-add", session.UserID)
+		assert.Equal(t, "token-add", session.AccessToken)
+		assert.Equal(t, "Running", session.State)
+	})
+
+	t.Run("ignores empty session ID", func(t *testing.T) {
+		operator := &mockSandboxOperator{}
+		sm := createTestSessionManager(operator, nil)
+
+		sm.OnSandboxAdd("", "sandbox-1", "user-1", "token-1", "Running")
+
+		// Should not store anything
+		_, ok := sm.GetSession("")
+		assert.False(t, ok)
+	})
+}
+
+func TestOnSandboxDelete(t *testing.T) {
+	t.Run("deletes existing session", func(t *testing.T) {
+		operator := &mockSandboxOperator{}
+		sm := createTestSessionManager(operator, nil)
+
+		// Pre-store a session
+		sm.sessions.Store("session-delete", &UserSession{
+			SessionID: "session-delete",
+			SandboxID: "sandbox-delete",
+		})
+
+		sm.OnSandboxDelete("session-delete")
+
+		_, ok := sm.GetSession("session-delete")
+		assert.False(t, ok)
+	})
+
+	t.Run("handles non-existing session gracefully", func(t *testing.T) {
+		operator := &mockSandboxOperator{}
+		sm := createTestSessionManager(operator, nil)
+
+		// Should not panic
+		sm.OnSandboxDelete("non-existing")
+	})
+
+	t.Run("ignores empty session ID", func(t *testing.T) {
+		operator := &mockSandboxOperator{}
+		sm := createTestSessionManager(operator, nil)
+
+		// Pre-store a session
+		sm.sessions.Store("valid-session", &UserSession{
+			SessionID: "valid-session",
+		})
+
+		sm.OnSandboxDelete("")
+
+		// Other sessions should not be affected
+		_, ok := sm.GetSession("valid-session")
+		assert.True(t, ok)
+	})
+}
+
+func TestOnSandboxUpdate(t *testing.T) {
+	t.Run("updates existing session", func(t *testing.T) {
+		operator := &mockSandboxOperator{}
+		sm := createTestSessionManager(operator, nil)
+
+		// Pre-store a session
+		sm.sessions.Store("session-update", &UserSession{
+			SessionID:   "session-update",
+			UserID:      "user-1",
+			SandboxID:   "sandbox-1",
+			State:       "pending",
+			AccessToken: "old-token",
+		})
+
+		// Update the session
+		sm.OnSandboxUpdate("session-update", "sandbox-1", "user-1", "new-token", "running")
+
+		session, ok := sm.GetSession("session-update")
+		assert.True(t, ok)
+		require.NotNil(t, session)
+		assert.Equal(t, "running", session.State)
+		assert.Equal(t, "new-token", session.AccessToken)
+	})
+
+	t.Run("creates session if not exists", func(t *testing.T) {
+		operator := &mockSandboxOperator{}
+		sm := createTestSessionManager(operator, nil)
+
+		sm.OnSandboxUpdate("new-session", "sandbox-new", "user-new", "token-new", "Running")
+
+		session, ok := sm.GetSession("new-session")
+		assert.True(t, ok)
+		require.NotNil(t, session)
+		assert.Equal(t, "new-session", session.SessionID)
+		assert.Equal(t, "sandbox-new", session.SandboxID)
+	})
+}

--- a/pkg/servers/mcp/types.go
+++ b/pkg/servers/mcp/types.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"time"
+)
+
+// ToolNames defines the names of all available MCP tools
+const (
+	ToolRunCode     = "run_code"
+	ToolRunCodeOnce = "run_code_once"
+	ToolRunCommand  = "run_command"
+)
+
+// ServerConfig contains configuration for the MCP server
+type ServerConfig struct {
+	// Port is the port MCP server listens on
+	Port int
+	// DefaultTemplate is the default sandbox template ID
+	DefaultTemplate string
+	// SandboxTTL is the TTL (time-to-live) for sandbox auto-reclamation
+	// This value will be used to configure MaxIdleTime when claiming sandboxes
+	// When configured via HTTP headers or environment variables, values are specified in seconds.
+	SandboxTTL time.Duration
+	// ExecutionTimeout is the timeout for code/command execution
+	// When configured via HTTP headers or environment variables, values are specified in seconds.
+	ExecutionTimeout time.Duration
+	// MCPEndpointPath is the MCP service endpoint path
+	MCPEndpointPath string
+	// SessionSyncPort is the port for session peer synchronization
+	SessionSyncPort int
+}
+
+// UserSessionConfig contains user-customizable session configuration
+// Users can override default values via HTTP headers
+type UserSessionConfig struct {
+	// Template overrides DefaultTemplate if specified
+	Template string
+	// SandboxTTL overrides default SandboxTTL if specified (in seconds)
+	SandboxTTL *time.Duration
+	// ExecutionTimeout overrides default ExecutionTimeout if specified (in seconds)
+	ExecutionTimeout *time.Duration
+}
+
+// DefaultServerConfig returns default configuration
+func DefaultServerConfig() *ServerConfig {
+	return &ServerConfig{
+		Port:             8082,
+		DefaultTemplate:  "code-interpreter",
+		SandboxTTL:       5 * time.Minute,
+		ExecutionTimeout: 60 * time.Second,
+		MCPEndpointPath:  "/mcp",
+		SessionSyncPort:  7790,
+	}
+}
+
+// UserSession represents a user's session with associated sandbox
+type UserSession struct {
+	// SessionID is the MCP protocol session identifier
+	SessionID string
+	// UserID is the unique identifier of the user
+	UserID string
+	// SandboxID is the ID of the sandbox associated with this session
+	SandboxID string
+	// TemplateID is the template used to create the sandbox
+	TemplateID string
+	// State is the current state of the sandbox
+	State string
+	// AccessToken is the token for accessing the sandbox
+	AccessToken string
+}
+
+// RunCodeRequest represents a request to execute code
+// Aligned with E2B Code Interpreter Python client interface
+type RunCodeRequest struct {
+	// Code is the code to execute (required)
+	Code string `json:"code" jsonschema:"required" jsonschema_description:"The code to execute in Jupyter Notebook cell format"`
+	// Language is the programming language (optional, defaults to python, supports: python, javascript)
+	Language string `json:"language,omitempty" jsonschema_description:"Programming language for code execution (python or javascript, defaults to python)"`
+}
+
+// RunCodeOnceRequest represents a request to execute code in a one-time sandbox
+// Each call creates a new sandbox and cleans it up after execution
+type RunCodeOnceRequest struct {
+	// Code is the code to execute (required)
+	Code string `json:"code" jsonschema:"required" jsonschema_description:"The code to execute in Jupyter Notebook cell format"`
+	// Language is the programming language (optional, defaults to python, supports: python, javascript)
+	Language string `json:"language,omitempty" jsonschema_description:"Programming language for code execution (python or javascript, defaults to python)"`
+}
+
+// ExecutionLogs represents the logs from code execution
+type ExecutionLogs struct {
+	Stdout []string `json:"stdout" jsonschema_description:"Standard output lines from code execution"`
+	Stderr []string `json:"stderr" jsonschema_description:"Standard error lines from code execution"`
+}
+
+// ExecutionError represents an error during code execution
+type ExecutionError struct {
+	Name      string `json:"name" jsonschema_description:"Error name/type"`
+	Value     string `json:"value" jsonschema_description:"Error message"`
+	Traceback string `json:"traceback" jsonschema_description:"Error traceback"`
+}
+
+// ExecutionResult represents a result from code execution
+// Supports multiple MIME types aligned with E2B Code Interpreter Execution model
+type ExecutionResult struct {
+	Text         string                 `json:"text,omitempty" jsonschema_description:"Text representation of the result"`
+	HTML         string                 `json:"html,omitempty" jsonschema_description:"HTML representation of the result"`
+	Markdown     string                 `json:"markdown,omitempty" jsonschema_description:"Markdown representation of the result"`
+	JSON         map[string]interface{} `json:"json,omitempty" jsonschema_description:"JSON representation of the result"`
+	PNG          string                 `json:"png,omitempty" jsonschema_description:"PNG image (base64 encoded)"`
+	SVG          string                 `json:"svg,omitempty" jsonschema_description:"SVG image representation"`
+	LaTeX        string                 `json:"latex,omitempty" jsonschema_description:"LaTeX representation of the result"`
+	IsMainResult bool                   `json:"is_main_result,omitempty" jsonschema_description:"Whether this is the main result of the cell"`
+	Extra        map[string]interface{} `json:"extra,omitempty" jsonschema_description:"Additional result metadata"`
+}
+
+// RunCodeResponse represents the response from code execution
+// This structure conforms to E2B Code Interpreter Server response format
+type RunCodeResponse struct {
+	Error          *ExecutionError   `json:"error,omitempty" jsonschema_description:"Error information if execution failed"`
+	Logs           ExecutionLogs     `json:"logs" jsonschema_description:"Execution logs containing stdout and stderr"`
+	Results        []ExecutionResult `json:"results" jsonschema_description:"Execution results (rich output display)"`
+	SandboxID      string            `json:"sandbox_id" jsonschema_description:"ID of the sandbox where code was executed"`
+	ExecutionCount *int              `json:"execution_count,omitempty" jsonschema_description:"Execution count of the cell"`
+}
+
+// RunCommandRequest represents a request to execute a shell command
+// Aligned with E2B Commands Python client interface
+type RunCommandRequest struct {
+	// Cmd is the command to execute (required)
+	Cmd string `json:"cmd" jsonschema:"required" jsonschema_description:"The shell command to execute"`
+	// Envs specifies environment variables for the command
+	Envs map[string]string `json:"envs,omitempty" jsonschema_description:"Environment variables used for the command"`
+	// Cwd specifies the working directory for the command
+	Cwd *string `json:"cwd,omitempty" jsonschema_description:"Working directory to run the command"`
+}
+
+// RunCommandResponse represents the response from command execution
+// Aligned with E2B CommandResult model
+type RunCommandResponse struct {
+	// Stdout contains the standard output from the command
+	Stdout string `json:"stdout" jsonschema_description:"Standard output from the command execution"`
+	// Stderr contains the standard error output from the command
+	Stderr string `json:"stderr" jsonschema_description:"Standard error output from the command execution"`
+	// ExitCode is the exit code of the command
+	ExitCode int `json:"exit_code" jsonschema_description:"Exit code of the command (0 typically indicates success)"`
+	// SandboxID is the ID of the sandbox where command was executed
+	SandboxID string `json:"sandbox_id" jsonschema_description:"ID of the sandbox where the command was executed"`
+	// Error contains error message if command execution failed
+	Error string `json:"error,omitempty" jsonschema_description:"Error message if command execution failed"`
+}
+
+// MCP error codes (aligned with JSON-RPC / mcp-go definitions)
+// See: https://github.com/mark3labs/mcp-go/blob/main/mcp/types.go#L403-L422
+const (
+	ErrorCodeAuthFailed       = -32001
+	ErrorCodeSandboxCreation  = -32002
+	ErrorCodeCodeExecution    = -32003
+	ErrorCodeFileOperation    = -32004
+	ErrorCodeTimeout          = -32005
+	ErrorCodeInternalError    = -32603
+	ErrorCodeCommandExecution = -32006
+)
+
+// MCPError represents an MCP protocol error
+type MCPError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// Error implements the error interface
+func (e *MCPError) Error() string {
+	return e.Message
+}
+
+// NewMCPError creates a new MCP error
+func NewMCPError(code int, message string, data interface{}) *MCPError {
+	return &MCPError{
+		Code:    code,
+		Message: message,
+		Data:    data,
+	}
+}

--- a/pkg/servers/mcp/utils.go
+++ b/pkg/servers/mcp/utils.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+)
+
+type contextKey string
+
+const (
+	userContextKey       contextKey = "user"
+	userSessionConfigKey contextKey = "userSessionConfig"
+)
+
+// GetSessionID extracts MCP session ID from context
+// SessionManagementMiddleware guarantees sessionID exists, so this should always succeed
+func GetSessionID(ctx context.Context) (string, error) {
+	// Get MCP client session from context (guaranteed by middleware)
+	if clientSession := server.ClientSessionFromContext(ctx); clientSession != nil {
+		sessionID := clientSession.SessionID()
+		if sessionID != "" {
+			return sessionID, nil
+		}
+	}
+
+	// Should never reach here due to middleware validation
+	return "", NewMCPError(ErrorCodeInternalError, "sessionID not found in context despite middleware validation", nil)
+}
+
+// SetUserContext sets user in context
+func SetUserContext(ctx context.Context, user *models.CreatedTeamAPIKey) context.Context {
+	return context.WithValue(ctx, userContextKey, user)
+}
+
+// GetUserFromContext extracts user from context
+func GetUserFromContext(ctx context.Context) (*models.CreatedTeamAPIKey, error) {
+	value := ctx.Value(userContextKey)
+	if value == nil {
+		return nil, NewMCPError(ErrorCodeAuthFailed, "User not found in context", nil)
+	}
+
+	user, ok := value.(*models.CreatedTeamAPIKey)
+	if !ok {
+		return nil, NewMCPError(ErrorCodeAuthFailed, "Invalid user in context", nil)
+	}
+
+	return user, nil
+}
+
+// SetUserSessionConfig sets user session configuration in context
+func SetUserSessionConfig(ctx context.Context, config *UserSessionConfig) context.Context {
+	return context.WithValue(ctx, userSessionConfigKey, config)
+}
+
+// GetUserSessionConfig extracts user session configuration from context
+// Returns nil if not set (will fallback to server defaults)
+func GetUserSessionConfig(ctx context.Context) *UserSessionConfig {
+	if value := ctx.Value(userSessionConfigKey); value != nil {
+		if config, ok := value.(*UserSessionConfig); ok {
+			return config
+		}
+	}
+	return nil
+}
+
+// MaskAPIKey returns the first 4 characters of an API key for logging
+func MaskAPIKey(apiKey string) string {
+	if len(apiKey) <= 4 {
+		return "****"
+	}
+	return apiKey[:4] + strings.Repeat("*", len(apiKey)-4)
+}

--- a/pkg/servers/mcp/utils_test.go
+++ b/pkg/servers/mcp/utils_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaskAPIKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiKey   string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			apiKey:   "",
+			expected: "****",
+		},
+		{
+			name:     "1 character",
+			apiKey:   "a",
+			expected: "****",
+		},
+		{
+			name:     "4 characters",
+			apiKey:   "abcd",
+			expected: "****",
+		},
+		{
+			name:     "5 characters",
+			apiKey:   "abcde",
+			expected: "abcd*",
+		},
+		{
+			name:     "normal api key",
+			apiKey:   "sk-abc123def456",
+			expected: "sk-a***********",
+		},
+		{
+			name:     "uuid format key",
+			apiKey:   "550e8400-e29b-41d4-a716-446655440000",
+			expected: "550e********************************",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MaskAPIKey(tt.apiKey)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSetGetUserContext(t *testing.T) {
+	testUser := &models.CreatedTeamAPIKey{
+		ID:   uuid.New(),
+		Name: "test-user",
+		Key:  "test-key",
+	}
+
+	t.Run("set and get user from context", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = SetUserContext(ctx, testUser)
+
+		user, err := GetUserFromContext(ctx)
+		assert.NoError(t, err)
+		assert.NotNil(t, user)
+		assert.Equal(t, testUser.ID, user.ID)
+		assert.Equal(t, testUser.Name, user.Name)
+	})
+
+	t.Run("get user from empty context", func(t *testing.T) {
+		ctx := context.Background()
+
+		user, err := GetUserFromContext(ctx)
+		assert.Error(t, err)
+		assert.Nil(t, user)
+		assert.IsType(t, &MCPError{}, err)
+		assert.Equal(t, ErrorCodeAuthFailed, err.(*MCPError).Code)
+	})
+
+	t.Run("get user with wrong type in context", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), userContextKey, "invalid-type")
+
+		user, err := GetUserFromContext(ctx)
+		assert.Error(t, err)
+		assert.Nil(t, user)
+		assert.Contains(t, err.Error(), "Invalid user")
+	})
+}
+
+func TestSetGetUserSessionConfig(t *testing.T) {
+	sandboxTTL := 5 * time.Minute
+	execTimeout := 60 * time.Second
+
+	testConfig := &UserSessionConfig{
+		Template:         "test-template",
+		SandboxTTL:       &sandboxTTL,
+		ExecutionTimeout: &execTimeout,
+	}
+
+	t.Run("set and get session config", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = SetUserSessionConfig(ctx, testConfig)
+
+		config := GetUserSessionConfig(ctx)
+		assert.NotNil(t, config)
+		assert.Equal(t, "test-template", config.Template)
+		assert.Equal(t, sandboxTTL, *config.SandboxTTL)
+		assert.Equal(t, execTimeout, *config.ExecutionTimeout)
+	})
+
+	t.Run("get config from empty context returns nil", func(t *testing.T) {
+		ctx := context.Background()
+
+		config := GetUserSessionConfig(ctx)
+		assert.Nil(t, config)
+	})
+
+	t.Run("get config with wrong type returns nil", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), userSessionConfigKey, "invalid-type")
+
+		config := GetUserSessionConfig(ctx)
+		assert.Nil(t, config)
+	})
+
+	t.Run("config with nil fields", func(t *testing.T) {
+		emptyConfig := &UserSessionConfig{
+			Template: "only-template",
+		}
+		ctx := context.Background()
+		ctx = SetUserSessionConfig(ctx, emptyConfig)
+
+		config := GetUserSessionConfig(ctx)
+		assert.NotNil(t, config)
+		assert.Equal(t, "only-template", config.Template)
+		assert.Nil(t, config.SandboxTTL)
+		assert.Nil(t, config.ExecutionTimeout)
+	})
+}

--- a/pkg/utils/sandbox-manager/proxyutils/default.go
+++ b/pkg/utils/sandbox-manager/proxyutils/default.go
@@ -34,7 +34,7 @@ var (
 	DefaultRequestFunc  = requestSandbox
 )
 
-func requestSandbox(ctx context.Context, s *agentsv1alpha1.Sandbox, method, path string, port int, body io.Reader) (*http.Response, error) {
+func requestSandbox(ctx context.Context, s *agentsv1alpha1.Sandbox, method, path string, port int, body io.Reader, headers http.Header) (*http.Response, error) {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(s))
 	if s.Status.Phase != agentsv1alpha1.SandboxRunning {
 		return nil, errors.New("sandbox is not running")
@@ -43,6 +43,12 @@ func requestSandbox(ctx context.Context, s *agentsv1alpha1.Sandbox, method, path
 	r, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+	// Set custom headers
+	for key, values := range headers {
+		for _, value := range values {
+			r.Header.Add(key, value)
+		}
 	}
 	log.Info("requesting sandbox", "url", url)
 	return ProxyRequest(r)

--- a/pkg/utils/sandbox-manager/proxyutils/default_test.go
+++ b/pkg/utils/sandbox-manager/proxyutils/default_test.go
@@ -165,7 +165,7 @@ func TestRequestSandbox(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := requestSandbox(t.Context(), tt.sandbox, "GET", "/", port, nil)
+			_, err := requestSandbox(t.Context(), tt.sandbox, "GET", "/", port, nil, nil)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
```
┌─────────────┐    ┌─────────────┐
│   E2B API   │    │   MCP API   │   <-- External Protocol Interfaces
└──────┬──────┘    └──────┬──────┘
       │                  │
       └────────┬─────────┘
                ▼
        ┌───────────────┐
        │ SandboxManager│              <-- Unified Management Layer
        └───────┬───────┘
                ▼
        ┌───────────────┐
        │  Sandbox CRs  │              <-- Kubernetes Resources
        └───────────────┘
```
Both E2B and MCP APIs share the same underlying sandbox infrastructure - they are simply different protocol adapters over the unified sandbox management layer.

**Changes**
**1. MCP Server Integration** (`cmd/sandbox-manager/main.go`)
- Add MCP server alongside existing E2B server
- Configure via environment variables: `MCP_SERVER_ENABLED`, `MCP_SERVER_PORT`, `MCP_SANDBOX_TTL`, `MCP_SESSION_SYNC_PORT`

**2. Sandbox Event Callback** (`pkg/sandbox-manager/infra/`)
- Add `SandboxEventHandler` interface to propagate sandbox lifecycle events to MCP session layer
- Enable MCP sessions to track their associated sandbox state

**3. Session-Sandbox Binding** (`api/v1alpha1/sandboxset_types.go`)
- Add `AnnotationMCPSessionID` to link MCP sessions with underlying sandboxes

**4. Expose Shared Components** (`pkg/servers/e2b/core.go`, `pkg/sandbox-manager/core.go`)
- Expose `SandboxManager` and `KeyStorage` for MCP server reuse
- Add `ListPeers()` for MCP cluster discovery



### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

