### PR TITLE
[Feature] Improve claim sandbox failure diagnostics

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -19,7 +19,6 @@ package cache
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 
 	"golang.org/x/sync/singleflight"
@@ -184,12 +183,8 @@ func (c *Cache) Run(ctx context.Context) error {
 	go func() {
 		// It is possible that the mgr is already started in another goroutine
 		if err := c.mgr.Start(mgrCtx); err != nil {
-			if strings.Contains(err.Error(), "already started") {
-				log.Info("controller manager already started")
-			} else {
-				log.Error(err, "controller manager exited with error")
-				panic(fmt.Errorf("failed to start controller manager: %w", err))
-			}
+			log.Error(err, "controller manager exited with error")
+			panic(fmt.Errorf("failed to start controller manager: %w", err))
 		}
 	}()
 	cache := c.mgr.GetCache()

--- a/pkg/cache/controllers/test_helpers.go
+++ b/pkg/cache/controllers/test_helpers.go
@@ -52,6 +52,7 @@ type MockManager struct {
 	apiReader    client.Reader
 	scheme       *runtime.Scheme
 	addCallCount atomic.Int32
+	startCount   atomic.Int32
 	// failOnNthAdd specifies which (1-based) call to Add() should return addError.
 	// 0 means never fail.
 	failOnNthAdd int
@@ -136,6 +137,7 @@ func (m *MockManager) GetEventRecorderFor(_ string) record.EventRecorder { retur
 
 // Start satisfies both cluster.Cluster and manager.Manager.
 func (m *MockManager) Start(ctx context.Context) error {
+	m.startCount.Add(1)
 	if m.waitSimEnabled && m.waitHooks != nil {
 		m.initWaitReconcilers()
 		go m.runWaitSimulation(ctx)
@@ -251,6 +253,10 @@ func (m *MockManager) GetControllerOptions() ctrlcfg.Controller {
 // addCallsCount returns how many times Add() was invoked.
 func (m *MockManager) addCallsCount() int {
 	return int(m.addCallCount.Load())
+}
+
+func (m *MockManager) StartCallsCount() int {
+	return int(m.startCount.Load())
 }
 
 var _ ctrl.Manager = (*MockManager)(nil)

--- a/pkg/cache/interface.go
+++ b/pkg/cache/interface.go
@@ -31,8 +31,9 @@ import (
 // reaches a desired state (e.g., sandbox becomes Running after Resume).
 //
 // All Get/List methods read exclusively from the in-process informer store; they never issue
-// live API calls. Run must be called once to start the underlying informers and wait for the
-// initial sync before any other method is used.
+// live API calls. The underlying manager cache must be synced before any other method is used.
+// Call Run for a Cache with an owned manager. When a Cache reuses another operator's manager,
+// do not call Run; the owner manager starts and syncs the cache during manager.Start.
 type Provider interface {
 	GetClaimedSandbox(ctx context.Context, opts GetClaimedSandboxOptions) (*agentsv1alpha1.Sandbox, error)
 
@@ -70,8 +71,8 @@ type Provider interface {
 	// CheckpointId); fails on Terminating/Failed.
 	NewCheckpointTask(ctx context.Context, cp *agentsv1alpha1.Checkpoint) *cacheutils.WaitTask[*agentsv1alpha1.Checkpoint]
 
-	// Run must be called once before any other Provider method is invoked.
-	// Returns an error if any informer fails to start or if the cache sync times out.
+	// Run starts an owned manager and waits for cache sync.
+	// Do not call Run for a cache backed by an externally owned manager.
 	Run(ctx context.Context) error
 
 	// Stop shuts down all underlying informers and releases associated resources.

--- a/pkg/cache/utils/errors.go
+++ b/pkg/cache/utils/errors.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	// ErrWaitNotSatisfied matches wait failures where the object did not reach
+	// the requested state before the wait completed.
+	ErrWaitNotSatisfied = &WaitNotSatisfiedError{}
+	// ErrWaitTaskConflict matches failures caused by another wait action
+	// already registered for the same object.
+	ErrWaitTaskConflict = &WaitTaskConflictError{}
+)
+
+// WaitNotSatisfiedError reports that a wait task finished while the object was
+// still not in the requested state.
+type WaitNotSatisfiedError struct {
+	Object            client.ObjectKey
+	Action            WaitAction
+	DuringDoubleCheck bool
+}
+
+func (e *WaitNotSatisfiedError) Error() string {
+	if e != nil && e.DuringDoubleCheck {
+		return "object is not satisfied during double check"
+	}
+	return "object is not satisfied"
+}
+
+func (e *WaitNotSatisfiedError) Is(target error) bool {
+	_, ok := target.(*WaitNotSatisfiedError)
+	return ok
+}
+
+// WaitTaskConflictError reports that a wait task cannot be registered because
+// another action is already waiting on the same object.
+type WaitTaskConflictError struct {
+	ExistingAction WaitAction
+	NewAction      WaitAction
+}
+
+func (e *WaitTaskConflictError) Error() string {
+	if e == nil {
+		return "wait task conflict"
+	}
+	return fmt.Sprintf("another action(%s)'s wait task already exists", e.ExistingAction)
+}
+
+func (e *WaitTaskConflictError) Is(target error) bool {
+	_, ok := target.(*WaitTaskConflictError)
+	return ok
+}

--- a/pkg/cache/utils/wait.go
+++ b/pkg/cache/utils/wait.go
@@ -103,7 +103,7 @@ func WaitForObjectSatisfied[T client.Object](ctx context.Context, waitHooks *syn
 	}
 	if timeout <= 0 {
 		log.Info("waiting is skipped due to zero timeout")
-		return fmt.Errorf("object is not satisfied")
+		return &WaitNotSatisfiedError{Object: objKey, Action: action}
 	}
 	value, exists := waitHooks.LoadOrStore(key, NewWaitEntry(ctx, action, satisfiedFunc))
 	if exists {
@@ -113,7 +113,7 @@ func WaitForObjectSatisfied[T client.Object](ctx context.Context, waitHooks *syn
 	}
 	entry := value.(*WaitEntry[T])
 	if entry.Action != action {
-		err := fmt.Errorf("another action(%s)'s wait task already exists", entry.Action)
+		err := &WaitTaskConflictError{ExistingAction: entry.Action, NewAction: action}
 		log.Error(err, "wait hook conflict", "existing", entry.Action, "new", action)
 		return err
 	}
@@ -148,7 +148,7 @@ func DoubleCheckObjectSatisfied[T client.Object](ctx context.Context, obj T, upd
 		return err
 	}
 	if !satisfied {
-		err = fmt.Errorf("object is not satisfied during double check")
+		err = &WaitNotSatisfiedError{Object: client.ObjectKeyFromObject(obj), DuringDoubleCheck: true}
 		log.Error(err, "object not satisfied")
 		return err
 	}

--- a/pkg/cache/utils/wait_test.go
+++ b/pkg/cache/utils/wait_test.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -406,6 +407,67 @@ func TestWaitForObjectSatisfied_ContextTimeout(t *testing.T) {
 	assert.Contains(t, err.Error(), "not satisfied")
 }
 
+func TestWaitForObjectSatisfied_NotSatisfiedErrorIsTyped(t *testing.T) {
+	tests := []struct {
+		name                  string
+		timeout               time.Duration
+		ctx                   func(t *testing.T) context.Context
+		wantAction            WaitAction
+		wantDuringDoubleCheck bool
+	}{
+		{
+			name:       "zero timeout",
+			timeout:    0,
+			wantAction: WaitActionResume,
+			ctx: func(t *testing.T) context.Context {
+				t.Helper()
+				return context.Background()
+			},
+		},
+		{
+			name:                  "wait timeout",
+			timeout:               30 * time.Millisecond,
+			wantDuringDoubleCheck: true,
+			ctx: func(t *testing.T) context.Context {
+				t.Helper()
+				return context.Background()
+			},
+		},
+		{
+			name:                  "context canceled",
+			timeout:               time.Hour,
+			wantDuringDoubleCheck: true,
+			ctx: func(t *testing.T) context.Context {
+				t.Helper()
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := newTestSandbox("sbx-typed-not-satisfied", "default")
+			var hooks sync.Map
+
+			err := WaitForObjectSatisfied[*agentsv1alpha1.Sandbox](
+				tt.ctx(t), &hooks, sbx, WaitActionResume,
+				identityUpdate,
+				func(obj *agentsv1alpha1.Sandbox) (bool, error) { return false, nil },
+				tt.timeout,
+			)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrWaitNotSatisfied)
+			var waitErr *WaitNotSatisfiedError
+			assert.True(t, errors.As(err, &waitErr))
+			assert.Equal(t, tt.wantDuringDoubleCheck, waitErr.DuringDoubleCheck)
+			assert.Equal(t, tt.wantAction, waitErr.Action)
+		})
+	}
+}
+
 func TestWaitForObjectSatisfied_ActionConflict(t *testing.T) {
 	sbx := newTestSandbox("sbx-conflict", "default")
 	var hooks sync.Map
@@ -438,6 +500,11 @@ func TestWaitForObjectSatisfied_ActionConflict(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
+	assert.ErrorIs(t, err, ErrWaitTaskConflict)
+	var conflictErr *WaitTaskConflictError
+	assert.True(t, errors.As(err, &conflictErr))
+	assert.Equal(t, WaitActionResume, conflictErr.ExistingAction)
+	assert.Equal(t, WaitActionPause, conflictErr.NewAction)
 
 	// Close the entry so the first goroutine can exit (its internal timeout is 1 hour)
 	key := WaitHookKey[*agentsv1alpha1.Sandbox](sbx)
@@ -676,6 +743,10 @@ func TestDoubleCheckObjectSatisfied_NotSatisfied(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not satisfied")
+	assert.ErrorIs(t, err, ErrWaitNotSatisfied)
+	var waitErr *WaitNotSatisfiedError
+	assert.True(t, errors.As(err, &waitErr))
+	assert.True(t, waitErr.DuringDoubleCheck)
 }
 
 func TestDoubleCheckObjectSatisfied_Satisfied(t *testing.T) {

--- a/pkg/controller/sandboxclaim/sandboxclaim_controller.go
+++ b/pkg/controller/sandboxclaim/sandboxclaim_controller.go
@@ -72,20 +72,6 @@ func Add(mgr manager.Manager) error {
 		return fmt.Errorf("failed to create cache: %w", err)
 	}
 
-	// Register cache as a runnable so it starts when manager starts
-	err = mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-		klog.Info("Starting SandboxClaim cache and waiting for sync...")
-		if err := cache.Run(ctx); err != nil {
-			klog.Errorf("cache run error: %v", err)
-			return err
-		}
-		klog.Info("SandboxClaim cache synced successfully")
-		return nil
-	}))
-	if err != nil {
-		return fmt.Errorf("failed to add cache runnable: %w", err)
-	}
-
 	recorder := mgr.GetEventRecorderFor("sandboxclaim")
 	err = (&Reconciler{
 		Client:   mgr.GetClient(),

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"strings"
 	"sync"
 	"time"
 
@@ -126,8 +127,16 @@ func TryClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions, pickCa
 		metrics.Wait = time.Since(startWaiting)
 		log.Info("got a free claim worker", "cost", metrics.Wait)
 	}
+	var pickedSandboxKey string
 	defer func() {
 		freeWorkerOnce()
+		if err != nil {
+			key := pickedSandboxKey
+			if claimed == nil {
+				key = "" // no sandbox locked
+			}
+			metrics.RecordPickSandboxFailure(key, err)
+		}
 		metrics.LastError = err
 		log.Info("try claim sandbox result", "metrics", metrics.String())
 		clearFailedSandbox(ctx, claimed, err, opts.ReserveFailedSandbox)
@@ -140,6 +149,9 @@ func TryClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions, pickCa
 	if err != nil {
 		log.Error(err, "failed to select available sandbox")
 		return
+	}
+	if sbx != nil && sbx.Sandbox != nil {
+		pickedSandboxKey = DefaultGetPickFailureKey(sbx.Sandbox)
 	}
 	// Clean up pickCache based on lockType:
 	// - LockTypeUpdate/LockTypeSpeculate: delete from pickCache (picked from pool)
@@ -169,6 +181,10 @@ func TryClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions, pickCa
 			err = retriableError{Message: fmt.Sprintf("failed to lock sandbox: %s", err)}
 		}
 		return
+	}
+	// The picked sandbox key may be changed after lock, for example, when lockType is LockTypeCreate
+	if sbx != nil && sbx.Sandbox != nil {
+		pickedSandboxKey = DefaultGetPickFailureKey(sbx.Sandbox)
 	}
 	metrics.LockType = lockType
 	metrics.PickAndLock = time.Since(pickStart)
@@ -241,6 +257,15 @@ func clearFailedSandbox(ctx context.Context, sbx infra.Sandbox, err error, reser
 
 func getPickKey(sbx *v1alpha1.Sandbox) string {
 	return client.ObjectKeyFromObject(sbx).String()
+}
+
+var DefaultGetPickFailureKey = getPickFailureKey
+
+func getPickFailureKey(sbx *v1alpha1.Sandbox) string {
+	if sbx.GetName() == "" {
+		return ""
+	}
+	return getPickKey(sbx)
 }
 
 func pickAnAvailableSandbox(ctx context.Context, opts infra.ClaimSandboxOptions, pickCache *sync.Map, cache infracache.Provider, limiter *rate.Limiter) (*Sandbox, infra.LockType, error) {
@@ -600,6 +625,12 @@ func waitForSandboxReady(ctx context.Context, sbx *Sandbox, opts infra.ClaimSand
 	log.Info("waiting for sandbox ready", "timeout", opts.WaitReadyTimeout)
 	if err = cache.NewSandboxWaitReadyTask(ctx, sbx.Sandbox).Wait(opts.WaitReadyTimeout); err != nil {
 		log.Error(err, "failed to wait for sandbox ready")
+		if strings.Contains(err.Error(), "not satisfied") {
+			if refreshErr := sbx.InplaceRefresh(ctx, true); refreshErr != nil {
+				log.Error(refreshErr, "failed to refresh sandbox for ready failure diagnosis")
+			}
+			err = errors.New(sandboxReadyFailureMessage(sbx.Sandbox))
+		}
 		return
 	}
 	// Use deepcopy to avoid data race
@@ -608,6 +639,56 @@ func waitForSandboxReady(ctx context.Context, sbx *Sandbox, opts infra.ClaimSand
 		return
 	}
 	return
+}
+
+func sandboxReadyFailureMessage(sbx *v1alpha1.Sandbox) string {
+	readyCond := GetSandboxCondition(sbx, v1alpha1.SandboxConditionReady)
+	inplaceCond := GetSandboxCondition(sbx, v1alpha1.SandboxConditionInplaceUpdate)
+	state, _ := stateutils.GetSandboxState(sbx)
+
+	reason := sandboxReadyFailureReason(sbx, state, readyCond, inplaceCond)
+	fields := []string{
+		fmt.Sprintf("reason=%s", reason),
+		fmt.Sprintf("state=%s", state),
+		fmt.Sprintf("ready=%s", readyCond.Reason),
+	}
+	if inplaceCond.Reason != "" {
+		fields = append(fields, fmt.Sprintf("inplaceUpdate=%s", inplaceCond.Reason))
+	}
+	if sbx.Status.ObservedGeneration != sbx.Generation {
+		fields = append(fields, fmt.Sprintf("generation=%d/%d", sbx.Status.ObservedGeneration, sbx.Generation))
+	}
+	return fmt.Sprintf("sandbox %s/%s is not ready before wait timeout: %s", sbx.Namespace, sbx.Name, strings.Join(fields, ", "))
+}
+
+func sandboxReadyFailureReason(sbx *v1alpha1.Sandbox, state string, readyCond, inplaceCond metav1.Condition) string {
+	if sbx.Status.ObservedGeneration != sbx.Generation {
+		return "controller has not observed latest generation"
+	}
+	if inplaceCond.Reason == v1alpha1.SandboxInplaceUpdateReasonInplaceUpdating {
+		return "inplace update is still in progress"
+	}
+	if sbx.Status.PodInfo.PodIP == "" {
+		return "sandbox has no pod IP"
+	}
+	if readyCond.Reason == v1alpha1.SandboxReadyReasonStartContainerFailed {
+		reason := fmt.Sprintf("ready condition reports %s", readyCond.Reason)
+		if readyCond.Message != "" {
+			reason = fmt.Sprintf("%s: %s", reason, readyCond.Message)
+		}
+		return reason
+	}
+	if state != v1alpha1.SandboxStateRunning {
+		return fmt.Sprintf("sandbox state is %s", state)
+	}
+	if readyCond.Reason != "" {
+		reason := fmt.Sprintf("ready condition reports %s", readyCond.Reason)
+		if readyCond.Message != "" {
+			reason = fmt.Sprintf("%s: %s", reason, readyCond.Message)
+		}
+		return reason
+	}
+	return "sandbox ready condition is not satisfied"
 }
 
 func checkSandboxReady(ctx context.Context, sbx *v1alpha1.Sandbox) (bool, error) {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/openkruise/agents/api/v1alpha1"
 	infracache "github.com/openkruise/agents/pkg/cache"
+	cacheutils "github.com/openkruise/agents/pkg/cache/utils"
 	"github.com/openkruise/agents/pkg/controller/sandboxset"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
@@ -625,7 +626,7 @@ func waitForSandboxReady(ctx context.Context, sbx *Sandbox, opts infra.ClaimSand
 	log.Info("waiting for sandbox ready", "timeout", opts.WaitReadyTimeout)
 	if err = cache.NewSandboxWaitReadyTask(ctx, sbx.Sandbox).Wait(opts.WaitReadyTimeout); err != nil {
 		log.Error(err, "failed to wait for sandbox ready")
-		if strings.Contains(err.Error(), "not satisfied") {
+		if errors.Is(err, cacheutils.ErrWaitNotSatisfied) {
 			if refreshErr := sbx.InplaceRefresh(ctx, true); refreshErr != nil {
 				log.Error(refreshErr, "failed to refresh sandbox for ready failure diagnosis")
 			}

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -857,6 +858,116 @@ func TestCheckSandboxInplaceUpdate(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestSandboxReadyFailureMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		sbx  *v1alpha1.Sandbox
+		want string
+	}{
+		{
+			name: "controller has not observed latest generation",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "sbx-1",
+					Namespace:  "default",
+					Generation: 4,
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase:              v1alpha1.SandboxRunning,
+					ObservedGeneration: 3,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1alpha1.SandboxConditionReady),
+							Status: metav1.ConditionTrue,
+							Reason: v1alpha1.SandboxReadyReasonPodReady,
+						},
+					},
+					PodInfo: v1alpha1.PodInfo{PodIP: "1.2.3.4"},
+				},
+			},
+			want: "sandbox default/sbx-1 is not ready before wait timeout: reason=controller has not observed latest generation, state=running, ready=PodReady, generation=3/4",
+		},
+		{
+			name: "inplace update is still in progress",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "sbx-1",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase:              v1alpha1.SandboxRunning,
+					ObservedGeneration: 1,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1alpha1.SandboxConditionReady),
+							Status: metav1.ConditionTrue,
+							Reason: v1alpha1.SandboxReadyReasonPodReady,
+						},
+						{
+							Type:   string(v1alpha1.SandboxConditionInplaceUpdate),
+							Reason: v1alpha1.SandboxInplaceUpdateReasonInplaceUpdating,
+						},
+					},
+					PodInfo: v1alpha1.PodInfo{PodIP: "1.2.3.4"},
+				},
+			},
+			want: "sandbox default/sbx-1 is not ready before wait timeout: reason=inplace update is still in progress, state=running, ready=PodReady, inplaceUpdate=InplaceUpdating",
+		},
+		{
+			name: "sandbox has no pod ip",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "sbx-1",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase:              v1alpha1.SandboxRunning,
+					ObservedGeneration: 1,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1alpha1.SandboxConditionReady),
+							Status: metav1.ConditionTrue,
+							Reason: v1alpha1.SandboxReadyReasonPodReady,
+						},
+					},
+				},
+			},
+			want: "sandbox default/sbx-1 is not ready before wait timeout: reason=sandbox has no pod IP, state=running, ready=PodReady",
+		},
+		{
+			name: "ready condition reports failure with message",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "sbx-1",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase:              v1alpha1.SandboxRunning,
+					ObservedGeneration: 1,
+					Conditions: []metav1.Condition{
+						{
+							Type:    string(v1alpha1.SandboxConditionReady),
+							Reason:  v1alpha1.SandboxReadyReasonStartContainerFailed,
+							Message: "process exited",
+						},
+					},
+					PodInfo: v1alpha1.PodInfo{PodIP: "1.2.3.4"},
+				},
+			},
+			want: "sandbox default/sbx-1 is not ready before wait timeout: reason=ready condition reports StartContainerFailed: process exited, state=dead, ready=StartContainerFailed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sandboxReadyFailureMessage(tt.sbx))
 		})
 	}
 }
