### PR TITLE
refactor: unify post-resume initialization into sandbox-controller

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -295,6 +295,10 @@ const (
 
 	// SandboxConditionUpgrading means upgrade state.
 	SandboxConditionUpgrading SandboxConditionType = "Upgrading"
+
+	// SandboxConditionPostResumeInit indicates the result of post-resume initialization
+	// which includes runtime re-initialization and CSI storage re-mount.
+	SandboxConditionPostResumeInit SandboxConditionType = "PostResumeInit"
 )
 
 const (
@@ -325,6 +329,10 @@ const (
 	// SandboxConditionResume Reason
 	SandboxResumeReasonCreatePod = "CreatePod"
 	SandboxResumeReasonResumePod = "ResumePod"
+
+	// SandboxConditionPostResumeInit Reason
+	SandboxPostResumeInitReasonSucceeded = "Succeeded"
+	SandboxPostResumeInitReasonFailed    = "Failed"
 )
 
 // +genclient

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -227,15 +227,49 @@ func (r *commonControl) EnsureSandboxResumed(ctx context.Context, args EnsureFun
 	pCond := utils.GetPodCondition(&pod.Status, corev1.PodReady)
 	if pod.Status.Phase == corev1.PodRunning && pCond != nil && pCond.Status == corev1.ConditionTrue {
 		newStatus.Phase = agentsv1alpha1.SandboxRunning
+
+		// Sync PodInfo (IP/NodeName/UID) before Initialize to ensure runtimeURL is resolvable
+		// (pod IP may have changed after resume). Note: we intentionally do NOT set Ready=True
+		// here; Ready is only set after Initialize succeeds, so that sandbox-manager's
+		// NewSandboxResumeTask (which gates on state==Running, requiring Ready==True)
+		// won't observe a premature Running state before init/CSI-mount completes.
+		newStatus.NodeName = pod.Spec.NodeName
+		newStatus.SandboxIp = pod.Status.PodIP
+		newStatus.PodInfo = agentsv1alpha1.PodInfo{
+			PodIP:    pod.Status.PodIP,
+			NodeName: pod.Spec.NodeName,
+			PodUID:   pod.UID,
+		}
+
+		// re-initialize sandbox after resuming or upgrading (includes runtime re-init and CSI storage re-mount)
+		if err := r.initializer.Initialize(ctx, box, newStatus); err != nil {
+			klog.ErrorS(err, "post-resume initialization failed (runtime re-init or CSI re-mount)", "sandbox", klog.KObj(box))
+			r.recorder.Event(box, corev1.EventTypeWarning, "PostResumeInitFailed",
+				fmt.Sprintf("Failed to perform post-resume initialization (runtime re-init + CSI storage re-mount): %v", err))
+			utils.SetSandboxCondition(newStatus, metav1.Condition{
+				Type:               string(agentsv1alpha1.SandboxConditionPostResumeInit),
+				Status:             metav1.ConditionFalse,
+				Reason:             agentsv1alpha1.SandboxPostResumeInitReasonFailed,
+				Message:            utils.TruncateConditionMessage(fmt.Sprintf("Runtime re-init or CSI storage re-mount failed: %v", err)),
+				LastTransitionTime: metav1.Now(),
+			})
+			return err
+		}
+		r.recorder.Event(box, corev1.EventTypeNormal, "PostResumeInitSucceeded",
+			"Post-resume initialization completed successfully (runtime re-init + CSI storage re-mount)")
+		utils.SetSandboxCondition(newStatus, metav1.Condition{
+			Type:               string(agentsv1alpha1.SandboxConditionPostResumeInit),
+			Status:             metav1.ConditionTrue,
+			Reason:             agentsv1alpha1.SandboxPostResumeInitReasonSucceeded,
+			Message:            "Runtime re-init and CSI storage re-mount completed",
+			LastTransitionTime: metav1.Now(),
+		})
+
+		// Initialize succeeded: now set Ready=True to signal sandbox-manager's
+		// NewSandboxResumeTask that all post-resume initialization is done.
 		rCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady))
 		rCond.Status = metav1.ConditionStatus(pCond.Status)
 		rCond.LastTransitionTime = pCond.LastTransitionTime
-
-		// re-initialize sandbox after resuming or upgrading
-		if err := r.initializer.Initialize(ctx, box, newStatus); err != nil {
-			return err
-		}
-
 		utils.SetSandboxCondition(newStatus, *rCond)
 	}
 	return nil

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -618,6 +618,8 @@ func TestCommonControl_EnsureSandboxResumed(t *testing.T) {
 		args           EnsureFuncArgs
 		podExist       bool
 		wantErr        bool
+		expectError    string
+		initializer    SandboxInitializer // nil defaults to &defaultSandboxInitializer{}
 		expectedStatus *agentsv1alpha1.SandboxStatus
 	}{
 		{
@@ -762,6 +764,84 @@ func TestCommonControl_EnsureSandboxResumed(t *testing.T) {
 						LastTransitionTime: now,
 						Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
 					},
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionPostResumeInit),
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: now,
+						Reason:             agentsv1alpha1.SandboxPostResumeInitReasonSucceeded,
+						Message:            "Runtime re-init and CSI storage re-mount completed",
+					},
+				},
+			},
+		},
+		{
+			name: "pod is running and ready, but initializer fails",
+			args: EnsureFuncArgs{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-sandbox",
+						Namespace: "default",
+						UID:       "pod-uid-123",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node-1",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						PodIP: "10.0.0.5",
+						Conditions: []corev1.PodCondition{
+							{
+								Type:               corev1.PodReady,
+								Status:             corev1.ConditionTrue,
+								LastTransitionTime: now,
+							},
+						},
+					},
+				},
+				Box: &agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-sandbox",
+						Namespace: "default",
+					},
+				},
+				NewStatus: &agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxResuming,
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(agentsv1alpha1.SandboxConditionReady),
+							Status:             metav1.ConditionFalse,
+							LastTransitionTime: now,
+							Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
+						},
+					},
+				},
+			},
+			podExist:    true,
+			wantErr:     true,
+			expectError: "runtime re-init failed",
+			initializer: &mockSandboxInitializer{err: fmt.Errorf("runtime re-init failed")},
+			expectedStatus: &agentsv1alpha1.SandboxStatus{
+				Phase:    agentsv1alpha1.SandboxRunning,
+				NodeName: "node-1",
+				SandboxIp: "10.0.0.5",
+				PodInfo: agentsv1alpha1.PodInfo{
+					PodIP:    "10.0.0.5",
+					NodeName: "node-1",
+					PodUID:   "pod-uid-123",
+				},
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionReady),
+						Status:             metav1.ConditionFalse,
+						LastTransitionTime: now,
+						Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
+					},
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionPostResumeInit),
+						Status:             metav1.ConditionFalse,
+						Reason:             agentsv1alpha1.SandboxPostResumeInitReasonFailed,
+						Message:            "Runtime re-init or CSI storage re-mount failed: runtime re-init failed",
+					},
 				},
 			},
 		},
