### PR TITLE
fix(e2b): enforce connect timeout extension semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,4 @@ cython_debug/
 
 .gomodcache/
 .modcache/
+.DS_Store

--- a/pkg/servers/e2b/AGENTS.md
+++ b/pkg/servers/e2b/AGENTS.md
@@ -1,0 +1,96 @@
+# `pkg/servers/e2b` Guide
+
+This directory is the sandbox-manager's E2B-compatible HTTP API layer. It wraps the core `sandbox-manager` logic into REST endpoints that follow the [E2B OpenAPI specification](https://github.com/e2b-dev/E2B/blob/main/spec/openapi.yml). All route handlers live on the `Controller` struct and delegate real work to `sandbox-manager/infra` and related packages.
+
+## Upstream E2B OpenAPI Spec
+**IMPORTANT**: Before working on E2B APIs, you have to learn the upstream E2B OpenAPI spec with the following steps:
+
+1. Download the spec file (openapi) from https://raw.githubusercontent.com/e2b-dev/E2B/refs/heads/main/spec/openapi.yml
+2. Use your file search tool to find the part you need. **Never Read the Entire Spec, It's Extremely Large**.
+
+## Architecture
+
+```
+Controller (core.go)
+├── Init()          → builds SandboxManager, registers routes, inits KeyStorage
+├── Run()           → starts HTTP server, signal handling, KeyStorage lifecycle
+└── registerRoutes() (routes.go) → wires all endpoints to http.ServeMux
+```
+
+The controller depends on:
+- `sandbox-manager.SandboxManager` for sandbox lifecycle operations (claim, delete, pause, resume, clone, checkpoint).
+- `keys.KeyStorage` for API key authentication (optional; nil when auth is disabled).
+- `adapters.E2BAdapter` for Envoy traffic routing (native vs customized E2B path mapping).
+
+## File Responsibilities
+
+| File | Responsibility |
+|---|---|
+| `core.go` | `Controller` struct, `NewController`, `Init`, `Run`, server lifecycle |
+| `routes.go` | Route registration, `CheckApiKey` / `CheckAdminKey` middleware, `RegisterE2BRoute` dual-path helper |
+| `create.go` | `POST /sandboxes` — create via claim (SandboxSet) or clone (Checkpoint) |
+| `services.go` | `GET /sandboxes/{id}`, `DELETE /sandboxes/{id}`, `BrowserUse`, `Debug` |
+| `list.go` | `GET /v2/sandboxes` (list sandboxes with pagination/filter), `GET /snapshots` (list checkpoints) |
+| `pause_resume.go` | `POST .../pause`, `POST .../resume`, `POST .../connect` with timeout management |
+| `timeout.go` | `POST .../timeout` — set sandbox timeout |
+| `snapshot.go` | `POST .../snapshots` — create checkpoint |
+| `templates.go` | `GET /templates`, `GET /templates/{id}`, `DELETE /templates/{id}` |
+| `api_key.go` | `GET /api-keys`, `POST /api-keys`, `DELETE /api-keys/{id}` (admin-only) |
+| `sandbox.go` | `getSandboxOfUser`, `convertToE2BSandbox`, `ParseTimeout`, metadata helpers |
+| `metadata.go` | Metadata key blacklist (E2B / internal prefixes) |
+
+## Subdirectories
+
+- **`adapters/`** — E2B request mapping for two host/path styles: native E2B style (e.g. `api.domain.com/sandboxes`) and customized proxy style (e.g. `domain.com/api/sandboxes`). All routes are dual-registered for both adapters.
+- **`keys/`** — API key persistence (`KeyStorage` interface, Secret / MySQL backends). Has its own `AGENTS.md`.
+- **`models/`** — Request/response models, validation, error types, constants.
+
+## Key Design Decisions
+
+### Dual-Path Registration
+Every E2B route is registered twice via `RegisterE2BRoute`: once for the native E2B host/path style (e.g. `api.domain.com/sandboxes`) and once for the customized proxy style (e.g. `domain.com/api/sandboxes`). Do not register routes directly on `mux` — always use `RegisterE2BRoute`.
+
+### Authentication Flow
+1. `CheckApiKey` middleware extracts `X-API-KEY` header, validates via `KeyStorage`, and injects user into context.
+2. When `keys` is nil (auth disabled), all requests use `AnonymousUser` with admin privileges.
+3. Sandbox ownership is verified per-request: the API key owner must match the sandbox owner.
+4. Admin-only endpoints (API key management) chain `CheckAdminKey` after `CheckApiKey`.
+
+### Timeout Semantics
+- **Pause**: sets timeout far into the future (1000 years) so paused sandboxes are kept indefinitely.
+- **Resume**: sets timeout strictly to the requested value (no extend-only merge).
+- **Connect (Running)**: extend-only — never shortens the effective deadline. If the requested deadline is earlier than the current one, the update is silently skipped.
+- **Connect (Paused → Resume)**: sets timeout strictly to the requested value (same as Resume).
+- **SetTimeout**: only applies to running sandboxes; conflicts return `409`.
+
+### Create Sandbox
+- If `templateID` matches a SandboxSet → claim path (`ClaimSandbox`).
+- If `templateID` matches a Checkpoint → clone path (`CloneSandbox`).
+- Otherwise → `400 Template or Checkpoint not found`.
+
+## Rules For Modification
+
+1. **Check E2B spec first**: Read https://github.com/e2b-dev/E2B/blob/main/spec/openapi.yml before changing any endpoint behavior, status codes, or request/response shapes.
+2. **Preserve status code compatibility**: Some E2B endpoints use non-standard codes (e.g. `SetTimeout` returns `500` instead of `400` for validation errors). Do not "fix" these without verifying the E2B spec.
+3. **Keep dual-path registration**: New endpoints must use `RegisterE2BRoute`, not raw `mux.HandleFunc`.
+4. **Timeout rules**: Resume and Connect(Paused→Resume) set timeout strictly to the request value. Connect(Running) is extend-only — cannot shorten. Do not change this unless the product contract changes.
+5. **Middleware ordering**: `CheckAdminKey` must always come after `CheckApiKey`.
+6. **Model changes**: Request/response types live in `models/`. Keep validation logic in `models/validation.go`.
+
+## Tests
+
+- Each handler file has a corresponding `*_test.go`. Update the matching test file when changing handler logic.
+- Tests use `httptest` and mock `SandboxManager`. Follow table-driven style.
+- Middleware tests are in `routes_test.go`.
+
+## Review Focus: Interface Behavior Consistency with E2B
+
+When reviewing code in this module, focus on the following areas to ensure interface behavior remains fully consistent with the upstream E2B specification:
+
+1. **HTTP Status Codes**: Every endpoint must return status codes matching the E2B OpenAPI spec, including non-standard ones (e.g. `SetTimeout` returns `500` for validation errors). Do not "fix" these unless the E2B spec itself has changed.
+2. **Request/Response Structure**: Field names, types, required/optional status, and default values in both request and response bodies must align with the E2B spec. Note that E2B uses `camelCase` (not `snake_case`) field naming.
+3. **Timeout Semantics**: Pause / Resume / Connect / SetTimeout have strictly distinct timeout behaviors (see Timeout Semantics under Key Design Decisions). Review each case individually.
+4. **Error Response Format**: E2B error responses follow a specific JSON structure (e.g. `error` / `message` fields). Ensure all error paths return the spec-compliant format rather than custom structures.
+5. **Parameter Validation Boundaries**: Value ranges, defaults, and overflow handling for `limit`, `timeout`, `metadata`, etc. must match the E2B spec.
+6. **Sandbox State Transitions**: Constraints and side effects of operations like Pause → Resume, Connect(Paused → Resume), and Delete on sandbox state must match E2B behavior.
+7. **Authentication & Authorization**: `X-API-KEY` header validation, anonymous mode, and admin privilege determination must align with the E2B multi-tenant model.

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -134,7 +134,6 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 	// We only enforce the extend-only guard for sandboxes that were already running when Connect was called.
 	// Paused->resume requests should always apply the requested timeout directly.
 	state, pauseResumeReason := sbx.GetState()
