### PR TITLE
fix(controller): fix sbx fails to enter the Running stage when using templateRef

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -55,6 +55,15 @@ rules:
 - apiGroups:
   - agents.kruise.io
   resources:
+  - checkpoints
+  - sandboxtemplates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - agents.kruise.io
+  resources:
   - sandboxclaims
   verbs:
   - delete

--- a/pkg/controller/sandbox/core/util.go
+++ b/pkg/controller/sandbox/core/util.go
@@ -34,6 +34,17 @@ import (
 
 // HashSandbox calculates the hash value using sandbox.spec.template
 func HashSandbox(box *agentsv1alpha1.Sandbox) (string, string) {
+	if box.Spec.Template == nil {
+		if box.Spec.TemplateRef == nil {
+			return "", ""
+		}
+		// templateRef mode does not carry inline PodTemplate in Sandbox spec.
+		// Use TemplateRef itself as a stable revision key to avoid nil dereference.
+		by, _ := json.Marshal(box.Spec.TemplateRef)
+		hash := utils.HashData(by)
+		return hash, hash
+	}
+
 	// hash using sandbox.spec.template
 	by, _ := json.Marshal(*box.Spec.Template)
 	hash := utils.HashData(by)

--- a/pkg/controller/sandbox/core/util_test.go
+++ b/pkg/controller/sandbox/core/util_test.go
@@ -191,6 +191,19 @@ func TestHashSandbox(t *testing.T) {
 			},
 			validateDifferentHashes: true,
 		},
+		{
+			name: "sandbox with templateRef only",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						TemplateRef: &agentsv1alpha1.SandboxTemplateRef{
+							Name: "template-a",
+						},
+					},
+				},
+			},
+			validateDifferentHashes: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -230,6 +243,25 @@ func TestHashSandbox(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestHashSandboxWithNilTemplateAndNilTemplateRef(t *testing.T) {
+	sandbox := &agentsv1alpha1.Sandbox{
+		Spec: agentsv1alpha1.SandboxSpec{
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template:    nil,
+				TemplateRef: nil,
+			},
+		},
+	}
+
+	hash, hashWithoutImageResources := HashSandbox(sandbox)
+	if hash != "" {
+		t.Fatalf("expected empty hash, got %q", hash)
+	}
+	if hashWithoutImageResources != "" {
+		t.Fatalf("expected empty hashWithoutImageResources, got %q", hashWithoutImageResources)
 	}
 }
 

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -84,6 +84,8 @@ type SandboxReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=agents.kruise.io,resources=sandboxes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=agents.kruise.io,resources=sandboxtemplates,verbs=get;list;watch
+// +kubebuilder:rbac:groups=agents.kruise.io,resources=checkpoints,verbs=get;list;watch
 // +kubebuilder:rbac:groups=agents.kruise.io,resources=sandboxes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=agents.kruise.io,resources=sandboxes/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
@@ -120,7 +122,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 	// Record sandbox lifecycle metrics on every reconcile
 	recordSandboxMetrics(box)
 
