### PR TITLE
feat: add label selector for Pod informer to reduce cache size

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -24,7 +24,10 @@ import (
 	"os"
 
 	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
@@ -34,6 +37,8 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -43,6 +48,7 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/client"
 	"github.com/openkruise/agents/pkg/controller"
+	"github.com/openkruise/agents/pkg/utils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 	"github.com/openkruise/agents/pkg/utils/fieldindex"
 	customwebhook "github.com/openkruise/agents/pkg/webhook"
@@ -221,7 +227,15 @@ func main() {
 		setupLog.Error(err, "unable to set up client")
 		os.Exit(1)
 	}
+	podLabelReq, err := labels.NewRequirement(utils.PodLabelCreatedBy, selection.Exists, nil)
+	if err != nil {
+		setupLog.Error(err, "unable to create pod label requirement")
+		os.Exit(1)
+	}
+	podLabelSelector := labels.NewSelector().Add(*podLabelReq)
+
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
+
 		Scheme:                  scheme,
 		Metrics:                 metricsServerOptions,
 		WebhookServer:           webhookServer,
@@ -229,6 +243,13 @@ func main() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "f57b9a68.kruise.io",
 		LeaderElectionNamespace: leaderElectionNamespace,
+		Cache: ctrlcache.Options{
+			ByObject: map[ctrlclient.Object]ctrlcache.ByObject{
+				&corev1.Pod{}: {
+					Label: podLabelSelector,
+				},
+			},
+		},
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -1009,6 +1009,9 @@ func TestCommonControl_createPod(t *testing.T) {
 	if pod.Annotations[utils.PodAnnotationCreatedBy] != utils.CreatedBySandbox {
 		t.Errorf("Expected pod annotation %s to be %s, got %s", utils.PodAnnotationCreatedBy, utils.CreatedBySandbox, pod.Annotations[utils.PodAnnotationCreatedBy])
 	}
+	if pod.Labels[utils.PodLabelCreatedBy] != utils.CreatedBySandbox {
+		t.Errorf("Expected pod label %s to be %s, got %s", utils.PodLabelCreatedBy, utils.CreatedBySandbox, pod.Labels[utils.PodLabelCreatedBy])
+	}
 
 	sandboxWithPVC := &agentsv1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/sandbox/core/util.go
+++ b/pkg/controller/sandbox/core/util.go
@@ -100,6 +100,7 @@ func GeneratePodFromSandbox(ctx context.Context, cli client.Client, box *agentsv
 	if pod.Labels == nil {
 		pod.Labels = map[string]string{}
 	}
+	pod.Labels[utils.PodLabelCreatedBy] = utils.CreatedBySandbox
 	// todo, when resume, create Pod based on the revision from the paused state.
 	pod.Labels[agentsv1alpha1.PodLabelTemplateHash] = revision
 

--- a/pkg/controller/sandbox/core/util_test.go
+++ b/pkg/controller/sandbox/core/util_test.go
@@ -463,10 +463,13 @@ func TestGeneratePodFromSandbox(t *testing.T) {
 				if len(pod.OwnerReferences) != 1 {
 					t.Errorf("expected 1 owner reference, got %d", len(pod.OwnerReferences))
 				}
-				if pod.Annotations[utils.PodAnnotationCreatedBy] != utils.CreatedBySandbox {
-					t.Errorf("annotation %s = %s, want %s", utils.PodAnnotationCreatedBy, pod.Annotations[utils.PodAnnotationCreatedBy], utils.CreatedBySandbox)
-				}
-				if pod.Labels[agentsv1alpha1.PodLabelTemplateHash] != "rev-001" {
+			if pod.Annotations[utils.PodAnnotationCreatedBy] != utils.CreatedBySandbox {
+				t.Errorf("annotation %s = %s, want %s", utils.PodAnnotationCreatedBy, pod.Annotations[utils.PodAnnotationCreatedBy], utils.CreatedBySandbox)
+			}
+			if pod.Labels[utils.PodLabelCreatedBy] != utils.CreatedBySandbox {
+				t.Errorf("label %s = %s, want %s", utils.PodLabelCreatedBy, pod.Labels[utils.PodLabelCreatedBy], utils.CreatedBySandbox)
+			}
+			if pod.Labels[agentsv1alpha1.PodLabelTemplateHash] != "rev-001" {
 					t.Errorf("label PodLabelTemplateHash = %s, want rev-001", pod.Labels[agentsv1alpha1.PodLabelTemplateHash])
 				}
 				if len(pod.Spec.Containers) != 1 || pod.Spec.Containers[0].Image != "nginx:latest" {
@@ -509,9 +512,12 @@ func TestGeneratePodFromSandbox(t *testing.T) {
 				if pod.Annotations["team"] != "platform" {
 					t.Errorf("annotation team = %s, want platform", pod.Annotations["team"])
 				}
-				if pod.Annotations[utils.PodAnnotationCreatedBy] != utils.CreatedBySandbox {
-					t.Errorf("annotation CreatedBy missing or wrong: %s", pod.Annotations[utils.PodAnnotationCreatedBy])
-				}
+			if pod.Annotations[utils.PodAnnotationCreatedBy] != utils.CreatedBySandbox {
+				t.Errorf("annotation CreatedBy missing or wrong: %s", pod.Annotations[utils.PodAnnotationCreatedBy])
+			}
+			if pod.Labels[utils.PodLabelCreatedBy] != utils.CreatedBySandbox {
+				t.Errorf("label CreatedBy missing or wrong: %s", pod.Labels[utils.PodLabelCreatedBy])
+			}
 			},
 		},
 		{

--- a/pkg/controller/sandbox/pod_event_handler.go
+++ b/pkg/controller/sandbox/pod_event_handler.go
@@ -29,26 +29,24 @@ import (
 )
 
 // SandboxPodEventHandler watches Pods created by the Sandbox controller.
+// The informer cache is already filtered by label selector (agents.kruise.io/created-by),
+// so all events here are guaranteed to be agent-related pods.
 type SandboxPodEventHandler struct{}
 
 func (e *SandboxPodEventHandler) Create(_ context.Context, evt event.TypedCreateEvent[client.Object], w workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	if evt.Object.GetAnnotations()[utils.PodAnnotationCreatedBy] != "" {
-		w.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(evt.Object)})
-	}
+	w.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(evt.Object)})
 }
 
 func (e *SandboxPodEventHandler) Update(_ context.Context, evt event.TypedUpdateEvent[client.Object], w workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 	oldObj := evt.ObjectOld.(*corev1.Pod)
 	newObj := evt.ObjectNew.(*corev1.Pod)
-	if newObj.Annotations[utils.PodAnnotationCreatedBy] != "" && isActivePodUpdate(oldObj, newObj) {
+	if isActivePodUpdate(oldObj, newObj) {
 		w.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(evt.ObjectNew)})
 	}
 }
 
 func (e *SandboxPodEventHandler) Delete(_ context.Context, evt event.TypedDeleteEvent[client.Object], w workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	if evt.Object.GetAnnotations()[utils.PodAnnotationCreatedBy] != "" {
-		w.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(evt.Object)})
-	}
+	w.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(evt.Object)})
 }
 
 func (e *SandboxPodEventHandler) Generic(context.Context, event.TypedGenericEvent[client.Object], workqueue.TypedRateLimitingInterface[reconcile.Request]) {

--- a/pkg/utils/constant.go
+++ b/pkg/utils/constant.go
@@ -5,6 +5,9 @@ const (
 	SandboxFinalizer = "agents.kruise.io/sandbox"
 	// PodAnnotationCreatedBy is used to identify Pod source: created by Sandbox controller or externally created (bypassing Sandbox syntax sugar)
 	PodAnnotationCreatedBy = "agents.kruise.io/created-by"
+	// PodLabelCreatedBy is a label mirroring PodAnnotationCreatedBy, used as a label selector
+	// for informer filtering so that only agent-related pods are cached.
+	PodLabelCreatedBy = "agents.kruise.io/created-by"
 
 	// default sandbox deploy namespace
 	DefaultSandboxDeployNamespace = "sandbox-system"


### PR DESCRIPTION


<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
- Add agents.kruise.io/created-by as a label
- Configure the controller-runtime manager cache with label selector
- Remove redundant label check in SandboxPodEventHandler
- Add related UTs

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

Fix: https://github.com/openkruise/agents/issues/194
### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

