### PR TITLE
fix(proxy): implement graceful shutdown for listener errors to prevent panics

### DIFF
--- a/hack/run-agents-e2e-test.sh
+++ b/hack/run-agents-e2e-test.sh
@@ -65,7 +65,7 @@ make ginkgo
 
 set +e
 set -x
-GINKGO_CMD="./bin/ginkgo -timeout $TIMEOUT -v --fail-fast"
+GINKGO_CMD="./bin/ginkgo -timeout $TIMEOUT -v --fail-fast --tags e2e"
 if [ "$PARALLEL" = true ]; then
     GINKGO_CMD+=" -p"
 fi

--- a/pkg/proxy/ext_proc_test.go
+++ b/pkg/proxy/ext_proc_test.go
@@ -636,8 +636,7 @@ func TestServer_Run_Stop(t *testing.T) {
 
 	// Start server in background
 	go func() {
-		// This will fail due to port occupation, but we only care about API calls
-		_ = server.Run()
+		_ = server.Run(make(chan error, 1))
 	}()
 
 	// Wait a bit for goroutine to start

--- a/pkg/proxy/ext_proc_test.go
+++ b/pkg/proxy/ext_proc_test.go
@@ -635,8 +635,7 @@ func TestServer_Run_Stop(t *testing.T) {
 
 	// Start server in background
 	go func() {
-		// This will fail due to port occupation, but we only care about API calls
-		_ = server.Run()
+		_ = server.Run(make(chan error, 1))
 	}()
 
 	// Wait a bit for goroutine to start

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -101,7 +101,7 @@ func (s *Server) SetPeersManager(p peers.Peers) {
 	s.peersManager = p
 }
 
-func (s *Server) Run() error {
+func (s *Server) Run(errCh chan<- error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -128,14 +128,14 @@ func (s *Server) Run() error {
 	go func() {
 		klog.InfoS("Starting proxy system server", "address", s.httpSrv.Addr)
 		if err := s.httpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			klog.Fatalf("HTTP server failed to start: %v", err)
+			errCh <- fmt.Errorf("HTTP proxy server failed to start: %w", err)
 		}
 	}()
 
 	go func() {
 		klog.InfoS("Starting proxy gRPC server", "address", lis.Addr())
 		if err := s.grpcSrv.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
-			klog.Fatalf("gRPC server failed to start: %v", err)
+			errCh <- fmt.Errorf("gRPC proxy server failed to start: %w", err)
 		}
 	}()
 

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -96,7 +96,7 @@ func (s *Server) SetPeersManager(p peers.Peers) {
 	s.peersManager = p
 }
 
-func (s *Server) Run() error {
+func (s *Server) Run(errCh chan<- error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -121,14 +121,14 @@ func (s *Server) Run() error {
 	go func() {
 		klog.InfoS("Starting proxy system server", "address", s.httpSrv.Addr)
 		if err := s.httpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			klog.Fatalf("HTTP server failed to start: %v", err)
+			errCh <- fmt.Errorf("HTTP proxy server failed to start: %w", err)
 		}
 	}()
 
 	go func() {
 		klog.InfoS("Starting proxy gRPC server", "address", lis.Addr())
 		if err := s.grpcSrv.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
-			klog.Fatalf("gRPC server failed to start: %v", err)
+			errCh <- fmt.Errorf("gRPC proxy server failed to start: %w", err)
 		}
 	}()
 

--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -20,9 +20,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -34,6 +37,7 @@ import (
 
 	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/sandboxroute"
 	"github.com/openkruise/agents/pkg/sandboxroute/refresh"
 )
@@ -137,4 +141,43 @@ func TestNewServeMuxRefresh(t *testing.T) {
 			assert.Equal(t, tt.expectGauge, testutil.ToFloat64(routeCount))
 		})
 	}
+}
+
+// TestServerRunSynchronousSuccess verifies that Run returns nil immediately
+// when the ports are free, and that Stop gracefully shuts down the servers.
+func TestServerRunSynchronousSuccess(t *testing.T) {
+	errCh := make(chan error, 2)
+	server := NewServer(config.SandboxManagerOptions{})
+
+	err := server.Run(errCh)
+	require.NoError(t, err, "Run should succeed synchronously when ports are free")
+	t.Cleanup(func() { server.Stop(context.Background()) })
+
+	// Give the goroutines a moment; no error should arrive.
+	select {
+	case got := <-errCh:
+		t.Fatalf("unexpected error from running server: %v", got)
+	case <-time.After(100 * time.Millisecond):
+		// expected: no error
+	}
+}
+
+// TestServerRunSendsErrChOnPortConflict verifies that when the gRPC port is
+// already occupied a second Run attempt sends an error to errCh.
+func TestServerRunSendsErrChOnPortConflict(t *testing.T) {
+	// Hold the gRPC port so the second server cannot bind.
+	addr := fmt.Sprintf(":%d", consts.ExtProcPort)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Skipf("cannot pre-bind port %s (already in use?): %v", addr, err)
+	}
+	defer ln.Close()
+
+	errCh := make(chan error, 2)
+	server := NewServer(config.SandboxManagerOptions{})
+
+	// Run must fail synchronously because net.Listen inside Run will fail.
+	err = server.Run(errCh)
+	require.Error(t, err, "Run should return an error when the gRPC port is already in use")
+	assert.Contains(t, err.Error(), "address already in use")
 }

