### PR TITLE
feat(controller): consider SandboxTemplate for SandboxSet rolling update

### DIFF
--- a/pkg/controller/sandboxset/revision.go
+++ b/pkg/controller/sandboxset/revision.go
@@ -19,45 +19,72 @@ limitations under the License.
 package sandboxset
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"hash"
 	"hash/fnv"
 	"strconv"
 
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	apps "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/dump"
 	"k8s.io/apimachinery/pkg/util/rand"
-
-	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// getPatch returns a strategic merge patch that can be applied to restore a StatefulSet to a
-// previous version. If the returned error is nil the patch is valid. The current state that we save is just the
-// PodSpecTemplate. We can modify this later to encompass more state (or less) and remain compatible with previously
-// recorded patches.
-func (r *Reconciler) getPatch(set *agentsv1alpha1.SandboxSet) ([]byte, error) {
-	str, err := runtime.Encode(r.Codec, set)
-	if err != nil {
-		return nil, err
-	}
-	var raw map[string]interface{}
-	err = json.Unmarshal(str, &raw)
-	if err != nil {
-		return nil, err
-	}
-	objCopy := make(map[string]interface{})
+// getPatch serialises the subset of the SandboxSet spec that determines the
+// template revision hash. Both spec.template (inline) and spec.templateRef are
+// normalised to the same `spec.template` key so that they yield identical
+// hashes whenever they describe the same pod template. This also guarantees
+// that switching between inline template and templateRef (or between two
+// templateRefs) only triggers a rolling update when the underlying pod
+// template actually differs.
+func (r *Reconciler) getPatch(ctx context.Context, set *agentsv1alpha1.SandboxSet) ([]byte, error) {
 	specCopy := make(map[string]interface{})
-	spec := raw["spec"].(map[string]interface{})
-	template := spec["template"].(map[string]interface{})
-	specCopy["template"] = template
-	template["$patch"] = "replace"
-	objCopy["spec"] = specCopy
-	patch, err := json.Marshal(objCopy)
-	return patch, err
+	// spec.template and spec.templateRef are mutually exclusive; prefer
+	// templateRef when set and fall back to the inline template otherwise.
+	if set.Spec.TemplateRef != nil {
+		tpl := &agentsv1alpha1.SandboxTemplate{}
+		if err := r.Get(ctx, client.ObjectKey{
+			Namespace: set.Namespace,
+			Name:      set.Spec.TemplateRef.Name,
+		}, tpl); err != nil {
+			return nil, fmt.Errorf("failed to resolve sandbox template %s/%s: %w",
+				set.Namespace, set.Spec.TemplateRef.Name, err)
+		}
+		if tpl.Spec.Template != nil {
+			templateRaw, err := json.Marshal(tpl.Spec.Template)
+			if err != nil {
+				return nil, err
+			}
+			var templateMap map[string]interface{}
+			if err := json.Unmarshal(templateRaw, &templateMap); err != nil {
+				return nil, err
+			}
+			templateMap["$patch"] = "replace"
+			specCopy["template"] = templateMap
+		}
+	} else if set.Spec.Template != nil {
+		str, err := runtime.Encode(r.Codec, set)
+		if err != nil {
+			return nil, err
+		}
+		var raw map[string]interface{}
+		if err = json.Unmarshal(str, &raw); err != nil {
+			return nil, err
+		}
+		if spec, ok := raw["spec"].(map[string]interface{}); ok {
+			if template, ok := spec["template"].(map[string]interface{}); ok {
+				template["$patch"] = "replace"
+				specCopy["template"] = template
+			}
+		}
+	}
+	return json.Marshal(map[string]interface{}{"spec": specCopy})
 }
 
 // NewControllerRevision returns a ControllerRevision with a ControllerRef pointing to parent and indicating that

--- a/pkg/controller/sandboxset/revision_test.go
+++ b/pkg/controller/sandboxset/revision_test.go
@@ -1,0 +1,295 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandboxset
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+)
+
+// newRevisionTestReconciler builds a Reconciler backed by a fake client for
+// revision-related unit tests.
+func newRevisionTestReconciler(objs ...client.Object) *Reconciler {
+	c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(objs...).Build()
+	return &Reconciler{
+		Client: c,
+		Scheme: testScheme,
+		Codec:  codec,
+	}
+}
+
+// samplePodTemplate returns a minimal pod template with the given image and
+// optional labels, used to compose SandboxSet / SandboxTemplate fixtures.
+func samplePodTemplate(image string, labels map[string]string) *corev1.PodTemplateSpec {
+	return &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Labels: labels},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main", Image: image}},
+		},
+	}
+}
+
+func TestReconciler_getPatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		sbs     *v1alpha1.SandboxSet
+		objects []client.Object
+		wantErr bool
+		// errContains is asserted only when wantErr is true.
+		errContains string
+		// verify runs only when wantErr is false and inspects the decoded
+		// `spec` object returned by getPatch.
+		verify func(t *testing.T, spec map[string]interface{})
+	}{
+		{
+			name: "inline template is normalised to spec.template with $patch=replace",
+			sbs: &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "inline", Namespace: "default"},
+				Spec: v1alpha1.SandboxSetSpec{
+					Replicas: 3,
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: samplePodTemplate("img:v1", map[string]string{"app": "inline"}),
+					},
+				},
+			},
+			verify: func(t *testing.T, spec map[string]interface{}) {
+				template, ok := spec["template"].(map[string]interface{})
+				require.True(t, ok, "spec.template must be present for inline template")
+				assert.Equal(t, "replace", template["$patch"])
+				_, refExists := spec["templateRef"]
+				assert.False(t, refExists, "spec.templateRef must not appear in specCopy")
+			},
+		},
+		{
+			name: "templateRef resolves and normalises to spec.template",
+			sbs: &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "ref-sbs", Namespace: "default"},
+				Spec: v1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						TemplateRef: &v1alpha1.SandboxTemplateRef{Name: "tpl-a"},
+					},
+				},
+			},
+			objects: []client.Object{
+				&v1alpha1.SandboxTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: "tpl-a", Namespace: "default"},
+					Spec: v1alpha1.SandboxTemplateSpec{
+						Template: samplePodTemplate("img:v1", map[string]string{"app": "ref"}),
+					},
+				},
+			},
+			verify: func(t *testing.T, spec map[string]interface{}) {
+				template, ok := spec["template"].(map[string]interface{})
+				require.True(t, ok, "templateRef branch should normalise to spec.template")
+				assert.Equal(t, "replace", template["$patch"])
+				// spec.templateRef must NOT be written: the hash key is normalised
+				// to spec.template regardless of inline vs templateRef.
+				_, refExists := spec["templateRef"]
+				assert.False(t, refExists, "spec.templateRef must not appear in specCopy")
+			},
+		},
+		{
+			name: "templateRef not found propagates a resolve error",
+			sbs: &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "ref-missing", Namespace: "default"},
+				Spec: v1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						TemplateRef: &v1alpha1.SandboxTemplateRef{Name: "does-not-exist"},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "failed to resolve sandbox template",
+		},
+		{
+			name: "neither template nor templateRef yields spec without template",
+			sbs: &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "empty", Namespace: "default"},
+			},
+			verify: func(t *testing.T, spec map[string]interface{}) {
+				_, tplExists := spec["template"]
+				assert.False(t, tplExists, "spec.template must be absent when neither source is set")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newRevisionTestReconciler(tt.objects...)
+			raw, err := r.getPatch(context.Background(), tt.sbs)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			var decoded map[string]interface{}
+			require.NoError(t, json.Unmarshal(raw, &decoded))
+			spec, ok := decoded["spec"].(map[string]interface{})
+			require.True(t, ok, "spec must be present")
+			if tt.verify != nil {
+				tt.verify(t, spec)
+			}
+		})
+	}
+}
+
+// TestReconciler_newRevision covers the hashing behaviour of newRevision across
+// inline / templateRef combinations and the error path when a referenced
+// SandboxTemplate is missing.
+//
+// When compareWith is non-nil, the test computes a revision for both sbs and
+// compareWith using the shared reconciler, and asserts hash equality per
+// expectEqual. When wantErr is true, only sbs is invoked and the error is
+// asserted.
+func TestReconciler_newRevision(t *testing.T) {
+	samePod := samplePodTemplate("img:v1", map[string]string{"app": "same"})
+
+	tests := []struct {
+		name        string
+		objects     []client.Object
+		sbs         *v1alpha1.SandboxSet
+		compareWith *v1alpha1.SandboxSet
+		expectEqual bool
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "inline and templateRef describing the same pod produce identical hash",
+			objects: []client.Object{
+				&v1alpha1.SandboxTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: "tpl-dup", Namespace: "default"},
+					Spec:       v1alpha1.SandboxTemplateSpec{Template: samePod.DeepCopy()},
+				},
+			},
+			sbs: &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "dup", Namespace: "default"},
+				Spec: v1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: samePod.DeepCopy(),
+					},
+				},
+			},
+			compareWith: &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "dup", Namespace: "default"},
+				Spec: v1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						TemplateRef: &v1alpha1.SandboxTemplateRef{Name: "tpl-dup"},
+					},
+				},
+			},
+			expectEqual: true,
+		},
+		{
+			name: "different referenced SandboxTemplates produce different hash",
+			objects: []client.Object{
+				&v1alpha1.SandboxTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: "tpl-v1", Namespace: "default"},
+					Spec:       v1alpha1.SandboxTemplateSpec{Template: samplePodTemplate("img:v1", nil)},
+				},
+				&v1alpha1.SandboxTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: "tpl-v2", Namespace: "default"},
+					Spec:       v1alpha1.SandboxTemplateSpec{Template: samplePodTemplate("img:v2", nil)},
+				},
+			},
+			sbs: &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "diff", Namespace: "default"},
+				Spec: v1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						TemplateRef: &v1alpha1.SandboxTemplateRef{Name: "tpl-v1"},
+					},
+				},
+			},
+			compareWith: &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "diff", Namespace: "default"},
+				Spec: v1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						TemplateRef: &v1alpha1.SandboxTemplateRef{Name: "tpl-v2"},
+					},
+				},
+			},
+			expectEqual: false,
+		},
+		{
+			name: "templateRef not found returns resolve error",
+			sbs: &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "missing", Namespace: "default"},
+				Spec: v1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						TemplateRef: &v1alpha1.SandboxTemplateRef{Name: "no-such-tpl"},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "failed to resolve sandbox template",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newRevisionTestReconciler(tt.objects...)
+
+			crA, err := r.newRevision(context.Background(), tt.sbs, 1, nil)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+			hashA := crA.Labels[ControllerRevisionHashLabel]
+			require.NotEmpty(t, hashA)
+
+			if tt.compareWith == nil {
+				return
+			}
+			crB, err := r.newRevision(context.Background(), tt.compareWith, 1, nil)
+			require.NoError(t, err)
+			hashB := crB.Labels[ControllerRevisionHashLabel]
+			require.NotEmpty(t, hashB)
+
+			if tt.expectEqual {
+				assert.Equal(t, hashA, hashB,
+					"revisions describing the same pod template must share the same hash")
+			} else {
+				assert.NotEqual(t, hashA, hashB,
+					"revisions describing different pod templates must have different hashes")
+			}
+		})
+	}
+}

