### PR TITLE
to achieve dynamic remounting of CSI storage after a sandbox instance…

### DIFF
--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -46,12 +46,12 @@ type commonControl struct {
 	rateLimiter          *RateLimiter
 }
 
-func NewCommonControl(c client.Client, recorder record.EventRecorder, rl *RateLimiter) SandboxControl {
+func NewCommonControl(args SandboxControlArgs) SandboxControl {
 	control := &commonControl{
-		Client:               c,
-		recorder:             recorder,
-		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(c, inplaceupdate.DefaultGeneratePatchBodyFunc),
-		rateLimiter:          rl,
+		Client:               args.Client,
+		recorder:             args.Recorder,
+		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(args.Client, inplaceupdate.DefaultGeneratePatchBodyFunc),
+		rateLimiter:          args.RateLimiter,
 	}
 	return control
 }

--- a/pkg/controller/sandbox/core/common_inplace_update_handler.go
+++ b/pkg/controller/sandbox/core/common_inplace_update_handler.go
@@ -45,7 +45,7 @@ func handleInPlaceUpdateCommon(
 ) (bool, error) {
 	logger := handler.GetLogger(ctx, box)
 
-	_, hashImmutablePart := HashSandbox(box)
+	_, hashImmutablePart := utils.HashSandbox(box)
 
 	// old Pod do not include Labels[pod-template-hash] and do not support inplace update.
 	// Check if inplace update is supported

--- a/pkg/controller/sandbox/core/common_inplace_update_handler_test.go
+++ b/pkg/controller/sandbox/core/common_inplace_update_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
 )
 
@@ -313,7 +314,7 @@ func TestHandleInPlaceUpdateCommon_QoSChangeRejected(t *testing.T) {
 		},
 	}
 
