### PR TITLE
feat(observability): add /healthz, /readyz, reconcile metrics, and webhook admission metrics

### DIFF
--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -83,6 +83,7 @@ func main() {
 	var kubeClientQPS float64
 	var kubeClientBurst int
 	var memberlistBindPort int
+	var healthProbeBindAddress string
 	var e2bKeyStorage string
 	var e2bKeyStorageDisableAutoMigrate bool
 
@@ -111,6 +112,8 @@ func main() {
 	pflag.Float64Var(&kubeClientQPS, "kube-client-qps", 500, "QPS for Kubernetes client")
 	pflag.IntVar(&kubeClientBurst, "kube-client-burst", 1000, "Burst for Kubernetes client")
 	pflag.IntVar(&memberlistBindPort, "memberlist-bind-port", 7946, "Port for memberlist gossip (default 7946)")
+	pflag.StringVar(&healthProbeBindAddress, "health-probe-bind-address", ":8081",
+		"The address the /healthz and /readyz endpoints bind to. Set to empty string to disable.")
 	pflag.StringVar(&e2bKeyStorage, "e2b-key-storage", "secret",
 		"Storage backend for E2B API keys. Valid values: 'secret' (K8s Secret, default), 'mysql' (MySQL via GORM). "+
 			"When --e2b-key-storage=mysql and auth is enabled, set MySQL DSN via environment variable "+E2BKeyStorageDSNEnvVar)
@@ -221,7 +224,7 @@ func main() {
 	}
 
 	sandboxController := e2b.NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSelector, e2bMaxTimeout, e2bMinResumeTimeout, maxClaimWorkers, maxCreateQPS, uint32(extProcMaxConcurrency),
-		port, memberlistBindPort, keyCfg, clientConfig)
+		port, memberlistBindPort, healthProbeBindAddress, keyCfg, clientConfig)
 
 	if err := sandboxController.Init(); err != nil {
 		klog.Fatalf("Failed to initialize sandbox controller: %v", err)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -151,20 +151,31 @@ func NewControllerManager(cfg *rest.Config, opts config.SandboxManagerOptions) (
 		return nil, fmt.Errorf("failed to create controller manager: %w", err)
 	}
 
-	// Register basic /healthz and /readyz checks when the probe server is enabled.
-	// Empty HealthProbeBindAddress disables the probe server entirely, in which case
-	// AddHealthzCheck / AddReadyzCheck are no-ops semantically — we still register
-	// to fail fast if controller-runtime's contract changes.
-	if opts.HealthProbeBindAddress != "" {
-		if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
-			return nil, fmt.Errorf("failed to add healthz check: %w", err)
-		}
-		if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {
-			return nil, fmt.Errorf("failed to add readyz check: %w", err)
-		}
+	if err := registerProbeChecks(mgr, opts.HealthProbeBindAddress); err != nil {
+		return nil, err
 	}
 
 	return mgr, nil
+}
+
+// registerProbeChecks registers basic /healthz and /readyz checks on mgr when
+// the probe server is enabled (i.e. addr is non-empty). When addr is empty the
+// probe server is disabled by controller-runtime and registering checks would
+// be wasted work, so this is a no-op.
+//
+// Extracted from NewControllerManager so the registration logic can be unit
+// tested with a mock manager without needing a real *rest.Config.
+func registerProbeChecks(mgr ctrl.Manager, addr string) error {
+	if addr == "" {
+		return nil
+	}
+	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
+		return fmt.Errorf("failed to add healthz check: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {
+		return fmt.Errorf("failed to add readyz check: %w", err)
+	}
+	return nil
 }
 
 // NewCache creates a new Cache instance from a pre-configured controller manager.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -35,6 +35,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
@@ -143,11 +144,24 @@ func NewControllerManager(cfg *rest.Config, opts config.SandboxManagerOptions) (
 		Scheme:                 scheme,
 		Cache:                  ctrlcache.Options{ByObject: byObject, DefaultUnsafeDisableDeepCopy: ptr.To(true)},
 		Metrics:                metricsserver.Options{BindAddress: "0"},
-		HealthProbeBindAddress: "",
+		HealthProbeBindAddress: opts.HealthProbeBindAddress,
 		LeaderElection:         false,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create controller manager: %w", err)
+	}
+
+	// Register basic /healthz and /readyz checks when the probe server is enabled.
+	// Empty HealthProbeBindAddress disables the probe server entirely, in which case
+	// AddHealthzCheck / AddReadyzCheck are no-ops semantically — we still register
+	// to fail fast if controller-runtime's contract changes.
+	if opts.HealthProbeBindAddress != "" {
+		if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
+			return nil, fmt.Errorf("failed to add healthz check: %w", err)
+		}
+		if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {
+			return nil, fmt.Errorf("failed to add readyz check: %w", err)
+		}
 	}
 
 	return mgr, nil

