### PR TITLE
add security identity provider with FeatureGate-controlled token issuance and propagation

### DIFF
--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -197,6 +197,7 @@ func main() {
 
 	sandboxController := e2b.NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSelector, e2bMaxTimeout, maxClaimWorkers, maxCreateQPS, uint32(extProcMaxConcurrency),
 		port, memberlistBindPort, keyCfg, clientConfig)
+
 	if err := sandboxController.Init(); err != nil {
 		klog.Fatalf("Failed to initialize sandbox controller: %v", err)
 	}

--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	"golang.org/x/time/rate"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -341,7 +340,7 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 		if hasAgentRuntime {
 			opts.InitRuntime = &config.InitRuntimeOptions{
 				EnvVars:     claim.Spec.EnvVars,
-				AccessToken: uuid.NewString(),
+				AccessToken: config.NewDefaultAccessToken(),
 			}
 		} else {
 			logger.Error(fmt.Errorf("agent-runtime not configured in SandboxSet"), "SkipInitRuntime is false but no agent-runtime found, skip InitRuntime",

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -49,6 +49,10 @@ const (
 	// SandboxMultiClusterNaming enables embedding a cluster ID hash in the Sandbox generateName
 	// to prevent naming collisions across multiple clusters.
 	SandboxMultiClusterNaming featuregate.Feature = "SandboxMultiClusterNaming"
+
+	// SecurityIdentityProviderGate enables issuing sandbox access tokens via an external
+	// identity provider service instead of random UUID generation.
+	SecurityIdentityProviderGate featuregate.Feature = "SecurityIdentityProvider"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -60,6 +64,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	CachePodLabelSelectorGate:        {Default: true, PreRelease: featuregate.Alpha},
 	SandboxInPlaceResourceResizeGate: {Default: true, PreRelease: featuregate.Alpha},
 	SandboxMultiClusterNaming:        {Default: false, PreRelease: featuregate.Alpha},
+	SecurityIdentityProviderGate:     {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/pkg/identity/common_provider.go
+++ b/pkg/identity/common_provider.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"k8s.io/klog/v2"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+// defaultTokenProvider is the default community implementation that generates
+// random tokens without contacting any external identity provider service.
+// It implements IdentityProvider with no-op propagation.
+type defaultTokenProvider struct{}
+
+// NewDefaultTokenProvider creates a TokenProvider that generates random tokens.
+// This is the default strategy used when no identity provider service is configured.
+func NewDefaultTokenProvider() TokenProvider {
+	return &defaultTokenProvider{}
+}
+
+// NewDefaultIdentityProvider creates an IdentityProvider with default token issuance
+// and no-op security token propagation. This is the community default.
+func NewDefaultIdentityProvider() IdentityProvider {
+	return &defaultTokenProvider{}
+}
+
+func (u *defaultTokenProvider) IssueToken(_ context.Context, _ TokenRequest) (*TokenResponse, error) {
+	return &TokenResponse{
+		RequestID:   uuid.NewString(),
+		AccessToken: uuid.NewString(),
+	}, nil
+}
+
+// PropagateSecurityToken is a no-op for the default provider.
+// Community mode has no propagators registered.
+func (u *defaultTokenProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse) error {
+	return nil
+}
+
+// fallbackIdentityProvider wraps a primary IdentityProvider and falls back to the
+// community default provider when the primary IssueToken returns an error.
+// This ensures that sandbox claim is never blocked by an external identity provider outage.
+//
+// For PropagateSecurityToken, errors are returned directly without fallback,
+// since the community default propagation is a no-op and degrading to it would
+// silently lose important token propagation work.
+type fallbackIdentityProvider struct {
+	primary  IdentityProvider
+	fallback IdentityProvider
+}
+
+// NewFallbackIdentityProvider creates an IdentityProvider that delegates to the primary provider
+// and automatically falls back to UUID-based token generation on IssueToken error.
+func NewFallbackIdentityProvider(primary IdentityProvider) IdentityProvider {
+	return &fallbackIdentityProvider{
+		primary:  primary,
+		fallback: NewDefaultIdentityProvider(),
+	}
+}
+
+func (f *fallbackIdentityProvider) IssueToken(ctx context.Context, req TokenRequest) (*TokenResponse, error) {
+	logger := klog.FromContext(ctx)
+	resp, err := f.primary.IssueToken(ctx, req)
+	if err != nil {
+		logger.Error(err, "primary identity provider failed, falling back to UUID token provider")
+		return f.fallback.IssueToken(ctx, req)
+	}
+	return resp, nil
+}
+
+func (f *fallbackIdentityProvider) PropagateSecurityToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tokenResp *TokenResponse) error {
+	return f.primary.PropagateSecurityToken(ctx, sbx, tokenResp)
+}

--- a/pkg/identity/common_provider_test.go
+++ b/pkg/identity/common_provider_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+// ---------------------------------------------------------------------------
+// defaultTokenProvider
+// ---------------------------------------------------------------------------
+
+func TestNewDefaultTokenProvider(t *testing.T) {
+	provider := NewDefaultTokenProvider()
+	require.NotNil(t, provider)
+	_, ok := provider.(*defaultTokenProvider)
+	assert.True(t, ok, "should return *defaultTokenProvider")
+}
+
+func TestNewDefaultIdentityProvider(t *testing.T) {
+	provider := NewDefaultIdentityProvider()
+	require.NotNil(t, provider)
+	_, ok := provider.(*defaultTokenProvider)
+	assert.True(t, ok, "should return *defaultTokenProvider implementing IdentityProvider")
+}
+
+func TestDefaultTokenProvider_IssueToken(t *testing.T) {
+	provider := NewDefaultTokenProvider()
+	ctx := context.Background()
+
+	resp, err := provider.IssueToken(ctx, TokenRequest{TokenType: TokenTypeAgent})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.RequestID, "RequestID should be a non-empty string")
+	assert.NotEmpty(t, resp.AccessToken, "AccessToken should be a non-empty string")
+
+	// Two calls should produce different tokens.
+	resp2, err := provider.IssueToken(ctx, TokenRequest{TokenType: TokenTypeAgent})
+	require.NoError(t, err)
+	assert.NotEqual(t, resp.AccessToken, resp2.AccessToken, "each call should produce a unique token")
+}
+
+func TestDefaultTokenProvider_PropagateSecurityToken(t *testing.T) {
+	provider := NewDefaultIdentityProvider()
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+	}
+	err := provider.PropagateSecurityToken(context.Background(), sbx, &TokenResponse{AccessToken: "tok"})
+	assert.NoError(t, err, "PropagateSecurityToken should be a no-op")
+}
+
+// ---------------------------------------------------------------------------
+// fallbackIdentityProvider
+// ---------------------------------------------------------------------------
+
+// mockIdentityProvider is a simple mock for IdentityProvider used in fallback tests.
+type mockIdentityProvider struct {
+	issueResp    *TokenResponse
+	issueErr     error
+	propagateErr error
+}
+
+func (m *mockIdentityProvider) IssueToken(_ context.Context, _ TokenRequest) (*TokenResponse, error) {
+	return m.issueResp, m.issueErr
+}
+
+func (m *mockIdentityProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse) error {
+	return m.propagateErr
+}
+
+func TestNewFallbackIdentityProvider(t *testing.T) {
+	primary := &mockIdentityProvider{}
+	p := NewFallbackIdentityProvider(primary)
+	require.NotNil(t, p)
+	fp, ok := p.(*fallbackIdentityProvider)
+	require.True(t, ok)
+	assert.Equal(t, primary, fp.primary)
+	assert.NotNil(t, fp.fallback, "fallback should be the default provider")
+}
+
+func TestFallbackIdentityProvider_IssueToken_PrimarySuccess(t *testing.T) {
+	expected := &TokenResponse{RequestID: "req-1", AccessToken: "primary-token"}
+	primary := &mockIdentityProvider{issueResp: expected}
+	p := NewFallbackIdentityProvider(primary)
+
+	resp, err := p.IssueToken(context.Background(), TokenRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, expected, resp, "should return primary provider's response")
+}
+
+func TestFallbackIdentityProvider_IssueToken_PrimaryError_FallbackToDefault(t *testing.T) {
+	primary := &mockIdentityProvider{issueErr: fmt.Errorf("primary down")}
+	p := NewFallbackIdentityProvider(primary)
+
+	resp, err := p.IssueToken(context.Background(), TokenRequest{})
+	require.NoError(t, err, "fallback should not return error")
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.AccessToken, "fallback should produce a UUID token")
+}
+
+func TestFallbackIdentityProvider_PropagateSecurityToken_DelegatesToPrimary(t *testing.T) {
+	primary := &mockIdentityProvider{propagateErr: fmt.Errorf("propagation failed")}
+	p := NewFallbackIdentityProvider(primary)
+
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+	}
+	err := p.PropagateSecurityToken(context.Background(), sbx, &TokenResponse{AccessToken: "tok"})
+	assert.Error(t, err, "PropagateSecurityToken should return primary's error directly")
+	assert.Contains(t, err.Error(), "propagation failed")
+}

