### PR TITLE
feat: add Pausing phase to Sandbox lifecycle (#250)

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -243,6 +243,8 @@ const (
 	// SandboxRunning means the pod has been bound to a node and all of the containers have been started.
 	// At least one container is still running or is in the process of being restarted.
 	SandboxRunning SandboxPhase = "Running"
+	// SandboxPausing means the sandbox is entering hibernation (pod deletion in progress).
+	SandboxPausing SandboxPhase = "Pausing"
 	// SandboxPaused means the sandbox has entered the paused state.
 	SandboxPaused SandboxPhase = "Paused"
 	// SandboxResuming means the sandbox has entered the resume state

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -178,12 +178,13 @@ func (r *commonControl) EnsureSandboxPaused(ctx context.Context, args EnsureFunc
 	}
 
 	// Pod deletion completed, paused completed
-	// cond.Status == metav1.ConditionFalse just for sure
-	if pod == nil && cond.Status == metav1.ConditionFalse {
-		cond.Status = metav1.ConditionTrue
-		cond.LastTransitionTime = metav1.Now()
-		utils.SetSandboxCondition(newStatus, *cond)
-		klog.InfoS("Pod deletion completed, pause phase completed", "sandbox", klog.KObj(box))
+	if pod == nil {
+		if cond.Status == metav1.ConditionFalse {
+			cond.Status = metav1.ConditionTrue
+			cond.LastTransitionTime = metav1.Now()
+			utils.SetSandboxCondition(newStatus, *cond)
+			klog.InfoS("Pod deletion completed, pause phase completed", "sandbox", klog.KObj(box))
+		}
 		return nil
 	}
 	// Pod deletion incomplete, waiting
@@ -226,17 +227,12 @@ func (r *commonControl) EnsureSandboxResumed(ctx context.Context, args EnsureFun
 	// when pod is ready, sandbox status from resuming to running
 	pCond := utils.GetPodCondition(&pod.Status, corev1.PodReady)
 	if pod.Status.Phase == corev1.PodRunning && pCond != nil && pCond.Status == corev1.ConditionTrue {
-		newStatus.Phase = agentsv1alpha1.SandboxRunning
-		rCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady))
-		rCond.Status = metav1.ConditionStatus(pCond.Status)
-		rCond.LastTransitionTime = pCond.LastTransitionTime
-
 		// re-initialize sandbox after resuming or upgrading
 		if err := r.initializer.Initialize(ctx, box, newStatus); err != nil {
 			return err
 		}
-
-		utils.SetSandboxCondition(newStatus, *rCond)
+		newStatus.Phase = agentsv1alpha1.SandboxRunning
+		syncSandboxStatusFromPod(pod, newStatus)
 	}
 	return nil
 }

--- a/pkg/controller/sandbox/core/rateLimiter.go
+++ b/pkg/controller/sandbox/core/rateLimiter.go
@@ -165,7 +165,7 @@ func isCreatingSandbox(box *agentsv1alpha1.Sandbox) bool {
 	if !box.DeletionTimestamp.IsZero() {
 		return false
 	}
-	if box.Status.Phase == agentsv1alpha1.SandboxPaused || box.Status.Phase == agentsv1alpha1.SandboxResuming ||
+	if box.Status.Phase == agentsv1alpha1.SandboxPausing || box.Status.Phase == agentsv1alpha1.SandboxPaused || box.Status.Phase == agentsv1alpha1.SandboxResuming ||
 		box.Status.Phase == agentsv1alpha1.SandboxSucceeded || box.Status.Phase == agentsv1alpha1.SandboxFailed {
 		return false
 	}

--- a/pkg/controller/sandbox/core/rateLimiter_test.go
+++ b/pkg/controller/sandbox/core/rateLimiter_test.go
@@ -147,6 +147,11 @@ func TestIsCreatingSandbox(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "phase Pausing is not creating",
+			box:      newSandbox("default", "box1", agentsv1alpha1.SandboxPausing),
+			expected: false,
+		},
+		{
 			name:     "phase Paused is not creating",
 			box:      newSandbox("default", "box1", agentsv1alpha1.SandboxPaused),
 			expected: false,

--- a/pkg/controller/sandbox/metrics.go
+++ b/pkg/controller/sandbox/metrics.go
@@ -163,6 +163,7 @@ var (
 	allPhases = []agentsv1alpha1.SandboxPhase{
 		agentsv1alpha1.SandboxPending,
 		agentsv1alpha1.SandboxRunning,
+		agentsv1alpha1.SandboxPausing,
 		agentsv1alpha1.SandboxPaused,
 		agentsv1alpha1.SandboxResuming,
 		agentsv1alpha1.SandboxSucceeded,

--- a/pkg/controller/sandbox/metrics_test.go
+++ b/pkg/controller/sandbox/metrics_test.go
@@ -126,6 +126,7 @@ func TestRecordSandboxMetrics_StatusPhase(t *testing.T) {
 	}{
 		{name: "Pending phase", phase: agentsv1alpha1.SandboxPending},
 		{name: "Running phase", phase: agentsv1alpha1.SandboxRunning},
+		{name: "Pausing phase", phase: agentsv1alpha1.SandboxPausing},
 		{name: "Paused phase", phase: agentsv1alpha1.SandboxPaused},
 		{name: "Resuming phase", phase: agentsv1alpha1.SandboxResuming},
 		{name: "Succeeded phase", phase: agentsv1alpha1.SandboxSucceeded},
@@ -534,10 +535,10 @@ func TestRecordSandboxMetrics_Info(t *testing.T) {
 			NodeName: "node-1",
 		},
 	}
-
+	
 	recordSandboxMetrics(sandbox)
 	defer deleteSandboxMetrics("default", "info-sandbox")
-
+	
 	val := testutil.ToFloat64(sandboxInfo.WithLabelValues("default", "info-sandbox",
 		"my-sandboxset", "node-1", "my-template"))
 	if val != 1 {

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -231,8 +231,8 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 		requeueAfter, err = r.getControl(args.Pod).EnsureSandboxRunning(ctx, args)
 	case agentsv1alpha1.SandboxRunning:
 		err = r.getControl(args.Pod).EnsureSandboxUpdated(ctx, args)
-	case agentsv1alpha1.SandboxPaused:
-		err = r.EnsureSandboxPaused(ctx, args)
+	case agentsv1alpha1.SandboxPausing, agentsv1alpha1.SandboxPaused:
+		err = r.getControl(args.Pod).EnsureSandboxPaused(ctx, args)
 	case agentsv1alpha1.SandboxResuming:
 		err = r.getControl(args.Pod).EnsureSandboxResumed(ctx, args)
 	case agentsv1alpha1.SandboxUpgrading:
@@ -333,12 +333,12 @@ func calculateStatus(args core.EnsureFuncArgs) (*agentsv1alpha1.SandboxStatus, b
 			return newStatus, true
 		}
 
-		// If it is paused, first set the sandbox to the Paused state.
-		// To prevent loss of state information, the state immediately before Paused must currently be Running.
+		// If it is paused, first set the sandbox to the Pausing state (transitional).
+		// To prevent loss of state information, the state immediately before Pausing must currently be Running.
 		if box.Spec.Paused {
 			// The paused and resumed condition are exclusive
 			utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionResumed))
-			newStatus.Phase = agentsv1alpha1.SandboxPaused
+			newStatus.Phase = agentsv1alpha1.SandboxPausing
 			// Check for upgrade: if template has changed (hash mismatch), transition to Upgrading phase
 		} else if pod != nil && pod.Labels[agentsv1alpha1.PodLabelTemplateHash] != newStatus.UpdateRevision &&
 			box.Spec.UpgradePolicy != nil && box.Spec.UpgradePolicy.Type == agentsv1alpha1.SandboxUpgradePolicyRecreate {
@@ -349,10 +349,17 @@ func calculateStatus(args core.EnsureFuncArgs) (*agentsv1alpha1.SandboxStatus, b
 			utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionUpgrading))
 		}
 
+	case agentsv1alpha1.SandboxPausing:
+		cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
+		// Transition to Paused only when the condition confirms pod deletion is complete
+		if cond != nil && cond.Status == metav1.ConditionTrue {
+			newStatus.Phase = agentsv1alpha1.SandboxPaused
+		}
+
 	case agentsv1alpha1.SandboxPaused:
 		cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
 		// sandbox will only enter the resuming state after successful paused
-		if cond.Status == metav1.ConditionTrue && !box.Spec.Paused {
+		if cond != nil && cond.Status == metav1.ConditionTrue && !box.Spec.Paused {
 			// delete paused condition
 			utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
 			newStatus.Phase = agentsv1alpha1.SandboxResuming
@@ -363,7 +370,7 @@ func calculateStatus(args core.EnsureFuncArgs) (*agentsv1alpha1.SandboxStatus, b
 				LastTransitionTime: metav1.Now(),
 			}
 			utils.SetSandboxCondition(newStatus, rCond)
-		} else if !box.Spec.Paused && cond.Status == metav1.ConditionFalse {
+		} else if !box.Spec.Paused && (cond == nil || cond.Status == metav1.ConditionFalse) {
 			klog.InfoS("sandbox pause not completed, cannot enter resume state temporarily", "sandbox", klog.KObj(box))
 		}
 

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -314,7 +314,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 			wantErr:       false,
 		},
 		{
-			name: "sandbox paused - should set to paused",
+			name: "sandbox paused - should set to pausing",
 			sandbox: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "paused-sandbox",
@@ -348,7 +348,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 					Phase: corev1.PodRunning,
 				},
 			},
-			expectedPhase: agentsv1alpha1.SandboxPaused,
+			expectedPhase: agentsv1alpha1.SandboxPausing,
 			wantErr:       false,
 		},
 		{
@@ -1518,7 +1518,7 @@ func TestCalculateStatus(t *testing.T) {
 					},
 				},
 			},