--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"errors"
+	"testing"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+)
+
+// probeMgr is a tiny ctrl.Manager that records and reports back the
+// AddHealthzCheck / AddReadyzCheck calls made by registerProbeChecks. Other
+// methods inherit from the embedded nil interface and will panic if called —
+// the helper under test only touches the two we override.
+type probeMgr struct {
+	ctrl.Manager // intentionally nil; do not call other methods
+	healthzAdded int
+	readyzAdded  int
+	healthzErr   error
+	readyzErr    error
+}
+
+func (p *probeMgr) AddHealthzCheck(_ string, _ healthz.Checker) error {
+	p.healthzAdded++
+	return p.healthzErr
+}
+
+func (p *probeMgr) AddReadyzCheck(_ string, _ healthz.Checker) error {
+	p.readyzAdded++
+	return p.readyzErr
+}
+
+func TestRegisterProbeChecks(t *testing.T) {
+	t.Run("no-op when addr is empty", func(t *testing.T) {
+		mgr := &probeMgr{}
+		if err := registerProbeChecks(mgr, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if mgr.healthzAdded != 0 || mgr.readyzAdded != 0 {
+			t.Errorf("expected no checks when addr is empty, got h=%d r=%d",
+				mgr.healthzAdded, mgr.readyzAdded)
+		}
+	})
+
+	t.Run("registers both checks when addr is set", func(t *testing.T) {
+		mgr := &probeMgr{}
+		if err := registerProbeChecks(mgr, ":8081"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if mgr.healthzAdded != 1 {
+			t.Errorf("AddHealthzCheck calls = %d, want 1", mgr.healthzAdded)
+		}
+		if mgr.readyzAdded != 1 {
+			t.Errorf("AddReadyzCheck calls = %d, want 1", mgr.readyzAdded)
+		}
+	})
+
+	t.Run("propagates AddHealthzCheck error", func(t *testing.T) {
+		want := errors.New("boom-healthz")
+		mgr := &probeMgr{healthzErr: want}
+		err := registerProbeChecks(mgr, ":8081")
+		if err == nil || !errors.Is(err, want) {
+			t.Errorf("expected wrapped error from AddHealthzCheck, got %v", err)
+		}
+		if mgr.readyzAdded != 0 {
+			t.Error("AddReadyzCheck should not be called when AddHealthzCheck fails")
+		}
+	})
+
+	t.Run("propagates AddReadyzCheck error", func(t *testing.T) {
+		want := errors.New("boom-readyz")
+		mgr := &probeMgr{readyzErr: want}
+		err := registerProbeChecks(mgr, ":8081")
+		if err == nil || !errors.Is(err, want) {
+			t.Errorf("expected wrapped error from AddReadyzCheck, got %v", err)
+		}
+		if mgr.healthzAdded != 1 {
+			t.Errorf("AddHealthzCheck should still have been called once, got %d", mgr.healthzAdded)
+		}
+	})
+}

--- a/pkg/controller/sandbox/metrics.go
+++ b/pkg/controller/sandbox/metrics.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
@@ -252,6 +253,20 @@ var (
 		[]string{"namespace", "name", "type"},
 	)
 
+	// sandbox_reconcile_duration_seconds tracks the wall-clock duration of every
+	// Reconcile call, partitioned by namespace and final result.
+	// result label values: "success" (returned without requeue, no error),
+	// "requeue" (returned with Requeue=true or RequeueAfter>0, no error),
+	// "error" (returned a non-nil error).
+	sandboxReconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "sandbox_reconcile_duration_seconds",
+			Help:    "Duration of Sandbox controller Reconcile calls in seconds, partitioned by result.",
+			Buckets: prometheus.ExponentialBuckets(0.001, 2, 14), // 1ms -> ~16s
+		},
+		[]string{"namespace", "result"},
+	)
+
 	// allPhases enumerates all possible sandbox phases for metric cleanup.
 	allPhases = []agentsv1alpha1.SandboxPhase{
 		agentsv1alpha1.SandboxPending,
@@ -325,7 +340,27 @@ func init() {
 		sandboxDeletionDuration,
 		sandboxRuntimeContainerAbnormal,
 		sandboxStatusAbnormal,
+		sandboxReconcileDuration,
 	)
+}
+
+// observeReconcileDuration records a Reconcile-call duration into the
+// sandbox_reconcile_duration_seconds histogram. result must be one of
+// "success", "requeue", "error".
+func observeReconcileDuration(namespace, result string, d time.Duration) {
+	sandboxReconcileDuration.WithLabelValues(namespace, result).Observe(d.Seconds())
+}
+
+// reconcileResultLabel maps a (Result, err) pair returned by Reconcile to a
+// result label value used by sandbox_reconcile_duration_seconds.
+func reconcileResultLabel(res ctrl.Result, err error) string {
+	if err != nil {
+		return "error"
+	}
+	if res.Requeue || res.RequeueAfter > 0 {
+		return "requeue"
+	}
+	return "success"
 }
 
 // InitSandboxLabelsMetric initializes the sandbox_labels metric with the given

