### PR TITLE
Persist Sandbox status on reconcile errors

### DIFF
--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -242,11 +242,8 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 	if err != nil {
-		//todo, call updateSandboxStatus
-		if newStatus.Phase == agentsv1alpha1.SandboxUpgrading {
-			if retErr := r.updateSandboxStatus(ctx, *newStatus, box); retErr != nil {
-				klog.ErrorS(retErr, "failed to persist upgrade status on error", "sandbox", klog.KObj(box))
-			}
+		if retErr := r.updateSandboxStatus(ctx, *newStatus, box); retErr != nil {
+			klog.ErrorS(retErr, "failed to persist sandbox status on error", "sandbox", klog.KObj(box))
 		}
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -43,6 +43,33 @@ import (
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 )
 
+type failingStatusUpdateControl struct{}
+
+func (failingStatusUpdateControl) EnsureSandboxRunning(ctx context.Context, args core.EnsureFuncArgs) (time.Duration, error) {
+	return 0, nil
+}
+
+func (failingStatusUpdateControl) EnsureSandboxUpdated(ctx context.Context, args core.EnsureFuncArgs) error {
+	args.NewStatus.Message = "sandbox update failed"
+	return fmt.Errorf("simulated update error")
+}
+
+func (failingStatusUpdateControl) EnsureSandboxPaused(ctx context.Context, args core.EnsureFuncArgs) error {
+	return nil
+}
+
+func (failingStatusUpdateControl) EnsureSandboxResumed(ctx context.Context, args core.EnsureFuncArgs) error {
+	return nil
+}
+
+func (failingStatusUpdateControl) EnsureSandboxUpgraded(ctx context.Context, args core.EnsureFuncArgs) error {
+	return nil
+}
+
+func (failingStatusUpdateControl) EnsureSandboxTerminated(ctx context.Context, args core.EnsureFuncArgs) error {
+	return nil
+}
+
 func TestAdd_FeatureGateDisabled(t *testing.T) {
 	// When SandboxGate feature gate is disabled, Add should return nil immediately
 	// without touching the manager.
@@ -784,6 +811,81 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 				t.Errorf("Expected requeue after %v, but got %v", tt.expectRequeueAfter, result.RequeueAfter)
 			}
 		})
+	}
+}
+
+func TestSandboxReconciler_Reconcile_PersistsStatusOnControlError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	sandbox := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "error-status-sandbox",
+			Namespace:  "default",
+			Finalizers: []string{utils.SandboxFinalizer},
+		},
+		Spec: agentsv1alpha1.SandboxSpec{
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test", Image: "nginx:latest"}},
+					},
+				},
+			},
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxRunning,
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sandbox.Name,
+			Namespace: sandbox.Namespace,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	core.ResourceVersionExpectations.Delete(sandbox)
+	defer core.ResourceVersionExpectations.Delete(sandbox)
+	core.ScaleExpectation.DeleteExpectations(utils.GetControllerKey(sandbox))
+	defer core.ScaleExpectation.DeleteExpectations(utils.GetControllerKey(sandbox))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(sandbox, pod).
+		WithStatusSubresource(&agentsv1alpha1.Sandbox{}).
+		Build()
+	reconciler := &SandboxReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+		controls: map[string]core.SandboxControl{
+			core.CommonControlName: failingStatusUpdateControl{},
+		},
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: sandbox.Namespace,
+		Name:      sandbox.Name,
+	}})
+	if err == nil {
+		t.Fatal("Expected reconcile to return the control error")
+	}
+	if err.Error() != "simulated update error" {
+		t.Fatalf("Expected simulated update error, got %v", err)
+	}
+
+	updated := &agentsv1alpha1.Sandbox{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: sandbox.Namespace, Name: sandbox.Name}, updated); err != nil {
+		t.Fatalf("Failed to get updated sandbox: %v", err)
+	}
+	if updated.Status.Message != "sandbox update failed" {
+		t.Fatalf("Expected status message to be persisted, got %q", updated.Status.Message)
+	}
+	if updated.Status.Phase != agentsv1alpha1.SandboxRunning {
+		t.Fatalf("Expected phase %s, got %s", agentsv1alpha1.SandboxRunning, updated.Status.Phase)
 	}
 }
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR ensures the Sandbox controller persists computed status updates even when phase-specific reconcile logic returns an error.

Previously, most control-error paths returned immediately without calling `updateSandboxStatus`. Only the `Upgrading` phase had special-case status persistence. This meant useful status changes could be lost when reconcile failed, making the Kubernetes `Sandbox.status` less accurate during failed pause/resume/update/upgrade operations.

## Changes

- Call `updateSandboxStatus` on all control errors, not only `SandboxUpgrading`.
- Preserve existing retry behavior by still returning the original reconcile error.
- Log status persistence errors without masking the original control error.
- Add a focused controller test that verifies status is persisted even when the control logic mutates `newStatus` and then returns an error.

## Why

Users should be able to inspect `Sandbox.status` and understand what happened, even if the controller hit an error and will retry.

This improves visibility for fields such as:

- `status.phase`
- `status.message`
- `status.conditions`


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
"NONE" but resolves the TODO at sandbox_controller.go (line 245)

### Ⅲ. Describe how to verify it
```bash
go test ./pkg/controller/sandbox
go test ./pkg/webhook/sandboxset/validating
```


### Ⅳ. Special notes for reviews
I also did manual kind verification
Deployed the locally built controller image into kind:

```bash
make docker-build-controller CONTROLLER_IMG=agent-sandbox-controller:latest
kind load docker-image agent-sandbox-controller:latest --name openkruise
kubectl -n sandbox-system rollout restart deploy/sandbox-controller-manager
kubectl -n sandbox-system rollout status deploy/sandbox-controller-manager
```
Created a demo Sandbox and confirmed it reached Running:
```bash
kubectl apply -f - <<'EOF'
apiVersion: agents.kruise.io/v1alpha1
kind: Sandbox
metadata:
  name: status-demo
  namespace: default
spec:
  template:
    spec:
      containers:
      - name: app
        image: nginx:latest
EOF

kubectl get sandbox status-demo -o yaml
kubectl get pod status-demo
```
Triggered a failing recreate upgrade with a failing preUpgrade hook:
```bash
kubectl patch sandbox status-demo --type merge -p '{
  "spec": {
    "upgradePolicy": {
      "type": "Recreate"
    },
    "lifecycle": {
      "preUpgrade": {
        "exec": {
          "command": ["sh", "-c", "exit 1"]
        }
      }
    },
    "template": {
      "spec": {
        "containers": [
          {
            "name": "app",
            "image": "nginx:1.25"
          }
        ]
      }
    }
  }
}'

```
Confirmed status was persisted with the failed upgrade state:
```bash
status:
  conditions:
  - lastTransitionTime: "2026-05-11T18:40:04Z"
    message: sandbox is upgrading
    reason: Upgrading
    status: "False"
    type: Ready
  - lastTransitionTime: "2026-05-11T18:38:07Z"
    message: ""
    reason: Succeeded
    status: "True"
    type: InplaceUpdate
  - lastTransitionTime: "2026-05-11T18:40:04Z"
    message: 'hook execution error: unavailable: dial tcp 10.244.0.8:49983: connect:
      connection refused'
    reason: PreUpgradeFailed
    status: "False"
    type: Upgrading
  nodeName: openkruise-control-plane
```

