### PR TITLE
Pausing Phase for Sandbox

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -243,7 +243,9 @@ const (
 	// SandboxRunning means the pod has been bound to a node and all of the containers have been started.
 	// At least one container is still running or is in the process of being restarted.
 	SandboxRunning SandboxPhase = "Running"
-	// SandboxPaused means the sandbox has entered the paused state.
+	// SandboxPausing means the sandbox is transitioning to the paused state (pod being deleted).
+	SandboxPausing SandboxPhase = "Pausing"
+	// SandboxPaused means the sandbox has completed pausing (pod deleted, hibernation finished).
 	SandboxPaused SandboxPhase = "Paused"
 	// SandboxResuming means the sandbox has entered the resume state
 	SandboxResuming SandboxPhase = "Resuming"

--- a/pkg/controller/sandbox/core/interface.go
+++ b/pkg/controller/sandbox/core/interface.go
@@ -48,7 +48,7 @@ type SandboxControl interface {
 	// EnsureSandboxUpdated handle sandbox with status phase = Running
 	EnsureSandboxUpdated(ctx context.Context, args EnsureFuncArgs) error
 
-	// EnsureSandboxPaused handle sandbox with status phase = Paused
+	// EnsureSandboxPaused handle sandbox with status phase = Pausing
 	EnsureSandboxPaused(ctx context.Context, args EnsureFuncArgs) error
 
 	// EnsureSandboxResumed handle sandbox with status phase = Resuming

--- a/pkg/controller/sandbox/metrics.go
+++ b/pkg/controller/sandbox/metrics.go
@@ -241,6 +241,7 @@ var (
 	allPhases = []agentsv1alpha1.SandboxPhase{
 		agentsv1alpha1.SandboxPending,
 		agentsv1alpha1.SandboxRunning,
+		agentsv1alpha1.SandboxPausing,
 		agentsv1alpha1.SandboxPaused,
 		agentsv1alpha1.SandboxResuming,
 		agentsv1alpha1.SandboxSucceeded,

--- a/pkg/controller/sandbox/metrics_test.go
+++ b/pkg/controller/sandbox/metrics_test.go
@@ -127,6 +127,7 @@ func TestRecordSandboxMetrics_StatusPhase(t *testing.T) {
 	}{
 		{name: "Pending phase", phase: agentsv1alpha1.SandboxPending},
 		{name: "Running phase", phase: agentsv1alpha1.SandboxRunning},
+		{name: "Pausing phase", phase: agentsv1alpha1.SandboxPausing},
 		{name: "Paused phase", phase: agentsv1alpha1.SandboxPaused},
 		{name: "Resuming phase", phase: agentsv1alpha1.SandboxResuming},
 		{name: "Succeeded phase", phase: agentsv1alpha1.SandboxSucceeded},

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -231,8 +231,11 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 		requeueAfter, err = r.getControl(args.Pod).EnsureSandboxRunning(ctx, args)
 	case agentsv1alpha1.SandboxRunning:
 		err = r.getControl(args.Pod).EnsureSandboxUpdated(ctx, args)
-	case agentsv1alpha1.SandboxPaused:
+	case agentsv1alpha1.SandboxPausing:
 		err = r.EnsureSandboxPaused(ctx, args)
+	case agentsv1alpha1.SandboxPaused:
+		// Paused is terminal for the pause flow - nothing to do.
+		// Transition to Resuming happens in calculateStatus when spec.Paused becomes false.
 	case agentsv1alpha1.SandboxResuming:
 		err = r.getControl(args.Pod).EnsureSandboxResumed(ctx, args)
 	case agentsv1alpha1.SandboxUpgrading:
@@ -333,11 +336,18 @@ func calculateStatus(args core.EnsureFuncArgs) (*agentsv1alpha1.SandboxStatus, b
 			return newStatus, true
 		}
 
-		// If it is paused, first set the sandbox to the Paused state.
-		// To prevent loss of state information, the state immediately before Paused must currently be Running.
+		// If it is paused, first set the sandbox to the Pausing state.
+		// To prevent loss of state information, the state immediately before Pausing must currently be Running.
 		if box.Spec.Paused {
 			// The paused and resumed condition are exclusive
 			utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionResumed))
+			newStatus.Phase = agentsv1alpha1.SandboxPausing
+		}
+
+	case agentsv1alpha1.SandboxPausing:
+		cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
+		if cond != nil && cond.Status == metav1.ConditionTrue {
+			// Pod deletion completed, transition to fully Paused
 			newStatus.Phase = agentsv1alpha1.SandboxPaused
 			// Check for upgrade: if template has changed (hash mismatch), transition to Upgrading phase
 		} else if pod != nil && pod.Labels[agentsv1alpha1.PodLabelTemplateHash] != newStatus.UpdateRevision &&
@@ -348,11 +358,14 @@ func calculateStatus(args core.EnsureFuncArgs) (*agentsv1alpha1.SandboxStatus, b
 			newStatus.Phase = agentsv1alpha1.SandboxUpgrading
 			utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionUpgrading))
 		}
+		if !box.Spec.Paused {
+			logger.Info("sandbox pause not completed, cannot enter resume state temporarily")
+		}
 
 	case agentsv1alpha1.SandboxPaused:
 		cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
 		// sandbox will only enter the resuming state after successful paused
-		if cond.Status == metav1.ConditionTrue && !box.Spec.Paused {
+		if cond != nil && cond.Status == metav1.ConditionTrue && !box.Spec.Paused {
 			// delete paused condition
 			utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
 			newStatus.Phase = agentsv1alpha1.SandboxResuming

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -314,7 +314,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 			wantErr:       false,
 		},
 		{
-			name: "sandbox paused - should set to paused",
+			name: "sandbox paused - should set to pausing",
 			sandbox: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "paused-sandbox",
@@ -348,7 +348,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 					Phase: corev1.PodRunning,
 				},
 			},
-			expectedPhase: agentsv1alpha1.SandboxPaused,
+			expectedPhase: agentsv1alpha1.SandboxPausing,
 			wantErr:       false,
 		},
 		{
@@ -1482,7 +1482,7 @@ func TestCalculateStatus(t *testing.T) {
 			expectedShouldReq: true,
 		},
 		{
-			name: "running phase with paused spec should set to paused",
+			name: "running phase with paused spec should set to pausing",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -1518,7 +1518,7 @@ func TestCalculateStatus(t *testing.T) {
 					},
 				},
 			},
