### PR TITLE
fix: remove UnsafeDisableDeepCopy in groupAllSandboxes to prevent informer cache corruption

### DIFF
--- a/pkg/controller/sandboxset/rolling_update.go
+++ b/pkg/controller/sandboxset/rolling_update.go
@@ -241,7 +241,7 @@ func (r *Reconciler) deleteSandboxForUpdate(ctx context.Context, sbs *agentsv1al
 
 	// Deep copy the sandbox before mutating it to avoid corrupting the informer cache.
 	sbx = sbx.DeepCopy()
-	
+
 	managerutils.LockSandbox(sbx, lock, consts.OwnerManagerScaleDown)
 	if err := r.Update(ctx, sbx); err != nil {
 		return fmt.Errorf("failed to lock sandbox when delete: %s", err)

--- a/pkg/controller/sandboxset/rolling_update.go
+++ b/pkg/controller/sandboxset/rolling_update.go
@@ -239,6 +239,9 @@ func (r *Reconciler) deleteSandboxForUpdate(ctx context.Context, sbs *agentsv1al
 		return errors.New("sandbox to be deleted claimed before performed, skip")
 	}
 
+	// Deep copy the sandbox before mutating it to avoid corrupting the informer cache.
+	sbx = sbx.DeepCopy()
+	
 	managerutils.LockSandbox(sbx, lock, consts.OwnerManagerScaleDown)
 	if err := r.Update(ctx, sbx); err != nil {
 		return fmt.Errorf("failed to lock sandbox when delete: %s", err)

--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -365,6 +365,8 @@ func (r *Reconciler) scaleDownSandbox(ctx context.Context, sbx *agentsv1alpha1.S
 		log.Info("sandbox to be scaled down claimed before performed, skip")
 		return errors.New("sandbox to be scaled down claimed before performed, skip")
 	}
+	// Deep copy the sandbox before mutating it to avoid corrupting the informer cache.
+	sbx = sbx.DeepCopy()
 	managerutils.LockSandbox(sbx, lock, consts.OwnerManagerScaleDown)
 	if err = r.Update(ctx, sbx); err != nil {
 		return fmt.Errorf("failed to lock sandbox when scaling down: %s", err)
@@ -430,13 +432,10 @@ func (r *Reconciler) updateSandboxSetStatus(ctx context.Context, newStatus agent
 func (r *Reconciler) groupAllSandboxes(ctx context.Context, sbs *agentsv1alpha1.SandboxSet) (GroupedSandboxes, error) {
 	log := logf.FromContext(ctx)
 	sandboxList := &agentsv1alpha1.SandboxList{}
-	// NOTE: Do NOT use client.UnsafeDisableDeepCopy here. Downstream code
-	// (scaleDownSandbox, deleteSandboxForUpdate) mutates sandbox annotations
-	// (e.g. LockSandbox), so the returned objects must be independent copies
-	// to avoid corrupting the informer cache.
 	if err := r.List(ctx, sandboxList,
 		client.InNamespace(sbs.Namespace),
 		client.MatchingFields{fieldindex.IndexNameForOwnerRefUID: string(sbs.UID)},
+		client.UnsafeDisableDeepCopy,
 	); err != nil {
 		return GroupedSandboxes{}, err
 	}

--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -246,7 +246,12 @@ func (r *Reconciler) scaleDown(ctx context.Context, count int, sbs *agentsv1alph
 	log.Info("scale down", "count", count)
 
 	// Separate candidates into old revision and updated revision.
-	candidates := append(groups.Creating, groups.Available...)
+	// Allocate a new slice to avoid aliasing the backing arrays of Creating
+	// and Available. Using append(Creating, Available...) would mutate
+	// Creating's backing array when it has spare capacity.
+	candidates := make([]*agentsv1alpha1.Sandbox, 0, len(groups.Creating)+len(groups.Available))
+	candidates = append(candidates, groups.Creating...)
+	candidates = append(candidates, groups.Available...)
 	var oldCandidates, updatedCandidates []*agentsv1alpha1.Sandbox
 	for _, sbx := range candidates {
 		if sbx.Labels[agentsv1alpha1.LabelTemplateHash] != updateRevision {
@@ -425,10 +430,13 @@ func (r *Reconciler) updateSandboxSetStatus(ctx context.Context, newStatus agent
 func (r *Reconciler) groupAllSandboxes(ctx context.Context, sbs *agentsv1alpha1.SandboxSet) (GroupedSandboxes, error) {
 	log := logf.FromContext(ctx)
 	sandboxList := &agentsv1alpha1.SandboxList{}
+	// NOTE: Do NOT use client.UnsafeDisableDeepCopy here. Downstream code
+	// (scaleDownSandbox, deleteSandboxForUpdate) mutates sandbox annotations
+	// (e.g. LockSandbox), so the returned objects must be independent copies
+	// to avoid corrupting the informer cache.
 	if err := r.List(ctx, sandboxList,
 		client.InNamespace(sbs.Namespace),
 		client.MatchingFields{fieldindex.IndexNameForOwnerRefUID: string(sbs.UID)},
-		client.UnsafeDisableDeepCopy,
 	); err != nil {
 		return GroupedSandboxes{}, err
 	}


### PR DESCRIPTION
## What

Remove client.UnsafeDisableDeepCopy from groupAllSandboxes and fix slice aliasing in scaleDown to prevent informer cache corruption during concurrent scale-down and rolling update operations.

## Why

1. **Cache Corruption**: groupAllSandboxes lists sandboxes with client.UnsafeDisableDeepCopy, returning raw informer cache pointers. Downstream code mutates these pointers, silently corrupting the shared informer cache.
2. **Slice Aliasing**: scaleDown used ppend(groups.Creating, groups.Available...) which is a Go slice aliasing trap — when Creating has spare capacity, Available elements silently overwrite its memory.

## Changes

- Removed client.UnsafeDisableDeepCopy from the groupAllSandboxes List call.
- Fixed slice aliasing by replacing the buggy ppend with explicit make + dual appends.

Fixes #386
Fixes #388