@@ -821,17 +901,26 @@ func TestCommonControl_EnsureSandboxResumed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+			init := tt.initializer
+			if init == nil {
+				init = &defaultSandboxInitializer{}
+			}
 			control := &commonControl{
 				Client:               fc,
 				recorder:             record.NewFakeRecorder(10),
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fc, inplaceupdate.DefaultGeneratePatchBodyFunc),
-				initializer:          &defaultSandboxInitializer{},
+				initializer:          init,
 			}
 
 			err := control.EnsureSandboxResumed(context.TODO(), tt.args)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("EnsureSandboxResumed() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if tt.expectError != "" && err != nil {
+				if !contains(err.Error(), tt.expectError) {
+					t.Errorf("EnsureSandboxResumed() error = %v, expectError contains %q", err, tt.expectError)
+				}
 			}
 
 			// Verify that pod was created if it didn't exist
@@ -844,7 +933,18 @@ func TestCommonControl_EnsureSandboxResumed(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(tt.args.NewStatus, tt.expectedStatus) {
-				t.Errorf("Expected sandbox(%s), got(%s)", utils.DumpJson(tt.expectedStatus), utils.DumpJson(tt.args.NewStatus))
+				// Normalize LastTransitionTime for conditions set via metav1.Now() inside the function
+				// (e.g., PostResumeInit) to avoid nanosecond-level mismatch with test's `now`.
+				for i := range tt.args.NewStatus.Conditions {
+					for j := range tt.expectedStatus.Conditions {
+						if tt.args.NewStatus.Conditions[i].Type == tt.expectedStatus.Conditions[j].Type {
+							tt.expectedStatus.Conditions[j].LastTransitionTime = tt.args.NewStatus.Conditions[i].LastTransitionTime
+						}
+					}
+				}
+				if !reflect.DeepEqual(tt.args.NewStatus, tt.expectedStatus) {
+					t.Errorf("Expected sandbox(%s), got(%s)", utils.DumpJson(tt.expectedStatus), utils.DumpJson(tt.args.NewStatus))
+				}
 			}
 		})
 	}