--- a/pkg/identity/default_provider.go
+++ b/pkg/identity/default_provider.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"context"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+// provider is the global IdentityProvider instance.
+//
+// Community default: defaultTokenProvider with random token generation and no-op propagation.
+// Enterprise deployment: Override by calling RegisterProvider() during init() phase to replace
+// the default with a custom implementation.
+//
+// Only one provider exists at a time. RegisterProvider overwrites the previous one.
+//
+// IMPORTANT: This variable MUST only be set during init() phase via RegisterProvider().
+// It is NOT safe to modify at runtime due to concurrent access from multiple goroutines.
+var provider IdentityProvider = NewDefaultIdentityProvider()
+
+// RegisterProvider registers a custom IdentityProvider implementation, overriding
+// the community default. This should be called during init() or application startup.
+//
+// The registered provider is automatically wrapped with fallback behavior:
+// if IssueToken fails, it degrades to UUID-based token generation to ensure
+// sandbox claim is never blocked by an external identity provider outage.
+func RegisterProvider(p IdentityProvider) {
+	provider = NewFallbackIdentityProvider(p)
+}
+
+// IssueToken delegates to the registered provider to generate an access token.
+func IssueToken(ctx context.Context, req TokenRequest) (*TokenResponse, error) {
+	return provider.IssueToken(ctx, req)
+}
+
+// PropagateSecurityToken delegates to the registered provider to execute
+// post-token processing (e.g., writing credentials into the sandbox runtime).
+func PropagateSecurityToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tokenResp *TokenResponse) error {
+	return provider.PropagateSecurityToken(ctx, sbx, tokenResp)
+}

--- a/pkg/identity/interface.go
+++ b/pkg/identity/interface.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"context"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+// IdentityProvider is the unified interface for sandbox identity management.
+// It combines token issuance with post-token security propagation.
+//
+// Community default (defaultTokenProvider):
+//   - IssueToken: generates random tokens using the default strategy.
+//   - PropagateSecurityToken: no-op (no propagators registered).
+//
+// Enterprise deployment (secureIdentityProvider):
+//   - IssueToken: calls HTTPS identity provider service with default fallback.
+//   - PropagateSecurityToken: executes registered propagators (e.g., write credential files).
+type IdentityProvider interface {
+	// IssueToken generates an access token for the given token request.
+	IssueToken(ctx context.Context, req TokenRequest) (*TokenResponse, error)
+
+	// PropagateSecurityToken executes post-token processing after a token is issued,
+	// such as writing credentials into the sandbox runtime.
+	PropagateSecurityToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tokenResp *TokenResponse) error
+}
+
+// TokenProvider is the low-level interface for issuing sandbox access tokens.
+// Implementations can provide default random tokens or identity-aware tokens
+// from an external identity provider service.
+type TokenProvider interface {
+	// IssueToken generates an access token for the given token request.
+	// The context can carry deadlines and cancellation signals.
+	IssueToken(ctx context.Context, req TokenRequest) (*TokenResponse, error)
+}