@@ -2121,6 +2232,215 @@ func TestTryClaimSandbox_LockConflict(t *testing.T) {
 
 			// Clean up expectation state
 			expectationutils.ResourceVersionExpectationDelete(sbx)
+		})
+	}
+}
+
+func TestBuildClaimErrorWithPickSandboxFailures(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		lastError   error
+		failures    []infra.PickSandboxFailure
+		expectError string
+		expectJSON  []infra.PickSandboxFailure
+	}{
+		{
+			name: "nil error returns nil",
+		},
+		{
+			name:        "without failures keeps old message",
+			err:         errors.New("timed out waiting for the condition"),
+			lastError:   errors.New("no available sandboxes"),
+			expectError: "timed out waiting for the condition, last error: no available sandboxes",
+		},
+		{
+			name:      "with failures appends json suffix",
+			err:       errors.New("timed out waiting for the condition"),
+			lastError: errors.New("failed to init runtime"),
+			failures: []infra.PickSandboxFailure{
+				{Key: "default/sbx-1", Reason: "failed to init runtime", Count: 2},
+				{Key: "", Reason: "no available sandboxes", Count: 3},
+			},
+			expectError: "pick sandbox failures: ",
+			expectJSON: []infra.PickSandboxFailure{
+				{Key: "default/sbx-1", Reason: "failed to init runtime", Count: 2},
+				{Key: "", Reason: "no available sandboxes", Count: 3},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := buildClaimError(tt.err, tt.lastError, tt.failures)
+			if tt.err == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+			if tt.expectJSON == nil {
+				assert.NotContains(t, err.Error(), "pick sandbox failures:")
+				return
+			}
+			parts := strings.Split(err.Error(), "pick sandbox failures: ")
+			require.Len(t, parts, 2)
+			var got []infra.PickSandboxFailure
+			require.NoError(t, json.Unmarshal([]byte(parts[1]), &got))
+			assert.Equal(t, tt.expectJSON, got)
+		})
+	}
+}
+
+func TestTryClaimSandboxRecordsPickSandboxFailures(t *testing.T) {
+	utils.InitLogOutput()
+	existTemplate := "test-template"
+
+	tests := []struct {
+		name      string
+		options   infra.ClaimSandboxOptions
+		setup     func(t *testing.T, fc client.Client)
+		want      []infra.PickSandboxFailure
+		wantError string
+	}{
+		{
+			name: "records no pick failure with empty key",
+			options: infra.ClaimSandboxOptions{
+				User:     "test-user",
+				Template: existTemplate,
+			},
+			want: []infra.PickSandboxFailure{
+				{Key: "", Reason: "no available sandboxes for template test-template (no stock)", Count: 1},
+			},
+			wantError: "no stock",
+		},
+		{
+			name: "records picked sandbox key after wait ready failure",
+			options: infra.ClaimSandboxOptions{
+				User:     "test-user",
+				Template: existTemplate,
+				InplaceUpdate: &config.InplaceUpdateOptions{
+					Image: "new-image",
+				},
+			},
+			setup: func(t *testing.T, fc client.Client) {
+				createAvailableSandboxForFailureRecord(t, fc, existTemplate, func(sbx *v1alpha1.Sandbox) {
+					sbx.Status.Conditions = []metav1.Condition{
+						{
+							Type:    string(v1alpha1.SandboxConditionReady),
+							Status:  metav1.ConditionTrue,
+							Reason:  v1alpha1.SandboxReadyReasonStartContainerFailed,
+							Message: "by test",
+						},
+					}
+				})
+			},
+			want: []infra.PickSandboxFailure{
+				{Key: "default/test-sbx", Reason: "failed to wait for sandbox ready: sandbox start container failed: by test", Count: 1},
+			},
+			wantError: "sandbox start container failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testInfra, fc := NewTestInfra(t)
+			if tt.setup != nil {
+				tt.setup(t, fc)
+			}
+			opts, err := ValidateAndInitClaimOptions(tt.options)
+			require.NoError(t, err)
+
+			_, metrics, err := TryClaimSandbox(t.Context(), opts, &testInfra.pickCache, testInfra.Cache, testInfra.claimLockChannel, testInfra.createLimiter)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantError)
+			assert.Equal(t, tt.want, metrics.PickSandboxFailures)
+		})
+	}
+}
+
+func createAvailableSandboxForFailureRecord(t *testing.T, fc client.Client, template string, mutate func(sbx *v1alpha1.Sandbox)) {
+	t.Helper()
+	sbx := &v1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sbx",
+			Namespace: "default",
+			Labels: map[string]string{
+				v1alpha1.LabelSandboxTemplate:        template,
+				agentsv1alpha1.LabelSandboxIsClaimed: "false",
+			},
+			Annotations:       map[string]string{},
+			OwnerReferences:   GetSbsOwnerReference(),
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: v1alpha1.SandboxSpec{
+			EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "main", Image: "old-image"}},
+					},
+				},
+			},
+		},
+		Status: v1alpha1.SandboxStatus{
+			Phase: v1alpha1.SandboxRunning,
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(v1alpha1.SandboxConditionReady),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			PodInfo: v1alpha1.PodInfo{
+				PodIP: "1.2.3.4",
+			},
+		},
+	}
+	if mutate != nil {
+		mutate(sbx)
+	}
+	CreateSandboxWithStatus(t, fc, sbx)
+	require.Eventually(t, func() bool {
+		var got v1alpha1.Sandbox
+		return fc.Get(t.Context(), types.NamespacedName{Namespace: sbx.Namespace, Name: sbx.Name}, &got) == nil
+	}, 100*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestInfraClaimSandboxAggregatesPickSandboxFailuresInError(t *testing.T) {
+	utils.InitLogOutput()
+	tests := []struct {
+		name        string
+		options     infra.ClaimSandboxOptions
+		expectKey   string
+		expectError string
+	}{
+		{
+			name: "aggregates repeated no stock retries",
+			options: infra.ClaimSandboxOptions{
+				User:         "test-user",
+				Template:     "test-template",
+				ClaimTimeout: 100 * time.Millisecond,
+			},
+			expectKey:   "",
+			expectError: "no stock",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testInfra, _ := NewTestInfra(t)
+			_, metrics, err := testInfra.ClaimSandbox(t.Context(), tt.options)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+			assert.Len(t, metrics.PickSandboxFailures, 1)
+			assert.Equal(t, tt.expectKey, metrics.PickSandboxFailures[0].Key)
+			assert.Greater(t, metrics.PickSandboxFailures[0].Count, 1)
+
+			parts := strings.Split(err.Error(), "pick sandbox failures: ")
+			require.Len(t, parts, 2)
+			var got []infra.PickSandboxFailure
+			require.NoError(t, json.Unmarshal([]byte(parts[1]), &got))
+			require.Len(t, got, 1)
+			assert.Equal(t, metrics.PickSandboxFailures[0], got[0])
 		})
 	}
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -18,6 +18,7 @@ package sandboxcr
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -158,6 +159,7 @@ func (i *Infra) ClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions
 		metrics.InitRuntime += tryMetrics.InitRuntime
 		metrics.CSIMount += tryMetrics.CSIMount
 		metrics.LockType = tryMetrics.LockType
+		metrics.MergePickSandboxFailures(tryMetrics.PickSandboxFailures)
 		if tryMetrics.LastError != nil {
 			metrics.LastError = tryMetrics.LastError
 		}
@@ -168,14 +170,22 @@ func (i *Infra) ClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions
 		}
 		return claimErr
 	})
