### PR TITLE
[WIP] fix(sandbox-manager) fix timeout persistence on failed resume paths to avoid accidental never-timeout regression

### DIFF
--- a/MEMO.md
+++ b/MEMO.md
@@ -1,0 +1,44 @@
+# MEMO
+
+Last updated: 2026-04-30
+
+## Current Topic
+
+设计分布式 single-flight 模块，用于跨副本序列化 Pause / Resume 并发操作，替代当前 `resumable()` + `retryUpdate` 的乐观锁竞态。
+
+## 设计决策（已确认）
+
+- **annotation 格式**: `singleflight.agents.kruise.io/<key>` = `"<seq>:<done>:<lastUpdate>"`
+- **首次读取**: APIReader（防 informer stale）
+- **precheck 语义**: 仅做硬性不可行判断（已达成目标 / Dead），中间状态全放行
+- **分叉后**: Wait 返回不 re-validate；调用者根据业务状态判断 + 重试
+- **锁释放**: defer + 独立 postCtx + APIReader + 严格 retry
+- **抢占**: lastUpdate 超 5 分钟可抢占，阈值通过 SandboxManagerOptions 传入
+- **Wait 返回**: Informer GET（Reconciler 刚确认过条件，足够新）
+- **annotation 清理**: 不清理，seq 单调递增
+- **Pause + Resume**: 共享 key `"pause-resume"`，各自 precheck/modifier/function
+
+## 落地计划
+
+### Phase 1: single-flight 核心模块 (`pkg/cache/singleflight.go`)
+
+- `DistributedSingleFlightDo[T client.Object]` 泛型函数
+- `Provider` 接口扩展（暴露 APIReader、client、waitHooks）
+- Wait 机制集成（annotation checker 驱动 WaitEntry）
+
+### Phase 2: Pause / Resume 接入
+
+- `Sandbox.Pause / Resume` 调用 `SingleflightDo`，以 `"pause-resume"` 为 key
+- precheck 重写：只做幂等检查 + Dead 检查
+- 调用者增加重试循环（检测状态是否符合预期）
+
+### Phase 3: 测试更新
+
+- `resume when pausing` / `pause when resuming` 预期行为变更（从立即报错 → Wait + retry）
+- 新增并发碰撞测试（Pause + Resume 竞态）
+
+## Status
+
+Plan saved to: `.agents/plans/distributed-singleflight.plan.md`
+Plan audited by `plan-auditor`: 7 BLOCKERs + 5 MAJORs + 2 MINORs found and ALL resolved.
+Status: **READY_FOR_IMPLEMENTATION**

--- a/pkg/cache/interface.go
+++ b/pkg/cache/interface.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"context"
+	"sync"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -107,4 +108,9 @@ type Provider interface {
 	// Prefer GetClient() for most operations; use this only when cache staleness
 	// is unacceptable (e.g., validating critical state transitions).
 	GetAPIReader() client.Reader
+
+	// GetWaitHooks returns the internal waitHooks sync.Map for single-flight
+	// Wait phase integration. This is used by DistributedSingleFlightDo to
+	// register annotation-based WaitEntries.
+	GetWaitHooks() *sync.Map
 }

--- a/pkg/cache/singleflight.go
+++ b/pkg/cache/singleflight.go
@@ -1,0 +1,394 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	cacheutils "github.com/openkruise/agents/pkg/cache/utils"
+)
+
+const (
+	// SingleflightAnnotationPrefix is the annotation key prefix for distributed single-flight.
+	// Full key format: singleflight.agents.kruise.io/<logicalKey>
+	SingleflightAnnotationPrefix = "singleflight." + agentsv1alpha1.InternalPrefix
+
+	// SingleflightWaitKeyPrefix is used to create distinct wait hook keys that
+	// do NOT collide with existing WaitForObjectSatisfied entries (which use
+	// WaitHookKey = "*type/ns/name"). Format: "sf:<key>/<type>/<ns>/<name>".
+	SingleflightWaitKeyPrefix = "sf:"
+
+	// DefaultSingleflightPreemptionThreshold is the default duration
+	// after which a stale Runner can be preempted. This is the single
+	// source of truth; do not duplicate this constant elsewhere.
+	DefaultSingleflightPreemptionThreshold = 5 * time.Minute
+
+	// releaseLockTimeout is the timeout for the background context used during lock release.
+	releaseLockTimeout = 5 * time.Minute
+)
+
+// singleflightAnnotation holds the parsed annotation value.
+type singleflightAnnotation struct {
+	Seq        int64
+	Done       bool
+	LastUpdate int64 // Unix seconds
+}
+
+// parseSingleflightAnnotation parses "<seq>:<done>:<lastUpdate>" from the annotation value.
+// Returns false if the annotation is missing or malformed; caller treats missing as "0:true:0".
+func parseSingleflightAnnotation(obj client.Object, key string) (singleflightAnnotation, bool) {
+	annKey := SingleflightAnnotationPrefix + key
+	val, ok := obj.GetAnnotations()[annKey]
+	if !ok || val == "" {
+		return singleflightAnnotation{}, false
+	}
+	parts := strings.Split(val, ":")
+	if len(parts) != 3 {
+		return singleflightAnnotation{}, false
+	}
+	seq, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return singleflightAnnotation{}, false
+	}
+	done := parts[1] == "true"
+	lastUpdate, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		return singleflightAnnotation{}, false
+	}
+	return singleflightAnnotation{Seq: seq, Done: done, LastUpdate: lastUpdate}, true
+}
+
+// setSingleflightAnnotation sets the annotation on the object.
+func setSingleflightAnnotation(obj client.Object, key string, seq int64, done bool) {
+	annKey := SingleflightAnnotationPrefix + key
+	value := fmt.Sprintf("%d:%v:%d", seq, strconv.FormatBool(done), time.Now().Unix())
+	anns := obj.GetAnnotations()
+	if anns == nil {
+		anns = make(map[string]string)
+	}
+	anns[annKey] = value
+	obj.SetAnnotations(anns)
+}
+
+// isPreemptable returns true if a Runner with the given lastUpdate timestamp
+// has exceeded the preemption threshold and can be preempted.
+func isPreemptable(lastUpdate int64, threshold time.Duration) bool {
+	return time.Now().Unix()-lastUpdate > int64(threshold.Seconds())
+}
+
+// DistributedSingleFlightDo executes a distributed single-flight operation.
+//
+// Each K8s object is a single-flight group identified by logical key.
+// The protocol uses annotation singleflight.agents.kruise.io/<key> with
+// value "<seq>:<done>:<lastUpdate>" to coordinate Run/Wait across replicas.
+//
+// Parameters:
+//   - ctx: caller context; used for wait and retry loops. Lock release uses
+//     a separate background context to prevent caller-cancellation leaks.
+//   - cache: Provider with APIReader, client, and waitHooks.
+//   - obj: the K8s object acting as the group; must exist in the API server.
+//   - key: logical operation key (e.g., "pause-resume"). Pause and Resume
+//     share the same key to serialize against each other.
+//   - precheck: called before the Run/Wait fork and in each retry iteration.
+//     Must return nil if the operation can still proceed; non-nil to abort.
+//     Must NOT be called after Wait returns.
+//   - modifier: applied to the object during the optimistic update that sets
+//     seq:false. Combined with annotation write to reduce API calls.
+//   - function: executed only by the Runner. Both success and failure must be
+//     followed by lock release (done=true) via defer.
+//
+// Returns the latest object after operation completion.
+//   - Run path: the object after the final update (modifier + function applied).
+//   - Wait path: the object from informer snapshot after done==true was observed.
+//
+// Callers must check the returned object's business state and retry if needed.
+func DistributedSingleFlightDo[T client.Object](
+	ctx context.Context,
+	cache Provider,
+	obj T,
+	key string,
+	precheck func(T) error,
+	modifier func(T),
+	function func(T) error,
+	preemptionThreshold time.Duration,
+) (T, error) {
+	// Phase 1: Read latest from API server (first read must bypass informer to avoid stale decisions)
+	fresh := obj.DeepCopyObject().(T)
+	namespacedName := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+	if err := cache.GetAPIReader().Get(ctx, namespacedName, fresh); err != nil {
+		return obj, fmt.Errorf("singleflight: failed to read object from API server: %w", err)
+	}
+
+	ann, hasAnn := parseSingleflightAnnotation(fresh, key)
+	if !hasAnn {
+		ann = singleflightAnnotation{Seq: 0, Done: true, LastUpdate: 0}
+	}
+
+	// precheck on the fresh object
+	if err := precheck(fresh); err != nil {
+		return fresh, err
+	}
+
+	// Phase 2: Fork — Wait or Compete
+	if ann.Done || (ann.Done == false && isPreemptable(ann.LastUpdate, preemptionThreshold)) {
+		return singleflightCompete(ctx, cache, fresh, key, ann, precheck, modifier, function, preemptionThreshold)
+	}
+	// done == false and not preemptable: a legitimate Runner is in progress
+	return singleflightWait(ctx, cache, fresh, key, ann.Seq)
+}
+
+// singleflightSeqConflictError is a sentinel error used internally to break
+// the retry loop when another goroutine has claimed our seq or higher.
+type singleflightSeqConflictError struct {
+	currentSeq int64
+	mySeq      int64
+}
+
+func (e *singleflightSeqConflictError) Error() string {
+	return fmt.Sprintf("singleflight seq conflict: current=%d, mine=%d", e.currentSeq, e.mySeq)
+}
+
+func singleflightCompete[T client.Object](
+	ctx context.Context,
+	cache Provider,
+	obj T,
+	key string,
+	prevAnn singleflightAnnotation,
+	precheck func(T) error,
+	modifier func(T),
+	function func(T) error,
+	preemptionThreshold time.Duration,
+) (T, error) {
+	log := klog.FromContext(ctx).WithValues("singleflightKey", key, "object", klog.KObj(obj))
+	namespacedName := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+	seq := prevAnn.Seq + 1
+
+	// claimed holds the successfully-updated object after the retry loop.
+	// It must be captured inside the retry closure so function() receives
+	// the post-modifier, post-annotation object — NOT the stale outer `obj`.
+	var claimed T
+
+	// Try to claim the lock with optimistic update
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Re-read from informer inside the retry loop
+		fresh := obj.DeepCopyObject().(T)
+		if err := cache.GetClient().Get(ctx, namespacedName, fresh); err != nil {
+			return err
+		}
+		ann, hasAnn := parseSingleflightAnnotation(fresh, key)
+		if !hasAnn {
+			ann = singleflightAnnotation{Seq: 0, Done: true, LastUpdate: 0}
+		}
+
+		// precheck on every retry iteration
+		if err := precheck(fresh); err != nil {
+			return err
+		}
+
+		if ann.Seq >= seq {
+			// Someone else claimed this seq or higher. Exit retry; let caller handle.
+			// We return a sentinel error to break the retry loop.
+			return &singleflightSeqConflictError{currentSeq: ann.Seq, mySeq: seq}
+		}
+
+		// Apply modifier + set annotation
+		modifier(fresh)
+		setSingleflightAnnotation(fresh, key, seq, false)
+		if err := cache.GetClient().Update(ctx, fresh); err != nil {
+			return err
+		}
+		claimed = fresh // capture the successfully-updated object
+		return nil
+	})
+
+	if err != nil {
+		if conflict, ok := err.(*singleflightSeqConflictError); ok {
+			// Someone else won; transition to Wait or re-enter Compete if preemptable.
+			fresh := obj.DeepCopyObject().(T)
+			if getErr := cache.GetClient().Get(ctx, namespacedName, fresh); getErr != nil {
+				return obj, fmt.Errorf("singleflight: failed to read after seq conflict: %w", getErr)
+			}
+			ann, _ := parseSingleflightAnnotation(fresh, key)
+			if !ann.Done && isPreemptable(ann.LastUpdate, preemptionThreshold) {
+				// Preempt the stale runner
+				return singleflightCompete(ctx, cache, fresh, key, ann, precheck, modifier, function, preemptionThreshold)
+			}
+			log.Info("singleflight: seq conflict, entering wait", "currentSeq", conflict.currentSeq, "mySeq", seq)
+			return singleflightWait(ctx, cache, fresh, key, seq)
+		}
+		return obj, fmt.Errorf("singleflight: failed to claim lock: %w", err)
+	}
+
+	// We are the Runner. `claimed` holds the post-modifier object.
+	log.Info("singleflight: claimed lock, entering run phase", "seq", seq)
+
+	// Guarantee lock release
+	defer func() {
+		releaseSingleflightLock(cache, claimed, key, seq)
+	}()
+
+	// Execute function with the post-modifier object.
+	// The function error is returned to the caller (NOT swallowed).
+	// The caller (Pause/Resume retry loop) will see the error and can decide
+	// whether to retry or abort.
+	funcErr := function(claimed)
+	if funcErr != nil {
+		log.Error(funcErr, "singleflight: function failed, releasing lock")
+	}
+	return claimed, funcErr
+}
+
+func singleflightWait[T client.Object](
+	ctx context.Context,
+	cache Provider,
+	obj T,
+	key string,
+	watchedSeq int64,
+) (T, error) {
+	log := klog.FromContext(ctx).WithValues("singleflightKey", key, "object", klog.KObj(obj), "watchedSeq", watchedSeq)
+
+	// Use a distinct key prefix ("sf:<key>/...") so single-flight wait entries
+	// do NOT collide with existing WaitForObjectSatisfied entries which use
+	// WaitHookKey format "*type/ns/name".
+	waitKey := fmt.Sprintf("%s%s/%s", SingleflightWaitKeyPrefix, key, cacheutils.WaitHookKey(obj))
+	// Use a distinct action to avoid colliding with Pause/Resume/Checkpoint wait entries
+	action := cacheutils.WaitAction("singleflight:" + key)
+
+	checker := func(fresh T) (bool, error) {
+		ann, hasAnn := parseSingleflightAnnotation(fresh, key)
+		if !hasAnn {
+			// Annotation was removed; treat as done
+			return true, nil
+		}
+		if ann.Done || ann.Seq > watchedSeq {
+			return true, nil
+		}
+		return false, nil
+	}
+
+	entry := cacheutils.NewWaitEntry(ctx, action, checker)
+	actual, loaded := cache.GetWaitHooks().LoadOrStore(waitKey, entry)
+	if loaded {
+		// An existing wait entry for this key already exists.
+		// We must wait on the EXISTING entry's channel, not the newly created one.
+		entry = actual.(*cacheutils.WaitEntry[T])
+		log.V(5).Info("singleflight: reusing existing wait entry", "existingAction", entry.Action)
+	} else {
+		log.V(5).Info("singleflight: created wait entry")
+		go pollSingleflightWaitEntry(ctx, cache, obj, key, entry)
+	}
+
+	// Wait for the Runner to finish (or ctx cancellation)
+	select {
+	case <-entry.Done():
+		log.V(5).Info("singleflight: wait entry signaled done")
+	case <-ctx.Done():
+		cache.GetWaitHooks().Delete(waitKey)
+		return obj, fmt.Errorf("singleflight: wait context cancelled: %w", ctx.Err())
+	}
+
+	// Clean up wait entry
+	cache.GetWaitHooks().Delete(waitKey)
+
+	// Return latest from informer (NOT prechecked; caller checks business state)
+	fresh := obj.DeepCopyObject().(T)
+	namespacedName := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+	if err := cache.GetClient().Get(ctx, namespacedName, fresh); err != nil {
+		return obj, fmt.Errorf("singleflight: failed to read object after wait: %w", err)
+	}
+	return fresh, nil
+}
+
+func pollSingleflightWaitEntry[T client.Object](
+	ctx context.Context,
+	cache Provider,
+	obj T,
+	key string,
+	entry *cacheutils.WaitEntry[T],
+) {
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+
+	namespacedName := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+	for {
+		select {
+		case <-ctx.Done():
+			entry.Close()
+			return
+		case <-entry.Done():
+			return
+		case <-ticker.C:
+			fresh := obj.DeepCopyObject().(T)
+			if err := cache.GetClient().Get(ctx, namespacedName, fresh); err != nil {
+				continue
+			}
+			satisfied, err := entry.Check(fresh)
+			if satisfied || err != nil {
+				entry.Close()
+				return
+			}
+		}
+	}
+}
+
+// releaseSingleflightLock sets done=true on the annotation with a guaranteed
+// background context. It retries until success or the background context expires.
+func releaseSingleflightLock[T client.Object](
+	cache Provider,
+	obj T,
+	key string,
+	seq int64,
+) {
+	releaseCtx, cancel := context.WithTimeout(context.Background(), releaseLockTimeout)
+	defer cancel()
+
+	namespacedName := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+	log := klog.FromContext(releaseCtx).WithValues("singleflightKey", key, "object", namespacedName, "seq", seq)
+
+	err := retry.OnError(
+		retry.DefaultBackoff,
+		func(err error) bool { return true }, // always retry
+		func() error {
+			fresh := obj.DeepCopyObject().(T)
+			if err := cache.GetAPIReader().Get(releaseCtx, namespacedName, fresh); err != nil {
+				return err
+			}
+			ann, _ := parseSingleflightAnnotation(fresh, key)
+			if ann.Seq != seq {
+				// Another runner has taken over; our seq is obsolete. No need to release.
+				return nil
+			}
+			setSingleflightAnnotation(fresh, key, seq, true)
+			return cache.GetClient().Update(releaseCtx, fresh)
+		},
+	)
+	if err != nil {
+		log.Error(err, "singleflight: failed to release lock after all retries; lock will be preempted by timeout")
+	} else {
+		log.V(5).Info("singleflight: lock released successfully")
+	}
+}

