### PR TITLE
fix: include stdout/stderr in lifecycle hook failure messages

### DIFF
--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -537,10 +537,12 @@ func (r *commonControl) executeUpgradeAction(ctx context.Context, pod *corev1.Po
 
 	exitCode, stdout, stderr, err := r.lifecycleHookFunc(ctx, box, action)
 	if err != nil {
-		return upgradeActionResult{Succeeded: false, Message: fmt.Sprintf("hook execution error: %v", err)}
+		msg := fmt.Sprintf("hook execution error: %v, stderr: %s, stdout: %s", err, stderr, stdout)
+		return upgradeActionResult{Succeeded: false, Message: utils.TruncateConditionMessage(msg)}
 	}
 	if exitCode != 0 {
-		return upgradeActionResult{Succeeded: false, Message: fmt.Sprintf("hook failed with exit code %d, stdout: %s, stderr: %s", exitCode, stdout, stderr)}
+		msg := fmt.Sprintf("hook failed with exit code %d, stderr: %s, stdout: %s", exitCode, stderr, stdout)
+		return upgradeActionResult{Succeeded: false, Message: utils.TruncateConditionMessage(msg)}
 	}
 	return upgradeActionResult{Succeeded: true, Message: fmt.Sprintf("hook succeeded, stdout: %s", stdout)}
 }

--- a/pkg/controller/sandbox/core/lifecycle_handler.go
+++ b/pkg/controller/sandbox/core/lifecycle_handler.go
@@ -59,7 +59,7 @@ func ExecuteLifecycleHook(ctx context.Context, box *agentsv1alpha1.Sandbox, acti
 		Timeout: timeout,
 	})
 	if err != nil {
-		return -1, "", "", err
+		return -1, strings.Join(result.Stdout, ""), strings.Join(result.Stderr, ""), err
 	}
 
 	return result.ExitCode, strings.Join(result.Stdout, ""), strings.Join(result.Stderr, ""), nil

--- a/pkg/controller/sandbox/core/upgrade_control_test.go
+++ b/pkg/controller/sandbox/core/upgrade_control_test.go
@@ -19,8 +19,10 @@ package core
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -117,6 +119,58 @@ func newTestCommonControl(hookFunc LifecycleHookFunc, objects ...client.Object) 
 		rateLimiter:          NewRateLimiter(),
 		lifecycleHookFunc:    hookFunc,
 		initializer:          &defaultSandboxInitializer{},
+	}
+}
+
+func TestExecuteUpgradeAction(t *testing.T) {
+	action := &agentsv1alpha1.UpgradeAction{
+		Exec:           &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "echo test"}},
+		TimeoutSeconds: 30,
+	}
+	pod := newRunningPod()
+	box := newUpgradeTestSandbox(&agentsv1alpha1.SandboxLifecycle{PreUpgrade: action}, nil)
+
+	tests := []struct {
+		name           string
+		hookFunc       LifecycleHookFunc
+		expectSuccess  bool
+		expectContains string
+	}{
+		{
+			name:           "error with stderr included in message",
+			hookFunc:       mockLifecycleHookFunc(-1, "", "permission denied", fmt.Errorf("connection refused")),
+			expectSuccess:  false,
+			expectContains: "permission denied",
+		},
+		{
+			name:           "error with stdout when stderr is empty",
+			hookFunc:       mockLifecycleHookFunc(-1, "partial output", "", fmt.Errorf("timeout")),
+			expectSuccess:  false,
+			expectContains: "partial output",
+		},
+		{
+			name:           "non-zero exit code with stderr included",
+			hookFunc:       mockLifecycleHookFunc(1, "", "command not found", nil),
+			expectSuccess:  false,
+			expectContains: "command not found",
+		},
+		{
+			name: "message truncated when exceeding max length",
+			hookFunc: mockLifecycleHookFunc(-1, "", strings.Repeat("x", 1100), fmt.Errorf("exec failed")),
+			expectSuccess:  false,
+			expectContains: "...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := newTestCommonControl(tt.hookFunc, box.DeepCopy(), pod.DeepCopy())
+			result := ctrl.executeUpgradeAction(context.Background(), pod, box, action)
+			assert.Equal(t, tt.expectSuccess, result.Succeeded)
+			assert.Contains(t, result.Message, tt.expectContains)
+			// Verify truncation: message must not exceed MaxConditionMessageLen + len("...")
+			assert.LessOrEqual(t, len(result.Message), utils.MaxConditionMessageLen+3)
+		})
 	}
 }
 

