### PR TITLE
feat: Implement tracing for major sandbox api

### DIFF
--- a/pkg/sandbox-manager/api.go
+++ b/pkg/sandbox-manager/api.go
@@ -10,26 +10,54 @@ import (
 	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/utils/tracing"
 	utils "github.com/openkruise/agents/pkg/utils/sandbox-manager"
 )
 
 // ClaimSandbox attempts to lock a Pod and assign it to the current caller
 func (m *SandboxManager) ClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, error) {
 	log := klog.FromContext(ctx)
+
+	spanCtx, span := tracing.StartClaimSandboxSpan(ctx, "", opts.Template, opts.User, opts.ClaimTimeout)
+	defer span.End()
+
 	if !m.infra.HasTemplate(opts.Template) {
 		// Requirement: Track failure in API layer
+<<<<<<< HEAD
 		sandboxClaimCreationResponses.WithLabelValues("failure").Inc()
 		sandboxClaimTotal.WithLabelValues("failure", "unknown").Inc()
 		return nil, errors.NewError(errors.ErrorNotFound, fmt.Sprintf("template %s not found", opts.Template))
 	}
 	sandbox, claimMetrics, err := m.infra.ClaimSandbox(ctx, opts)
+=======
+		SandboxCreationResponses.WithLabelValues("failure").Inc()
+		tracing.RecordSpanError(
+			span,
+			errors.NewError(errors.ErrorNotFound, fmt.Sprintf("template %s not found", opts.Template)),
+			"template not found",
+			string(errors.ErrorNotFound),
+		)
+		return nil, errors.NewError(errors.ErrorNotFound, fmt.Sprintf("template %s not found", opts.Template))
+	}
+	tracing.RecordSpanEvent(span, tracing.EventTemplateFound)
+
+	sandbox, metrics, err := m.infra.ClaimSandbox(spanCtx, opts)
+>>>>>>> 447b6f2 (Enable tracing for major sandbox api)
 	if err != nil {
 		log.Error(err, "failed to claim sandbox", "metrics", claimMetrics.String())
 		// Requirement: Track failure in API layer
+<<<<<<< HEAD
 		sandboxClaimCreationResponses.WithLabelValues("failure").Inc()
 		sandboxClaimTotal.WithLabelValues("failure", "unknown").Inc()
+=======
+		SandboxCreationResponses.WithLabelValues("failure").Inc()
+		tracing.RecordSpanError(span, err, "failed to claim sandbox", string(errors.ErrorInternal))
+>>>>>>> 447b6f2 (Enable tracing for major sandbox api)
 		return nil, errors.NewError(errors.ErrorInternal, fmt.Sprintf("failed to claim sandbox: %v", err))
 	}
+	tracing.RecordClaimMetrics(span, metrics)
+	tracing.AddSandboxDetails(span, sandbox)
+	tracing.RecordSpanEvent(span, tracing.EventSandboxLocked)
 
 	// Success: Record metrics
 	sandboxClaimCreationResponses.WithLabelValues("success").Inc()