--- a/pkg/controller/sandboxset/rolling_update_test.go
+++ b/pkg/controller/sandboxset/rolling_update_test.go
@@ -447,7 +447,7 @@ func TestReconcile_RollingUpdate(t *testing.T) {
 			}
 			sbs := getSandboxSet(tt.replicas)
 			assert.NoError(t, k8sClient.Create(ctx, sbs))
-			newStatus, err := reconciler.initNewStatus(sbs)
+			newStatus, err := reconciler.initNewStatus(ctx, sbs)
 			assert.NoError(t, err)
 
 			// Use an old hash to create sandboxes (simulate old revision)
@@ -509,7 +509,7 @@ func TestReconcile_RollingUpdate_SurgeGate(t *testing.T) {
 	// replicas=4, default maxSurge=20% (ceil→1), maxUnavailable=20% (floor→0)
 	sbs := getSandboxSet(4)
 	assert.NoError(t, k8sClient.Create(ctx, sbs))
-	newStatus, err := reconciler.initNewStatus(sbs)
+	newStatus, err := reconciler.initNewStatus(ctx, sbs)
 	assert.NoError(t, err)
 	newHash := newStatus.UpdateRevision
 

--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -118,7 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	recordSandboxSetMetrics(sbs)
 
 	// Preparation
-	newStatus, err := r.initNewStatus(sbs)
+	newStatus, err := r.initNewStatus(ctx, sbs)
 	if err != nil {
 		log.Error(err, "failed to init new status")
 		return ctrl.Result{}, err
@@ -327,7 +327,19 @@ func calculateScaleDelta(sbs *agentsv1alpha1.SandboxSet, newStatus *agentsv1alph
 }
 
 func (r *Reconciler) createSandbox(ctx context.Context, sbs *agentsv1alpha1.SandboxSet, revision string) (*agentsv1alpha1.Sandbox, error) {
-	sbx := NewSandboxFromSandboxSet(sbs)
+	var refTemplate *agentsv1alpha1.SandboxTemplate
+	if sbs.Spec.TemplateRef != nil {
+		refTemplate = &agentsv1alpha1.SandboxTemplate{}
+		if err := r.Get(ctx, client.ObjectKey{
+			Namespace: sbs.Namespace,
+			Name:      sbs.Spec.TemplateRef.Name,
+		}, refTemplate); err != nil {
+			r.Recorder.Eventf(sbs, corev1.EventTypeWarning, EventCreateSandboxFailed, "Failed to resolve sandbox template: %s", err)
+			return nil, fmt.Errorf("failed to resolve sandbox template %s/%s: %w",
+				sbs.Namespace, sbs.Spec.TemplateRef.Name, err)
+		}
+	}
+	sbx := NewSandboxFromSandboxSet(sbs, refTemplate)
 	sbx.Labels[agentsv1alpha1.LabelTemplateHash] = revision
 	if err := ctrl.SetControllerReference(sbs, sbx, r.Scheme); err != nil {
 		return nil, err

--- a/pkg/controller/sandboxset/sandboxset_controller_test.go
+++ b/pkg/controller/sandboxset/sandboxset_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -313,7 +314,7 @@ func TestReconcile_DeleteDead(t *testing.T) {
 				Codec:    codec,
 			}
 			assert.NoError(t, k8sClient.Create(ctx, sbs))
-			newStatus, err := reconciler.initNewStatus(sbs)
+			newStatus, err := reconciler.initNewStatus(ctx, sbs)
 
 			assert.NoError(t, err)
 			sbs.Status = *newStatus
@@ -575,7 +576,7 @@ func TestReconcile_BasicScale(t *testing.T) {
 				Recorder: eventRecorder,
 				Codec:    codec,
 			}
-			newStatus, err := reconciler.initNewStatus(sbs)
+			newStatus, err := reconciler.initNewStatus(ctx, sbs)
 
 			assert.NoError(t, err)
 			sbs.Status = *newStatus
@@ -786,7 +787,7 @@ func TestSandboxSetReconcile_WithVolumeClaimTemplates(t *testing.T) {
 			}
 
 			assert.NoError(t, k8sClient.Create(ctx, sbs))
-			newStatus, err := reconciler.initNewStatus(sbs)
+			newStatus, err := reconciler.initNewStatus(ctx, sbs)
 			assert.NoError(t, err)
 			sbs.Status = *newStatus
 
@@ -1041,6 +1042,131 @@ func TestCalculateScaleDelta(t *testing.T) {
 				// Scale down case: MaxUnavailable should not affect scale down
 				assert.Equal(t, int(tt.replicas-tt.statusReplicas), delta,
 					"scale down should return the full negative delta")
+			}
+		})
+	}
+}
+
+// TestReconciler_createSandbox covers the SandboxTemplate resolution branch
+// introduced in createSandbox: when spec.templateRef is set, the controller
+// must Get the referenced SandboxTemplate, propagate its labels/annotations
+// to the new Sandbox, or surface the Get error as a Warning event when the
+// template is missing.
+func TestReconciler_createSandbox(t *testing.T) {
+	utils.InitLogOutput()
+
+	mkSBS := func(name string, ref *v1alpha1.SandboxTemplateRef, inline *corev1.PodTemplateSpec) *v1alpha1.SandboxSet {
+		return &v1alpha1.SandboxSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				UID:       types.UID("uid-" + name),
+			},
+			Spec: v1alpha1.SandboxSetSpec{
+				Replicas: 1,
+				EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+					TemplateRef: ref,
+					Template:    inline,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		sbs              *v1alpha1.SandboxSet
+		existingTemplate *v1alpha1.SandboxTemplate
+		wantErr          string
+		wantWarning      bool
+		checkSandbox     func(t *testing.T, sbx *v1alpha1.Sandbox)
+	}{
+		{
+			name: "inline template creates sandbox successfully",
+			sbs: mkSBS("inline-sbs", nil, &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "inline"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "img:v1"}}},
+			}),
+			checkSandbox: func(t *testing.T, sbx *v1alpha1.Sandbox) {
+				assert.Equal(t, "inline", sbx.Labels["app"])
+				assert.Equal(t, "inline-sbs", sbx.Labels[v1alpha1.LabelSandboxTemplate])
+			},
+		},
+		{
+			name: "templateRef resolved successfully and labels inherited",
+			sbs:  mkSBS("ref-sbs", &v1alpha1.SandboxTemplateRef{Name: "tpl-ok"}, nil),
+			existingTemplate: &v1alpha1.SandboxTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "tpl-ok", Namespace: "default"},
+				Spec: v1alpha1.SandboxTemplateSpec{
+					Template: &corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels:      map[string]string{"app": "from-tpl"},
+							Annotations: map[string]string{"source": "tpl"},
+						},
+						Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "img:v1"}}},
+					},
+				},
+			},
+			checkSandbox: func(t *testing.T, sbx *v1alpha1.Sandbox) {
+				assert.Equal(t, "from-tpl", sbx.Labels["app"])
+				assert.Equal(t, "tpl", sbx.Annotations["source"])
+				assert.Equal(t, "tpl-ok", sbx.Labels[v1alpha1.LabelSandboxTemplate])
+			},
+		},
+		{
+			name:        "templateRef not found returns error and emits warning",
+			sbs:         mkSBS("missing-sbs", &v1alpha1.SandboxTemplateRef{Name: "does-not-exist"}, nil),
+			wantErr:     "failed to resolve sandbox template",
+			wantWarning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sClient := NewClient()
+			if tt.existingTemplate != nil {
+				assert.NoError(t, k8sClient.Create(ctx, tt.existingTemplate))
+			}
+			eventRecorder := record.NewFakeRecorder(10)
+			reconciler := &Reconciler{
+				Client:   k8sClient,
+				Scheme:   testScheme,
+				Recorder: eventRecorder,
+				Codec:    codec,
+			}
+
+			sbx, err := reconciler.createSandbox(ctx, tt.sbs, "rev-1")
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, sbx)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, sbx)
+				assert.Equal(t, "rev-1", sbx.Labels[v1alpha1.LabelTemplateHash])
+				assert.Equal(t, tt.sbs.Namespace, sbx.Namespace)
+				// Controller owner ref should be set.
+				var foundOwner bool
+				for _, ref := range sbx.OwnerReferences {
+					if ref.UID == tt.sbs.UID && ref.Controller != nil && *ref.Controller {
+						foundOwner = true
+					}
+				}
+				assert.True(t, foundOwner, "sandbox must have SandboxSet as controller owner")
+				if tt.checkSandbox != nil {
+					tt.checkSandbox(t, sbx)
+				}
+			}
+
+			if tt.wantWarning {
+				select {
+				case evt := <-eventRecorder.Events:
+					assert.Contains(t, evt, "Warning")
+					assert.Contains(t, evt, EventCreateSandboxFailed)
+				default:
+					t.Errorf("expected a warning event but got none")
+				}
 			}
 		})
 	}