-			expectedPhase:     agentsv1alpha1.SandboxPaused,
+			expectedPhase:     agentsv1alpha1.SandboxPausing,
 			expectedShouldReq: false,
 			checkConditions: func(t *testing.T, status *agentsv1alpha1.SandboxStatus) {
 				// Should remove resumed condition
@@ -1528,6 +1528,78 @@ func TestCalculateStatus(t *testing.T) {
 					}
 				}
 			},
+		},
+		{
+			name: "pausing phase with paused condition true should transition to paused",
+			pod:  nil,
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-sandbox",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused: true,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+							},
+						},
+					},
+				},
+			},
+			initStatus: &agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPausing,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(agentsv1alpha1.SandboxConditionPaused),
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+			expectedPhase:     agentsv1alpha1.SandboxPaused,
+			expectedShouldReq: false,
+		},
+		{
+			name: "pausing phase with paused condition false should stay pausing",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-sandbox",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused: true,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+							},
+						},
+					},
+				},
+			},
+			initStatus: &agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPausing,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(agentsv1alpha1.SandboxConditionPaused),
+						Status: metav1.ConditionFalse,
+					},
+				},
+			},
+			expectedPhase:     agentsv1alpha1.SandboxPausing,
+			expectedShouldReq: false,
 		},
 		{
 			name: "paused phase with paused condition true and not paused spec should set to resuming",
@@ -1592,46 +1664,6 @@ func TestCalculateStatus(t *testing.T) {
 					t.Errorf("Resumed condition should be added")
 				}
 			},