-	autoPause, currentEndAt := ParseTimeout(sbx)
 
 	// Step 1: Resuming the sandbox if it is paused
 	statusCode := http.StatusOK
@@ -154,6 +153,7 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 
 	// Step 2: Update the sandbox timeout
 	log.Info("updating sandbox timeout")
+	autoPause, currentEndAt := ParseTimeout(sbx)
 	if err := sc.updateConnectTimeout(ctx, sbx, request.TimeoutSeconds, state, autoPause, currentEndAt); err != nil {
 		log.Error(err, "failed to update sandbox timeout")
 		return web.ApiResponse[*models.Sandbox]{}, err

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -1,17 +1,18 @@
 package e2b
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
 
-	"github.com/openkruise/agents/pkg/utils/runtime"
 	"k8s.io/klog/v2"
 
 	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
+	"github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 func (sc *Controller) PauseSandbox(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
@@ -57,17 +58,6 @@ func (sc *Controller) buildPauseTimeoutOptions(sbx infra.Sandbox, now time.Time)
 	return opts
 }
 
-// shouldSkipRunningSandboxTimeoutUpdate implements the E2B rule for already-running sandboxes:
-// only persist a new timeout when it extends the current effective deadline (strictly later than currentEndAt).
-// currentEndAt is the effective EndAt from ParseTimeout (PauseTime when auto-pause, else ShutdownTime).
-func shouldSkipRunningSandboxTimeoutUpdate(currentEndAt, now time.Time, requestTimeoutSeconds int) (skip bool, requestedEndAt time.Time) {
-	requestedEndAt = TimeAfterSeconds(now, requestTimeoutSeconds)
-	if currentEndAt.IsZero() {
-		return false, requestedEndAt
-	}
-	return !requestedEndAt.After(currentEndAt), requestedEndAt
-}
-
 // ResumeSandbox is DEPRECATED and kept only for old SDK compatibility.
 //
 // E2B exposes one "connect" behavior, but different SDK versions call different endpoints:
@@ -91,7 +81,7 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 	if apiErr != nil {
 		return web.ApiResponse[struct{}]{}, apiErr
 	}