--- a/pkg/identity/security_token_propagator.go
+++ b/pkg/identity/security_token_propagator.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+// SecurityTokenPropagator is a function that propagates an issued security token
+// into the sandbox runtime after a successful token issuance.
+// It is invoked only when a security token has been successfully issued via the identity provider.
+//
+// Parameters:
+//   - ctx: The context carrying logging and cancellation.
+//   - sbx: The claimed sandbox Kubernetes object (used to derive runtime URL, access token, etc.).
+//   - tokenResp: The issued token response to be written into the sandbox runtime.
+//
+// Community default: No propagators registered — this is a no-op.
+// Enterprise deployment: Register propagators via RegisterSecurityTokenPropagator() to inject
+// tokens into the sandbox runtime (e.g., write credential files via RunCommand).
+type SecurityTokenPropagator func(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tokenResp *TokenResponse) error
+
+// securityTokenPropagators holds all registered propagator functions.
+// Enterprise packages register handlers here during init() via RegisterSecurityTokenPropagator().
+// These are consumed by initSecureProvider() when creating the secureIdentityProvider.
+// Community code does not register any handlers — the slice stays empty.
+//
+// IMPORTANT: This slice MUST only be modified during init() phase via RegisterSecurityTokenPropagator().
+// It is NOT safe to modify at runtime due to concurrent reads from multiple goroutines.
+var securityTokenPropagators []SecurityTokenPropagator
+
+// RegisterSecurityTokenPropagator appends a propagator to the global registry.
+// Enterprise packages call this during init() to register token processing handlers
+// (e.g., WriteSecurityTokenToRuntime). The registered propagators are incorporated into
+// the secureIdentityProvider when initSecureProvider() runs.
+func RegisterSecurityTokenPropagator(propagator SecurityTokenPropagator) {
+	securityTokenPropagators = append(securityTokenPropagators, propagator)
+	klog.Infof("security token propagator registered, total: %d", len(securityTokenPropagators))
+}
+
+// SecurityTokenPropagatorCount returns the number of registered security token propagators.
+func SecurityTokenPropagatorCount() int {
+	return len(securityTokenPropagators)
+}

--- a/pkg/identity/security_token_propagator_test.go
+++ b/pkg/identity/security_token_propagator_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+func TestRegisterSecurityTokenPropagator(t *testing.T) {
+	// Save and restore the global slice.
+	saved := securityTokenPropagators
+	defer func() { securityTokenPropagators = saved }()
+	securityTokenPropagators = nil
+
+	assert.Equal(t, 0, SecurityTokenPropagatorCount())
+
+	// Register first propagator.
+	RegisterSecurityTokenPropagator(func(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse) error {
+		return nil
+	})
+	assert.Equal(t, 1, SecurityTokenPropagatorCount())
+
+	// Register second propagator.
+	RegisterSecurityTokenPropagator(func(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse) error {
+		return fmt.Errorf("err")
+	})
+	assert.Equal(t, 2, SecurityTokenPropagatorCount())
+}
+
+func TestSecurityTokenPropagatorCount_Empty(t *testing.T) {
+	saved := securityTokenPropagators
+	defer func() { securityTokenPropagators = saved }()
+	securityTokenPropagators = nil
+
+	assert.Equal(t, 0, SecurityTokenPropagatorCount())
+}

