### PR TITLE
fix: log security warning when auth disabled and remove API key from 401 response

### DIFF
--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -97,14 +97,18 @@ func (sc *Controller) CheckApiKey(ctx context.Context, r *http.Request) (context
 	var user *models.CreatedTeamAPIKey
 	var ok bool
 	if sc.keys == nil {
+		// Authentication is disabled: every request is treated as AnonymousUser.
+		// Log a prominent warning so operators are aware of this insecure state.
+		klog.FromContext(ctx).Error(nil, "[SECURITY] API key storage is not configured — authentication is DISABLED, all requests are granted admin access")
 		user = AnonymousUser
 	} else {
 		user, ok = sc.keys.LoadByKey(ctx, apiKey)
 		if !ok {
 			middleWareLog.Info("failed to load key by API-KEY")
+			// Do NOT echo the submitted key value — it aids brute-force validation.
 			return ctx, &web.ApiError{
 				Code:    http.StatusUnauthorized,
-				Message: fmt.Sprintf("Invalid API Key: %s", apiKey),
+				Message: "Invalid API Key",
 			}
 		}
 	}

--- a/pkg/servers/e2b/routes_test.go
+++ b/pkg/servers/e2b/routes_test.go
@@ -82,14 +82,14 @@ func TestCheckApiKey_WithRealSetup(t *testing.T) {
 			apiKeyHeader: "invalid-key",
 			expectError:  true,
 			expectedCode: http.StatusUnauthorized,
-			expectedMsg:  "Invalid API Key: invalid-key",
+			expectedMsg:  "Invalid API Key",
 		},
 		{
 			name:         "empty X-API-KEY header",
 			apiKeyHeader: "",
 			expectError:  true,
 			expectedCode: http.StatusUnauthorized,
-			expectedMsg:  "Invalid API Key: ",
+			expectedMsg:  "Invalid API Key",
 		},
 	}
 


### PR DESCRIPTION
## What

Two security hardening changes to `pkg/servers/e2b/routes.go`:

1. **Log a security warning when authentication is disabled** — when `keyCfg` is `nil`, every request silently received admin-level `AnonymousUser` access with no operator visibility. Now logs an `Error`-level message on every request so misconfigured deployments are immediately detectable in logs/alerts.

2. **Stop echoing submitted API key in 401 responses** — the previous error message `"Invalid API Key: <submitted-key>"` reflected the caller's key back in the response body, aiding brute-force key validation. Replaced with the static message `"Invalid API Key"`.

## Why

- A single Helm misconfiguration (missing key Secret) silently exposed all sandbox management APIs with admin privileges
- Operators had no signal that auth was disabled unless they audited the startup config
- Leaking the submitted key in 401 aids attackers in confirming partial key guesses

## Changes

- `routes.go`: Add `klog.Error` warning in `CheckApiKey` when `sc.keys == nil`
- `routes.go`: Replace `fmt.Sprintf("Invalid API Key: %s", apiKey)` with `"Invalid API Key"`
- `routes_test.go`: Update test expectations to match new generic 401 message

## Testing

- `go test github.com/openkruise/agents/pkg/servers/e2b -run TestCheckApiKey` ✅
- `go build ./pkg/servers/e2b/...` ✅

Fixes #389