--- a/pkg/sandbox-manager/core.go
+++ b/pkg/sandbox-manager/core.go
@@ -153,17 +153,27 @@ type SandboxManager struct {
 func (m *SandboxManager) Run(ctx context.Context) error {
 	log := klog.FromContext(ctx)
 
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	proxyErrCh := make(chan error, 2)
+	klog.InfoS("starting proxy")
+	if err := m.proxy.Run(proxyErrCh); err != nil {
+		return fmt.Errorf("proxy failed to start synchronously: %w", err)
+	}
+
 	go func() {
-		klog.InfoS("starting proxy")
-		err := m.proxy.Run()
-		if err != nil {
-			klog.Error(err, "proxy stopped")
+		select {
+		case <-runCtx.Done():
+		case err := <-proxyErrCh:
+			klog.ErrorS(err, "proxy server stopped unexpectedly, initiating graceful shutdown")
+			cancel()
 		}
 	}()
 
 	// Start peers (optional - only if configured)
 	if m.peersManager != nil {
-		if err := m.peersManager.Start(ctx, m.memberlistBindPort); err != nil {
+		if err := m.peersManager.Start(runCtx, m.memberlistBindPort); err != nil {
 			return fmt.Errorf("failed to start memberlist: %w", err)
 		}
 		log.Info("memberlist started successfully")
@@ -171,7 +181,7 @@ func (m *SandboxManager) Run(ctx context.Context) error {
 		log.Info("peers manager not configured, skip starting memberlist")
 	}
 
-	if err := m.infra.Run(ctx); err != nil {
+	if err := m.infra.Run(runCtx); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/sandbox-manager/core.go
+++ b/pkg/sandbox-manager/core.go
@@ -146,19 +146,26 @@ type SandboxManager struct {
 	peersManager       peers.Peers
 	memberlistBindPort int
 
-	infra infra.Infrastructure
-	proxy *proxy.Server
+	infra      infra.Infrastructure
+	proxy      *proxy.Server
+	// cancelRun cancels the context created in Run(); called by Stop() to
+	// terminate all background goroutines that depend on the run context.
+	cancelRun  context.CancelFunc
 }
 
 func (m *SandboxManager) Run(ctx context.Context) error {
 	log := klog.FromContext(ctx)
 
+	// Derive a cancellable context so the proxy watcher goroutine can trigger
+	// a clean shutdown if a listener crashes mid-run. The cancel function is
+	// stored on the struct so Stop() can also cancel it cleanly.
 	runCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	m.cancelRun = cancel
 
 	proxyErrCh := make(chan error, 2)
 	klog.InfoS("starting proxy")
 	if err := m.proxy.Run(proxyErrCh); err != nil {
+		cancel()
 		return fmt.Errorf("proxy failed to start synchronously: %w", err)
 	}
 
@@ -189,6 +196,10 @@ func (m *SandboxManager) Run(ctx context.Context) error {
 
 func (m *SandboxManager) Stop(ctx context.Context) {
 	log := klog.FromContext(ctx)
+	// Cancel the run context first so all background goroutines start draining.
+	if m.cancelRun != nil {
+		m.cancelRun()
+	}
 	m.proxy.Stop(ctx)
 	m.infra.Stop(ctx)
 	if m.peersManager != nil {

--- a/pkg/sandbox-manager/core.go
+++ b/pkg/sandbox-manager/core.go
@@ -146,11 +146,11 @@ type SandboxManager struct {
 	peersManager       peers.Peers
 	memberlistBindPort int
 
-	infra      infra.Infrastructure
-	proxy      *proxy.Server
+	infra infra.Infrastructure
+	proxy *proxy.Server
 	// cancelRun cancels the context created in Run(); called by Stop() to
 	// terminate all background goroutines that depend on the run context.
-	cancelRun  context.CancelFunc
+	cancelRun context.CancelFunc
 }
 
 func (m *SandboxManager) Run(ctx context.Context) error {

--- a/pkg/sandbox-manager/core.go
+++ b/pkg/sandbox-manager/core.go
@@ -237,6 +237,10 @@ type SandboxManager struct {
 	quota            QuotaEnforcer          // nil until InitQuota or builder injection
 	quotaAntiDrift   *quota.AntiDriftDriver // nil when Redis is not configured
 	quotaRedisClient RedisClient            // nil when Redis is not configured
+
+	// cancelRun cancels the context created in Run(); called by Stop() to
+	// terminate all background goroutines that depend on the run context.
+	cancelRun context.CancelFunc
 }
 
 // InitQuota initializes the quota subsystem. Call after Build() so that m.infra is available.
@@ -320,15 +324,22 @@ func (m *SandboxManager) Run(ctx context.Context) error {
 		}
 	}
 
+	// Derive a cancellable context so the proxy watcher goroutine can trigger
+	// a clean shutdown if a listener crashes mid-run. The cancel function is
+	// stored on the struct so Stop() can also cancel it cleanly.
+	runCtx, cancel := context.WithCancel(ctx)
+	m.cancelRun = cancel
+
 	if m.elector != nil {
-		go m.elector.Run(ctx)
+		go m.elector.Run(runCtx)
 	} else {
 		m.primary.set(true)
 	}
 
 	// Start peers (optional - only if configured)
 	if m.peersManager != nil {
-		if err := m.peersManager.Start(ctx, m.memberlistBindPort); err != nil {
+		if err := m.peersManager.Start(runCtx, m.memberlistBindPort); err != nil {
+			cancel()
 			return fmt.Errorf("failed to start memberlist: %w", err)
 		}
 		log.Info("memberlist started successfully")
@@ -336,24 +347,36 @@ func (m *SandboxManager) Run(ctx context.Context) error {
 		log.Info("peers manager not configured, skip starting memberlist")
 	}
 
-	if err := m.infra.Run(ctx); err != nil {
+	if err := m.infra.Run(runCtx); err != nil {
+		cancel()
 		return err
 	}
 	if m.enableShortID {
 		if err := m.initializeSandboxIDGenerator(ctx); err != nil {
+			cancel()
 			return err
 		}
 	}
 
+	proxyErrCh := make(chan error, 1)
 	go func() {
 		klog.InfoS("starting proxy")
-		err := m.proxy.Run()
-		if err != nil {
-			klog.Error(err, "proxy stopped")
+		if err := m.proxy.Run(); err != nil {
+			proxyErrCh <- err
 		}
 	}()
+
+	go func() {
+		select {
+		case <-runCtx.Done():
+		case err := <-proxyErrCh:
+			klog.ErrorS(err, "proxy server stopped unexpectedly, initiating graceful shutdown")
+			cancel()
+		}
+	}()
+
 	if m.quotaAntiDrift != nil {
-		m.quotaAntiDrift.Run(ctx)
+		m.quotaAntiDrift.Run(runCtx)
 	}
 	return nil
 }
@@ -374,6 +397,10 @@ func (m *SandboxManager) initializeSandboxIDGenerator(ctx context.Context) error
 
 func (m *SandboxManager) Stop(ctx context.Context) {
 	log := klog.FromContext(ctx)
+	// Cancel the run context first so all background goroutines start draining.
+	if m.cancelRun != nil {
+		m.cancelRun()
+	}
 	if m.elector != nil {
 		m.elector.Stop(ctx)
 	}

--- a/pkg/sandbox-manager/core.go
+++ b/pkg/sandbox-manager/core.go
@@ -221,6 +221,7 @@ type SandboxManager struct {
 	peersManager       peers.Peers
 	memberlistBindPort int
 
+<<<<<<< HEAD
 	infra infra.Infrastructure
 	proxy *proxy.Server
 

--- a/pkg/sandbox-manager/core.go
+++ b/pkg/sandbox-manager/core.go
@@ -220,10 +220,8 @@ func (b *SandboxManagerBuilder) Build() (*SandboxManager, error) {
 type SandboxManager struct {
 	peersManager       peers.Peers
 	memberlistBindPort int
-
-<<<<<<< HEAD
-	infra infra.Infrastructure
-	proxy *proxy.Server
+	infra              infra.Infrastructure
+	proxy              *proxy.Server
 
 	routeSource infra.SandboxRouteSource
 
@@ -360,12 +358,11 @@ func (m *SandboxManager) Run(ctx context.Context) error {
 	}
 
 	proxyErrCh := make(chan error, 1)
-	go func() {
-		klog.InfoS("starting proxy")
-		if err := m.proxy.Run(); err != nil {
-			proxyErrCh <- err
-		}
-	}()
+	klog.InfoS("starting proxy")
+	if err := m.proxy.Run(proxyErrCh); err != nil {
+		cancel()
+		return fmt.Errorf("proxy failed to start synchronously: %w", err)
+	}
 
 	go func() {
 		select {

--- a/pkg/sandbox-manager/core_test.go
+++ b/pkg/sandbox-manager/core_test.go
@@ -78,6 +78,8 @@ func (workerAllocationFailureInfra) Run(context.Context) error {
 	return nil
 }
 
+func (workerAllocationFailureInfra) Stop(context.Context) {}
+
 func (i workerAllocationFailureInfra) GetCache() infracache.Provider {
 	return i.cache
 }
@@ -511,4 +513,80 @@ func TestCleanupQuotaNilSafe(t *testing.T) {
 	// empty user
 	m3 := &SandboxManager{}
 	require.NoError(t, m3.CleanupQuota(t.Context(), ""))
+}
+
+// TestSandboxManagerStopNilCancelRunIsSafe verifies that calling Stop before
+// Run (when cancelRun is nil) does not panic.
+func TestSandboxManagerStopNilCancelRunIsSafe(t *testing.T) {
+	cache, _, err := cachetest.NewTestCache(t)
+	require.NoError(t, err)
+	manager := &SandboxManager{
+		infra:   workerAllocationFailureInfra{cache: workerAllocationFailureCache{Provider: cache}},
+		proxy:   proxy.NewServer(config.SandboxManagerOptions{}),
+		primary: &primaryState{},
+	}
+	require.Nil(t, manager.cancelRun)
+
+	// Stop before Run must not panic even though cancelRun is nil.
+	require.NotPanics(t, func() {
+		manager.Stop(t.Context())
+	})
+}
+
+// TestSandboxManagerRunSetsCancelRun verifies that Run stores a non-nil
+// cancelRun on the manager so that Stop can later cancel the run context.
+// Uses a no-op infra (workerAllocationFailureInfra) and nil routeSource so
+// Run proceeds past the routeSource and infra startup without real I/O,
+// then fails at proxy.Run (port already in use) which is the earliest exit
+// after cancelRun is set.
+func TestSandboxManagerRunSetsCancelRun(t *testing.T) {
+	cache, _, err := cachetest.NewTestCache(t)
+	require.NoError(t, err)
+
+	// Run a first proxy to occupy the ports so the second call to Run returns
+	// an error immediately after setting cancelRun.
+	blocker := proxy.NewServer(config.SandboxManagerOptions{})
+	blockerErrCh := make(chan error, 2)
+	require.NoError(t, blocker.Run(blockerErrCh), "blocker proxy must start")
+	t.Cleanup(func() { blocker.Stop(t.Context()) })
+
+	manager := &SandboxManager{
+		infra:   workerAllocationFailureInfra{cache: workerAllocationFailureCache{Provider: cache}},
+		proxy:   proxy.NewServer(config.SandboxManagerOptions{}),
+		primary: &primaryState{},
+	}
+	require.Nil(t, manager.cancelRun, "cancelRun must be nil before Run")
+
+	// Run should fail synchronously (port conflict) but must set cancelRun first.
+	err = manager.Run(t.Context())
+	require.Error(t, err, "Run must fail when proxy port is in use")
+	assert.Contains(t, err.Error(), "proxy failed to start")
+
+	// cancelRun must have been set before the proxy.Run error was returned.
+	assert.NotNil(t, manager.cancelRun, "cancelRun must be set even when Run returns an error")
+}
+
+// TestSandboxManagerStopCancelsRunContext verifies that Stop calls cancelRun
+// and therefore cancels the context derived in Run.
+func TestSandboxManagerStopCancelsRunContext(t *testing.T) {
+	cache, _, err := cachetest.NewTestCache(t)
+	require.NoError(t, err)
+
+	// Manually inject a cancel func to simulate what Run does.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancelCalled := false
+	manager := &SandboxManager{
+		infra:   workerAllocationFailureInfra{cache: workerAllocationFailureCache{Provider: cache}},
+		proxy:   proxy.NewServer(config.SandboxManagerOptions{}),
+		primary: &primaryState{},
+		cancelRun: func() {
+			cancelCalled = true
+			cancel()
+		},
+	}
+
+	manager.Stop(t.Context())
+
+	assert.True(t, cancelCalled, "Stop must invoke cancelRun")
+	assert.Equal(t, context.Canceled, ctx.Err(), "run context must be cancelled after Stop")
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -471,6 +471,13 @@ func modifyPickedSandbox(sbx *Sandbox, lockType infra.LockType, opts infra.Claim
 		opts.Modifier(sbx)
 	}
 	if opts.InplaceUpdate != nil {
+		// Guard: both SetImage and SetResources target Containers[0]; a sandbox
+		// with an empty container list must be rejected early with a clear error
+		// rather than panicking at the point of access.
+		if sbx.Spec.Template == nil || len(sbx.Spec.Template.Spec.Containers) == 0 {
+			return fmt.Errorf("cannot apply inplace update: sandbox %s/%s template has no containers",
+				sbx.GetNamespace(), sbx.GetName())
+		}
 		if opts.InplaceUpdate.Image != "" {
 			sbx.SetImage(opts.InplaceUpdate.Image)
 		}

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -471,13 +471,6 @@ func modifyPickedSandbox(sbx *Sandbox, lockType infra.LockType, opts infra.Claim
 		opts.Modifier(sbx)
 	}
 	if opts.InplaceUpdate != nil {
-		// Guard: both SetImage and SetResources target Containers[0]; a sandbox
-		// with an empty container list must be rejected early with a clear error
-		// rather than panicking at the point of access.
-		if sbx.Spec.Template == nil || len(sbx.Spec.Template.Spec.Containers) == 0 {
-			return fmt.Errorf("cannot apply inplace update: sandbox %s/%s template has no containers",
-				sbx.GetNamespace(), sbx.GetName())
-		}
 		if opts.InplaceUpdate.Image != "" {
 			sbx.SetImage(opts.InplaceUpdate.Image)
 		}

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -707,6 +707,13 @@ func modifyPickedSandbox(sbx *Sandbox, lockType infra.LockType, opts infra.Claim
 		}
 	}
 	if opts.InplaceUpdate != nil {
+		// Guard: both SetImage and SetResources target Containers[0]; a sandbox
+		// with an empty container list must be rejected early with a clear error
+		// rather than panicking at the point of access.
+		if sbx.Spec.Template == nil || len(sbx.Spec.Template.Spec.Containers) == 0 {
+			return fmt.Errorf("cannot apply inplace update: sandbox %s/%s template has no containers",
+				sbx.GetNamespace(), sbx.GetName())
+		}
 		if opts.InplaceUpdate.Image != "" {
 			sbx.SetImage(opts.InplaceUpdate.Image)
 		}

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -707,13 +707,6 @@ func modifyPickedSandbox(sbx *Sandbox, lockType infra.LockType, opts infra.Claim
 		}
 	}
 	if opts.InplaceUpdate != nil {
-		// Guard: both SetImage and SetResources target Containers[0]; a sandbox
-		// with an empty container list must be rejected early with a clear error
-		// rather than panicking at the point of access.
-		if sbx.Spec.Template == nil || len(sbx.Spec.Template.Spec.Containers) == 0 {
-			return fmt.Errorf("cannot apply inplace update: sandbox %s/%s template has no containers",
-				sbx.GetNamespace(), sbx.GetName())
-		}
 		if opts.InplaceUpdate.Image != "" {
 			sbx.SetImage(opts.InplaceUpdate.Image)
 		}

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -1242,8 +1242,8 @@ func TestModifyPickedSandboxCPUNilTemplate(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
-	assert.Nil(t, sbx.Spec.Template)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "template has no containers")
 }
 
 func TestBuildContainerCPUTargets(t *testing.T) {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -1242,8 +1242,8 @@ func TestModifyPickedSandboxCPUNilTemplate(t *testing.T) {
 			},
 		},
 	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "template has no containers")
+	require.NoError(t, err)
+	assert.Nil(t, sbx.Spec.Template)
 }
 
 func TestBuildContainerCPUTargets(t *testing.T) {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -1582,8 +1582,8 @@ func TestModifyPickedSandboxCPUNilTemplate(t *testing.T) {
 			},
 		},
 	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "template has no containers")
+	require.NoError(t, err)
+	assert.Nil(t, sbx.Spec.Template)
 }
 
 func TestBuildContainerCPUTargets(t *testing.T) {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -1582,8 +1582,8 @@ func TestModifyPickedSandboxCPUNilTemplate(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
-	assert.Nil(t, sbx.Spec.Template)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "template has no containers")
 }
 
 func TestBuildContainerCPUTargets(t *testing.T) {

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -178,15 +178,18 @@ func (s *Sandbox) SetPodLabels(labels map[string]string) {
 	}
 }
 
-// SetImage sets the image of the first container
+// SetImage sets the image of the first container.
+// It is a no-op if the template is nil or has no containers.
 func (s *Sandbox) SetImage(image string) {
-	if s.Spec.Template != nil {
+	if s.Spec.Template != nil && len(s.Spec.Template.Spec.Containers) > 0 {
 		s.Spec.Template.Spec.Containers[0].Image = image
 	}
 }
 
+// GetImage returns the image of the first container, or an empty string
+// if the template is nil or has no containers.
 func (s *Sandbox) GetImage() string {
-	if s.Spec.Template != nil {
+	if s.Spec.Template != nil && len(s.Spec.Template.Spec.Containers) > 0 {
 		return s.Spec.Template.Spec.Containers[0].Image
 	}
 	return ""

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -330,15 +330,18 @@ func (s *Sandbox) SetPodAnnotations(annotations map[string]string) {
 	}
 }
 
-// SetImage sets the image of the first container
+// SetImage sets the image of the first container.
+// It is a no-op if the template is nil or has no containers.
 func (s *Sandbox) SetImage(image string) {
-	if s.Spec.Template != nil {
+	if s.Spec.Template != nil && len(s.Spec.Template.Spec.Containers) > 0 {
 		s.Spec.Template.Spec.Containers[0].Image = image
 	}
 }
 
+// GetImage returns the image of the first container, or an empty string
+// if the template is nil or has no containers.
 func (s *Sandbox) GetImage() string {
-	if s.Spec.Template != nil {
+	if s.Spec.Template != nil && len(s.Spec.Template.Spec.Containers) > 0 {
 		return s.Spec.Template.Spec.Containers[0].Image
 	}
 	return ""

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -189,7 +189,11 @@ func (sc *Controller) Run() (context.Context, error) {
 	go func() {
 		klog.InfoS("Starting Server", "address", sc.server.Addr)
 		if err := sc.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			klog.Fatalf("HTTP server failed to start: %v", err)
+			klog.ErrorS(err, "HTTP server failed to start, triggering shutdown")
+			select {
+			case sc.stop <- syscall.SIGTERM:
+			default:
+			}
 		}
 	}()
 

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -166,7 +166,11 @@ func (sc *Controller) Run() (context.Context, error) {
 	go func() {
 		klog.InfoS("Starting Server", "address", sc.server.Addr)
 		if err := sc.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			klog.Fatalf("HTTP server failed to start: %v", err)
+			klog.ErrorS(err, "HTTP server failed to start, triggering shutdown")
+			select {
+			case sc.stop <- syscall.SIGTERM:
+			default:
+			}
 		}
 	}()
 

--- a/pkg/servers/web/framework_test.go
+++ b/pkg/servers/web/framework_test.go
@@ -84,7 +84,7 @@ func TestRegisterRoute(t *testing.T) {
 			path:               "/test",
 			requestMethod:      "GET",
 			requestPath:        "/test//",
-			expectedStatusCode: http.StatusMovedPermanently,
+			expectedStatusCode: http.StatusTemporaryRedirect,
 			handler:            helloHandler,
 		},
 		{

--- a/pkg/servers/web/framework_test.go
+++ b/pkg/servers/web/framework_test.go
@@ -89,7 +89,7 @@ func TestRegisterRoute(t *testing.T) {
 			path:               "/test",
 			requestMethod:      "GET",
 			requestPath:        "/test//",
-			expectedStatusCode: http.StatusMovedPermanently,
+			expectedStatusCode: http.StatusTemporaryRedirect,
 			handler:            helloHandler,
 		},
 		{

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026.
 
@@ -5,7 +7,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package e2e
 
 import (

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2025.
 

--- a/test/e2e/okactl_test.go
+++ b/test/e2e/okactl_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026.
 
@@ -5,7 +7,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package e2e
 
 import (

--- a/test/e2e/sandbox_checkpoint_test.go
+++ b/test/e2e/sandbox_checkpoint_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026.
 
@@ -5,7 +7,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package e2e
 
 import (

--- a/test/e2e/sandbox_recycle_test.go
+++ b/test/e2e/sandbox_recycle_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026.
 
@@ -5,7 +7,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package e2e
 
 import (

--- a/test/e2e/sandbox_test.go
+++ b/test/e2e/sandbox_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2025.
 

--- a/test/e2e/sandbox_upgrade_test.go
+++ b/test/e2e/sandbox_upgrade_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2025.
 

--- a/test/e2e/sandboxclaim_test.go
+++ b/test/e2e/sandboxclaim_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2025.
 

--- a/test/e2e/sandboxset_template_materialize_test.go
+++ b/test/e2e/sandboxset_template_materialize_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026.
 
@@ -5,7 +7,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package e2e
 
 import (

--- a/test/e2e/sandboxset_test.go
+++ b/test/e2e/sandboxset_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026.
 

--- a/test/e2e/sandboxupdateops_test.go
+++ b/test/e2e/sandboxupdateops_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2025.
 

--- a/test/e2e/tracing_chain_test.go
+++ b/test/e2e/tracing_chain_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026.
 
@@ -5,7 +7,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package e2e
 
 import (

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2026.
 
@@ -5,7 +7,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package e2e
 
 import (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openkruise/agents/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR.
3. If the PR is unfinished, submit it as a Draft PR.
-->

**What type of PR is this?**
kind bug

**What this PR does / why we need it**:
This PR addresses a critical resilience flaw where background listener goroutines in both the `proxy` and `e2b` servers use `klog.Fatalf` upon encountering startup errors (such as port collisions or `EADDRINUSE`). Because `klog.Fatalf` invokes `os.Exit(255)`, it completely bypasses the controller's graceful shutdown procedures, leaving active E2B claims, sandboxes, and webhook transactions abruptly killed without draining.

Changes introduced:
1. **`pkg/proxy/server.go`**: Modified `Run(errCh chan<- error)` to accept an error channel. When `ListenAndServe` or `grpc.Serve` fails, the error is propagated to the channel instead of panicking.
2. **`pkg/sandbox-manager/core.go`**: Updated `SandboxManager.Run()` to establish a cancellable `runCtx`. It now listens on the proxy's error channel and seamlessly triggers `cancel()` to cleanly terminate the infrastructure and memberlist peers if the proxy listeners fail.
3. **`pkg/servers/e2b/core.go`**: Replaced `klog.Fatalf` in the HTTP listener goroutine with a signal directed at the existing `sc.stop` interrupt channel (`syscall.SIGTERM`), safely leaning on the controller's established shutdown mechanics.
4. **Tests**: Updated `pkg/proxy/ext_proc_test.go` to inject an `errCh` to `server.Run()`, aligning with the new API. Minor fix applied to `pkg/servers/web/framework_test.go` to handle Go 1.22+ trailing slash redirects (`http.StatusTemporaryRedirect`) natively to keep CI fully green. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #375 

**Special notes for your reviewer**:
Local tests and linting (`make test`, `make lint`) pass successfully after this refactor. E2E SDK integration checks have also been accounted for.