-	autoPause, timeout := ParseTimeout(sbx)
+	autoPause, currentEndAt := ParseTimeout(sbx)
 
 	if state, reason := sbx.GetState(); state != v1alpha1.SandboxStatePaused {
 		log.Info("skip resume sandbox: sandbox is not paused", "state", state, "reason", reason)
@@ -110,7 +100,7 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 	// Only set timeout if the sandbox has a timeout configured (not never-timeout).
 	// After resume, the timeout is set strictly to the requested value (no extend-only merge).
 	now := time.Now()
-	if !timeout.IsZero() {
+	if !currentEndAt.IsZero() {
 		opts := sc.buildSetTimeoutOptions(autoPause, now, request.TimeoutSeconds)
 		log.Info("sandbox resumed, resetting sandbox timeout", "timeout", opts)
 		if err := sbx.SaveTimeout(ctx, opts); err != nil {
@@ -140,12 +130,13 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 	if apiErr != nil {
 		return web.ApiResponse[*models.Sandbox]{}, apiErr
 	}
-	autoPause, currentEndAt := ParseTimeout(sbx)
-	state, pauseResumeReason := sbx.GetState()
 	// `state` is intentionally the pre-connect snapshot.
 	// We only enforce the extend-only guard for sandboxes that were already running when Connect was called.
 	// Paused->resume requests should always apply the requested timeout directly.
+	state, pauseResumeReason := sbx.GetState()
+	autoPause, currentEndAt := ParseTimeout(sbx)
 
+	// Step 1: Resuming the sandbox if it is paused
 	statusCode := http.StatusOK
 	if state == v1alpha1.SandboxStatePaused {
 		log.Info("sandbox is paused, will resume it", "reason", pauseResumeReason)
@@ -161,35 +152,47 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 		log.Info("sandbox is not paused, skip resuming", "state", state, "reason", pauseResumeReason)
 	}
 
-	// Only set timeout if the sandbox has a timeout configured (not never-timeout).
-	// Running: do not shorten or keep-equal TTL on connect (see shouldSkipRunningSandboxTimeoutUpdate).
-	// Paused→resumed: use the requested timeout directly (no extend-only merge).
-	timeoutEnabled := !currentEndAt.IsZero()
-	now := time.Now()
-	if timeoutEnabled && state == v1alpha1.SandboxStateRunning {
-		skip, requestedEndAt := shouldSkipRunningSandboxTimeoutUpdate(currentEndAt, now, request.TimeoutSeconds)
-		if skip {
-			timeoutEnabled = false
-			log.Info("skip resetting timeout for running sandbox",
-				"currentEndAt", currentEndAt,
-				"requestedEndAt", requestedEndAt,
-				"requestedTimeoutSeconds", request.TimeoutSeconds)
-		}
+	// Step 2: Update the sandbox timeout
+	log.Info("updating sandbox timeout")
+	if err := sc.updateConnectTimeout(ctx, sbx, request.TimeoutSeconds, state, autoPause, currentEndAt); err != nil {
+		log.Error(err, "failed to update sandbox timeout")
+		return web.ApiResponse[*models.Sandbox]{}, err
 	}
+	log.Info("sandbox timeout updated")
 
-	if timeoutEnabled {
-		opts := sc.buildSetTimeoutOptions(autoPause, now, request.TimeoutSeconds)
-		log.Info("resetting timeout", "timeout", opts)
-		if err := sbx.SaveTimeout(ctx, opts); err != nil {
-			return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
-				Message: fmt.Sprintf("Failed to set sandbox timeout: %v", err),
-			}
-		}
-	} else if currentEndAt.IsZero() {
-		log.Info("skip resetting timeout for never-timeout sandbox")
-	}
 	return web.ApiResponse[*models.Sandbox]{
 		Code: statusCode,
 		Body: sc.convertToE2BSandbox(sbx, runtime.GetAccessToken(sbx)),
-	}, apiErr
+	}, nil
+}
+
+func (sc *Controller) updateConnectTimeout(ctx context.Context, sbx infra.Sandbox, timeoutSeconds int, preConnectState string, autoPause bool, currentEndAt time.Time) *web.ApiError {
+	log := klog.FromContext(ctx).WithValues("sandboxID", sbx.GetSandboxID())
+
+	// Rule 1: Sandboxes without endAt are never-timeout, should not have their timeout updated
+	if currentEndAt.IsZero() {
+		log.Info("skip resetting timeout for never-timeout sandbox")
+		return nil
+	}
+
+	now := time.Now()
+	requestedEndAt := TimeAfterSeconds(now, timeoutSeconds)
+	// Rule 2: For running sandboxes, the timeout will update only if the new timeout is longer than the existing one.
+	if preConnectState == v1alpha1.SandboxStateRunning && currentEndAt.After(requestedEndAt) {
+		log.Info("skip resetting timeout for running sandbox for shorter timeout",
+			"currentEndAt", currentEndAt,
+			"requestedEndAt", requestedEndAt,
+			"requestedTimeoutSeconds", timeoutSeconds)
+		return nil
+	}
+
+	opts := sc.buildSetTimeoutOptions(autoPause, now, timeoutSeconds)
+	log.Info("saving timeout to sandbox", "timeout", opts, "currentEndAt", currentEndAt,
+		"requestedEndAt", requestedEndAt, "requestedTimeoutSeconds", timeoutSeconds)
+	if err := sbx.SaveTimeout(ctx, opts); err != nil {
+		return &web.ApiError{
+			Message: fmt.Sprintf("Failed to set sandbox timeout: %v", err),
+		}
+	}
+	return nil
 }

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -57,6 +57,25 @@ func (sc *Controller) buildPauseTimeoutOptions(sbx infra.Sandbox, now time.Time)
 	return opts
 }
 
+// shouldSkipRunningSandboxTimeoutUpdate implements the E2B rule for already-running sandboxes:
+// only persist a new timeout when it extends the current effective deadline (strictly later than currentEndAt).
+// currentEndAt is the effective EndAt from ParseTimeout (PauseTime when auto-pause, else ShutdownTime).
+func shouldSkipRunningSandboxTimeoutUpdate(currentEndAt, now time.Time, requestTimeoutSeconds int) (skip bool, requestedEndAt time.Time) {
+	requestedEndAt = TimeAfterSeconds(now, requestTimeoutSeconds)
+	if currentEndAt.IsZero() {
+		return false, requestedEndAt
+	}
+	return !requestedEndAt.After(currentEndAt), requestedEndAt
+}
+
+// ResumeSandbox is DEPRECATED and kept only for old SDK compatibility.
+//
+// E2B exposes one "connect" behavior, but different SDK versions call different endpoints:
+// - New SDK: calls ConnectSandbox directly.
+// - Old SDK: first calls SetSandboxTimeout; that path returns 500 on this flow, then falls back to ResumeSandbox.
+//
+// Because ResumeSandbox is only used for the paused->running flow, it always applies the requested timeout directly.
+// The running-sandbox "extend only" guard is intentionally implemented in ConnectSandbox only.
 func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
 	id := r.PathValue("sandboxID")
 	ctx := r.Context()
@@ -88,9 +107,11 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 		}
 	}
 
