### PR TITLE
feat(observability): Add unified Kubernetes Event emission and structured logging for CRD lifecycle steps

### DIFF
--- a/pkg/controller/events/events.go
+++ b/pkg/controller/events/events.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package events defines Kubernetes Event Reason constants used across all controllers.
+package events
+
+// Sandbox lifecycle event reasons represent state transitions and operations on individual Sandbox resources.
+const (
+	SandboxCreating        = "SandboxCreating"
+	SandboxPodCreated      = "SandboxPodCreated"
+	SandboxPodCreateFailed = "SandboxPodCreateFailed"
+	SandboxRunning         = "SandboxRunning"
+	SandboxPaused          = "SandboxPaused"
+	SandboxResumed         = "SandboxResumed"
+	SandboxUpgrading       = "SandboxUpgrading"
+	SandboxUpgraded        = "SandboxUpgraded"
+	SandboxFailed          = "SandboxFailed"
+	SandboxDeleting        = "SandboxDeleting"
+)
+
+// SandboxSet lifecycle event reasons represent operations on SandboxSet resources including scaling and rolling updates.
+const (
+	SandboxCreated                   = "SandboxCreated"
+	CreateSandboxFailed              = "CreateSandboxFailed"
+	SandboxScaledDown                = "SandboxScaledDown"
+	FailedSandboxDeleted             = "FailedSandboxDeleted"
+	SandboxSetScalingUp              = "SandboxSetScalingUp"
+	SandboxSetScalingDown            = "SandboxSetScalingDown"
+	SandboxSetRollingUpdate          = "SandboxSetRollingUpdate"
+	SandboxSetRollingUpdateCompleted = "SandboxSetRollingUpdateCompleted"
+)
+
+// SandboxClaim lifecycle event reasons represent claim binding, completion, and error conditions.
+const (
+	SandboxClaimBinding   = "SandboxClaimBinding"
+	SandboxClaimCompleted = "ClaimCompleted"
+	SandboxClaimed        = "SandboxClaimed"
+	NoAvailableSandboxes  = "NoAvailableSandboxes"
+	SandboxClaimTTLDelete = "SandboxClaimTTLDelete"
+	FeatureGateDisabled   = "FeatureGateDisabled"
+	UnknownPhase          = "UnknownPhase"
+)
+
+// SandboxUpdateOps lifecycle event reasons represent in-place update operation progress.
+const (
+	UpdateOpsStarted     = "UpdateOpsStarted"
+	UpdateOpsProgressing = "UpdateOpsProgressing"
+	UpdateOpsCompleted   = "UpdateOpsCompleted"
+	UpdateOpsFailed      = "UpdateOpsFailed"
+)

--- a/pkg/controller/events/events.go
+++ b/pkg/controller/events/events.go
@@ -19,11 +19,12 @@ package events
 
 // Sandbox lifecycle event reasons represent state transitions and operations on individual Sandbox resources.
 const (
-	SandboxCreating        = "SandboxCreating"
 	SandboxPodCreated      = "SandboxPodCreated"
 	SandboxPodCreateFailed = "SandboxPodCreateFailed"
-	SandboxRunning         = "SandboxRunning"
+	SandboxReady           = "SandboxReady"
+	SandboxPausing         = "SandboxPausing"
 	SandboxPaused          = "SandboxPaused"
+	SandboxResuming        = "SandboxResuming"
 	SandboxResumed         = "SandboxResumed"
 	SandboxUpgrading       = "SandboxUpgrading"
 	SandboxUpgraded        = "SandboxUpgraded"

--- a/pkg/controller/events/events_test.go
+++ b/pkg/controller/events/events_test.go
@@ -29,11 +29,12 @@ func TestEventReasonConstants_Unique(t *testing.T) {
 		value string
 	}{
 		// Sandbox lifecycle events
-		{"SandboxCreating", SandboxCreating},
 		{"SandboxPodCreated", SandboxPodCreated},
 		{"SandboxPodCreateFailed", SandboxPodCreateFailed},
-		{"SandboxRunning", SandboxRunning},
+		{"SandboxReady", SandboxReady},
+		{"SandboxPausing", SandboxPausing},
 		{"SandboxPaused", SandboxPaused},
+		{"SandboxResuming", SandboxResuming},
 		{"SandboxResumed", SandboxResumed},
 		{"SandboxUpgrading", SandboxUpgrading},
 		{"SandboxUpgraded", SandboxUpgraded},
@@ -94,11 +95,12 @@ func TestEventReasonConstants_NonEmpty(t *testing.T) {
 		name  string
 		value string
 	}{
-		{"SandboxCreating", SandboxCreating},
 		{"SandboxPodCreated", SandboxPodCreated},
 		{"SandboxPodCreateFailed", SandboxPodCreateFailed},
-		{"SandboxRunning", SandboxRunning},
+		{"SandboxReady", SandboxReady},
+		{"SandboxPausing", SandboxPausing},
 		{"SandboxPaused", SandboxPaused},
+		{"SandboxResuming", SandboxResuming},
 		{"SandboxResumed", SandboxResumed},
 		{"SandboxUpgrading", SandboxUpgrading},
 		{"SandboxUpgraded", SandboxUpgraded},

--- a/pkg/controller/events/events_test.go
+++ b/pkg/controller/events/events_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventReasonConstants_Unique(t *testing.T) {
+	// Collect all event reason constants and verify no duplicate values exist.
+	allReasons := []struct {
+		name  string
+		value string
+	}{
+		// Sandbox lifecycle events
+		{"SandboxCreating", SandboxCreating},
+		{"SandboxPodCreated", SandboxPodCreated},
+		{"SandboxPodCreateFailed", SandboxPodCreateFailed},
+		{"SandboxRunning", SandboxRunning},
+		{"SandboxPaused", SandboxPaused},
+		{"SandboxResumed", SandboxResumed},
+		{"SandboxUpgrading", SandboxUpgrading},
+		{"SandboxUpgraded", SandboxUpgraded},
+		{"SandboxFailed", SandboxFailed},
+		{"SandboxDeleting", SandboxDeleting},
+
+		// SandboxSet lifecycle events
+		{"SandboxCreated", SandboxCreated},
+		{"CreateSandboxFailed", CreateSandboxFailed},
+		{"SandboxScaledDown", SandboxScaledDown},
+		{"FailedSandboxDeleted", FailedSandboxDeleted},
+		{"SandboxSetScalingUp", SandboxSetScalingUp},
+		{"SandboxSetScalingDown", SandboxSetScalingDown},
+		{"SandboxSetRollingUpdate", SandboxSetRollingUpdate},
+		{"SandboxSetRollingUpdateCompleted", SandboxSetRollingUpdateCompleted},
+
+		// SandboxClaim lifecycle events
+		{"SandboxClaimBinding", SandboxClaimBinding},
+		{"SandboxClaimCompleted", SandboxClaimCompleted},
+		{"SandboxClaimed", SandboxClaimed},
+		{"NoAvailableSandboxes", NoAvailableSandboxes},
+		{"SandboxClaimTTLDelete", SandboxClaimTTLDelete},
+		{"FeatureGateDisabled", FeatureGateDisabled},
+		{"UnknownPhase", UnknownPhase},
+
+		// SandboxUpdateOps lifecycle events
+		{"UpdateOpsStarted", UpdateOpsStarted},
+		{"UpdateOpsProgressing", UpdateOpsProgressing},
+		{"UpdateOpsCompleted", UpdateOpsCompleted},
+		{"UpdateOpsFailed", UpdateOpsFailed},
+	}
+
+	tests := []struct {
+		name string
+	}{
+		{name: "all event reason constants have unique values"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seen := make(map[string]string) // value -> constant name
+			for _, r := range allReasons {
+				if existingName, exists := seen[r.value]; exists {
+					t.Errorf("duplicate event reason value %q: used by both %q and %q",
+						r.value, existingName, r.name)
+				}
+				seen[r.value] = r.name
+			}
+			assert.Equal(t, len(allReasons), len(seen),
+				"expected all constants to have unique values")
+		})
+	}
+}
+
+func TestEventReasonConstants_NonEmpty(t *testing.T) {
+	// Verify that no event reason constant is an empty string.
+	allReasons := []struct {
+		name  string
+		value string
+	}{
+		{"SandboxCreating", SandboxCreating},
+		{"SandboxPodCreated", SandboxPodCreated},
+		{"SandboxPodCreateFailed", SandboxPodCreateFailed},
+		{"SandboxRunning", SandboxRunning},
+		{"SandboxPaused", SandboxPaused},
+		{"SandboxResumed", SandboxResumed},
+		{"SandboxUpgrading", SandboxUpgrading},
+		{"SandboxUpgraded", SandboxUpgraded},
+		{"SandboxFailed", SandboxFailed},
+		{"SandboxDeleting", SandboxDeleting},
+		{"SandboxCreated", SandboxCreated},
+		{"CreateSandboxFailed", CreateSandboxFailed},
+		{"SandboxScaledDown", SandboxScaledDown},
+		{"FailedSandboxDeleted", FailedSandboxDeleted},
+		{"SandboxSetScalingUp", SandboxSetScalingUp},
+		{"SandboxSetScalingDown", SandboxSetScalingDown},
+		{"SandboxSetRollingUpdate", SandboxSetRollingUpdate},
+		{"SandboxSetRollingUpdateCompleted", SandboxSetRollingUpdateCompleted},
+		{"SandboxClaimBinding", SandboxClaimBinding},
+		{"SandboxClaimCompleted", SandboxClaimCompleted},
+		{"SandboxClaimed", SandboxClaimed},
+		{"NoAvailableSandboxes", NoAvailableSandboxes},
+		{"SandboxClaimTTLDelete", SandboxClaimTTLDelete},
+		{"FeatureGateDisabled", FeatureGateDisabled},
+		{"UnknownPhase", UnknownPhase},
+		{"UpdateOpsStarted", UpdateOpsStarted},
+		{"UpdateOpsProgressing", UpdateOpsProgressing},
+		{"UpdateOpsCompleted", UpdateOpsCompleted},
+		{"UpdateOpsFailed", UpdateOpsFailed},
+	}
+
+	tests := []struct {
+		name string
+	}{
+		{name: "all event reason constants are non-empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, r := range allReasons {
+				assert.NotEmpty(t, r.value, "event reason constant %q should not be empty", r.name)
+			}
+		})
+	}
+}

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -90,7 +90,7 @@ func (r *commonControl) EnsureSandboxRunning(ctx context.Context, args EnsureFun
 		newStatus.Phase = agentsv1alpha1.SandboxRunning
 		syncSandboxStatusFromPod(pod, newStatus)
 		klog.InfoS("Sandbox transitioned to Running", "sandbox", klog.KObj(box))
-		r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxRunning, "Sandbox is now running")
+		r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxReady, "Sandbox is now Ready")
 		return 0, nil
 	}
 
@@ -242,7 +242,7 @@ func (r *commonControl) EnsureSandboxResumed(ctx context.Context, args EnsureFun
 
 		utils.SetSandboxCondition(newStatus, *rCond)
 		klog.InfoS("Sandbox resumed successfully", "sandbox", klog.KObj(box))
-		r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxResumed, "Sandbox resumed and running")
+		r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxResumed, "Sandbox resumed successfully and Ready")
 	}
 	return nil
 }
@@ -287,7 +287,6 @@ func (r *commonControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureFu
 		}
 		utils.SetSandboxCondition(newStatus, *upgradeCond)
 		klog.InfoS("Sandbox upgrade started", "sandbox", klog.KObj(box))
-		r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxUpgrading, "Sandbox upgrade started")
 	}
 
 	switch upgradeCond.Reason {

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -32,6 +32,7 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/agent-runtime/storages"
+	"github.com/openkruise/agents/pkg/controller/events"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
 	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
@@ -88,6 +89,8 @@ func (r *commonControl) EnsureSandboxRunning(ctx context.Context, args EnsureFun
 	if pod.Status.Phase == corev1.PodRunning {
 		newStatus.Phase = agentsv1alpha1.SandboxRunning
 		syncSandboxStatusFromPod(pod, newStatus)
+		klog.InfoS("Sandbox transitioned to Running", "sandbox", klog.KObj(box))
+		r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxRunning, "Sandbox is now running")
 		return 0, nil
 	}
 
@@ -184,6 +187,7 @@ func (r *commonControl) EnsureSandboxPaused(ctx context.Context, args EnsureFunc
 		cond.LastTransitionTime = metav1.Now()
 		utils.SetSandboxCondition(newStatus, *cond)
 		klog.InfoS("Pod deletion completed, pause phase completed", "sandbox", klog.KObj(box))
+		r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxPaused, "Sandbox paused successfully")
 		return nil
 	}
 	// Pod deletion incomplete, waiting
@@ -237,6 +241,8 @@ func (r *commonControl) EnsureSandboxResumed(ctx context.Context, args EnsureFun
 		}
 
 		utils.SetSandboxCondition(newStatus, *rCond)
+		klog.InfoS("Sandbox resumed successfully", "sandbox", klog.KObj(box))
+		r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxResumed, "Sandbox resumed and running")
 	}
 	return nil
 }
@@ -280,6 +286,8 @@ func (r *commonControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureFu
 			LastTransitionTime: metav1.Now(),
 		}
 		utils.SetSandboxCondition(newStatus, *upgradeCond)
