### PR TITLE
fix: update EnvdVersion from 0.1.1 to 0.2.10

### DIFF
--- a/pkg/servers/e2b/sandbox.go
+++ b/pkg/servers/e2b/sandbox.go
@@ -48,7 +48,7 @@ func (sc *Controller) convertToE2BSandbox(sbx infra.Sandbox, accessToken string)
 		SandboxID:       sbx.GetSandboxID(),
 		TemplateID:      sbx.GetTemplate(),
 		Domain:          sc.domain,
-		EnvdVersion:     "0.1.1",
+		EnvdVersion:     "0.2.10",
 		EnvdAccessToken: accessToken,
 	}
 	sandbox.State, _ = sbx.GetState()


### PR DESCRIPTION
## Summary
Update the hardcoded `EnvdVersion` in `convertToE2BSandbox` function from `"0.1.1"` to `"0.2.10"` to match the latest envd release.

## Changes
- Modified `pkg/servers/e2b/sandbox.go`: Updated `EnvdVersion` field from `"0.1.1"` to `"0.2.10"`

## Test plan
- [ ] Verify the version string is correctly updated
- [ ] Ensure no other hardcoded version references exist

🤖 Generated with [Qoder][https://qoder.com]