### PR TITLE
fix: include stdout/stderr in hook execution error message

### DIFF
--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -537,7 +537,7 @@ func (r *commonControl) executeUpgradeAction(ctx context.Context, pod *corev1.Po
 
 	exitCode, stdout, stderr, err := r.lifecycleHookFunc(ctx, box, action)
 	if err != nil {
-		return upgradeActionResult{Succeeded: false, Message: fmt.Sprintf("hook execution error: %v", err)}
+		return upgradeActionResult{Succeeded: false, Message: fmt.Sprintf("hook execution error: %v, stdout: %s, stderr: %s", err, stdout, stderr)}
 	}
 	if exitCode != 0 {
 		return upgradeActionResult{Succeeded: false, Message: fmt.Sprintf("hook failed with exit code %d, stdout: %s, stderr: %s", exitCode, stdout, stderr)}


### PR DESCRIPTION
## Background

When lifecycle hook execution returns an error, executeUpgradeAction currently includes only the error string in the condition message and discards stdout/stderr. This makes hook failures difficult to debug without exec-ing into the pod.

The exitCode != 0 path already includes both stdout and stderr in the message, so this change makes the error path consistent with that behavior.

## Changes

- Include stdout and stderr in error-path condition messages alongside the error string

## Verification

- Ran existing tests
- No new tests added because this change only extends the existing condition message formatting

Fixes #379