-	// Only set timeout if the sandbox has a timeout configured (not never-timeout)
+	// Only set timeout if the sandbox has a timeout configured (not never-timeout).
+	// After resume, the timeout is set strictly to the requested value (no extend-only merge).
+	now := time.Now()
 	if !timeout.IsZero() {
-		opts := sc.buildSetTimeoutOptions(autoPause, time.Now(), request.TimeoutSeconds)
+		opts := sc.buildSetTimeoutOptions(autoPause, now, request.TimeoutSeconds)
 		log.Info("sandbox resumed, resetting sandbox timeout", "timeout", opts)
 		if err := sbx.SaveTimeout(ctx, opts); err != nil {
 			return web.ApiResponse[struct{}]{}, &web.ApiError{
@@ -119,11 +140,15 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 	if apiErr != nil {
 		return web.ApiResponse[*models.Sandbox]{}, apiErr
 	}
-	autoPause, timeout := ParseTimeout(sbx)
+	autoPause, currentEndAt := ParseTimeout(sbx)
+	state, pauseResumeReason := sbx.GetState()
+	// `state` is intentionally the pre-connect snapshot.
+	// We only enforce the extend-only guard for sandboxes that were already running when Connect was called.
+	// Paused->resume requests should always apply the requested timeout directly.
 
-	var statusCode = http.StatusOK
-	if state, reason := sbx.GetState(); state == v1alpha1.SandboxStatePaused {
-		log.Info("sandbox is paused, will resume it", "reason", reason)
+	statusCode := http.StatusOK
+	if state == v1alpha1.SandboxStatePaused {
+		log.Info("sandbox is paused, will resume it", "reason", pauseResumeReason)
 		if err := sc.manager.ResumeSandbox(ctx, sbx); err != nil {
 			log.Error(err, "failed to resume sandbox")
 			return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
@@ -133,19 +158,34 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 		statusCode = http.StatusCreated
 		log.Info("sandbox resumed", "timeout", sbx.GetTimeout())
 	} else {
-		log.Info("sandbox is not paused, skip resuming", "state", state, "reason", reason)
+		log.Info("sandbox is not paused, skip resuming", "state", state, "reason", pauseResumeReason)
 	}
 
-	// Only set timeout if the sandbox has a timeout configured (not never-timeout)
-	if !timeout.IsZero() {
-		opts := sc.buildSetTimeoutOptions(autoPause, time.Now(), request.TimeoutSeconds)
+	// Only set timeout if the sandbox has a timeout configured (not never-timeout).
+	// Running: do not shorten or keep-equal TTL on connect (see shouldSkipRunningSandboxTimeoutUpdate).
+	// Paused→resumed: use the requested timeout directly (no extend-only merge).
+	timeoutEnabled := !currentEndAt.IsZero()
+	now := time.Now()
+	if timeoutEnabled && state == v1alpha1.SandboxStateRunning {
+		skip, requestedEndAt := shouldSkipRunningSandboxTimeoutUpdate(currentEndAt, now, request.TimeoutSeconds)
+		if skip {
+			timeoutEnabled = false
+			log.Info("skip resetting timeout for running sandbox",
+				"currentEndAt", currentEndAt,
+				"requestedEndAt", requestedEndAt,
+				"requestedTimeoutSeconds", request.TimeoutSeconds)
+		}
+	}
+
+	if timeoutEnabled {
+		opts := sc.buildSetTimeoutOptions(autoPause, now, request.TimeoutSeconds)
 		log.Info("resetting timeout", "timeout", opts)
 		if err := sbx.SaveTimeout(ctx, opts); err != nil {
 			return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
 				Message: fmt.Sprintf("Failed to set sandbox timeout: %v", err),
 			}
 		}
-	} else {
+	} else if currentEndAt.IsZero() {
 		log.Info("skip resetting timeout for never-timeout sandbox")
 	}
 	return web.ApiResponse[*models.Sandbox]{

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -134,6 +134,7 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 	// We only enforce the extend-only guard for sandboxes that were already running when Connect was called.
 	// Paused->resume requests should always apply the requested timeout directly.
 	state, pauseResumeReason := sbx.GetState()
+	autoPause, currentEndAt := ParseTimeout(sbx)
 
 	// Step 1: Resuming the sandbox if it is paused
 	statusCode := http.StatusOK
@@ -153,7 +154,6 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 
 	// Step 2: Update the sandbox timeout
 	log.Info("updating sandbox timeout")
-	autoPause, currentEndAt := ParseTimeout(sbx)
 	if err := sc.updateConnectTimeout(ctx, sbx, request.TimeoutSeconds, state, autoPause, currentEndAt); err != nil {
 		log.Error(err, "failed to update sandbox timeout")
 		return web.ApiResponse[*models.Sandbox]{}, err

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -66,6 +66,7 @@ func TestPauseSandbox(t *testing.T) {
 }
 
 func TestConnectSandbox(t *testing.T) {
+	DefaultTimeoutSeconds := 300
 	tests := []struct {
 		name         string
 		paused       bool   // if sandbox is set paused
@@ -77,28 +78,28 @@ func TestConnectSandbox(t *testing.T) {
 		{
 			name:         "running sandbox",
 			paused:       false,
-			timeout:      300,
+			timeout:      DefaultTimeoutSeconds,
 			expectStatus: http.StatusOK,
 		},
 		{
 			name:         "resume sandbox: paused",
 			paused:       true,
 			pausing:      false,
-			timeout:      300,
+			timeout:      DefaultTimeoutSeconds,
 			expectStatus: http.StatusCreated,
 		},
 		{
 			name:         "resume sandbox: pausing",
 			paused:       true,
 			pausing:      true,
-			timeout:      300,
+			timeout:      DefaultTimeoutSeconds,
 			expectStatus: http.StatusInternalServerError,
 		},
 		{
 			name:         "not found",
 			paused:       false,
 			sandboxID:    "not-exist",
-			timeout:      300,
+			timeout:      DefaultTimeoutSeconds,
 			expectStatus: http.StatusNotFound,
 		},
 		{
@@ -123,6 +124,7 @@ func TestConnectSandbox(t *testing.T) {
 			defer cleanup()
 
 			createResp, err := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+				Timeout: DefaultTimeoutSeconds,
 				Metadata: map[string]string{
 					models.ExtensionKeySkipInitRuntime: agentsv1alpha1.True,
 				},
@@ -180,7 +182,7 @@ func TestConnectSandbox(t *testing.T) {
 				"sandboxID": tt.sandboxID,
 			}, user))
 
-			if tt.expectStatus >= 300 {
+			if tt.expectStatus >= DefaultTimeoutSeconds {
 				require.NotNil(t, err, fmt.Sprintf("%v", err))
 				if err.Code == 0 {
 					err.Code = http.StatusInternalServerError
@@ -197,51 +199,6 @@ func TestConnectSandbox(t *testing.T) {
 					fmt.Sprintf("expect end at: %s, but got %s", expectEndAt, endAt))
 			}
 			<-done
-		})
-	}
-}
-
-func TestShouldSkipRunningSandboxTimeoutUpdate(t *testing.T) {
-	now := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
-	currentEndAt := now.Add(10 * time.Minute)
-
-	tests := []struct {
-		name                  string
-		currentEndAt          time.Time
-		requestTimeoutSeconds int
-		wantSkip              bool
-	}{
-		{
-			name:                  "shorter_deadline_skips",
-			currentEndAt:          currentEndAt,
-			requestTimeoutSeconds: 60,
-			wantSkip:              true,
-		},
-		{
-			name:                  "equal_deadline_skips",
-			currentEndAt:          currentEndAt,
-			requestTimeoutSeconds: int(currentEndAt.Sub(now) / time.Second),
-			wantSkip:              true,
-		},
-		{
-			name:                  "longer_deadline_does_not_skip",
-			currentEndAt:          currentEndAt,
-			requestTimeoutSeconds: int(currentEndAt.Sub(now)/time.Second) + 120,
-			wantSkip:              false,
-		},
-		{
-			name:                  "zero_current_never_skips",
-			currentEndAt:          time.Time{},
-			requestTimeoutSeconds: 30,
-			wantSkip:              false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			skip, reqEnd := shouldSkipRunningSandboxTimeoutUpdate(tt.currentEndAt, now, tt.requestTimeoutSeconds)
-			assert.Equal(t, tt.wantSkip, skip)
-			assert.Equal(t, TimeAfterSeconds(now, tt.requestTimeoutSeconds), reqEnd)
 		})
 	}
 }
@@ -296,7 +253,6 @@ func TestConnectSandboxRunningTimeoutGuard(t *testing.T) {
 				shutdownBefore = sbxBefore.Spec.ShutdownTime.Time
 			}
 
-			time.Sleep(20 * time.Millisecond)
 			connectNow := time.Now()
 			connectResp, apiErr := controller.ConnectSandbox(NewRequest(t, nil, models.SetTimeoutRequest{
 				TimeoutSeconds: tt.requestTimeout,
@@ -472,6 +428,160 @@ func TestResumeSandbox(t *testing.T) {
 				assert.WithinDuration(t, now.Add(time.Duration(tt.timeout)*time.Second), endAt, 5*time.Second)
 			}
 			<-done
+		})
+	}
+}
+
+func TestUpdateConnectTimeout(t *testing.T) {
+	templateName := "test-update-connect-timeout"
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+	}
+
+	tests := []struct {
+		name            string
+		initialTimeout  int
+		timeoutSeconds  int
+		preConnectState string
+		autoPause       bool
+		neverTimeout    bool // override currentEndAt to zero
+		expectUpdated   bool
+	}{
+		{
+			name:            "never-timeout is skipped",
+			initialTimeout:  300,
+			timeoutSeconds:  300,
+			preConnectState: agentsv1alpha1.SandboxStateRunning,
+			neverTimeout:    true,
+			expectUpdated:   false,
+		},
+		{
+			name:            "running sandbox, shorter timeout is skipped",
+			initialTimeout:  600,
+			timeoutSeconds:  300,
+			preConnectState: agentsv1alpha1.SandboxStateRunning,
+			expectUpdated:   false,
+		},
+		{
+			name:            "running sandbox, longer timeout updates",
+			initialTimeout:  300,
+			timeoutSeconds:  600,
+			preConnectState: agentsv1alpha1.SandboxStateRunning,
+			expectUpdated:   true,
+		},
+		{
+			name:            "running sandbox, equal timeout updates",
+			initialTimeout:  300,
+			timeoutSeconds:  300,
+			preConnectState: agentsv1alpha1.SandboxStateRunning,
+			expectUpdated:   true,
+		},
+		{
+			name:            "resumed sandbox (was paused), shorter timeout updates",
+			initialTimeout:  600,
+			timeoutSeconds:  300,
+			preConnectState: agentsv1alpha1.SandboxStatePaused,
+			expectUpdated:   true,
+		},
+		{
+			name:            "running sandbox with auto-pause, shorter timeout is skipped",
+			initialTimeout:  600,
+			timeoutSeconds:  300,
+			preConnectState: agentsv1alpha1.SandboxStateRunning,
+			autoPause:       true,
+			expectUpdated:   false,
+		},
+		{
+			name:            "running sandbox with auto-pause, longer timeout updates",
+			initialTimeout:  300,
+			timeoutSeconds:  600,
+			preConnectState: agentsv1alpha1.SandboxStateRunning,
+			autoPause:       true,
+			expectUpdated:   true,
+		},
+		{
+			name:            "running sandbox with auto-pause, equal timeout updates",
+			initialTimeout:  300,
+			timeoutSeconds:  300,
+			preConnectState: agentsv1alpha1.SandboxStateRunning,
+			autoPause:       true,
+			expectUpdated:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller, client, teardown := Setup(t)
+			defer teardown()
+
+			cleanup := CreateSandboxPool(t, controller, templateName, 1)
+			defer cleanup()
+
+			createResp, err := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+				TemplateID: templateName,
+				Timeout:    tt.initialTimeout,
+				AutoPause:  tt.autoPause,
+				Metadata: map[string]string{
+					models.ExtensionKeySkipInitRuntime: agentsv1alpha1.True,
+				},
+			}, nil, user))
+			require.Nil(t, err)
+			require.Equal(t, models.SandboxStateRunning, createResp.Body.State)
+			AvoidGetFromCache(t, createResp.Body.SandboxID, client.SandboxClient)
+
+			req := NewRequest(t, nil, nil, map[string]string{
+				"sandboxID": createResp.Body.SandboxID,
+			}, user)
+			sbx, apiErr := controller.getSandboxOfUser(req.Context(), createResp.Body.SandboxID)
+			require.Nil(t, apiErr)
+			require.NotNil(t, sbx)
+
+			_, currentEndAt := ParseTimeout(sbx)
+			if tt.neverTimeout {
+				currentEndAt = time.Time{}
+			}
+
+			beforeCall := time.Now()
+			result := controller.updateConnectTimeout(req.Context(), sbx, tt.timeoutSeconds,
+				tt.preConnectState, tt.autoPause, currentEndAt)
+			require.Nil(t, result)
+
+			updatedSbx := GetSandbox(t, createResp.Body.SandboxID, client.SandboxClient)
+
+			if tt.expectUpdated {
+				expectedEndAt := beforeCall.Add(time.Duration(tt.timeoutSeconds) * time.Second)
+				if tt.autoPause {
+					// For auto-pause: ShutdownTime = now + maxTimeout, PauseTime = now + timeoutSeconds
+					require.NotNil(t, updatedSbx.Spec.ShutdownTime)
+					assert.WithinDuration(t, beforeCall.Add(time.Duration(controller.maxTimeout)*time.Second),
+						updatedSbx.Spec.ShutdownTime.Time, 5*time.Second,
+						"ShutdownTime should be maxTimeout from call time")
+					require.NotNil(t, updatedSbx.Spec.PauseTime)
+					assert.WithinDuration(t, expectedEndAt, updatedSbx.Spec.PauseTime.Time, 5*time.Second,
+						"PauseTime should be updated to requested timeout")
+				} else {
+					require.NotNil(t, updatedSbx.Spec.ShutdownTime)
+					assert.WithinDuration(t, expectedEndAt, updatedSbx.Spec.ShutdownTime.Time, 5*time.Second,
+						"ShutdownTime should be updated to requested timeout")
+					require.Nil(t, updatedSbx.Spec.PauseTime)
+				}
+			} else if !tt.neverTimeout {
+				// For skipped running sandbox cases: ShutdownTime should be unchanged
+				initialEndAt, parseErr := time.Parse(time.RFC3339, createResp.Body.EndAt)
+				require.NoError(t, parseErr)
+				if tt.autoPause {
+					// For auto-pause, EndAt reflects PauseTime
+					require.NotNil(t, updatedSbx.Spec.PauseTime)
+					assert.WithinDuration(t, initialEndAt, updatedSbx.Spec.PauseTime.Time, 5*time.Second,
+						"PauseTime should be unchanged")
+				} else {
+					require.NotNil(t, updatedSbx.Spec.ShutdownTime)
+					assert.WithinDuration(t, initialEndAt, updatedSbx.Spec.ShutdownTime.Time, 5*time.Second,
+						"ShutdownTime should be unchanged")
+				}
+			}
 		})
 	}
 }

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -201,6 +201,141 @@ func TestConnectSandbox(t *testing.T) {
 	}
 }
 