--- a/pkg/controller/sandbox/metrics_test.go
+++ b/pkg/controller/sandbox/metrics_test.go
@@ -26,6 +26,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 )
@@ -2197,6 +2198,49 @@ func TestRecordRuntimeContainerAbnormal(t *testing.T) {
 	}
 }
 
+func TestReconcileResultLabel(t *testing.T) {
+	tests := []struct {
+		name   string
+		result ctrl.Result
+		err    error
+		want   string
+	}{
+		{
+			name:   "non-nil error wins over everything",
+			result: ctrl.Result{Requeue: true},
+			err:    errReconcileTest,
+			want:   "error",
+		},
+		{
+			name:   "Requeue true → requeue",
+			result: ctrl.Result{Requeue: true},
+			err:    nil,
+			want:   "requeue",
+		},
+		{
+			name:   "RequeueAfter > 0 → requeue",
+			result: ctrl.Result{RequeueAfter: 5 * time.Second},
+			err:    nil,
+			want:   "requeue",
+		},
+		{
+			name:   "zero result + nil err → success",
+			result: ctrl.Result{},
+			err:    nil,
+			want:   "success",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reconcileResultLabel(tt.result, tt.err); got != tt.want {
+				t.Errorf("reconcileResultLabel(%+v, %v) = %q, want %q",
+					tt.result, tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDeleteSandboxMetrics_ClearsRuntimeContainerAbnormal(t *testing.T) {
 	ns, name := "default", "cleanup-sandbox"
 
@@ -2219,3 +2263,38 @@ func TestDeleteSandboxMetrics_ClearsRuntimeContainerAbnormal(t *testing.T) {
 		t.Errorf("after delete, csi-sidecar series = %v, want 0", val)
 	}
 }
+
+func TestObserveReconcileDuration(t *testing.T) {
+	const ns = "test-reconcile-ns"
+
+	// Reset just our partition before exercising it.
+	sandboxReconcileDuration.DeleteLabelValues(ns, "success")
+	sandboxReconcileDuration.DeleteLabelValues(ns, "requeue")
+	sandboxReconcileDuration.DeleteLabelValues(ns, "error")
+
+	observeReconcileDuration(ns, "success", 50*time.Millisecond)
+	observeReconcileDuration(ns, "success", 75*time.Millisecond)
+	observeReconcileDuration(ns, "requeue", 10*time.Millisecond)
+
+	successHist := histogramSampleCount(t, sandboxReconcileDuration, ns, "success")
+	if successHist != 2 {
+		t.Errorf("success histogram sample count = %d, want 2", successHist)
+	}
+
+	requeueHist := histogramSampleCount(t, sandboxReconcileDuration, ns, "requeue")
+	if requeueHist != 1 {
+		t.Errorf("requeue histogram sample count = %d, want 1", requeueHist)
+	}
+
+	errorHist := histogramSampleCount(t, sandboxReconcileDuration, ns, "error")
+	if errorHist != 0 {
+		t.Errorf("error histogram sample count = %d, want 0", errorHist)
+	}
+}
+
+// errReconcileTest is a sentinel used by TestReconcileResultLabel.
+var errReconcileTest = &reconcileTestError{msg: "boom"}
+
+type reconcileTestError struct{ msg string }
+
+func (e *reconcileTestError) Error() string { return e.msg }

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -99,6 +99,13 @@ type SandboxReconciler struct {
 
 //nolint:gocyclo // This function handles multiple reconciliation scenarios which require branching logic
 func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (crl ctrl.Result, err error) {
+	// Record reconcile duration partitioned by namespace and result. Deferred
+	// first so it runs last (LIFO) and captures the final values of crl/err.
+	reconcileStart := time.Now()
+	defer func() {
+		observeReconcileDuration(req.Namespace, reconcileResultLabel(crl, err), time.Since(reconcileStart))
+	}()
+
 	// fetch pod
 	pod := &corev1.Pod{}
 	err = r.Get(ctx, req.NamespacedName, pod)
@@ -313,7 +320,12 @@ func (r *SandboxReconciler) updateSandboxStatus(ctx context.Context, newStatus a
 		return err
 	}
 	core.ResourceVersionExpectations.Expect(rcvObject)
-	klog.InfoS("update sandbox status success", "sandbox", klog.KObj(box), "status", utils.DumpJson(newStatus))
+	// Avoid allocating utils.DumpJson(newStatus) on every successful status update;
+	// callers can correlate via the structured fields below or raise klog verbosity
+	// to log the patched body before the request when debugging.
+	klog.InfoS("update sandbox status success", "sandbox", klog.KObj(box),
+		"phase", newStatus.Phase, "observedGeneration", newStatus.ObservedGeneration,
+		"updateRevision", newStatus.UpdateRevision)
 	box.Status = newStatus
 	// Update metrics after status change (pod=nil: container metrics already recorded in Reconcile)
 	recordSandboxMetrics(box, nil)

--- a/pkg/sandbox-manager/config/manager.go
+++ b/pkg/sandbox-manager/config/manager.go
@@ -38,6 +38,9 @@ type SandboxManagerOptions struct {
 	MemberlistBindPort         int
 	DisableRouteReconciliation bool
 	RestConfig                 *rest.Config
+	// HealthProbeBindAddress is the address the controller-runtime manager binds for /healthz and /readyz.
+	// Empty string disables the probe endpoints (backward compatible default).
+	HealthProbeBindAddress string
 }
 
 func InitOptions(opts SandboxManagerOptions) SandboxManagerOptions {

--- a/pkg/sandbox-manager/config/manager_test.go
+++ b/pkg/sandbox-manager/config/manager_test.go
@@ -185,6 +185,7 @@ func TestInitOptions(t *testing.T) {
 				SandboxNamespace:           "sandbox-ns",
 				SandboxLabelSelector:       "env=prod",
 				DisableRouteReconciliation: true,
+				HealthProbeBindAddress:     ":8081",
 			},
 			expectSystemNamespace:    utils.DefaultSandboxDeployNamespace,
 			expectMaxClaimWorkers:    consts.DefaultClaimWorkers,
@@ -217,6 +218,8 @@ func TestInitOptions(t *testing.T) {
 			if tt.input.DisableRouteReconciliation {
 				assert.True(t, result.DisableRouteReconciliation)
 			}
+			assert.Equal(t, tt.input.HealthProbeBindAddress, result.HealthProbeBindAddress,
+				"HealthProbeBindAddress should be preserved verbatim (no defaulting)")
 		})
 	}
 }

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -46,15 +46,16 @@ type Controller struct {
 	minResumeTimeoutValue int
 
 	// manager params
-	systemNamespace       string // the namespace where the sandbox manager is running
-	peerSelector          string
-	maxClaimWorkers       int
-	maxCreateQPS          int
-	extProcMaxConcurrency uint32
-	sandboxLabelSelector  string
-	sandboxNamespace      string
-	memberlistBindPort    int
-	keyCfg                *keys.Config
+	systemNamespace        string // the namespace where the sandbox manager is running
+	peerSelector           string
+	maxClaimWorkers        int
+	maxCreateQPS           int
+	extProcMaxConcurrency  uint32
+	sandboxLabelSelector   string
+	sandboxNamespace       string
+	memberlistBindPort     int
+	healthProbeBindAddress string
+	keyCfg                 *keys.Config
 
 	// fields
 	mux             *http.ServeMux
@@ -69,23 +70,24 @@ type Controller struct {
 }
 
 // NewController creates a new E2B Controller
-func NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSelector string, maxTimeout, minResumeTimeout, maxClaimWorkers, maxCreateQPS int, extProcMaxConcurrency uint32, port, memberlistBindPort int, keyCfg *keys.Config, clientConfig *rest.Config) *Controller {
+func NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSelector string, maxTimeout, minResumeTimeout, maxClaimWorkers, maxCreateQPS int, extProcMaxConcurrency uint32, port, memberlistBindPort int, healthProbeBindAddress string, keyCfg *keys.Config, clientConfig *rest.Config) *Controller {
 	sc := &Controller{
-		mux:                   http.NewServeMux(),
-		domain:                domain,
-		clientConfig:          clientConfig,
-		port:                  port,
-		maxTimeout:            maxTimeout,
-		minResumeTimeoutValue: minResumeTimeout,
-		systemNamespace:       sysNs, // the namespace where the sandbox manager is running
-		peerSelector:          peerSelector,
-		sandboxNamespace:      sandboxNamespace,
-		sandboxLabelSelector:  sandboxLabelSelector,
-		maxClaimWorkers:       maxClaimWorkers,
-		maxCreateQPS:          maxCreateQPS,
-		extProcMaxConcurrency: extProcMaxConcurrency,
-		memberlistBindPort:    memberlistBindPort,
-		keyCfg:                keyCfg,
+		mux:                    http.NewServeMux(),
+		domain:                 domain,
+		clientConfig:           clientConfig,
+		port:                   port,
+		maxTimeout:             maxTimeout,
+		minResumeTimeoutValue:  minResumeTimeout,
+		systemNamespace:        sysNs, // the namespace where the sandbox manager is running
+		peerSelector:           peerSelector,
+		sandboxNamespace:       sandboxNamespace,
+		sandboxLabelSelector:   sandboxLabelSelector,
+		maxClaimWorkers:        maxClaimWorkers,
+		maxCreateQPS:           maxCreateQPS,
+		extProcMaxConcurrency:  extProcMaxConcurrency,
+		memberlistBindPort:     memberlistBindPort,
+		healthProbeBindAddress: healthProbeBindAddress,
+		keyCfg:                 keyCfg,
 	}
 
 	sc.server = &http.Server{
@@ -123,15 +125,16 @@ func (sc *Controller) Init() error {
 
 func (sc *Controller) sandboxManagerOptions() config.SandboxManagerOptions {
 	return config.SandboxManagerOptions{
-		SystemNamespace:       sc.systemNamespace,
-		PeerSelector:          sc.peerSelector,
-		SandboxNamespace:      sc.sandboxNamespace,
-		SandboxLabelSelector:  sc.sandboxLabelSelector,
-		MaxClaimWorkers:       sc.maxClaimWorkers,
-		ExtProcMaxConcurrency: sc.extProcMaxConcurrency,
-		MaxCreateQPS:          sc.maxCreateQPS,
-		MemberlistBindPort:    sc.memberlistBindPort,
-		RestConfig:            sc.clientConfig,
+		SystemNamespace:        sc.systemNamespace,
+		PeerSelector:           sc.peerSelector,
+		SandboxNamespace:       sc.sandboxNamespace,
+		SandboxLabelSelector:   sc.sandboxLabelSelector,
+		MaxClaimWorkers:        sc.maxClaimWorkers,
+		ExtProcMaxConcurrency:  sc.extProcMaxConcurrency,
+		MaxCreateQPS:           sc.maxCreateQPS,
+		MemberlistBindPort:     sc.memberlistBindPort,
+		HealthProbeBindAddress: sc.healthProbeBindAddress,
+		RestConfig:             sc.clientConfig,
 	}
 }
 

--- a/pkg/servers/e2b/core_test.go
+++ b/pkg/servers/e2b/core_test.go
@@ -505,3 +505,69 @@ func AssertEndAt(t *testing.T, expect time.Time, endAt string) {
 	assert.NoError(t, err)
 	assert.WithinDuration(t, expect, endAtTime, 5*time.Second)
 }
+
+// TestNewController_FieldPlumbing exercises the constructor and the option
+// builder so every assignment path — including the newer
+// healthProbeBindAddress field — is covered without requiring a real
+// Kubernetes API server.
+func TestNewController_FieldPlumbing(t *testing.T) {
+	const (
+		domain         = "example.test"
+		sysNs          = "sandbox-system"
+		peerSelector   = "component=sandbox-manager"
+		sandboxNs      = "sandbox-pool"
+		sandboxLabel   = "env=prod"
+		maxTimeout     = 600
+		minResume      = 30
+		maxClaim       = 7
+		maxQPS         = 11
+		extProcConcur  = uint32(13)
+		port           = 9100
+		memberlistPort = 7800
+		probeAddr      = ":8081"
+	)
+
+	sc := NewController(domain, sysNs, peerSelector, sandboxNs, sandboxLabel,
+		maxTimeout, minResume, maxClaim, maxQPS, extProcConcur, port, memberlistPort, probeAddr,
+		nil, nil)
+	require.NotNil(t, sc)
+
+	// Verify constructor populated every field we plumb today.
+	assert.Equal(t, domain, sc.domain)
+	assert.Equal(t, sysNs, sc.systemNamespace)
+	assert.Equal(t, peerSelector, sc.peerSelector)
+	assert.Equal(t, sandboxNs, sc.sandboxNamespace)
+	assert.Equal(t, sandboxLabel, sc.sandboxLabelSelector)
+	assert.Equal(t, maxTimeout, sc.maxTimeout)
+	assert.Equal(t, minResume, sc.minResumeTimeoutValue)
+	assert.Equal(t, maxClaim, sc.maxClaimWorkers)
+	assert.Equal(t, maxQPS, sc.maxCreateQPS)
+	assert.Equal(t, extProcConcur, sc.extProcMaxConcurrency)
+	assert.Equal(t, port, sc.port)
+	assert.Equal(t, memberlistPort, sc.memberlistBindPort)
+	assert.Equal(t, probeAddr, sc.healthProbeBindAddress)
+
+	// Verify the options builder forwards each field — including the new
+	// HealthProbeBindAddress — into the SandboxManagerOptions struct that
+	// flows through to NewControllerManager.
+	opts := sc.sandboxManagerOptions()
+	assert.Equal(t, sysNs, opts.SystemNamespace)
+	assert.Equal(t, peerSelector, opts.PeerSelector)
+	assert.Equal(t, sandboxNs, opts.SandboxNamespace)
+	assert.Equal(t, sandboxLabel, opts.SandboxLabelSelector)
+	assert.Equal(t, maxClaim, opts.MaxClaimWorkers)
+	assert.Equal(t, maxQPS, opts.MaxCreateQPS)
+	assert.Equal(t, extProcConcur, opts.ExtProcMaxConcurrency)
+	assert.Equal(t, memberlistPort, opts.MemberlistBindPort)
+	assert.Equal(t, probeAddr, opts.HealthProbeBindAddress)
+}
+
+// TestNewController_DisabledHealthProbe verifies the empty-string path through
+// NewController and sandboxManagerOptions, which corresponds to the operator
+// opting out of the probe server.
+func TestNewController_DisabledHealthProbe(t *testing.T) {
+	sc := NewController("d", "ns", "ps", "", "", 1, 1, 1, 1, 1, 8080, 7946, "", nil, nil)
+	require.NotNil(t, sc)
+	assert.Equal(t, "", sc.healthProbeBindAddress)
+	assert.Equal(t, "", sc.sandboxManagerOptions().HealthProbeBindAddress)
+}

--- a/pkg/servers/e2b/core_test.go
+++ b/pkg/servers/e2b/core_test.go
@@ -93,7 +93,7 @@ func SetupWithMinResumeTimeout(t *testing.T, minResumeTimeout int) (*Controller,
 	cache, fc, cacheErr := cachetest.NewTestCache(t)
 	require.NoError(t, cacheErr)
 	controller := NewController("example.com", namespace, "component=sandbox-manager", "", "", models.DefaultMaxTimeout, minResumeTimeout, 10,
-		0, 0, TestServerPort, config.DefaultMemberlistBindPort, &keys.Config{
+		0, 0, TestServerPort, config.DefaultMemberlistBindPort, "", &keys.Config{
 			Mode:      keys.StorageModeSecret,
 			Namespace: namespace,
 			AdminKey:  InitKey,

--- a/pkg/webhook/metrics.go
+++ b/pkg/webhook/metrics.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var (
+	// sandbox_admission_duration_seconds tracks per-call latency of admission
+	// webhook handlers, partitioned by webhook path, admission operation, and
+	// whether the request was allowed.
+	admissionDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "sandbox_admission_duration_seconds",
+			Help:    "Duration of admission webhook handler invocations in seconds.",
+			Buckets: prometheus.ExponentialBuckets(0.001, 2, 12), // 1ms -> ~4s
+		},
+		[]string{"webhook", "operation", "allowed"},
+	)
+
+	// sandbox_admission_total counts admission webhook handler invocations,
+	// partitioned by webhook path, operation, and whether the request was allowed.
+	admissionTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sandbox_admission_total",
+			Help: "Total number of admission webhook handler invocations.",
+		},
+		[]string{"webhook", "operation", "allowed"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(admissionDuration, admissionTotal)
+}
+
+// instrumentedHandler wraps an admission.Handler with Prometheus instrumentation:
+// it records both a latency histogram and a call counter for each invocation,
+// labelled by webhook path, admission operation, and allow/deny outcome.
+type instrumentedHandler struct {
+	inner admission.Handler
+	path  string
+}
+
+// newInstrumentedHandler wraps h so each Handle call observes the admission
+// metrics. path is used as the "webhook" label value (e.g. "/validate-pod-delete").
+func newInstrumentedHandler(path string, h admission.Handler) admission.Handler {
+	return &instrumentedHandler{inner: h, path: path}
+}
+
+func (i *instrumentedHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	start := time.Now()
+	resp := i.inner.Handle(ctx, req)
+	elapsed := time.Since(start).Seconds()
+
+	operation := string(req.Operation)
+	allowed := strconv.FormatBool(resp.Allowed)
+	admissionDuration.WithLabelValues(i.path, operation, allowed).Observe(elapsed)
+	admissionTotal.WithLabelValues(i.path, operation, allowed).Inc()
+
+	return resp
+}

--- a/pkg/webhook/metrics_test.go
+++ b/pkg/webhook/metrics_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	admissionv1 "k8s.io/api/admission/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// fakeHandler is a minimal admission.Handler used to exercise the
+// instrumented wrapper without requiring a real webhook stack.
+type fakeHandler struct {
+	resp admission.Response
+}
+
+func (f *fakeHandler) Handle(_ context.Context, _ admission.Request) admission.Response {
+	return f.resp
+}
+
+func makeRequest(op admissionv1.Operation) admission.Request {
+	return admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: op}}
+}
+
+func TestInstrumentedHandler_RecordsAllowed(t *testing.T) {
+	const path = "/test-allowed"
+	resetCounter(admissionTotal, path, "CREATE", "true")
+	resetCounter(admissionTotal, path, "CREATE", "false")
+
+	h := newInstrumentedHandler(path, &fakeHandler{resp: admission.Allowed("ok")})
+	resp := h.Handle(context.Background(), makeRequest(admissionv1.Create))
+	if !resp.Allowed {
+		t.Fatalf("inner handler said Allowed but wrapper returned Allowed=false")
+	}
+
+	gotAllowed := testutil.ToFloat64(admissionTotal.WithLabelValues(path, "CREATE", "true"))
+	if gotAllowed != 1 {
+		t.Errorf("admission_total{webhook=%q,operation=CREATE,allowed=true} = %v, want 1", path, gotAllowed)
+	}
+	gotDenied := testutil.ToFloat64(admissionTotal.WithLabelValues(path, "CREATE", "false"))
+	if gotDenied != 0 {
+		t.Errorf("denied counter unexpectedly incremented: got %v, want 0", gotDenied)
+	}
+}
+
+func TestInstrumentedHandler_RecordsDenied(t *testing.T) {
+	const path = "/test-denied"
+	resetCounter(admissionTotal, path, "DELETE", "false")
+
+	h := newInstrumentedHandler(path, &fakeHandler{resp: admission.Denied("nope")})
+	resp := h.Handle(context.Background(), makeRequest(admissionv1.Delete))
+	if resp.Allowed {
+		t.Fatalf("inner handler said Denied but wrapper returned Allowed=true")
+	}
+
+	gotDenied := testutil.ToFloat64(admissionTotal.WithLabelValues(path, "DELETE", "false"))
+	if gotDenied != 1 {
+		t.Errorf("admission_total{webhook=%q,operation=DELETE,allowed=false} = %v, want 1", path, gotDenied)
+	}
+}
+
+func TestInstrumentedHandler_RecordsErrored(t *testing.T) {
+	const path = "/test-errored"
+	resetCounter(admissionTotal, path, "UPDATE", "false")
+
+	// admission.Errored returns Allowed=false with an HTTP status code, which
+	// should be counted on the denied side of the counter.
+	h := newInstrumentedHandler(path, &fakeHandler{resp: admission.Errored(http.StatusBadRequest, errBadDecode)})
+	resp := h.Handle(context.Background(), makeRequest(admissionv1.Update))
+	if resp.Allowed {
+		t.Fatalf("Errored response unexpectedly Allowed=true")
+	}
+	got := testutil.ToFloat64(admissionTotal.WithLabelValues(path, "UPDATE", "false"))
+	if got != 1 {
+		t.Errorf("errored response counter = %v, want 1", got)
+	}
+}
+
+func TestInstrumentedHandler_PassesThroughResponse(t *testing.T) {
+	const path = "/test-passthrough"
+	expected := admission.Allowed("custom-message")
+	h := newInstrumentedHandler(path, &fakeHandler{resp: expected})
+	got := h.Handle(context.Background(), makeRequest(admissionv1.Create))
+	if got.Allowed != expected.Allowed || got.Result.Message != expected.Result.Message {
+		t.Errorf("response was mutated by wrapper: got %+v, want %+v", got, expected)
+	}
+}
+
+func TestInstrumentedHandler_DurationObserved(t *testing.T) {
+	const path = "/test-duration"
+	// Drop existing series so we can assert on a clean count.
+	admissionDuration.DeleteLabelValues(path, "CREATE", "true")
+
+	h := newInstrumentedHandler(path, &fakeHandler{resp: admission.Allowed("ok")})
+	for i := 0; i < 3; i++ {
+		h.Handle(context.Background(), makeRequest(admissionv1.Create))
+	}
+
+	hist, err := admissionDuration.GetMetricWithLabelValues(path, "CREATE", "true")
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues failed: %v", err)
+	}
+	count := histogramVecSampleCount(t, hist.(prometheus.Histogram))
+	if count != 3 {
+		t.Errorf("duration histogram sample count = %d, want 3", count)
+	}
+}
+
+// resetCounter zeroes a single label series on a CounterVec by deleting it.
+// Subsequent WithLabelValues calls return a fresh zero-valued counter.
+func resetCounter(vec *prometheus.CounterVec, labels ...string) {
+	vec.DeleteLabelValues(labels...)
+}
+
+// histogramVecSampleCount returns the observation count from a Histogram by
+// reading its DTO representation.
+func histogramVecSampleCount(t *testing.T, h prometheus.Histogram) uint64 {
+	t.Helper()
+	dtoMetric := &dto.Metric{}
+	if err := h.Write(dtoMetric); err != nil {
+		t.Fatalf("histogram Write failed: %v", err)
+	}
+	return dtoMetric.GetHistogram().GetSampleCount()
+}
+
+// errBadDecode is a sentinel used in error-path tests.
+var errBadDecode = &decodeError{msg: "bad decode"}
+
+type decodeError struct{ msg string }
+
+func (d *decodeError) Error() string { return d.msg }

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -63,9 +63,10 @@ func SetupWithManager(logger logr.Logger, mgr manager.Manager) error {
 			HandlerMap[handler.Path()] = handler
 		}
 	}
-	// register admission handlers
+	// register admission handlers, wrapping each in a Prometheus-instrumented
+	// decorator so admission latency and admit/deny counts are observable.
 	for path, handler := range HandlerMap {
-		server.Register(path, &webhook.Admission{Handler: handler})
+		server.Register(path, &webhook.Admission{Handler: newInstrumentedHandler(path, handler)})
 		logger.Info("Registered webhook handler", "path", path)
 	}
 	ctx := klog.NewContext(context.Background(), logger)


### PR DESCRIPTION
## Summary

This is the **first of two PRs** for #353. It closes the K8s-facing gaps in `sandbox-manager` so operators can actually tell what's going on:

- **(a)** Adds `/healthz` and `/readyz` HTTP endpoints so Kubernetes liveness/readiness probes work properly.
- **(b)** Adds a Prometheus histogram for how long each `Sandbox` reconcile takes, and removes a hot-path JSON dump that allocated on every status update.
- **(c)** Adds Prometheus latency + count metrics for every admission webhook, by wrapping each handler in a small decorator. No webhook changes its behavior.

The other three sub-pieces — peer-state metrics, key-cache hit/miss counters, and log-message cleanup — will land in a follow-up PR against the same issue.

## Why this matters

`sandbox-manager` already publishes a lot of *sandbox-level* metrics (`sandbox_creation_duration`, `sandbox_status_phase`, etc.) — but operators have no way to answer simpler questions like:

- "Is this pod actually healthy, or just bound to a port?"
- "Why are reconciles slow today?"
- "Which webhook is making my API server feel slow?"

That's the gap this PR closes.

## What's new

### (a) Health probes

The controller-runtime manager already supports `/healthz` and `/readyz` — the option was just disabled in `pkg/cache/cache.go` (`HealthProbeBindAddress: ""`). This PR enables it via a new `--health-probe-bind-address` flag.

- Default: `:8081` (kubebuilder convention).
- Disable: pass `--health-probe-bind-address=""`.
- When enabled, both endpoints respond `200 OK` once the manager has started.

### (b) Reconcile metrics

New histogram: **`sandbox_reconcile_duration_seconds{namespace,result}`**, where `result` is `success` / `requeue` / `error`.

Also drops a `utils.DumpJson(newStatus)` call from the success log line in `updateSandboxStatus`. That JSON marshal happened on **every** status update; replaced with three structured fields (`phase`, `observedGeneration`, `updateRevision`) which are cheaper to allocate and easier to query in log aggregators.

### (c) Webhook admission metrics

Two new metrics:

- **`sandbox_admission_duration_seconds{webhook,operation,allowed}`** — how long each handler takes.
- **`sandbox_admission_total{webhook,operation,allowed}`** — admit/deny counts.

Implementation is a tiny `instrumentedHandler` decorator wrapped around every existing handler at registration. No handler logic changes — `Handle()` returns whatever the inner handler returns.

## Backward compatibility

- Default port `:8081` is the kubebuilder convention; operators who don't want the new port can disable it with an empty string.
- The new metrics are purely additive — existing metrics are untouched.
- The webhook decorator is transparent: every existing admission decision passes through unchanged.
- No new dependencies.

## Tests

- Round-trip test for the new `HealthProbeBindAddress` field.
- 4 cases for the result-label mapping (`success` / `requeue` / `error`).
- Histogram observation count assertion for reconcile duration.
- 5 cases for the webhook decorator: allowed, denied, errored, response pass-through, and duration recorded.

All affected packages green: `pkg/sandbox-manager/...`, `pkg/cache/...`, `pkg/servers/e2b/...`, `pkg/webhook/...`, `pkg/controller/...`, `cmd/...`.

> Note: end-to-end probe testing would need an envtest-backed `*rest.Config` (controller-runtime's manager dials the API server during construction). This repo doesn't have envtest set up yet — happy to file a separate issue for that if it's useful.

## Checklist

- [x] Build + vet pass
- [x] All affected-package tests pass
- [x] No new dependencies

**fixes #353 (sub-pieces a, b, c). Sub-pieces (d) memberlist peer-state, (e) key-cache hit/miss, and (f) structured-field logging on hot paths will land in a follow-up PR against the same issue.**
