### PR TITLE
fix: register scale-up expectations before creating sandboxes

### DIFF
--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -344,12 +344,18 @@ func (r *Reconciler) createSandbox(ctx context.Context, sbs *agentsv1alpha1.Sand
 	if err := ctrl.SetControllerReference(sbs, sbx, r.Scheme); err != nil {
 		return nil, err
 	}
+	// Register the expectation BEFORE calling Create so that if the informer
+	// delivers the Create event before this goroutine reaches ExpectScale, the
+	// ObserveScale call in the event handler finds a matching expectation.
+	// If Create fails, cancel the expectation immediately so it does not block
+	// reconciliation for the full 30s timeout.
+	scaleUpExpectation.ExpectScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
 	if err := r.Create(ctx, sbx); err != nil {
+		scaleUpExpectation.ObserveScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
 		r.Recorder.Eventf(sbs, corev1.EventTypeWarning, EventCreateSandboxFailed, "Failed to create sandbox: %s", err)
 		return nil, err
 	}
 	sandboxSetSandboxesCreatedTotal.WithLabelValues(sbs.Namespace, sbs.Name).Inc()
-	scaleUpExpectation.ExpectScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
 	r.Recorder.Eventf(sbs, corev1.EventTypeNormal, EventSandboxCreated, "Sandbox %s created", klog.KObj(sbx))
 	return sbx, nil
 }

--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -392,12 +392,18 @@ func (r *Reconciler) createSandbox(ctx context.Context, sbs *agentsv1alpha1.Sand
 	if err := ctrl.SetControllerReference(sbs, sbx, r.Scheme); err != nil {
 		return nil, err
 	}
+	// Register the expectation BEFORE calling Create so that if the informer
+	// delivers the Create event before this goroutine reaches ExpectScale, the
+	// ObserveScale call in the event handler finds a matching expectation.
+	// If Create fails, cancel the expectation immediately so it does not block
+	// reconciliation for the full 30s timeout.
+	scaleUpExpectation.ExpectScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
 	if err := r.Create(ctx, sbx); err != nil {
+		scaleUpExpectation.ObserveScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
 		r.Recorder.Eventf(sbs, corev1.EventTypeWarning, EventCreateSandboxFailed, "Failed to create sandbox: %s", err)
 		return nil, err
 	}
 	sandboxSetSandboxesCreatedTotal.WithLabelValues(sbs.Namespace, sbs.Name).Inc()
-	scaleUpExpectation.ExpectScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
 	r.Recorder.Eventf(sbs, corev1.EventTypeNormal, EventSandboxCreated, "Sandbox %s created", klog.KObj(sbx))
 	return sbx, nil
 }

--- a/pkg/controller/sandboxset/sandboxset_controller_test.go
+++ b/pkg/controller/sandboxset/sandboxset_controller_test.go
@@ -588,6 +588,8 @@ func TestReconcile_BasicScale(t *testing.T) {
 			})
 			assert.NoError(t, err)
 			checkFunc(tt.expectTotalSandboxes, tt.expectNewSandboxes)(t, k8sClient, sbs)
+			scaleUpExpectation.DeleteExpectations(GetControllerKey(sbs))
+			scaleDownExpectation.DeleteExpectations(GetControllerKey(sbs))
 
 			// reconcile again to refresh status
 			_, err = reconciler.Reconcile(ctx, ctrl.Request{

--- a/pkg/controller/sandboxset/sandboxset_controller_test.go
+++ b/pkg/controller/sandboxset/sandboxset_controller_test.go
@@ -622,6 +622,8 @@ func TestReconcile_BasicScale(t *testing.T) {
 			})
 			assert.NoError(t, err)
 			checkFunc(tt.expectTotalSandboxes, tt.expectNewSandboxes)(t, k8sClient, sbs)
+			scaleUpExpectation.DeleteExpectations(GetControllerKey(sbs))
+			scaleDownExpectation.DeleteExpectations(GetControllerKey(sbs))
 
 			// reconcile again to refresh status
 			_, err = reconciler.Reconcile(ctx, ctrl.Request{


### PR DESCRIPTION
## What

Fixed a critical race condition in the `SandboxSet` controller where `ExpectScale` was called **after** `r.Create`.

## Why

Under high load or high QPS, the Kubernetes API server can deliver the `Create` event to the controller's informer faster than the controller can execute the next line of code. If `r.Create` succeeds but the `Create` event is processed before `ExpectScale` is called:

1.  `ObserveScale` (in the event handler) finds no registered expectation for that sandbox and is a no-op.
2.  `ExpectScale` is then called, registering an expectation that will **never be satisfied** by an event (since the event already passed).
3.  The controller's `SatisfiesExpectations` check then blocks any further reconciliation for that `SandboxSet` until the expectation times out (default 30 seconds).

This results in severe "stalls" in warm pool replenishment.

## Changes

-   **Code**: Moved `scaleUpExpectation.ExpectScale` **before** the `r.Create` call.
-   **Code**: Added a call to `ObserveScale` in the `r.Create` error path to ensure failed creations don't leave orphaned expectations.
-   **Tests**: Updated `TestReconcile_BasicScale` to manually clear expectations between reconcile calls. This is necessary because the fake test client doesn't trigger the watch events that would normally clear expectations in a real cluster.

## Testing

-   `go test ./pkg/controller/sandboxset/...` ✅ (All tests pass with the expectation cleanup).
-   Manual verification of logic flow.

Fixes #392