-	return claimedSandbox, metrics, buildClaimError(err, metrics.LastError)
+	return claimedSandbox, metrics, buildClaimError(err, metrics.LastError, metrics.PickSandboxFailures)
 }
 
-func buildClaimError(err error, lastError error) error {
+func buildClaimError(err error, lastError error, failures []infra.PickSandboxFailure) error {
 	if err == nil {
 		return nil
 	}
-	return fmt.Errorf("%v, last error: %v", err, lastError)
+	base := fmt.Sprintf("%v, last error: %v", err, lastError)
+	if len(failures) == 0 {
+		return fmt.Errorf("%s", base)
+	}
+	raw, marshalErr := json.Marshal(failures)
+	if marshalErr != nil {
+		return fmt.Errorf("%s, pick sandbox failures marshal error: %v", base, marshalErr)
+	}
+	return fmt.Errorf("%s, pick sandbox failures: %s", base, string(raw))
 }
 
 func (i *Infra) CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions) (infra.Sandbox, infra.CloneMetrics, error) {

--- a/pkg/sandbox-manager/infra/types.go
+++ b/pkg/sandbox-manager/infra/types.go
@@ -82,16 +82,24 @@ type CreateCheckpointOptions struct {
 }
 
 type ClaimMetrics struct {
-	Retries     int
-	Total       time.Duration
-	Wait        time.Duration
-	RetryCost   time.Duration
-	PickAndLock time.Duration
-	WaitReady   time.Duration
-	InitRuntime time.Duration
-	CSIMount    time.Duration
-	LockType    LockType
-	LastError   error
+	Retries             int
+	Total               time.Duration
+	Wait                time.Duration
+	RetryCost           time.Duration
+	PickAndLock         time.Duration
+	WaitReady           time.Duration
+	InitRuntime         time.Duration
+	CSIMount            time.Duration
+	LockType            LockType
+	LastError           error
+	PickSandboxFailures []PickSandboxFailure
+}
+
+// PickSandboxFailure describes a group of claim attempts that failed with the same picked sandbox and reason.
+type PickSandboxFailure struct {
+	Key    string `json:"key"`
+	Reason string `json:"reason"`
+	Count  int    `json:"count"`
 }
 
 type LockType string
@@ -102,17 +110,54 @@ const (
 	LockTypeSpeculate = LockType("speculate")
 )
 
-func (m ClaimMetrics) String() string {
+func (m *ClaimMetrics) String() string {
 	var lastErrStr string
 	if m.LastError != nil {
 		// Replace newlines and control characters to ensure single-line output
-		errMsg := m.LastError.Error()
-		// Replace common control characters with space
-		replacer := strings.NewReplacer("\n", " ", "\r", " ", "\t", " ")
-		lastErrStr = replacer.Replace(errMsg)
+		lastErrStr = sanitizeErrorMessage(m.LastError)
 	}
 	return fmt.Sprintf("ClaimMetrics{Retries: %d, Total: %v, Wait: %v, RetryCost: %v, PickAndLock: %v, LockType: %v, WaitReady: %v, InitRuntime: %v, CSIMount: %v, LastError: %v}",
 		m.Retries, m.Total, m.Wait, m.RetryCost, m.PickAndLock, m.LockType, m.WaitReady, m.InitRuntime, m.CSIMount, lastErrStr)
+}
+
+// RecordPickSandboxFailure records one failed claim attempt and aggregates repeated key/reason pairs.
+func (m *ClaimMetrics) RecordPickSandboxFailure(key string, err error) {
+	if err == nil {
+		return
+	}
+	m.mergePickSandboxFailure(PickSandboxFailure{
+		Key:    key,
+		Reason: sanitizeErrorMessage(err),
+		Count:  1,
+	})
+}
+
+// MergePickSandboxFailures merges pre-aggregated pick failure records into the metrics.
+func (m *ClaimMetrics) MergePickSandboxFailures(failures []PickSandboxFailure) {
+	for _, failure := range failures {
+		m.mergePickSandboxFailure(failure)
+	}
+}
+
+func (m *ClaimMetrics) mergePickSandboxFailure(failure PickSandboxFailure) {
+	if failure.Count <= 0 {
+		failure.Count = 1
+	}
+	for i := range m.PickSandboxFailures {
+		if m.PickSandboxFailures[i].Key == failure.Key && m.PickSandboxFailures[i].Reason == failure.Reason {
+			m.PickSandboxFailures[i].Count += failure.Count
+			return
+		}
+	}
+	m.PickSandboxFailures = append(m.PickSandboxFailures, failure)
+}
+
+func sanitizeErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	replacer := strings.NewReplacer("\n", " ", "\r", " ", "\t", " ")
+	return replacer.Replace(err.Error())
 }
 
 type CloneMetrics struct {

--- a/pkg/sandbox-manager/infra/types_test.go
+++ b/pkg/sandbox-manager/infra/types_test.go
@@ -311,3 +311,89 @@ func TestClaimMetrics_String_LongError(t *testing.T) {
 		t.Errorf("ClaimMetrics.String() should contain the error content")
 	}
 }
+
+func TestClaimMetrics_RecordPickSandboxFailure(t *testing.T) {
+	tests := []struct {
+		name     string
+		record   func(metrics *ClaimMetrics)
+		expected []PickSandboxFailure
+	}{
+		{
+			name: "records new failure with count one",
+			record: func(metrics *ClaimMetrics) {
+				metrics.RecordPickSandboxFailure("default/sbx-1", errors.New("failed to lock sandbox"))
+			},
+			expected: []PickSandboxFailure{
+				{Key: "default/sbx-1", Reason: "failed to lock sandbox", Count: 1},
+			},
+		},
+		{
+			name: "aggregates same key and reason",
+			record: func(metrics *ClaimMetrics) {
+				metrics.RecordPickSandboxFailure("default/sbx-1", errors.New("failed to lock sandbox"))
+				metrics.RecordPickSandboxFailure("default/sbx-1", errors.New("failed to lock sandbox"))
+			},
+			expected: []PickSandboxFailure{
+				{Key: "default/sbx-1", Reason: "failed to lock sandbox", Count: 2},
+			},
+		},
+		{
+			name: "keeps different reasons separate and sanitizes control characters",
+			record: func(metrics *ClaimMetrics) {
+				metrics.RecordPickSandboxFailure("", errors.New("no available\nsandboxes"))
+				metrics.RecordPickSandboxFailure("", errors.New("all candidates\tpicked"))
+			},
+			expected: []PickSandboxFailure{
+				{Key: "", Reason: "no available sandboxes", Count: 1},
+				{Key: "", Reason: "all candidates picked", Count: 1},
+			},
+		},
+		{
+			name: "ignores nil error",
+			record: func(metrics *ClaimMetrics) {
+				metrics.RecordPickSandboxFailure("default/sbx-1", nil)
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := &ClaimMetrics{}
+			tt.record(metrics)
+			if len(metrics.PickSandboxFailures) != len(tt.expected) {
+				t.Fatalf("expected %d failures, got %d: %#v", len(tt.expected), len(metrics.PickSandboxFailures), metrics.PickSandboxFailures)
+			}
+			for i := range tt.expected {
+				if metrics.PickSandboxFailures[i] != tt.expected[i] {
+					t.Fatalf("failure[%d] = %#v, want %#v", i, metrics.PickSandboxFailures[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestClaimMetrics_MergePickSandboxFailures(t *testing.T) {
+	metrics := &ClaimMetrics{
+		PickSandboxFailures: []PickSandboxFailure{
+			{Key: "default/sbx-1", Reason: "failed to lock sandbox", Count: 2},
+		},
+	}
+	metrics.MergePickSandboxFailures([]PickSandboxFailure{
+		{Key: "default/sbx-1", Reason: "failed to lock sandbox", Count: 3},
+		{Key: "", Reason: "no available sandboxes", Count: 4},
+	})
+
+	expected := []PickSandboxFailure{
+		{Key: "default/sbx-1", Reason: "failed to lock sandbox", Count: 5},
+		{Key: "", Reason: "no available sandboxes", Count: 4},
+	}
+	if len(metrics.PickSandboxFailures) != len(expected) {
+		t.Fatalf("expected %d failures, got %d: %#v", len(expected), len(metrics.PickSandboxFailures), metrics.PickSandboxFailures)
+	}
+	for i := range expected {
+		if metrics.PickSandboxFailures[i] != expected[i] {
+			t.Fatalf("failure[%d] = %#v, want %#v", i, metrics.PickSandboxFailures[i], expected[i])
+		}
+	}
+}

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -142,6 +142,7 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 	id := r.PathValue("sandboxID")
 	ctx := r.Context()
 	log := klog.FromContext(ctx).WithValues("sandboxID", id)
+	log.Info("connecting sandbox")
 
 	request, apiErr := ParseSetTimeoutRequest(r, sc.maxTimeout)
 	if apiErr != nil {


### PR DESCRIPTION
## What changed

- Record claim retry pick failure diagnostics in ClaimMetrics, including sandbox key, failure reason, and repeat count.
- Append the aggregated pick failure JSON list to claim errors so E2B CreateSandbox API errors expose retry-stage sandbox selection diagnostics.
- Add focused unit tests for metrics aggregation, claim error JSON suffixes, and wait-ready failure detail.
- Remove MEMO.md from version control.

## Why

When CreateSandbox fails after entering retry claim sandbox logic, the returned API error only exposed the final wrapped error. This makes it hard to identify which sandboxes were picked during retries and why those attempts failed.

## Validation

- go test ./pkg/sandbox-manager/infra
- go test ./pkg/sandbox-manager/infra/sandboxcr