--- a/pkg/controller/sandbox/core/sandbox_initializer.go
+++ b/pkg/controller/sandbox/core/sandbox_initializer.go
@@ -47,22 +47,14 @@ func (d *defaultSandboxInitializer) Initialize(ctx context.Context, box *agentsv
 //  1. Re-init runtime (if initRuntimeRequest annotation is set)
 //  2. Re-mount CSI storage concurrently (if CSI mount annotations are set)
 //
-// The controller only handles initialization for sandboxes claimed by a SandboxClaim
-// (identified by the claim-name label). Non-claimed sandboxes are handled by E2B's Resume flow.
+// This is the unified initialization logic for all sandboxes after resume or recreate upgrade.
+// Both E2B and SandboxClaim paths rely on this to re-initialize runtime and CSI mounts.
 func Initialize(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus,
 	client client.Client, apiReader client.Reader, storageRegistry storages.VolumeMountProviderRegistry) error {
 	if client == nil || apiReader == nil {
 		return nil
 	}
 	logger := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(box))
-
-	// Only handle initialization for sandboxes claimed by a SandboxClaim.
-	// Non-claimed sandboxes are managed by E2B's Resume flow which handles runtime re-init
-	// and CSI re-mount independently.
-	if box.Labels[agentsv1alpha1.LabelSandboxClaimName] == "" {
-		logger.Info("sandbox is not claimed by SandboxClaim, skipping controller re-initialization")
-		return nil
-	}
 
 	// build a lightweight sandbox object with the latest status for runtime operations
 	sbxForInit := &agentsv1alpha1.Sandbox{

--- a/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
@@ -815,7 +815,7 @@ func TestSandbox_Resume(t *testing.T) {
 			simulateResumeCompleted: true,
 		},
 		{
-			name: "resume paused sandbox with init runtime 500 error",
+			name: "resume paused sandbox with controller post-resume init failure (runtime 500)",
 			initSandbox: func(sbx *v1alpha1.Sandbox) {
 				sbx.Status.Phase = v1alpha1.SandboxPaused
 				sbx.Status.Conditions = append(sbx.Status.Conditions, metav1.Condition{
@@ -826,11 +826,14 @@ func TestSandbox_Resume(t *testing.T) {
 				state, reason := sandboxutils.GetSandboxState(sbx)
 				assert.Equal(t, v1alpha1.SandboxStatePaused, state, reason)
 			},
-			expectedState:           "",
-			expectError:             "failed to perform ReInit after resume",
-			initErrCode:             500,
-			withInitRuntime:         true,
-			simulateResumeCompleted: true,
+			// When controller's Initialize fails (e.g. runtime returns 500), it sets
+			// PostResumeInit=False and does NOT set Ready=True. E2B Resume times out
+			// because NewSandboxResumeTask gates on Ready=True.
+			expectedState:   "",
+			expectError:     "object is not satisfied during double check",
+			initErrCode:     500,
+			withInitRuntime: true,
+			useShortTimeout: true,
 		},
 		{
 			name: "resume pausing sandbox",

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -33,12 +33,10 @@ import (
 	"github.com/openkruise/agents/pkg/agent-runtime/storages"
 	"github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/proxy"
-	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/utils"
-	csimountutils "github.com/openkruise/agents/pkg/utils/csiutils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
 	"github.com/openkruise/agents/pkg/utils/runtime"
 	sandboxManagerUtils "github.com/openkruise/agents/pkg/utils/sandbox-manager"
@@ -382,11 +380,6 @@ func (s *Sandbox) Resume(ctx context.Context, _ infra.ResumeOptions) error {
 
 	state, reason := s.GetState()
 	log.Info("try to resume sandbox", "state", state, "reason", reason)
-	initRuntimeOpts, err := runtime.GetInitRuntimeRequest(s.Sandbox)
-	if err != nil {
-		log.Error(err, "failed to get init runtime request")
-		return fmt.Errorf("failed to get init runtime request: %w", err)
-	}
 	resumeUpdated, err := s.retryUpdate(ctx, func(sbx *agentsv1alpha1.Sandbox) (bool, error) {
 		if !sbx.Spec.Paused {
 			// Resume is first-writer-wins: only the request that flips
@@ -409,7 +402,7 @@ func (s *Sandbox) Resume(ctx context.Context, _ infra.ResumeOptions) error {
 	log.Info("sandbox resumed", "cost", time.Since(start))
 
 	// If the original context deadline was consumed by the wait, create a fresh
-	// context for post-resume operations (ReInit, CSI mount, inplace refresh).
+	// context for post-resume operations (inplace refresh).
 	// This can happen when the wait succeeds via double-check right at the deadline boundary.
 	postCtx := ctx
 	if ctx.Err() != nil {
@@ -418,7 +411,7 @@ func (s *Sandbox) Resume(ctx context.Context, _ infra.ResumeOptions) error {
 		defer postCancel()
 		log.Info("original context expired after wait, using fresh context for post-resume operations")
 	}
-	if err = s.InplaceRefresh(postCtx, false); err != nil {
+	if err := s.InplaceRefresh(postCtx, false); err != nil {
 		log.Error(err, "failed to refresh sandbox after resume")
 		return err
 	}
@@ -433,45 +426,9 @@ func (s *Sandbox) Resume(ctx context.Context, _ infra.ResumeOptions) error {
 		return nil
 	}
 
-	// E2B only handles post-resume initialization for non-claimed sandboxes.
-	// Claimed sandboxes (with claim-name label) are handled by the controller's Initialize function.
-	if s.Labels[agentsv1alpha1.LabelSandboxClaimName] == "" {
-		// Perform ReInit if initRuntimeOpts is set
-		if initRuntimeOpts != nil {
-			log.Info("will re-init runtime after resume")
-			if _, err := runtime.InitRuntime(postCtx, s.Sandbox, *initRuntimeOpts, s.refreshFunc()); err != nil {
-				log.Error(err, "failed to perform ReInit after resume")
-				return fmt.Errorf("failed to perform ReInit after resume: %w", err)
-			}
-			log.Info("ReInit completed after resume")
-		}
-
-		// Perform csi mount after resume
-		csiMountConfigRequests, err := runtime.GetCsiMountExtensionRequest(s.Sandbox)
-		if err != nil {
-			log.Error(err, "failed to get csi mount request")
-			return fmt.Errorf("failed to get csi mount request: %w", err)
-		}
-
-		if len(csiMountConfigRequests) != 0 {
-			log.Info("will re-mount csi storage after resume")
-			startTime := time.Now()
-			csiClient := csimountutils.NewCSIMountHandler(s.Cache.GetClient(), s.Cache.GetAPIReader(), s.storageRegistry, utils.DefaultSandboxDeployNamespace)
-			mountConfigs, resolveErr := resolveCSIMountConfigs(postCtx, csiClient, csiMountConfigRequests)
-			if resolveErr != nil {
-				return resolveErr
-			}
-			opts := config.CSIMountOptions{MountOptionList: mountConfigs}
-			if _, mountErr := runtime.ProcessCSIMounts(postCtx, s.Sandbox, opts); mountErr != nil {
-				log.Error(mountErr, "failed to remount csi storage after resume")
-				return fmt.Errorf("failed to remount csi storage after resume: %v", mountErr)
-			}
-			log.Info("remount csi storage completed after resume", "costTime", time.Since(startTime))
-		}
-	} else {
-		log.Info("sandbox is claimed by SandboxClaim, skipping E2B post-resume initialization",
-			"claimName", s.Labels[agentsv1alpha1.LabelSandboxClaimName])
-	}
+	// Post-resume initialization (ReInit + CSI mount) is now handled by the sandbox-controller's
+	// Initialize function. The controller gates the Running state on successful initialization,
+	// so by the time NewSandboxResumeTask completes, all mounts are already done.
 
 	return nil
 }
@@ -499,22 +456,6 @@ func (s *Sandbox) CreateCheckpoint(ctx context.Context, opts infra.CreateCheckpo
 }
 
 var _ infra.Sandbox = &Sandbox{}
-
-// resolveCSIMountConfigs converts CSIMountConfig requests into MountConfig
-// by calling CSIMountOptionsConfig for each request sequentially.
-func resolveCSIMountConfigs(ctx context.Context, csiClient *csimountutils.CSIMountHandler, requests []agentsv1alpha1.CSIMountConfig) ([]config.MountConfig, error) {
-	log := klog.FromContext(ctx)
-	results := make([]config.MountConfig, 0, len(requests))
-	for _, req := range requests {
-		driverName, csiReqConfigRaw, err := csiClient.CSIMountOptionsConfig(ctx, req)
-		if err != nil {
-			log.Error(err, "failed to generate csi mount options config", "mountConfigRequest", req)
-			return nil, fmt.Errorf("failed to generate csi mount options config, err: %v", err)
-		}
-		results = append(results, config.MountConfig{Driver: driverName, RequestRaw: csiReqConfigRaw})
-	}
-	return results, nil
-}
 
 func AsSandbox(sbx *agentsv1alpha1.Sandbox, cache cache.Provider) *Sandbox {
 	return &Sandbox{


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Consolidate CSI mount and ReInit logic from sandbox-manager (E2B layer)
into the sandbox-controller's Initialize function, making it the single
source of truth for all post-resume/recreate initialization.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