--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package identity provides an abstraction for issuing identity-aware access tokens
+// for sandboxes. It supports both a default random token strategy (community default) and
+// an identity provider service that issues tokens via HTTPS (enterprise deployment).
+package identity
+
+// TokenType represents the type of token being requested.
+type TokenType string
+
+const (
+	// TokenTypePrincipal requests a token for a principal (user or service).
+	TokenTypePrincipal TokenType = "Principal"
+	// TokenTypeAgent requests a token for an agent sandbox.
+	TokenTypeAgent TokenType = "Agent"
+)
+
+// TokenRequest represents a request to issue an identity-aware access token.
+type TokenRequest struct {
+	// TokenType indicates the type of token being requested.
+	TokenType TokenType `json:"tokenType"`
+
+	// Principal contains the identity of the requesting entity. Required when TokenType is "Principal".
+	Principal *PrincipalInfo `json:"principal,omitempty"`
+
+	// Sandbox contains the sandbox workload metadata. Optional, used when TokenType is "Agent".
+	Sandbox *SandboxInfo `json:"sandbox,omitempty"`
+
+	// Metadata contains additional key-value pairs for the token request.
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// PrincipalInfo represents the identity of the entity requesting the token.
+type PrincipalInfo struct {
+	// PrincipalName is the name of the principal (e.g. "third-party-app").
+	PrincipalName string `json:"principalName"`
+}
+
+// SandboxInfo contains metadata about the sandbox for which a token is being issued.
+type SandboxInfo struct {
+	// PodName is the Kubernetes pod name backing this sandbox.
+	PodName string `json:"podName,omitempty"`
+
+	// PodNamespace is the Kubernetes namespace of the sandbox pod.
+	PodNamespace string `json:"podNamespace,omitempty"`
+
+	// SandboxID is the unique identifier of the sandbox (namespace/name/uid format).
+	SandboxID string `json:"sandboxId,omitempty"`
+
+	// SandboxName is the name of the sandbox resource.
+	SandboxName string `json:"sandboxName,omitempty"`
+
+	// SandboxUID is the UID of the sandbox resource.
+	SandboxUID string `json:"sandboxUid,omitempty"`
+}
+
+// TokenResponse represents the response from an identity provider.
+type TokenResponse struct {
+	// RequestID is the unique identifier of this token issuance request.
+	RequestID string `json:"requestId"`
+
+	// AccessToken is the issued identity-aware access token.
+	AccessToken string `json:"accessToken"`
+
+	// SandboxClientID is the client identifier associated with this sandbox.
+	SandboxClientID string `json:"sandboxClientId,omitempty"`
+
+	// AccessTokenExpiration is the expiration time of the access token in RFC3339 format.
+	AccessTokenExpiration string `json:"accessTokenExpiration,omitempty"`
+}
+
+type TokenRefreshStatus struct {
+	// AccessTokenExpiration is the expiration time of the refreshed access token in RFC3339 format
+	AccessTokenExpiration string `json:"accessTokenExpiration,omitempty"`
+}

--- a/pkg/sandbox-manager/config/infra.go
+++ b/pkg/sandbox-manager/config/infra.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package config
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openkruise/agents/pkg/identity"
+)
 
 type InitRuntimeOptions struct {
 	EnvVars     map[string]string `json:"envVars,omitempty"`
@@ -25,12 +30,21 @@ type InitRuntimeOptions struct {
 	SkipRefresh bool              `json:"skipRefresh,omitempty"`
 }
 
+// NewDefaultAccessToken generates a default access token using UUID.
+func NewDefaultAccessToken() string {
+	return uuid.NewString()
+}
+
 const DefaultCSIMountConcurrency = 3
 
 type CSIMountOptions struct {
 	MountOptionList    []MountConfig `json:"mountOptionList"`
 	MountOptionListRaw string        `json:"mountOptionListRaw"`    // the raw json string for mount options
 	Concurrency        int           `json:"concurrency,omitempty"` // max concurrent CSI mount operations, 0 or negative means unlimited, default is DefaultCSIMountConcurrency
+}
+
+type SecurityTokenOptions struct {
+	identity.TokenResponse
 }
 
 type MountConfig struct {

--- a/pkg/sandbox-manager/config/infra_test.go
+++ b/pkg/sandbox-manager/config/infra_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDefaultAccessToken(t *testing.T) {
+	token := NewDefaultAccessToken()
+	assert.NotEmpty(t, token, "token should not be empty")
+	_, err := uuid.Parse(token)
+	require.NoError(t, err, "token should be a valid UUID")
+
+	// Consecutive calls should produce unique tokens
+	token2 := NewDefaultAccessToken()
+	assert.NotEqual(t, token, token2, "consecutive calls should produce unique tokens")
+}
+
+func TestDefaultCSIMountConcurrency(t *testing.T) {
+	assert.Equal(t, 3, DefaultCSIMountConcurrency, "default CSI mount concurrency should be 3")
+}

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -39,13 +39,18 @@ import (
 	infracache "github.com/openkruise/agents/pkg/cache"
 	cacheutils "github.com/openkruise/agents/pkg/cache/utils"
 	"github.com/openkruise/agents/pkg/controller/sandboxset"
+	"github.com/openkruise/agents/pkg/features"
+	"github.com/openkruise/agents/pkg/identity"
+	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/logs"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
+	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 	"github.com/openkruise/agents/pkg/utils/runtime"
-	utils "github.com/openkruise/agents/pkg/utils/sandbox-manager"
+	sandboxManagerUtils "github.com/openkruise/agents/pkg/utils/sandbox-manager"
 	"github.com/openkruise/agents/pkg/utils/sandbox-manager/expectationutils"
 	stateutils "github.com/openkruise/agents/pkg/utils/sandboxutils"
 )
@@ -85,7 +90,7 @@ func ValidateAndInitClaimOptions(opts infra.ClaimSandboxOptions) (infra.ClaimSan
 		opts.CandidateCounts = consts.DefaultPoolingCandidateCounts
 	}
 	if opts.LockString == "" {
-		opts.LockString = utils.NewLockString()
+		opts.LockString = sandboxManagerUtils.NewLockString()
 	}
 	if opts.ClaimTimeout <= 0 {
 		opts.ClaimTimeout = DefaultClaimTimeout
@@ -219,6 +224,40 @@ func TryClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions, pickCa
 		}
 		metrics.Total += metrics.InitRuntime
 		log.Info("runtime inited", "cost", metrics.InitRuntime)
+	}
+
+	// Step 4: When SecurityIdentityProvider feature gate is enabled,
+	// the manager attempts to issue a security token via the identity provider, records its refresh status into
+	// sandbox annotations, and propagate the token to the runtime.
+	// On token issuance failure, the original UUID token is preserved (fallback behavior).
+	// On status recording or propagation failure, a retriable error is returned.
+	if utilfeature.DefaultFeatureGate.Enabled(features.SecurityIdentityProviderGate) {
+		opts.SecurityToken = &config.SecurityTokenOptions{}
+		log.Info("starting to issue security token via identity provider")
+		metrics.SecurityToken, err = issueSecurityToken(ctx, sbx, opts.SecurityToken)
+		if err == nil {
+			metrics.Total += metrics.SecurityToken
+			// 4.1: to record security token refresh status in sandbox annotations
+			if err = recordSecurityTokenRefreshStatus(sbx, opts); err != nil {
+				log.Error(err, "failed to modify picked sandbox for security token status")
+				err = retriableError{Message: fmt.Sprintf("failed to modify picked sandbox for security token status: %s", err)}
+				return
+			}
+
+			log.Info("propagating security token to runtime", "propagatorCount", identity.SecurityTokenPropagatorCount())
+			startTime := time.Now()
+			// 4.2: to propagate security token to runtime
+			if err = identity.PropagateSecurityToken(ctx, sbx.Sandbox, &opts.SecurityToken.TokenResponse); err != nil {
+				log.Error(err, "security token propagation failed")
+				err = retriableError{Message: fmt.Sprintf("security token propagation failed: %s", err)}
+				return
+			}
+			log.Info("security token propagated", "cost", time.Since(startTime))
+
+		} else {
+			log.Error(err, "failed to issue security token, keeping original UUID token as fallback")
+			err = nil // clear error to avoid affecting downstream flow
+		}
 	}
 
 	if opts.CSIMount != nil {
@@ -421,6 +460,43 @@ func pickFromCandidates(ctx context.Context, candidates []*v1alpha1.Sandbox, pic
 	return nil, errors.New("all candidates are picked")
 }
 
+// issueSecurityToken issues a security token for the given sandbox using the registered identity provider.
+// The issued access token is written into the sandbox's SecurityToken option for downstream consumption.
+func issueSecurityToken(ctx context.Context, sbx *Sandbox, opts *config.SecurityTokenOptions) (time.Duration, error) {
+	ctx = logs.Extend(ctx, "action", "issueSecurityToken")
+	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx.Sandbox))
+	start := time.Now()
+
+	sbxLabels := sbx.GetLabels()
+	metadata := make(map[string]string)
+	for k, v := range sbxLabels {
+		if strings.HasPrefix(k, utils.SecurityMetadataPrefix) {
+			metadata[k] = v
+		}
+	}
+
+	tokenResp, err := identity.IssueToken(ctx, identity.TokenRequest{
+		TokenType: identity.TokenTypeAgent,
+		Sandbox: &identity.SandboxInfo{
+			PodName:      sbx.Name,
+			PodNamespace: sbx.Namespace,
+			SandboxID:    fmt.Sprintf("%s/%s/%s", sbx.Namespace, sbx.Name, sbx.UID),
+			SandboxName:  sbx.Name,
+			SandboxUID:   string(sbx.UID),
+		},
+		Metadata: metadata,
+	})
+	if err != nil {
+		log.Error(err, "failed to issue security token")
+		return time.Since(start), fmt.Errorf("failed to issue security token: %w", err)
+	}
+
+	// Write the full issued token response back into the options for downstream use
+	opts.TokenResponse = *tokenResp
+	log.Info("security token issued", "costTime", time.Since(start))
+	return time.Since(start), nil
+}
+
 var FilteredAnnotationsOnCreation []string
 
 func newSandboxFromSandboxSet(ctx context.Context, opts infra.ClaimSandboxOptions, cache infracache.Provider, limiter *rate.Limiter) (*Sandbox, infra.LockType, error) {
@@ -517,6 +593,26 @@ func modifyPickedSandbox(sbx *Sandbox, lockType infra.LockType, opts infra.Claim
 	return nil
 }
 
+// recordSecurityTokenRefreshStatus records the security token refresh status into sandbox annotations.
+func recordSecurityTokenRefreshStatus(sbx *Sandbox, opts infra.ClaimSandboxOptions) error {
+	if opts.SecurityToken == nil {
+		return nil
+	}
+	tokenRefreshStatusJSON, err := json.Marshal(identity.TokenRefreshStatus{
+		AccessTokenExpiration: opts.SecurityToken.AccessTokenExpiration,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal token refresh expiration status: %w", err)
+	}
+	annotations := sbx.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string, 1)
+	}
+	annotations[utils.AgentKeyTokenRefreshStatus] = string(tokenRefreshStatusJSON)
+	sbx.SetAnnotations(annotations)
+	return nil
+}
+
 // SetResources applies in-place resource resize to the first container.
 func (s *Sandbox) SetResources(requests, limits corev1.ResourceList) {
 	if s.Spec.Template == nil {
@@ -548,7 +644,7 @@ func performLockSandbox(ctx context.Context, sbx *Sandbox, lockType infra.LockTy
 	ctx = logs.Extend(ctx, "action", "performLockSandbox")
 	log := klog.FromContext(ctx)
 	c := cache.GetClient()
-	utils.LockSandbox(sbx.Sandbox, opts.LockString, opts.User)
+	sandboxManagerUtils.LockSandbox(sbx.Sandbox, opts.LockString, opts.User)
 	var updated *v1alpha1.Sandbox
 	var err error
 	if lockType == infra.LockTypeCreate {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -49,10 +49,13 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	infracache "github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/cache/controllers"
+	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/proxy"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	pkgutils "github.com/openkruise/agents/pkg/utils"
+	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 	"github.com/openkruise/agents/pkg/utils/runtime"
 	utils "github.com/openkruise/agents/pkg/utils/sandbox-manager"
 	"github.com/openkruise/agents/pkg/utils/sandbox-manager/expectationutils"
@@ -2056,6 +2059,172 @@ func TestModifyPickedSandbox_CSIMount(t *testing.T) {
 	}
 }
 
+func TestRecordSecurityTokenRefreshStatus(t *testing.T) {
+	tests := []struct {
+		name             string
+		opts             infra.ClaimSandboxOptions
+		expectedAnnos    map[string]string
+		notExpectedAnnos []string
+	}{
+		{
+			name: "with security token and expiration",
+			opts: infra.ClaimSandboxOptions{
+				SecurityToken: &config.SecurityTokenOptions{
+					TokenResponse: identity.TokenResponse{
+						AccessToken:           "security-access-token",
+						AccessTokenExpiration: "2026-12-31T23:59:59Z",
+					},
+				},
+			},
+			expectedAnnos: map[string]string{
+				pkgutils.AgentKeyTokenRefreshStatus: `{"accessTokenExpiration":"2026-12-31T23:59:59Z"}`,
+			},
+		},
+		{
+			name: "with security token without expiration",
+			opts: infra.ClaimSandboxOptions{
+				SecurityToken: &config.SecurityTokenOptions{
+					TokenResponse: identity.TokenResponse{
+						AccessToken: "at-456",
+					},
+				},
+			},
+			expectedAnnos: map[string]string{
+				// AccessTokenExpiration is omitempty, so empty value produces "{}"
+				pkgutils.AgentKeyTokenRefreshStatus: `{}`,
+			},
+		},
+		{
+			name: "without security token",
+			opts: infra.ClaimSandboxOptions{
+				SecurityToken: nil,
+			},
+			notExpectedAnnos: []string{
+				pkgutils.AgentKeyTokenRefreshStatus,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := &Sandbox{
+				Sandbox: &v1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-sandbox",
+						Namespace:   "default",
+						Annotations: make(map[string]string),
+					},
+				},
+			}
+
+			err := recordSecurityTokenRefreshStatus(sbx, tt.opts)
+			require.NoError(t, err)
+
+			annotations := sbx.GetAnnotations()
+
+			// Check expected annotations with exact value match
+			for key, expectedValue := range tt.expectedAnnos {
+				assert.Equal(t, expectedValue, annotations[key], "annotation %s should match", key)
+			}
+
+			// Check not expected annotations
+			for _, key := range tt.notExpectedAnnos {
+				assert.Empty(t, annotations[key], "annotation %s should not be set", key)
+			}
+
+			// For the "with expiration" case, verify JSON round-trip
+			if tt.name == "with security token and expiration" {
+				raw := annotations[pkgutils.AgentKeyTokenRefreshStatus]
+				require.NotEmpty(t, raw)
+				var decoded identity.TokenRefreshStatus
+				require.NoError(t, json.Unmarshal([]byte(raw), &decoded))
+				assert.Equal(t, "2026-12-31T23:59:59Z", decoded.AccessTokenExpiration)
+			}
+		})
+	}
+}
+
+func TestRecordSecurityTokenRefreshStatus_NilAnnotations(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialAnnos  map[string]string
+		opts          infra.ClaimSandboxOptions
+		expectedValue string
+	}{
+		{
+			name:         "nil annotations map is created",
+			initialAnnos: nil,
+			opts: infra.ClaimSandboxOptions{
+				SecurityToken: &config.SecurityTokenOptions{
+					TokenResponse: identity.TokenResponse{
+						AccessToken:           "token-1",
+						AccessTokenExpiration: "2026-06-01T00:00:00Z",
+					},
+				},
+			},
+			expectedValue: `{"accessTokenExpiration":"2026-06-01T00:00:00Z"}`,
+		},
+		{
+			name: "existing annotations are preserved",
+			initialAnnos: map[string]string{
+				"existing-key": "existing-value",
+			},
+			opts: infra.ClaimSandboxOptions{
+				SecurityToken: &config.SecurityTokenOptions{
+					TokenResponse: identity.TokenResponse{
+						AccessToken:           "token-2",
+						AccessTokenExpiration: "2026-07-01T00:00:00Z",
+					},
+				},
+			},
+			expectedValue: `{"accessTokenExpiration":"2026-07-01T00:00:00Z"}`,
+		},
+		{
+			name:         "nil security token is no-op with nil annotations",
+			initialAnnos: nil,
+			opts: infra.ClaimSandboxOptions{
+				SecurityToken: nil,
+			},
+			expectedValue: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := &Sandbox{
+				Sandbox: &v1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-sandbox",
+						Namespace:   "default",
+						Annotations: tt.initialAnnos,
+					},
+				},
+			}
+
+			err := recordSecurityTokenRefreshStatus(sbx, tt.opts)
+			require.NoError(t, err)
+
+			annotations := sbx.GetAnnotations()
+
+			if tt.expectedValue != "" {
+				assert.Equal(t, tt.expectedValue, annotations[pkgutils.AgentKeyTokenRefreshStatus])
+			} else {
+				// When SecurityToken is nil, annotations should remain unchanged
+				if tt.initialAnnos == nil {
+					assert.Nil(t, annotations)
+				}
+			}
+
+			// Verify existing annotations are preserved
+			if tt.initialAnnos != nil {
+				for k, v := range tt.initialAnnos {
+					assert.Equal(t, v, annotations[k], "existing annotation %s should be preserved", k)
+				}
+			}
+		})
+	}
+}
+
 // TestTryClaimSandbox_LockConflict tests the error handling in TryClaimSandbox when
 // performLockSandbox fails (claim.go lines 168-179). It verifies:
 // - Conflict error: ResourceVersionExpectation is set and a retriableError is returned.