-	_, hashWithoutImageAndResource := HashSandbox(&agentsv1alpha1.Sandbox{
+	_, hashWithoutImageAndResource := utils.HashSandbox(&agentsv1alpha1.Sandbox{
 		Spec: agentsv1alpha1.SandboxSpec{
 			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
 				Template: &corev1.PodTemplateSpec{
@@ -438,7 +439,7 @@ func TestHandleInPlaceUpdateCommon_ResizeInfeasibleFailFast(t *testing.T) {
 		},
 	}
 
-	_, hashWithoutImageAndResource := HashSandbox(&agentsv1alpha1.Sandbox{
+	_, hashWithoutImageAndResource := utils.HashSandbox(&agentsv1alpha1.Sandbox{
 		Spec: agentsv1alpha1.SandboxSpec{
 			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
 				Template: &corev1.PodTemplateSpec{Spec: pod.Spec},
@@ -539,7 +540,7 @@ func TestHandleInPlaceUpdateCommon_TerminalFailureNotOverwritten(t *testing.T) {
 		},
 	}
 
-	_, hashWithoutImageAndResource := HashSandbox(&agentsv1alpha1.Sandbox{
+	_, hashWithoutImageAndResource := utils.HashSandbox(&agentsv1alpha1.Sandbox{
 		Spec: agentsv1alpha1.SandboxSpec{
 			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
 				Template: &corev1.PodTemplateSpec{Spec: pod.Spec},

--- a/pkg/controller/sandbox/core/interface.go
+++ b/pkg/controller/sandbox/core/interface.go
@@ -26,6 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/sandbox-manager/clients"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/utils/expectations"
 	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
 )
@@ -59,9 +61,17 @@ type SandboxControl interface {
 	EnsureSandboxTerminated(ctx context.Context, args EnsureFuncArgs) error
 }
 
-func NewSandboxControl(c client.Client, recorder record.EventRecorder, rl *RateLimiter) map[string]SandboxControl {
+type SandboxControlArgs struct {
+	Client        client.Client
+	Recorder      record.EventRecorder
+	RateLimiter   *RateLimiter
+	SandboxClient *clients.ClientSet
+	Cache         *sandboxcr.Cache
+}
+
+func NewSandboxControl(args SandboxControlArgs) map[string]SandboxControl {
 	controls := map[string]SandboxControl{}
-	controls[CommonControlName] = NewCommonControl(c, recorder, rl)
+	controls[CommonControlName] = NewCommonControl(args)
 	return controls
 }
 

--- a/pkg/controller/sandbox/core/util.go
+++ b/pkg/controller/sandbox/core/util.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -31,42 +30,6 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/utils"
 )
-
-// HashSandbox calculates the hash value using sandbox.spec.template
-func HashSandbox(box *agentsv1alpha1.Sandbox) (string, string) {
-	if box.Spec.Template == nil {
-		if box.Spec.TemplateRef == nil {
-			return "", ""
-		}
-		// templateRef mode does not carry inline PodTemplate in Sandbox spec.
-		// Use TemplateRef itself as a stable revision key to avoid nil dereference.
-		by, _ := json.Marshal(box.Spec.TemplateRef)
-		hash := utils.HashData(by)
-		return hash, hash
-	}
-
-	// hash using sandbox.spec.template
-	by, _ := json.Marshal(*box.Spec.Template)
-	hash := utils.HashData(by)
-
-	// hash using sandbox.spec.template without image and resources
-	tempClone := box.Spec.Template.DeepCopy()
-	tempClone.Labels = nil
-	tempClone.Annotations = nil
-	for i := range tempClone.Spec.Containers {
-		container := &tempClone.Spec.Containers[i]
-		container.Image = ""
-		container.Resources = corev1.ResourceRequirements{}
-	}
-	for i := range tempClone.Spec.InitContainers {
-		container := &tempClone.Spec.InitContainers[i]
-		container.Image = ""
-		container.Resources = corev1.ResourceRequirements{}
-	}
-	by, _ = json.Marshal(*tempClone)
-	hashImmutablePart := utils.HashData(by)
-	return hash, hashImmutablePart
-}
 
 // GeneratePVCName generates a persistent volume claim name from template name and sandbox name
 func GeneratePVCName(templateName, sandboxName string) (string, error) {

--- a/pkg/controller/sandbox/core/util_test.go
+++ b/pkg/controller/sandbox/core/util_test.go
@@ -28,244 +28,6 @@ import (
 	"github.com/openkruise/agents/pkg/utils"
 )
 
-func TestHashSandbox(t *testing.T) {
-	tests := []struct {
-		name                              string
-		sandbox                           *agentsv1alpha1.Sandbox
-		expectedHash                      string
-		expectedHashWithoutImageResources string
-		validateDifferentHashes           bool
-	}{
-		{
-			name: "basic sandbox with containers",
-			sandbox: &agentsv1alpha1.Sandbox{
-				Spec: agentsv1alpha1.SandboxSpec{
-					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
-						Template: &corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name:  "test-container",
-										Image: "nginx:latest",
-										Resources: corev1.ResourceRequirements{
-											Requests: corev1.ResourceList{
-												corev1.ResourceCPU:    resource.MustParse("100m"),
-												corev1.ResourceMemory: resource.MustParse("128Mi"),
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			validateDifferentHashes: true,
-		},
-		{
-			name: "sandbox with init containers",
-			sandbox: &agentsv1alpha1.Sandbox{
-				Spec: agentsv1alpha1.SandboxSpec{
-					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
-						Template: &corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								InitContainers: []corev1.Container{
-									{
-										Name:  "init-container",
-										Image: "busybox:latest",
-										Resources: corev1.ResourceRequirements{
-											Requests: corev1.ResourceList{
-												corev1.ResourceCPU:    resource.MustParse("50m"),
-												corev1.ResourceMemory: resource.MustParse("64Mi"),
-											},
-										},
-									},
-								},
-								Containers: []corev1.Container{
-									{
-										Name:  "test-container",
-										Image: "nginx:latest",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			validateDifferentHashes: true,
-		},
-		{
-			name: "sandbox with multiple containers",
-			sandbox: &agentsv1alpha1.Sandbox{
-				Spec: agentsv1alpha1.SandboxSpec{
-					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
-						Template: &corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								InitContainers: []corev1.Container{
-									{
-										Name:  "init-container-1",
-										Image: "busybox:1.28",
-										Resources: corev1.ResourceRequirements{
-											Requests: corev1.ResourceList{
-												corev1.ResourceCPU:    resource.MustParse("50m"),
-												corev1.ResourceMemory: resource.MustParse("64Mi"),
-											},
-										},
-									},
-									{
-										Name:  "init-container-2",
-										Image: "alpine:latest",
-									},
-								},
-								Containers: []corev1.Container{
-									{
-										Name:  "app-container",
-										Image: "myapp:1.0",
-										Resources: corev1.ResourceRequirements{
-											Limits: corev1.ResourceList{
-												corev1.ResourceCPU:    resource.MustParse("500m"),
-												corev1.ResourceMemory: resource.MustParse("512Mi"),
-											},
-										},
-									},
-									{
-										Name:  "sidecar-container",
-										Image: "sidecar:latest",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			validateDifferentHashes: true,
-		},
-		{
-			name: "sandbox with empty containers",
-			sandbox: &agentsv1alpha1.Sandbox{
-				Spec: agentsv1alpha1.SandboxSpec{
-					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
-						Template: &corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{},
-							},
-						},
-					},
-				},
-			},
-			validateDifferentHashes: false, // Both hashes should be the same when no containers have images/resources
-		},
-		{
-			name: "sandbox with labels in template but empty containers",
-			sandbox: &agentsv1alpha1.Sandbox{
-				Spec: agentsv1alpha1.SandboxSpec{
-					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
-						Template: &corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"app": "test",
-								},
-							},
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{},
-							},
-						},
-					},
-				},
-			},
-			validateDifferentHashes: true, // Both hashes should be the same when no containers have images/resources
-		},
-		{
-			name: "sandbox with volumes and other fields",
-			sandbox: &agentsv1alpha1.Sandbox{
-				Spec: agentsv1alpha1.SandboxSpec{
-					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
-						Template: &corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"app": "test",
-								},
-							},
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name:  "test-container",
-										Image: "nginx:latest",
-									},
-								},
-								Volumes: []corev1.Volume{
-									{
-										Name: "test-volume",
-										VolumeSource: corev1.VolumeSource{
-											EmptyDir: &corev1.EmptyDirVolumeSource{},
-										},
-									},
-								},
-								NodeSelector: map[string]string{
-									"kubernetes.io/os": "linux",
-								},
-							},
-						},
-					},
-				},
-			},
-			validateDifferentHashes: true,
-		},
-		{
-			name: "sandbox with templateRef only",
-			sandbox: &agentsv1alpha1.Sandbox{
-				Spec: agentsv1alpha1.SandboxSpec{
-					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
-						TemplateRef: &agentsv1alpha1.SandboxTemplateRef{
-							Name: "template-a",
-						},
-					},
-				},
-			},
-			validateDifferentHashes: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			hash, hashWithoutImageResources := HashSandbox(tt.sandbox)
-
-			// Verify both hashes are not empty
-			if hash == "" {
-				t.Errorf("HashSandbox() returned empty hash")
-			}
-			if hashWithoutImageResources == "" {
-				t.Errorf("HashSandbox() returned empty hashWithoutImageResources")
-			}
-
-			// Verify consistency - same input should always produce same output
-			hash2, hashWithoutImageResources2 := HashSandbox(tt.sandbox)
-			if hash != hash2 {
-				t.Errorf("HashSandbox() is not consistent for hash: got %s, want %s", hash, hash2)
-			}
-			if hashWithoutImageResources != hashWithoutImageResources2 {
-				t.Errorf("HashSandbox() is not consistent for hashWithoutImageResources: got %s, want %s", hashWithoutImageResources, hashWithoutImageResources2)
-			}
-
-			// Validate that hashes have expected format (from HashData function)
-			if len(hash) < 5 || len(hashWithoutImageResources) < 5 { // Basic length check
-				t.Errorf("HashSandbox() returned hashes that are too short: %s, %s", hash, hashWithoutImageResources)
-			}
-
-			// Check if the hashes should be different based on the presence of images/resources
-			if tt.validateDifferentHashes {
-				if hash == hashWithoutImageResources {
-					t.Errorf("Expected different hashes when image/resources are present, but got same: %s", hash)
-				}
-			} else {
-				if hash != hashWithoutImageResources {
-					t.Errorf("Expected same hashes when no image/resources differences, but got different: %s vs %s", hash, hashWithoutImageResources)
-				}
-			}
-		})
-	}
-}
-
 func TestHashSandboxWithNilTemplateAndNilTemplateRef(t *testing.T) {
 	sandbox := &agentsv1alpha1.Sandbox{
 		Spec: agentsv1alpha1.SandboxSpec{
@@ -276,7 +38,7 @@ func TestHashSandboxWithNilTemplateAndNilTemplateRef(t *testing.T) {
 		},
 	}
 
-	hash, hashWithoutImageResources := HashSandbox(sandbox)
+	hash, hashWithoutImageResources := utils.HashSandbox(sandbox)
 	if hash != "" {
 		t.Fatalf("expected empty hash, got %q", hash)
 	}
@@ -321,8 +83,8 @@ func TestHashSandboxWithDifferentImages(t *testing.T) {
 		},
 	}
 
-	hash1, hashWithoutImageResources1 := HashSandbox(sandbox1)
-	hash2, hashWithoutImageResources2 := HashSandbox(sandbox2)
+	hash1, hashWithoutImageResources1 := utils.HashSandbox(sandbox1)
+	hash2, hashWithoutImageResources2 := utils.HashSandbox(sandbox2)
 
 	// Full hashes should be different because images are different
 	if hash1 == hash2 {
@@ -384,8 +146,8 @@ func TestHashSandboxWithDifferentResources(t *testing.T) {
 		},
 	}
 
-	hash1, hashWithoutImageResources1 := HashSandbox(sandbox1)
-	hash2, hashWithoutImageResources2 := HashSandbox(sandbox2)
+	hash1, hashWithoutImageResources1 := utils.HashSandbox(sandbox1)
+	hash2, hashWithoutImageResources2 := utils.HashSandbox(sandbox2)
 
 	// Full hashes should be different because resources are different
 	if hash1 == hash2 {

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -43,9 +43,13 @@ import (
 	"github.com/openkruise/agents/pkg/controller/sandbox/core"
 	"github.com/openkruise/agents/pkg/discovery"
 	"github.com/openkruise/agents/pkg/features"
+	"github.com/openkruise/agents/pkg/sandbox-manager/clients"
+	managerconfig "github.com/openkruise/agents/pkg/sandbox-manager/config"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
+	"github.com/openkruise/agents/pkg/utils/webhookutils"
 )
 
 func init() {
@@ -61,11 +65,30 @@ func Add(mgr manager.Manager) error {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.SandboxGate) || !discovery.DiscoverGVK(sandboxControllerKind) {
 		return nil
 	}
+
+	clientSet, err := clients.NewClientSetWithConfig(mgr.GetConfig())
+	if err != nil {
+		return fmt.Errorf("failed to create manager client set: %w", err)
+	}
+	// Initialize cache
+	cache, err := sandboxcr.NewCache(clientSet, managerconfig.SandboxManagerOptions{
+		SystemNamespace: webhookutils.GetNamespace(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create cache: %w", err)
+	}
+
 	rateLimiter := core.NewRateLimiter()
-	err := (&SandboxReconciler{
+	err = (&SandboxReconciler{
 		Client:      mgr.GetClient(),
 		Scheme:      mgr.GetScheme(),
-		controls:    core.NewSandboxControl(mgr.GetClient(), mgr.GetEventRecorderFor("sandbox"), rateLimiter),
+		controls:    core.NewSandboxControl(core.SandboxControlArgs{
+			Client:        mgr.GetClient(),
+			Recorder:      mgr.GetEventRecorderFor("sandbox"),
+			RateLimiter:   rateLimiter,
+			SandboxClient: clientSet,
+			Cache:         cache,
+		}),
 		rateLimiter: rateLimiter,
 	}).SetupWithManager(mgr)
 	if err != nil {
@@ -264,7 +287,7 @@ func (r *SandboxReconciler) addSandboxFinalizerAndHash(ctx context.Context, box 
 	if originObj.Annotations == nil {
 		originObj.Annotations = make(map[string]string)
 	}
-	_, hashImmutablePart := core.HashSandbox(box)
+	_, hashImmutablePart := utils.HashSandbox(box)
 	originObj.Annotations[agentsv1alpha1.SandboxHashImmutablePart] = hashImmutablePart
 	if err := client.IgnoreNotFound(r.Patch(ctx, originObj, patch)); err != nil {
 		logger.Error(err, "failed to patch sandbox finalizer and hash")
@@ -300,7 +323,7 @@ func calculateStatus(args core.EnsureFuncArgs) (*agentsv1alpha1.SandboxStatus, b
 	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
 	logger := logf.FromContext(context.TODO()).WithValues("sandbox", klog.KObj(box))
 
-	hash, _ := core.HashSandbox(box)
+	hash, _ := utils.HashSandbox(box)
 	newStatus.ObservedGeneration = box.Generation
 	newStatus.UpdateRevision = hash
 	if newStatus.Phase == "" {

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -705,7 +705,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 			reconciler := &SandboxReconciler{
 				Client:      client,
 				Scheme:      scheme,
-				controls:    core.NewSandboxControl(client, fakeRecorder, rl),
+				controls:    core.NewSandboxControl(core.SandboxControlArgs{Client: client, Recorder: fakeRecorder, RateLimiter: rl}),
 				rateLimiter: rl,
 			}
 			req := ctrl.Request{
@@ -904,7 +904,7 @@ func TestSandboxReconciler_ShutdownTime(t *testing.T) {
 	reconciler := &SandboxReconciler{
 		Client:      client,
 		Scheme:      scheme,
-		controls:    core.NewSandboxControl(client, fakeRecorder, rl),
+		controls:    core.NewSandboxControl(core.SandboxControlArgs{Client: client, Recorder: fakeRecorder, RateLimiter: rl}),
 		rateLimiter: rl,
 	}
 
@@ -2127,9 +2127,13 @@ func TestReconcile_SandboxLifecycle_ClearSpecThenDelete(t *testing.T) {
 		Build()
 	rl := core.NewRateLimiter()
 	reconciler := &SandboxReconciler{
-		Client:      fakeClient,
-		Scheme:      scheme,
-		controls:    core.NewSandboxControl(fakeClient, fakeRecorder, rl),
+		Client: fakeClient,
+		Scheme: scheme,
+		controls: core.NewSandboxControl(core.SandboxControlArgs{
+			Client:      fakeClient,
+			Recorder:    fakeRecorder,
+			RateLimiter: rl,
+		}),
 		rateLimiter: rl,
 	}
 
@@ -2451,7 +2455,7 @@ func TestSandboxReconciler_Reconcile_RateLimitFeatureGate(t *testing.T) {
 			reconciler := &SandboxReconciler{
 				Client:      fakeClient,
 				Scheme:      scheme,
-				controls:    core.NewSandboxControl(fakeClient, fakeRecorder, rl),
+				controls:    core.NewSandboxControl(core.SandboxControlArgs{Client: fakeClient, Recorder: fakeRecorder, RateLimiter: rl}),
 				rateLimiter: rl,
 			}
 

--- a/pkg/sandbox-manager/config/infra.go
+++ b/pkg/sandbox-manager/config/infra.go
@@ -6,6 +6,7 @@ type InitRuntimeOptions struct {
 	EnvVars     map[string]string `json:"envVars,omitempty"`
 	AccessToken string            `json:"accessToken,omitempty"`
 	ReInit      bool              `json:"-"`
+	SkipRefresh bool              `json:"skipRefresh"`
 }
 
 const DefaultCSIMountConcurrency = 3

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -183,7 +183,7 @@ func TryClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions, pickCa
 
 	if opts.InitRuntime != nil {
 		log.Info("starting to init runtime", "opts", opts.InitRuntime)
-		metrics.InitRuntime, err = initRuntime(ctx, sbx, *opts.InitRuntime)
+		metrics.InitRuntime, err = InitRuntime(ctx, sbx, *opts.InitRuntime)
 		if err != nil {
 			log.Error(err, "failed to init runtime")
 			err = retriableError{Message: fmt.Sprintf("failed to init runtime: %s", err)}
@@ -537,7 +537,7 @@ func performLockSandbox(ctx context.Context, sbx *Sandbox, lockType infra.LockTy
 	return err
 }
 
-func initRuntime(ctx context.Context, sbx *Sandbox, opts config.InitRuntimeOptions) (time.Duration, error) {
+func InitRuntime(ctx context.Context, sbx *Sandbox, opts config.InitRuntimeOptions) (time.Duration, error) {
 	ctx = logs.Extend(ctx, "action", "initRuntime")
 	log := klog.FromContext(ctx).WithValues("sandboxID", sbx.GetName(), "resourceVersion", sbx.GetResourceVersion())
 	start := time.Now()
@@ -564,10 +564,12 @@ func initRuntime(ctx context.Context, sbx *Sandbox, opts config.InitRuntimeOptio
 			}
 		}()
 
-		initErr = sbx.InplaceRefresh(ctx, false)
-		if initErr != nil {
-			log.Error(initErr, "failed to refresh sandbox")
-			return initErr
+		if !opts.SkipRefresh {
+			initErr = sbx.InplaceRefresh(ctx, false)
+			if initErr != nil {
+				log.Error(initErr, "failed to refresh sandbox")
+				return initErr
+			}
 		}
 		runtimeURL := sbx.GetRuntimeURL()
 		if runtimeURL == "" {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -1903,7 +1903,7 @@ func TestModifyPickedSandbox_CSIMount(t *testing.T) {
 				},
 			},
 			expectedAnnos: map[string]string{
-				v1alpha1.AnnotationInitRuntimeRequest:            `{"envVars":{"KEY1":"value1","KEY2":"value2"}}`,
+				v1alpha1.AnnotationInitRuntimeRequest:            `{"envVars":{"KEY1":"value1","KEY2":"value2"},"skipRefresh":false}`,
 				models.ExtensionKeyClaimWithCSIMount_MountConfig: `{"mountOptionList":[{"pvName":"csi-pv","mountPath":"/mnt/data"}]}`,
 			},
 		},
@@ -1990,7 +1990,7 @@ func TestModifyPickedSandbox_InitRuntime(t *testing.T) {
 				},
 			},
 			expectedAnnos: map[string]string{
-				v1alpha1.AnnotationInitRuntimeRequest: `{"envVars":{"ENV1":"value1","ENV2":"value2"},"accessToken":"test-token"}`,
+				v1alpha1.AnnotationInitRuntimeRequest: `{"envVars":{"ENV1":"value1","ENV2":"value2"},"accessToken":"test-token","skipRefresh":false}`,
 				v1alpha1.AnnotationRuntimeAccessToken: "test-token",
 			},
 		},
@@ -2004,7 +2004,7 @@ func TestModifyPickedSandbox_InitRuntime(t *testing.T) {
 				},
 			},
 			expectedAnnos: map[string]string{
-				v1alpha1.AnnotationInitRuntimeRequest: `{"envVars":{"TEST_ENV":"test_value"}}`,
+				v1alpha1.AnnotationInitRuntimeRequest: `{"envVars":{"TEST_ENV":"test_value"},"skipRefresh":false}`,
 			},
 			notExpectedAnnos: []string{
 				v1alpha1.AnnotationRuntimeAccessToken,

--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -206,7 +206,7 @@ func cloneReInitRuntime(ctx context.Context, sbx *Sandbox, opts infra.CloneSandb
 	initRuntimeOpts.ReInit = true
 	log.Info("re-init runtime")
 	var err error
-	metrics.InitRuntime, err = initRuntime(ctx, sbx, *initRuntimeOpts)
+	metrics.InitRuntime, err = InitRuntime(ctx, sbx, *initRuntimeOpts)
 	if err != nil {
 		log.Error(err, "failed to init runtime")
 		return metrics, fmt.Errorf("failed to init runtime: %w", err)

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -298,7 +298,7 @@ func (s *Sandbox) Resume(ctx context.Context) error {
 	// Perform ReInit if initRuntimeOpts is set
 	if initRuntimeOpts != nil {
 		log.Info("will re-init runtime after resume")
-		if _, err := initRuntime(ctx, s, *initRuntimeOpts); err != nil {
+		if _, err := InitRuntime(ctx, s, *initRuntimeOpts); err != nil {
 			log.Error(err, "failed to perform ReInit after resume")
 			return fmt.Errorf("failed to perform ReInit after resume: %w", err)
 		}
@@ -306,7 +306,7 @@ func (s *Sandbox) Resume(ctx context.Context) error {
 	}
 
 	// Perform csi mount after resume
-	csiMountConfigRequests, err := getCsiMountExtensionRequest(s.Sandbox)
+	csiMountConfigRequests, err := GetCsiMountExtensionRequest(s.Sandbox)
 	if err != nil {
 		log.Error(err, "failed to get csi mount request")
 		return fmt.Errorf("failed to get csi mount request: %w", err)

--- a/pkg/sandbox-manager/infra/sandboxcr/utils.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/utils.go
@@ -58,7 +58,7 @@ func getInitRuntimeRequest(s metav1.Object) (*config.InitRuntimeOptions, error) 
 	return initRuntimeOpts, nil
 }
 
-func getCsiMountExtensionRequest(s metav1.Object) ([]v1alpha1.CSIMountConfig, error) {
+func GetCsiMountExtensionRequest(s metav1.Object) ([]v1alpha1.CSIMountConfig, error) {
 	var csiMountRequests []v1alpha1.CSIMountConfig
 	csiMountRequestsRaw := s.GetAnnotations()[models.ExtensionKeyClaimWithCSIMount_MountConfig]
 	if csiMountRequestsRaw == "" {

--- a/pkg/sandbox-manager/infra/sandboxcr/utils_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/utils_test.go
@@ -5,11 +5,129 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openkruise/agents/api/v1alpha1"
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/openkruise/agents/pkg/utils"
 )
+
+func TestHashSandboxWithDifferentImages(t *testing.T) {
+	// Test that changing only image results in different full hash but same hash without image/resources
+	sandbox1 := &agentsv1alpha1.Sandbox{
+		Spec: agentsv1alpha1.SandboxSpec{
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "nginx:1.19", // Different image
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	sandbox2 := &agentsv1alpha1.Sandbox{
+		Spec: agentsv1alpha1.SandboxSpec{
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "nginx:1.20", // Different image
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	hash1, hashWithoutImageResources1 := utils.HashSandbox(sandbox1)
+	hash2, hashWithoutImageResources2 := utils.HashSandbox(sandbox2)
+
+	// Full hashes should be different because images are different
+	if hash1 == hash2 {
+		t.Errorf("Expected different full hashes for different images, but got same: %s", hash1)
+	}
+
+	// Hashes without images/resources should be the same
+	if hashWithoutImageResources1 != hashWithoutImageResources2 {
+		t.Errorf("Expected same hashes without images/resources, but got different: %s vs %s",
+			hashWithoutImageResources1, hashWithoutImageResources2)
+	}
+}
+
+func TestHashSandboxWithDifferentResources(t *testing.T) {
+	// Test that changing only resources results in different full hash but same hash without image/resources
+	sandbox1 := &agentsv1alpha1.Sandbox{
+		Spec: agentsv1alpha1.SandboxSpec{
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "nginx:latest",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("100m"),
+										corev1.ResourceMemory: resource.MustParse("128Mi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	sandbox2 := &agentsv1alpha1.Sandbox{
+		Spec: agentsv1alpha1.SandboxSpec{
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "nginx:latest",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("200m"),  // Different resource
+										corev1.ResourceMemory: resource.MustParse("256Mi"), // Different resource
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	hash1, hashWithoutImageResources1 := utils.HashSandbox(sandbox1)
+	hash2, hashWithoutImageResources2 := utils.HashSandbox(sandbox2)
+
+	// Full hashes should be different because resources are different
+	if hash1 == hash2 {
+		t.Errorf("Expected different full hashes for different resources, but got same: %s", hash1)
+	}
+
+	// Hashes without images/resources should be the same
+	if hashWithoutImageResources1 != hashWithoutImageResources2 {
+		t.Errorf("Expected same hashes without images/resources, but got different: %s vs %s",
+			hashWithoutImageResources1, hashWithoutImageResources2)
+	}
+}
 
 func TestSetSandboxCondition(t *testing.T) {
 	tests := []struct {
@@ -253,7 +371,7 @@ func TestGetCsiMountExtensionRequest(t *testing.T) {
 				},
 			}
 
-			result, err := getCsiMountExtensionRequest(sandbox)
+			result, err := GetCsiMountExtensionRequest(sandbox)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -365,7 +483,7 @@ func TestGetCsiMountExtensionRequest_v2(t *testing.T) {
 				},
 			}
 
-			result, err := getCsiMountExtensionRequest(sandbox)
+			result, err := GetCsiMountExtensionRequest(sandbox)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/pkg/utils/hash_utils.go
+++ b/pkg/utils/hash_utils.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+// HashSandbox calculates the hash value using sandbox.spec.template
+func HashSandbox(box *agentsv1alpha1.Sandbox) (string, string) {
+	if box.Spec.Template == nil {
+		return "", ""
+	}
+	// hash using sandbox.spec.template
+	by, _ := json.Marshal(*box.Spec.Template)
+	hash := HashData(by)
+
+	// hash using sandbox.spec.template without image and resources
+	tempClone := box.Spec.Template.DeepCopy()
+	for i := range tempClone.Spec.Containers {
+		container := &tempClone.Spec.Containers[i]
+		container.Image = ""
+		container.Resources = corev1.ResourceRequirements{}
+	}
+	for i := range tempClone.Spec.InitContainers {
+		container := &tempClone.Spec.InitContainers[i]
+		container.Image = ""
+		container.Resources = corev1.ResourceRequirements{}
+	}
+	by, _ = json.Marshal(*tempClone)
+	hashWithoutImageResources := HashData(by)
+	return hash, hashWithoutImageResources
+}

--- a/pkg/utils/hash_utils_test.go
+++ b/pkg/utils/hash_utils_test.go
@@ -1,0 +1,216 @@
+package utils
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+func TestHashSandbox(t *testing.T) {
+	tests := []struct {
+		name                              string
+		sandbox                           *agentsv1alpha1.Sandbox
+		expectedHash                      string
+		expectedHashWithoutImageResources string
+		validateDifferentHashes           bool
+	}{
+		{
+			name: "basic sandbox with containers",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "test-container",
+										Image: "nginx:latest",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("100m"),
+												corev1.ResourceMemory: resource.MustParse("128Mi"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validateDifferentHashes: true,
+		},
+		{
+			name: "sandbox with init containers",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								InitContainers: []corev1.Container{
+									{
+										Name:  "init-container",
+										Image: "busybox:latest",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("50m"),
+												corev1.ResourceMemory: resource.MustParse("64Mi"),
+											},
+										},
+									},
+								},
+								Containers: []corev1.Container{
+									{
+										Name:  "test-container",
+										Image: "nginx:latest",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validateDifferentHashes: true,
+		},
+		{
+			name: "sandbox with multiple containers",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								InitContainers: []corev1.Container{
+									{
+										Name:  "init-container-1",
+										Image: "busybox:1.28",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("50m"),
+												corev1.ResourceMemory: resource.MustParse("64Mi"),
+											},
+										},
+									},
+									{
+										Name:  "init-container-2",
+										Image: "alpine:latest",
+									},
+								},
+								Containers: []corev1.Container{
+									{
+										Name:  "app-container",
+										Image: "myapp:1.0",
+										Resources: corev1.ResourceRequirements{
+											Limits: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("500m"),
+												corev1.ResourceMemory: resource.MustParse("512Mi"),
+											},
+										},
+									},
+									{
+										Name:  "sidecar-container",
+										Image: "sidecar:latest",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validateDifferentHashes: true,
+		},
+		{
+			name: "sandbox with empty containers",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{},
+							},
+						},
+					},
+				},
+			},
+			validateDifferentHashes: false, // Both hashes should be the same when no containers have images/resources
+		},
+		{
+			name: "sandbox with volumes and other fields",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"app": "test",
+								},
+							},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "test-container",
+										Image: "nginx:latest",
+									},
+								},
+								Volumes: []corev1.Volume{
+									{
+										Name: "test-volume",
+										VolumeSource: corev1.VolumeSource{
+											EmptyDir: &corev1.EmptyDirVolumeSource{},
+										},
+									},
+								},
+								NodeSelector: map[string]string{
+									"kubernetes.io/os": "linux",
+								},
+							},
+						},
+					},
+				},
+			},
+			validateDifferentHashes: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash, hashWithoutImageResources := HashSandbox(tt.sandbox)
+
+			// Verify both hashes are not empty
+			if hash == "" {
+				t.Errorf("HashSandbox() returned empty hash")
+			}
+			if hashWithoutImageResources == "" {
+				t.Errorf("HashSandbox() returned empty hashWithoutImageResources")
+			}
+
+			// Verify consistency - same input should always produce same output
+			hash2, hashWithoutImageResources2 := HashSandbox(tt.sandbox)
+			if hash != hash2 {
+				t.Errorf("HashSandbox() is not consistent for hash: got %s, want %s", hash, hash2)
+			}
+			if hashWithoutImageResources != hashWithoutImageResources2 {
+				t.Errorf("HashSandbox() is not consistent for hashWithoutImageResources: got %s, want %s", hashWithoutImageResources, hashWithoutImageResources2)
+			}
+
+			// Validate that hashes have expected format (from HashData function)
+			if len(hash) < 5 || len(hashWithoutImageResources) < 5 { // Basic length check
+				t.Errorf("HashSandbox() returned hashes that are too short: %s, %s", hash, hashWithoutImageResources)
+			}
+
+			// Check if the hashes should be different based on the presence of images/resources
+			if tt.validateDifferentHashes {
+				if hash == hashWithoutImageResources {
+					t.Errorf("Expected different hashes when image/resources are present, but got same: %s", hash)
+				}
+			} else {
+				if hash != hashWithoutImageResources {
+					t.Errorf("Expected same hashes when no image/resources differences, but got different: %s vs %s", hash, hashWithoutImageResources)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
… resumes from hibernation

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
1\ In order to achieve dynamic remounting of CSI storage after a sandbox instance resumes from hibernation, some shared code logic needs to be adjusted in advance. The next PR will implement CSI storage remounting after hibernation and resume based on the object-oriented approach of SandboxClaim.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