+func TestShouldSkipRunningSandboxTimeoutUpdate(t *testing.T) {
+	now := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	currentEndAt := now.Add(10 * time.Minute)
+
+	tests := []struct {
+		name                  string
+		currentEndAt          time.Time
+		requestTimeoutSeconds int
+		wantSkip              bool
+	}{
+		{
+			name:                  "shorter_deadline_skips",
+			currentEndAt:          currentEndAt,
+			requestTimeoutSeconds: 60,
+			wantSkip:              true,
+		},
+		{
+			name:                  "equal_deadline_skips",
+			currentEndAt:          currentEndAt,
+			requestTimeoutSeconds: int(currentEndAt.Sub(now) / time.Second),
+			wantSkip:              true,
+		},
+		{
+			name:                  "longer_deadline_does_not_skip",
+			currentEndAt:          currentEndAt,
+			requestTimeoutSeconds: int(currentEndAt.Sub(now)/time.Second) + 120,
+			wantSkip:              false,
+		},
+		{
+			name:                  "zero_current_never_skips",
+			currentEndAt:          time.Time{},
+			requestTimeoutSeconds: 30,
+			wantSkip:              false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skip, reqEnd := shouldSkipRunningSandboxTimeoutUpdate(tt.currentEndAt, now, tt.requestTimeoutSeconds)
+			assert.Equal(t, tt.wantSkip, skip)
+			assert.Equal(t, TimeAfterSeconds(now, tt.requestTimeoutSeconds), reqEnd)
+		})
+	}
+}
+
+func TestConnectSandboxRunningTimeoutGuard(t *testing.T) {
+	templateName := "test-template-connect-timeout-guard"
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+	}
+	tests := []struct {
+		name            string
+		autoPause       bool
+		initialTimeout  int
+		requestTimeout  int
+		expectUnchanged bool
+	}{
+		{name: "shorter running timeout is ignored", autoPause: false, initialTimeout: 600, requestTimeout: 300, expectUnchanged: true},
+		{name: "longer running timeout extends", autoPause: false, initialTimeout: 300, requestTimeout: 600, expectUnchanged: false},
+		{name: "shorter auto-pause timeout is ignored", autoPause: true, initialTimeout: 600, requestTimeout: 300, expectUnchanged: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller, client, teardown := Setup(t)
+			defer teardown()
+			cleanup := CreateSandboxPool(t, controller, templateName, 1)
+			defer cleanup()
+
+			createResp, err := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+				TemplateID: templateName,
+				AutoPause:  tt.autoPause,
+				Timeout:    tt.initialTimeout,
+				Metadata: map[string]string{
+					models.ExtensionKeySkipInitRuntime: agentsv1alpha1.True,
+				},
+			}, nil, user))
+			require.Nil(t, err)
+			assert.Equal(t, models.SandboxStateRunning, createResp.Body.State)
+			AvoidGetFromCache(t, createResp.Body.SandboxID, client.SandboxClient)
+
+			baselineEndAt := createResp.Body.EndAt
+			baselineParsed, parseErr := time.Parse(time.RFC3339, baselineEndAt)
+			require.NoError(t, parseErr)
+
+			sbxBefore := GetSandbox(t, createResp.Body.SandboxID, client.SandboxClient)
+			var pauseBefore, shutdownBefore time.Time
+			if sbxBefore.Spec.PauseTime != nil {
+				pauseBefore = sbxBefore.Spec.PauseTime.Time
+			}
+			if sbxBefore.Spec.ShutdownTime != nil {
+				shutdownBefore = sbxBefore.Spec.ShutdownTime.Time
+			}
+
+			time.Sleep(20 * time.Millisecond)
+			connectNow := time.Now()
+			connectResp, apiErr := controller.ConnectSandbox(NewRequest(t, nil, models.SetTimeoutRequest{
+				TimeoutSeconds: tt.requestTimeout,
+			}, map[string]string{
+				"sandboxID": createResp.Body.SandboxID,
+			}, user))
+			require.Nil(t, apiErr)
+			assert.Equal(t, http.StatusOK, connectResp.Code)
+			assert.Equal(t, models.SandboxStateRunning, connectResp.Body.State)
+
+			if tt.expectUnchanged {
+				endAtAfter, parseErr2 := time.Parse(time.RFC3339, connectResp.Body.EndAt)
+				require.NoError(t, parseErr2)
+				assert.WithinDuration(t, baselineParsed, endAtAfter, 2*time.Second,
+					"EndAt should match pre-connect baseline when shorter/equal connect timeout is ignored")
+				sbxAfter := GetSandbox(t, createResp.Body.SandboxID, client.SandboxClient)
+				if !pauseBefore.IsZero() {
+					require.NotNil(t, sbxAfter.Spec.PauseTime)
+					assert.WithinDuration(t, pauseBefore, sbxAfter.Spec.PauseTime.Time, time.Second)
+				}
+				if !shutdownBefore.IsZero() {
+					require.NotNil(t, sbxAfter.Spec.ShutdownTime)
+					assert.WithinDuration(t, shutdownBefore, sbxAfter.Spec.ShutdownTime.Time, time.Second)
+				}
+			} else {
+				AssertEndAt(t, connectNow.Add(time.Duration(tt.requestTimeout)*time.Second), connectResp.Body.EndAt)
+				sbxAfter := GetSandbox(t, createResp.Body.SandboxID, client.SandboxClient)
+				if tt.autoPause {
+					require.NotNil(t, sbxAfter.Spec.PauseTime)
+					assert.WithinDuration(t, connectNow.Add(time.Duration(tt.requestTimeout)*time.Second), sbxAfter.Spec.PauseTime.Time, 5*time.Second)
+				} else {
+					require.NotNil(t, sbxAfter.Spec.ShutdownTime)
+					assert.WithinDuration(t, connectNow.Add(time.Duration(tt.requestTimeout)*time.Second), sbxAfter.Spec.ShutdownTime.Time, 5*time.Second)
+				}
+			}
+		})
+	}
+}
+
 func TestResumeSandbox(t *testing.T) {
 	templateName := "test-template"
 	user := &models.CreatedTeamAPIKey{

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -182,7 +182,7 @@ func TestConnectSandbox(t *testing.T) {
 				"sandboxID": tt.sandboxID,
 			}, user))
 