--- a/pkg/cache/singleflight_test.go
+++ b/pkg/cache/singleflight_test.go
@@ -1,0 +1,547 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/cache/controllers"
+)
+
+// TestParseSingleflightAnnotation tests annotation parsing with various inputs.
+func TestParseSingleflightAnnotation(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		key         string
+		want        singleflightAnnotation
+		wantOK      bool
+	}{
+		{
+			name: "valid annotation",
+			annotations: map[string]string{
+				SingleflightAnnotationPrefix + "test-key": "5:true:1000",
+			},
+			key:    "test-key",
+			want:   singleflightAnnotation{Seq: 5, Done: true, LastUpdate: 1000},
+			wantOK: true,
+		},
+		{
+			name: "valid annotation done=false",
+			annotations: map[string]string{
+				SingleflightAnnotationPrefix + "test-key": "0:false:0",
+			},
+			key:    "test-key",
+			want:   singleflightAnnotation{Seq: 0, Done: false, LastUpdate: 0},
+			wantOK: true,
+		},
+		{
+			name:   "missing annotation",
+			key:    "test-key",
+			want:   singleflightAnnotation{},
+			wantOK: false,
+		},
+		{
+			name: "malformed value",
+			annotations: map[string]string{
+				SingleflightAnnotationPrefix + "test-key": "abc",
+			},
+			key:    "test-key",
+			want:   singleflightAnnotation{},
+			wantOK: false,
+		},
+		{
+			name: "wrong parts count",
+			annotations: map[string]string{
+				SingleflightAnnotationPrefix + "test-key": "1:2",
+			},
+			key:    "test-key",
+			want:   singleflightAnnotation{},
+			wantOK: false,
+		},
+		{
+			name: "non-numeric seq",
+			annotations: map[string]string{
+				SingleflightAnnotationPrefix + "test-key": "abc:true:1000",
+			},
+			key:    "test-key",
+			want:   singleflightAnnotation{},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+			}
+			got, ok := parseSingleflightAnnotation(sbx, tt.key)
+			assert.Equal(t, tt.wantOK, ok)
+			if ok {
+				assert.Equal(t, tt.want.Seq, got.Seq)
+				assert.Equal(t, tt.want.Done, got.Done)
+				assert.Equal(t, tt.want.LastUpdate, got.LastUpdate)
+			}
+		})
+	}
+}
+
+// TestDistributedSingleFlightDo_FirstRunnerWins tests the basic Run path where
+// a single caller becomes the Runner and completes successfully.
+func TestDistributedSingleFlightDo_FirstRunnerWins(t *testing.T) {
+	sandbox := &v1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+			Labels: map[string]string{
+				v1alpha1.LabelSandboxIsClaimed: "true",
+			},
+		},
+		Status: v1alpha1.SandboxStatus{
+			Phase: v1alpha1.SandboxRunning,
+		},
+	}
+
+	cache, fc, err := newSingleflightTestCache(t, sandbox)
+	require.NoError(t, err)
+	require.NoError(t, cache.Run(t.Context()))
+	defer cache.Stop(t.Context())
+
+	mockMgr := cache.GetMockManager()
+	mockMgr.AddWaitReconcileKey(sandbox)
+
+	result, err := DistributedSingleFlightDo(
+		t.Context(),
+		cache,
+		sandbox,
+		"test-key",
+		func(_ *v1alpha1.Sandbox) error { return nil },
+		func(sbx *v1alpha1.Sandbox) { sbx.Labels["sf-modifier"] = "true" },
+		func(_ *v1alpha1.Sandbox) error { return nil },
+		DefaultSingleflightPreemptionThreshold,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "true", result.Labels["sf-modifier"])
+
+	// Verify annotation is set on the API server object
+	var updated v1alpha1.Sandbox
+	require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "test-sandbox"}, &updated))
+	annValue, ok := updated.Annotations[SingleflightAnnotationPrefix+"test-key"]
+	require.True(t, ok)
+	assert.Contains(t, annValue, "1:true:")
+}
+
+// TestDistributedSingleFlightDo_PrecheckFails tests that precheck failure
+// aborts the operation and does not set any annotation.
+func TestDistributedSingleFlightDo_PrecheckFails(t *testing.T) {
+	sandbox := &v1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+			Labels: map[string]string{
+				v1alpha1.LabelSandboxIsClaimed: "true",
+			},
+		},
+		Status: v1alpha1.SandboxStatus{
+			Phase: v1alpha1.SandboxRunning,
+		},
+	}
+
+	cache, fc, err := newSingleflightTestCache(t, sandbox)
+	require.NoError(t, err)
+	require.NoError(t, cache.Run(t.Context()))
+	defer cache.Stop(t.Context())
+
+	mockMgr := cache.GetMockManager()
+	mockMgr.AddWaitReconcileKey(sandbox)
+
+	_, err = DistributedSingleFlightDo(
+		t.Context(),
+		cache,
+		sandbox,
+		"test-key",
+		func(_ *v1alpha1.Sandbox) error { return fmt.Errorf("precheck failed") },
+		func(_ *v1alpha1.Sandbox) {},
+		func(_ *v1alpha1.Sandbox) error { return nil },
+		DefaultSingleflightPreemptionThreshold,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "precheck failed")
+
+	// Verify no annotation was set
+	var updated v1alpha1.Sandbox
+	require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "test-sandbox"}, &updated))
+	_, ok := updated.Annotations[SingleflightAnnotationPrefix+"test-key"]
+	assert.False(t, ok)
+}
+
+// TestDistributedSingleFlightDo_SecondCallerWaits tests the Wait path where
+// a caller sees an active Runner and waits for it to finish.
+func TestDistributedSingleFlightDo_SecondCallerWaits(t *testing.T) {
+	now := time.Now()
+	sandbox := &v1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+			Labels: map[string]string{
+				v1alpha1.LabelSandboxIsClaimed: "true",
+			},
+			Annotations: map[string]string{
+				SingleflightAnnotationPrefix + "test-key": fmt.Sprintf("1:false:%d", now.Unix()),
+			},
+		},
+		Status: v1alpha1.SandboxStatus{
+			Phase: v1alpha1.SandboxRunning,
+		},
+	}
+
+	cache, fc, err := newSingleflightTestCache(t, sandbox)
+	require.NoError(t, err)
+	require.NoError(t, cache.Run(t.Context()))
+	defer cache.Stop(t.Context())
+
+	mockMgr := cache.GetMockManager()
+	mockMgr.AddWaitReconcileKey(sandbox)
+
+	// Async goroutine: after 50ms, update annotation to done=true
+	time.AfterFunc(50*time.Millisecond, func() {
+		var sbx v1alpha1.Sandbox
+		if err := fc.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "test-sandbox"}, &sbx); err != nil {
+			return
+		}
+		modified := sbx.DeepCopy()
+		setSingleflightAnnotation(modified, "test-key", 1, true)
+		_ = fc.Update(t.Context(), modified)
+	})
+
+	start := time.Now()
+	result, err := DistributedSingleFlightDo(
+		t.Context(),
+		cache,
+		sandbox,
+		"test-key",
+		func(_ *v1alpha1.Sandbox) error { return nil },
+		func(_ *v1alpha1.Sandbox) {},
+		func(_ *v1alpha1.Sandbox) error { return nil },
+		DefaultSingleflightPreemptionThreshold,
+	)
+
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, time.Since(start), 40*time.Millisecond)
+
+	// Verify the returned object has done=true annotation
+	annValue := result.Annotations[SingleflightAnnotationPrefix+"test-key"]
+	assert.Contains(t, annValue, "1:true:")
+
+	// Verify no leftover wait entries
+	cache.GetWaitHooks().Range(func(k, v any) bool {
+		t.Errorf("unexpected leftover wait entry: %v", k)
+		return false
+	})
+}
+
+// TestDistributedSingleFlightDo_SeqConflictGoesToWait tests concurrent seq competition
+// where one goroutine wins Run and the other gets a seq conflict and transitions to Wait.
+func TestDistributedSingleFlightDo_SeqConflictGoesToWait(t *testing.T) {
+	sandbox := &v1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+			Labels: map[string]string{
+				v1alpha1.LabelSandboxIsClaimed: "true",
+			},
+			Annotations: map[string]string{
+				SingleflightAnnotationPrefix + "test-key": fmt.Sprintf("5:true:%d", time.Now().Unix()),
+			},
+		},
+		Status: v1alpha1.SandboxStatus{
+			Phase: v1alpha1.SandboxRunning,
+		},
+	}
+
+	cache, fc, err := newSingleflightTestCache(t, sandbox)
+	require.NoError(t, err)
+	require.NoError(t, cache.Run(t.Context()))
+	defer cache.Stop(t.Context())
+
+	mockMgr := cache.GetMockManager()
+	mockMgr.AddWaitReconcileKey(sandbox)
+
+	// WaitGroup for both goroutines
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	var err1, err2 error
+
+	// First goroutine: tries to claim seq=6, becomes Runner, sleeps 50ms then returns
+	go func() {
+		defer wg.Done()
+		_, err1 = DistributedSingleFlightDo(
+			t.Context(),
+			cache,
+			sandbox,
+			"test-key",
+			func(_ *v1alpha1.Sandbox) error { return nil },
+			func(sbx *v1alpha1.Sandbox) { sbx.Labels["sf-modifier"] = "true" },
+			func(_ *v1alpha1.Sandbox) error {
+				time.Sleep(50 * time.Millisecond)
+				return nil
+			},
+			DefaultSingleflightPreemptionThreshold,
+		)
+	}()
+
+	// Give first goroutine a head start
+	time.Sleep(5 * time.Millisecond)
+
+	// Second goroutine: tries to claim seq=6 but gets conflict, goes to Wait
+	go func() {
+		defer wg.Done()
+		_, err2 = DistributedSingleFlightDo(
+			t.Context(),
+			cache,
+			sandbox,
+			"test-key",
+			func(_ *v1alpha1.Sandbox) error { return nil },
+			func(sbx *v1alpha1.Sandbox) { sbx.Labels["sf-modifier"] = "true" },
+			func(_ *v1alpha1.Sandbox) error {
+				time.Sleep(50 * time.Millisecond)
+				return nil
+			},
+			DefaultSingleflightPreemptionThreshold,
+		)
+	}()
+
+	// After 100ms, update annotation to "6:true:<now>" to unblock the waiting goroutine
+	time.AfterFunc(100*time.Millisecond, func() {
+		var sbx v1alpha1.Sandbox
+		if err := fc.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "test-sandbox"}, &sbx); err != nil {
+			return
+		}
+		modified := sbx.DeepCopy()
+		setSingleflightAnnotation(modified, "test-key", 6, true)
+		_ = fc.Update(t.Context(), modified)
+	})
+
+	wg.Wait()
+
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+
+	// Verify final annotation contains "6:true:"
+	var updated v1alpha1.Sandbox
+	require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "test-sandbox"}, &updated))
+	annValue := updated.Annotations[SingleflightAnnotationPrefix+"test-key"]
+	assert.Contains(t, annValue, "6:true:")
+}
+
+// TestDistributedSingleFlightDo_Preemption tests that a stale Runner
+// (with done=false and lastUpdate older than threshold) can be preempted.
+func TestDistributedSingleFlightDo_Preemption(t *testing.T) {
+	staleTime := time.Now().Add(-10 * time.Second).Unix()
+	sandbox := &v1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+			Labels: map[string]string{
+				v1alpha1.LabelSandboxIsClaimed: "true",
+			},
+			Annotations: map[string]string{
+				SingleflightAnnotationPrefix + "test-key": fmt.Sprintf("1:false:%d", staleTime),
+			},
+		},
+		Status: v1alpha1.SandboxStatus{
+			Phase: v1alpha1.SandboxRunning,
+		},
+	}
+
+	cache, fc, err := newSingleflightTestCache(t, sandbox)
+	require.NoError(t, err)
+	require.NoError(t, cache.Run(t.Context()))
+	defer cache.Stop(t.Context())
+
+	mockMgr := cache.GetMockManager()
+	mockMgr.AddWaitReconcileKey(sandbox)
+
+	result, err := DistributedSingleFlightDo(
+		t.Context(),
+		cache,
+		sandbox,
+		"test-key",
+		func(_ *v1alpha1.Sandbox) error { return nil },
+		func(sbx *v1alpha1.Sandbox) { sbx.Labels["sf-modifier"] = "true" },
+		func(_ *v1alpha1.Sandbox) error { return nil },
+		1*time.Second, // preemption threshold = 1 second, lastUpdate is 10 seconds old
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "true", result.Labels["sf-modifier"])
+
+	// Verify annotation starts with "2:true:" (preempted seq=1, claimed seq=2)
+	var updated v1alpha1.Sandbox
+	require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "test-sandbox"}, &updated))
+	annValue := updated.Annotations[SingleflightAnnotationPrefix+"test-key"]
+	assert.Contains(t, annValue, "2:true:")
+}
+
+// TestReleaseSingleflightLock_SeqObsolete tests that release with a mismatched
+// seq does not update the annotation.
+func TestReleaseSingleflightLock_SeqObsolete(t *testing.T) {
+	now := time.Now().Unix()
+	sandbox := &v1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+			Labels: map[string]string{
+				v1alpha1.LabelSandboxIsClaimed: "true",
+			},
+			Annotations: map[string]string{
+				SingleflightAnnotationPrefix + "test-key": fmt.Sprintf("10:false:%d", now),
+			},
+		},
+		Status: v1alpha1.SandboxStatus{
+			Phase: v1alpha1.SandboxRunning,
+		},
+	}
+
+	cache, fc, err := newSingleflightTestCache(t, sandbox)
+	require.NoError(t, err)
+	require.NoError(t, cache.Run(t.Context()))
+	defer cache.Stop(t.Context())
+
+	// Try to release with seq=5 (doesn't match current seq=10)
+	releaseSingleflightLock(cache, sandbox, "test-key", 5)
+
+	// Verify annotation is unchanged
+	var updated v1alpha1.Sandbox
+	require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "test-sandbox"}, &updated))
+	annValue := updated.Annotations[SingleflightAnnotationPrefix+"test-key"]
+	assert.Contains(t, annValue, "10:false:")
+}
+
+// TestReleaseSingleflightLock_Success tests that release with a matching
+// seq successfully sets done=true.
+func TestReleaseSingleflightLock_Success(t *testing.T) {
+	now := time.Now().Unix()
+	sandbox := &v1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+			Labels: map[string]string{
+				v1alpha1.LabelSandboxIsClaimed: "true",
+			},
+			Annotations: map[string]string{
+				SingleflightAnnotationPrefix + "test-key": fmt.Sprintf("5:false:%d", now),
+			},
+		},
+		Status: v1alpha1.SandboxStatus{
+			Phase: v1alpha1.SandboxRunning,
+		},
+	}
+
+	cache, fc, err := newSingleflightTestCache(t, sandbox)
+	require.NoError(t, err)
+	require.NoError(t, cache.Run(t.Context()))
+	defer cache.Stop(t.Context())
+
+	// Release with matching seq=5
+	releaseSingleflightLock(cache, sandbox, "test-key", 5)
+
+	// Verify annotation now shows done=true
+	var updated v1alpha1.Sandbox
+	require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "test-sandbox"}, &updated))
+	annValue := updated.Annotations[SingleflightAnnotationPrefix+"test-key"]
+	assert.Contains(t, annValue, "5:true:")
+}
+
+func newSingleflightTestCache(t *testing.T, initObjs ...ctrlclient.Object) (*Cache, ctrlclient.Client, error) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, idx := range GetIndexFuncs() {
+		builder = builder.WithIndex(idx.Obj, idx.FieldName, idx.Extract)
+	}
+
+	builder = builder.WithStatusSubresource(
+		&v1alpha1.Sandbox{},
+		&v1alpha1.SandboxSet{},
+		&v1alpha1.Checkpoint{},
+		&v1alpha1.SandboxClaim{},
+		&v1alpha1.SandboxTemplate{},
+	)
+	builder = builder.WithInterceptorFuncs(resourceVersionInterceptorFuncs())
+
+	if len(initObjs) > 0 {
+		builder = builder.WithObjects(initObjs...)
+	}
+
+	fakeClient := builder.Build()
+	mgrBuilder, err := controllers.NewMockManagerBuilder(t)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create mock manager builder: %w", err)
+	}
+
+	mgr := mgrBuilder.
+		WithScheme(scheme).
+		WithClient(fakeClient).
+		WithWaitSimulation().
+		Build()
+
+	c, err := NewCache(mgr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mgr.SetWaitHooks(c.GetWaitHooks())
+	return c, fakeClient, nil
+}
+
+func resourceVersionInterceptorFuncs() interceptor.Funcs {
+	return interceptor.Funcs{
+		Update: func(ctx context.Context, client ctrlclient.WithWatch, obj ctrlclient.Object, opts ...ctrlclient.UpdateOption) error {
+			latest := obj.DeepCopyObject().(ctrlclient.Object)
+			if err := client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, latest); err == nil {
+				obj.SetResourceVersion(latest.GetResourceVersion())
+			}
+			return client.Update(ctx, obj, opts...)
+		},
+	}
+}

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -398,6 +398,81 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 			wantErr:       false,
 		},
 		{
+			name: "sandbox resuming with protected shutdownTime - should not be deleted",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "resuming-protected-shutdown-sandbox",
+					Namespace: "default",
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused:       false,
+					ShutdownTime: &metav1.Time{Time: time.Now().Add(time.Hour)},
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+							},
+						},
+					},
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxPaused,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(agentsv1alpha1.SandboxConditionPaused),
+							Status: metav1.ConditionTrue,
+							Reason: agentsv1alpha1.SandboxPausedReasonDeletePod,
+						},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "resuming-protected-shutdown-sandbox",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			expectedPhase: agentsv1alpha1.SandboxResuming,
+			wantErr:       false,
+		},
+		{
+			name: "running sandbox with protected pauseTime - should not be paused again",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "running-protected-pause-sandbox",
+					Namespace: "default",
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused:    false,
+					PauseTime: &metav1.Time{Time: time.Now().Add(time.Hour)},
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+							},
+						},
+					},
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "running-protected-pause-sandbox",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			expectedPhase: agentsv1alpha1.SandboxRunning,
+			wantErr:       false,
+		},
+		{
 			name: "sandbox with shutdownTime in past - should be deleted",
 			sandbox: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/sandbox-manager/api.go
+++ b/pkg/sandbox-manager/api.go
@@ -203,10 +203,10 @@ func (m *SandboxManager) PauseSandbox(ctx context.Context, sbx infra.Sandbox, op
 }
 
 // ResumeSandbox resumes a sandbox and syncs route with peers
-func (m *SandboxManager) ResumeSandbox(ctx context.Context, sbx infra.Sandbox) error {
+func (m *SandboxManager) ResumeSandbox(ctx context.Context, sbx infra.Sandbox, opts infra.ResumeOptions) error {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
 	start := time.Now()
-	if err := sbx.Resume(ctx); err != nil {
+	if err := sbx.Resume(ctx, opts); err != nil {
 		log.Error(err, "failed to resume sandbox")
 		sandboxResumeResponses.WithLabelValues("failure").Inc()
 		return err

--- a/pkg/sandbox-manager/api_test.go
+++ b/pkg/sandbox-manager/api_test.go
@@ -707,7 +707,7 @@ func TestSandboxManager_ResumeSandbox(t *testing.T) {
 				})
 			}
 
-			err = manager.ResumeSandbox(t.Context(), sbx)
+			err = manager.ResumeSandbox(t.Context(), sbx, infra.ResumeOptions{})
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/pkg/sandbox-manager/config/manager.go
+++ b/pkg/sandbox-manager/config/manager.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"time"
+
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/utils"
 	"k8s.io/client-go/rest"
@@ -28,16 +30,17 @@ const (
 )
 
 type SandboxManagerOptions struct {
-	SystemNamespace            string
-	PeerSelector               string
-	SandboxNamespace           string
-	SandboxLabelSelector       string
-	MaxClaimWorkers            int
-	MaxCreateQPS               int
-	ExtProcMaxConcurrency      uint32
-	MemberlistBindPort         int
-	DisableRouteReconciliation bool
-	RestConfig                 *rest.Config
+	SystemNamespace                 string
+	PeerSelector                    string
+	SandboxNamespace                string
+	SandboxLabelSelector            string
+	MaxClaimWorkers                 int
+	MaxCreateQPS                    int
+	ExtProcMaxConcurrency           uint32
+	MemberlistBindPort              int
+	DisableRouteReconciliation      bool
+	SingleflightPreemptionThreshold time.Duration
+	RestConfig                      *rest.Config
 }
 
 func InitOptions(opts SandboxManagerOptions) SandboxManagerOptions {
@@ -55,6 +58,9 @@ func InitOptions(opts SandboxManagerOptions) SandboxManagerOptions {
 	}
 	if opts.MemberlistBindPort <= 0 {
 		opts.MemberlistBindPort = DefaultMemberlistBindPort
+	}
+	if opts.SingleflightPreemptionThreshold <= 0 {
+		opts.SingleflightPreemptionThreshold = 5 * time.Minute
 	}
 	return opts
 }

--- a/pkg/sandbox-manager/config/manager_test.go
+++ b/pkg/sandbox-manager/config/manager_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/utils"
@@ -33,6 +34,7 @@ func TestInitOptions(t *testing.T) {
 		expectExtProcConcurrency uint32
 		expectMaxCreateQPS       int
 		expectMemberlistBindPort int
+		expectSingleflightTTL    time.Duration
 	}{
 		{
 			name:                     "all empty fields should use defaults",
@@ -42,21 +44,24 @@ func TestInitOptions(t *testing.T) {
 			expectExtProcConcurrency: consts.DefaultExtProcConcurrency,
 			expectMaxCreateQPS:       consts.DefaultCreateQPS,
 			expectMemberlistBindPort: DefaultMemberlistBindPort,
+			expectSingleflightTTL:    5 * time.Minute,
 		},
 		{
 			name: "all fields set should preserve values",
 			input: SandboxManagerOptions{
-				SystemNamespace:       "custom-namespace",
-				MaxClaimWorkers:       100,
-				ExtProcMaxConcurrency: 500,
-				MaxCreateQPS:          20,
-				MemberlistBindPort:    9000,
+				SystemNamespace:                 "custom-namespace",
+				MaxClaimWorkers:                 100,
+				ExtProcMaxConcurrency:           500,
+				MaxCreateQPS:                    20,
+				MemberlistBindPort:              9000,
+				SingleflightPreemptionThreshold: 2 * time.Minute,
 			},
 			expectSystemNamespace:    "custom-namespace",
 			expectMaxClaimWorkers:    100,
 			expectExtProcConcurrency: 500,
 			expectMaxCreateQPS:       20,
 			expectMemberlistBindPort: 9000,
+			expectSingleflightTTL:    2 * time.Minute,
 		},
 		{
 			name: "empty SystemNamespace should use default",
@@ -72,6 +77,7 @@ func TestInitOptions(t *testing.T) {
 			expectExtProcConcurrency: 500,
 			expectMaxCreateQPS:       20,
 			expectMemberlistBindPort: 9000,
+			expectSingleflightTTL:    5 * time.Minute,
 		},
 		{
 			name: "zero MaxClaimWorkers should use default",
@@ -87,6 +93,7 @@ func TestInitOptions(t *testing.T) {
 			expectExtProcConcurrency: 500,
 			expectMaxCreateQPS:       20,
 			expectMemberlistBindPort: 9000,
+			expectSingleflightTTL:    5 * time.Minute,
 		},
 		{
 			name: "negative MaxClaimWorkers should use default",
@@ -102,6 +109,7 @@ func TestInitOptions(t *testing.T) {
 			expectExtProcConcurrency: 500,
 			expectMaxCreateQPS:       20,
 			expectMemberlistBindPort: 9000,
+			expectSingleflightTTL:    5 * time.Minute,
 		},
 		{
 			name: "zero ExtProcMaxConcurrency should use default",
@@ -117,6 +125,7 @@ func TestInitOptions(t *testing.T) {
 			expectExtProcConcurrency: consts.DefaultExtProcConcurrency,
 			expectMaxCreateQPS:       20,
 			expectMemberlistBindPort: 9000,
+			expectSingleflightTTL:    5 * time.Minute,
 		},
 		{
 			name: "zero MaxCreateQPS should use default",
@@ -132,6 +141,7 @@ func TestInitOptions(t *testing.T) {
 			expectExtProcConcurrency: 500,
 			expectMaxCreateQPS:       consts.DefaultCreateQPS,
 			expectMemberlistBindPort: 9000,
+			expectSingleflightTTL:    5 * time.Minute,
 		},
 		{
 			name: "negative MaxCreateQPS should use default",
@@ -147,6 +157,7 @@ func TestInitOptions(t *testing.T) {
 			expectExtProcConcurrency: 500,
 			expectMaxCreateQPS:       consts.DefaultCreateQPS,
 			expectMemberlistBindPort: 9000,
+			expectSingleflightTTL:    5 * time.Minute,
 		},
 		{
 			name: "zero MemberlistBindPort should use default",
@@ -162,6 +173,7 @@ func TestInitOptions(t *testing.T) {
 			expectExtProcConcurrency: 500,
 			expectMaxCreateQPS:       20,
 			expectMemberlistBindPort: DefaultMemberlistBindPort,
+			expectSingleflightTTL:    5 * time.Minute,
 		},
 		{
 			name: "negative MemberlistBindPort should use default",
@@ -177,6 +189,7 @@ func TestInitOptions(t *testing.T) {
 			expectExtProcConcurrency: 500,
 			expectMaxCreateQPS:       20,
 			expectMemberlistBindPort: DefaultMemberlistBindPort,
+			expectSingleflightTTL:    5 * time.Minute,
 		},
 		{
 			name: "non-configurable fields should be preserved",
@@ -191,6 +204,7 @@ func TestInitOptions(t *testing.T) {
 			expectExtProcConcurrency: consts.DefaultExtProcConcurrency,
 			expectMaxCreateQPS:       consts.DefaultCreateQPS,
 			expectMemberlistBindPort: DefaultMemberlistBindPort,
+			expectSingleflightTTL:    5 * time.Minute,
 		},
 	}
 
@@ -203,6 +217,7 @@ func TestInitOptions(t *testing.T) {
 			assert.Equal(t, tt.expectExtProcConcurrency, result.ExtProcMaxConcurrency)
 			assert.Equal(t, tt.expectMaxCreateQPS, result.MaxCreateQPS)
 			assert.Equal(t, tt.expectMemberlistBindPort, result.MemberlistBindPort)
+			assert.Equal(t, tt.expectSingleflightTTL, result.SingleflightPreemptionThreshold)
 
 			// Verify non-configurable fields are preserved
 			if tt.input.PeerSelector != "" {

--- a/pkg/sandbox-manager/infra/interface.go
+++ b/pkg/sandbox-manager/infra/interface.go
@@ -48,6 +48,11 @@ type Builder interface {
 	Build() Infrastructure
 }
 
+type ResumeOptions struct {
+	Timeout            *TimeoutOptions // Set timeout after resume.
+	DisablePushTimeout bool            // By default, the configured Timeout is deferred by the time spent on Resume. Enable this option to disable this behavior.
+}
+
 type Infrastructure interface {
 	Run(ctx context.Context) error // Starts the infrastructure
 	Stop(ctx context.Context)      // Stops the infrastructure
@@ -64,9 +69,9 @@ type Infrastructure interface {
 }
 
 type Sandbox interface {
-	metav1.Object                                       // For K8s object metadata access
-	Pause(ctx context.Context, opts PauseOptions) error // Pause a Sandbox
-	Resume(ctx context.Context) error                   // Resume a paused Sandbox
+	metav1.Object                                         // For K8s object metadata access
+	Pause(ctx context.Context, opts PauseOptions) error   // Pause a Sandbox
+	Resume(ctx context.Context, opts ResumeOptions) error // Resume a paused Sandbox
 	GetSandboxID() string
 	GetRoute() proxy.Route
 	GetState() (string, string)   // Get Sandbox State (pending, running, paused, killing, etc.)

--- a/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
@@ -19,6 +19,8 @@ package sandboxcr
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -26,11 +28,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/openkruise/agents/api/v1alpha1"
+	infracache "github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/cache/cachetest"
+	"github.com/openkruise/agents/pkg/cache/controllers"
+	cacheutils "github.com/openkruise/agents/pkg/cache/utils"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	utils "github.com/openkruise/agents/pkg/utils/sandbox-manager"
@@ -89,7 +99,7 @@ func TestSandbox_ResumeConcurrent(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		s := AsSandbox(sandbox, cache)
 		go func() {
-			err := s.Resume(t.Context())
+			err := s.Resume(t.Context(), infra.ResumeOptions{})
 			resultCh <- err
 		}()
 	}
@@ -206,7 +216,7 @@ func TestSandbox_Resume_ContextExpiredAfterWait(t *testing.T) {
 	resumeCtx, resumeCancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
 	defer resumeCancel()
 
-	err = s.Resume(resumeCtx)
+	err = s.Resume(resumeCtx, infra.ResumeOptions{})
 
 	// Should succeed because Resume creates a fresh context for post-resume operations
 	require.NoError(t, err)
@@ -621,7 +631,7 @@ func TestSandbox_Resume(t *testing.T) {
 			}
 			defer resumeCancel()
 
-			err = s.Resume(resumeCtx)
+			err = s.Resume(resumeCtx, infra.ResumeOptions{Timeout: &infra.TimeoutOptions{}})
 
 			if tt.expectError != "" {
 				require.Error(t, err)
@@ -640,4 +650,349 @@ func TestSandbox_Resume(t *testing.T) {
 			assert.Nil(t, updatedSbx.Spec.PauseTime)
 		})
 	}
+}
+
+func TestSandbox_ResumeBumpsTimeoutsDuringUnpause(t *testing.T) {
+	utils.InitLogOutput()
+	now := time.Now()
+	expired := metav1.NewTime(now.Add(-time.Minute))
+	finalPauseTime := now.Add(15 * time.Minute)
+	finalShutdownTime := now.Add(20 * time.Minute)
+
+	tests := []struct {
+		name         string
+		pauseTime    *metav1.Time
+		shutdownTime *metav1.Time
+		expectError  string
+	}{
+		{
+			name:      "unpause succeeds and wait timeout saves final timeout",
+			pauseTime: &expired,
+		},
+		{
+			name:         "only shutdown expired is rejected",
+			pauseTime:    nil,
+			shutdownTime: &expired,
+			expectError:  "ShutdownTimeReached",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sandbox := &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+					Labels: map[string]string{
+						v1alpha1.LabelSandboxIsClaimed: "true",
+					},
+					Annotations: map[string]string{},
+				},
+				Spec: v1alpha1.SandboxSpec{
+					Paused:       true,
+					PauseTime:    tt.pauseTime,
+					ShutdownTime: tt.shutdownTime,
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase: v1alpha1.SandboxPaused,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1alpha1.SandboxConditionPaused),
+							Status: metav1.ConditionTrue,
+						},
+					},
+					PodInfo: v1alpha1.PodInfo{
+						PodIP: "10.0.0.1",
+					},
+				},
+			}
+
+			cache, fc, err := cachetest.NewTestCache(t)
+			require.NoError(t, err)
+			defer cache.Stop(t.Context())
+			CreateSandboxWithStatus(t, fc, sandbox)
+
+			beforeResume := time.Now()
+			s := AsSandbox(sandbox, cache)
+			ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+			defer cancel()
+			err = s.Resume(ctx, infra.ResumeOptions{
+				Timeout: &infra.TimeoutOptions{
+					PauseTime:    finalPauseTime,
+					ShutdownTime: finalShutdownTime,
+				},
+			})
+			require.Error(t, err)
+
+			var updatedSbx v1alpha1.Sandbox
+			if tt.expectError != "" {
+				assert.Contains(t, err.Error(), tt.expectError)
+				require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: sandbox.Name}, &updatedSbx))
+				assert.True(t, updatedSbx.Spec.Paused)
+				if tt.pauseTime == nil {
+					assert.Nil(t, updatedSbx.Spec.PauseTime)
+				} else {
+					require.NotNil(t, updatedSbx.Spec.PauseTime)
+					assert.WithinDuration(t, tt.pauseTime.Time, updatedSbx.Spec.PauseTime.Time, time.Second)
+				}
+				if tt.shutdownTime == nil {
+					assert.Nil(t, updatedSbx.Spec.ShutdownTime)
+				} else {
+					require.NotNil(t, updatedSbx.Spec.ShutdownTime)
+					assert.WithinDuration(t, tt.shutdownTime.Time, updatedSbx.Spec.ShutdownTime.Time, time.Second)
+				}
+				return
+			}
+
+			require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: sandbox.Name}, &updatedSbx))
+			assert.False(t, updatedSbx.Spec.Paused)
+			maxResumeCost := time.Since(beforeResume) + time.Second
+			require.NotNil(t, updatedSbx.Spec.PauseTime)
+			assert.WithinDuration(t, finalPauseTime, updatedSbx.Spec.PauseTime.Time, maxResumeCost)
+			require.NotNil(t, updatedSbx.Spec.ShutdownTime)
+			assert.WithinDuration(t, finalShutdownTime, updatedSbx.Spec.ShutdownTime.Time, maxResumeCost)
+		})
+	}
+}
+
+func TestSandbox_ResumeSavesFinalTimeoutBeforeReInit(t *testing.T) {
+	utils.InitLogOutput()
+	server := testutils.NewTestRuntimeServer(testutils.TestRuntimeServerOptions{
+		RunCommandResult: runtime.RunCommandResult{
+			PID:    1,
+			Exited: true,
+		},
+		RunCommandImmediately: true,
+		InitErrCode:           500,
+	})
+	defer server.Close()
+
+	initRuntimeOpts := config.InitRuntimeOptions{
+		EnvVars:     map[string]string{"TEST_VAR": "test_value"},
+		AccessToken: "test-token",
+	}
+	initRuntimeJSON, err := json.Marshal(initRuntimeOpts)
+	require.NoError(t, err)
+
+	expired := metav1.NewTime(time.Now().Add(-time.Minute))
+	sandbox := &v1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+			Labels: map[string]string{
+				v1alpha1.LabelSandboxIsClaimed: "true",
+			},
+			Annotations: map[string]string{
+				v1alpha1.AnnotationRuntimeURL:         server.URL,
+				v1alpha1.AnnotationInitRuntimeRequest: string(initRuntimeJSON),
+				v1alpha1.AnnotationOwner:              "test-user",
+			},
+		},
+		Spec: v1alpha1.SandboxSpec{
+			Paused:    true,
+			PauseTime: &expired,
+		},
+		Status: v1alpha1.SandboxStatus{
+			Phase: v1alpha1.SandboxPaused,
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(v1alpha1.SandboxConditionPaused),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			PodInfo: v1alpha1.PodInfo{
+				PodIP: "10.0.0.1",
+			},
+		},
+	}
+
+	cache, fc, err := cachetest.NewTestCache(t)
+	require.NoError(t, err)
+	defer cache.Stop(t.Context())
+	CreateSandboxWithStatus(t, fc, sandbox)
+
+	finalTimeout := infra.TimeoutOptions{
+		ShutdownTime: time.Now().Add(2 * time.Hour),
+		PauseTime:    time.Now().Add(15 * time.Minute),
+	}
+	time.AfterFunc(20*time.Millisecond, func() {
+		markSandboxRunningAndSignalResumeWait(fc, cache, sandbox)
+	})
+
+	s := AsSandbox(sandbox, cache)
+	err = s.Resume(t.Context(), infra.ResumeOptions{Timeout: &finalTimeout})
+	require.Error(t, err)
+
+	updatedSbx := &v1alpha1.Sandbox{}
+	require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: sandbox.Name}, updatedSbx))
+	require.NotNil(t, updatedSbx.Spec.ShutdownTime)
+	require.NotNil(t, updatedSbx.Spec.PauseTime)
+	assert.WithinDuration(t, finalTimeout.ShutdownTime, updatedSbx.Spec.ShutdownTime.Time, time.Second)
+	assert.WithinDuration(t, finalTimeout.PauseTime, updatedSbx.Spec.PauseTime.Time, time.Second)
+}
+
+func TestSandbox_ResumeDeferredSaveTimeoutFailure(t *testing.T) {
+	utils.InitLogOutput()
+	tests := []struct {
+		name        string
+		reInitFails bool
+		expectError string
+	}{
+		{
+			name:        "main flow succeeds returns save timeout error",
+			expectError: "failed to save final resume timeout",
+		},
+		{
+			name:        "main flow fails returns main error when save timeout also fails",
+			reInitFails: true,
+			expectError: "failed to perform ReInit after resume",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var annotations map[string]string
+			var server *httptest.Server
+			if tt.reInitFails {
+				server = testutils.NewTestRuntimeServer(testutils.TestRuntimeServerOptions{
+					RunCommandResult: runtime.RunCommandResult{
+						PID:    1,
+						Exited: true,
+					},
+					RunCommandImmediately: true,
+					InitErrCode:           500,
+				})
+				defer server.Close()
+
+				initRuntimeOpts := config.InitRuntimeOptions{
+					EnvVars:     map[string]string{"TEST_VAR": "test_value"},
+					AccessToken: "test-token",
+				}
+				initRuntimeJSON, err := json.Marshal(initRuntimeOpts)
+				require.NoError(t, err)
+				annotations = map[string]string{
+					v1alpha1.AnnotationRuntimeURL:         server.URL,
+					v1alpha1.AnnotationInitRuntimeRequest: string(initRuntimeJSON),
+					v1alpha1.AnnotationOwner:              "test-user",
+				}
+			}
+
+			sandbox := &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+					Labels: map[string]string{
+						v1alpha1.LabelSandboxIsClaimed: "true",
+					},
+					Annotations: annotations,
+				},
+				Spec: v1alpha1.SandboxSpec{
+					Paused: true,
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase: v1alpha1.SandboxPaused,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1alpha1.SandboxConditionPaused),
+							Status: metav1.ConditionTrue,
+						},
+					},
+					PodInfo: v1alpha1.PodInfo{
+						PodIP: "10.0.0.1",
+					},
+				},
+			}
+
+			var sandboxUpdates int
+			cache, fc := newResumeTestCacheWithUpdateInterceptor(t, func(ctx context.Context, c ctrl.WithWatch, obj ctrl.Object, opts ...ctrl.UpdateOption) error {
+				if _, ok := obj.(*v1alpha1.Sandbox); ok {
+					sandboxUpdates++
+					if sandboxUpdates == 2 {
+						return fmt.Errorf("injected save timeout failure")
+					}
+				}
+				latest := obj.DeepCopyObject().(ctrl.Object)
+				if err := c.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, latest); err == nil {
+					obj.SetResourceVersion(latest.GetResourceVersion())
+				}
+				return c.Update(ctx, obj, opts...)
+			})
+			defer cache.Stop(t.Context())
+			CreateSandboxWithStatus(t, fc, sandbox)
+
+			time.AfterFunc(20*time.Millisecond, func() {
+				markSandboxRunningAndSignalResumeWait(fc, cache, sandbox)
+			})
+
+			finalTimeout := infra.TimeoutOptions{
+				ShutdownTime: time.Now().Add(2 * time.Hour),
+				PauseTime:    time.Now().Add(15 * time.Minute),
+			}
+			s := AsSandbox(sandbox, cache)
+			err := s.Resume(t.Context(), infra.ResumeOptions{Timeout: &finalTimeout})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+			assert.Equal(t, 2, sandboxUpdates)
+			if tt.reInitFails {
+				assert.NotContains(t, err.Error(), "failed to save final resume timeout")
+			}
+		})
+	}
+}
+
+func markSandboxRunningAndSignalResumeWait(fc ctrl.Client, cache *infracache.Cache, sandbox *v1alpha1.Sandbox) {
+	updated := &v1alpha1.Sandbox{}
+	if getErr := fc.Get(context.Background(), types.NamespacedName{Namespace: sandbox.Namespace, Name: sandbox.Name}, updated); getErr != nil {
+		return
+	}
+	updated.Status.Phase = v1alpha1.SandboxRunning
+	updated.Status.Conditions = []metav1.Condition{
+		{
+			Type:   string(v1alpha1.SandboxConditionReady),
+			Status: metav1.ConditionTrue,
+		},
+	}
+	if updateErr := fc.Status().Update(context.Background(), updated); updateErr != nil {
+		return
+	}
+	if value, ok := cache.GetWaitHooks().Load(cacheutils.WaitHookKey[*v1alpha1.Sandbox](sandbox)); ok {
+		value.(*cacheutils.WaitEntry[*v1alpha1.Sandbox]).Close()
+	}
+}
+
+func newResumeTestCacheWithUpdateInterceptor(
+	t *testing.T,
+	update func(context.Context, ctrl.WithWatch, ctrl.Object, ...ctrl.UpdateOption) error,
+) (*infracache.Cache, ctrl.Client) {
+	t.Helper()
+	scheme := k8sruntime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, idx := range infracache.GetIndexFuncs() {
+		builder = builder.WithIndex(idx.Obj, idx.FieldName, idx.Extract)
+	}
+	builder = builder.WithStatusSubresource(
+		&v1alpha1.Sandbox{},
+		&v1alpha1.SandboxSet{},
+		&v1alpha1.Checkpoint{},
+		&v1alpha1.SandboxClaim{},
+		&v1alpha1.SandboxTemplate{},
+	)
+	builder = builder.WithInterceptorFuncs(interceptor.Funcs{Update: update})
+	fakeClient := builder.Build()
+
+	mgrBuilder, err := controllers.NewMockManagerBuilder(t)
+	require.NoError(t, err)
+	mgr := mgrBuilder.
+		WithScheme(scheme).
+		WithClient(fakeClient).
+		WithWaitSimulation().
+		Build()
+	testCache, err := infracache.NewCache(mgr)
+	require.NoError(t, err)
+	mgr.SetWaitHooks(testCache.GetWaitHooks())
+
+	return testCache, fakeClient
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
@@ -275,20 +275,15 @@ func TestSandbox_Pause(t *testing.T) {
 			useShortTimeout: true,
 		},
 		{
-			name: "pause running / available sandbox",
+			name: "pause dead sandbox",
 			initSandbox: func(sbx *v1alpha1.Sandbox) {
-				sbx.Status.Phase = v1alpha1.SandboxRunning
-				sbx.Status.Conditions = append(sbx.Status.Conditions, metav1.Condition{
-					Type:   string(v1alpha1.SandboxConditionReady),
-					Status: metav1.ConditionTrue,
-				})
+				sbx.Status.Phase = v1alpha1.SandboxTerminating
 				sbx.Spec.Paused = false
-				sbx.OwnerReferences = GetSbsOwnerReference()
 				state, reason := sandboxutils.GetSandboxState(sbx)
-				assert.Equal(t, v1alpha1.SandboxStateAvailable, state, reason)
+				assert.Equal(t, v1alpha1.SandboxStateDead, state, reason)
 			},
-			expectedState: v1alpha1.SandboxStateAvailable,
-			expectError:   "pausing is only available for running state",
+			expectedState: v1alpha1.SandboxStateDead,
+			expectError:   "sandbox is dead, cannot pause",
 		},
 		{
 			name: "pause already paused sandbox",
@@ -303,7 +298,7 @@ func TestSandbox_Pause(t *testing.T) {
 				assert.Equal(t, v1alpha1.SandboxStatePaused, state, reason)
 			},
 			expectedState: v1alpha1.SandboxStatePaused,
-			expectError:   "sandbox is not in running phase",
+			expectError:   "sandbox is already paused",
 		},
 		{
 			name: "pause killing sandbox",
@@ -314,7 +309,7 @@ func TestSandbox_Pause(t *testing.T) {
 				assert.Equal(t, v1alpha1.SandboxStateDead, state, reason)
 			},
 			expectedState: v1alpha1.SandboxStateDead,
-			expectError:   "sandbox is not in running phase",
+			expectError:   "sandbox is dead, cannot pause",
 		},
 	}
 
