### PR TITLE
Validate SandboxSet volume claim template mounts

### DIFF
--- a/pkg/webhook/sandboxset/validating/sandboxset_create_update.go
+++ b/pkg/webhook/sandboxset/validating/sandboxset_create_update.go
@@ -23,12 +23,13 @@ import (
 	"net/http"
 	"strings"
 
+	apicorev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/core"
-	corev1 "k8s.io/kubernetes/pkg/apis/core/v1"
+	corev1conv "k8s.io/kubernetes/pkg/apis/core/v1"
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -125,15 +126,56 @@ func validateSandboxSetPodTemplateSpec(spec agentsv1alpha1.SandboxSetSpec, fldPa
 	errList := field.ErrorList{}
 	coreTemplate := &core.PodTemplateSpec{}
 
-	if len(spec.VolumeClaimTemplates) != 0 {
-		//TODO: validate the podtemplate if VolumeClaimTemplates is not empty
-		return errList
-	}
-
-	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(spec.Template.DeepCopy(), coreTemplate, nil); err != nil {
+	if err := corev1conv.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(spec.Template.DeepCopy(), coreTemplate, nil); err != nil {
 		errList = append(errList, field.Invalid(fldPath.Child("template"), spec.Template, fmt.Sprintf("Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec failed: %v", err)))
 		return errList
 	}
+	if len(spec.VolumeClaimTemplates) != 0 {
+		errList = append(errList, validateVolumeClaimTemplateMounts(spec, fldPath)...)
+		for _, template := range spec.VolumeClaimTemplates {
+			coreTemplate.Spec.Volumes = append(coreTemplate.Spec.Volumes, core.Volume{
+				Name: template.Name,
+				VolumeSource: core.VolumeSource{
+					PersistentVolumeClaim: &core.PersistentVolumeClaimVolumeSource{
+						ClaimName: template.Name,
+					},
+				},
+			})
+		}
+	}
 	errList = append(errList, corevalidation.ValidatePodTemplateSpec(coreTemplate, fldPath.Child("template"), webhookutils.DefaultPodValidationOptions)...)
+	return errList
+}
+
+func validateVolumeClaimTemplateMounts(spec agentsv1alpha1.SandboxSetSpec, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+	mountedVolumeNames := map[string]struct{}{}
+
+	recordMounts := func(containers []apicorev1.Container) {
+		for i := range containers {
+			for j := range containers[i].VolumeMounts {
+				mountedVolumeNames[containers[i].VolumeMounts[j].Name] = struct{}{}
+			}
+		}
+	}
+	recordMounts(spec.Template.Spec.InitContainers)
+	recordMounts(spec.Template.Spec.Containers)
+	for i := range spec.Template.Spec.EphemeralContainers {
+		for j := range spec.Template.Spec.EphemeralContainers[i].VolumeMounts {
+			mountedVolumeNames[spec.Template.Spec.EphemeralContainers[i].VolumeMounts[j].Name] = struct{}{}
+		}
+	}
+
+	for i, template := range spec.VolumeClaimTemplates {
+		if template.Name == "" {
+			continue
+		}
+		if _, mounted := mountedVolumeNames[template.Name]; !mounted {
+			errList = append(errList, field.Required(
+				fldPath.Child("template").Child("spec").Child("containers").Child("volumeMounts"),
+				fmt.Sprintf("volumeClaimTemplates[%d] %q must be mounted by at least one container, init container, or ephemeral container", i, template.Name),
+			))
+		}
+	}
 	return errList
 }

--- a/pkg/webhook/sandboxset/validating/sandboxset_create_update.go
+++ b/pkg/webhook/sandboxset/validating/sandboxset_create_update.go
@@ -171,9 +171,10 @@ func validateVolumeClaimTemplateMounts(spec agentsv1alpha1.SandboxSetSpec, fldPa
 			continue
 		}
 		if _, mounted := mountedVolumeNames[template.Name]; !mounted {
-			errList = append(errList, field.Required(
-				fldPath.Child("template").Child("spec").Child("containers").Child("volumeMounts"),
-				fmt.Sprintf("volumeClaimTemplates[%d] %q must be mounted by at least one container, init container, or ephemeral container", i, template.Name),
+			errList = append(errList, field.Invalid(
+				fldPath.Child("volumeClaimTemplates").Index(i).Child("metadata").Child("name"),
+				template.Name,
+				"must be mounted by at least one container, init container, or ephemeral container",
 			))
 		}
 	}

--- a/pkg/webhook/sandboxset/validating/sandboxset_create_update_test.go
+++ b/pkg/webhook/sandboxset/validating/sandboxset_create_update_test.go
@@ -109,6 +109,12 @@ func TestSandboxSetValidatingHandler_Handle(t *testing.T) {
 										Image:                    "nginx:latest",
 										ImagePullPolicy:          corev1.PullAlways,
 										TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+										VolumeMounts: []corev1.VolumeMount{
+											{
+												Name:      "test-pvc",
+												MountPath: "/data",
+											},
+										},
 									},
 								},
 							},
@@ -130,6 +136,110 @@ func TestSandboxSetValidatingHandler_Handle(t *testing.T) {
 			},
 			expectAllow: true,
 			expectError: false,
+		},
+		{
+			name: "Invalid SandboxSet with unmounted VolumeClaimTemplate",
+			sandboxSet: &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sbs",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.SandboxSetSpec{
+					Replicas: 3,
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"app": "test",
+								},
+							},
+							Spec: corev1.PodSpec{
+								RestartPolicy:                 corev1.RestartPolicyAlways,
+								DNSPolicy:                     corev1.DNSClusterFirst,
+								TerminationGracePeriodSeconds: new(int64),
+								Containers: []corev1.Container{
+									{
+										Name:                     "test",
+										Image:                    "nginx:latest",
+										ImagePullPolicy:          corev1.PullAlways,
+										TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+									},
+								},
+							},
+						},
+						VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "test-pvc",
+								},
+								Spec: corev1.PersistentVolumeClaimSpec{
+									AccessModes: []corev1.PersistentVolumeAccessMode{
+										corev1.ReadWriteOnce,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectAllow:  false,
+			expectError:  true,
+			errorMessage: "must be mounted by at least one container",
+		},
+		{
+			name: "Invalid SandboxSet with VolumeClaimTemplate and mismatched volume mount",
+			sandboxSet: &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sbs",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.SandboxSetSpec{
+					Replicas: 3,
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"app": "test",
+								},
+							},
+							Spec: corev1.PodSpec{
+								RestartPolicy:                 corev1.RestartPolicyAlways,
+								DNSPolicy:                     corev1.DNSClusterFirst,
+								TerminationGracePeriodSeconds: new(int64),
+								Containers: []corev1.Container{
+									{
+										Name:                     "test",
+										Image:                    "nginx:latest",
+										ImagePullPolicy:          corev1.PullAlways,
+										TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+										VolumeMounts: []corev1.VolumeMount{
+											{
+												Name:      "other-pvc",
+												MountPath: "/data",
+											},
+										},
+									},
+								},
+							},
+						},
+						VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "test-pvc",
+								},
+								Spec: corev1.PersistentVolumeClaimSpec{
+									AccessModes: []corev1.PersistentVolumeAccessMode{
+										corev1.ReadWriteOnce,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectAllow:  false,
+			expectError:  true,
+			errorMessage: "must be mounted by at least one container",
 		},
 		{
 			name: "Valid SandboxSet with templateref",


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR adds validation for `SandboxSet` resources that define `volumeClaimTemplates`.

Previously, the SandboxSet validating webhook skipped pod template validation whenever `volumeClaimTemplates` was non-empty. That meant invalid pod template configurations could pass admission, including cases where a PVC template was defined but never mounted by the pod.

## Changes

- Continue validating the `PodTemplateSpec` even when `spec.volumeClaimTemplates` is present.
- Build the effective pod template by adding generated PVC-backed volumes for each `VolumeClaimTemplate`.
- Validate that every named `VolumeClaimTemplate` is mounted by at least one:
  - container
  - init container
  - ephemeral container
- Add webhook tests for:
  - valid SandboxSet with a mounted `VolumeClaimTemplate`
  - invalid SandboxSet with an unmounted `VolumeClaimTemplate`
  - invalid SandboxSet with a mismatched volume mount name
  
## Behavior

A `SandboxSet` with:


volumeClaimTemplates:
  - metadata:
      name: data

must include a matching volume mount such as:

containers:
  - name: app
    volumeMounts:
      - name: data
        mountPath: /data

If the claim template is not mounted, admission returns a validation error.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
"NONE"

But solves the TODO at sandboxset_create_update.go (line 129) "//TODO: validate the podtemplate if VolumeClaimTemplates is not empty
"
### Ⅲ. Describe how to verify it

go test ./pkg/webhook/sandboxset/validating

I have ran this test on my local machine 
<img width="857" height="55" alt="image" src="https://github.com/user-attachments/assets/3491a67f-62e6-4652-82e4-287821737c8f" />


### Ⅳ. Special notes for reviews