+		klog.InfoS("Sandbox upgrade started", "sandbox", klog.KObj(box))
+		r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxUpgrading, "Sandbox upgrade started")
 	}
 
 	switch upgradeCond.Reason {
@@ -364,6 +372,8 @@ func (r *commonControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureFu
 			Message:            "",
 			LastTransitionTime: metav1.Now(),
 		})
+		klog.InfoS("Sandbox upgraded successfully", "sandbox", klog.KObj(box))
+		r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxUpgraded, "Sandbox upgrade completed successfully")
 	}
 
 	return nil
@@ -373,6 +383,8 @@ func (r *commonControl) EnsureSandboxTerminated(ctx context.Context, args Ensure
 	pod, box, _ := args.Pod, args.Box, args.NewStatus
 	var err error
 	if pod == nil {
+		klog.InfoS("Sandbox termination started", "sandbox", klog.KObj(box))
+		r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxDeleting, "Sandbox termination/finalizer cleanup started")
 		_, err = utils.PatchFinalizer(ctx, r.Client, box, utils.RemoveFinalizerOpType, utils.SandboxFinalizer)
 		if err != nil {
 			klog.ErrorS(err, "update sandbox finalizer failed", "sandbox", klog.KObj(box))
@@ -385,6 +397,8 @@ func (r *commonControl) EnsureSandboxTerminated(ctx context.Context, args Ensure
 		return nil
 	}
 
+	klog.InfoS("Sandbox termination started", "sandbox", klog.KObj(box))
+	r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxDeleting, "Sandbox termination/finalizer cleanup started")
 	err = client.IgnoreNotFound(r.Delete(ctx, pod))
 	if err != nil {
 		klog.ErrorS(err, "delete pod failed", "sandbox", klog.KObj(box))
@@ -415,10 +429,12 @@ func (r *commonControl) createPod(ctx context.Context, box *agentsv1alpha1.Sandb
 		ScaleExpectation.ObserveScale(GetControllerKey(box), expectations.Create, box.Name)
 		if !errors.IsAlreadyExists(err) {
 			klog.ErrorS(err, "create pod failed", "sandbox", klog.KObj(box))
+			r.recorder.Eventf(box, corev1.EventTypeWarning, events.SandboxPodCreateFailed, "Failed to create pod: %v", err)
 			return nil, err
 		}
 	}
-	klog.InfoS("Create pod success", "sandbox", klog.KObj(box), "Body", utils.DumpJson(pod))
+	klog.InfoS("Create pod success", "sandbox", klog.KObj(box), "pod", pod.Name)
+	r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxPodCreated, "Pod %s created for sandbox", pod.Name)
 	return pod, nil
 }
 

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -227,6 +227,17 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 	// calculate sandbox status
 	var shouldRequeue bool
 	newStatus, shouldRequeue = calculateStatus(args)
+	// Emit events on sandbox phase transitions detected by calculateStatus.
+	if box.Status.Phase != newStatus.Phase {
+		switch newStatus.Phase {
+		case agentsv1alpha1.SandboxPaused:
+			r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxPausing, "Sandbox is pausing")
+		case agentsv1alpha1.SandboxUpgrading:
+			r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxUpgrading, "Sandbox upgrade started")
+		case agentsv1alpha1.SandboxResuming:
+			r.recorder.Eventf(box, corev1.EventTypeNormal, events.SandboxResuming, "Sandbox is resuming")
+		}
+	}
 	if shouldRequeue {
 		// Emit event when sandbox enters Failed state
 		if newStatus.Phase == agentsv1alpha1.SandboxFailed {

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/controller/events"
 	"github.com/openkruise/agents/pkg/controller/sandbox/core"
 	"github.com/openkruise/agents/pkg/discovery"
 	"github.com/openkruise/agents/pkg/features"
@@ -62,13 +64,15 @@ func Add(mgr manager.Manager) error {
 	}
 
 	rateLimiter := core.NewRateLimiter()
+	recorder := mgr.GetEventRecorderFor("sandbox")
 	err := (&SandboxReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		recorder: recorder,
 		controls: core.NewSandboxControl(core.SandboxControlArgs{
 			Client:      mgr.GetClient(),
 			APIReader:   mgr.GetAPIReader(),
-			Recorder:    mgr.GetEventRecorderFor("sandbox"),
+			Recorder:    recorder,
 			RateLimiter: rateLimiter,
 		}), rateLimiter: rateLimiter,
 	}).SetupWithManager(mgr)
@@ -83,6 +87,7 @@ func Add(mgr manager.Manager) error {
 type SandboxReconciler struct {
 	client.Client
 	Scheme      *runtime.Scheme
+	recorder    record.EventRecorder
 	controls    map[string]core.SandboxControl
 	rateLimiter *core.RateLimiter
 }
@@ -223,6 +228,11 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 	var shouldRequeue bool
 	newStatus, shouldRequeue = calculateStatus(args)
 	if shouldRequeue {
+		// Emit event when sandbox enters Failed state
+		if newStatus.Phase == agentsv1alpha1.SandboxFailed {
+			klog.InfoS("Sandbox entered Failed state", "sandbox", klog.KObj(box), "message", newStatus.Message)
+			r.recorder.Eventf(box, corev1.EventTypeWarning, events.SandboxFailed, "Sandbox failed: %s", newStatus.Message)
+		}
 		return reconcile.Result{RequeueAfter: requeueAfter}, r.updateSandboxStatus(ctx, *newStatus, box)
 	}
 

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -735,8 +735,9 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 			client := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&agentsv1alpha1.Sandbox{}).WithObjects(objects...).Build()
 			rl := core.NewRateLimiter()
 			reconciler := &SandboxReconciler{
-				Client: client,
-				Scheme: scheme,
+				Client:   client,
+				Scheme:   scheme,
+				recorder: fakeRecorder,
 				controls: core.NewSandboxControl(core.SandboxControlArgs{
 					Client:      client,
 					Recorder:    fakeRecorder,

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -3019,8 +3019,9 @@ func TestReconcile_UpgradingPhase(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&agentsv1alpha1.Sandbox{}).WithObjects(sandbox, pod).Build()
 	rl := core.NewRateLimiter()
 	reconciler := &SandboxReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		recorder: fakeRecorder,
 		controls: core.NewSandboxControl(core.SandboxControlArgs{
 			Client:      fakeClient,
 			Recorder:    fakeRecorder,

--- a/pkg/controller/sandbox/sandbox_events_test.go
+++ b/pkg/controller/sandbox/sandbox_events_test.go
@@ -120,7 +120,7 @@ func TestSandboxLifecycleEvents(t *testing.T) {
 					Phase: corev1.PodRunning,
 				},
 			},
-			expectEvents: []string{events.SandboxRunning},
+			expectEvents: []string{events.SandboxReady},
 		},
 		{
 			name: "running sandbox with deleted pod emits SandboxFailed event",

--- a/pkg/controller/sandbox/sandbox_events_test.go
+++ b/pkg/controller/sandbox/sandbox_events_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandbox
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/controller/events"
+	"github.com/openkruise/agents/pkg/controller/sandbox/core"
+)
+
+func TestSandboxLifecycleEvents(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	tests := []struct {
+		name         string
+		sandbox      *agentsv1alpha1.Sandbox
+		pod          *corev1.Pod
+		expectEvents []string
+	}{
+		{
+			name: "sandbox pending with no pod emits SandboxPodCreated event on pod creation",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "create-pod-sandbox",
+					Namespace:  "default",
+					Generation: 1,
+					Finalizers: []string{"agents.kruise.io/sandbox-protection"},
+					Annotations: map[string]string{
+						agentsv1alpha1.SandboxHashImmutablePart: "fakehash",
+					},
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "test-container",
+										Image: "nginx:latest",
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxPending,
+				},
+			},
+			pod:          nil,
+			expectEvents: []string{events.SandboxPodCreated},
+		},
+		{
+			name: "sandbox pending with running pod emits SandboxRunning event",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "running-sandbox",
+					Namespace:  "default",
+					Generation: 1,
+					Finalizers: []string{"agents.kruise.io/sandbox-protection"},
+					Annotations: map[string]string{
+						agentsv1alpha1.SandboxHashImmutablePart: "fakehash",
+					},
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "test-container",
+										Image: "nginx:latest",
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxPending,
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "running-sandbox",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			expectEvents: []string{events.SandboxRunning},
+		},
+		{
+			name: "running sandbox with deleted pod emits SandboxFailed event",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "failed-sandbox",
+					Namespace:  "default",
+					Generation: 1,
+					Finalizers: []string{"agents.kruise.io/sandbox-protection"},
+					Annotations: map[string]string{
+						agentsv1alpha1.SandboxHashImmutablePart: "fakehash",
+					},
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "test-container",
+										Image: "nginx:latest",
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+				},
+			},
+			pod:          nil, // pod is missing
+			expectEvents: []string{events.SandboxFailed},
+		},
+		{
+			name: "paused sandbox with pod deleted emits SandboxPaused event",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "paused-sandbox",
+					Namespace:  "default",
+					Generation: 1,
+					Finalizers: []string{"agents.kruise.io/sandbox-protection"},
+					Annotations: map[string]string{
+						agentsv1alpha1.SandboxHashImmutablePart: "fakehash",
+					},
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused: true,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "test-container",
+										Image: "nginx:latest",
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxPaused,
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(agentsv1alpha1.SandboxConditionPaused),
+							Status:             metav1.ConditionFalse,
+							Reason:             "DeletePod",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+					PodInfo: agentsv1alpha1.PodInfo{
+						PodIP: "1.2.3.4",
+					},
+				},
+			},
+			pod:          nil, // Pod already deleted
+			expectEvents: []string{events.SandboxPaused},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objects := []client.Object{}
+			if tt.sandbox != nil {
+				objects = append(objects, tt.sandbox)
+			}
+			if tt.pod != nil {
+				objects = append(objects, tt.pod)
+			}
+
+			fakeRecorder := record.NewFakeRecorder(100)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&agentsv1alpha1.Sandbox{}).
+				WithObjects(objects...).
+				Build()
+			rl := core.NewRateLimiter()
+			reconciler := &SandboxReconciler{
+				Client:   fakeClient,
+				Scheme:   scheme,
+				recorder: fakeRecorder,
+				controls: core.NewSandboxControl(core.SandboxControlArgs{
+					Client:      fakeClient,
+					Recorder:    fakeRecorder,
+					RateLimiter: rl,
+				}),
+				rateLimiter: rl,
+			}
+
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      tt.sandbox.Name,
+					Namespace: tt.sandbox.Namespace,
+				},
+			}
+
+			_, _ = reconciler.Reconcile(context.Background(), req)
+
+			// Collect all emitted events
+			close(fakeRecorder.Events)
+			var gotEvents []string
+			for e := range fakeRecorder.Events {
+				gotEvents = append(gotEvents, e)
+			}
+
+			// Verify expected events
+			for _, expected := range tt.expectEvents {
+				found := false
+				for _, got := range gotEvents {
+					if strings.Contains(got, expected) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected event containing %q not found in %v", expected, gotEvents)
+			}
+		})
+	}
+}