-		},
-		{
-			name: "paused phase with paused condition false and not paused spec should stay paused",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-sandbox",
-					Namespace: "default",
-				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-				},
-			},
-			box: &agentsv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-sandbox",
-					Namespace:  "default",
-					Generation: 1,
-				},
-				Spec: agentsv1alpha1.SandboxSpec{
-					Paused: false,
-					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
-						Template: &corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
-							},
-						},
-					},
-				},
-			},
-			initStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxPaused,
-				Conditions: []metav1.Condition{
-					{
-						Type:   string(agentsv1alpha1.SandboxConditionPaused),
-						Status: metav1.ConditionFalse,
-					},
-				},
-			},
-			expectedPhase:     agentsv1alpha1.SandboxPaused,
-			expectedShouldReq: false,
 		},
 		{
 			name: "running phase with running pod should stay running",


### PR DESCRIPTION

### Ⅰ. Describe what this PR does
This PR introduces a new transitional lifecycle phase, Pausing, for the Sandbox resource.
Previously, when a Sandbox was set to Paused: true, it would transition directly from Running to Paused while the underlying Pod deletion was still in progress.

- Added SandboxPausing to SandboxPhase in the API.
- Updated the controller's state machine:
- Running -> Pausing (triggered when Spec.Paused is true).
- Pausing -> Paused (only after the SandboxPaused condition confirms the Pod is fully deleted).
- Updated Prometheus metrics to track the Pausing phase.
- Updated the Rate Limiter to treat Pausing as a non-creating phase, ensuring it doesn't block high-priority Sandbox creation.

### Ⅱ. Does this pull request fix one issue?
fixes #250 
### Ⅲ. Describe how to verify it
- Unit Tests: Updated `sandbox_controller_test.go`, `metrics_test.go`, and `rateLimiter_test.go` to cover the new state transitions. 
- E2E Tests: Verified the Sandbox lifecycle in a Kind cluster. The controller correctly transitions through Pausing before reaching Paused during hibernation.
- Manual Verification: Observed Sandbox status transitions using kubectl get sandbox -w while toggling the spec.paused field.


