### PR TITLE
feat(observability): implement end-to-end request ID propagation

### DIFF
--- a/pkg/sandbox-manager/logs/context.go
+++ b/pkg/sandbox-manager/logs/context.go
@@ -23,6 +23,12 @@ import (
 	"k8s.io/klog/v2"
 )
 
+type contextKey string
+
+const (
+	RequestIDKey contextKey = "requestID"
+)
+
 func NewContext(keysAndValues ...any) context.Context {
 	logger := klog.LoggerWithValues(klog.Background(), "contextID", uuid.NewString())
 	return klog.NewContext(context.Background(), logger.WithValues(keysAndValues...))
@@ -38,4 +44,17 @@ func NewContextFrom(parent context.Context, keysAndValues ...any) context.Contex
 func Extend(ctx context.Context, keysAndValues ...any) context.Context {
 	logger := klog.FromContext(ctx)
 	return klog.NewContext(ctx, logger.WithValues(keysAndValues...))
+}
+
+// WithRequestID returns a new context with the request ID stored as a value.
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	return context.WithValue(ctx, RequestIDKey, requestID)
+}
+
+// GetRequestID extracts the request ID from the context.
+func GetRequestID(ctx context.Context) string {
+	if val, ok := ctx.Value(RequestIDKey).(string); ok {
+		return val
+	}
+	return ""
 }

--- a/pkg/sandbox-manager/logs/context_test.go
+++ b/pkg/sandbox-manager/logs/context_test.go
@@ -164,3 +164,25 @@ func TestNewContext_DoesNotInheritCancellation(t *testing.T) {
 		// Expected: context remains active
 	}
 }
+
+func TestRequestID(t *testing.T) {
+	requestID := "test-request-id"
+	ctx := context.Background()
+
+	// Test GetRequestID with empty context
+	if got := GetRequestID(ctx); got != "" {
+		t.Errorf("Expected empty request ID, got %s", got)
+	}
+
+	// Test WithRequestID and GetRequestID
+	ctx = WithRequestID(ctx, requestID)
+	if got := GetRequestID(ctx); got != requestID {
+		t.Errorf("Expected request ID %s, got %s", requestID, got)
+	}
+
+	// Test Extend with RequestID
+	extendedCtx := Extend(ctx, "extra", "value")
+	if got := GetRequestID(extendedCtx); got != requestID {
+		t.Errorf("Expected request ID %s to be preserved in extended context, got %s", requestID, got)
+	}
+}

