### PR TITLE
fix(utils): panic when logging sidecar config error

### DIFF
--- a/pkg/utils/sidecarutils/sidecar_config_inject.go
+++ b/pkg/utils/sidecarutils/sidecar_config_inject.go
@@ -63,7 +63,7 @@ func parseInjectConfig(ctx context.Context, configKey string, configRaw map[stri
 
 	err := json.Unmarshal([]byte(configRaw[configKey]), &sidecarConfig)
 	if err != nil {
-		log.Error(err, "failed to unmarshal sidecar config for the %v", configKey)
+		log.Error(err, "failed to unmarshal sidecar config", "configKey", configKey)
 		return sidecarConfig, err
 	}
 	return sidecarConfig, nil


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Fix panic when unmarshal invalid sidecar config

```
panic: odd number of arguments passed as key-value pairs for logging

goroutine 805 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x3488d08, 0xc0018cf2c0}, {0x28c7220, 0xc000dd8300})
	/go/pkg/mod/k8s.io/apimachinery@v0.33.0/pkg/util/runtime/runtime.go:132 +0xbc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.2/pkg/internal/controller/controller.go:107 +0x112
panic({0x28c7220?, 0xc000dd8300?})
	/usr/local/go/src/runtime/panic.go:792 +0x132
go.uber.org/zap/zapcore.CheckWriteAction.OnWrite(0x1?, 0x1?, {0x0?, 0x0?, 0xc0005e2180?})
	/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/entry.go:196 +0x54
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc001a960d0, {0xc001b6f140, 0x1, 0x1})
	/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/entry.go:262 +0x24a
go.uber.org/zap.(*Logger).DPanic(0x300e2ad?, {0x309ff4b?, 0x28c7220?}, {0xc001b6f140, 0x1, 0x1})
	/go/pkg/mod/go.uber.org/zap@v1.27.0/logger.go:275 +0x4b
github.com/go-logr/zapr.(*zapLogger).handleFields(0xc0018cfe30, 0xffffffffffffffff, {0xc000dd82c0, 0x1, 0xc000cb4cf0?}, {0xc001b6f0c0, 0x1, 0xc000cb4cf8?})
	/go/pkg/mod/github.com/go-logr/zapr@v1.3.0/zapr.go:147 +0xd45
github.com/go-logr/zapr.(*zapLogger).Error(0xc0018cfe30, {0x3449840, 0xc000e07530}, {0x306c47a?, 0x7b0314?}, {0xc000dd82c0, 0x1, 0x1})
	/go/pkg/mod/github.com/go-logr/zapr@v1.3.0/zapr.go:207 +0x18d
github.com/go-logr/logr.Logger.Error({{0x3492c40?, 0xc0018cfe30?}, 0x1?}, {0x3449840, 0xc000e07530}, {0x306c47a, 0x2d}, {0xc000dd82c0, 0x1, 0x1})
	/go/pkg/mod/github.com/go-logr/logr@v1.4.3/logr.go:301 +0x145
github.com/openkruise/agents/pkg/utils/sidecarutils.parseInjectConfig({_, _}, {_, _}, _)
	/workspace/pkg/utils/sidecarutils/sidecar_config_inject.go:66 +0x1c6
```

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