--- a/pkg/controller/sandboxset/utils.go
+++ b/pkg/controller/sandboxset/utils.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -50,9 +51,9 @@ type GroupedSandboxes struct {
 	Dead      []*agentsv1alpha1.Sandbox // Sandboxes should be deleted
 }
 
-func (r *Reconciler) initNewStatus(ss *agentsv1alpha1.SandboxSet) (*agentsv1alpha1.SandboxSetStatus, error) {
+func (r *Reconciler) initNewStatus(ctx context.Context, ss *agentsv1alpha1.SandboxSet) (*agentsv1alpha1.SandboxSetStatus, error) {
 	newStatus := ss.Status.DeepCopy()
-	updateRevision, err := r.newRevision(ss, 0, nil)
+	updateRevision, err := r.newRevision(ctx, ss, 0, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -126,14 +127,22 @@ func clearAndInitInnerKeys(m map[string]string) map[string]string {
 // The Revision of the returned ControllerRevision is set to revision. If the returned error is nil, the returned
 // ControllerRevision is valid. StatefulSet revisions are stored as patches that re-apply the current state of set
 // to a new StatefulSet using a strategic merge patch to replace the saved state of the new StatefulSet.
-func (r *Reconciler) newRevision(set *agentsv1alpha1.SandboxSet, revision int64, collisionCount *int32) (*apps.ControllerRevision, error) {
-	patch, err := r.getPatch(set)
+func (r *Reconciler) newRevision(ctx context.Context, set *agentsv1alpha1.SandboxSet, revision int64, collisionCount *int32) (*apps.ControllerRevision, error) {
+	patch, err := r.getPatch(ctx, set)
 	if err != nil {
 		return nil, err
 	}
+	// When the SandboxSet uses spec.templateRef, spec.template is nil. The
+	// revision labels on ControllerRevision are only informational here
+	// (the hash label is what the controller actually reads), so fall back
+	// to an empty label set to avoid a nil dereference.
+	var templateLabels map[string]string
+	if set.Spec.Template != nil {
+		templateLabels = set.Spec.Template.Labels
+	}
 	cr, err := NewControllerRevision(set,
 		agentsv1alpha1.SandboxSetControllerKind,
-		set.Spec.Template.Labels,
+		templateLabels,
 		runtime.RawExtension{Raw: patch},
 		revision,
 		collisionCount)
@@ -172,15 +181,33 @@ func scaleExpectationSatisfied(ctx context.Context, scaleExpectation expectation
 	return false, dirty, requeueAfter
 }
 
-func NewSandboxFromSandboxSet(sbs *agentsv1alpha1.SandboxSet) *agentsv1alpha1.Sandbox {
+// NewSandboxFromSandboxSet builds a Sandbox object from the SandboxSet. When
+// spec.templateRef is used, refTemplate must be the resolved SandboxTemplate
+// so that its pod template labels/annotations can be inherited; callers pass
+// nil for the inline template case.
+func NewSandboxFromSandboxSet(sbs *agentsv1alpha1.SandboxSet, refTemplate *agentsv1alpha1.SandboxTemplate) *agentsv1alpha1.Sandbox {
 	generateName := fmt.Sprintf("%s-", sbs.Name)
-	template := sbs.Spec.Template.DeepCopy()
+	var template *corev1.PodTemplateSpec
+	var inheritedLabels, inheritedAnnotations map[string]string
+	// spec.template and spec.templateRef are mutually exclusive. Deep copy the
+	// source pod template before reading labels/annotations so subsequent
+	// mutations (clearAndInitInnerKeys, internal label writes) never leak
+	// back into the SandboxSet spec or the cached SandboxTemplate.
+	if sbs.Spec.Template != nil {
+		template = sbs.Spec.Template.DeepCopy()
+		inheritedLabels = template.Labels
+		inheritedAnnotations = template.Annotations
+	} else if refTemplate != nil && refTemplate.Spec.Template != nil {
+		templateCopy := refTemplate.Spec.Template.DeepCopy()
+		inheritedLabels = templateCopy.Labels
+		inheritedAnnotations = templateCopy.Annotations
+	}
 	sbx := &agentsv1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: generateName,
 			Namespace:    sbs.Namespace,
-			Labels:       template.Labels,
-			Annotations:  template.Annotations,
+			Labels:       inheritedLabels,
+			Annotations:  inheritedAnnotations,
 		},
 		Spec: agentsv1alpha1.SandboxSpec{
 			PersistentContents: sbs.Spec.PersistentContents,

--- a/pkg/controller/sandboxset/utils_test.go
+++ b/pkg/controller/sandboxset/utils_test.go
@@ -304,6 +304,7 @@ func TestNewSandboxFromSandboxSet(t *testing.T) {
 	tests := []struct {
 		name                       string
 		sandboxSet                 *agentsv1alpha1.SandboxSet
+		refTemplate                *agentsv1alpha1.SandboxTemplate
 		expectedGenerateName       string
 		expectedNamespace          string
 		expectedLabels             map[string]string
@@ -483,11 +484,87 @@ func TestNewSandboxFromSandboxSet(t *testing.T) {
 			expectedTemplateRef:        nil,
 			expectedPersistentContents: nil,
 		},
+		{
+			name: "templateRef with refTemplate inherits labels and annotations",
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ref-sbs",
+					Namespace: "ref-ns",
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						TemplateRef: &agentsv1alpha1.SandboxTemplateRef{Name: "my-template"},
+					},
+				},
+			},
+			refTemplate: &agentsv1alpha1.SandboxTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-template",
+					Namespace: "ref-ns",
+				},
+				Spec: agentsv1alpha1.SandboxTemplateSpec{
+					Template: &corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app":  "from-template",
+								"tier": "web",
+							},
+							Annotations: map[string]string{
+								"source": "sandbox-template",
+							},
+						},
+					},
+				},
+			},
+			expectedGenerateName: "ref-sbs-",
+			expectedNamespace:    "ref-ns",
+			expectedLabels: map[string]string{
+				"app":                                "from-template",
+				"tier":                               "web",
+				agentsv1alpha1.LabelSandboxPool:      "ref-sbs",
+				agentsv1alpha1.LabelSandboxTemplate:  "my-template",
+				agentsv1alpha1.LabelSandboxIsClaimed: "false",
+			},
+			expectedAnnotations: map[string]string{
+				"source": "sandbox-template",
+			},
+			expectedRuntimes:           nil,
+			expectedTemplateRef:        &agentsv1alpha1.SandboxTemplateRef{Name: "my-template"},
+			expectedPersistentContents: nil,
+		},
+		{
+			name: "templateRef with nil refTemplate does not panic",
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nil-ref-sbs",
+					Namespace: "default",
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						TemplateRef: &agentsv1alpha1.SandboxTemplateRef{Name: "missing"},
+					},
+				},
+			},
+			refTemplate:          nil,
+			expectedGenerateName: "nil-ref-sbs-",
+			expectedNamespace:    "default",
+			expectedLabels: map[string]string{
+				agentsv1alpha1.LabelSandboxPool:      "nil-ref-sbs",
+				agentsv1alpha1.LabelSandboxTemplate:  "missing",
+				agentsv1alpha1.LabelSandboxIsClaimed: "false",
+			},
+			expectedAnnotations:        map[string]string{},
+			expectedRuntimes:           nil,
+			expectedTemplateRef:        &agentsv1alpha1.SandboxTemplateRef{Name: "missing"},
+			expectedPersistentContents: nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sandbox := NewSandboxFromSandboxSet(tt.sandboxSet)
+			sandbox := NewSandboxFromSandboxSet(tt.sandboxSet, tt.refTemplate)
 
 			// Verify GenerateName
 			assert.Equal(t, tt.expectedGenerateName, sandbox.GenerateName, "GenerateName mismatch")

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -407,7 +407,17 @@ func newSandboxFromSandboxSet(ctx context.Context, opts infra.ClaimSandboxOption
 	if err != nil {
 		return nil, "", NoAvailableError(opts.Template, "cannot create new sandbox: "+err.Error())
 	}
-	sbx := sandboxset.NewSandboxFromSandboxSet(sbs)
+	var refTemplate *v1alpha1.SandboxTemplate
+	if sbs.Spec.TemplateRef != nil {
+		refTemplate = &v1alpha1.SandboxTemplate{}
+		if err := cache.GetClient().Get(ctx, client.ObjectKey{
+			Namespace: sbs.Namespace,
+			Name:      sbs.Spec.TemplateRef.Name,
+		}, refTemplate); err != nil {
+			return nil, "", NoAvailableError(opts.Template, "cannot resolve sandbox template: "+err.Error())
+		}
+	}
+	sbx := sandboxset.NewSandboxFromSandboxSet(sbs, refTemplate)
 	// sandbox manager creates high-priority sandbox
 	sbx.Annotations[v1alpha1.SandboxAnnotationPriority] = "100"
 	for _, anno := range FilteredAnnotationsOnCreation {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -2490,3 +2490,124 @@ func TestModifyPickedSandbox_InitRuntime(t *testing.T) {
 		})
 	}
 }
