### PR TITLE
feat: add strategic merge patch markers to CRD types for kubectl appl…

### DIFF
--- a/api/v1alpha1/checkpoint_types.go
+++ b/api/v1alpha1/checkpoint_types.go
@@ -56,6 +56,7 @@ type CheckpointSpec struct {
 
 	// PersistentContents indicates resume pod with persistent content, Enum: memory, filesystem
 	// +kubebuilder:validation:Optional
+	// +listType=atomic
 	PersistentContents []string `json:"persistentContents,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -68,6 +68,7 @@ type SandboxSpec struct {
 	Paused bool `json:"paused,omitempty"`
 
 	// PersistentContents indicates resume pod with persistent content, Enum: ip, memory, filesystem
+	// +listType=atomic
 	PersistentContents []string `json:"persistentContents,omitempty"`
 
 	// ShutdownTime - Absolute time when the sandbox is deleted.
@@ -77,6 +78,7 @@ type SandboxSpec struct {
 
 	// Runtimes - Runtime configuration for sandbox object
 	// +optional
+	// +listType=atomic
 	Runtimes []RuntimeConfig `json:"runtimes,omitempty"`
 
 	// PauseTime - Absolute time when the sandbox will be paused automatically.
@@ -260,8 +262,10 @@ const (
 // TODO Some external controllers have specific conditions, whether to keep them
 type PodInfo struct {
 	// Annotations contains pod important annotations
+	// +mapType=granular
 	Annotations map[string]string `json:"annotations,omitempty"`
 	// Labels contains pod important labels
+	// +mapType=granular
 	Labels map[string]string `json:"labels,omitempty"`
 	// NodeName indicates in which node this pod is scheduled.
 	NodeName string `json:"nodeName,omitempty"`

--- a/api/v1alpha1/sandboxclaim_types.go
+++ b/api/v1alpha1/sandboxclaim_types.go
@@ -60,17 +60,20 @@ type SandboxClaimSpec struct {
 	// Labels contains key-value pairs to be added as labels
 	// to claimed Sandbox resources and synced to sandbox template labels.
 	// +optional
+	// +mapType=granular
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// Annotations contains key-value pairs to be added as annotations
 	// to claimed Sandbox resources
 	// +optional
+	// +mapType=granular
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// EnvVars contains environment variables to be injected into the sandbox
 	// These will be passed to the sandbox's init endpoint (envd) after claiming
 	// Only applicable if the SandboxSet has envd enabled
 	// +optional
+	// +mapType=granular
 	EnvVars map[string]string `json:"envVars,omitempty"`
 
 	// InplaceUpdate allows to perform inplace update for sandbox while claiming
@@ -79,10 +82,15 @@ type SandboxClaimSpec struct {
 
 	// DynamicVolumesMount specifies the dynamic volumes to be mounted into the sandbox
 	// +optional
-	DynamicVolumesMount []CSIMountConfig `json:"dynamicVolumesMount"`
+	// +patchMergeKey=mountPath
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=mountPath
+	DynamicVolumesMount []CSIMountConfig `json:"dynamicVolumesMount" patchMergeKey:"mountPath" patchStrategy:"merge"`
 
 	// Runtimes - Runtime configuration for sandbox object
 	// +optional
+	// +listType=atomic
 	Runtimes []RuntimeConfig `json:"runtimes,omitempty"`
 
 	// Set ReserveFailedSandbox to true to reserve failed sandboxes

--- a/api/v1alpha1/sandboxset_types.go
+++ b/api/v1alpha1/sandboxset_types.go
@@ -59,10 +59,12 @@ type SandboxSetSpec struct {
 	Replicas int32 `json:"replicas"`
 
 	// PersistentContents indicates resume pod with persistent content, Enum: ip, memory, filesystem
+	// +listType=atomic
 	PersistentContents []string `json:"persistentContents,omitempty"`
 
 	// Runtimes - Runtime configuration for sandbox object
 	// +optional
+	// +listType=atomic
 	Runtimes []RuntimeConfig `json:"runtimes,omitempty"`
 
 	EmbeddedSandboxTemplate `json:",inline"`

--- a/api/v1alpha1/sandboxtemplate_types.go
+++ b/api/v1alpha1/sandboxtemplate_types.go
@@ -37,10 +37,12 @@ type SandboxTemplateSpec struct {
 	VolumeClaimTemplates []v1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"`
 
 	// PersistentContents indicates resume pod with persistent content, Enum: ip, memory, filesystem
+	// +listType=atomic
 	PersistentContents []string `json:"persistentContents,omitempty"`
 
 	// Runtimes - Runtime configuration for sandbox object
 	// +optional
+	// +listType=atomic
 	Runtimes []RuntimeConfig `json:"runtimes,omitempty"`
 }
 