--- a/pkg/servers/web/framework.go
+++ b/pkg/servers/web/framework.go
@@ -76,6 +76,7 @@ func RegisterRoute[T any](mux *http.ServeMux, method, path string, handler Handl
 		// Derive context from request context to inherit cancellation when client disconnects
 		ctx := logs.NewContextFrom(r.Context(),
 			"requestID", requestID, "api", fmt.Sprintf("%s %s", method, path))
+		ctx = logs.WithRequestID(ctx, requestID)
 		log := klog.FromContext(ctx)
 
 		defer func() {

--- a/pkg/utils/runtime/propagation_test.go
+++ b/pkg/utils/runtime/propagation_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+	"github.com/openkruise/agents/pkg/sandbox-manager/logs"
+	"github.com/openkruise/agents/proto/envd/process"
+)
+
+func TestInitRuntimePropagation(t *testing.T) {
+	requestID := "test-propagation-id"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, requestID, r.Header.Get("X-Request-ID"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sbx := newTestSandboxWithURL(server.URL)
+	ctx := logs.WithRequestID(context.Background(), requestID)
+
+	_, err := InitRuntime(ctx, sbx, config.InitRuntimeOptions{SkipRefresh: true}, nil)
+	require.NoError(t, err)
+}
+
+func TestRunCommandWithRuntimePropagation(t *testing.T) {
+	requestID := "test-grpc-propagation-id"
+
+	handler := &mockProcessHandler{
+		startFn: func(ctx context.Context, req *connect.Request[process.StartRequest], stream *connect.ServerStream[process.StartResponse]) error {
+			assert.Equal(t, requestID, req.Header().Get("X-Request-ID"))
+			return stream.Send(&process.StartResponse{Event: &process.ProcessEvent{
+				Event: &process.ProcessEvent_End{End: &process.ProcessEvent_EndEvent{ExitCode: 0, Exited: true}},
+			}})
+		},
+	}
+	_, sbx := newMockRuntimeServer(t, handler)
+
+	ctx := logs.WithRequestID(context.Background(), requestID)
+
+	_, err := RunCommandWithRuntime(ctx, RunCmdFuncArgs{
+		Sbx:           sbx,
+		ProcessConfig: &process.ProcessConfig{Cmd: "test"},
+		Timeout:       5 * time.Second,
+	})
+	require.NoError(t, err)
+}

--- a/pkg/utils/runtime/runtime.go
+++ b/pkg/utils/runtime/runtime.go
@@ -88,6 +88,9 @@ func RunCommandWithRuntime(ctx context.Context, args RunCmdFuncArgs) (RunCommand
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	clientContext, callInfo := connect.NewClientContext(ctxWithTimeout)
+	if requestID := logs.GetRequestID(ctx); requestID != "" {
+		callInfo.RequestHeader().Set("X-Request-ID", requestID)
+	}
 	callInfo.RequestHeader().Set("X-Access-Token", sandboxutils.GetAccessToken(sbx))
 	callInfo.RequestHeader().Set("Authorization", "Basic cm9vdDo=") // Basic root:
 
@@ -407,6 +410,9 @@ func InitRuntime(ctx context.Context, sbx *agentsv1alpha1.Sandbox, opts config.I
 		if initErr != nil {
 			log.Error(initErr, "failed to create request")
 			return initErr
+		}
+		if requestID := logs.GetRequestID(ctx); requestID != "" {
+			r.Header.Set("X-Request-ID", requestID)
 		}
 		resp, initErr := proxyutils.ProxyRequest(r)
 		defer func() {


### PR DESCRIPTION
# [Observability] Hardening Context Propagation for Request Tracing

## Summary
This PR implements end-to-end context propagation for the `sandbox-manager`. It ensures that the `X-Request-ID` generated at the E2B API gateway is correctly propagated to downstream components, specifically the `agent-runtime` sidecar, via both HTTP and Connect gRPC calls.

## Problem
Previously, while the `sandbox-manager` generated or extracted a `RequestID` for incoming requests, this ID was only stored in the local logger context. Downstream calls to the sandbox sidecar (e.g., during initialization or command execution) did not include this ID. This made it difficult to correlate sidecar logs with the originating user request in distributed environments.

## Solution
1.  **Context Utility Enhancements**: Added `WithRequestID` and `GetRequestID` helpers in `pkg/sandbox-manager/logs/context.go` to manage `RequestID` as a first-class context value.
2.  **Middleware Update**: Updated the `RegisterRoute` middleware in `pkg/servers/web/framework.go` to inject the `RequestID` into the context values.
3.  **HTTP Propagation**: Updated `InitRuntime` in `pkg/utils/runtime/runtime.go` to extract the `RequestID` from the context and set the `X-Request-ID` header on outgoing HTTP requests.
4.  **gRPC Propagation**: Updated `RunCommandWithRuntime` in `pkg/utils/runtime/runtime.go` to inject the `RequestID` into the Connect RPC request headers.

## Impact
-   **Improved Debugging**: Engineers can now trace a single user request across multiple microservices using a single `RequestID`.
-   **Auditability**: Provides a clear link between external API calls and internal sidecar operations.

## Checklist
- [x] RequestID context helpers implemented.
- [x] Web middleware updated for context injection.
- [x] HTTP propagation added to `InitRuntime`.
- [x] gRPC propagation added to `RunCommandWithRuntime`.
- [x] All unit tests passed.


**fixes #335**