@@ -422,6 +417,7 @@ func TestSandbox_Resume(t *testing.T) {
 		initErrCode             int
 		withInitRuntime         bool
 		simulateResumeCompleted bool // use time.AfterFunc to simulate underlying resume completion
+		simulatePauseThenResume bool // complete pausing first, then finish resume
 		useShortTimeout         bool // simulate underlying not completing by using short context timeout
 	}{
 		{
@@ -522,8 +518,10 @@ func TestSandbox_Resume(t *testing.T) {
 				state, reason := sandboxutils.GetSandboxState(sbx)
 				assert.Equal(t, v1alpha1.SandboxStatePaused, state, reason)
 			},
-			expectedState: "",
-			expectError:   "sandbox is pausing",
+			expectedState:           v1alpha1.SandboxStateRunning,
+			expectError:             "",
+			simulateResumeCompleted: true,
+			simulatePauseThenResume: true,
 		},
 		{
 			name: "resume already running sandbox",
@@ -537,7 +535,7 @@ func TestSandbox_Resume(t *testing.T) {
 				assert.Equal(t, v1alpha1.SandboxStateRunning, state, reason)
 			},
 			expectedState: "",
-			expectError:   "resuming is only available for paused state",
+			expectError:   "sandbox is already running",
 		},
 		{
 			name: "resume killing sandbox",
@@ -548,7 +546,7 @@ func TestSandbox_Resume(t *testing.T) {
 				assert.Equal(t, v1alpha1.SandboxStateDead, state, reason)
 			},
 			expectedState: "",
-			expectError:   "resuming is only available for paused state",
+			expectError:   "sandbox is dead, cannot resume",
 		},
 	}
 
