### PR TITLE
feat(e2b): add never-timeout extension for sandbox requests

### DIFF
--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -59,11 +59,13 @@ func (sc *Controller) CreateSandbox(r *http.Request) (web.ApiResponse[*models.Sa
 			//   - if autoPause == false: Set `ShutdownTime` to `time.Now().Add(maxTimeout)`
 			now := time.Now()
 			timeoutOptions := infra.TimeoutOptions{}
-			if request.AutoPause {
-				timeoutOptions.ShutdownTime = TimeAfterSeconds(now, sc.maxTimeout)
-				timeoutOptions.PauseTime = TimeAfterSeconds(now, request.Timeout)
-			} else {
-				timeoutOptions.ShutdownTime = TimeAfterSeconds(now, request.Timeout)
+			if !request.Extensions.NeverTimeout {
+				if request.AutoPause {
+					timeoutOptions.ShutdownTime = TimeAfterSeconds(now, sc.maxTimeout)
+					timeoutOptions.PauseTime = TimeAfterSeconds(now, request.Timeout)
+				} else {
+					timeoutOptions.ShutdownTime = TimeAfterSeconds(now, request.Timeout)
+				}
 			}
 			sbx.SetTimeout(timeoutOptions)
 			log.Info("timeout options calculated", "options", timeoutOptions)

--- a/pkg/servers/e2b/models/extensions.go
+++ b/pkg/servers/e2b/models/extensions.go
@@ -23,6 +23,7 @@ const (
 	ExtensionKeySkipInitRuntime              = v1alpha1.E2BPrefix + "skip-init-runtime"
 	ExtensionKeyReserveFailedSandbox         = v1alpha1.E2BPrefix + "reserve-failed-sandbox"
 	ExtensionKeyCreateOnNoStock              = v1alpha1.E2BPrefix + "create-on-no-stock"
+	ExtensionKeyNeverTimeout                 = v1alpha1.E2BPrefix + "never-timeout"
 )
 
 // Extensions for NewSandboxRequest
@@ -50,9 +51,11 @@ func (r *NewSandboxRequest) parseCommonExtensions() error {
 	r.Extensions.SkipInitRuntime = r.Metadata[ExtensionKeySkipInitRuntime] == v1alpha1.True
 	r.Extensions.ReserveFailedSandbox = r.Metadata[ExtensionKeyReserveFailedSandbox] == v1alpha1.True
 	r.Extensions.CreateOnNoStock = r.Metadata[ExtensionKeyCreateOnNoStock] == v1alpha1.True
+	r.Extensions.NeverTimeout = r.Metadata[ExtensionKeyNeverTimeout] == v1alpha1.True
 	delete(r.Metadata, ExtensionKeySkipInitRuntime)
 	delete(r.Metadata, ExtensionKeyReserveFailedSandbox)
 	delete(r.Metadata, ExtensionKeyCreateOnNoStock)
+	delete(r.Metadata, ExtensionKeyNeverTimeout)
 	var err error
 	if r.Extensions.TimeoutSeconds, err = r.parseAndRemoveIntExtension(ExtensionKeyClaimTimeout); err != nil {
 		return err

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -44,6 +44,7 @@ type NewSandboxRequestExtension struct {
 	CreateOnNoStock      bool
 	WaitReadySeconds     int
 	TimeoutSeconds       int
+	NeverTimeout         bool
 }
 
 type InplaceUpdateExtension struct {

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
@@ -189,6 +190,24 @@ func TestCreateSandbox(t *testing.T) {
 				Message: "Bad extension param: invalid image [bad-@@-image]: invalid reference format",
 			},
 		},
+		{
+			name:      "never timeout",
+			available: 1,
+			userName:  "test-user",
+			request: models.NewSandboxRequest{
+				TemplateID: templateName,
+				Timeout:    300,
+				Metadata: map[string]string{
+					models.ExtensionKeyNeverTimeout: v1alpha1.True,
+				},
+			},
+			postCheck: func(t *testing.T, resp *models.Sandbox) {
+				assert.Empty(t, resp.EndAt)
+				sbx, err := controller.manager.GetClaimedSandbox(t.Context(), keys.AdminKeyID.String(), resp.SandboxID)
+				assert.NoError(t, err)
+				assert.Equal(t, infra.TimeoutOptions{}, sbx.GetTimeout())
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -237,9 +256,11 @@ func TestCreateSandbox(t *testing.T) {
 				if tt.request.Timeout != 0 {
 					timeout = tt.request.Timeout
 				}
-				endAt, err := time.Parse(time.RFC3339, sbx.EndAt)
-				assert.NoError(t, err)
-				assert.WithinDuration(t, startedAt.Add(time.Duration(timeout)*time.Second), endAt, 5*time.Second)
+				if tt.request.Metadata[models.ExtensionKeyNeverTimeout] != v1alpha1.True {
+					endAt, err := time.Parse(time.RFC3339, sbx.EndAt)
+					assert.NoError(t, err)
+					assert.WithinDuration(t, startedAt.Add(time.Duration(timeout)*time.Second), endAt, 5*time.Second)
+				}
 				assert.Equal(t, models.SandboxStateRunning, sbx.State)
 			}
 		})


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

```python
sbx = Sandbox.create(template="desktop", metadata={
    "e2b.agents.kruise.io/never-timeout" = "true"
})
```


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