-			if tt.expectStatus >= DefaultTimeoutSeconds {
+			if tt.expectStatus >= 300 {
 				require.NotNil(t, err, fmt.Sprintf("%v", err))
 				if err.Code == 0 {
 					err.Code = http.StatusInternalServerError

--- a/pkg/servers/e2b/timeout_test.go
+++ b/pkg/servers/e2b/timeout_test.go
@@ -230,3 +230,51 @@ func TestSetTimeout(t *testing.T) {
 		})
 	}
 }
+
+// TestSetSandboxTimeoutStillShortensRunningSandbox locks scope: POST /timeout must still apply a shorter
+// timeout for running sandboxes; the connect-only "do not shorten" guard must not affect this endpoint.
+func TestSetSandboxTimeoutStillShortensRunningSandbox(t *testing.T) {
+	controller, client, teardown := Setup(t)
+	defer teardown()
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+	}
+	templateName := "test-timeout-shorten-scope"
+
+	cleanup := CreateSandboxPool(t, controller, templateName, 1)
+	defer cleanup()
+
+	initialTimeoutSeconds := 600
+	createResp, err := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+		TemplateID: templateName,
+		Timeout:    initialTimeoutSeconds,
+		Metadata: map[string]string{
+			models.ExtensionKeySkipInitRuntime: v1alpha1.True,
+		},
+	}, nil, user))
+	require.Nil(t, err)
+	assert.Equal(t, models.SandboxStateRunning, createResp.Body.State)
+	AvoidGetFromCache(t, createResp.Body.SandboxID, client.SandboxClient)
+
+	shorterSeconds := 300
+	beforeSet := time.Now()
+	_, apiError := controller.SetSandboxTimeout(NewRequest(t, nil, models.SetTimeoutRequest{
+		TimeoutSeconds: shorterSeconds,
+	}, map[string]string{
+		"sandboxID": createResp.Body.SandboxID,
+	}, user))
+	assert.Nil(t, apiError)
+
+	describeResp, err := controller.DescribeSandbox(NewRequest(t, nil, nil, map[string]string{
+		"sandboxID": createResp.Body.SandboxID,
+	}, user))
+	assert.Nil(t, err)
+	AssertEndAt(t, beforeSet.Add(time.Duration(shorterSeconds)*time.Second), describeResp.Body.EndAt)
+
+	sbx := GetSandbox(t, createResp.Body.SandboxID, client.SandboxClient)
+	require.NotNil(t, sbx.Spec.ShutdownTime)
+	assert.Nil(t, sbx.Spec.PauseTime)
+	assert.WithinDuration(t, beforeSet.Add(time.Duration(shorterSeconds)*time.Second), sbx.Spec.ShutdownTime.Time, 5*time.Second)
+}