@@ -2099,7 +2268,7 @@ func TestTryClaimSandbox_LockConflict(t *testing.T) {
 			// Build scheme
 			scheme := k8sruntime.NewScheme()
 			utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-			utilruntime.Must(agentsv1alpha1.AddToScheme(scheme))
+			utilruntime.Must(v1alpha1.AddToScheme(scheme))
 
 			// Build fake client with custom Update interceptor that returns the specified error for Sandbox updates.
 			// This simulates a conflict (or other error) during the lock step without affecting Create or Status updates.
@@ -2109,8 +2278,8 @@ func TestTryClaimSandbox_LockConflict(t *testing.T) {
 				builder = builder.WithIndex(idx.Obj, idx.FieldName, idx.Extract)
 			}
 			builder = builder.WithStatusSubresource(
-				&agentsv1alpha1.Sandbox{},
-				&agentsv1alpha1.SandboxSet{},
+				&v1alpha1.Sandbox{},
+				&v1alpha1.SandboxSet{},
 			)
 			builder = builder.WithInterceptorFuncs(interceptor.Funcs{
 				Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
@@ -2153,8 +2322,8 @@ func TestTryClaimSandbox_LockConflict(t *testing.T) {
 					Namespace: "default",
 					UID:       types.UID(uuid.NewString()),
 					Labels: map[string]string{
-						v1alpha1.LabelSandboxTemplate:        existTemplate,
-						agentsv1alpha1.LabelSandboxIsClaimed: "false",
+						v1alpha1.LabelSandboxTemplate:  existTemplate,
+						v1alpha1.LabelSandboxIsClaimed: "false",
 					},
 					CreationTimestamp: metav1.Now(),
 					Annotations:       map[string]string{},
@@ -2928,6 +3097,254 @@ func TestNewSandboxFromSandboxSet_TemplateRef(t *testing.T) {
 			// templateRef must be carried over to the Sandbox spec.
 			require.NotNil(t, sbx.Spec.TemplateRef)
 			assert.Equal(t, refName, sbx.Spec.TemplateRef.Name)
+		})
+	}
+}
+
+// mockIdentityProvider is a configurable mock for testing TryClaimSandbox security token flows.
+type mockIdentityProvider struct {
+	issueTokenFunc func(ctx context.Context, req identity.TokenRequest) (*identity.TokenResponse, error)
+	propagateFunc  func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error
+}
+
+func (m *mockIdentityProvider) IssueToken(ctx context.Context, req identity.TokenRequest) (*identity.TokenResponse, error) {
+	if m.issueTokenFunc != nil {
+		return m.issueTokenFunc(ctx, req)
+	}
+	return &identity.TokenResponse{AccessToken: uuid.NewString()}, nil
+}
+
+func (m *mockIdentityProvider) PropagateSecurityToken(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
+	if m.propagateFunc != nil {
+		return m.propagateFunc(ctx, sbx, tokenResp)
+	}
+	return nil
+}
+
+//goland:noinspection GoDeprecation
+func TestTryClaimSandbox_SecurityToken(t *testing.T) {
+	utils.InitLogOutput()
+
+	// Enable SecurityIdentityProviderGate for all sub-tests
+	require.NoError(t, utilfeature.DefaultMutableFeatureGate.Set("SecurityIdentityProvider=true"))
+	t.Cleanup(func() {
+		require.NoError(t, utilfeature.DefaultMutableFeatureGate.Set("SecurityIdentityProvider=false"))
+	})
+
+	existTemplate := "test-template"
+	user := "test-user"
+
+	tests := []struct {
+		name         string
+		options      infra.ClaimSandboxOptions
+		mockProvider *mockIdentityProvider
+		preModifier  func(sbx *v1alpha1.Sandbox)
+		expectError  string
+		postCheck    func(t *testing.T, sbx infra.Sandbox, metrics infra.ClaimMetrics)
+	}{
+		{
+			name: "issue security token success and propagate",
+			options: infra.ClaimSandboxOptions{
+				User:     user,
+				Template: existTemplate,
+				InitRuntime: &config.InitRuntimeOptions{
+					AccessToken: "original-uuid-token",
+				},
+				SecurityToken: &config.SecurityTokenOptions{
+					TokenResponse: identity.TokenResponse{AccessToken: "placeholder"},
+				},
+			},
+			mockProvider: &mockIdentityProvider{
+				issueTokenFunc: func(ctx context.Context, req identity.TokenRequest) (*identity.TokenResponse, error) {
+					return &identity.TokenResponse{AccessToken: "secure-token-123"}, nil
+				},
+				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
+					return nil
+				},
+			},
+			postCheck: func(t *testing.T, sbx infra.Sandbox, metrics infra.ClaimMetrics) {
+				annotations := sbx.GetAnnotations()
+				// Original UUID token is written via InitRuntime
+				assert.Equal(t, "original-uuid-token", annotations[v1alpha1.AnnotationRuntimeAccessToken])
+				// SecurityToken metrics should be recorded
+				assert.Greater(t, metrics.SecurityToken, time.Duration(0))
+				// TokenRefreshStatus annotation should be set
+				raw := annotations[pkgutils.AgentKeyTokenRefreshStatus]
+				assert.NotEmpty(t, raw)
+				var decoded identity.TokenRefreshStatus
+				require.NoError(t, json.Unmarshal([]byte(raw), &decoded))
+			},
+		},
+		{
+			name: "issue security token failure falls back to UUID transparently",
+			options: infra.ClaimSandboxOptions{
+				User:     user,
+				Template: existTemplate,
+				InitRuntime: &config.InitRuntimeOptions{
+					AccessToken: "original-uuid-token",
+				},
+				SecurityToken: &config.SecurityTokenOptions{
+					TokenResponse: identity.TokenResponse{AccessToken: "placeholder"},
+				},
+			},
+			mockProvider: &mockIdentityProvider{
+				issueTokenFunc: func(ctx context.Context, req identity.TokenRequest) (*identity.TokenResponse, error) {
+					return nil, fmt.Errorf("identity provider unavailable")
+				},
+			},
+			postCheck: func(t *testing.T, sbx infra.Sandbox, metrics infra.ClaimMetrics) {
+				// Fallback generates a UUID token automatically, so claim succeeds
+				annotations := sbx.GetAnnotations()
+				assert.Equal(t, "original-uuid-token", annotations[v1alpha1.AnnotationRuntimeAccessToken])
+				// TokenRefreshStatus IS set because fallback issuance succeeded
+				raw := annotations[pkgutils.AgentKeyTokenRefreshStatus]
+				assert.NotEmpty(t, raw)
+				var decoded identity.TokenRefreshStatus
+				require.NoError(t, json.Unmarshal([]byte(raw), &decoded))
+				// SecurityToken metrics should be recorded
+				assert.Greater(t, metrics.SecurityToken, time.Duration(0))
+			},
+		},
+		{
+			name: "propagate security token failure returns retriable error",
+			options: infra.ClaimSandboxOptions{
+				User:     user,
+				Template: existTemplate,
+				InitRuntime: &config.InitRuntimeOptions{
+					AccessToken: "original-uuid-token",
+				},
+				SecurityToken: &config.SecurityTokenOptions{
+					TokenResponse: identity.TokenResponse{AccessToken: "placeholder"},
+				},
+			},
+			mockProvider: &mockIdentityProvider{
+				issueTokenFunc: func(ctx context.Context, req identity.TokenRequest) (*identity.TokenResponse, error) {
+					return &identity.TokenResponse{AccessToken: "secure-token-456"}, nil
+				},
+				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
+					return fmt.Errorf("propagation failed")
+				},
+			},
+			expectError: "security token propagation failed",
+		},
+		{
+			name: "security token is issued even when access token is not UUID",
+			options: infra.ClaimSandboxOptions{
+				User:     user,
+				Template: existTemplate,
+				InitRuntime: &config.InitRuntimeOptions{
+					AccessToken: "some-token",
+				},
+			},
+			mockProvider: &mockIdentityProvider{
+				issueTokenFunc: func(ctx context.Context, req identity.TokenRequest) (*identity.TokenResponse, error) {
+					return &identity.TokenResponse{AccessToken: "issued-token"}, nil
+				},
+			},
+			postCheck: func(t *testing.T, sbx infra.Sandbox, metrics infra.ClaimMetrics) {
+				annotations := sbx.GetAnnotations()
+				// TokenRefreshStatus should be set since issuance succeeded
+				assert.NotEmpty(t, annotations[pkgutils.AgentKeyTokenRefreshStatus])
+				// SecurityToken metric should be recorded
+				assert.Greater(t, metrics.SecurityToken, time.Duration(0))
+			},
+		},
+		{
+			name: "security token is issued even when InitRuntime is nil",
+			options: infra.ClaimSandboxOptions{
+				User:     user,
+				Template: existTemplate,
+			},
+			mockProvider: &mockIdentityProvider{
+				issueTokenFunc: func(ctx context.Context, req identity.TokenRequest) (*identity.TokenResponse, error) {
+					return &identity.TokenResponse{AccessToken: "issued-token"}, nil
+				},
+			},
+			postCheck: func(t *testing.T, sbx infra.Sandbox, metrics infra.ClaimMetrics) {
+				annotations := sbx.GetAnnotations()
+				// TokenRefreshStatus should be set since issuance succeeded
+				assert.NotEmpty(t, annotations[pkgutils.AgentKeyTokenRefreshStatus])
+				// SecurityToken metric should be recorded
+				assert.Greater(t, metrics.SecurityToken, time.Duration(0))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup runtime server for InitRuntime
+			server := testutils.NewTestRuntimeServer(testutils.TestRuntimeServerOptions{
+				RunCommandResult:      runtime.RunCommandResult{PID: 1, Exited: true},
+				RunCommandImmediately: true,
+			})
+			defer server.Close()
+
+			// Save and restore the registered provider
+			identity.RegisterProvider(tt.mockProvider)
+			t.Cleanup(func() { identity.RegisterProvider(identity.NewDefaultIdentityProvider()) })
+
+			tt.options.ClaimTimeout = 500 * time.Millisecond
+			testInfra, fc := NewTestInfra(t)
+
+			// Create an available sandbox
+			sbx := &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sbx",
+					Namespace: "default",
+					Labels: map[string]string{
+						v1alpha1.LabelSandboxTemplate:        existTemplate,
+						agentsv1alpha1.LabelSandboxIsClaimed: "false",
+					},
+					CreationTimestamp: metav1.Now(),
+					Annotations: map[string]string{
+						v1alpha1.AnnotationRuntimeURL: server.URL,
+					},
+					OwnerReferences: GetSbsOwnerReference(),
+				},
+				Spec: v1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "main", Image: "test-image"}},
+							},
+						},
+					},
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase: v1alpha1.SandboxRunning,
+					Conditions: []metav1.Condition{
+						{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue},
+					},
+					PodInfo: v1alpha1.PodInfo{PodIP: "1.2.3.4"},
+				},
+			}
+			if tt.preModifier != nil {
+				tt.preModifier(sbx)
+			}
+			CreateSandboxWithStatus(t, fc, sbx)
+			require.Eventually(t, func() bool {
+				var got v1alpha1.Sandbox
+				return fc.Get(t.Context(), types.NamespacedName{Namespace: sbx.Namespace, Name: sbx.Name}, &got) == nil
+			}, 100*time.Millisecond, 5*time.Millisecond)
+
+			opts, err := ValidateAndInitClaimOptions(tt.options)
+			require.NoError(t, err)
+
+			claimed, metrics, claimErr := TryClaimSandbox(t.Context(), opts, &testInfra.pickCache, testInfra.Cache, testInfra.claimLockChannel, testInfra.createLimiter)
+
+			if tt.expectError != "" {
+				require.Error(t, claimErr)
+				assert.Contains(t, claimErr.Error(), tt.expectError)
+				var retryErr retriableError
+				assert.True(t, errors.As(claimErr, &retryErr), "error should be a retriableError")
+			} else {
+				require.NoError(t, claimErr)
+				require.NotNil(t, claimed)
+			}
+
+			if tt.postCheck != nil {
+				tt.postCheck(t, claimed, metrics)
+			}
 		})
 	}
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
@@ -32,13 +32,14 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
+	"github.com/openkruise/agents/pkg/utils/runtime"
+
 	"github.com/openkruise/agents/api/v1alpha1"
 	cachepkg "github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/cache/cachetest"
 	cacheutils "github.com/openkruise/agents/pkg/cache/utils"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
