### PR TITLE
Prometheus Metrics for SandboxManager

### DIFF
--- a/pkg/proxy/metrics.go
+++ b/pkg/proxy/metrics.go
@@ -1,0 +1,28 @@
+package proxy
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// RoutesTotal tracks the current number of routes in the proxy routing table.
+	RoutesTotal = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "sandboxmanager_routes_total",
+			Help: "Total number of routes currently managed",
+		},
+	)
+
+	// PeersTotal tracks the current number of peers connected.
+	PeersTotal = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "sandboxmanager_peers_total",
+			Help: "Total number of peers currently connected",
+		},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(RoutesTotal, PeersTotal)
+}

--- a/pkg/proxy/metrics_test.go
+++ b/pkg/proxy/metrics_test.go
@@ -1,0 +1,69 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+)
+
+func TestRoutesTotal_IncrementOnNewRoute(t *testing.T) {
+	s := NewServer(nil, nil, config.SandboxManagerOptions{})
+	ctx := context.Background()
+
+	before := testutil.ToFloat64(RoutesTotal)
+	s.SetRoute(ctx, Route{ID: "sb-1", IP: "1.2.3.4", UID: types.UID("uid-1"), ResourceVersion: "1"})
+	after := testutil.ToFloat64(RoutesTotal)
+
+	assert.Equal(t, float64(1), after-before, "RoutesTotal should increment by 1 on new route")
+}
+
+func TestRoutesTotal_NoIncrementOnUpdate(t *testing.T) {
+	s := NewServer(nil, nil, config.SandboxManagerOptions{})
+	ctx := context.Background()
+
+	s.SetRoute(ctx, Route{ID: "sb-2", IP: "1.2.3.4", UID: types.UID("uid-2"), ResourceVersion: "1"})
+	before := testutil.ToFloat64(RoutesTotal)
+
+	// Update same route with newer version
+	s.SetRoute(ctx, Route{ID: "sb-2", IP: "5.6.7.8", UID: types.UID("uid-2"), ResourceVersion: "2"})
+	after := testutil.ToFloat64(RoutesTotal)
+
+	assert.Equal(t, float64(0), after-before, "RoutesTotal should not increment on route update")
+}
+
+func TestRoutesTotal_DecrementOnDelete(t *testing.T) {
+	s := NewServer(nil, nil, config.SandboxManagerOptions{})
+	ctx := context.Background()
+
+	s.SetRoute(ctx, Route{ID: "sb-3", IP: "1.2.3.4", UID: types.UID("uid-3"), ResourceVersion: "1"})
+	before := testutil.ToFloat64(RoutesTotal)
+
+	s.DeleteRoute("sb-3")
+	after := testutil.ToFloat64(RoutesTotal)
+
+	assert.Equal(t, float64(-1), after-before, "RoutesTotal should decrement by 1 on delete")
+}
+
+func TestRoutesTotal_NoDecrementOnDeleteNonExistent(t *testing.T) {
+	s := NewServer(nil, nil, config.SandboxManagerOptions{})
+
+	before := testutil.ToFloat64(RoutesTotal)
+	s.DeleteRoute("non-existent")
+	after := testutil.ToFloat64(RoutesTotal)
+
+	assert.Equal(t, float64(0), after-before, "RoutesTotal should not change when deleting non-existent route")
+}
+
+func TestPeersTotal_SetOnSyncRouteWithPeers(t *testing.T) {
+	mp := newMockPeers()
+	s := NewServer(nil, mp, config.SandboxManagerOptions{})
+
+	// No peers
+	_ = s.SyncRouteWithPeers(Route{ID: "sb-1", IP: "1.2.3.4", ResourceVersion: "1"})
+	assert.Equal(t, float64(0), testutil.ToFloat64(PeersTotal))
+}

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -50,6 +50,7 @@ func (s *Server) SetRoute(ctx context.Context, route Route) {
 		old, loaded := s.routes.LoadOrStore(route.ID, route)
 		if !loaded {
 			// First write, success directly
+			RoutesTotal.Inc()
 			return
 		}
 
@@ -81,6 +82,7 @@ func (s *Server) SyncRouteWithPeers(route Route) error {
 	if s.peersManager != nil {
 		peerList = s.peersManager.GetPeers()
 	}
+	PeersTotal.Set(float64(len(peerList)))
 
 	if len(peerList) == 0 {
 		return nil
@@ -146,7 +148,9 @@ func (s *Server) ListPeers() []peers.Peer {
 }
 
 func (s *Server) DeleteRoute(id string) {
-	s.routes.Delete(id)
+	if _, loaded := s.routes.LoadAndDelete(id); loaded {
+		RoutesTotal.Dec()
+	}
 }
 
 // RequestAdapter is used to register the mapping from business-side sandbox requests to internal logic

--- a/pkg/sandbox-manager/api.go
+++ b/pkg/sandbox-manager/api.go
@@ -18,23 +18,36 @@ func (m *SandboxManager) ClaimSandbox(ctx context.Context, opts infra.ClaimSandb
 	if !m.infra.HasTemplate(opts.Template) {
 		// Requirement: Track failure in API layer
 		SandboxCreationResponses.WithLabelValues("failure").Inc()
+		SandboxClaimTotal.WithLabelValues("failure", "").Inc()
 		return nil, errors.NewError(errors.ErrorNotFound, fmt.Sprintf("template %s not found", opts.Template))
 	}
-	sandbox, metrics, err := m.infra.ClaimSandbox(ctx, opts)
+	sandbox, claimMetrics, err := m.infra.ClaimSandbox(ctx, opts)
 	if err != nil {
-		log.Error(err, "failed to claim sandbox", "metrics", metrics.String())
+		log.Error(err, "failed to claim sandbox", "metrics", claimMetrics.String())
 		// Requirement: Track failure in API layer
 		SandboxCreationResponses.WithLabelValues("failure").Inc()
+		SandboxClaimTotal.WithLabelValues("failure", "").Inc()
 		return nil, errors.NewError(errors.ErrorInternal, fmt.Sprintf("failed to claim sandbox: %v", err))
 	}
 
 	// Success: Record metrics
 	SandboxCreationResponses.WithLabelValues("success").Inc()
 	// Requirement: Only measure the latency when no error exists
-	SandboxCreationLatency.Observe(float64(metrics.Total.Milliseconds()))
+	SandboxCreationLatency.Observe(float64(claimMetrics.Total.Milliseconds()))
+
+	// Claim-specific metrics
+	SandboxClaimDuration.Observe(float64(claimMetrics.Total.Milliseconds()))
+	SandboxClaimTotal.WithLabelValues("success", string(claimMetrics.LockType)).Inc()
+	SandboxClaimRetries.Observe(float64(claimMetrics.Retries))
+	SandboxClaimStageDuration.WithLabelValues("wait").Observe(float64(claimMetrics.Wait.Milliseconds()))
+	SandboxClaimStageDuration.WithLabelValues("retry_cost").Observe(float64(claimMetrics.RetryCost.Milliseconds()))
+	SandboxClaimStageDuration.WithLabelValues("pick_and_lock").Observe(float64(claimMetrics.PickAndLock.Milliseconds()))
+	SandboxClaimStageDuration.WithLabelValues("wait_ready").Observe(float64(claimMetrics.WaitReady.Milliseconds()))
+	SandboxClaimStageDuration.WithLabelValues("init_runtime").Observe(float64(claimMetrics.InitRuntime.Milliseconds()))
+	SandboxClaimStageDuration.WithLabelValues("csi_mount").Observe(float64(claimMetrics.CSIMount.Milliseconds()))
 
 	state, reason := sandbox.GetState()
-	log.Info("sandbox claimed", "sandbox", klog.KObj(sandbox), "metrics", metrics.String(), "state", state, "reason", reason)
+	log.Info("sandbox claimed", "sandbox", klog.KObj(sandbox), "metrics", claimMetrics.String(), "state", state, "reason", reason)
 
 	// Sync route without refresh since sandbox was just claimed and state is already up-to-date
 	if err = m.syncRoute(ctx, sandbox, false); err != nil {
@@ -45,19 +58,30 @@ func (m *SandboxManager) ClaimSandbox(ctx context.Context, opts infra.ClaimSandb
 
 func (m *SandboxManager) CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions) (infra.Sandbox, error) {
 	log := klog.FromContext(ctx)
-	sandbox, metrics, err := m.infra.CloneSandbox(ctx, opts)
+	sandbox, cloneMetrics, err := m.infra.CloneSandbox(ctx, opts)
 	if err != nil {
-		log.Error(err, "failed to clone sandbox", "metrics", metrics)
+		log.Error(err, "failed to clone sandbox", "metrics", cloneMetrics)
 		SandboxCreationResponses.WithLabelValues("failure").Inc()
+		SandboxCloneTotal.WithLabelValues("failure").Inc()
 		return nil, errors.NewError(errors.ErrorInternal, fmt.Sprintf("failed to clone sandbox: %v", err))
 	}
 	// Success: Record metrics
 	SandboxCreationResponses.WithLabelValues("success").Inc()
 	// Requirement: Only measure the latency when no error exists
-	SandboxCreationLatency.Observe(float64(metrics.Total.Milliseconds()))
+	SandboxCreationLatency.Observe(float64(cloneMetrics.Total.Milliseconds()))
+
+	// Clone-specific metrics
+	SandboxCloneDuration.Observe(float64(cloneMetrics.Total.Milliseconds()))
+	SandboxCloneTotal.WithLabelValues("success").Inc()
+	SandboxCloneStageDuration.WithLabelValues("wait").Observe(float64(cloneMetrics.Wait.Milliseconds()))
+	SandboxCloneStageDuration.WithLabelValues("get_template").Observe(float64(cloneMetrics.GetTemplate.Milliseconds()))
+	SandboxCloneStageDuration.WithLabelValues("create_sandbox").Observe(float64(cloneMetrics.CreateSandbox.Milliseconds()))
+	SandboxCloneStageDuration.WithLabelValues("wait_ready").Observe(float64(cloneMetrics.WaitReady.Milliseconds()))
+	SandboxCloneStageDuration.WithLabelValues("init_runtime").Observe(float64(cloneMetrics.InitRuntime.Milliseconds()))
+	SandboxCloneStageDuration.WithLabelValues("csi_mount").Observe(float64(cloneMetrics.CSIMount.Milliseconds()))
 
 	state, reason := sandbox.GetState()
-	log.Info("sandbox cloned", "sandbox", klog.KObj(sandbox), "metrics", metrics.String(), "state", state, "reason", reason)
+	log.Info("sandbox cloned", "sandbox", klog.KObj(sandbox), "metrics", cloneMetrics.String(), "state", state, "reason", reason)
 
 	// Sync route without refresh since sandbox was just claimed and state is already up-to-date
 	if err = m.syncRoute(ctx, sandbox, false); err != nil {
@@ -151,10 +175,15 @@ func (m *SandboxManager) syncRoute(ctx context.Context, sbx infra.Sandbox, refre
 	route := sbx.GetRoute()
 	m.proxy.SetRoute(ctx, route)
 	err := m.proxy.SyncRouteWithPeers(route)
+	duration := float64(time.Since(start).Milliseconds())
 	if err != nil {
 		log.Error(err, "failed to sync route with peers")
+		RouteSyncTotal.WithLabelValues("sync_with_peers", "failure").Inc()
 		return err
 	}
+	RouteSyncDuration.WithLabelValues("sync_with_peers").Observe(duration)
+	RouteSyncTotal.WithLabelValues("sync_with_peers", "success").Inc()
+	RouteSyncDelay.Set(duration)
 	log.Info("route synced with peers", "cost", time.Since(start), "route", route)
 	return nil
 }
@@ -162,26 +191,38 @@ func (m *SandboxManager) syncRoute(ctx context.Context, sbx infra.Sandbox, refre
 // PauseSandbox pauses a sandbox and syncs route with peers
 func (m *SandboxManager) PauseSandbox(ctx context.Context, sbx infra.Sandbox, opts infra.PauseOptions) error {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
+	start := time.Now()
 	if err := sbx.Pause(ctx, opts); err != nil {
 		log.Error(err, "failed to pause sandbox")
+		SandboxPauseTotal.WithLabelValues("failure").Inc()
 		return err
 	}
 	if err := m.syncRoute(ctx, sbx, true); err != nil {
 		log.Error(err, "failed to sync route with peers after pause")
 	}
+	duration := float64(time.Since(start).Milliseconds())
+	SandboxPauseDuration.Observe(duration)
+	SandboxPauseTotal.WithLabelValues("success").Inc()
+	observeMax(SandboxPauseMaxDuration, duration)
 	return nil
 }
 
 // ResumeSandbox resumes a sandbox and syncs route with peers
 func (m *SandboxManager) ResumeSandbox(ctx context.Context, sbx infra.Sandbox) error {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
+	start := time.Now()
 	if err := sbx.Resume(ctx); err != nil {
 		log.Error(err, "failed to resume sandbox")
+		SandboxResumeTotal.WithLabelValues("failure").Inc()
 		return err
 	}
 	if err := m.syncRoute(ctx, sbx, true); err != nil {
 		log.Error(err, "failed to sync route with peers after resume")
 	}
+	duration := float64(time.Since(start).Milliseconds())
+	SandboxResumeDuration.Observe(duration)
+	SandboxResumeTotal.WithLabelValues("success").Inc()
+	observeMax(SandboxResumeMaxDuration, duration)
 	return nil
 }
 

--- a/pkg/sandbox-manager/metrics.go
+++ b/pkg/sandbox-manager/metrics.go
@@ -2,6 +2,7 @@ package sandbox_manager // Shared with api.go
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -23,9 +24,180 @@ var (
 		},
 		[]string{"result"}, // "success" or "failure"
 	)
+
+	// --- Pause metrics ---
+
+	SandboxPauseDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "sandboxmanager_pause_duration_ms",
+			Help:    "Pause operation latency in milliseconds",
+			Buckets: prometheus.ExponentialBuckets(10, 2, 10),
+		},
+	)
+
+	SandboxPauseMaxDuration = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "sandboxmanager_pause_max_duration_ms",
+			Help: "Maximum pause operation duration observed",
+		},
+	)
+
+	SandboxPauseTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sandboxmanager_pause_total",
+			Help: "Total number of pause operations",
+		},
+		[]string{"status"},
+	)
+
+	// --- Resume metrics ---
+
+	SandboxResumeDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "sandboxmanager_resume_duration_ms",
+			Help:    "Resume operation latency in milliseconds",
+			Buckets: prometheus.ExponentialBuckets(10, 2, 10),
+		},
+	)
+
+	SandboxResumeMaxDuration = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "sandboxmanager_resume_max_duration_ms",
+			Help: "Maximum resume operation duration observed",
+		},
+	)
+
+	SandboxResumeTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sandboxmanager_resume_total",
+			Help: "Total number of resume operations",
+		},
+		[]string{"status"},
+	)
+
+	// --- Claim metrics ---
+
+	SandboxClaimDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "sandboxmanager_claim_duration_ms",
+			Help:    "Total claim operation latency in milliseconds",
+			Buckets: prometheus.ExponentialBuckets(10, 2, 10),
+		},
+	)
+
+	SandboxClaimStageDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "sandboxmanager_claim_stage_duration_ms",
+			Help:    "Duration of each claim stage in milliseconds",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 12),
+		},
+		[]string{"stage"},
+	)
+
+	SandboxClaimTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sandboxmanager_claim_total",
+			Help: "Total number of claim operations",
+		},
+		[]string{"status", "lock_type"},
+	)
+
+	SandboxClaimRetries = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "sandboxmanager_claim_retries",
+			Help:    "Number of retries per claim operation",
+			Buckets: prometheus.LinearBuckets(0, 1, 11),
+		},
+	)
+
+	// --- Clone metrics ---
+
+	SandboxCloneDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "sandboxmanager_clone_duration_ms",
+			Help:    "Total clone operation latency in milliseconds",
+			Buckets: prometheus.ExponentialBuckets(10, 2, 10),
+		},
+	)
+
+	SandboxCloneStageDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "sandboxmanager_clone_stage_duration_ms",
+			Help:    "Duration of each clone stage in milliseconds",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 12),
+		},
+		[]string{"stage"},
+	)
+
+	SandboxCloneTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sandboxmanager_clone_total",
+			Help: "Total number of clone operations",
+		},
+		[]string{"status"},
+	)
+
+	// --- Route sync metrics ---
+
+	RouteSyncDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "sandboxmanager_route_sync_duration_ms",
+			Help:    "Route synchronization latency in milliseconds",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 10),
+		},
+		[]string{"type"},
+	)
+
+	RouteSyncTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sandboxmanager_route_sync_total",
+			Help: "Total number of route sync operations",
+		},
+		[]string{"type", "status"},
+	)
+
+	RouteSyncDelay = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "sandboxmanager_route_sync_delay_ms",
+			Help: "Current routing synchronization delay in milliseconds",
+		},
+	)
 )