--- a/test/e2b/test_sandbox.py
+++ b/test/e2b/test_sandbox.py
@@ -138,6 +138,27 @@ def test_timeout(sandbox_context):
         connect_sandbox(sandbox)
 
 
+def test_connect_shorter_timeout(sandbox_context):
+    sandbox: Sandbox = sandbox_context.add(Sandbox.create(
+        template="code-interpreter",
+        timeout=3600,
+        metadata={"test_case": "test_connect_shorter_timeout"},
+        headers={
+            "x-request-id": sandbox_context.request_id
+        }
+    ))
+
+    info_before = sandbox.get_info()
+    assert info_before.state == SandboxState.RUNNING
+
+    connect_sandbox(sandbox, timeout=300)
+    info_after = sandbox.get_info()
+    assert info_after.state == SandboxState.RUNNING
+
+    # For running sandboxes, connect(timeout=<shorter>) must not shorten endAt.
+    assert info_after.end_at == info_before.end_at
+
+
 def test_pause_connect_kill(sandbox_context):
     sandbox: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",


### PR DESCRIPTION
fixes #304 

## Summary
- Enforce **extend-only** timeout updates in `ConnectSandbox` when the sandbox is already `running` (no shorten / no equal-deadline rewrite).
- Keep `paused -> resume(connect)` behavior unchanged: apply requested timeout directly (no guard).
- Add regression coverage in Go and Python for connect-timeout semantics.
- Clarify SDK compatibility and dual route style docs in `pause_resume.go` and `pkg/servers/e2b/AGENTS.md`.

## Test Plan
- `go test -count=1 -run 'TestShouldSkipRunningSandboxTimeoutUpdate|TestConnectSandboxRunningTimeoutGuard|TestSetSandboxTimeoutStillShortensRunningSandbox' ./pkg/servers/e2b/...`