-	"github.com/openkruise/agents/pkg/utils/runtime"
 	utils "github.com/openkruise/agents/pkg/utils/sandbox-manager"
 	"github.com/openkruise/agents/pkg/utils/sandboxutils"
 	"github.com/openkruise/agents/pkg/utils/timeout"

--- a/pkg/sandbox-manager/infra/types.go
+++ b/pkg/sandbox-manager/infra/types.go
@@ -51,6 +51,8 @@ type ClaimSandboxOptions struct {
 	InitRuntime *config.InitRuntimeOptions `json:"initRuntime"`
 	// Set CSIMount to non-nil value to mount a CSI volume
 	CSIMount *config.CSIMountOptions `json:"CSIMount"`
+	// Set SecurityToken value in runtime
+	SecurityToken *config.SecurityTokenOptions `json:"securityToken"`
 	// Max ClaimTimeout duration
 	ClaimTimeout time.Duration `json:"claimTimeout"`
 	// Max WaitReadyTimeout duration
@@ -90,6 +92,7 @@ type ClaimMetrics struct {
 	WaitReady           time.Duration
 	InitRuntime         time.Duration
 	CSIMount            time.Duration
+	SecurityToken       time.Duration
 	LockType            LockType
 	LastError           error
 	PickSandboxFailures []PickSandboxFailure
@@ -116,8 +119,8 @@ func (m *ClaimMetrics) String() string {
 		// Replace newlines and control characters to ensure single-line output
 		lastErrStr = sanitizeErrorMessage(m.LastError)
 	}
-	return fmt.Sprintf("ClaimMetrics{Retries: %d, Total: %v, Wait: %v, RetryCost: %v, PickAndLock: %v, LockType: %v, WaitReady: %v, InitRuntime: %v, CSIMount: %v, LastError: %v}",
-		m.Retries, m.Total, m.Wait, m.RetryCost, m.PickAndLock, m.LockType, m.WaitReady, m.InitRuntime, m.CSIMount, lastErrStr)
+	return fmt.Sprintf("ClaimMetrics{Retries: %d, Total: %v, Wait: %v, RetryCost: %v, PickAndLock: %v, LockType: %v, WaitReady: %v, InitRuntime: %v, CSIMount: %v, SecurityToken: %v, LastError: %v}",
+		m.Retries, m.Total, m.Wait, m.RetryCost, m.PickAndLock, m.LockType, m.WaitReady, m.InitRuntime, m.CSIMount, m.SecurityToken, lastErrStr)
 }
 
 // RecordPickSandboxFailure records one failed claim attempt and aggregates repeated key/reason pairs.

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -91,6 +91,7 @@ func NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSe
 		Handler:           sc.mux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
+
 	return sc
 }
 

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 
@@ -81,7 +80,7 @@ func (sc *Controller) createSandboxWithClaim(ctx context.Context, request models
 	claimStart := time.Now()
 	var accessToken string
 	if request.Secure {
-		accessToken = uuid.NewString()
+		accessToken = config.NewDefaultAccessToken()
 	}
 	opts := infra.ClaimSandboxOptions{
 		Namespace:    sc.getNamespaceOfUser(user),

--- a/pkg/utils/constant.go
+++ b/pkg/utils/constant.go
@@ -43,6 +43,14 @@ const (
 )
 
 const (
+	// SecurityMetadataPrefix is the prefix for all security-related label/annotations.
+	SecurityMetadataPrefix = "security.agents.kruise.io/"
+	// AgentKeyTokenRefreshStatus is the Sandbox Annotation Key,
+	// used to store the JSON serialized result of TokenRefreshStatus
+	AgentKeyTokenRefreshStatus = SecurityMetadataPrefix + "token-status"
+)
+
+const (
 	True  = "true"
 	False = "false"
 

--- a/pkg/utils/runtime/runtime.go
+++ b/pkg/utils/runtime/runtime.go
@@ -24,17 +24,19 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/openkruise/agents/pkg/cache"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openkruise/agents/pkg/cache"
+
 	"github.com/openkruise/agents/api/v1alpha1"
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 
 	"github.com/openkruise/agents/pkg/agent-runtime/storages"
+
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"


### PR DESCRIPTION

feat: add security identity provider with FeatureGate-controlled token issuance and propagation

Introduce the identityprovider package for sandbox access token management:
- Define IdentityProvider/TokenProvider interfaces with UUID-based community default
- Add fallbackTokenProvider for graceful degradation on external provider failures
- Add SecurityTokenPropagator registration mechanism for internal extensibility
- Integrate security token issuance into sandbox claim flow (Step 1.5) behind SecurityIdentityProviderGate (default: disabled)
- Propagate full TokenResponse to downstream via SecurityTokenOptions
- Add AccessTokenType enum (uuid/identity_provider) to track token generation method
- Add comprehensive table-driven tests for claim security token flows

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