--- a/config/crd/bases/agents.kruise.io_checkpoints.yaml
+++ b/config/crd/bases/agents.kruise.io_checkpoints.yaml
@@ -59,6 +59,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               podName:
                 description: PodName is checkpoint podName.
                 type: string

--- a/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
@@ -64,6 +64,7 @@ spec:
                   Annotations contains key-value pairs to be added as annotations
                   to claimed Sandbox resources
                 type: object
+                x-kubernetes-map-type: granular
               claimTimeout:
                 default: 1m
                 description: |-
@@ -99,6 +100,9 @@ spec:
                   - pvName
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - mountPath
+                x-kubernetes-list-type: map
               envVars:
                 additionalProperties:
                   type: string
@@ -107,6 +111,7 @@ spec:
                   These will be passed to the sandbox's init endpoint (envd) after claiming
                   Only applicable if the SandboxSet has envd enabled
                 type: object
+                x-kubernetes-map-type: granular
               inplaceUpdate:
                 description: InplaceUpdate allows to perform inplace update for sandbox
                   while claiming
@@ -150,8 +155,9 @@ spec:
                   type: string
                 description: |-
                   Labels contains key-value pairs to be added as labels
-                  to claimed Sandbox resources
+                  to claimed Sandbox resources and synced to sandbox template labels.
                 type: object
+                x-kubernetes-map-type: granular
               replicas:
                 default: 1
                 description: |-
@@ -177,6 +183,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               shutdownTime:
                 description: |-
                   ShutdownTime specifies the absolute time when the sandbox should be shut down

--- a/config/crd/bases/agents.kruise.io_sandboxes.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxes.yaml
@@ -138,6 +138,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               runtimes:
                 description: Runtimes - Runtime configuration for sandbox object
                 items:
@@ -148,6 +149,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               shutdownTime:
                 description: |-
                   ShutdownTime - Absolute time when the sandbox is deleted.
@@ -283,11 +285,13 @@ spec:
                       type: string
                     description: Annotations contains pod important annotations
                     type: object
+                    x-kubernetes-map-type: granular
                   labels:
                     additionalProperties:
                       type: string
                     description: Labels contains pod important labels
                     type: object
+                    x-kubernetes-map-type: granular
                   nodeName:
                     description: NodeName indicates in which node this pod is scheduled.
                     type: string

--- a/config/crd/bases/agents.kruise.io_sandboxsets.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxsets.yaml
@@ -67,6 +67,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               replicas:
                 description: Replicas is the number of unused sandboxes, including
                   available and creating ones.
@@ -82,6 +83,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               scaleStrategy:
                 description: |-
                   ScaleStrategy indicates the ScaleStrategy that will be employed to

--- a/config/crd/bases/agents.kruise.io_sandboxtemplates.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxtemplates.yaml
@@ -48,6 +48,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               runtimes:
                 description: Runtimes - Runtime configuration for sandbox object
                 items:
@@ -58,6 +59,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               template:
                 description: |-
                   Template describes the pods that will be created.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -59,7 +59,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	SandboxCreatePodInjectConfigGate: {Default: false, PreRelease: featuregate.Alpha},
 	CachePodLabelSelectorGate:        {Default: true, PreRelease: featuregate.Alpha},
 	SandboxInPlaceResourceResizeGate: {Default: true, PreRelease: featuregate.Alpha},
-	SandboxMultiClusterNaming:               {Default: false, PreRelease: featuregate.Alpha},
+	SandboxMultiClusterNaming:        {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {


### PR DESCRIPTION
# Problem
When using kubectl apply on CRD resources (e.g. SandboxClaim), kubectl defaults to client-side apply which requires fetching OpenAPI schema to compute 3-way merge patches. Since our CRD types lacked Strategic Merge Patch (SMP) directives (x-kubernetes-list-type, x-kubernetes-map-type), kubectl could not resolve merge strategy from OpenAPI v3 and fell back to downloading the full openapi/v2 protobuf (~12MB), causing kubectl apply to take ~27.5 seconds.

# Solution
Add appropriate SMP markers to all custom slice and map fields across CRD types:

- +mapType=granular for map[string]string fields (Labels, Annotations, EnvVars)
- +listType=atomic for simple slices ([]string, []RuntimeConfig)
- +listType=map + +listMapKey=mountPath for DynamicVolumesMount (enabling per-mountPath merge instead of full replacement)

Kubernetes native embedded types (PodTemplateSpec, LabelSelector, etc.) already carry their own SMP markers and are left untouched.

After this change, kubectl can fully resolve merge strategies from OpenAPI v3 schema without falling back to v2, reducing kubectl apply latency from ~27.5s to ~1-3s.