+
+// TestNewSandboxFromSandboxSet_TemplateRef covers the SandboxTemplate
+// resolution branch in newSandboxFromSandboxSet: when the SandboxSet uses
+// spec.templateRef, the referenced SandboxTemplate must be fetched from the
+// cache and its pod template labels/annotations propagated to the new
+// Sandbox; if the SandboxTemplate cannot be resolved the function must
+// return a NoAvailable error rather than panicking.
+func TestNewSandboxFromSandboxSet_TemplateRef(t *testing.T) {
+	utils.InitLogOutput()
+
+	const templateName = "ref-sbs"
+	const refName = "my-sbt"
+
+	tests := []struct {
+		name       string
+		createSBT  bool
+		wantErr    string
+		wantLabels map[string]string
+		wantAnnos  map[string]string
+	}{
+		{
+			name:      "templateRef resolved and labels inherited",
+			createSBT: true,
+			wantLabels: map[string]string{
+				"app":                          "from-sbt",
+				v1alpha1.LabelSandboxTemplate:  refName,
+				v1alpha1.LabelSandboxPool:      templateName,
+				v1alpha1.LabelSandboxIsClaimed: "false",
+			},
+			wantAnnos: map[string]string{
+				"source":                           "sbt",
+				v1alpha1.SandboxAnnotationPriority: "100",
+			},
+		},
+		{
+			name:      "templateRef not found returns NoAvailable error",
+			createSBT: false,
+			wantErr:   "cannot resolve sandbox template",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			infraInstance, fc := NewTestInfra(t)
+			defer infraInstance.Stop(t.Context())
+
+			// SandboxSet that references the external SandboxTemplate.
+			sbs := &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      templateName,
+					Namespace: "default",
+				},
+				Spec: v1alpha1.SandboxSetSpec{
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						TemplateRef: &v1alpha1.SandboxTemplateRef{Name: refName},
+					},
+				},
+			}
+			require.NoError(t, fc.Create(t.Context(), sbs))
+
+			if tt.createSBT {
+				sbt := &v1alpha1.SandboxTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: refName, Namespace: "default"},
+					Spec: v1alpha1.SandboxTemplateSpec{
+						Template: &corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels:      map[string]string{"app": "from-sbt"},
+								Annotations: map[string]string{"source": "sbt"},
+							},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "main", Image: "img:v1"}},
+							},
+						},
+					},
+				}
+				require.NoError(t, fc.Create(t.Context(), sbt))
+			}
+
+			// Wait for the SandboxSet to be visible through the cache so
+			// PickSandboxSet can find it.
+			require.Eventually(t, func() bool {
+				_, err := infraInstance.Cache.PickSandboxSet(t.Context(), infracache.PickSandboxSetOptions{Name: templateName})
+				return err == nil
+			}, time.Second, 10*time.Millisecond)
+
+			if tt.createSBT {
+				// Also wait for the SandboxTemplate to be visible.
+				require.Eventually(t, func() bool {
+					got := &v1alpha1.SandboxTemplate{}
+					return infraInstance.Cache.GetClient().Get(t.Context(),
+						client.ObjectKey{Namespace: "default", Name: refName}, got) == nil
+				}, time.Second, 10*time.Millisecond)
+			}
+
+			opts := infra.ClaimSandboxOptions{
+				Template: templateName,
+				User:     "test-user",
+			}
+			sbx, _, err := newSandboxFromSandboxSet(t.Context(), opts, infraInstance.Cache, nil)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, sbx)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, sbx)
+			for k, v := range tt.wantLabels {
+				assert.Equal(t, v, sbx.GetLabels()[k], "label %s mismatch", k)
+			}
+			for k, v := range tt.wantAnnos {
+				assert.Equal(t, v, sbx.GetAnnotations()[k], "annotation %s mismatch", k)
+			}
+			// templateRef must be carried over to the Sandbox spec.
+			require.NotNil(t, sbx.Spec.TemplateRef)
+			assert.Equal(t, refName, sbx.Spec.TemplateRef.Name)
+		})
+	}
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Previously a SandboxSet only rolled its managed Sandboxes when its own spec changed; mutations to a referenced SandboxTemplate (via spec.templateRef) were silently ignored.

This PR wires that path up end-to-end: getPatch now folds the resolved SandboxTemplate.Spec into the revision hash, so any template change flips UpdateRevision and drives the existing rolling update logic.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Related to #256.

### Ⅲ. Describe how to verify it

1. Apply a SandboxTemplate + a SandboxSet referencing it with replicas and maxUnavailable;
2. Wait until available, then kubectl edit the template;
3. Old sandboxes managed by SandboxSet are gradually rolling updated.