-			expectedPhase:     agentsv1alpha1.SandboxPaused,
+			expectedPhase:     agentsv1alpha1.SandboxPausing,
 			expectedShouldReq: false,
 			checkConditions: func(t *testing.T, status *agentsv1alpha1.SandboxStatus) {
 				// Should remove resumed condition
@@ -1528,6 +1528,78 @@ func TestCalculateStatus(t *testing.T) {
 					}
 				}
 			},
+		},
+		{
+			name: "pausing phase with paused condition true should transition to paused",
+			pod:  nil,
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-sandbox",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused: true,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+							},
+						},
+					},
+				},
+			},
+			initStatus: &agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPausing,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(agentsv1alpha1.SandboxConditionPaused),
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+			expectedPhase:     agentsv1alpha1.SandboxPaused,
+			expectedShouldReq: false,
+		},
+		{
+			name: "pausing phase with paused condition false should stay pausing",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-sandbox",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused: true,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+							},
+						},
+					},
+				},
+			},
+			initStatus: &agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPausing,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(agentsv1alpha1.SandboxConditionPaused),
+						Status: metav1.ConditionFalse,
+					},
+				},
+			},
+			expectedPhase:     agentsv1alpha1.SandboxPausing,
+			expectedShouldReq: false,
 		},
 		{
 			name: "paused phase with paused condition true and not paused spec should set to resuming",
@@ -1594,7 +1666,7 @@ func TestCalculateStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "paused phase with paused condition false and not paused spec should stay paused",
+			name: "pausing phase with paused condition false and not paused spec should stay pausing",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -1622,7 +1694,7 @@ func TestCalculateStatus(t *testing.T) {
 				},
 			},
 			initStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxPaused,
