### PR TITLE
bugfix for a design flaw, the sandbox-controller inconsistently injec…

### DIFF
--- a/pkg/utils/sidecarutils/sidecar_config_inject.go
+++ b/pkg/utils/sidecarutils/sidecar_config_inject.go
@@ -174,7 +174,6 @@ func setMainContainerConfigWhenInjectRuntimeSidecar(ctx context.Context, mainCon
 			log.V(consts.DebugLogLevel).Info("conflicting postStart hooks detected, main container already has a postStart hook defined",
 				"existingHook", mainContainer.Lifecycle.PostStart,
 				"injectedHook", config.MainContainer.Lifecycle.PostStart)
-			return
 		}
 	} else {
 		// Main container doesn't have valid postStart, apply config if available

--- a/pkg/utils/sidecarutils/sidecar_config_inject_test.go
+++ b/pkg/utils/sidecarutils/sidecar_config_inject_test.go
@@ -378,10 +378,10 @@ func TestSetAgentRuntimeContainer(t *testing.T) {
 			},
 			expectedInitContainers:   1,
 			expectedContainers:       1,
-			expectedEnvCount:         0, // conflicting postStart, skip env injection
+			expectedEnvCount:         1, // conflicting postStart only skips postStart injection, env still injected
 			hasPostStartLifecycle:    true,
 			hasPostStartCommand:      true, // keeps existing command
-			expectedVolumeMountCount: 0,    // conflicting postStart, skip volumeMounts injection
+			expectedVolumeMountCount: 1,    // conflicting postStart only skips postStart injection, volumeMounts still injected
 		},
 	}
 
@@ -591,8 +591,8 @@ func TestSetMainContainerConfigWhenInjectRuntimeSidecar(t *testing.T) {
 					},
 				},
 			},
-			expectedEnvCount:         0, // conflicting postStart, skip all injection
-			expectedVolumeMountCount: 0, // conflicting postStart, skip all injection
+			expectedEnvCount:         1, // conflicting postStart only skips postStart injection, env still injected
+			expectedVolumeMountCount: 1, // conflicting postStart only skips postStart injection, volumeMounts still injected
 			hasPostStart:             true,
 			postStartCommand:         []string{"echo", "old"}, // keeps existing, NOT overridden
 		},


### PR DESCRIPTION
…ts volumes without injecting the corresponding postStart hook when one is already defined, potentially causing volumeMount errors due to missing volume configurations.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

There exists a category of cases where users wish to define their own postStart hook. The original code implementation dictates that if a postStart hook is already configured, the sandbox-controller by default disables its injection capability. However, due to an inconsistency in the design, although the postStart hook is not injected, the volume is still injected. This results in a fragmented behavior. In scenarios where users manually configure injection requirements but still expect volumes to be injected, this leads to errors upon initial creation—specifically, errors indicating volumeMounts referencing a non-existent volume configuration.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #286 

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