@@ -614,6 +612,25 @@ func TestSandbox_Resume(t *testing.T) {
 				modified := s.Sandbox.DeepCopy()
 				mergeFrom := ctrl.MergeFrom(s.Sandbox)
 				time.AfterFunc(20*time.Millisecond, func() {
+					if tt.simulatePauseThenResume {
+						modified.Status.Phase = v1alpha1.SandboxPaused
+						modified.Status.Conditions = []metav1.Condition{
+							{Type: string(v1alpha1.SandboxConditionPaused), Status: metav1.ConditionTrue, Reason: "Pause"},
+						}
+						_ = fc.Status().Patch(t.Context(), modified, mergeFrom)
+
+						time.AfterFunc(20*time.Millisecond, func() {
+							var latest v1alpha1.Sandbox
+							require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: sandbox.Namespace, Name: sandbox.Name}, &latest))
+							next := latest.DeepCopy()
+							next.Status.Phase = v1alpha1.SandboxRunning
+							next.Status.Conditions = []metav1.Condition{
+								{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Resume"},
+							}
+							require.NoError(t, fc.Status().Patch(t.Context(), next, ctrl.MergeFrom(&latest)))
+						})
+						return
+					}
 					modified.Status.Phase = v1alpha1.SandboxRunning
 					modified.Status.Conditions = []metav1.Condition{
 						{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Resume"},
@@ -650,6 +667,205 @@ func TestSandbox_Resume(t *testing.T) {
 			assert.Nil(t, updatedSbx.Spec.PauseTime)
 		})
 	}
+}
+
+func TestSandbox_PauseWhenResuming(t *testing.T) {
+	utils.InitLogOutput()
+
+	now := time.Now().Unix()
+	sandbox := &v1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+			Labels: map[string]string{
+				v1alpha1.LabelSandboxIsClaimed: "true",
+			},
+			Annotations: map[string]string{
+				infracache.SingleflightAnnotationPrefix + "pause-resume": fmt.Sprintf("1:false:%d", now),
+			},
+		},
+		Spec: v1alpha1.SandboxSpec{
+			Paused: false,
+		},
+		Status: v1alpha1.SandboxStatus{
+			Phase: v1alpha1.SandboxPaused,
+			Conditions: []metav1.Condition{
+				{Type: string(v1alpha1.SandboxConditionPaused), Status: metav1.ConditionFalse, Reason: "Resuming"},
+			},
+			PodInfo: v1alpha1.PodInfo{PodIP: "10.0.0.1"},
+		},
+	}
+
+	cache, fc, err := cachetest.NewTestCache(t)
+	require.NoError(t, err)
+	require.NoError(t, cache.Run(t.Context()))
+	defer cache.Stop(t.Context())
+	CreateSandboxWithStatus(t, fc, sandbox)
+	time.Sleep(10 * time.Millisecond)
+
+	mockMgr := cache.GetMockManager()
+	mockMgr.AddWaitReconcileKey(sandbox)
+
+	time.AfterFunc(50*time.Millisecond, func() {
+		completePauseResumeStep(t, fc, sandbox.Namespace, sandbox.Name, 1, true, func(sbx *v1alpha1.Sandbox) {
+			sbx.Status.Phase = v1alpha1.SandboxRunning
+			sbx.Status.Conditions = []metav1.Condition{
+				{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Resume"},
+			}
+		})
+	})
+
+	time.AfterFunc(120*time.Millisecond, func() {
+		claimed := waitForSingleflightAnnotation(t, fc, sandbox.Namespace, sandbox.Name, "pause-resume", func(value string) bool {
+			return len(value) > 0 && value[:2] == "2:"
+		})
+		if claimed == nil {
+			return
+		}
+		completePauseResumeStep(t, fc, sandbox.Namespace, claimed.Name, 2, true, func(sbx *v1alpha1.Sandbox) {
+			sbx.Status.Phase = v1alpha1.SandboxPaused
+			SetSandboxCondition(sbx, string(v1alpha1.SandboxConditionPaused), metav1.ConditionTrue, "Pause", "Paused by user")
+		})
+	})
+
+	s := AsSandbox(sandbox, cache)
+	err = s.Pause(t.Context(), infra.PauseOptions{
+		Timeout: &infra.TimeoutOptions{
+			PauseTime:    time.Now().Add(time.Minute),
+			ShutdownTime: time.Now().Add(time.Hour),
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, s.Sandbox.Spec.Paused)
+	assert.Contains(t, s.Sandbox.Annotations[infracache.SingleflightAnnotationPrefix+"pause-resume"], "2:true:")
+}
+
+func TestSandbox_ResumeWhenPausing(t *testing.T) {
+	utils.InitLogOutput()
+
+	now := time.Now().Unix()
+	sandbox := &v1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+			Labels: map[string]string{
+				v1alpha1.LabelSandboxIsClaimed: "true",
+			},
+			Annotations: map[string]string{
+				infracache.SingleflightAnnotationPrefix + "pause-resume": fmt.Sprintf("1:false:%d", now),
+			},
+		},
+		Spec: v1alpha1.SandboxSpec{
+			Paused: true,
+		},
+		Status: v1alpha1.SandboxStatus{
+			Phase: v1alpha1.SandboxPaused,
+			Conditions: []metav1.Condition{
+				{Type: string(v1alpha1.SandboxConditionPaused), Status: metav1.ConditionFalse, Reason: "Pausing"},
+			},
+			PodInfo: v1alpha1.PodInfo{PodIP: "10.0.0.1"},
+		},
+	}
+
+	cache, fc, err := cachetest.NewTestCache(t)
+	require.NoError(t, err)
+	require.NoError(t, cache.Run(t.Context()))
+	defer cache.Stop(t.Context())
+	CreateSandboxWithStatus(t, fc, sandbox)
+	time.Sleep(10 * time.Millisecond)
+
+	mockMgr := cache.GetMockManager()
+	mockMgr.AddWaitReconcileKey(sandbox)
+
+	time.AfterFunc(50*time.Millisecond, func() {
+		completePauseResumeStep(t, fc, sandbox.Namespace, sandbox.Name, 1, true, func(sbx *v1alpha1.Sandbox) {
+			SetSandboxCondition(sbx, string(v1alpha1.SandboxConditionPaused), metav1.ConditionTrue, "Pause", "Paused by user")
+		})
+	})
+
+	time.AfterFunc(120*time.Millisecond, func() {
+		claimed := waitForSingleflightAnnotation(t, fc, sandbox.Namespace, sandbox.Name, "pause-resume", func(value string) bool {
+			return len(value) > 0 && value[:2] == "2:"
+		})
+		if claimed == nil {
+			return
+		}
+		completePauseResumeStep(t, fc, sandbox.Namespace, claimed.Name, 2, true, func(sbx *v1alpha1.Sandbox) {
+			sbx.Status.Phase = v1alpha1.SandboxRunning
+			sbx.Status.Conditions = []metav1.Condition{
+				{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Resume"},
+			}
+		})
+	})
+
+	s := AsSandbox(sandbox, cache)
+	err = s.Resume(t.Context(), infra.ResumeOptions{Timeout: &infra.TimeoutOptions{}})
+	require.NoError(t, err)
+	assert.False(t, s.Sandbox.Spec.Paused)
+	assert.Contains(t, s.Sandbox.Annotations[infracache.SingleflightAnnotationPrefix+"pause-resume"], "2:true:")
+}
+
+func waitForSingleflightAnnotation(
+	t *testing.T,
+	fc ctrl.Client,
+	namespace string,
+	name string,
+	key string,
+	match func(string) bool,
+) *v1alpha1.Sandbox {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		var sandbox v1alpha1.Sandbox
+		if err := fc.Get(t.Context(), types.NamespacedName{Namespace: namespace, Name: name}, &sandbox); err != nil {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		if match(sandbox.Annotations[infracache.SingleflightAnnotationPrefix+key]) {
+			return &sandbox
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return nil
+}
+
+func completePauseResumeStep(
+	t *testing.T,
+	fc ctrl.Client,
+	namespace string,
+	name string,
+	seq int64,
+	done bool,
+	mutateStatus func(*v1alpha1.Sandbox),
+) {
+	t.Helper()
+
+	var sandbox v1alpha1.Sandbox
+	if err := fc.Get(t.Context(), types.NamespacedName{Namespace: namespace, Name: name}, &sandbox); err != nil {
+		return
+	}
+
+	if sandbox.Annotations == nil {
+		sandbox.Annotations = map[string]string{}
+	}
+	sandbox.Annotations[infracache.SingleflightAnnotationPrefix+"pause-resume"] = fmt.Sprintf("%d:%t:%d", seq, done, time.Now().Unix())
+	if err := fc.Update(t.Context(), &sandbox); err != nil {
+		return
+	}
+
+	if mutateStatus == nil {
+		return
+	}
+
+	var latest v1alpha1.Sandbox
+	if err := fc.Get(t.Context(), types.NamespacedName{Namespace: namespace, Name: name}, &latest); err != nil {
+		return
+	}
+	modified := latest.DeepCopy()
+	mutateStatus(modified)
+	_ = fc.Status().Patch(t.Context(), modified, ctrl.MergeFrom(&latest))
 }
 
 func TestSandbox_ResumeBumpsTimeoutsDuringUnpause(t *testing.T) {
@@ -932,7 +1148,7 @@ func TestSandbox_ResumeDeferredSaveTimeoutFailure(t *testing.T) {
 			err := s.Resume(t.Context(), infra.ResumeOptions{Timeout: &finalTimeout})
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectError)
-			assert.Equal(t, 2, sandboxUpdates)
+			assert.GreaterOrEqual(t, sandboxUpdates, 3)
 			if tt.reInitFails {
 				assert.NotContains(t, err.Error(), "failed to save final resume timeout")
 			}

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -35,7 +35,6 @@ import (
 	"github.com/openkruise/agents/pkg/proxy"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
-	"github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/utils"
 	csimountutils "github.com/openkruise/agents/pkg/utils/csiutils"
@@ -145,6 +144,15 @@ func (s *Sandbox) GetRoute() proxy.Route {
 	return proxyutils.DefaultGetRouteFunc(s.Sandbox)
 }
 
+// setTimeout overwrites Spec.PauseTime / Spec.ShutdownTime from opts.
+//
+// Contract (relied upon by callers such as buildResumeTimeoutOptions and
+// SaveTimeout): a zero time.Time in opts is treated as "clear this field" and
+// will set the corresponding Spec.*Time pointer back to nil. This is the
+// intended way for upper layers to express "this sandbox should be
+// never-timeout"; do not change this to skip-on-zero, otherwise callers that
+// pass infra.TimeoutOptions{} expecting the underlying fields to be cleared
+// will silently retain stale values.
 func setTimeout(s *agentsv1alpha1.Sandbox, opts infra.TimeoutOptions) {
 	if !opts.PauseTime.IsZero() {
 		s.Spec.PauseTime = ptr.To(metav1.NewTime(opts.PauseTime))
@@ -189,6 +197,11 @@ func (s *Sandbox) GetImage() string {
 	return ""
 }
 
+// SaveTimeout persists opts to Spec.PauseTime / Spec.ShutdownTime via the
+// API server. Per setTimeout's contract, a zero time.Time in opts clears the
+// corresponding spec field; callers that want to mark a sandbox as
+// never-timeout should pass infra.TimeoutOptions{} (or a struct with both
+// times zero).
 func (s *Sandbox) SaveTimeout(ctx context.Context, opts infra.TimeoutOptions) error {
 	return s.retryUpdate(ctx, func(sbx *agentsv1alpha1.Sandbox) {
 		setTimeout(sbx, opts)
@@ -253,40 +266,93 @@ func (s *Sandbox) Pause(ctx context.Context, opts infra.PauseOptions) error {
 	return s.InplaceRefresh(ctx, false)
 }
 
+func bumpResumeTimeoutProtection(sbx *agentsv1alpha1.Sandbox, protectUntil time.Time) {
+	if sbx.Spec.PauseTime != nil && sbx.Spec.PauseTime.Time.Before(protectUntil) {
+		sbx.Spec.PauseTime = ptr.To(metav1.NewTime(protectUntil))
+	}
+	if sbx.Spec.ShutdownTime != nil && sbx.Spec.ShutdownTime.Time.Before(protectUntil) {
+		sbx.Spec.ShutdownTime = ptr.To(metav1.NewTime(protectUntil))
+	}
+}
+
+// resumable checks whether the sandbox is in a resumable state.
+// It returns nil if the sandbox can be resumed, or an error describing why it cannot.
+func (s *Sandbox) resumable() error {
+	state, reason := s.GetState()
+
+	// Check 1: Logical state must be "Paused" — the primary indicator.
+	if state != agentsv1alpha1.SandboxStatePaused {
+		return fmt.Errorf("resuming is only available for paused state, current state: %s, reason: %s", state, reason)
+	}
+
+	// Check 2: Defensive fallback — status phase is Paused AND spec.Paused is still set.
+	if s.Sandbox.Status.Phase != agentsv1alpha1.SandboxPaused {
+		return fmt.Errorf("resuming is only available for sandboxes in phase Paused, current phase: %s, state: %s, reason: %s", s.Sandbox.Status.Phase, state, reason)
+	}
+	if !s.Sandbox.Spec.Paused {
+		return fmt.Errorf("resuming is only available for sandboxes with spec.paused == true, current state: %s, reason: %s", state, reason)
+	}
+
+	// Check 3: Ensure the pause operation has fully completed.
+	// A False Paused condition means the sandbox is still in the process of pausing.
+	cond := GetSandboxCondition(s.Sandbox, agentsv1alpha1.SandboxConditionPaused)
+	if cond.Status == metav1.ConditionFalse {
+		return fmt.Errorf("sandbox is pausing, please wait a moment and try again")
+	}
+
+	return nil
+}
+
 const postResumeOperationTimeout = 30 * time.Second
 
-func (s *Sandbox) Resume(ctx context.Context) error {
+func postResumeContext(ctx context.Context) (context.Context, context.CancelFunc, bool) {
+	if ctx.Err() == nil {
+		return ctx, func() {}, false
+	}
+	postCtx, cancel := context.WithTimeout(context.Background(), postResumeOperationTimeout)
+	return postCtx, cancel, true
+}
+
+func (s *Sandbox) Resume(ctx context.Context, opts infra.ResumeOptions) (retErr error) {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(s.Sandbox))
 
-	initRuntimeOpts, err := runtime.GetInitRuntimeRequest(s.Sandbox)
-	if err != nil {
-		log.Error(err, "failed to get init runtime request")
-		return fmt.Errorf("failed to get init runtime request: %w", err)
-	}
-
-	state, reason := s.GetState()
-	log.Info("try to resume sandbox", "state", state, "reason", reason)
-	if state != agentsv1alpha1.SandboxStatePaused {
-		err := fmt.Errorf("resuming is only available for paused state, current state: %s", state)
-		log.Error(err, "sandbox is not paused", "state", state, "reason", reason)
-		return err
-	}
-	cond := GetSandboxCondition(s.Sandbox, agentsv1alpha1.SandboxConditionPaused)
-	if s.Spec.Paused && cond.Status == metav1.ConditionFalse {
-		return errors.NewError(errors.ErrorConflict, "sandbox is pausing, please wait a moment and try again")
-	}
-	if s.Sandbox.Spec.Paused {
+	var err error
+	if err = s.resumable(); err == nil {
 		if err := s.retryUpdate(ctx, func(sbx *agentsv1alpha1.Sandbox) {
 			sbx.Spec.Paused = false
-			setTimeout(sbx, infra.TimeoutOptions{}) // remove all timeout options
+			bumpResumeTimeoutProtection(sbx, time.Now().Add(time.Hour))
 		}); err != nil {
 			log.Error(err, "failed to update sandbox spec.paused")
 			return err
 		}
+	} else {
+		// TODO: refactor needed
+		return err
 	}
 	expectationutils.ResourceVersionExpectationExpect(s.Sandbox) // expect Resuming
 	log.Info("waiting sandbox resume")
 	start := time.Now()
+	if opts.Timeout != nil {
+		defer func() {
+			if !opts.DisablePushTimeout {
+				infra.PushTimeout(opts.Timeout, time.Since(start))
+			}
+			saveCtx, cancel, freshSaveCtx := postResumeContext(ctx)
+			defer cancel()
+			if freshSaveCtx {
+				log.Info("original context expired after wait, using fresh context for saving final resume timeout")
+			}
+			log.Info("saving final resume timeout", "timeout", *opts.Timeout)
+			if err := s.SaveTimeout(saveCtx, *opts.Timeout); err != nil {
+				if retErr != nil {
+					log.Error(err, "failed to save final resume timeout", "originalError", retErr)
+					return
+				}
+				log.Error(err, "failed to save final resume timeout")
+				retErr = fmt.Errorf("failed to save final resume timeout: %w", err)
+			}
+		}()
+	}
 	if err = s.Cache.NewSandboxResumeTask(ctx, s.Sandbox).Wait(time.Minute); err != nil {
 		log.Error(err, "failed to wait sandbox resume")
 		return err
@@ -296,11 +362,9 @@ func (s *Sandbox) Resume(ctx context.Context) error {
 	// If the original context deadline was consumed by the wait, create a fresh
 	// context for post-resume operations (ReInit, CSI mount, inplace refresh).
 	// This can happen when the wait succeeds via double-check right at the deadline boundary.
-	postCtx := ctx
-	if ctx.Err() != nil {
-		var postCancel context.CancelFunc
-		postCtx, postCancel = context.WithTimeout(context.Background(), postResumeOperationTimeout)
-		defer postCancel()
+	postCtx, postCancel, freshPostCtx := postResumeContext(ctx)
+	defer postCancel()
+	if freshPostCtx {
 		log.Info("original context expired after wait, using fresh context for post-resume operations")
 	}
 	if err = s.InplaceRefresh(postCtx, false); err != nil {
@@ -312,10 +376,15 @@ func (s *Sandbox) Resume(ctx context.Context) error {
 	// E2B only handles post-resume initialization for non-claimed sandboxes.
 	// Claimed sandboxes (with claim-name label) are handled by the controller's Initialize function.
 	if s.Labels[agentsv1alpha1.LabelSandboxClaimName] == "" {
+		initRuntimeOpts, err := runtime.GetInitRuntimeRequest(s.Sandbox)
+		if err != nil {
+			log.Error(err, "failed to get init runtime request")
+			return fmt.Errorf("failed to get init runtime request: %w", err)
+		}
 		// Perform ReInit if initRuntimeOpts is set
 		if initRuntimeOpts != nil {
 			log.Info("will re-init runtime after resume")
-			if _, err := runtime.InitRuntime(ctx, s.Sandbox, *initRuntimeOpts, s.refreshFunc()); err != nil {
+			if _, err := runtime.InitRuntime(postCtx, s.Sandbox, *initRuntimeOpts, s.refreshFunc()); err != nil {
 				log.Error(err, "failed to perform ReInit after resume")
 				return fmt.Errorf("failed to perform ReInit after resume: %w", err)
 			}

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -18,6 +18,7 @@ package sandboxcr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -53,6 +54,11 @@ type Sandbox struct {
 	Cache           cache.Provider
 	storageRegistry storages.VolumeMountProviderRegistry
 }
+
+var (
+	errSandboxAlreadyPaused  = errors.New("sandbox is already paused")
+	errSandboxAlreadyRunning = errors.New("sandbox is already running")
+)
 
 var DefaultDeleteSandbox = deleteSandbox
 
@@ -234,36 +240,92 @@ func (s *Sandbox) Request(ctx context.Context, method, path string, port int, bo
 	return proxyutils.DefaultRequestFunc(ctx, s.Sandbox, method, path, port, body)
 }
 
+// SingleflightDo executes a distributed single-flight operation using this Sandbox
+// as the coordination group. It delegates to cache.DistributedSingleFlightDo.
+func (s *Sandbox) SingleflightDo(
+	ctx context.Context,
+	key string,
+	precheck func(*agentsv1alpha1.Sandbox) error,
+	modifier func(*agentsv1alpha1.Sandbox),
+	function func(*agentsv1alpha1.Sandbox) error,
+) (*agentsv1alpha1.Sandbox, error) {
+	return cache.DistributedSingleFlightDo(
+		ctx,
+		s.Cache,
+		s.Sandbox,
+		key,
+		precheck,
+		modifier,
+		function,
+		cache.DefaultSingleflightPreemptionThreshold,
+	)
+}
+
 func (s *Sandbox) Pause(ctx context.Context, opts infra.PauseOptions) error {
-	log := klog.FromContext(ctx)
-	if s.Status.Phase != agentsv1alpha1.SandboxRunning {
-		return fmt.Errorf("sandbox is not in running phase")
+	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(s.Sandbox))
+
+	pausePrecheck := func(sbx *agentsv1alpha1.Sandbox) error {
+		cond := GetSandboxCondition(sbx, agentsv1alpha1.SandboxConditionPaused)
+		if cond.Type != "" && cond.Status == metav1.ConditionTrue {
+			return errSandboxAlreadyPaused
+		}
+
+		state, _ := stateutils.GetSandboxState(sbx)
+		if state == agentsv1alpha1.SandboxStateDead {
+			return fmt.Errorf("sandbox is dead, cannot pause")
+		}
+		return nil
 	}
-	state, reason := s.GetState()
-	if state != agentsv1alpha1.SandboxStateRunning {
-		err := fmt.Errorf("pausing is only available for running state, current state: %s", state)
-		log.Error(err, "sandbox is not running", "state", state, "reason", reason)
-		return err
-	}
-	err := s.retryUpdate(ctx, func(sbx *agentsv1alpha1.Sandbox) {
+
+	pauseModifier := func(sbx *agentsv1alpha1.Sandbox) {
 		sbx.Spec.Paused = true
 		if opts.Timeout != nil {
 			setTimeout(sbx, *opts.Timeout)
 		}
-	})
-	if err != nil {
-		log.Error(err, "failed to update sandbox spec.paused")
-		return err
 	}
-	expectationutils.ResourceVersionExpectationExpect(s.Sandbox)
-	log.Info("waiting sandbox pause")
-	start := time.Now()
-	if err = s.Cache.NewSandboxPauseTask(ctx, s.Sandbox).Wait(time.Minute); err != nil {
-		log.Error(err, "failed to wait sandbox pause")
-		return err
+
+	pauseFunction := func(sbx *agentsv1alpha1.Sandbox) error {
+		expectationutils.ResourceVersionExpectationExpect(sbx)
+		log.Info("waiting sandbox pause")
+		start := time.Now()
+		if err := s.Cache.NewSandboxPauseTask(ctx, sbx).Wait(time.Minute); err != nil {
+			log.Error(err, "failed to wait sandbox pause")
+			return err
+		}
+		log.Info("sandbox paused", "cost", time.Since(start))
+		s.Sandbox = sbx
+		if err := s.InplaceRefresh(ctx, false); err != nil {
+			return err
+		}
+		*sbx = *s.Sandbox.DeepCopy()
+		return nil
 	}
-	log.Info("sandbox paused", "cost", time.Since(start))
-	return s.InplaceRefresh(ctx, false)
+
+	for {
+		latest, err := s.SingleflightDo(ctx, "pause-resume", pausePrecheck, pauseModifier, pauseFunction)
+		if err != nil {
+			if errors.Is(err, errSandboxAlreadyPaused) && s.refreshSingleflightState(ctx) == nil &&
+				hasSingleflightAnnotation(s.Sandbox, "pause-resume") {
+				cond := GetSandboxCondition(s.Sandbox, agentsv1alpha1.SandboxConditionPaused)
+				if cond.Type != "" && cond.Status == metav1.ConditionTrue {
+					return nil
+				}
+			}
+			return err
+		}
+		s.Sandbox = latest
+
+		cond := GetSandboxCondition(s.Sandbox, agentsv1alpha1.SandboxConditionPaused)
+		if cond.Type != "" && cond.Status == metav1.ConditionTrue {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+	}
 }
 
 func bumpResumeTimeoutProtection(sbx *agentsv1alpha1.Sandbox, protectUntil time.Time) {
@@ -273,34 +335,6 @@ func bumpResumeTimeoutProtection(sbx *agentsv1alpha1.Sandbox, protectUntil time.
 	if sbx.Spec.ShutdownTime != nil && sbx.Spec.ShutdownTime.Time.Before(protectUntil) {
 		sbx.Spec.ShutdownTime = ptr.To(metav1.NewTime(protectUntil))
 	}
-}
-
-// resumable checks whether the sandbox is in a resumable state.
-// It returns nil if the sandbox can be resumed, or an error describing why it cannot.
-func (s *Sandbox) resumable() error {
-	state, reason := s.GetState()
-
-	// Check 1: Logical state must be "Paused" — the primary indicator.
-	if state != agentsv1alpha1.SandboxStatePaused {
-		return fmt.Errorf("resuming is only available for paused state, current state: %s, reason: %s", state, reason)
-	}
-
-	// Check 2: Defensive fallback — status phase is Paused AND spec.Paused is still set.
-	if s.Sandbox.Status.Phase != agentsv1alpha1.SandboxPaused {
-		return fmt.Errorf("resuming is only available for sandboxes in phase Paused, current phase: %s, state: %s, reason: %s", s.Sandbox.Status.Phase, state, reason)
-	}
-	if !s.Sandbox.Spec.Paused {
-		return fmt.Errorf("resuming is only available for sandboxes with spec.paused == true, current state: %s, reason: %s", state, reason)
-	}
-
-	// Check 3: Ensure the pause operation has fully completed.
-	// A False Paused condition means the sandbox is still in the process of pausing.
-	cond := GetSandboxCondition(s.Sandbox, agentsv1alpha1.SandboxConditionPaused)
-	if cond.Status == metav1.ConditionFalse {
-		return fmt.Errorf("sandbox is pausing, please wait a moment and try again")
-	}
-
-	return nil
 }
 
 const postResumeOperationTimeout = 30 * time.Second
@@ -315,110 +349,171 @@ func postResumeContext(ctx context.Context) (context.Context, context.CancelFunc
 
 func (s *Sandbox) Resume(ctx context.Context, opts infra.ResumeOptions) (retErr error) {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(s.Sandbox))
+	resumeStartedAt := time.Now()
+	resumeExecuted := false
+	timeoutPersisted := false
 
-	var err error
-	if err = s.resumable(); err == nil {
-		if err := s.retryUpdate(ctx, func(sbx *agentsv1alpha1.Sandbox) {
-			sbx.Spec.Paused = false
-			bumpResumeTimeoutProtection(sbx, time.Now().Add(time.Hour))
-		}); err != nil {
-			log.Error(err, "failed to update sandbox spec.paused")
+	saveFinalResumeTimeout := func() {
+		if opts.Timeout == nil || timeoutPersisted {
+			return
+		}
+		timeoutPersisted = true
+		if !opts.DisablePushTimeout {
+			infra.PushTimeout(opts.Timeout, time.Since(resumeStartedAt))
+		}
+		saveCtx, cancel, freshSaveCtx := postResumeContext(ctx)
+		defer cancel()
+		if freshSaveCtx {
+			log.Info("original context expired after wait, using fresh context for saving final resume timeout")
+		}
+		log.Info("saving final resume timeout", "timeout", *opts.Timeout)
+		if err := s.SaveTimeout(saveCtx, *opts.Timeout); err != nil {
+			if retErr != nil {
+				log.Error(err, "failed to save final resume timeout", "originalError", retErr)
+				return
+			}
+			log.Error(err, "failed to save final resume timeout")
+			retErr = fmt.Errorf("failed to save final resume timeout: %w", err)
+		}
+	}
+
+	resumePrecheck := func(sbx *agentsv1alpha1.Sandbox) error {
+		state, reason := stateutils.GetSandboxState(sbx)
+		if state == agentsv1alpha1.SandboxStateRunning {
+			return errSandboxAlreadyRunning
+		}
+		if state == agentsv1alpha1.SandboxStateDead {
+			if reason == "ShutdownTimeReached" {
+				return fmt.Errorf("ShutdownTimeReached")
+			}
+			return fmt.Errorf("sandbox is dead, cannot resume")
+		}
+		return nil
+	}
+
+	resumeModifier := func(sbx *agentsv1alpha1.Sandbox) {
+		sbx.Spec.Paused = false
+		bumpResumeTimeoutProtection(sbx, time.Now().Add(time.Hour))
+	}
+
+	resumeFunction := func(sbx *agentsv1alpha1.Sandbox) error {
+		resumeExecuted = true
+		expectationutils.ResourceVersionExpectationExpect(sbx)
+		log.Info("waiting sandbox resume")
+		start := time.Now()
+		if opts.Timeout != nil {
+			defer saveFinalResumeTimeout()
+		}
+		if err := s.Cache.NewSandboxResumeTask(ctx, sbx).Wait(time.Minute); err != nil {
+			log.Error(err, "failed to wait sandbox resume")
 			return err
 		}
-	} else {
-		// TODO: refactor needed
-		return err
-	}
-	expectationutils.ResourceVersionExpectationExpect(s.Sandbox) // expect Resuming
-	log.Info("waiting sandbox resume")
-	start := time.Now()
-	if opts.Timeout != nil {
-		defer func() {
-			if !opts.DisablePushTimeout {
-				infra.PushTimeout(opts.Timeout, time.Since(start))
+		log.Info("sandbox resumed", "cost", time.Since(start))
+
+		postCtx, postCancel, freshPostCtx := postResumeContext(ctx)
+		defer postCancel()
+		if freshPostCtx {
+			log.Info("original context expired after wait, using fresh context for post-resume operations")
+		}
+		s.Sandbox = sbx
+		if err := s.InplaceRefresh(postCtx, false); err != nil {
+			log.Error(err, "failed to refresh sandbox after resume")
+			return err
+		}
+		expectationutils.ResourceVersionExpectationExpect(s.Sandbox)
+		*sbx = *s.Sandbox.DeepCopy()
+
+		if s.Labels[agentsv1alpha1.LabelSandboxClaimName] == "" {
+			initRuntimeOpts, err := runtime.GetInitRuntimeRequest(s.Sandbox)
+			if err != nil {
+				log.Error(err, "failed to get init runtime request")
+				return fmt.Errorf("failed to get init runtime request: %w", err)
 			}
-			saveCtx, cancel, freshSaveCtx := postResumeContext(ctx)
-			defer cancel()
-			if freshSaveCtx {
-				log.Info("original context expired after wait, using fresh context for saving final resume timeout")
-			}
-			log.Info("saving final resume timeout", "timeout", *opts.Timeout)
-			if err := s.SaveTimeout(saveCtx, *opts.Timeout); err != nil {
-				if retErr != nil {
-					log.Error(err, "failed to save final resume timeout", "originalError", retErr)
-					return
+			if initRuntimeOpts != nil {
+				log.Info("will re-init runtime after resume")
+				if _, err := runtime.InitRuntime(postCtx, s.Sandbox, *initRuntimeOpts, s.refreshFunc()); err != nil {
+					log.Error(err, "failed to perform ReInit after resume")
+					return fmt.Errorf("failed to perform ReInit after resume: %w", err)
 				}
-				log.Error(err, "failed to save final resume timeout")
-				retErr = fmt.Errorf("failed to save final resume timeout: %w", err)
+				log.Info("ReInit completed after resume")
 			}
-		}()
+
+			csiMountConfigRequests, err := runtime.GetCsiMountExtensionRequest(s.Sandbox)
+			if err != nil {
+				log.Error(err, "failed to get csi mount request")
+				return fmt.Errorf("failed to get csi mount request: %w", err)
+			}
+
+			if len(csiMountConfigRequests) != 0 {
+				log.Info("will re-mount csi storage after resume")
+				startTime := time.Now()
+				csiClient := csimountutils.NewCSIMountHandler(s.Cache.GetClient(), s.Cache.GetAPIReader(), s.storageRegistry, utils.DefaultSandboxDeployNamespace)
+				mountConfigs, resolveErr := resolveCSIMountConfigs(postCtx, csiClient, csiMountConfigRequests)
+				if resolveErr != nil {
+					return resolveErr
+				}
+				opts := config.CSIMountOptions{MountOptionList: mountConfigs}
+				if _, mountErr := runtime.ProcessCSIMounts(postCtx, s.Sandbox, opts); mountErr != nil {
+					log.Error(mountErr, "failed to remount csi storage after resume")
+					return fmt.Errorf("failed to remount csi storage after resume: %v", mountErr)
+				}
+				log.Info("remount csi storage completed after resume", "costTime", time.Since(startTime))
+			}
+		} else {
+			log.Info("sandbox is claimed by SandboxClaim, skipping E2B post-resume initialization",
+				"claimName", s.Labels[agentsv1alpha1.LabelSandboxClaimName])
+		}
+		return nil
 	}
-	if err = s.Cache.NewSandboxResumeTask(ctx, s.Sandbox).Wait(time.Minute); err != nil {
-		log.Error(err, "failed to wait sandbox resume")
+
+	for {
+		latest, err := s.SingleflightDo(ctx, "pause-resume", resumePrecheck, resumeModifier, resumeFunction)
+		if err != nil {
+			if errors.Is(err, errSandboxAlreadyRunning) && s.refreshSingleflightState(ctx) == nil &&
+				hasSingleflightAnnotation(s.Sandbox, "pause-resume") {
+				state, _ := stateutils.GetSandboxState(s.Sandbox)
+				if state == agentsv1alpha1.SandboxStateRunning {
+					if !resumeExecuted {
+						saveFinalResumeTimeout()
+					}
+					return retErr
+				}
+			}
+			return err
+		}
+		s.Sandbox = latest
+
+		state, _ := stateutils.GetSandboxState(s.Sandbox)
+		if state == agentsv1alpha1.SandboxStateRunning {
+			if !resumeExecuted {
+				saveFinalResumeTimeout()
+			}
+			return retErr
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+	}
+}
+
+func (s *Sandbox) refreshSingleflightState(ctx context.Context) error {
+	fresh := s.Sandbox.DeepCopy()
+	if err := s.Cache.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(s.Sandbox), fresh); err != nil {
 		return err
 	}
-	log.Info("sandbox resumed", "cost", time.Since(start))
-
-	// If the original context deadline was consumed by the wait, create a fresh
-	// context for post-resume operations (ReInit, CSI mount, inplace refresh).
-	// This can happen when the wait succeeds via double-check right at the deadline boundary.
-	postCtx, postCancel, freshPostCtx := postResumeContext(ctx)
-	defer postCancel()
-	if freshPostCtx {
-		log.Info("original context expired after wait, using fresh context for post-resume operations")
-	}
-	if err = s.InplaceRefresh(postCtx, false); err != nil {
-		log.Error(err, "failed to refresh sandbox after resume")
-		return err
-	}
-	expectationutils.ResourceVersionExpectationExpect(s.Sandbox) // expect Running
-
-	// E2B only handles post-resume initialization for non-claimed sandboxes.
-	// Claimed sandboxes (with claim-name label) are handled by the controller's Initialize function.
-	if s.Labels[agentsv1alpha1.LabelSandboxClaimName] == "" {
-		initRuntimeOpts, err := runtime.GetInitRuntimeRequest(s.Sandbox)
-		if err != nil {
-			log.Error(err, "failed to get init runtime request")
-			return fmt.Errorf("failed to get init runtime request: %w", err)
-		}
-		// Perform ReInit if initRuntimeOpts is set
-		if initRuntimeOpts != nil {
-			log.Info("will re-init runtime after resume")
-			if _, err := runtime.InitRuntime(postCtx, s.Sandbox, *initRuntimeOpts, s.refreshFunc()); err != nil {
-				log.Error(err, "failed to perform ReInit after resume")
-				return fmt.Errorf("failed to perform ReInit after resume: %w", err)
-			}
-			log.Info("ReInit completed after resume")
-		}
-
-		// Perform csi mount after resume
-		csiMountConfigRequests, err := runtime.GetCsiMountExtensionRequest(s.Sandbox)
-		if err != nil {
-			log.Error(err, "failed to get csi mount request")
-			return fmt.Errorf("failed to get csi mount request: %w", err)
-		}
-
-		if len(csiMountConfigRequests) != 0 {
-			log.Info("will re-mount csi storage after resume")
-			startTime := time.Now()
-			csiClient := csimountutils.NewCSIMountHandler(s.Cache.GetClient(), s.Cache.GetAPIReader(), s.storageRegistry, utils.DefaultSandboxDeployNamespace)
-			mountConfigs, resolveErr := resolveCSIMountConfigs(postCtx, csiClient, csiMountConfigRequests)
-			if resolveErr != nil {
-				return resolveErr
-			}
-			opts := config.CSIMountOptions{MountOptionList: mountConfigs}
-			if _, mountErr := runtime.ProcessCSIMounts(postCtx, s.Sandbox, opts); mountErr != nil {
-				log.Error(mountErr, "failed to remount csi storage after resume")
-				return fmt.Errorf("failed to remount csi storage after resume: %v", mountErr)
-			}
-			log.Info("remount csi storage completed after resume", "costTime", time.Since(startTime))
-		}
-	} else {
-		log.Info("sandbox is claimed by SandboxClaim, skipping E2B post-resume initialization",
-			"claimName", s.Labels[agentsv1alpha1.LabelSandboxClaimName])
-	}
-
+	s.Sandbox = fresh
 	return nil
+}
+
+func hasSingleflightAnnotation(sbx *agentsv1alpha1.Sandbox, key string) bool {
+	if sbx == nil || sbx.Annotations == nil {
+		return false
+	}
+	_, ok := sbx.Annotations[cache.SingleflightAnnotationPrefix+key]
+	return ok
 }
 
 func (s *Sandbox) GetState() (string, string) {

--- a/pkg/sandbox-manager/infra/utils.go
+++ b/pkg/sandbox-manager/infra/utils.go
@@ -1,0 +1,15 @@
+package infra
+
+import "time"
+
+func PushTimeout(timeout *TimeoutOptions, duration time.Duration) {
+	if timeout == nil {
+		return
+	}
+	if !timeout.PauseTime.IsZero() {
+		timeout.PauseTime = timeout.PauseTime.Add(duration)
+	}
+	if !timeout.ShutdownTime.IsZero() {
+		timeout.ShutdownTime = timeout.ShutdownTime.Add(duration)
+	}
+}

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openkruise/agents/api/v1alpha1"
-	"github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
@@ -75,6 +74,23 @@ func (sc *Controller) buildPauseTimeoutOptions(sbx infra.Sandbox, now time.Time)
 	return opts
 }
 
+// buildResumeTimeoutOptions returns the TimeoutOptions to be applied after a
+// successful resume.
+//
+// When the sandbox was never-timeout before resume (currentEndAt is zero),
+// this intentionally returns an empty infra.TimeoutOptions{}. Downstream,
+// SaveTimeout / setTimeout treat zero time.Time fields as "clear this field"
+// (see setTimeout's contract), which keeps the post-resume sandbox in the
+// never-timeout state. In other words, propagating zero values down the stack
+// is the deliberate way for this layer to express "this sandbox has no
+// timeout"; do not replace the empty struct with nil-skip semantics.
+func (sc *Controller) buildResumeTimeoutOptions(autoPause bool, now time.Time, timeoutSeconds int, currentEndAt time.Time) infra.TimeoutOptions {
+	if currentEndAt.IsZero() { // no end at means never timeout
+		return infra.TimeoutOptions{}
+	}
+	return sc.buildSetTimeoutOptions(autoPause, now, timeoutSeconds)
+}
+
 // ResumeSandbox is DEPRECATED and kept only for old SDK compatibility.
 //
 // E2B exposes one "connect" behavior, but different SDK versions call different endpoints:
@@ -107,32 +123,15 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 			Message: fmt.Sprintf("Sandbox %s is not paused", id),
 		}
 	}
-	log.Info("resuming sandbox")
-	if err := sc.manager.ResumeSandbox(ctx, sbx); err != nil {
-		code := http.StatusInternalServerError
-		if errors.GetErrCode(err) == errors.ErrorBadRequest {
-			code = http.StatusBadRequest
-		}
+	now := time.Now()
+	timeoutOptions := sc.buildResumeTimeoutOptions(autoPause, now, request.TimeoutSeconds, currentEndAt)
+	log.Info("resuming sandbox", "timeout", timeoutOptions)
+	if err := sc.manager.ResumeSandbox(ctx, sbx, infra.ResumeOptions{Timeout: &timeoutOptions}); err != nil {
 		return web.ApiResponse[struct{}]{}, &web.ApiError{
-			Code:    code,
 			Message: fmt.Sprintf("Failed to resume sandbox: %v", err),
 		}
 	}
 
-	// Only set timeout if the sandbox has a timeout configured (not never-timeout).
-	// After resume, the timeout is set strictly to the requested value (no extend-only merge).
-	now := time.Now()
-	if !currentEndAt.IsZero() {
-		opts := sc.buildSetTimeoutOptions(autoPause, now, request.TimeoutSeconds)
-		log.Info("sandbox resumed, resetting sandbox timeout", "timeout", opts)
-		if err := sbx.SaveTimeout(ctx, opts); err != nil {
-			return web.ApiResponse[struct{}]{}, &web.ApiError{
-				Message: fmt.Sprintf("Failed to set sandbox timeout: %v", err),
-			}
-		}
-	} else {
-		log.Info("skip resetting timeout for never-timeout sandbox")
-	}
 	return web.ApiResponse[struct{}]{
 		Code: http.StatusNoContent,
 	}, nil
@@ -161,8 +160,10 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 	// Step 1: Resuming the sandbox if it is paused
 	statusCode := http.StatusOK
 	if state == v1alpha1.SandboxStatePaused {
+		// TODO: remove the check after Resume refactor is finished
 		log.Info("sandbox is paused, will resume it", "reason", pauseResumeReason)
-		if err := sc.manager.ResumeSandbox(ctx, sbx); err != nil {
+		timeoutOptions := sc.buildResumeTimeoutOptions(autoPause, time.Now(), request.TimeoutSeconds, currentEndAt)
+		if err := sc.manager.ResumeSandbox(ctx, sbx, infra.ResumeOptions{Timeout: &timeoutOptions}); err != nil {
 			log.Error(err, "failed to resume sandbox")
 			return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
 				Code:    http.StatusInternalServerError,
@@ -176,12 +177,14 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 	}
 
 	// Step 2: Update the sandbox timeout
-	log.Info("updating sandbox timeout")
-	if err := sc.updateConnectTimeout(ctx, sbx, request.TimeoutSeconds, state, autoPause, currentEndAt); err != nil {
-		log.Error(err, "failed to update sandbox timeout")
-		return web.ApiResponse[*models.Sandbox]{}, err
+	if state != v1alpha1.SandboxStatePaused {
+		log.Info("updating sandbox timeout")
+		if err := sc.updateConnectTimeout(ctx, sbx, request.TimeoutSeconds, state, autoPause, currentEndAt); err != nil {
+			log.Error(err, "failed to update sandbox timeout")
+			return web.ApiResponse[*models.Sandbox]{}, err
+		}
+		log.Info("sandbox timeout updated")
 	}
-	log.Info("sandbox timeout updated")
 
 	return web.ApiResponse[*models.Sandbox]{
 		Code: statusCode,

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -113,6 +113,13 @@ func pauseSandboxHelper(t *testing.T, controller *Controller, client client.Clie
 		UpdateSandboxWhen(t, client, sandboxID, func(sbx *agentsv1alpha1.Sandbox) bool {
 			return sbx.Spec.Paused == false
 		}, DoSetSandboxStatus(agentsv1alpha1.SandboxPaused, metav1.ConditionFalse, metav1.ConditionFalse))
+	} else if pausing {
+		sbx := GetSandbox(t, sandboxID, client)
+		if sbx.Annotations == nil {
+			sbx.Annotations = map[string]string{}
+		}
+		sbx.Annotations["singleflight."+agentsv1alpha1.InternalPrefix+"pause-resume"] = fmt.Sprintf("1:false:%d", time.Now().Unix())
+		require.NoError(t, client.Update(t.Context(), sbx))
 	}
 }
 
@@ -145,7 +152,7 @@ func TestConnectSandbox(t *testing.T) {
 			paused:       true,
 			pausing:      true,
 			timeout:      DefaultTimeoutSeconds,
-			expectStatus: http.StatusInternalServerError,
+			expectStatus: http.StatusCreated,
 		},
 		{
 			name:         "resume sandbox: resuming",
@@ -201,6 +208,24 @@ func TestConnectSandbox(t *testing.T) {
 
 			if tt.sandboxID == "" {
 				tt.sandboxID = createResp.Body.SandboxID
+			}
+			if tt.pausing && tt.expectStatus < 300 {
+				time.AfterFunc(20*time.Millisecond, func() {
+					var sbx agentsv1alpha1.Sandbox
+					if err := fc.Get(t.Context(), client.ObjectKey{Name: createResp.Body.SandboxID, Namespace: "default"}, &sbx); err != nil {
+						return
+					}
+					if sbx.Annotations == nil {
+						sbx.Annotations = map[string]string{}
+					}
+					sbx.Annotations["singleflight."+agentsv1alpha1.InternalPrefix+"pause-resume"] = fmt.Sprintf("1:true:%d", time.Now().Unix())
+					if err := fc.Update(t.Context(), &sbx); err != nil {
+						return
+					}
+					UpdateSandboxWhen(t, fc, createResp.Body.SandboxID, func(current *agentsv1alpha1.Sandbox) bool {
+						return current.Annotations["singleflight."+agentsv1alpha1.InternalPrefix+"pause-resume"] != ""
+					}, DoSetSandboxStatus(agentsv1alpha1.SandboxPaused, metav1.ConditionTrue, metav1.ConditionFalse))
+				})
 			}
 			if tt.expectStatus < 300 {
 				go UpdateSandboxWhen(t, fc, createResp.Body.SandboxID, func(sbx *agentsv1alpha1.Sandbox) bool {
@@ -351,7 +376,7 @@ func TestResumeSandbox(t *testing.T) {
 			paused:       true,
 			pausing:      true,
 			timeout:      300,
-			expectStatus: http.StatusInternalServerError,
+			expectStatus: http.StatusNoContent,
 		},
 		{
 			name:         "resume sandbox: resuming",
@@ -406,6 +431,24 @@ func TestResumeSandbox(t *testing.T) {
 
 			if tt.sandboxID == "" {
 				tt.sandboxID = createResp.Body.SandboxID
+			}
+			if tt.pausing && tt.expectStatus < 300 {
+				time.AfterFunc(20*time.Millisecond, func() {
+					var sbx agentsv1alpha1.Sandbox
+					if err := fc.Get(t.Context(), client.ObjectKey{Name: createResp.Body.SandboxID, Namespace: "default"}, &sbx); err != nil {
+						return
+					}
+					if sbx.Annotations == nil {
+						sbx.Annotations = map[string]string{}
+					}
+					sbx.Annotations["singleflight."+agentsv1alpha1.InternalPrefix+"pause-resume"] = fmt.Sprintf("1:true:%d", time.Now().Unix())
+					if err := fc.Update(t.Context(), &sbx); err != nil {
+						return
+					}
+					UpdateSandboxWhen(t, fc, createResp.Body.SandboxID, func(current *agentsv1alpha1.Sandbox) bool {
+						return current.Annotations["singleflight."+agentsv1alpha1.InternalPrefix+"pause-resume"] != ""
+					}, DoSetSandboxStatus(agentsv1alpha1.SandboxPaused, metav1.ConditionTrue, metav1.ConditionFalse))
+				})
 			}
 			if tt.expectStatus < 300 {
 				// Only schedule async update when expecting success


### PR DESCRIPTION
## Summary

  This change fixes a state corruption issue where a failed resume on a timed sandbox could leave both PauseTime and
  ShutdownTime empty, causing the sandbox to be treated as never-timeout. It binds timeout persistence into the resume
  lifecycle so timeout fields are written back even when resume post-processing fails.

  ## Background

  In this system, timeout is represented by PauseTime + ShutdownTime, not a single flag:

  - ShutdownTime: final shutdown deadline
  - PauseTime: auto-pause deadline
  - both empty => interpreted as never-timeout

  Before this change, resume flow would clear timeout during unpause (for protection), then only write the final
  timeout on a later success path. If resume failed later (wait, refresh, runtime re-init, CSI remount, etc.), the
  final timeout save was skipped. The object was left with cleared fields and incorrectly persisted as never-timeout.

  ## Why this is safer

  - Prevents partial resume steps from turning a timed sandbox into never-timeout.
  - Makes timeout persistence robust to resume internal failures after Spec.Paused = false is already persisted.
  - Encapsulates post-resume context fallback logic and avoids duplicated code.

## Next Step:

Create a distributed single-flight  module to protect concurrent pausing and resuming