--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -25,15 +25,16 @@ import (
 
 	"github.com/google/uuid"
 	"golang.org/x/time/rate"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/agent-runtime/common"
 	"github.com/openkruise/agents/pkg/agent-runtime/storages"
 	"github.com/openkruise/agents/pkg/cache"
+	"github.com/openkruise/agents/pkg/controller/events"
 	"github.com/openkruise/agents/pkg/features"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
@@ -70,8 +71,14 @@ func NewCommonControl(c client.Client, recorder record.EventRecorder, cache cach
 
 // EnsureClaimClaiming handles the logic for claiming sandboxes
 func (c *commonControl) EnsureClaimClaiming(ctx context.Context, args ClaimArgs) (RequeueStrategy, error) {
-	log := logf.FromContext(ctx)
 	claim, sandboxSet := args.Claim, args.SandboxSet
+
+	// Only emit binding event when claim first enters Claiming phase
+	if claim.Status.Phase != agentsv1alpha1.SandboxClaimPhaseClaiming {
+		c.recorder.Eventf(claim, corev1.EventTypeNormal, events.SandboxClaimBinding,
+			"SandboxClaim %s starts binding sandboxes from pool %s", claim.Name, sandboxSet.Name)
+		klog.InfoS("SandboxClaim starts binding sandboxes", "sandboxClaim", klog.KObj(claim), "pool", sandboxSet.Name)
+	}
 
 	// Step 1: Get desired replicas
 	desiredReplicas := getDesiredReplicas(claim)
@@ -98,7 +105,8 @@ func (c *commonControl) EnsureClaimClaiming(ctx context.Context, args ClaimArgs)
 	// Step 4: Use max(statusCount, actualCount) to get current count
 	currentCount := statusCount
 	if actualCount > currentCount {
-		log.Info("Status count mismatch, using actual count",
+		klog.InfoS("Status count mismatch, using actual count",
+			"sandboxClaim", klog.KObj(claim),
 			"statusCount", statusCount,
 			"actualCount", actualCount)
 		currentCount = actualCount
@@ -109,10 +117,11 @@ func (c *commonControl) EnsureClaimClaiming(ctx context.Context, args ClaimArgs)
 
 	// Step 6: Check if already completed
 	if currentCount >= desiredReplicas {
-		log.Info("All replicas claimed",
+		klog.InfoS("All replicas claimed",
+			"sandboxClaim", klog.KObj(claim),
 			"claimed", currentCount,
 			"desired", desiredReplicas)
-		c.recorder.Event(claim, "Normal", "ClaimCompleted",
+		c.recorder.Event(claim, corev1.EventTypeNormal, events.SandboxClaimCompleted,
 			fmt.Sprintf("Successfully claimed %d/%d sandboxes", currentCount, desiredReplicas))
 		args.NewStatus.Message = fmt.Sprintf("Completed: %d/%d claimed", currentCount, desiredReplicas)
 		// Requeue immediately to transition to Completed phase
@@ -124,8 +133,8 @@ func (c *commonControl) EnsureClaimClaiming(ctx context.Context, args ClaimArgs)
 		if res := claim.Spec.InplaceUpdate.Resources; res != nil && (len(res.Requests) > 0 || len(res.Limits) > 0) {
 			if !utilfeature.DefaultFeatureGate.Enabled(features.SandboxInPlaceResourceResizeGate) {
 				msg := fmt.Sprintf("in-place resource resize is disabled by feature gate %s", features.SandboxInPlaceResourceResizeGate)
-				log.Info(msg)
-				c.recorder.Event(claim, "Warning", "FeatureGateDisabled", msg)
+				klog.InfoS("Feature gate disabled for in-place resource resize", "sandboxClaim", klog.KObj(claim), "featureGate", features.SandboxInPlaceResourceResizeGate)
+				c.recorder.Event(claim, corev1.EventTypeWarning, events.FeatureGateDisabled, msg)
 				TransitionToCompleted(args.NewStatus, "FeatureGateDisabled", msg)
 				return NoRequeue(), nil
 			}
@@ -139,7 +148,8 @@ func (c *commonControl) EnsureClaimClaiming(ctx context.Context, args ClaimArgs)
 	// Step 8: Perform claim
 	claimed, err := c.claimSandboxes(ctx, claim, sandboxSet, batchSize)
 	if err != nil {
-		log.Error(err, "Claim attempts completed with errors",
+		klog.ErrorS(err, "Claim attempts completed with errors",
+			"sandboxClaim", klog.KObj(claim),
 			"claimed", claimed, "attempted", batchSize)
 	}
 
@@ -150,20 +160,22 @@ func (c *commonControl) EnsureClaimClaiming(ctx context.Context, args ClaimArgs)
 
 	// Step 10: Record results and determine requeue strategy
 	if claimed > 0 {
-		log.Info("Claimed sandboxes in this cycle",
+		klog.InfoS("Claimed sandboxes in this cycle",
+			"sandboxClaim", klog.KObj(claim),
 			"claimed", claimed,
 			"total", finalCount,
 			"desired", desiredReplicas)
-		c.recorder.Event(claim, "Normal", "SandboxClaimed",
+		c.recorder.Event(claim, corev1.EventTypeNormal, events.SandboxClaimed,
 			fmt.Sprintf("Claimed %d sandbox(es), total: %d/%d", claimed, finalCount, desiredReplicas))
 		// Made progress, requeue immediately to continue claiming
 		return RequeueImmediately(), nil
 	}
 
 	// No progress - no available sandboxes
-	log.Info("No available sandboxes, will retry",
+	klog.InfoS("No available sandboxes, will retry",
+		"sandboxClaim", klog.KObj(claim),
 		"retryInterval", ClaimRetryInterval)
-	c.recorder.Event(claim, "Warning", "NoAvailableSandboxes",
+	c.recorder.Event(claim, corev1.EventTypeWarning, events.NoAvailableSandboxes,
 		fmt.Sprintf("No available sandboxes in pool %s", sandboxSet.Name))
 	// Retry after interval to avoid busy loop
 	return RequeueAfter(ClaimRetryInterval), nil
@@ -171,52 +183,49 @@ func (c *commonControl) EnsureClaimClaiming(ctx context.Context, args ClaimArgs)
 
 // EnsureClaimCompleted handles claim in Completed phase
 func (c *commonControl) EnsureClaimCompleted(ctx context.Context, args ClaimArgs) (RequeueStrategy, error) {
-	log := logf.FromContext(ctx)
 	claim := args.Claim
 
-	log.V(1).Info("EnsureClaimCompleted called", "phase", args.NewStatus.Phase)
+	klog.V(1).InfoS("EnsureClaimCompleted called", "sandboxClaim", klog.KObj(claim), "phase", args.NewStatus.Phase)
 
 	// Check if TTL cleanup is needed
 	if claim.Spec.TTLAfterCompleted != nil && args.NewStatus.CompletionTime != nil {
 		ttl := claim.Spec.TTLAfterCompleted.Duration
 		// Negative TTL means never delete - skip TTL cleanup
 		if ttl < 0 {
-			log.V(1).Info("TTL is negative, skipping automatic deletion (never delete)", "ttl", ttl)
+			klog.V(1).InfoS("TTL is negative, skipping automatic deletion (never delete)", "sandboxClaim", klog.KObj(claim), "ttl", ttl)
 			return NoRequeue(), nil
 		}
 		elapsed := time.Since(args.NewStatus.CompletionTime.Time)
 
-		log.Info("Checking TTL for cleanup", "ttl", ttl, "elapsed", elapsed, "completionTime", args.NewStatus.CompletionTime.Time)
+		klog.InfoS("Checking TTL for cleanup", "sandboxClaim", klog.KObj(claim), "ttl", ttl, "elapsed", elapsed, "completionTime", args.NewStatus.CompletionTime.Time)
 
 		// Check if TTL expired
 		if elapsed >= ttl {
-			log.Info("TTL expired, deleting SandboxClaim", "ttl", ttl, "elapsed", elapsed)
-			c.recorder.Event(claim, "Normal", "SandboxClaimTTLDelete", fmt.Sprintf("Deleting SandboxClaim after TTL of %v", ttl))
+			klog.InfoS("TTL expired, deleting SandboxClaim", "sandboxClaim", klog.KObj(claim), "ttl", ttl, "elapsed", elapsed)
+			c.recorder.Event(claim, corev1.EventTypeNormal, events.SandboxClaimTTLDelete, fmt.Sprintf("Deleting SandboxClaim after TTL of %v", ttl))
 			if err := c.Delete(ctx, claim); err != nil {
-				log.Error(err, "failed to delete SandboxClaim")
+				klog.ErrorS(err, "Failed to delete SandboxClaim", "sandboxClaim", klog.KObj(claim))
 				// Return error to trigger exponential backoff retry
 				return NoRequeue(), err
 			}
 
-			log.Info("SandboxClaim deleted successfully due to TTL expiration")
+			klog.InfoS("SandboxClaim deleted successfully due to TTL expiration", "sandboxClaim", klog.KObj(claim))
 			return NoRequeue(), nil
 		}
 
 		// TTL not yet expired, calculate remaining time
 		remaining := ttl - elapsed
-		log.V(1).Info("TTL not yet expired, will requeue", "remaining", remaining)
+		klog.V(1).InfoS("TTL not yet expired, will requeue", "sandboxClaim", klog.KObj(claim), "remaining", remaining)
 		return RequeueAfter(remaining), nil
 	}
 
 	// No TTL configured, no need to requeue
-	log.V(1).Info("No TTL cleanup configured", "hasTTL", claim.Spec.TTLAfterCompleted != nil, "hasCompletionTime", args.NewStatus.CompletionTime != nil)
+	klog.V(1).InfoS("No TTL cleanup configured", "sandboxClaim", klog.KObj(claim), "hasTTL", claim.Spec.TTLAfterCompleted != nil, "hasCompletionTime", args.NewStatus.CompletionTime != nil)
 	return NoRequeue(), nil
 }
 
 // claimSandboxes attempts to claim up to batchSize sandboxes from the pool
 func (c *commonControl) claimSandboxes(ctx context.Context, claim *agentsv1alpha1.SandboxClaim, sandboxSet *agentsv1alpha1.SandboxSet, batchSize int) (int, error) {
-	log := logf.FromContext(ctx)
-
 	// Validate and build claim options
 	opts, err := c.buildClaimOptions(ctx, claim, sandboxSet)
 	if err != nil {
@@ -230,11 +239,12 @@ func (c *commonControl) claimSandboxes(ctx context.Context, claim *agentsv1alpha
 		// Pass nil for rand so sandboxcr uses global rand (concurrent-safe).
 		sbx, metrics, claimErr := sandboxcr.TryClaimSandbox(ctx, opts, &c.pickCache, c.cache, claimLockChannel, limiter)
 		if claimErr != nil {
-			log.Error(claimErr, "Failed to claim sandbox")
+			klog.ErrorS(claimErr, "Failed to claim sandbox", "sandboxClaim", klog.KObj(claim))
 			return claimErr
 		}
 
-		log.Info("Successfully claimed sandbox",
+		klog.InfoS("Successfully claimed sandbox",
+			"sandboxClaim", klog.KObj(claim),
 			"sandbox", sbx.GetName(),
 			"totalCost", metrics.Total,
 			"pickAndLock", metrics.PickAndLock,
@@ -243,7 +253,7 @@ func (c *commonControl) claimSandboxes(ctx context.Context, claim *agentsv1alpha
 	})
 
 	if claimedCount > 0 {
-		log.Info("Claimed sandboxes successfully", "count", claimedCount, "attempted", batchSize)
+		klog.InfoS("Claimed sandboxes successfully", "sandboxClaim", klog.KObj(claim), "count", claimedCount, "attempted", batchSize)
 	}
 
 	return claimedCount, err
@@ -251,7 +261,6 @@ func (c *commonControl) claimSandboxes(ctx context.Context, claim *agentsv1alpha
 
 // buildClaimOptions constructs ClaimSandboxOptions for TryClaimSandbox
 func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1alpha1.SandboxClaim, sandboxSet *agentsv1alpha1.SandboxSet) (infra.ClaimSandboxOptions, error) {
-	logger := logf.FromContext(ctx).WithValues("SandboxClaim", klog.KObj(claim))
 	opts := infra.ClaimSandboxOptions{
 		User:     string(claim.UID), // Use UID to ensure uniqueness across claim recreations
 		Template: sandboxSet.Name,
@@ -344,8 +353,8 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 				AccessToken: uuid.NewString(),
 			}
 		} else {
-			logger.Error(fmt.Errorf("agent-runtime not configured in SandboxSet"), "SkipInitRuntime is false but no agent-runtime found, skip InitRuntime",
-				"sandboxSet", klog.KObj(sandboxSet), "claim", klog.KObj(claim))
+			klog.ErrorS(fmt.Errorf("agent-runtime not configured in SandboxSet"), "SkipInitRuntime is false but no agent-runtime found, skip InitRuntime",
+				"sandboxSet", klog.KObj(sandboxSet), "sandboxClaim", klog.KObj(claim))
 		}
 	}
 	if len(claim.Spec.DynamicVolumesMount) > 0 {
@@ -355,7 +364,7 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 			driverName, csiReqConfigRaw, genErr := csiClient.CSIMountOptionsConfig(ctx, mountConfig)
 			if genErr != nil {
 				errMsg := "failed to generate csi mount options config for sandbox"
-				logger.Error(genErr, errMsg, "mountConfigRequest", mountConfig)
+				klog.ErrorS(genErr, errMsg, "sandboxClaim", klog.KObj(claim), "mountConfigRequest", mountConfig)
 				return opts, fmt.Errorf("%s, err: %v", errMsg, genErr)
 			}
 			csiMountOptions = append(csiMountOptions, config.MountConfig{
@@ -370,7 +379,7 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 		// json marshal csi mount config to raw string
 		csiMountOptionsRaw, err := json.Marshal(claim.Spec.DynamicVolumesMount)
 		if err != nil {
-			logger.Error(err, "failed to marshal csi mount config")
+			klog.ErrorS(err, "Failed to marshal csi mount config", "sandboxClaim", klog.KObj(claim))
 			return opts, fmt.Errorf("failed to marshal csi mount config, err: %v", err)
 		}
 		opts.CSIMount.MountOptionListRaw = string(csiMountOptionsRaw)
@@ -386,7 +395,6 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 
 // countClaimedSandboxes counts sandboxes that are claimed by this claim
 func (c *commonControl) countClaimedSandboxes(ctx context.Context, claim *agentsv1alpha1.SandboxClaim) (int32, error) {
-	log := logf.FromContext(ctx)
 	sandboxes, err := c.cache.ListSandboxes(ctx, cache.ListSandboxesOptions{
 		User:      string(claim.UID),
 		Namespace: claim.Namespace,
@@ -398,7 +406,7 @@ func (c *commonControl) countClaimedSandboxes(ctx context.Context, claim *agents
 	for _, sbx := range sandboxes {
 		state, reason := stateutils.GetSandboxState(sbx)
 		if state == agentsv1alpha1.SandboxStateDead {
-			log.Info("skip counting dead sandbox", "reason", reason)
+			klog.InfoS("Skip counting dead sandbox", "sandboxClaim", klog.KObj(claim), "reason", reason)
 			continue
 		}
 		cnt++

--- a/pkg/controller/sandboxclaim/core/common_control_events_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_events_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/cache/cachetest"
+	"github.com/openkruise/agents/pkg/controller/events"
+)
+
+// drainEvents collects all events currently buffered in the recorder without blocking.
+func drainEvents(rec *record.FakeRecorder) []string {
+	var got []string
+	for {
+		select {
+		case e := <-rec.Events:
+			got = append(got, e)
+		default:
+			return got
+		}
+	}
+}
+
+// containsEvent reports whether any of evts contains substr.
+func containsEvent(evts []string, substr string) bool {
+	for _, e := range evts {
+		if strings.Contains(e, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCommonControl_EnsureClaimClaiming_BindingEventGuard verifies that the
+// SandboxClaimBinding event is emitted only on the first transition into the
+// Claiming phase and is suppressed on subsequent reconciles while the claim is
+// already in Claiming, preventing event spam on retries.
+func TestCommonControl_EnsureClaimClaiming_BindingEventGuard(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	tests := []struct {
+		name              string
+		currentPhase      agentsv1alpha1.SandboxClaimPhase
+		expectBindingFire bool
+	}{
+		{
+			name:              "first entry into Claiming emits SandboxClaimBinding",
+			currentPhase:      "",
+			expectBindingFire: true,
+		},
+		{
+			name:              "already in Claiming suppresses SandboxClaimBinding",
+			currentPhase:      agentsv1alpha1.SandboxClaimPhaseClaiming,
+			expectBindingFire: false,
+		},
+		{
+			name:              "transition from Completed back to Claiming emits SandboxClaimBinding",
+			currentPhase:      agentsv1alpha1.SandboxClaimPhaseCompleted,
+			expectBindingFire: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claim := &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "guard-claim",
+					Namespace: "default",
+					UID:       "guard-uid",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "guard-set",
+					Replicas:     int32Ptr(2),
+				},
+				Status: agentsv1alpha1.SandboxClaimStatus{
+					Phase:           tt.currentPhase,
+					ClaimedReplicas: 0,
+				},
+			}
+			sbs := &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "guard-set",
+					Namespace: "default",
+				},
+			}
+
+			cache, fakeClient, err := cachetest.NewTestCache(t, claim, sbs)
+			require.NoError(t, err)
+
+			rec := record.NewFakeRecorder(20)
+			ctrl := NewCommonControl(fakeClient, rec, cache)
+
+			args := ClaimArgs{
+				Claim:      claim,
+				SandboxSet: sbs,
+				NewStatus: &agentsv1alpha1.SandboxClaimStatus{
+					Phase:           agentsv1alpha1.SandboxClaimPhaseClaiming,
+					ClaimedReplicas: 0,
+				},
+			}
+
+			_, ensureErr := ctrl.EnsureClaimClaiming(context.Background(), args)
+			assert.NoError(t, ensureErr)
+
+			evts := drainEvents(rec)
+			fired := containsEvent(evts, events.SandboxClaimBinding)
+			assert.Equal(t, tt.expectBindingFire, fired,
+				"SandboxClaimBinding fire mismatch, got events: %v", evts)
+		})
+	}
+}
+
+// TestCommonControl_EnsureClaimCompleted_DeleteFailure exercises the error
+// branch where the underlying client.Delete fails after TTL expires. The TTL
+// delete event must still be recorded and the original delete error must be
+// propagated unchanged so the controller-runtime exponential backoff kicks in.
+func TestCommonControl_EnsureClaimCompleted_DeleteFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	claim := &agentsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ttl-fail-claim",
+			Namespace: "default",
+		},
+		Spec: agentsv1alpha1.SandboxClaimSpec{
+			TemplateName:      "fail-set",
+			TTLAfterCompleted: &metav1.Duration{Duration: 5 * time.Second},
+		},
+	}
+
+	pastCompletion := metav1.NewTime(time.Now().Add(-30 * time.Second))
+	newStatus := &agentsv1alpha1.SandboxClaimStatus{
+		Phase:          agentsv1alpha1.SandboxClaimPhaseCompleted,
+		CompletionTime: &pastCompletion,
+	}
+
+	wantErr := fmt.Errorf("simulated delete failure")
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(claim).
+		WithStatusSubresource(&agentsv1alpha1.SandboxClaim{}).
+		Build()
+	wrapped := interceptor.NewClient(base, interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			return wantErr
+		},
+	})
+
+	rec := record.NewFakeRecorder(10)
+	ctrl := NewCommonControl(wrapped, rec, nil)
+
+	strategy, err := ctrl.EnsureClaimCompleted(context.Background(), ClaimArgs{
+		Claim:     claim,
+		NewStatus: newStatus,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "simulated delete failure")
+	assert.False(t, strategy.Immediate, "should not requeue immediately when delete fails")
+	assert.Equal(t, time.Duration(0), strategy.After, "should rely on caller backoff after delete error")
+
+	evts := drainEvents(rec)
+	assert.True(t, containsEvent(evts, events.SandboxClaimTTLDelete),
+		"SandboxClaimTTLDelete event expected before delete error, got events: %v", evts)
+}
+
+// TestCommonControl_EnsureClaimCompleted_NegativeTTLNoEvent asserts that a
+// negative TTL short-circuits without emitting deletion events even when the
+// completion time is far in the past. This guards against accidental event
+// emission for the "never delete" configuration semantics.
+func TestCommonControl_EnsureClaimCompleted_NegativeTTLNoEvent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	claim := &agentsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "never-delete-claim",
+			Namespace: "default",
+		},
+		Spec: agentsv1alpha1.SandboxClaimSpec{
+			TemplateName:      "neg-set",
+			TTLAfterCompleted: &metav1.Duration{Duration: -1 * time.Second},
+		},
+	}
+	completion := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+	newStatus := &agentsv1alpha1.SandboxClaimStatus{
+		Phase:          agentsv1alpha1.SandboxClaimPhaseCompleted,
+		CompletionTime: &completion,
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(claim).
+		WithStatusSubresource(&agentsv1alpha1.SandboxClaim{}).
+		Build()
+	rec := record.NewFakeRecorder(10)
+	ctrl := NewCommonControl(fakeClient, rec, nil)
+
+	strategy, err := ctrl.EnsureClaimCompleted(context.Background(), ClaimArgs{
+		Claim:     claim,
+		NewStatus: newStatus,
+	})
+	require.NoError(t, err)
+	assert.False(t, strategy.Immediate)
+	assert.Equal(t, time.Duration(0), strategy.After)
+
+	evts := drainEvents(rec)
+	assert.False(t, containsEvent(evts, events.SandboxClaimTTLDelete),
+		"negative TTL must not emit SandboxClaimTTLDelete, got events: %v", evts)
+}

--- a/pkg/controller/sandboxclaim/sandboxclaim_controller.go
+++ b/pkg/controller/sandboxclaim/sandboxclaim_controller.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"reflect"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,13 +36,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	infracache "github.com/openkruise/agents/pkg/cache"
+	"github.com/openkruise/agents/pkg/controller/events"
 	"github.com/openkruise/agents/pkg/controller/sandboxclaim/core"
 	"github.com/openkruise/agents/pkg/discovery"
 	"github.com/openkruise/agents/pkg/features"
@@ -112,8 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
-	logger := logf.FromContext(ctx).WithValues("sandboxclaim", klog.KObj(claim))
-	logger.Info("Began to process SandboxClaim for reconcile")
+	klog.InfoS("Began to process SandboxClaim for reconcile", "sandboxClaim", klog.KObj(claim))
 
 	// Record sandbox claim lifecycle metrics on every reconcile
 	recordSandboxClaimMetrics(claim)
@@ -122,10 +122,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	core.ResourceVersionExpectations.Observe(claim)
 	if isSatisfied, unsatisfiedDuration := core.ResourceVersionExpectations.IsSatisfied(claim); !isSatisfied {
 		if unsatisfiedDuration < expectations.ExpectationTimeout {
-			logger.Info("Not satisfied resourceVersion for SandboxClaim, wait for cache event")
+			klog.InfoS("Not satisfied resourceVersion for SandboxClaim, wait for cache event", "sandboxClaim", klog.KObj(claim))
 			return reconcile.Result{RequeueAfter: expectations.ExpectationTimeout - unsatisfiedDuration}, nil
 		}
-		logger.Info("Expectation unsatisfied overtime for SandboxClaim, wait for cache event timeout", "timeout", unsatisfiedDuration)
+		klog.InfoS("Expectation unsatisfied overtime for SandboxClaim, wait for cache event timeout", "sandboxClaim", klog.KObj(claim), "timeout", unsatisfiedDuration)
 		core.ResourceVersionExpectations.Delete(claim)
 	}
 
@@ -137,7 +137,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	sandboxSetKey := client.ObjectKey{Namespace: claim.Namespace, Name: claim.Spec.TemplateName}
 	if err := r.Get(ctx, sandboxSetKey, sandboxSet); err != nil {
 		if errors.IsNotFound(err) {
-			logger.Info("SandboxSet not found, marking claim as completed")
+			klog.InfoS("SandboxSet not found, marking claim as completed", "sandboxClaim", klog.KObj(claim), "sandboxSet", claim.Spec.TemplateName)
 			core.TransitionToCompleted(newStatus, "SandboxSetNotFound",
 				fmt.Sprintf("SandboxSet %s not found", claim.Spec.TemplateName))
 			return ctrl.Result{}, r.updateClaimStatus(ctx, *newStatus, claim)
@@ -171,32 +171,32 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		strategy, err = r.getControl().EnsureClaimCompleted(ctx, args)
 
 	default:
-		logger.Info("Unknown phase encountered", "phase", newStatus.Phase)
-		r.recorder.Event(claim, "Warning", "UnknownPhase",
+		klog.InfoS("Unknown phase encountered", "sandboxClaim", klog.KObj(claim), "phase", newStatus.Phase)
+		r.recorder.Event(claim, corev1.EventTypeWarning, events.UnknownPhase,
 			fmt.Sprintf("Unknown phase: %s", newStatus.Phase))
 		return ctrl.Result{}, nil
 	}
 
 	if err != nil {
 		// Return error to controller-runtime for exponential backoff retry
-		logger.Error(err, "Failed to ensure claim, will retry with backoff")
+		klog.ErrorS(err, "Failed to ensure claim, will retry with backoff", "sandboxClaim", klog.KObj(claim))
 		return reconcile.Result{}, err
 	}
 
 	// Update status after successful execution
 	// If update fails, return error to trigger retry (but lose calculated strategy)
 	if err := r.updateClaimStatus(ctx, *newStatus, claim); err != nil {
-		logger.Error(err, "Failed to update status, will retry")
+		klog.ErrorS(err, "Failed to update status, will retry", "sandboxClaim", klog.KObj(claim))
 		return ctrl.Result{}, err
 	}
 
 	// Convert RequeueStrategy to ctrl.Result
 	if strategy.Immediate {
-		logger.V(1).Info("Immediate requeue requested")
+		klog.V(1).InfoS("Immediate requeue requested", "sandboxClaim", klog.KObj(claim))
 		return ctrl.Result{Requeue: true}, nil
 	}
 	if strategy.After > 0 {
-		logger.V(1).Info("Delayed requeue requested", "after", strategy.After)
+		klog.V(1).InfoS("Delayed requeue requested", "sandboxClaim", klog.KObj(claim), "after", strategy.After)
 		return ctrl.Result{RequeueAfter: strategy.After}, nil
 	}
 	// No requeue, wait for Watch events
@@ -208,8 +208,6 @@ func (r *Reconciler) getControl() core.ClaimControl {
 }
 
 func (r *Reconciler) updateClaimStatus(ctx context.Context, newStatus agentsv1alpha1.SandboxClaimStatus, claim *agentsv1alpha1.SandboxClaim) error {
-	logger := logf.FromContext(ctx).WithValues("sandboxclaim", klog.KObj(claim))
-
 	if reflect.DeepEqual(claim.Status, newStatus) {
 		return nil
 	}
@@ -226,14 +224,14 @@ func (r *Reconciler) updateClaimStatus(ctx context.Context, newStatus agentsv1al
 
 	err := client.IgnoreNotFound(r.Status().Patch(ctx, rcvObject, client.RawPatch(types.MergePatchType, []byte(patchStatus))))
 	if err != nil {
-		logger.Error(err, "update sandboxclaim status failed", "patchStatus", patchStatus)
+		klog.ErrorS(err, "Update sandboxclaim status failed", "sandboxClaim", klog.KObj(claim), "patchStatus", patchStatus)
 		return err
 	}
 
 	// Set expectation for resource version
 	core.ResourceVersionExpectations.Expect(rcvObject)
 
-	logger.Info("update sandboxclaim status success", "status", utils.DumpJson(newStatus))
+	klog.InfoS("Update sandboxclaim status success", "sandboxClaim", klog.KObj(claim), "status", utils.DumpJson(newStatus))
 	return nil
 }
 

--- a/pkg/controller/sandboxclaim/sandboxclaim_events_test.go
+++ b/pkg/controller/sandboxclaim/sandboxclaim_events_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandboxclaim
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/controller/events"
+	"github.com/openkruise/agents/pkg/controller/sandboxclaim/core"
+)
+
+func TestSandboxClaimLifecycleEvents(t *testing.T) {
+	tests := []struct {
+		name         string
+		claim        *agentsv1alpha1.SandboxClaim
+		sandboxSet   *agentsv1alpha1.SandboxSet
+		expectEvents []string
+	}{
+		{
+			name: "completed claim with TTL expired emits SandboxClaimTTLDelete event",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "ttl-claim",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:       "test-sandboxset",
+					Replicas:           int32Ptr(1),
+					TTLAfterCompleted:  &metav1.Duration{Duration: 1 * time.Second},
+				},
+				Status: agentsv1alpha1.SandboxClaimStatus{
+					Phase:           agentsv1alpha1.SandboxClaimPhaseCompleted,
+					ClaimedReplicas: 1,
+					CompletionTime: &metav1.Time{
+						Time: time.Now().Add(-5 * time.Second), // Completed 5s ago
+					},
+					ClaimStartTime: &metav1.Time{
+						Time: time.Now().Add(-10 * time.Second),
+					},
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandboxset",
+					Namespace: "default",
+				},
+			},
+			expectEvents: []string{events.SandboxClaimTTLDelete},
+		},
+		{
+			name: "claim with unknown phase emits UnknownPhase event",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "unknown-phase-claim",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "test-sandboxset",
+					Replicas:     int32Ptr(1),
+				},
+				Status: agentsv1alpha1.SandboxClaimStatus{
+					Phase: "SomeInvalidPhase",
+					ClaimStartTime: &metav1.Time{
+						Time: time.Now(),
+					},
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandboxset",
+					Namespace: "default",
+				},
+			},
+			expectEvents: []string{events.UnknownPhase},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = agentsv1alpha1.AddToScheme(scheme)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.claim, tt.sandboxSet).
+				WithStatusSubresource(&agentsv1alpha1.SandboxClaim{}).
+				Build()
+
+			fakeRecorder := record.NewFakeRecorder(100)
+
+			reconciler := &Reconciler{
+				Client:   fakeClient,
+				Scheme:   scheme,
+				controls: core.NewClaimControl(fakeClient, fakeRecorder, nil),
+				recorder: fakeRecorder,
+			}
+
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      tt.claim.Name,
+					Namespace: tt.claim.Namespace,
+				},
+			}
+
+			_, _ = reconciler.Reconcile(context.Background(), req)
+
+			// Collect all emitted events
+			close(fakeRecorder.Events)
+			var gotEvents []string
+			for e := range fakeRecorder.Events {
+				gotEvents = append(gotEvents, e)
+			}
+
+			// Verify expected events
+			for _, expected := range tt.expectEvents {
+				found := false
+				for _, got := range gotEvents {
+					if strings.Contains(got, expected) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected event containing %q not found in %v", expected, gotEvents)
+			}
+		})
+	}
+}

--- a/pkg/controller/sandboxset/rolling_update.go
+++ b/pkg/controller/sandboxset/rolling_update.go
@@ -22,13 +22,14 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/controller/events"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
@@ -154,9 +155,8 @@ func getMaxUnavailablePods(sbs *agentsv1alpha1.SandboxSet, replicas int) int {
 }
 
 // logUpdateInfo logs the update info for debugging.
-func logUpdateInfo(ctx context.Context, info *UpdateInfo) {
-	log := logf.FromContext(ctx)
-	log.Info("update info calculated",
+func logUpdateInfo(_ context.Context, info *UpdateInfo) {
+	klog.InfoS("Update info calculated",
 		"currentUpdated", info.CurrentUpdated,
 		"toUpdate", info.ToUpdate,
 		"allowedUnavailable", info.AllowedUnavailable)
@@ -170,7 +170,6 @@ func (r *Reconciler) performRollingUpdate(
 	updateGroups *UpdateGroupedSandboxes,
 	updateInfo *UpdateInfo,
 ) (int, error) {
-	log := logf.FromContext(ctx)
 	controllerKey := GetControllerKey(sbs)
 	lock := uuid.New().String()
 	logUpdateInfo(ctx, updateInfo)
@@ -194,13 +193,13 @@ func (r *Reconciler) performRollingUpdate(
 		successes, err := utils.DoItSlowlyWithInputs(oldCreating, initialBatchSize, deleteFunc)
 		totalDeleted += successes
 		if err != nil {
-			log.Error(err, "failed to delete some old creating sandboxes", "success", successes, "fails", len(oldCreating)-successes)
+			klog.ErrorS(err, "Failed to delete some old creating sandboxes", "sandboxSet", klog.KObj(sbs), "success", successes, "fails", len(oldCreating)-successes)
 			return totalDeleted, err
 		}
 	}
 
 	if len(updateGroups.OldAvailable) <= 0 {
-		log.Info("no old available sandboxes to delete")
+		klog.InfoS("No old available sandboxes to delete", "sandboxSet", klog.KObj(sbs))
 		return totalDeleted, nil
 	}
 
@@ -208,7 +207,7 @@ func (r *Reconciler) performRollingUpdate(
 	// Delete old available pods based on unavailable budget.
 	// New sandboxes will be created by scaleUp in the next reconcile.
 	deleteCount = min(updateInfo.AllowedUnavailable, len(updateGroups.OldAvailable))
-	log.Info("rolling update plan", "deleteCount", deleteCount)
+	klog.InfoS("Rolling update plan", "sandboxSet", klog.KObj(sbs), "deleteCount", deleteCount)
 
 	// Delete old available sandboxes in batches
 	if deleteCount > 0 {
@@ -218,7 +217,7 @@ func (r *Reconciler) performRollingUpdate(
 		successes, err := utils.DoItSlowlyWithInputs(toDelete, initialBatchSize, deleteFunc)
 		totalDeleted += successes
 		if err != nil {
-			log.Error(err, "failed to delete some old available sandboxes", "success", successes, "fails", deleteCount-successes)
+			klog.ErrorS(err, "Failed to delete some old available sandboxes", "sandboxSet", klog.KObj(sbs), "success", successes, "fails", deleteCount-successes)
 			return totalDeleted, err
 		}
 	}
@@ -228,14 +227,13 @@ func (r *Reconciler) performRollingUpdate(
 
 // deleteSandboxForUpdate deletes a sandbox as part of rolling update.
 func (r *Reconciler) deleteSandboxForUpdate(ctx context.Context, sbs *agentsv1alpha1.SandboxSet, sbx *agentsv1alpha1.Sandbox, lock string) error {
-	log := logf.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
-	log.V(consts.DebugLogLevel).Info("deleting sandbox for rolling update")
+	klog.V(consts.DebugLogLevel).InfoS("Deleting sandbox for rolling update", "sandboxSet", klog.KObj(sbs), "sandbox", klog.KObj(sbx))
 
 	if sbx.DeletionTimestamp != nil {
 		return nil
 	}
 	if sbx.Annotations[agentsv1alpha1.AnnotationLock] != "" && sbx.Annotations[agentsv1alpha1.AnnotationOwner] != consts.OwnerManagerScaleDown {
-		log.Info("sandbox to be deleted claimed before performed, skip")
+		klog.InfoS("Sandbox to be deleted claimed before performed, skip", "sandboxSet", klog.KObj(sbs), "sandbox", klog.KObj(sbx))
 		return errors.New("sandbox to be deleted claimed before performed, skip")
 	}
 
@@ -247,10 +245,10 @@ func (r *Reconciler) deleteSandboxForUpdate(ctx context.Context, sbs *agentsv1al
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		log.Error(err, "failed to delete sandbox for rolling update")
+		klog.ErrorS(err, "Failed to delete sandbox for rolling update", "sandboxSet", klog.KObj(sbs), "sandbox", klog.KObj(sbx))
 		return err
 	}
 
-	r.Recorder.Eventf(sbs, "Normal", "RollingUpdate", "Deleted sandbox %s for update", klog.KObj(sbx))
+	r.Recorder.Eventf(sbs, corev1.EventTypeNormal, events.SandboxSetRollingUpdate, "Deleted sandbox %s for update", klog.KObj(sbx))
 	return nil
 }

--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -333,7 +333,7 @@ func (r *Reconciler) createSandbox(ctx context.Context, sbs *agentsv1alpha1.Sand
 			Namespace: sbs.Namespace,
 			Name:      sbs.Spec.TemplateRef.Name,
 		}, refTemplate); err != nil {
-			r.Recorder.Eventf(sbs, corev1.EventTypeWarning, EventCreateSandboxFailed, "Failed to resolve sandbox template: %s", err)
+			r.Recorder.Eventf(sbs, corev1.EventTypeWarning, events.CreateSandboxFailed, "Failed to resolve sandbox template: %s", err)
 			return nil, fmt.Errorf("failed to resolve sandbox template %s/%s: %w",
 				sbs.Namespace, sbs.Spec.TemplateRef.Name, err)
 		}

--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -38,10 +38,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/controller/events"
 	"github.com/openkruise/agents/pkg/discovery"
 	"github.com/openkruise/agents/pkg/features"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
@@ -87,13 +87,6 @@ type Reconciler struct {
 	Codec    runtime.Codec
 }
 
-const (
-	EventSandboxCreated       = "SandboxCreated"
-	EventCreateSandboxFailed  = "CreateSandboxFailed"
-	EventSandboxScaledDown    = "SandboxScaledDown"
-	EventFailedSandboxDeleted = "FailedSandboxDeleted"
-)
-
 // +kubebuilder:rbac:groups=agents.kruise.io,resources=sandboxsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=agents.kruise.io,resources=sandboxsets/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=agents.kruise.io,resources=sandboxsets/finalizers,verbs=update
@@ -101,8 +94,7 @@ const (
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	totalStart := time.Now()
-	log := logf.FromContext(ctx).WithValues("sandboxset", req.NamespacedName)
-	ctx = logf.IntoContext(ctx, log)
+	klog.InfoS("Reconciling SandboxSet", "sandboxSet", req.NamespacedName)
 	sbs := &agentsv1alpha1.SandboxSet{}
 	if err := r.Get(ctx, req.NamespacedName, sbs); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -120,14 +112,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Preparation
 	newStatus, err := r.initNewStatus(ctx, sbs)
 	if err != nil {
-		log.Error(err, "failed to init new status")
+		klog.ErrorS(err, "Failed to init new status", "sandboxSet", klog.KObj(sbs))
 		return ctrl.Result{}, err
 	}
 
 	controllerKey := GetControllerKey(sbs)
 	groups, err := r.groupAllSandboxes(ctx, sbs)
 	if err != nil {
-		log.Error(err, "failed to group sandboxes")
+		klog.ErrorS(err, "Failed to group sandboxes", "sandboxSet", klog.KObj(sbs))
 		return ctrl.Result{}, err
 	}
 	var requeueAfter time.Duration
@@ -145,7 +137,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			},
 		})
 		if err != nil {
-			log.Error(err, "failed to generate selector")
+			klog.ErrorS(err, "Failed to generate selector", "sandboxSet", klog.KObj(sbs))
 		} else {
 			newStatus.Selector = selector.String()
 		}
@@ -155,31 +147,31 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Step 1: perform scale
 	start := time.Now()
 	delta := calculateScaleDelta(sbs, newStatus)
-	log.Info("performing scale", "expect", sbs.Spec.Replicas, "actual", newStatus.Replicas,
+	klog.InfoS("Performing scale", "sandboxSet", klog.KObj(sbs), "expect", sbs.Spec.Replicas, "actual", newStatus.Replicas,
 		"available", newStatus.AvailableReplicas, "delta", delta)
 	if delta > 0 {
 		err = r.scaleUp(ctx, delta, sbs, newStatus.UpdateRevision)
 	} else if delta < 0 {
 		if !scaleUpSatisfied || !scaleDownSatisfied {
-			log.Info("skip scale down for scaleUpExpectation or scaleDownExpectation is not satisfied")
+			klog.InfoS("Skip scale down for expectations not satisfied", "sandboxSet", klog.KObj(sbs))
 		} else {
 			err = r.scaleDown(ctx, -delta, sbs, groups, newStatus.UpdateRevision)
 		}
 	}
 	if err != nil {
-		log.Error(err, "failed to perform scale", "cost", time.Since(start))
+		klog.ErrorS(err, "Failed to perform scale", "sandboxSet", klog.KObj(sbs), "cost", time.Since(start))
 		allErrors = errors.Join(allErrors, err)
 	} else {
-		log.Info("scale finished", "cost", time.Since(start))
+		klog.InfoS("Scale finished", "sandboxSet", klog.KObj(sbs), "cost", time.Since(start))
 	}
 
 	// Step 2: delete dead sandboxes
 	start = time.Now()
 	if err = r.deleteDeadSandboxes(ctx, groups.Dead); err != nil {
-		log.Error(err, "failed to perform garbage collection")
+		klog.ErrorS(err, "Failed to perform garbage collection", "sandboxSet", klog.KObj(sbs))
 		allErrors = errors.Join(allErrors, err)
 	} else {
-		log.Info("all dead sandboxes deleted", "cost", time.Since(start))
+		klog.InfoS("All dead sandboxes deleted", "sandboxSet", klog.KObj(sbs), "cost", time.Since(start))
 	}
 
 	// Step 3: perform rolling update if needed
@@ -187,7 +179,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if delta == 0 && scaleUpSatisfied && scaleDownSatisfied {
 		updateGroups := buildUpdateGroups(groups, newStatus.UpdateRevision)
 		if updateGroups == nil {
-			log.Info("skip rolling update: scale expectations not satisfied, waiting for pending operations")
+			klog.InfoS("Skip rolling update: scale expectations not satisfied", "sandboxSet", klog.KObj(sbs))
 		} else if needsUpdate(updateGroups) {
 			start = time.Now()
 			updateInfo := calculateUpdateInfo(sbs, updateGroups)
@@ -196,25 +188,32 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			newStatus.UpdatedAvailableReplicas = int32(len(updateGroups.UpdatedAvailable))
 
 			if !isUpdateComplete(updateInfo) {
-				log.Info("performing rolling update", "toUpdate", updateInfo.ToUpdate)
+				klog.InfoS("Performing rolling update", "sandboxSet", klog.KObj(sbs), "toUpdate", updateInfo.ToUpdate)
+				r.Recorder.Eventf(sbs, corev1.EventTypeNormal, events.SandboxSetRollingUpdate, "Rolling update started, %d sandboxes to update", updateInfo.ToUpdate)
 				deleted, err := r.performRollingUpdate(ctx, sbs, updateGroups, updateInfo)
 				if err != nil {
-					log.Error(err, "failed to perform rolling update")
+					klog.ErrorS(err, "Failed to perform rolling update", "sandboxSet", klog.KObj(sbs))
 					allErrors = errors.Join(allErrors, err)
 				} else {
-					log.Info("rolling update step finished", "deleted", deleted, "cost", time.Since(start))
+					klog.InfoS("Rolling update step finished", "sandboxSet", klog.KObj(sbs), "deleted", deleted, "cost", time.Since(start))
 				}
 			}
 		} else {
 			// All sandboxes are up to date
 			newStatus.UpdatedReplicas = newStatus.Replicas
 			newStatus.UpdatedAvailableReplicas = newStatus.AvailableReplicas
+			// Only emit completion event when transitioning from an in-progress rolling update
+			if sbs.Status.UpdatedReplicas < sbs.Status.Replicas {
+				klog.InfoS("All sandboxes are up to date", "sandboxSet", klog.KObj(sbs))
+				r.Recorder.Eventf(sbs, corev1.EventTypeNormal, events.SandboxSetRollingUpdateCompleted,
+					"Rolling update completed, all sandboxes are up to date")
+			}
 		}
 	}
 
-	log.Info("reconcile done", "totalCost", time.Since(totalStart))
+	klog.InfoS("Reconcile done", "sandboxSet", klog.KObj(sbs), "totalCost", time.Since(totalStart))
 	if err = r.updateSandboxSetStatus(ctx, *newStatus, sbs); err != nil {
-		log.Error(err, "failed to update sandboxset status")
+		klog.ErrorS(err, "Failed to update sandboxset status", "sandboxSet", klog.KObj(sbs))
 		allErrors = errors.Join(allErrors, err)
 	}
 	return ctrl.Result{RequeueAfter: requeueAfter}, allErrors
@@ -222,28 +221,28 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 // scaleUp is allowed when scaleUpExpectation is satisfied
 func (r *Reconciler) scaleUp(ctx context.Context, count int, sbs *agentsv1alpha1.SandboxSet, revision string) error {
-	log := logf.FromContext(ctx)
-	log.Info("scale up", "count", count)
+	klog.InfoS("Scaling up SandboxSet", "sandboxSet", klog.KObj(sbs), "count", count)
+	r.Recorder.Eventf(sbs, corev1.EventTypeNormal, events.SandboxSetScalingUp, "Scaling up SandboxSet from %d to %d replicas", int(sbs.Spec.Replicas)-count, int(sbs.Spec.Replicas))
 	successes, err := utils.DoItSlowly(count, initialBatchSize, func() error {
 		created, err := r.createSandbox(ctx, sbs, revision)
 		if err != nil {
-			log.Error(err, "failed to create sandbox")
+			klog.ErrorS(err, "Failed to create sandbox", "sandboxSet", klog.KObj(sbs))
 			return err
 		}
-		log.V(consts.DebugLogLevel).Info("sandbox created", "sandbox", klog.KObj(created))
+		klog.V(consts.DebugLogLevel).InfoS("Sandbox created", "sandboxSet", klog.KObj(sbs), "sandbox", klog.KObj(created))
 		return nil
 	})
-	log.Info("scale up finished", "successes", successes, "fails", count-successes)
+	klog.InfoS("Scale up finished", "sandboxSet", klog.KObj(sbs), "successes", successes, "fails", count-successes)
 	return err
 }
 
 // scaleDown is allowed when both scaleUpExpectation and scaleDownExpectation are satisfied.
 // It prioritizes deleting old revision sandboxes first, then updated ones.
 func (r *Reconciler) scaleDown(ctx context.Context, count int, sbs *agentsv1alpha1.SandboxSet, groups GroupedSandboxes, updateRevision string) error {
-	log := logf.FromContext(ctx)
 	controllerKey := GetControllerKey(sbs)
 	lock := uuid.New().String()
-	log.Info("scale down", "count", count)
+	klog.InfoS("Scaling down SandboxSet", "sandboxSet", klog.KObj(sbs), "count", count)
+	r.Recorder.Eventf(sbs, corev1.EventTypeNormal, events.SandboxSetScalingDown, "Scaling down SandboxSet from %d to %d replicas", int(sbs.Spec.Replicas)+count, int(sbs.Spec.Replicas))
 
 	// Separate candidates into old revision and updated revision.
 	candidates := append(groups.Creating, groups.Available...)
@@ -261,7 +260,7 @@ func (r *Reconciler) scaleDown(ctx context.Context, count int, sbs *agentsv1alph
 		scaleDownExpectation.ExpectScale(controllerKey, expectations.Delete, key.Name)
 		err := r.scaleDownSandbox(ctx, sbx, lock)
 		if err != nil {
-			log.Error(err, "failed to scale down sandbox")
+			klog.ErrorS(err, "Failed to scale down sandbox", "sandboxSet", klog.KObj(sbs), "sandbox", key.Name)
 			scaleDownExpectation.ObserveScale(controllerKey, expectations.Delete, key.Name)
 		}
 		return err
@@ -273,7 +272,7 @@ func (r *Reconciler) scaleDown(ctx context.Context, count int, sbs *agentsv1alph
 	successes, err := utils.DoItSlowlyWithInputs(oldToDelete, initialBatchSize, deleteFunc)
 	totalSuccesses += successes
 	if err != nil {
-		log.Info("scale down finished", "success", totalSuccesses, "fails", len(oldToDelete)-successes)
+		klog.InfoS("Scale down finished with errors", "sandboxSet", klog.KObj(sbs), "success", totalSuccesses, "fails", len(oldToDelete)-successes)
 		return err
 	}
 
@@ -287,11 +286,11 @@ func (r *Reconciler) scaleDown(ctx context.Context, count int, sbs *agentsv1alph
 	successes, err = utils.DoItSlowlyWithInputs(updatedToDelete, initialBatchSize, deleteFunc)
 	totalSuccesses += successes
 	if err != nil {
-		log.Info("scale down finished", "success", totalSuccesses, "fails", len(updatedToDelete)-successes)
+		klog.InfoS("Scale down finished with errors", "sandboxSet", klog.KObj(sbs), "success", totalSuccesses, "fails", len(updatedToDelete)-successes)
 		return err
 	}
 
-	log.Info("scale down finished", "success", totalSuccesses)
+	klog.InfoS("Scale down finished", "sandboxSet", klog.KObj(sbs), "success", totalSuccesses)
 	return nil
 }
 
@@ -345,19 +344,18 @@ func (r *Reconciler) createSandbox(ctx context.Context, sbs *agentsv1alpha1.Sand
 		return nil, err
 	}
 	if err := r.Create(ctx, sbx); err != nil {
-		r.Recorder.Eventf(sbs, corev1.EventTypeWarning, EventCreateSandboxFailed, "Failed to create sandbox: %s", err)
+		r.Recorder.Eventf(sbs, corev1.EventTypeWarning, events.CreateSandboxFailed, "Failed to create sandbox: %s", err)
 		return nil, err
 	}
 	scaleUpExpectation.ExpectScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
-	r.Recorder.Eventf(sbs, corev1.EventTypeNormal, EventSandboxCreated, "Sandbox %s created", klog.KObj(sbx))
+	r.Recorder.Eventf(sbs, corev1.EventTypeNormal, events.SandboxCreated, "Sandbox %s created", klog.KObj(sbx))
 	return sbx, nil
 }
 
 func (r *Reconciler) scaleDownSandbox(ctx context.Context, sbx *agentsv1alpha1.Sandbox, lock string) (err error) {
-	log := logf.FromContext(ctx).WithValues("sandbox", client.ObjectKeyFromObject(sbx)).V(consts.DebugLogLevel)
-	log.Info("try to scale down sandbox")
+	klog.V(consts.DebugLogLevel).InfoS("Try to scale down sandbox", "sandbox", klog.KObj(sbx))
 	if sbx.Annotations[agentsv1alpha1.AnnotationLock] != "" && sbx.Annotations[agentsv1alpha1.AnnotationOwner] != consts.OwnerManagerScaleDown {
-		log.Info("sandbox to be scaled down claimed before performed, skip")
+		klog.V(consts.DebugLogLevel).InfoS("Sandbox to be scaled down claimed before performed, skip", "sandbox", klog.KObj(sbx))
 		return errors.New("sandbox to be scaled down claimed before performed, skip")
 	}
 	managerutils.LockSandbox(sbx, lock, consts.OwnerManagerScaleDown)
@@ -365,11 +363,11 @@ func (r *Reconciler) scaleDownSandbox(ctx context.Context, sbx *agentsv1alpha1.S
 		return fmt.Errorf("failed to lock sandbox when scaling down: %s", err)
 	}
 	if err = r.Delete(ctx, sbx); err != nil {
-		log.Error(err, "failed to delete sandbox")
+		klog.ErrorS(err, "Failed to delete sandbox", "sandbox", klog.KObj(sbx))
 		return err
 	}
-	log.Info("sandbox locked and deleted")
-	r.Recorder.Eventf(sbx, corev1.EventTypeNormal, EventSandboxScaledDown, "Sandbox %s locked and deleted", klog.KObj(sbx))
+	klog.V(consts.DebugLogLevel).InfoS("Sandbox locked and deleted", "sandbox", klog.KObj(sbx))
+	r.Recorder.Eventf(sbx, corev1.EventTypeNormal, events.SandboxScaledDown, "Sandbox %s locked and deleted", klog.KObj(sbx))
 	return nil
 }
 
@@ -377,18 +375,17 @@ func (r *Reconciler) scaleDownSandbox(ctx context.Context, sbx *agentsv1alpha1.S
 // require maintaining replica counts (or rather, only needs to maintain the dead group's replica count at 0), so just
 // delete all dead sandboxes.
 func (r *Reconciler) deleteDeadSandboxes(ctx context.Context, dead []*agentsv1alpha1.Sandbox) error {
-	log := logf.FromContext(ctx).V(consts.DebugLogLevel)
 	failNum := 0
 	for _, sbx := range dead {
 		if sbx.DeletionTimestamp != nil {
 			continue
 		}
 		if err := r.Delete(ctx, sbx); err != nil {
-			log.Error(err, "failed to delete sandbox")
+			klog.ErrorS(err, "Failed to delete sandbox", "sandbox", klog.KObj(sbx))
 			failNum++
 		}
-		log.Info("sandbox deleted", "sandbox", klog.KObj(sbx))
-		r.Recorder.Eventf(sbx, corev1.EventTypeNormal, EventFailedSandboxDeleted, "Sandbox %s deleted", klog.KObj(sbx))
+		klog.V(consts.DebugLogLevel).InfoS("Sandbox deleted", "sandbox", klog.KObj(sbx))
+		r.Recorder.Eventf(sbx, corev1.EventTypeNormal, events.FailedSandboxDeleted, "Sandbox %s deleted", klog.KObj(sbx))
 	}
 	if failNum > 0 {
 		return fmt.Errorf("failed to delete %d sandboxes", failNum)
@@ -397,10 +394,9 @@ func (r *Reconciler) deleteDeadSandboxes(ctx context.Context, dead []*agentsv1al
 }
 
 func (r *Reconciler) updateSandboxSetStatus(ctx context.Context, newStatus agentsv1alpha1.SandboxSetStatus, sbs *agentsv1alpha1.SandboxSet) error {
-	log := logf.FromContext(ctx).V(consts.DebugLogLevel)
 	clone := sbs.DeepCopy()
 	if err := r.Get(ctx, client.ObjectKey{Namespace: sbs.Namespace, Name: sbs.Name}, clone); err != nil {
-		log.Error(err, "failed to get updated sandboxset from client")
+		klog.ErrorS(err, "Failed to get updated sandboxset from client", "sandboxSet", klog.KObj(sbs))
 		return client.IgnoreNotFound(err)
 	}
 	if reflect.DeepEqual(clone.Status, newStatus) {
@@ -409,7 +405,7 @@ func (r *Reconciler) updateSandboxSetStatus(ctx context.Context, newStatus agent
 	clone.Status = newStatus
 	err := r.Status().Update(ctx, clone)
 	if err == nil {
-		log.Info("update sandboxset status success", "status", utils.DumpJson(newStatus))
+		klog.V(consts.DebugLogLevel).InfoS("Update sandboxset status success", "sandboxSet", klog.KObj(sbs), "status", utils.DumpJson(newStatus))
 		// Update metrics for availableReplicas and replicas
 		sandboxSetReplicas.WithLabelValues(sbs.Namespace, sbs.Name).Set(float64(newStatus.Replicas))
 		sandboxSetAvailableReplicas.WithLabelValues(sbs.Namespace, sbs.Name).Set(float64(newStatus.AvailableReplicas))
@@ -417,13 +413,12 @@ func (r *Reconciler) updateSandboxSetStatus(ctx context.Context, newStatus agent
 		sandboxSetUpdatedReplicas.WithLabelValues(sbs.Namespace, sbs.Name).Set(float64(newStatus.UpdatedReplicas))
 		sandboxSetUpdatedAvailableReplicas.WithLabelValues(sbs.Namespace, sbs.Name).Set(float64(newStatus.UpdatedAvailableReplicas))
 	} else {
-		log.Error(err, "update sandboxset status failed")
+		klog.ErrorS(err, "Update sandboxset status failed", "sandboxSet", klog.KObj(sbs))
 	}
 	return err
 }
 
 func (r *Reconciler) groupAllSandboxes(ctx context.Context, sbs *agentsv1alpha1.SandboxSet) (GroupedSandboxes, error) {
-	log := logf.FromContext(ctx)
 	sandboxList := &agentsv1alpha1.SandboxList{}
 	if err := r.List(ctx, sandboxList,
 		client.InNamespace(sbs.Namespace),
@@ -436,7 +431,6 @@ func (r *Reconciler) groupAllSandboxes(ctx context.Context, sbs *agentsv1alpha1.
 	for i := range sandboxList.Items {
 		sbx := &sandboxList.Items[i]
 		scaleUpExpectation.ObserveScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
-		debugLog := log.V(consts.DebugLogLevel).WithValues("sandbox", sbx.Name)
 		state, reason := stateutils.GetSandboxState(sbx)
 		switch state {
 		case agentsv1alpha1.SandboxStateCreating:
@@ -452,9 +446,9 @@ func (r *Reconciler) groupAllSandboxes(ctx context.Context, sbs *agentsv1alpha1.
 		default: // unknown, impossible, just in case
 			return GroupedSandboxes{}, fmt.Errorf("cannot find state for sandbox %s", sbx.Name)
 		}
-		debugLog.Info("sandbox is grouped", "state", state, "reason", reason)
+		klog.V(consts.DebugLogLevel).InfoS("Sandbox is grouped", "sandboxSet", klog.KObj(sbs), "sandbox", sbx.Name, "state", state, "reason", reason)
 	}
-	log.Info("sandbox group done", "total", len(sandboxList.Items), "creating", len(groups.Creating),
+	klog.InfoS("Sandbox group done", "sandboxSet", klog.KObj(sbs), "total", len(sandboxList.Items), "creating", len(groups.Creating),
 		"available", len(groups.Available), "used", len(groups.Used), "failed", len(groups.Dead))
 	return groups, nil
 }

--- a/pkg/controller/sandboxset/sandboxset_controller_test.go
+++ b/pkg/controller/sandboxset/sandboxset_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/controller/events"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/utils/fieldindex"
 	utils "github.com/openkruise/agents/pkg/utils/sandbox-manager"
@@ -284,7 +285,7 @@ func TestReconcile_DeleteDead(t *testing.T) {
 				createAvailableSandboxes: 1,
 			},
 			replicas:     1,
-			expectEvents: []string{EventFailedSandboxDeleted, EventFailedSandboxDeleted},
+			expectEvents: []string{events.FailedSandboxDeleted, events.FailedSandboxDeleted},
 			checkFunc:    checkFunc(1),
 		},
 		{
@@ -295,7 +296,7 @@ func TestReconcile_DeleteDead(t *testing.T) {
 				createAvailableSandboxes: 1,
 			},
 			replicas:     1,
-			expectEvents: []string{EventFailedSandboxDeleted, EventFailedSandboxDeleted},
+			expectEvents: []string{events.FailedSandboxDeleted, events.FailedSandboxDeleted},
 			checkFunc:    checkFunc(1),
 		},
 	}
@@ -369,7 +370,7 @@ func TestReconcile_BasicScale(t *testing.T) {
 			replicas:             2,
 			expectTotalSandboxes: 2,
 			expectNewSandboxes:   2,
-			expectEvents:         []string{EventSandboxCreated, EventSandboxCreated},
+			expectEvents:         []string{events.SandboxSetScalingUp, events.SandboxCreated, events.SandboxCreated},
 		},
 		{
 			name:     "1 claimed, scale up from 1 to 2",
@@ -382,7 +383,7 @@ func TestReconcile_BasicScale(t *testing.T) {
 			expectStatusAvailable: 1,
 			expectNewSandboxes:    1,
 			expectEvents: []string{
-				EventSandboxCreated,
+				events.SandboxSetScalingUp, events.SandboxCreated, events.SandboxSetRollingUpdateCompleted,
 			},
 		},
 		{
@@ -407,7 +408,7 @@ func TestReconcile_BasicScale(t *testing.T) {
 			expectTotalSandboxes: 6,
 			expectNewSandboxes:   2,
 			expectEvents: []string{
-				EventSandboxCreated, EventSandboxCreated,
+				events.SandboxSetScalingUp, events.SandboxCreated, events.SandboxCreated,
 			},
 		},
 		{
@@ -420,7 +421,7 @@ func TestReconcile_BasicScale(t *testing.T) {
 			expectTotalSandboxes:  2,
 			expectStatusAvailable: 1,
 			expectNewSandboxes:    1,
-			expectEvents:          []string{EventSandboxCreated},
+			expectEvents:          []string{events.SandboxSetScalingUp, events.SandboxCreated, events.SandboxSetRollingUpdateCompleted},
 		},
 		{
 			name:     "1 killed, scale up from 1 to 2, 1 gc",
@@ -432,7 +433,7 @@ func TestReconcile_BasicScale(t *testing.T) {
 			expectTotalSandboxes:  2,
 			expectStatusAvailable: 1,
 			expectNewSandboxes:    1,
-			expectEvents:          []string{EventSandboxCreated, EventFailedSandboxDeleted},
+			expectEvents:          []string{events.SandboxSetScalingUp, events.SandboxCreated, events.FailedSandboxDeleted, events.SandboxSetRollingUpdateCompleted},
 		},
 		{
 			name:     "scale down 1 available",
@@ -442,7 +443,7 @@ func TestReconcile_BasicScale(t *testing.T) {
 			},
 			expectTotalSandboxes:  2,
 			expectStatusAvailable: 2,
-			expectEvents:          []string{EventSandboxScaledDown},
+			expectEvents:          []string{events.SandboxSetScalingDown, events.SandboxScaledDown},
 		},
 		{
 			name:     "scale down 1 creating",
@@ -453,7 +454,7 @@ func TestReconcile_BasicScale(t *testing.T) {
 			},
 			expectTotalSandboxes:  2,
 			expectStatusAvailable: 2,
-			expectEvents:          []string{EventSandboxScaledDown},
+			expectEvents:          []string{events.SandboxSetScalingDown, events.SandboxScaledDown},
 		},
 		{
 			name:     "complex",
@@ -467,9 +468,10 @@ func TestReconcile_BasicScale(t *testing.T) {
 				createDeletedSandboxes:     2, // should gc
 			},
 			expectEvents: []string{
-				EventSandboxCreated,
-				EventFailedSandboxDeleted, EventFailedSandboxDeleted,
-				EventFailedSandboxDeleted, EventFailedSandboxDeleted,
+				events.SandboxSetScalingUp, events.SandboxCreated,
+				events.FailedSandboxDeleted, events.FailedSandboxDeleted,
+				events.FailedSandboxDeleted, events.FailedSandboxDeleted,
+				events.SandboxSetRollingUpdateCompleted,
 			},
 			expectTotalSandboxes:  7,
 			expectStatusAvailable: 2,
@@ -485,7 +487,7 @@ func TestReconcile_BasicScale(t *testing.T) {
 			expectTotalSandboxes:  3,
 			expectStatusAvailable: 1,
 			expectNewSandboxes:    1,
-			expectEvents:          []string{EventSandboxCreated},
+			expectEvents:          []string{events.SandboxSetScalingUp, events.SandboxCreated, events.SandboxSetRollingUpdateCompleted},
 		},
 		{
 			name:     "user story 1, step 2: pause it",
@@ -509,7 +511,7 @@ func TestReconcile_BasicScale(t *testing.T) {
 			expectTotalSandboxes:  4,
 			expectStatusAvailable: 1,
 			expectNewSandboxes:    1,
-			expectEvents:          []string{EventSandboxCreated},
+			expectEvents:          []string{events.SandboxSetScalingUp, events.SandboxCreated, events.SandboxSetRollingUpdateCompleted},
 		},
 		{
 			name:     "user story 1, step 4: claim the third",
@@ -522,7 +524,7 @@ func TestReconcile_BasicScale(t *testing.T) {
 			expectTotalSandboxes:  5,
 			expectStatusAvailable: 1,
 			expectNewSandboxes:    1,
-			expectEvents:          []string{EventSandboxCreated},
+			expectEvents:          []string{events.SandboxSetScalingUp, events.SandboxCreated, events.SandboxSetRollingUpdateCompleted},
 		},
 		{
 			name:     "user story 1, step 5: claim the forth",
@@ -535,7 +537,7 @@ func TestReconcile_BasicScale(t *testing.T) {
 			expectTotalSandboxes:  6,
 			expectStatusAvailable: 1,
 			expectNewSandboxes:    1,
-			expectEvents:          []string{EventSandboxCreated},
+			expectEvents:          []string{events.SandboxSetScalingUp, events.SandboxCreated, events.SandboxSetRollingUpdateCompleted},
 		},
 		{
 			name:     "user story 1, step 6: kill the first",
@@ -623,7 +625,7 @@ func TestReconcile_ScaleDown(t *testing.T) {
 			request: createSandboxRequest{
 				createAvailableSandboxes: 1,
 			},
-			expectEvents: []string{EventSandboxScaledDown},
+			expectEvents: []string{events.SandboxSetScalingDown, events.SandboxScaledDown},
 			checkFunc: func(t *testing.T, sandboxes []v1alpha1.Sandbox) {
 				assert.Equal(t, 0, len(sandboxes))
 			},
@@ -634,7 +636,7 @@ func TestReconcile_ScaleDown(t *testing.T) {
 			request: createSandboxRequest{
 				createCreatingSandboxes: 1,
 			},
-			expectEvents: []string{EventSandboxScaledDown},
+			expectEvents: []string{events.SandboxSetScalingDown, events.SandboxScaledDown},
 			checkFunc: func(t *testing.T, sandboxes []v1alpha1.Sandbox) {
 				assert.Equal(t, 0, len(sandboxes))
 			},
@@ -657,7 +659,7 @@ func TestReconcile_ScaleDown(t *testing.T) {
 				createAvailableSandboxes: 2,
 				createCreatingSandboxes:  2,
 			},
-			expectEvents: []string{EventSandboxScaledDown, EventSandboxScaledDown, EventSandboxScaledDown},
+			expectEvents: []string{events.SandboxSetScalingDown, events.SandboxScaledDown, events.SandboxScaledDown, events.SandboxScaledDown},
 			checkFunc: func(t *testing.T, sandboxes []v1alpha1.Sandbox) {
 				assert.Equal(t, 1, len(sandboxes))
 				// available left
@@ -678,7 +680,8 @@ func TestReconcile_ScaleDown(t *testing.T) {
 			checkFunc: func(t *testing.T, sandboxes []v1alpha1.Sandbox) {
 				assert.Equal(t, 1, len(sandboxes))
 			},
-			expectError: true,
+			expectEvents: []string{events.SandboxSetScalingDown},
+			expectError:  true,
 		},
 		{
 			name:     "scale down manager-owned locked sandboxes",
@@ -690,7 +693,7 @@ func TestReconcile_ScaleDown(t *testing.T) {
 			checkFunc: func(t *testing.T, sandboxes []v1alpha1.Sandbox) {
 				assert.Equal(t, 0, len(sandboxes))
 			},
-			expectEvents: []string{EventSandboxScaledDown},
+			expectEvents: []string{events.SandboxSetScalingDown, events.SandboxScaledDown},
 		},
 	}
 

--- a/pkg/controller/sandboxset/sandboxset_controller_test.go
+++ b/pkg/controller/sandboxset/sandboxset_controller_test.go
@@ -1166,7 +1166,7 @@ func TestReconciler_createSandbox(t *testing.T) {
 				select {
 				case evt := <-eventRecorder.Events:
 					assert.Contains(t, evt, "Warning")
-					assert.Contains(t, evt, EventCreateSandboxFailed)
+					assert.Contains(t, evt, events.CreateSandboxFailed)
 				default:
 					t.Errorf("expected a warning event but got none")
 				}

--- a/pkg/controller/sandboxset/sandboxset_events_test.go
+++ b/pkg/controller/sandboxset/sandboxset_events_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandboxset
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/controller/events"
+)
+
+// TestReconcile_RollingUpdateCompletedEventGuard verifies the state-transition guard
+// added in PR #352: the SandboxSetRollingUpdateCompleted event must be emitted only
+// when transitioning from an in-progress rolling update (UpdatedReplicas < Replicas)
+// to fully updated, not on every reconcile after the rollout is already complete.
+func TestReconcile_RollingUpdateCompletedEventGuard(t *testing.T) {
+	tests := []struct {
+		name string
+		// pre-existing persisted sbs.Status before the reconcile
+		preStatus    v1alpha1.SandboxSetStatus
+		expectEvents []string
+	}{
+		{
+			name: "transition emits completion event",
+			// Status reflects an in-progress rolling update from a previous reconcile:
+			// 2 replicas exist, but none have been counted as updated yet. With all
+			// sandboxes already at the latest revision in the cluster, the next
+			// reconcile must emit RollingUpdateCompleted exactly once.
+			preStatus: v1alpha1.SandboxSetStatus{
+				Replicas:          2,
+				AvailableReplicas: 2,
+				UpdatedReplicas:   0,
+			},
+			expectEvents: []string{events.SandboxSetRollingUpdateCompleted},
+		},
+		{
+			name: "already up to date suppresses event",
+			// Previous reconcile already observed the rollout as complete
+			// (UpdatedReplicas == Replicas). The guard must suppress the event
+			// to avoid duplicate notifications on every steady-state reconcile.
+			preStatus: v1alpha1.SandboxSetStatus{
+				Replicas:          2,
+				AvailableReplicas: 2,
+				UpdatedReplicas:   2,
+			},
+			expectEvents: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sClient := NewClient()
+			eventRecorder := record.NewFakeRecorder(10)
+			reconciler := &Reconciler{
+				Client:   k8sClient,
+				Scheme:   testScheme,
+				Recorder: eventRecorder,
+				Codec:    codec,
+			}
+
+			sbs := getSandboxSet(2)
+			assert.NoError(t, k8sClient.Create(ctx, sbs))
+
+			// Compute the proper UpdateRevision so that pre-created sandboxes match it.
+			newStatus, err := reconciler.initNewStatus(ctx, sbs)
+			assert.NoError(t, err)
+			tt.preStatus.UpdateRevision = newStatus.UpdateRevision
+
+			// Persist the desired pre-reconcile status into the client.
+			sbs.Status = tt.preStatus
+			assert.NoError(t, k8sClient.Status().Update(ctx, sbs))
+
+			// Pre-create 2 available sandboxes already at the latest revision.
+			// This ensures: delta == 0, no rolling update needed, the controller
+			// flows into the "All sandboxes are up to date" branch where the guard lives.
+			CreateSandboxes(t, createSandboxRequest{createAvailableSandboxes: 2}, sbs, k8sClient)
+
+			scaleUpExpectation.DeleteExpectations(GetControllerKey(sbs))
+			scaleDownExpectation.DeleteExpectations(GetControllerKey(sbs))
+
+			_, err = reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(sbs),
+			})
+			assert.NoError(t, err)
+
+			CheckAllEvents(t, eventRecorder, tt.expectEvents)
+		})
+	}
+}
+
+// TestReconcile_RollingUpdateStartEvent verifies that the SandboxSetRollingUpdate
+// event added in PR #352 is emitted when a rolling update actually begins (i.e.
+// some sandboxes still need to be updated).
+func TestReconcile_RollingUpdateStartEvent(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := NewClient()
+	eventRecorder := record.NewFakeRecorder(20)
+	reconciler := &Reconciler{
+		Client:   k8sClient,
+		Scheme:   testScheme,
+		Recorder: eventRecorder,
+		Codec:    codec,
+	}
+
+	sbs := getSandboxSet(3)
+	assert.NoError(t, k8sClient.Create(ctx, sbs))
+
+	// Pre-create sandboxes pinned to an old hash; the controller's UpdateRevision
+	// will be re-computed from the spec, so these will be classified as "old".
+	newStatus, err := reconciler.initNewStatus(ctx, sbs)
+	assert.NoError(t, err)
+	newStatus.UpdateRevision = "old-hash"
+	sbs.Status = *newStatus
+	CreateSandboxes(t, createSandboxRequest{createCreatingSandboxes: 3}, sbs, k8sClient)
+
+	// Reset status revision so initNewStatus re-derives the latest one.
+	sbs.Status.UpdateRevision = ""
+	assert.NoError(t, k8sClient.Status().Update(ctx, sbs))
+
+	scaleUpExpectation.DeleteExpectations(GetControllerKey(sbs))
+	scaleDownExpectation.DeleteExpectations(GetControllerKey(sbs))
+
+	_, err = reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(sbs),
+	})
+	assert.NoError(t, err)
+
+	// Drain events; we expect at least one SandboxSetRollingUpdate event.
+	var sawStart bool
+	for {
+		select {
+		case ev := <-eventRecorder.Events:
+			if containsEvent(ev, corev1.EventTypeNormal, events.SandboxSetRollingUpdate) {
+				sawStart = true
+			}
+			continue
+		default:
+		}
+		break
+	}
+	assert.True(t, sawStart, "expected SandboxSetRollingUpdate event when rolling update begins")
+}
+
+// containsEvent matches the FakeRecorder format "TYPE REASON MESSAGE" with a prefix check.
+func containsEvent(event, tp, reason string) bool {
+	prefix := tp + " " + reason
+	return len(event) >= len(prefix) && event[:len(prefix)] == prefix
+}

--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/controller/events"
 	"github.com/openkruise/agents/pkg/discovery"
 	"github.com/openkruise/agents/pkg/utils/expectations"
 )
@@ -177,12 +178,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	switch {
 	case ops.Status.Phase == "" || ops.Status.Phase == agentsv1alpha1.SandboxUpdateOpsPending:
 		newStatus.Phase = agentsv1alpha1.SandboxUpdateOpsUpdating
+		klog.InfoS("SandboxUpdateOps transitioning from Pending to Updating",
+			"sandboxUpdateOps", klog.KObj(ops), "totalSandboxes", total)
+		r.Recorder.Eventf(ops, v1.EventTypeNormal, events.UpdateOpsStarted,
+			"SandboxUpdateOps %s started updating %d sandboxes", ops.Name, total)
 
 	case updated+failed == total && len(candidates) == 0:
 		if failed > 0 {
 			newStatus.Phase = agentsv1alpha1.SandboxUpdateOpsFailed
+			klog.InfoS("SandboxUpdateOps transitioning to Failed",
+				"sandboxUpdateOps", klog.KObj(ops), "failed", failed, "updated", updated)
+			r.Recorder.Eventf(ops, v1.EventTypeWarning, events.UpdateOpsFailed,
+				"SandboxUpdateOps %s failed with %d failed sandboxes out of %d total", ops.Name, failed, total)
 		} else {
 			newStatus.Phase = agentsv1alpha1.SandboxUpdateOpsCompleted
+			klog.InfoS("SandboxUpdateOps transitioning to Completed",
+				"sandboxUpdateOps", klog.KObj(ops), "updated", updated)
+			r.Recorder.Eventf(ops, v1.EventTypeNormal, events.UpdateOpsCompleted,
+				"SandboxUpdateOps %s completed successfully, %d sandboxes updated", ops.Name, updated)
 		}
 	}
 
@@ -199,14 +212,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 			if err := r.applySandboxPatch(ctx, candidates[i], ops); err != nil {
 				klog.ErrorS(err, "Failed to apply patch to sandbox",
-					"sandbox", klog.KObj(candidates[i]), "ops", klog.KObj(ops))
-				r.Recorder.Eventf(ops, v1.EventTypeWarning, "PatchFailed",
+					"sandbox", klog.KObj(candidates[i]), "sandboxUpdateOps", klog.KObj(ops))
+				r.Recorder.Eventf(ops, v1.EventTypeWarning, events.UpdateOpsFailed,
 					"Failed to patch sandbox %s: %v", candidates[i].Name, err)
 				if patchErr == nil {
 					patchErr = err
 				}
 			} else {
-				r.Recorder.Eventf(ops, v1.EventTypeNormal, "SandboxUpgrading",
+				klog.InfoS("Sandbox upgrade initiated",
+					"sandbox", klog.KObj(candidates[i]), "sandboxUpdateOps", klog.KObj(ops))
+				r.Recorder.Eventf(ops, v1.EventTypeNormal, events.UpdateOpsProgressing,
 					"Upgrading sandbox %s", candidates[i].Name)
 			}
 		}

--- a/pkg/controller/sandboxupdateops/sandboxupdateops_events_test.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_events_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandboxupdateops
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/controller/events"
+)
+
+func TestSandboxUpdateOpsLifecycleEvents(t *testing.T) {
+	tests := []struct {
+		name         string
+		ops          *agentsv1alpha1.SandboxUpdateOps
+		sandboxes    []*agentsv1alpha1.Sandbox
+		expectEvents []string
+	}{
+		{
+			name:      "pending ops with candidates emits UpdateOpsStarted event",
+			ops:       newSandboxUpdateOps("test-ops", "default", agentsv1alpha1.SandboxUpdateOpsPending, false, nil),
+			sandboxes: []*agentsv1alpha1.Sandbox{newSandbox("sbx-1", "default", "", agentsv1alpha1.SandboxRunning, nil)},
+			expectEvents: []string{
+				events.UpdateOpsStarted,
+				events.UpdateOpsProgressing,
+			},
+		},
+		{
+			name: "all sandboxes completed emits UpdateOpsCompleted event",
+			ops:  newSandboxUpdateOps("test-ops", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil),
+			sandboxes: []*agentsv1alpha1.Sandbox{
+				newSandbox("sbx-1", "default", "test-ops", agentsv1alpha1.SandboxRunning, []metav1.Condition{
+					{Type: string(agentsv1alpha1.SandboxConditionUpgrading), Reason: agentsv1alpha1.SandboxUpgradingReasonSucceeded, Status: metav1.ConditionTrue},
+				}),
+			},
+			expectEvents: []string{events.UpdateOpsCompleted},
+		},
+		{
+			name: "sandbox upgrade failure emits UpdateOpsFailed event",
+			ops:  newSandboxUpdateOps("test-ops", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil),
+			sandboxes: []*agentsv1alpha1.Sandbox{
+				newSandbox("sbx-1", "default", "test-ops", agentsv1alpha1.SandboxRunning, []metav1.Condition{
+					{Type: string(agentsv1alpha1.SandboxConditionUpgrading), Reason: agentsv1alpha1.SandboxUpgradingReasonPreUpgradeFailed, Status: metav1.ConditionFalse},
+				}),
+			},
+			expectEvents: []string{events.UpdateOpsFailed},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objs []runtime.Object
+			objs = append(objs, tt.ops)
+			for _, sbx := range tt.sandboxes {
+				objs = append(objs, sbx)
+			}
+
+			// Build reconciler using the existing helper pattern
+			r := newTestReconciler(objs...)
+
+			// Replace recorder with a fresh one so we can inspect events
+			fakeRecorder := record.NewFakeRecorder(100)
+			r.Recorder = fakeRecorder
+
+			_, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: tt.ops.Name, Namespace: tt.ops.Namespace},
+			})
+			assert.NoError(t, err)
+
+			// Collect all emitted events
+			close(fakeRecorder.Events)
+			var gotEvents []string
+			for e := range fakeRecorder.Events {
+				gotEvents = append(gotEvents, e)
+			}
+
+			// Verify expected events
+			for _, expected := range tt.expectEvents {
+				found := false
+				for _, got := range gotEvents {
+					if strings.Contains(got, expected) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected event containing %q not found in %v", expected, gotEvents)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
## Add unified Kubernetes Event emission and structured logging for CRD lifecycle steps

### Background

Currently, Kubernetes Event emission coverage across controllers is inconsistent:

| Controller | Event Coverage | Notes |
|---|---|---|
| SandboxClaim | ~100% | Claim flow well covered |
| SandboxSet | ~80% | Missing scale/update events |
| Sandbox | ~30% | Only in-place update has events |
| SandboxUpdateOps | ~20% | Only 2 basic events |

Additionally, logging uses a mix of `logf.FromContext` and `klog`, lacking a unified structured format for observability.

### Proposal

#### 1. Centralized Event Constants Package

Create `pkg/controller/events/` package defining all Event Reason constants, grouped by entity (Sandbox, SandboxSet, SandboxClaim, SandboxUpdateOps), ensuring global uniqueness and consistent naming.

#### 2. Lifecycle Event Emission

Add Kubernetes Event emission at key lifecycle steps for all controllers:

- **Sandbox**: `PodCreated`, `PodCreateFailed`, `Running`, `Paused`, `Resumed`, `Upgrading`, `Upgraded`, `Failed`, `Deleting`
- **SandboxSet**: `ScalingUp`, `ScalingDown`, `RollingUpdate`, `RollingUpdateCompleted`
- **SandboxClaim**: `ClaimBinding` (+ migrate existing hardcoded strings to constants)
- **SandboxUpdateOps**: `Started`, `Progressing`, `Completed`, `Failed`

#### 3. Unified Structured Logging

Unify all controller logging to `klog.InfoS`/`klog.ErrorS` with structured key-value pairs and `klog.KObj` for Kubernetes object identification.

#### 4. State-Transition Guards

Add guards to prevent duplicate event emission on Reconcile retries — events only fire on actual state transitions.

### Acceptance Criteria

- [ ] All lifecycle events emitted at correct lifecycle points
- [ ] Events only fire on actual state transitions (no spam on retries)
- [ ] Unified `klog` structured logging across all 4 controllers
- [ ] Unit tests for event constant uniqueness and emission verification
- [ ] `go build`, `go vet`, and `go test` all pass