+
+// observeMax updates a Gauge to the maximum of its current value and the new value.
+func observeMax(g prometheus.Gauge, val float64) {
+	m := &dto.Metric{}
+	_ = g.Write(m)
+	if val > m.GetGauge().GetValue() {
+		g.Set(val)
+	}
+}
 
 func init() {
 	// Register custom metrics with the global prometheus registry
-	metrics.Registry.MustRegister(SandboxCreationLatency, SandboxCreationResponses)
+	metrics.Registry.MustRegister(
+		SandboxCreationLatency,
+		SandboxCreationResponses,
+		// Pause
+		SandboxPauseDuration,
+		SandboxPauseMaxDuration,
+		SandboxPauseTotal,
+		// Resume
+		SandboxResumeDuration,
+		SandboxResumeMaxDuration,
+		SandboxResumeTotal,
+		// Claim
+		SandboxClaimDuration,
+		SandboxClaimStageDuration,
+		SandboxClaimTotal,
+		SandboxClaimRetries,
+		// Clone
+		SandboxCloneDuration,
+		SandboxCloneStageDuration,
+		SandboxCloneTotal,
+		// Route sync
+		RouteSyncDuration,
+		RouteSyncTotal,
+		RouteSyncDelay,
+	)
 }

--- a/pkg/sandbox-manager/metrics_test.go
+++ b/pkg/sandbox-manager/metrics_test.go
@@ -1,0 +1,57 @@
+package sandbox_manager
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestObserveMax(t *testing.T) {
+	g := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "test_observe_max",
+		Help: "test gauge",
+	})
+
+	// Initial value should be 0
+	assert.Equal(t, float64(0), testutil.ToFloat64(g))
+
+	// Set to 100
+	observeMax(g, 100)
+	assert.Equal(t, float64(100), testutil.ToFloat64(g))
+
+	// Lower value should not update
+	observeMax(g, 50)
+	assert.Equal(t, float64(100), testutil.ToFloat64(g))
+
+	// Higher value should update
+	observeMax(g, 200)
+	assert.Equal(t, float64(200), testutil.ToFloat64(g))
+
+	// Equal value should not change
+	observeMax(g, 200)
+	assert.Equal(t, float64(200), testutil.ToFloat64(g))
+}
+
+func TestMetricsRegistered(t *testing.T) {
+	// Verify all metrics are non-nil (init() registered them)
+	assert.NotNil(t, SandboxCreationLatency)
+	assert.NotNil(t, SandboxCreationResponses)
+	assert.NotNil(t, SandboxPauseDuration)
+	assert.NotNil(t, SandboxPauseMaxDuration)
+	assert.NotNil(t, SandboxPauseTotal)
+	assert.NotNil(t, SandboxResumeDuration)
+	assert.NotNil(t, SandboxResumeMaxDuration)
+	assert.NotNil(t, SandboxResumeTotal)
+	assert.NotNil(t, SandboxClaimDuration)
+	assert.NotNil(t, SandboxClaimStageDuration)
+	assert.NotNil(t, SandboxClaimTotal)
+	assert.NotNil(t, SandboxClaimRetries)
+	assert.NotNil(t, SandboxCloneDuration)
+	assert.NotNil(t, SandboxCloneStageDuration)
+	assert.NotNil(t, SandboxCloneTotal)
+	assert.NotNil(t, RouteSyncDuration)
+	assert.NotNil(t, RouteSyncTotal)
+	assert.NotNil(t, RouteSyncDelay)
+}