-	if box.Spec.Template == nil {
+	if box.Spec.Template == nil && box.Spec.TemplateRef == nil {
 		if !box.DeletionTimestamp.IsZero() {
 			newStatus := box.Status.DeepCopy()
 			args := core.EnsureFuncArgs{Pod: pod, Box: box, NewStatus: newStatus}

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
@@ -2,6 +2,8 @@ package sandboxcr
 
 import (
 	"context"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -20,6 +22,7 @@ import (
 	"github.com/openkruise/agents/pkg/proxy"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/utils"
+	"github.com/openkruise/agents/pkg/utils/sandbox-manager/proxyutils"
 )
 
 func ConvertPodToSandboxCR(pod *corev1.Pod) *v1alpha1.Sandbox {
@@ -351,6 +354,91 @@ func TestSandbox_GetTimeout(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestSandbox_SetImageAndGetImage(t *testing.T) {
+	t.Run("set and get image with template", func(t *testing.T) {
+		s := &Sandbox{
+			Sandbox: &v1alpha1.Sandbox{
+				Spec: v1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "app",
+										Image: "nginx:old",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		s.SetImage("nginx:new")
+		assert.Equal(t, "nginx:new", s.GetImage())
+	})
+
+	t.Run("set and get image with nil template", func(t *testing.T) {
+		s := &Sandbox{
+			Sandbox: &v1alpha1.Sandbox{
+				Spec: v1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: nil,
+					},
+				},
+			},
+		}
+
+		assert.NotPanics(t, func() {
+			s.SetImage("nginx:new")
+		})
+		assert.Equal(t, "", s.GetImage())
+	})
+}
+
+func TestSandbox_GetSandboxID(t *testing.T) {
+	s := &Sandbox{
+		Sandbox: &v1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "test-sandbox",
+			},
+		},
+	}
+
+	assert.Equal(t, "default--test-sandbox", s.GetSandboxID())
+}
+
+func TestSandbox_Request(t *testing.T) {
+	orig := proxyutils.DefaultRequestFunc
+	t.Cleanup(func() {
+		proxyutils.DefaultRequestFunc = orig
+	})
+
+	proxyutils.DefaultRequestFunc = func(ctx context.Context, sbx *v1alpha1.Sandbox, method, path string, port int, body io.Reader) (*http.Response, error) {
+		assert.Equal(t, "GET", method)
+		assert.Equal(t, "/healthz", path)
+		assert.Equal(t, 8080, port)
+		assert.Equal(t, "default", sbx.Namespace)
+		assert.Equal(t, "test-sandbox", sbx.Name)
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	}
+
+	s := &Sandbox{
+		Sandbox: &v1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "test-sandbox",
+			},
+		},
+	}
+	resp, err := s.Request(context.Background(), "GET", "/healthz", 8080, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func TestSandbox_SaveTimeout(t *testing.T) {

--- a/test/e2e/sandbox_test.go
+++ b/test/e2e/sandbox_test.go
@@ -103,10 +103,85 @@ var _ = Describe("Sandbox", func() {
 					Namespace: sandbox.Namespace,
 				}, sandbox)
 				return sandbox.Status.Phase
-			}, time.Second*30, time.Millisecond*500).Should(Equal(agentsv1alpha1.SandboxRunning))
+			}, time.Second*90, time.Millisecond*500).Should(Equal(agentsv1alpha1.SandboxRunning))
 
 			By("Verifying the sandbox has latest revision")
 			Expect(sandbox.Status.UpdateRevision).NotTo(BeEmpty())
+		})
+
+		It("should create sandbox from templateRef and transition to running phase", func() {
+			templateName := fmt.Sprintf("test-template-%d", time.Now().UnixNano())
+			templateImage := "nginx:stable-alpine3.23"
+			sandboxTemplate := &agentsv1alpha1.SandboxTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      templateName,
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxTemplateSpec{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "test-container",
+									Image: templateImage,
+									Ports: []corev1.ContainerPort{
+										{
+											Name:          "http",
+											ContainerPort: 80,
+										},
+									},
+								},
+							},
+							RestartPolicy: corev1.RestartPolicyNever,
+						},
+					},
+				},
+			}
+
+			By("Creating a new SandboxTemplate")
+			Expect(k8sClient.Create(ctx, sandboxTemplate)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, sandboxTemplate)
+			}()
+
+			sandbox = &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-sandbox-template-ref-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						TemplateRef: &agentsv1alpha1.SandboxTemplateRef{
+							Name: templateName,
+						},
+					},
+				},
+			}
+
+			By("Creating a new Sandbox with templateRef")
+			Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+
+			By("Waiting for sandbox to reach Running phase")
+			Eventually(func() agentsv1alpha1.SandboxPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      sandbox.Name,
+					Namespace: sandbox.Namespace,
+				}, sandbox)
+				return sandbox.Status.Phase
+			}, time.Second*60, time.Millisecond*500).Should(Equal(agentsv1alpha1.SandboxRunning))
+
+			By("Verifying pod image is from SandboxTemplate")
+			pod := &corev1.Pod{}
+			Eventually(func() string {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      sandbox.Name,
+					Namespace: sandbox.Namespace,
+				}, pod)
+				if len(pod.Spec.Containers) == 0 {
+					return ""
+				}
+				return pod.Spec.Containers[0].Image
+			}, time.Second*30, time.Millisecond*500).Should(Equal(templateImage))
 		})
 	})
 


### PR DESCRIPTION

### Background
create sbx by using templateRef, but sbx fails to enter the Running stage.

use below case can reproduce this problem
```
kubectl apply -f - <<EOF
apiVersion: agents.kruise.io/v1alpha1
kind: SandboxTemplate
metadata:
  name: nginx-template
spec:
  template:
    spec:
      restartPolicy: Never
      containers:
      - name: test-container
        image: nginx:stable-alpine3.23
        ports:
        - name: http
          containerPort: 80
---
apiVersion: agents.kruise.io/v1alpha1
kind: Sandbox
metadata:
  name: sbx-template-ref
spec:
  templateRef:
    name: nginx-template
EOF

```

after apply yaml above, I found there some ERROR msgs in controller:
```
2026-04-06T16:46:49.4983862Z E0406 16:39:59.406477       1 reflector.go:200] "Failed to watch" err="failed to list *v1alpha1.SandboxTemplate: sandboxtemplates.agents.kruise.io is forbidden: User \"system:serviceaccount:sandbox-system:sandbox-controller-manager\" cannot list resource \"sandboxtemplates\" in API group \"agents.kruise.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.33.0/tools/cache/reflector.go:285" type="*v1alpha1.SandboxTemplate"
```

In addition to permission issues, the following fixes seems also required:
- allow reconcile when spec.templateRef is set (without inline spec.template)
- make HashSandbox safe for templateRef-only sandboxes to prevent nil dereference


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

I add a new e2e test case "should create sandbox from templateRef and transition to running phase" to verify it


### Ⅳ. Special notes for reviews