--- a/pkg/utils/constant.go
+++ b/pkg/utils/constant.go
@@ -18,6 +18,8 @@ package utils
 
 import (
 	"context"
+	"os"
+	"strconv"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -38,8 +40,7 @@ const (
 	PodConditionContainersPaused  = "ContainersPaused"
 	PodConditionContainersResumed = "ContainersResumed"
 
-	// MaxConditionMessageLen is the max length for a Condition.Message.
-	MaxConditionMessageLen = 256
+	// MaxConditionMessageLen was moved to a var block below for env-based configuration.
 )
 
 const (
@@ -51,6 +52,10 @@ const (
 )
 
 var (
+	// MaxConditionMessageLen is the max length for a Condition.Message.
+	// Configurable via MAX_CONDITION_MESSAGE_LEN env var, defaults to 1024.
+	MaxConditionMessageLen = getEnvIntOrDefault("MAX_CONDITION_MESSAGE_LEN", 1024)
+
 	CacheBackoff = wait.Backoff{
 		Duration: 100 * time.Millisecond,
 		Factor:   2.0,
@@ -68,4 +73,13 @@ func RetryIfContextNotCanceled(ctx context.Context) func(err error) bool {
 			return true
 		}
 	}
+}
+
+func getEnvIntOrDefault(key string, defaultVal int) int {
+	if v := os.Getenv(key); v != "" {
+		if i, err := strconv.Atoi(v); err == nil && i > 0 {
+			return i
+		}
+	}
+	return defaultVal
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -150,6 +150,11 @@ func TestSetSandboxCondition(t *testing.T) {
 }
 
 func TestTruncateConditionMessage(t *testing.T) {
+	// Ensure default MaxConditionMessageLen is 1024 (no env override in this test).
+	if MaxConditionMessageLen != 1024 {
+		t.Fatalf("expected default MaxConditionMessageLen=1024, got %d", MaxConditionMessageLen)
+	}
+
 	tests := []struct {
 		name     string
 		msg      string
@@ -177,6 +182,64 @@ func TestTruncateConditionMessage(t *testing.T) {
 			got := TruncateConditionMessage(tt.msg)
 			if got != tt.expected {
 				t.Fatalf("TruncateConditionMessage() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTruncateConditionMessage_EnvOverride(t *testing.T) {
+	original := MaxConditionMessageLen
+	defer func() { MaxConditionMessageLen = original }()
+
+	tests := []struct {
+		name     string
+		envVal   string
+		wantLen  int
+	}{
+		{
+			name:    "valid env value",
+			envVal:  "512",
+			wantLen: 512,
+		},
+		{
+			name:    "invalid env value falls back to default",
+			envVal:  "not_a_number",
+			wantLen: 1024,
+		},
+		{
+			name:    "zero env value falls back to default",
+			envVal:  "0",
+			wantLen: 1024,
+		},
+		{
+			name:    "negative env value falls back to default",
+			envVal:  "-1",
+			wantLen: 1024,
+		},
+		{
+			name:    "empty env value falls back to default",
+			envVal:  "",
+			wantLen: 1024,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envVal != "" {
+				t.Setenv("MAX_CONDITION_MESSAGE_LEN", tt.envVal)
+			}
+			MaxConditionMessageLen = getEnvIntOrDefault("MAX_CONDITION_MESSAGE_LEN", 1024)
+
+			if MaxConditionMessageLen != tt.wantLen {
+				t.Fatalf("MaxConditionMessageLen = %d, want %d", MaxConditionMessageLen, tt.wantLen)
+			}
+
+			// Verify truncation works with overridden length
+			longMsg := strings.Repeat("x", tt.wantLen+5)
+			got := TruncateConditionMessage(longMsg)
+			expected := strings.Repeat("x", tt.wantLen) + "..."
+			if got != expected {
+				t.Fatalf("TruncateConditionMessage() len = %d, want %d", len(got), len(expected))
 			}
 		})
 	}

--- a/test/e2e/sandboxupdateops_test.go
+++ b/test/e2e/sandboxupdateops_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -522,6 +523,134 @@ var _ = Describe("SandboxUpdateOps E2E", func() {
 				Expect(pod.Spec.Containers[0].Image).To(Equal(updateImage),
 					"sandbox %s should have updated image after recovery", sbx.Name)
 			}
+		})
+
+		It("should include stderr in Upgrading Condition message when preUpgrade hook fails", func() {
+			labelValue := fmt.Sprintf("batch-stderr-%d", time.Now().UnixNano())
+
+			By("Creating a Sandbox and waiting for Running")
+			sbx := newOpsSandbox(
+				fmt.Sprintf("ops-stderr-%s-0", labelValue[:10]),
+				labelValue, nil, nil,
+			)
+			Expect(k8sClient.Create(ctx, sbx)).To(Succeed())
+			waitSandboxRunning(sbx)
+			klog.InfoS("Sandbox is Running", "name", sbx.Name)
+
+			By("Creating SandboxUpdateOps with preUpgrade hook that outputs to stderr and exits 1")
+			const stderrMessage = "ERROR: something failed in preUpgrade hook"
+			ops := &agentsv1alpha1.SandboxUpdateOps{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("ops-stderr-%s", labelValue[:10]),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxUpdateOpsSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{batchLabel: labelValue},
+					},
+					Patch: mustMarshalPatch(corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "test-container", Image: updateImage},
+							},
+						},
+					}),
+					Lifecycle: &agentsv1alpha1.SandboxLifecycle{
+						PreUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec:           &corev1.ExecAction{Command: []string{"/bin/bash", "-c", fmt.Sprintf("echo \"%s\" >&2; exit 1", stderrMessage)}},
+							TimeoutSeconds: 30,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ops)).To(Succeed())
+			klog.InfoS("Created SandboxUpdateOps with stderr hook", "name", ops.Name)
+
+			By("Verifying Sandbox Upgrading Condition contains stderr message")
+			Eventually(func(g Gomega) {
+				updated := &agentsv1alpha1.Sandbox{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), updated)).To(Succeed())
+				g.Expect(updated.Status.Phase).To(Equal(agentsv1alpha1.SandboxUpgrading),
+					"sandbox should be in Upgrading phase")
+
+				var upgradingCond *metav1.Condition
+				for i := range updated.Status.Conditions {
+					if updated.Status.Conditions[i].Type == string(agentsv1alpha1.SandboxConditionUpgrading) {
+						upgradingCond = &updated.Status.Conditions[i]
+						break
+					}
+				}
+				g.Expect(upgradingCond).NotTo(BeNil(), "should have Upgrading condition")
+				g.Expect(upgradingCond.Reason).To(Equal(agentsv1alpha1.SandboxUpgradingReasonPreUpgradeFailed),
+					"condition reason should be PreUpgradeFailed")
+				g.Expect(upgradingCond.Message).To(ContainSubstring(stderrMessage),
+					"condition message should contain stderr output, got: %s", upgradingCond.Message)
+				klog.InfoS("Verified stderr in condition message",
+					"sandbox", updated.Name, "message", upgradingCond.Message)
+			}, 60*time.Second, time.Second).Should(Succeed())
+
+			By("Verifying message truncation for long stderr output")
+			// Create another sandbox to test truncation with a long stderr message
+			longLabelValue := fmt.Sprintf("batch-long-%d", time.Now().UnixNano())
+			sbxLong := newOpsSandbox(
+				fmt.Sprintf("ops-long-%s-0", longLabelValue[:10]),
+				longLabelValue, nil, nil,
+			)
+			Expect(k8sClient.Create(ctx, sbxLong)).To(Succeed())
+			waitSandboxRunning(sbxLong)
+
+			// Generate a long stderr message (> 1024 chars, the default MaxConditionMessageLen)
+			longMsg := strings.Repeat("X", 1100)
+			opsLong := &agentsv1alpha1.SandboxUpdateOps{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("ops-long-%s", longLabelValue[:10]),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxUpdateOpsSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{batchLabel: longLabelValue},
+					},
+					Patch: mustMarshalPatch(corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "test-container", Image: updateImage},
+							},
+						},
+					}),
+					Lifecycle: &agentsv1alpha1.SandboxLifecycle{
+						PreUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec:           &corev1.ExecAction{Command: []string{"/bin/bash", "-c", fmt.Sprintf("echo \"%s\" >&2; exit 1", longMsg)}},
+							TimeoutSeconds: 30,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, opsLong)).To(Succeed())
+			klog.InfoS("Created SandboxUpdateOps with long stderr", "name", opsLong.Name)
+
+			Eventually(func(g Gomega) {
+				updated := &agentsv1alpha1.Sandbox{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sbxLong), updated)).To(Succeed())
+				g.Expect(updated.Status.Phase).To(Equal(agentsv1alpha1.SandboxUpgrading))
+
+				var upgradingCond *metav1.Condition
+				for i := range updated.Status.Conditions {
+					if updated.Status.Conditions[i].Type == string(agentsv1alpha1.SandboxConditionUpgrading) {
+						upgradingCond = &updated.Status.Conditions[i]
+						break
+					}
+				}
+				g.Expect(upgradingCond).NotTo(BeNil())
+				g.Expect(upgradingCond.Reason).To(Equal(agentsv1alpha1.SandboxUpgradingReasonPreUpgradeFailed))
+				// Verify message is truncated: should end with "..." and be at most 1024+3 chars
+				g.Expect(len(upgradingCond.Message) <= 1027).To(BeTrue(),
+					"condition message should be truncated to at most 1024+3 chars, got %d: %s",
+					len(upgradingCond.Message), upgradingCond.Message)
+				g.Expect(upgradingCond.Message).To(HaveSuffix("..."),
+					"truncated message should end with '...', got: %s", upgradingCond.Message)
+				klog.InfoS("Verified truncated condition message",
+					"sandbox", updated.Name, "messageLen", len(upgradingCond.Message))
+			}, 60*time.Second, time.Second).Should(Succeed())
 		})
 
 		It("should handle bad image failure with MaxUnavailable=1 and recover after delete recreate", func() {


### PR DESCRIPTION
# Background
When a lifecycle hook (preUpgrade/postUpgrade) fails, the controller only logs:
`"hook execution error: process error: exit status 1"`
Users have no way to know why the hook failed without SSH-ing into the sandbox pod — the command's stdout/stderr is silently discarded.

# Changes

- Fix stdout/stderr loss on error path — ExecuteLifecycleHook now returns already-captured stdout/stderr even when RunCommandWithRuntime returns an error.
- Enrich error messages — executeUpgradeAction appends stderr and stdout to the Condition message, giving users immediate visibility into hook failures.
- Configurable message truncation — MaxConditionMessageLen is now a variable (default 1024) configurable via MAX_CONDITION_MESSAGE_LEN env var, up from the previous hardcoded 256.