@@ -43,14 +71,18 @@ func (m *SandboxManager) ClaimSandbox(ctx context.Context, opts infra.ClaimSandb
 	log.Info("sandbox claimed", "sandbox", klog.KObj(sandbox), "metrics", claimMetrics.String(), "state", state, "reason", reason)
 
 	// Sync route without refresh since sandbox was just claimed and state is already up-to-date
-	if err = m.syncRoute(ctx, sandbox, false); err != nil {
+	if err = m.syncRoute(spanCtx, sandbox, false); err != nil {
 		log.Error(err, "failed to sync route with peers after claim")
+	} else {
+		tracing.RecordSpanEvent(span, tracing.EventRouteSynced)
 	}
+	tracing.RecordSpanSuccess(span)
 	return sandbox, nil
 }
 
 func (m *SandboxManager) CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions) (infra.Sandbox, error) {
 	log := klog.FromContext(ctx)
+<<<<<<< HEAD
 	sandbox, cloneMetrics, err := m.infra.CloneSandbox(ctx, opts)
 	if err != nil {
 		log.Error(err, "failed to clone sandbox", "metrics", cloneMetrics)
@@ -61,14 +93,37 @@ func (m *SandboxManager) CloneSandbox(ctx context.Context, opts infra.CloneSandb
 	// Clone-specific metrics
 	sandboxCloneDuration.Observe(cloneMetrics.Total.Seconds())
 	sandboxCloneTotal.WithLabelValues("success").Inc()
+=======
+
+	spanCtx, span := tracing.StartCloneSandboxSpan(ctx, "", opts.CheckPointID, opts.User, opts.CloneTimeout)
+	defer span.End()
+
+	sandbox, metrics, err := m.infra.CloneSandbox(spanCtx, opts)
+	if err != nil {
+		log.Error(err, "failed to clone sandbox", "metrics", metrics)
+		SandboxCreationResponses.WithLabelValues("failure").Inc()
+		tracing.RecordSpanError(span, err, "failed to clone sandbox", string(errors.ErrorInternal))
+		return nil, errors.NewError(errors.ErrorInternal, fmt.Sprintf("failed to clone sandbox: %v", err))
+	}
+	tracing.RecordCloneMetrics(span, metrics)
+	tracing.AddSandboxDetails(span, sandbox)
+	tracing.RecordSpanEvent(span, tracing.EventSandboxCreated)
+	// Success: Record metrics
+	SandboxCreationResponses.WithLabelValues("success").Inc()
+	// Requirement: Only measure the latency when no error exists
+	SandboxCreationLatency.Observe(float64(metrics.Total.Milliseconds()))
+>>>>>>> 447b6f2 (Enable tracing for major sandbox api)
 
 	state, reason := sandbox.GetState()
 	log.Info("sandbox cloned", "sandbox", klog.KObj(sandbox), "metrics", cloneMetrics.String(), "state", state, "reason", reason)
 
 	// Sync route without refresh since sandbox was just claimed and state is already up-to-date
-	if err = m.syncRoute(ctx, sandbox, false); err != nil {
+	if err = m.syncRoute(spanCtx, sandbox, false); err != nil {
 		log.Error(err, "failed to sync route with peers after claim")
+	} else {
+		tracing.RecordSpanEvent(span, tracing.EventRouteSynced)
 	}
+	tracing.RecordSpanSuccess(span)
 	return sandbox, nil
 }
 
@@ -172,6 +227,7 @@ func (m *SandboxManager) syncRoute(ctx context.Context, sbx infra.Sandbox, refre
 // PauseSandbox pauses a sandbox and syncs route with peers
 func (m *SandboxManager) PauseSandbox(ctx context.Context, sbx infra.Sandbox, opts infra.PauseOptions) error {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
+<<<<<<< HEAD
 	start := time.Now()
 	if err := sbx.Pause(ctx, opts); err != nil {
 		log.Error(err, "failed to pause sandbox")
@@ -181,8 +237,24 @@ func (m *SandboxManager) PauseSandbox(ctx context.Context, sbx infra.Sandbox, op
 	sandboxPauseResponses.WithLabelValues("success").Inc()
 	sandboxPauseDuration.Observe(time.Since(start).Seconds())
 	if err := m.syncRoute(ctx, sbx, true); err != nil {
-		log.Error(err, "failed to sync route with peers after pause")
+=======
+
+	spanCtx, span := tracing.StartPauseSandboxSpan(ctx, sbx.GetSandboxID(), sbx.GetRoute().Owner, sbx)
+	defer span.End()
+
+	tracing.RecordSpanEvent(span, tracing.EventPauseRequested)
+	if err := sbx.Pause(spanCtx, opts); err != nil {
+		log.Error(err, "failed to pause sandbox")
+		tracing.RecordSpanError(span, err, "failed to pause sandbox", "pause_error")
+		return err
 	}
+	if err := m.syncRoute(spanCtx, sbx, true); err != nil {
+>>>>>>> 447b6f2 (Enable tracing for major sandbox api)
+		log.Error(err, "failed to sync route with peers after pause")
+	} else {
+		tracing.RecordSpanEvent(span, tracing.EventRouteSynced)
+	}
+	tracing.RecordSpanSuccess(span)
 	return nil
 }
 

--- a/pkg/sandbox-manager/api.go
+++ b/pkg/sandbox-manager/api.go
@@ -23,14 +23,8 @@ func (m *SandboxManager) ClaimSandbox(ctx context.Context, opts infra.ClaimSandb
 
 	if !m.infra.HasTemplate(opts.Template) {
 		// Requirement: Track failure in API layer
-<<<<<<< HEAD
 		sandboxClaimCreationResponses.WithLabelValues("failure").Inc()
 		sandboxClaimTotal.WithLabelValues("failure", "unknown").Inc()
-		return nil, errors.NewError(errors.ErrorNotFound, fmt.Sprintf("template %s not found", opts.Template))
-	}
-	sandbox, claimMetrics, err := m.infra.ClaimSandbox(ctx, opts)
-=======
-		SandboxCreationResponses.WithLabelValues("failure").Inc()
 		tracing.RecordSpanError(
 			span,
 			errors.NewError(errors.ErrorNotFound, fmt.Sprintf("template %s not found", opts.Template)),
@@ -41,21 +35,16 @@ func (m *SandboxManager) ClaimSandbox(ctx context.Context, opts infra.ClaimSandb
 	}
 	tracing.RecordSpanEvent(span, tracing.EventTemplateFound)
 
-	sandbox, metrics, err := m.infra.ClaimSandbox(spanCtx, opts)
->>>>>>> 447b6f2 (Enable tracing for major sandbox api)
+	sandbox, claimMetrics, err := m.infra.ClaimSandbox(spanCtx, opts)
 	if err != nil {
 		log.Error(err, "failed to claim sandbox", "metrics", claimMetrics.String())
 		// Requirement: Track failure in API layer
-<<<<<<< HEAD
 		sandboxClaimCreationResponses.WithLabelValues("failure").Inc()
 		sandboxClaimTotal.WithLabelValues("failure", "unknown").Inc()
-=======
-		SandboxCreationResponses.WithLabelValues("failure").Inc()
 		tracing.RecordSpanError(span, err, "failed to claim sandbox", string(errors.ErrorInternal))
->>>>>>> 447b6f2 (Enable tracing for major sandbox api)
 		return nil, errors.NewError(errors.ErrorInternal, fmt.Sprintf("failed to claim sandbox: %v", err))
 	}
-	tracing.RecordClaimMetrics(span, metrics)
+	tracing.RecordClaimMetrics(span, claimMetrics)
 	tracing.AddSandboxDetails(span, sandbox)
 	tracing.RecordSpanEvent(span, tracing.EventSandboxLocked)
 
@@ -82,37 +71,24 @@ func (m *SandboxManager) ClaimSandbox(ctx context.Context, opts infra.ClaimSandb
 
 func (m *SandboxManager) CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions) (infra.Sandbox, error) {
 	log := klog.FromContext(ctx)
-<<<<<<< HEAD
-	sandbox, cloneMetrics, err := m.infra.CloneSandbox(ctx, opts)
-	if err != nil {
-		log.Error(err, "failed to clone sandbox", "metrics", cloneMetrics)
-		sandboxCloneTotal.WithLabelValues("failure").Inc()
-		return nil, errors.NewError(errors.ErrorInternal, fmt.Sprintf("failed to clone sandbox: %v", err))
-	}
-
-	// Clone-specific metrics
-	sandboxCloneDuration.Observe(cloneMetrics.Total.Seconds())
-	sandboxCloneTotal.WithLabelValues("success").Inc()
-=======
 
 	spanCtx, span := tracing.StartCloneSandboxSpan(ctx, "", opts.CheckPointID, opts.User, opts.CloneTimeout)
 	defer span.End()
 
-	sandbox, metrics, err := m.infra.CloneSandbox(spanCtx, opts)
+	sandbox, cloneMetrics, err := m.infra.CloneSandbox(spanCtx, opts)
 	if err != nil {
-		log.Error(err, "failed to clone sandbox", "metrics", metrics)
-		SandboxCreationResponses.WithLabelValues("failure").Inc()
+		log.Error(err, "failed to clone sandbox", "metrics", cloneMetrics)
+		sandboxCloneTotal.WithLabelValues("failure").Inc()
 		tracing.RecordSpanError(span, err, "failed to clone sandbox", string(errors.ErrorInternal))
 		return nil, errors.NewError(errors.ErrorInternal, fmt.Sprintf("failed to clone sandbox: %v", err))
 	}
-	tracing.RecordCloneMetrics(span, metrics)
+	tracing.RecordCloneMetrics(span, cloneMetrics)
 	tracing.AddSandboxDetails(span, sandbox)
 	tracing.RecordSpanEvent(span, tracing.EventSandboxCreated)
-	// Success: Record metrics
-	SandboxCreationResponses.WithLabelValues("success").Inc()
-	// Requirement: Only measure the latency when no error exists
-	SandboxCreationLatency.Observe(float64(metrics.Total.Milliseconds()))
->>>>>>> 447b6f2 (Enable tracing for major sandbox api)
+
+	// Clone-specific metrics
+	sandboxCloneDuration.Observe(cloneMetrics.Total.Seconds())
+	sandboxCloneTotal.WithLabelValues("success").Inc()
 
 	state, reason := sandbox.GetState()
 	log.Info("sandbox cloned", "sandbox", klog.KObj(sandbox), "metrics", cloneMetrics.String(), "state", state, "reason", reason)
@@ -227,17 +203,7 @@ func (m *SandboxManager) syncRoute(ctx context.Context, sbx infra.Sandbox, refre
 // PauseSandbox pauses a sandbox and syncs route with peers
 func (m *SandboxManager) PauseSandbox(ctx context.Context, sbx infra.Sandbox, opts infra.PauseOptions) error {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
-<<<<<<< HEAD
 	start := time.Now()
-	if err := sbx.Pause(ctx, opts); err != nil {
-		log.Error(err, "failed to pause sandbox")
-		sandboxPauseResponses.WithLabelValues("failure").Inc()
-		return err
-	}
-	sandboxPauseResponses.WithLabelValues("success").Inc()
-	sandboxPauseDuration.Observe(time.Since(start).Seconds())
-	if err := m.syncRoute(ctx, sbx, true); err != nil {
-=======
 
 	spanCtx, span := tracing.StartPauseSandboxSpan(ctx, sbx.GetSandboxID(), sbx.GetRoute().Owner, sbx)
 	defer span.End()
@@ -245,11 +211,13 @@ func (m *SandboxManager) PauseSandbox(ctx context.Context, sbx infra.Sandbox, op
 	tracing.RecordSpanEvent(span, tracing.EventPauseRequested)
 	if err := sbx.Pause(spanCtx, opts); err != nil {
 		log.Error(err, "failed to pause sandbox")
+		sandboxPauseResponses.WithLabelValues("failure").Inc()
 		tracing.RecordSpanError(span, err, "failed to pause sandbox", "pause_error")
 		return err
 	}
+	sandboxPauseResponses.WithLabelValues("success").Inc()
+	sandboxPauseDuration.Observe(time.Since(start).Seconds())
 	if err := m.syncRoute(spanCtx, sbx, true); err != nil {
->>>>>>> 447b6f2 (Enable tracing for major sandbox api)
 		log.Error(err, "failed to sync route with peers after pause")
 	} else {
 		tracing.RecordSpanEvent(span, tracing.EventRouteSynced)

--- a/pkg/utils/tracing/constants.go
+++ b/pkg/utils/tracing/constants.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import "go.opentelemetry.io/otel/attribute"
+
+const (
+	SpanClaimSandbox     = "sandbox.claim"
+	SpanCloneSandbox     = "sandbox.clone"
+	SpanPauseSandbox     = "sandbox.pause"
+	SpanDeleteSandbox    = "sandbox.delete"
+	SpanGetSandbox       = "sandbox.get"
+	SpanListSandboxes    = "sandboxes.list"
+	SpanCreateCheckpoint = "checkpoint.create"
+	SpanDeleteCheckpoint = "checkpoint.delete"
+)
+
+const (
+	AttrSandboxID          = "sandbox.id"
+	AttrSandboxName        = "sandbox.name"
+	AttrSandboxState       = "sandbox.state"
+	AttrSandboxNode        = "sandbox.node"
+	AttrSandboxNamespace   = "sandbox.namespace"
+	AttrTemplateID         = "sandbox.template_id"
+	AttrCheckpointID       = "sandbox.checkpoint_id"
+	AttrUserID             = "sandbox.user_id"
+	AttrPauseTimeout       = "sandbox.pause_timeout"
+	AttrClaimTimeout       = "sandbox.claim_timeout"
+	AttrCloneTimeout       = "sandbox.clone_timeout"
+	AttrWaitReadyTimeout   = "sandbox.wait_ready_timeout"
+	AttrAccessTokenSet     = "sandbox.access_token_set"
+	AttrInitRuntimeSkipped = "sandbox.init_runtime_skipped"
+)
+
+const (
+	AttrInfraOperation = "infra.operation"
+	AttrPoolSize       = "infra.pool_size"
+	AttrCandidateCount = "infra.candidate_count"
+)
+
+const (
+	AttrErrorCode    = "error.code"
+	AttrErrorMessage = "error.message"
+	AttrErrorType    = "error.type"
+)
+
+const (
+	EventTemplateFound    = "template.found"
+	EventCheckpointFound  = "checkpoint.found"
+	EventSandboxLocked    = "sandbox.locked"
+	EventSandboxCreated   = "sandbox.created"
+	EventRouteSynced      = "route.synced"
+	EventPauseRequested   = "pause.requested"
+	EventSandboxRefreshed = "sandbox.refreshed"
+)
+
+func SandboxAttributes(sandboxID, name, namespace, user string, state interface{}) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.String(AttrSandboxID, sandboxID),
+		attribute.String(AttrUserID, user),
+	}
+	if name != "" {
+		attrs = append(attrs, attribute.String(AttrSandboxName, name))
+	}
+	if namespace != "" {
+		attrs = append(attrs, attribute.String(AttrSandboxNamespace, namespace))
+	}
+	if state != nil {
+		attrs = append(attrs, attribute.String(AttrSandboxState, toStringAttr(state)))
+	}
+	return attrs
+}
+
+func toStringAttr(v interface{}) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}

--- a/pkg/utils/tracing/sandbox.go
+++ b/pkg/utils/tracing/sandbox.go
@@ -80,11 +80,8 @@ func RecordClaimMetrics(span trace.Span, metrics infra.ClaimMetrics) {
 		attribute.Int64("claim.total_ms", int64(metrics.Total.Milliseconds())),
 		attribute.Int64("claim.wait_ms", int64(metrics.Wait.Milliseconds())),
 	)
-	if metrics.PickTime > 0 {
-		span.SetAttributes(attribute.Int64("claim.pick_time_ms", int64(metrics.PickTime.Milliseconds())))
-	}
-	if metrics.LockTime > 0 {
-		span.SetAttributes(attribute.Int64("claim.lock_time_ms", int64(metrics.LockTime.Milliseconds())))
+	if metrics.PickAndLock > 0 {
+		span.SetAttributes(attribute.Int64("claim.pick_and_lock_ms", int64(metrics.PickAndLock.Milliseconds())))
 	}
 }
 

--- a/pkg/utils/tracing/sandbox.go
+++ b/pkg/utils/tracing/sandbox.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+)
+
+func StartClaimSandboxSpan(ctx context.Context, sandboxID, templateID, user string, timeout time.Duration) (context.Context, trace.Span) {
+	tracer := GetTracer()
+	attrs := []attribute.KeyValue{
+		attribute.String(AttrSandboxID, sandboxID),
+		attribute.String(AttrTemplateID, templateID),
+		attribute.String(AttrUserID, user),
+	}
+	if timeout > 0 {
+		attrs = append(attrs, attribute.Int64(AttrClaimTimeout, int64(timeout.Milliseconds())))
+	}
+	spanCtx, span := tracer.Start(ctx, SpanClaimSandbox)
+	span.SetAttributes(attrs...)
+	return spanCtx, span
+}
+
+func StartCloneSandboxSpan(ctx context.Context, sandboxID, checkpointID, user string, timeout time.Duration) (context.Context, trace.Span) {
+	tracer := GetTracer()
+	attrs := []attribute.KeyValue{
+		attribute.String(AttrSandboxID, sandboxID),
+		attribute.String(AttrCheckpointID, checkpointID),
+		attribute.String(AttrUserID, user),
+	}
+	if timeout > 0 {
+		attrs = append(attrs, attribute.Int64(AttrCloneTimeout, int64(timeout.Milliseconds())))
+	}
+	spanCtx, span := tracer.Start(ctx, SpanCloneSandbox)
+	span.SetAttributes(attrs...)
+	return spanCtx, span
+}
+
+func StartPauseSandboxSpan(ctx context.Context, sandboxID, user string, sbx infra.Sandbox) (context.Context, trace.Span) {
+	tracer := GetTracer()
+	attrs := []attribute.KeyValue{
+		attribute.String(AttrSandboxID, sandboxID),
+		attribute.String(AttrUserID, user),
+	}
+	if sbx != nil {
+		if state, _ := sbx.GetState(); state != "" {
+			attrs = append(attrs, attribute.String(AttrSandboxState, string(state)))
+		}
+	}
+	spanCtx, span := tracer.Start(ctx, SpanPauseSandbox)
+	span.SetAttributes(attrs...)
+	return spanCtx, span
+}
+
+func RecordClaimMetrics(span trace.Span, metrics infra.ClaimMetrics) {
+	if span == nil {
+		return
+	}
+	span.SetAttributes(
+		attribute.Int64("claim.total_ms", int64(metrics.Total.Milliseconds())),
+		attribute.Int64("claim.wait_ms", int64(metrics.Wait.Milliseconds())),
+	)
+	if metrics.PickTime > 0 {
+		span.SetAttributes(attribute.Int64("claim.pick_time_ms", int64(metrics.PickTime.Milliseconds())))
+	}
+	if metrics.LockTime > 0 {
+		span.SetAttributes(attribute.Int64("claim.lock_time_ms", int64(metrics.LockTime.Milliseconds())))
+	}
+}
+
+func RecordCloneMetrics(span trace.Span, metrics infra.CloneMetrics) {
+	if span == nil {
+		return
+	}
+	span.SetAttributes(attribute.Int64("clone.total_ms", int64(metrics.Total.Milliseconds())))
+	if metrics.Wait > 0 {
+		span.SetAttributes(attribute.Int64("clone.wait_ms", int64(metrics.Wait.Milliseconds())))
+	}
+}
+
+func AddSandboxDetails(span trace.Span, sbx infra.Sandbox) {
+	if span == nil || sbx == nil {
+		return
+	}
+	state, reason := sbx.GetState()
+	if state != "" {
+		span.SetAttributes(attribute.String(AttrSandboxState, string(state)))
+	}
+	if reason != "" {
+		span.SetAttributes(attribute.String("sandbox.state_reason", reason))
+	}
+}

--- a/pkg/utils/tracing/span.go
+++ b/pkg/utils/tracing/span.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func StartSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span, func()) {
+	tracer := GetTracer()
+	spanCtx, span := tracer.Start(ctx, name)
+	if len(attrs) > 0 {
+		span.SetAttributes(attrs...)
+	}
+	return spanCtx, span, func() { span.End() }
+}
+
+func RecordSpanError(span trace.Span, err error, errorMessage string, errorCode string) {
+	if span == nil || err == nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetAttributes(
+		attribute.String(AttrErrorMessage, errorMessage),
+		attribute.String(AttrErrorCode, errorCode),
+	)
+	span.SetStatus(codes.Error, errorMessage)
+}
+
+func RecordSpanSuccess(span trace.Span) {
+	if span == nil {
+		return
+	}
+	span.SetStatus(codes.Ok, "success")
+}
+
+func RecordSpanEvent(span trace.Span, eventName string, attrs ...attribute.KeyValue) {
+	if span == nil {
+		return
+	}
+	span.AddEvent(eventName, trace.WithAttributes(attrs...))
+}
+
+func RecordSpanMetrics(span trace.Span, duration time.Duration, attrs ...attribute.KeyValue) {
+	if span == nil {
+		return
+	}
+	metricAttrs := append([]attribute.KeyValue{attribute.Int64("operation.duration_ms", duration.Milliseconds())}, attrs...)
+	span.SetAttributes(metricAttrs...)
+}
+
+func EndSpan(span trace.Span, err error, message string) {
+	if span == nil {
+		return
+	}
+	if err != nil {
+		RecordSpanError(span, err, message, "")
+	} else {
+		RecordSpanSuccess(span)
+	}
+	span.End()
+}

--- a/pkg/utils/tracing/tracer.go
+++ b/pkg/utils/tracing/tracer.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"sync"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var (
+	tracer trace.Tracer
+	once   sync.Once
+)
+
+// GetTracer returns a global tracer instance for sandbox operations.
+func GetTracer() trace.Tracer {
+	once.Do(func() {
+		tracer = otel.Tracer("github.com/openkruise/agents/sandbox-operations")
+	})
+	return tracer
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Implemented execution-level OpenTelemetry tracing at the sandbox manager business-logic layer for sandbox creation and pause flows.
This adds spans for ClaimSandbox (template create path), CloneSandbox (checkpoint-restore create path), and PauseSandbox, with structured attributes, milestone events, error status recording, and timing metrics for better internal observability.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #23 

### Ⅲ. Describe how to verify it
Run sandbox create (template and checkpoint-restore) and pause operations, then check your trace backend (Jaeger/OTLP) for spans `sandbox.claim`, `sandbox.clone`, and `sandbox.pause` with expected events/attributes.