+				Phase: agentsv1alpha1.SandboxPausing,
 				Conditions: []metav1.Condition{
 					{
 						Type:   string(agentsv1alpha1.SandboxConditionPaused),
@@ -1630,7 +1702,7 @@ func TestCalculateStatus(t *testing.T) {
 					},
 				},
 			},
-			expectedPhase:     agentsv1alpha1.SandboxPaused,
+			expectedPhase:     agentsv1alpha1.SandboxPausing,
 			expectedShouldReq: false,
 		},
 		{

--- a/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
@@ -55,6 +55,208 @@ type apiReaderOverrideCache struct {
 func (c *apiReaderOverrideCache) GetAPIReader() ctrl.Reader {
 	if c.apiReader == nil {
 		return c.Provider.GetAPIReader()
+//goland:noinspection GoDeprecation
+func TestSandbox_SetPause(t *testing.T) {
+	utils.InitLogOutput()
+	tests := []struct {
+		name            string
+		initSandbox     func(sbx *v1alpha1.Sandbox)
+		operatePause    bool
+		expectPaused    bool
+		expectedState   string
+		expectError     bool
+		initErrCode     int
+		withInitRuntime bool
+	}{
+		{
+			name: "pause running / running sandbox",
+			initSandbox: func(sbx *v1alpha1.Sandbox) {
+				sbx.Status.Phase = v1alpha1.SandboxRunning
+				sbx.Status.Conditions = append(sbx.Status.Conditions, metav1.Condition{
+					Type:   string(v1alpha1.SandboxConditionReady),
+					Status: metav1.ConditionTrue,
+				}, metav1.Condition{
+					// Hack: make the sync pause success
+					Type:   string(v1alpha1.SandboxConditionPaused),
+					Status: metav1.ConditionTrue,
+				})
+				sbx.Spec.Paused = false
+				state, reason := sandboxutils.GetSandboxState(sbx)
+				assert.Equal(t, v1alpha1.SandboxStateRunning, state, reason)
+			},
+			operatePause:  true,
+			expectPaused:  true,
+			expectedState: v1alpha1.SandboxStatePaused,
+			expectError:   false,
+		},
+		{
+			name: "pause running / available sandbox",
+			initSandbox: func(sbx *v1alpha1.Sandbox) {
+				sbx.Status.Phase = v1alpha1.SandboxRunning
+				sbx.Status.Conditions = append(sbx.Status.Conditions, metav1.Condition{
+					Type:   string(v1alpha1.SandboxConditionReady),
+					Status: metav1.ConditionTrue,
+				})
+				sbx.Spec.Paused = false
+				sbx.OwnerReferences = GetSbsOwnerReference()
+				state, reason := sandboxutils.GetSandboxState(sbx)
+				assert.Equal(t, v1alpha1.SandboxStateAvailable, state, reason)
+			},
+			operatePause:  true,
+			expectPaused:  true,
+			expectedState: v1alpha1.SandboxStateAvailable,
+			expectError:   true,
+		},
+		{
+			name: "resume paused / paused sandbox",
+			initSandbox: func(sbx *v1alpha1.Sandbox) {
+				sbx.Status.Phase = v1alpha1.SandboxPaused
+				sbx.Status.Conditions = append(sbx.Status.Conditions, metav1.Condition{
+					Type:   string(v1alpha1.SandboxConditionPaused),
+					Status: metav1.ConditionTrue,
+				})
+				sbx.Spec.Paused = true
+				state, reason := sandboxutils.GetSandboxState(sbx)
+				assert.Equal(t, v1alpha1.SandboxStatePaused, state, reason)
+			},
+			operatePause:  false,
+			expectPaused:  false,
+			expectedState: v1alpha1.SandboxStateRunning,
+			expectError:   false,
+		},
+		{
+			name: "resume paused / paused sandbox with init runtime success",
+			initSandbox: func(sbx *v1alpha1.Sandbox) {
+				sbx.Status.Phase = v1alpha1.SandboxPaused
+				sbx.Status.Conditions = append(sbx.Status.Conditions, metav1.Condition{
+					Type:   string(v1alpha1.SandboxConditionPaused),
+					Status: metav1.ConditionTrue,
+				})
+				sbx.Spec.Paused = true
+				state, reason := sandboxutils.GetSandboxState(sbx)
+				assert.Equal(t, v1alpha1.SandboxStatePaused, state, reason)
+			},
+			operatePause:    false,
+			expectPaused:    false,
+			expectedState:   v1alpha1.SandboxStateRunning,
+			expectError:     false,
+			initErrCode:     0,
+			withInitRuntime: true,
+		},
+		{
+			name: "resume paused / paused sandbox with init runtime 401 (ReInit success)",
+			initSandbox: func(sbx *v1alpha1.Sandbox) {
+				sbx.Status.Phase = v1alpha1.SandboxPaused
+				sbx.Status.Conditions = append(sbx.Status.Conditions, metav1.Condition{
+					Type:   string(v1alpha1.SandboxConditionPaused),
+					Status: metav1.ConditionTrue,
+				})
+				sbx.Spec.Paused = true
+				state, reason := sandboxutils.GetSandboxState(sbx)
+				assert.Equal(t, v1alpha1.SandboxStatePaused, state, reason)
+			},
+			operatePause:    false,
+			expectPaused:    false,
+			expectedState:   v1alpha1.SandboxStateRunning,
+			expectError:     false,
+			initErrCode:     401,
+			withInitRuntime: true,
+		},
+		{
+			name: "resume paused / paused sandbox with init runtime 500 error",
+			initSandbox: func(sbx *v1alpha1.Sandbox) {
+				sbx.Status.Phase = v1alpha1.SandboxPaused
+				sbx.Status.Conditions = append(sbx.Status.Conditions, metav1.Condition{
+					Type:   string(v1alpha1.SandboxConditionPaused),
+					Status: metav1.ConditionTrue,
+				})
+				sbx.Spec.Paused = true
+				state, reason := sandboxutils.GetSandboxState(sbx)
+				assert.Equal(t, v1alpha1.SandboxStatePaused, state, reason)
+			},
+			operatePause:    false,
+			expectPaused:    false,
+			expectedState:   v1alpha1.SandboxStateRunning,
+			expectError:     true,
+			initErrCode:     500,
+			withInitRuntime: true,
+		},
+		{
+			name: "resume paused / pausing sandbox",
+			initSandbox: func(sbx *v1alpha1.Sandbox) {
+				sbx.Status.Phase = v1alpha1.SandboxPausing
+				sbx.Status.Conditions = append(sbx.Status.Conditions, metav1.Condition{
+					Type:   string(v1alpha1.SandboxConditionPaused),
+					Status: metav1.ConditionFalse,
+				})
+				sbx.Spec.Paused = true
+				state, reason := sandboxutils.GetSandboxState(sbx)
+				assert.Equal(t, v1alpha1.SandboxStatePaused, state, reason)
+			},
+			operatePause:  false,
+			expectPaused:  false,
+			expectedState: v1alpha1.SandboxStateRunning,
+			expectError:   true,
+		},
+		{
+			name: "pause already paused sandbox",
+			initSandbox: func(sbx *v1alpha1.Sandbox) {
+				sbx.Status.Phase = v1alpha1.SandboxPaused
+				sbx.Status.Conditions = append(sbx.Status.Conditions, metav1.Condition{
+					Type:   string(v1alpha1.SandboxConditionPaused),
+					Status: metav1.ConditionTrue,
+				})
+				sbx.Spec.Paused = true
+				state, reason := sandboxutils.GetSandboxState(sbx)
+				assert.Equal(t, v1alpha1.SandboxStatePaused, state, reason)
+			},
+			operatePause:  true,
+			expectPaused:  true,
+			expectedState: v1alpha1.SandboxStatePaused,
+			expectError:   true,
+		},
+		{
+			name: "resume already running sandbox",
+			initSandbox: func(sbx *v1alpha1.Sandbox) {
+				sbx.Status.Phase = v1alpha1.SandboxRunning
+				sbx.Status.Conditions = append(sbx.Status.Conditions, metav1.Condition{
+					Type:   string(v1alpha1.SandboxConditionReady),
+					Status: metav1.ConditionTrue,
+				})
+				state, reason := sandboxutils.GetSandboxState(sbx)
+				assert.Equal(t, v1alpha1.SandboxStateRunning, state, reason)
+			},
+			operatePause:  false,
+			expectPaused:  false,
+			expectedState: v1alpha1.SandboxStateRunning,
+			expectError:   true,
+		},
+		{
+			name: "resume killing sandbox",
+			initSandbox: func(sbx *v1alpha1.Sandbox) {
+				sbx.Status.Phase = v1alpha1.SandboxTerminating
+				sbx.Spec.Paused = true
+				state, reason := sandboxutils.GetSandboxState(sbx)
+				assert.Equal(t, v1alpha1.SandboxStateDead, state, reason)
+			},
+			operatePause:  false,
+			expectPaused:  true,
+			expectedState: v1alpha1.SandboxStateDead,
+			expectError:   true,
+		},
+		{
+			name: "pause killing sandbox",
+			initSandbox: func(sbx *v1alpha1.Sandbox) {
+				sbx.Status.Phase = v1alpha1.SandboxTerminating
+				sbx.Spec.Paused = false
+				state, reason := sandboxutils.GetSandboxState(sbx)
+				assert.Equal(t, v1alpha1.SandboxStateDead, state, reason)
+			},
+			operatePause:  true,
+			expectPaused:  true,
+			expectedState: v1alpha1.SandboxStateDead,
+			expectError:   true,
+		},
 	}
 	return c.apiReader
 }

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -198,6 +198,40 @@ func TestConnectSandbox(t *testing.T) {
 
 			if tt.paused {
 				pauseSandboxHelper(t, controller, fc, createResp.Body.SandboxID, tt.pausing, tt.resuming, user)
+				pauseResp, err := controller.PauseSandbox(req)
+				assert.Nil(t, err)
+				AvoidGetFromCache(t, createResp.Body.SandboxID, client.SandboxClient)
+				assert.Equal(t, http.StatusNoContent, pauseResp.Code)
+				describeResp, err := controller.DescribeSandbox(req)
+				assert.Nil(t, err)
+				assert.Equal(t, models.SandboxStatePaused, describeResp.Body.State)
+				var condStatus metav1.ConditionStatus
+				if tt.pausing {
+					condStatus = metav1.ConditionFalse
+				} else {
+					condStatus = metav1.ConditionTrue
+				}
+				pausePhase := agentsv1alpha1.SandboxPaused
+				if tt.pausing {
+					pausePhase = agentsv1alpha1.SandboxPausing
+				}
+				UpdateSandboxWhen(t, client.SandboxClient, describeResp.Body.SandboxID, func(sbx *agentsv1alpha1.Sandbox) bool {
+					return sbx.Spec.Paused == true
+				}, DoSetSandboxStatus(pausePhase, condStatus, metav1.ConditionFalse))
+				// Only start goroutine to resume sandbox if it's fully paused (not pausing)
+				// When pausing, the test expects ConnectSandbox to fail, so no need to simulate resume
+				if !tt.pausing {
+					go func() {
+						defer close(done)
+						UpdateSandboxWhen(t, client.SandboxClient, describeResp.Body.SandboxID, func(sbx *agentsv1alpha1.Sandbox) bool {
+							return sbx.Spec.Paused == false
+						}, DoSetSandboxStatus(agentsv1alpha1.SandboxRunning, metav1.ConditionFalse, metav1.ConditionTrue))
+					}()
+				} else {
+					close(done)
+				}
+			} else {
+				close(done)
 			}
 
 			if tt.sandboxID == "" {
@@ -516,6 +550,40 @@ func TestResumeSandbox(t *testing.T) {
 
 			if tt.paused {
 				pauseSandboxHelper(t, controller, fc, createResp.Body.SandboxID, tt.pausing, tt.resuming, user)
+				pauseResp, err := controller.PauseSandbox(req)
+				assert.Nil(t, err)
+				assert.Equal(t, http.StatusNoContent, pauseResp.Code)
+				describeResp, err := controller.DescribeSandbox(req)
+				assert.Nil(t, err)
+				assert.Equal(t, models.SandboxStatePaused, describeResp.Body.State)
+				status := metav1.ConditionTrue
+				if tt.pausing {
+					status = metav1.ConditionFalse
+				}
+				sbx := GetSandbox(t, createResp.Body.SandboxID, client.SandboxClient)
+				if tt.pausing {
+					sbx.Status.Phase = agentsv1alpha1.SandboxPausing
+				} else {
+					sbx.Status.Phase = agentsv1alpha1.SandboxPaused
+				}
+				utils.SetSandboxCondition(&sbx.Status, metav1.Condition{
+					Type:   string(agentsv1alpha1.SandboxConditionPaused),
+					Status: status,
+				})
+				_, err2 := client.ApiV1alpha1().Sandboxes(sbx.Namespace).UpdateStatus(context.Background(), sbx, metav1.UpdateOptions{})
+				assert.NoError(t, err2)
+				time.AfterFunc(60*time.Millisecond, func() {
+					sbx := GetSandbox(t, createResp.Body.SandboxID, client.SandboxClient)
+					sbx.Status.Phase = agentsv1alpha1.SandboxRunning
+					sbx.Status.Conditions = append(sbx.Status.Conditions, metav1.Condition{
+						Type:   string(agentsv1alpha1.SandboxConditionReady),
+						Status: metav1.ConditionTrue,
+					})
+					_, _ = client.ApiV1alpha1().Sandboxes(sbx.Namespace).UpdateStatus(context.Background(), sbx, metav1.UpdateOptions{})
+					close(done)
+				})
+			} else {
+				close(done)
 			}
 
 			if tt.sandboxID == "" {

--- a/pkg/utils/sandboxutils/utils.go
+++ b/pkg/utils/sandboxutils/utils.go
@@ -83,7 +83,7 @@ func GetSandboxState(sbx *agentsv1alpha1.Sandbox) (state string, reason string) 
 				}
 			}
 		} else {
-			// Paused and Resuming phases are both treated as paused state
+			// Pausing, Paused and Resuming phases are all treated as paused state
 			return agentsv1alpha1.SandboxStatePaused, "NotRunningResourceClaimed"
 		}
 	}

--- a/pkg/utils/sandboxutils/utils_test.go
+++ b/pkg/utils/sandboxutils/utils_test.go
@@ -254,6 +254,16 @@ func TestGetSandboxState(t *testing.T) {
 			expectedState:  agentsv1alpha1.SandboxStatePaused,
 			expectedReason: "NotRunningResourceClaimed",
 		},
+		{
+			name: "Pausing Sandbox claimed",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxPausing,
+				},
+			},
+			expectedState:  agentsv1alpha1.SandboxStatePaused,
+			expectedReason: "NotRunningResourceClaimed",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Added a Pausing intermediate phase to the Sandbox lifecycle so users can distinguish between "hibernation in progress" and "hibernation complete":

Before: Running -> Paused (pod may still be deleting)
After: Running -> Pausing (pod being deleted) -> Paused (hibernation complete)


### Ⅱ. Does this pull request fix one issue?
Fixees #250 

### Ⅲ. Describe how to verify it

Unit tests(passing)
```
go test ./pkg/controller/sandbox/... -v -run "TestCalculateStatus"
go test ./pkg/utils/sandboxutils/... -v
go test ./pkg/servers/e2b -v -run "TestPauseSandbox|TestConnectSandbox|TestResumeSandbox"
```



### Ⅳ. Special notes for reviews