--- a/pkg/servers/e2b/metrics.go
+++ b/pkg/servers/e2b/metrics.go
@@ -1,0 +1,30 @@
+package e2b
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// SnapshotDuration tracks snapshot creation latency.
+	SnapshotDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "sandboxmanager_snapshot_duration_ms",
+			Help:    "Snapshot creation latency in milliseconds",
+			Buckets: prometheus.ExponentialBuckets(100, 2, 10), // 100ms to ~100s
+		},
+	)
+
+	// SnapshotTotal tracks total snapshot operations.
+	SnapshotTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sandboxmanager_snapshot_total",
+			Help: "Total number of snapshot operations",
+		},
+		[]string{"status"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(SnapshotDuration, SnapshotTotal)
+}

--- a/pkg/servers/e2b/metrics_test.go
+++ b/pkg/servers/e2b/metrics_test.go
@@ -1,0 +1,12 @@
+package e2b
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSnapshotMetricsRegistered(t *testing.T) {
+	assert.NotNil(t, SnapshotDuration)
+	assert.NotNil(t, SnapshotTotal)
+}

--- a/pkg/servers/e2b/snapshot.go
+++ b/pkg/servers/e2b/snapshot.go
@@ -17,6 +17,7 @@ func (sc *Controller) CreateSnapshot(r *http.Request) (web.ApiResponse[*models.S
 	ctx := r.Context()
 	sandboxID := r.PathValue("sandboxID")
 	log := klog.FromContext(ctx)
+	start := time.Now()
 	request, parseErr := sc.parseCreateSnapshotRequest(r)
 	if parseErr != nil {
 		return web.ApiResponse[*models.Snapshot]{}, parseErr
@@ -41,10 +42,13 @@ func (sc *Controller) CreateSnapshot(r *http.Request) (web.ApiResponse[*models.S
 	})
 	if err != nil {
 		log.Error(err, "failed to create checkpoint")
+		SnapshotTotal.WithLabelValues("failure").Inc()
 		return web.ApiResponse[*models.Snapshot]{}, &web.ApiError{
 			Message: err.Error(),
 		}
 	}
+	SnapshotDuration.Observe(float64(time.Since(start).Milliseconds()))
+	SnapshotTotal.WithLabelValues("success").Inc()
 	return web.ApiResponse[*models.Snapshot]{
 		Code: http.StatusCreated,
 		Body: &models.Snapshot{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds comprehensive Prometheus metrics to the SandboxManager to improve observability across all major sandbox lifecycle operations. Prior to this change, only two metrics existed (`sandbox_creation_latency_ms`, `sandbox_creation_responses`), leaving pause/resume, claim stages, clone stages, snapshot creation, and route synchronization completely unobservable.

**New metrics added (20 total across 6 categories):**

| Metric | Type | Description |
|---|---|---|
| `sandboxmanager_pause_duration_ms` | Histogram | Pause operation latency |
| `sandboxmanager_pause_max_duration_ms` | Gauge | All-time max pause duration |
| `sandboxmanager_pause_total` | Counter | Pause operation count by outcome |
| `sandboxmanager_resume_duration_ms` | Histogram | Resume operation latency |
| `sandboxmanager_resume_max_duration_ms` | Gauge | All-time max resume duration |
| `sandboxmanager_resume_total` | Counter | Resume operation count by outcome |
| `sandboxmanager_claim_duration_ms` | Histogram | Total claim operation latency |
| `sandboxmanager_claim_stage_duration_ms` | Histogram | Per-stage claim breakdown |
| `sandboxmanager_claim_total` | Counter | Claim count by outcome and lock strategy |
| `sandboxmanager_claim_retries` | Histogram | Retries per claim operation |
| `sandboxmanager_clone_duration_ms` | Histogram | Total clone operation latency |
| `sandboxmanager_clone_stage_duration_ms` | Histogram | Per-stage clone breakdown |
| `sandboxmanager_clone_total` | Counter | Clone count by outcome |
| `sandboxmanager_snapshot_duration_ms` | Histogram | Snapshot creation latency |
| `sandboxmanager_snapshot_total` | Counter | Snapshot count by outcome |
| `sandboxmanager_route_sync_duration_ms` | Histogram | Route sync latency |
| `sandboxmanager_route_sync_total` | Counter | Route sync count by type and outcome |
| `sandboxmanager_route_sync_delay_ms` | Gauge | Last observed route sync delay |
| `sandboxmanager_routes_total` | Gauge | Current number of managed routes |
| `sandboxmanager_peers_total` | Gauge | Current number of connected peers |



### Ⅱ. Does this pull request fix one issue?

fixes #263 

### Ⅲ. Describe how to verify it

All unit tests are passing.
Example queries once scraped by Prometheus:
```
# Pause success rate
rate(sandboxmanager_pause_total{status="success"}[5m])
  / rate(sandboxmanager_pause_total[5m])

# Claim p99 latency per stage
histogram_quantile(0.99,
  rate(sandboxmanager_claim_stage_duration_ms_bucket[5m]))

# Route sync p99
histogram_quantile(0.99,
  rate(sandboxmanager_route_sync_duration_ms_bucket[5m]))

# Current routing table size
sandboxmanager_routes_total

```

