### PR TITLE
add support for egress control injection

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -47,6 +47,9 @@ const (
 	// RuntimeConfigForInjectAgentRuntime is a valid value for RuntimeConfig.Name.
 	// When set, enables agent runtime sidecar injection for the sandbox.
 	RuntimeConfigForInjectAgentRuntime = "agent-runtime"
+	// RuntimeConfigForInjectEgressControl is a valid value for RuntimeConfig.Name.
+	// When set, enables egress control sidecar injection for the sandbox.
+	RuntimeConfigForInjectEgressControl = "egress-control"
 )
 
 type RuntimeConfig struct {

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -436,8 +436,7 @@ func (r *commonControl) createPod(ctx context.Context, box *agentsv1alpha1.Sandb
 
 	// to avoid the performance issue, using the controller to inject csi containers
 	// fetch the configmap and parse the configuration based on the controller runtime
-	podTemplate := &pod.Spec
-	injectErr := sidecarutils.InjectPodTemplateCSIAndRuntimeSidecar(ctx, box, podTemplate, r.Client)
+	injectErr := sidecarutils.InjectSandboxRuntimes(ctx, box, pod, r.Client)
 	if injectErr != nil {
 		klog.ErrorS(injectErr, "failed to inject pod template with csi sidecar or runtime sidecar", "sandbox", klog.KObj(box))
 		return nil, injectErr

--- a/pkg/utils/sidecarutils/config_types.go
+++ b/pkg/utils/sidecarutils/config_types.go
@@ -21,9 +21,11 @@ import (
 )
 
 const (
-	KEY_CSI_INJECTION_CONFIG     = "csi"
-	KEY_RUNTIME_INJECTION_CONFIG = "agent-runtime"
-	SandboxInjectionConfigName   = "sandbox-injection-config"
+	KEY_CSI_INJECTION_CONFIG            = "csi"
+	KEY_EGRESS_CONTROL_INJECTION_CONFIG = "egress-control"
+	KEY_RUNTIME_INJECTION_CONFIG        = "agent-runtime"
+
+	SandboxInjectionConfigName = "sandbox-injection-config"
 )
 
 type SidecarInjectConfig struct {
@@ -34,4 +36,13 @@ type SidecarInjectConfig struct {
 	Sidecars []corev1.Container `json:"csiSidecar"`
 	// Support injection for volume mount configurations
 	Volumes []corev1.Volume `json:"volume"`
+
+	// Annotations to be added to the pod.
+	Annotations map[string]string `json:"annotations"`
+	// Labels to be added to the pod.
+	Labels map[string]string `json:"labels"`
+	// InitContainers to be appended to the pod spec.
+	InitContainers []corev1.Container `json:"initContainers"`
+	// Containers to be appended to the pod spec.
+	Containers []corev1.Container `json:"containers"`
 }

--- a/pkg/utils/sidecarutils/egress-control/health_probe.go
+++ b/pkg/utils/sidecarutils/egress-control/health_probe.go
@@ -1,0 +1,338 @@
+package egresscontrol
+
+// Package egresscontrol provides Istio sidecar health probe rewriting.
+//
+// When Istio's envoy proxy intercepts all pod traffic, Kubernetes probes (readiness,
+// liveness, startup) must be redirected through the pilot agent on port 15020.
+// This package converts the original probes into HTTP probes pointing at the
+// pilot agent's /app-health/* endpoints, and serializes the original probe
+// definitions into the ISTIO_KUBE_APP_PROBERS env var on the istio-proxy container.
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/openkruise/agents/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	ProxyContainerName           = "istio-proxy"
+	KubeAppProberEnv             = "ISTIO_KUBE_APP_PROBERS"
+	HealthProbeRewriteAnnotation = "networking.agents.kruise.io/health-probe-rewrite"
+	SidecarProxyAnnotation       = "networking.agents.kruise.io/sidecar-proxy"
+)
+
+// findSidecar returns the pointer to the first container whose name matches the "istio-proxy".
+func findSidecar(pod *corev1.Pod) *corev1.Container {
+	proxyContainerName := pod.Annotations[SidecarProxyAnnotation]
+	if proxyContainerName == "" {
+		proxyContainerName = ProxyContainerName
+	}
+	return findContainerFromPod(proxyContainerName, pod)
+}
+
+// findContainerFromPod returns the pointer to the first container whose name matches in init containers or regular containers
+func findContainerFromPod(name string, pod *corev1.Pod) *corev1.Container {
+	if c := utils.FindContainer(name, pod.Spec.Containers); c != nil {
+		return c
+	}
+	return utils.FindContainer(name, pod.Spec.InitContainers)
+}
+
+// convertAppProber returns an overwritten `Probe` for pilot agent to take over.
+func convertAppProber(probe *corev1.Probe, newURL string, statusPort int) *corev1.Probe {
+	if probe == nil {
+		return nil
+	}
+	if probe.HTTPGet != nil {
+		return convertAppProberHTTPGet(probe, newURL, statusPort)
+	} else if probe.TCPSocket != nil {
+		return convertAppProberTCPSocket(probe, newURL, statusPort)
+	} else if probe.GRPC != nil {
+		return convertAppProberGRPC(probe, newURL, statusPort)
+	}
+
+	return nil
+}
+
+// rewriteHTTPGetAction rewrites a HTTPGet action with given URL and port.
+// Also rewrites the scheme to HTTP if the scheme is HTTPS
+// as pilot agent uses https to request application endpoint.
+func rewriteHTTPGetAction(action *corev1.HTTPGetAction, url string, port int) {
+	action.Port = intstr.FromInt32(int32(port))
+	action.Path = url
+	// Kubelet -> HTTP -> Pilot Agent -> HTTPS -> Application
+	if action.Scheme == corev1.URISchemeHTTPS {
+		action.Scheme = corev1.URISchemeHTTP
+	}
+}
+
+// convertAppLifecycleHandler returns an overwritten `LifecycleHandler` for pilot agent to take over.
+func convertAppLifecycleHandler(lifecycleHandler *corev1.LifecycleHandler, newURL string, statusPort int) *corev1.LifecycleHandler {
+	if lifecycleHandler == nil {
+		return nil
+	}
+	if lifecycleHandler.HTTPGet != nil {
+		return convertAppLifecycleHandlerHTTPGet(lifecycleHandler, newURL, statusPort)
+	}
+	if lifecycleHandler.TCPSocket != nil {
+		return convertAppLifecycleHandlerTCPSocket(lifecycleHandler, newURL, statusPort)
+	}
+	return nil
+}
+
+// convertAppLifecycleHandlerHTTPGet returns an overwritten `LifecycleHandler` with HTTPGet for pilot agent to take over.
+func convertAppLifecycleHandlerHTTPGet(lifecycleHandler *corev1.LifecycleHandler, newURL string, statusPort int) *corev1.LifecycleHandler {
+	lh := lifecycleHandler.DeepCopy()
+	rewriteHTTPGetAction(lh.HTTPGet, newURL, statusPort)
+	return lh
+}
+
+// convertAppLifecycleHandlerTCPSocket returns an overwritten `LifecycleHandler` with TCPSocket for pilot agent to take over.
+func convertAppLifecycleHandlerTCPSocket(lifecycleHandler *corev1.LifecycleHandler, newURL string, statusPort int) *corev1.LifecycleHandler {
+	lh := lifecycleHandler.DeepCopy()
+	// the sidecar intercepts all tcp connections, so we change it to a HTTP probe and the sidecar will check tcp
+	lh.HTTPGet = &corev1.HTTPGetAction{}
+	rewriteHTTPGetAction(lh.HTTPGet, newURL, statusPort)
+	lh.TCPSocket = nil
+	return lh
+}
+
+// convertAppProberHTTPGet returns an overwritten `Probe` (HttpGet) for pilot agent to take over.
+func convertAppProberHTTPGet(probe *corev1.Probe, newURL string, statusPort int) *corev1.Probe {
+	p := probe.DeepCopy()
+	rewriteHTTPGetAction(p.HTTPGet, newURL, statusPort)
+	return p
+}
+
+// convertAppProberTCPSocket returns an overwritten `Probe` (TcpSocket) for pilot agent to take over.
+func convertAppProberTCPSocket(probe *corev1.Probe, newURL string, statusPort int) *corev1.Probe {
+	p := probe.DeepCopy()
+	// the sidecar intercepts all tcp connections, so we change it to a HTTP probe and the sidecar will check tcp
+	p.HTTPGet = &corev1.HTTPGetAction{}
+	rewriteHTTPGetAction(p.HTTPGet, newURL, statusPort)
+	p.TCPSocket = nil
+	return p
+}
+
+// convertAppProberGRPC returns an overwritten `Probe` (gRPC) for pilot agent to take over.
+func convertAppProberGRPC(probe *corev1.Probe, newURL string, statusPort int) *corev1.Probe {
+	p := probe.DeepCopy()
+	// the sidecar intercepts all gRPC connections, so we change it to a HTTP probe and the sidecar will check gRPC
+	p.HTTPGet = &corev1.HTTPGetAction{}
+	rewriteHTTPGetAction(p.HTTPGet, newURL, statusPort)
+	// For gRPC prober, we change to HTTP,
+	// and pilot agent uses gRPC to request application prober endpoint.
+	// Kubelet -> HTTP -> Pilot Agent -> gRPC -> Application
+	p.GRPC = nil
+	return p
+}
+
+type KubeAppProbers map[string]*Prober
+
+// Prober represents a single container prober
+type Prober struct {
+	HTTPGet        *corev1.HTTPGetAction   `json:"httpGet,omitempty"`
+	TCPSocket      *corev1.TCPSocketAction `json:"tcpSocket,omitempty"`
+	GRPC           *corev1.GRPCAction      `json:"grpc,omitempty"`
+	TimeoutSeconds int32                   `json:"timeoutSeconds,omitempty"`
+}
+
+// dumpAppProbers returns a json encoded string as `status.KubeAppProbers`.
+// Also update the probers so that all usages of named port will be resolved to integer.
+func dumpAppProbers(pod *corev1.Pod, targetPort int32) string {
+	out := KubeAppProbers{}
+	updateNamedPort := func(p *Prober, portMap map[string]int32) *Prober {
+		if p == nil {
+			return nil
+		}
+		if p.GRPC != nil {
+			// don't need to update for gRPC probe port as it only supports integer
+			return p
+		}
+		if p.HTTPGet == nil && p.TCPSocket == nil {
+			return nil
+		}
+
+		var probePort *intstr.IntOrString
+		if p.HTTPGet != nil {
+			probePort = &p.HTTPGet.Port
+		} else {
+			probePort = &p.TCPSocket.Port
+		}
+
+		if probePort.Type == intstr.String {
+			port, exists := portMap[probePort.StrVal]
+			if !exists {
+				return nil
+			}
+			*probePort = intstr.FromInt32(port)
+		} else if probePort.IntVal == targetPort {
+			// Already is rewritten
+			return nil
+		}
+		return p
+	}
+	for _, c := range allContainers(pod) {
+		if c.Name == ProxyContainerName {
+			continue
+		}
+		readyz, livez, startupz, prestopz, poststartz := formatProberURL(c.Name)
+		portMap := map[string]int32{}
+		for _, p := range c.Ports {
+			if p.Name != "" {
+				portMap[p.Name] = p.ContainerPort
+			}
+		}
+		if h := updateNamedPort(kubeProbeToInternalProber(c.ReadinessProbe), portMap); h != nil {
+			out[readyz] = h
+		}
+		if h := updateNamedPort(kubeProbeToInternalProber(c.LivenessProbe), portMap); h != nil {
+			out[livez] = h
+		}
+		if h := updateNamedPort(kubeProbeToInternalProber(c.StartupProbe), portMap); h != nil {
+			out[startupz] = h
+		}
+		if c.Lifecycle != nil {
+			if h := updateNamedPort(kubeLifecycleHandlerToInternalProber(c.Lifecycle.PreStop), portMap); h != nil {
+				out[prestopz] = h
+			}
+			if h := updateNamedPort(kubeLifecycleHandlerToInternalProber(c.Lifecycle.PostStart), portMap); h != nil {
+				out[poststartz] = h
+			}
+		}
+	}
+	// prevent generate '{}'
+	if len(out) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func allContainers(pod *corev1.Pod) []corev1.Container {
+	return append(slices.Clone(pod.Spec.InitContainers), pod.Spec.Containers...)
+}
+
+// patchRewriteProbe generates the patch for webhook.
+func patchRewriteProbe(pod *corev1.Pod, defaultPort int32) {
+	statusPort := int(defaultPort)
+	for i, c := range pod.Spec.Containers {
+		// Skip sidecar container.
+		if c.Name == ProxyContainerName {
+			continue
+		}
+		convertProbe(&c, statusPort)
+		pod.Spec.Containers[i] = c
+	}
+	for i, c := range pod.Spec.InitContainers {
+		// Skip sidecar container.
+		if c.Name == ProxyContainerName {
+			continue
+		}
+		convertProbe(&c, statusPort)
+		pod.Spec.InitContainers[i] = c
+	}
+}
+
+func convertProbe(c *corev1.Container, statusPort int) {
+	readyz, livez, startupz, prestopz, poststartz := formatProberURL(c.Name)
+	if probePatch := convertAppProber(c.ReadinessProbe, readyz, statusPort); probePatch != nil {
+		c.ReadinessProbe = probePatch
+	}
+	if probePatch := convertAppProber(c.LivenessProbe, livez, statusPort); probePatch != nil {
+		c.LivenessProbe = probePatch
+	}
+	if probePatch := convertAppProber(c.StartupProbe, startupz, statusPort); probePatch != nil {
+		c.StartupProbe = probePatch
+	}
+	if c.Lifecycle != nil {
+		if lifecycleHandlerPatch := convertAppLifecycleHandler(c.Lifecycle.PreStop, prestopz, statusPort); lifecycleHandlerPatch != nil {
+			c.Lifecycle.PreStop = lifecycleHandlerPatch
+		}
+		if lifecycleHandlerPatch := convertAppLifecycleHandler(c.Lifecycle.PostStart, poststartz, statusPort); lifecycleHandlerPatch != nil {
+			c.Lifecycle.PostStart = lifecycleHandlerPatch
+		}
+	}
+}
+
+// kubeProbeToInternalProber converts a Kubernetes Probe to an Istio internal Prober
+func kubeProbeToInternalProber(probe *corev1.Probe) *Prober {
+	if probe == nil {
+		return nil
+	}
+
+	if probe.HTTPGet != nil {
+		return &Prober{
+			HTTPGet:        probe.HTTPGet,
+			TimeoutSeconds: probe.TimeoutSeconds,
+		}
+	}
+
+	if probe.TCPSocket != nil {
+		return &Prober{
+			TCPSocket:      probe.TCPSocket,
+			TimeoutSeconds: probe.TimeoutSeconds,
+		}
+	}
+
+	if probe.GRPC != nil {
+		return &Prober{
+			GRPC:           probe.GRPC,
+			TimeoutSeconds: probe.TimeoutSeconds,
+		}
+	}
+
+	return nil
+}
+
+// kubeLifecycleHandlerToInternalProber converts a Kubernetes LifecycleHandler to an Istio internal Prober
+func kubeLifecycleHandlerToInternalProber(lifecycleHandler *corev1.LifecycleHandler) *Prober {
+	if lifecycleHandler == nil {
+		return nil
+	}
+	if lifecycleHandler.HTTPGet != nil {
+		return &Prober{
+			HTTPGet: lifecycleHandler.HTTPGet,
+		}
+	}
+	if lifecycleHandler.TCPSocket != nil {
+		return &Prober{
+			TCPSocket: lifecycleHandler.TCPSocket,
+		}
+	}
+
+	return nil
+}
+
+// formatProberURL returns a set of HTTP URLs that pilot agent will serve to take over Kubernetes
+// app probers.
+func formatProberURL(container string) (string, string, string, string, string) {
+	return fmt.Sprintf("/app-health/%v/readyz", container),
+		fmt.Sprintf("/app-health/%v/livez", container),
+		fmt.Sprintf("/app-health/%v/startupz", container),
+		fmt.Sprintf("/app-lifecycle/%v/prestopz", container),
+		fmt.Sprintf("/app-lifecycle/%v/poststartz", container)
+}
+
+func ApplyHealthProbeRewrite(pod *corev1.Pod) error {
+	if pod.Annotations[HealthProbeRewriteAnnotation] != "true" {
+		return nil
+	}
+	sidecar := findSidecar(pod)
+	if sidecar == nil {
+		return nil
+	}
+
+	if prober := dumpAppProbers(pod, 15020); prober != "" {
+		sidecar.Env = append(sidecar.Env, corev1.EnvVar{Name: KubeAppProberEnv, Value: prober})
+	}
+	patchRewriteProbe(pod, 15020)
+	return nil
+}

--- a/pkg/utils/sidecarutils/egress-control/health_probe_test.go
+++ b/pkg/utils/sidecarutils/egress-control/health_probe_test.go
@@ -1,0 +1,1119 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package egresscontrol
+
+import (
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestFindContainerFromPod(t *testing.T) {
+	tests := []struct {
+		name       string
+		pod        *corev1.Pod
+		lookup     string
+		expectNil  bool
+		expectName string
+	}{
+		{
+			name: "find in containers",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers:     []corev1.Container{{Name: "app"}, {Name: "sidecar"}},
+					InitContainers: []corev1.Container{{Name: "init"}},
+				},
+			},
+			lookup:     "app",
+			expectNil:  false,
+			expectName: "app",
+		},
+		{
+			name: "find in init containers",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers:     []corev1.Container{{Name: "app"}},
+					InitContainers: []corev1.Container{{Name: "init"}},
+				},
+			},
+			lookup:     "init",
+			expectNil:  false,
+			expectName: "init",
+		},
+		{
+			name: "not found",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "app"}},
+				},
+			},
+			lookup:    "missing",
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := findContainerFromPod(tt.lookup, tt.pod)
+			if tt.expectNil && c != nil {
+				t.Errorf("expected nil, got %q", c.Name)
+			}
+			if !tt.expectNil && (c == nil || c.Name != tt.expectName) {
+				t.Errorf("expected %q, got %v", tt.expectName, c)
+			}
+		})
+	}
+}
+
+func TestFindSidecar(t *testing.T) {
+	t.Run("sidecar in containers", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: ProxyContainerName}},
+			},
+		}
+		c := findSidecar(pod)
+		if c == nil || c.Name != ProxyContainerName {
+			t.Errorf("expected to find %q, got %v", ProxyContainerName, c)
+		}
+	})
+
+	t.Run("sidecar in init containers", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{Name: ProxyContainerName}},
+			},
+		}
+		c := findSidecar(pod)
+		if c == nil || c.Name != ProxyContainerName {
+			t.Errorf("expected to find %q, got %v", ProxyContainerName, c)
+		}
+	})
+
+	t.Run("no sidecar", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app"}},
+			},
+		}
+		if c := findSidecar(pod); c != nil {
+			t.Errorf("expected nil, got %q", c.Name)
+		}
+	})
+}
+
+func TestRewriteHTTPGetAction(t *testing.T) {
+	tests := []struct {
+		name         string
+		action       *corev1.HTTPGetAction
+		url          string
+		port         int
+		expectPath   string
+		expectPort   int32
+		expectScheme corev1.URIScheme
+	}{
+		{
+			name:         "HTTP scheme preserved",
+			action:       &corev1.HTTPGetAction{Path: "/old", Port: intstr.FromInt32(8080), Scheme: corev1.URISchemeHTTP},
+			url:          "/new",
+			port:         15020,
+			expectPath:   "/new",
+			expectPort:   15020,
+			expectScheme: corev1.URISchemeHTTP,
+		},
+		{
+			name:         "HTTPS scheme rewritten to HTTP",
+			action:       &corev1.HTTPGetAction{Path: "/old", Port: intstr.FromInt32(8080), Scheme: corev1.URISchemeHTTPS},
+			url:          "/new",
+			port:         15020,
+			expectPath:   "/new",
+			expectPort:   15020,
+			expectScheme: corev1.URISchemeHTTP,
+		},
+		{
+			name:         "empty scheme defaults to HTTP",
+			action:       &corev1.HTTPGetAction{Path: "/old", Port: intstr.FromInt32(8080)},
+			url:          "/health",
+			port:         15000,
+			expectPath:   "/health",
+			expectPort:   15000,
+			expectScheme: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rewriteHTTPGetAction(tt.action, tt.url, tt.port)
+			if tt.action.Path != tt.expectPath {
+				t.Errorf("path: expected %q, got %q", tt.expectPath, tt.action.Path)
+			}
+			if tt.action.Port.IntVal != tt.expectPort {
+				t.Errorf("port: expected %d, got %d", tt.expectPort, tt.action.Port.IntVal)
+			}
+			if tt.action.Scheme != tt.expectScheme {
+				t.Errorf("scheme: expected %q, got %q", tt.expectScheme, tt.action.Scheme)
+			}
+		})
+	}
+}
+
+func TestConvertAppProber(t *testing.T) {
+	t.Run("nil probe returns nil", func(t *testing.T) {
+		if result := convertAppProber(nil, "/readyz", 15020); result != nil {
+			t.Errorf("expected nil, got %v", result)
+		}
+	})
+
+	t.Run("HTTPGet probe converted", func(t *testing.T) {
+		probe := &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{Path: "/health", Port: intstr.FromInt32(8080)},
+			},
+		}
+		result := convertAppProber(probe, "/readyz", 15020)
+		if result == nil || result.HTTPGet == nil {
+			t.Fatal("expected HTTPGet probe to be converted")
+		}
+		if result.HTTPGet.Path != "/readyz" {
+			t.Errorf("expected path /readyz, got %s", result.HTTPGet.Path)
+		}
+		if result.HTTPGet.Port.IntVal != 15020 {
+			t.Errorf("expected port 15020, got %d", result.HTTPGet.Port.IntVal)
+		}
+	})
+
+	t.Run("TCPSocket probe converted to HTTP", func(t *testing.T) {
+		probe := &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt32(8080)},
+			},
+		}
+		result := convertAppProber(probe, "/readyz", 15020)
+		if result == nil {
+			t.Fatal("expected TCP probe to be converted")
+		}
+		if result.HTTPGet == nil {
+			t.Error("expected TCP to be converted to HTTPGet")
+		}
+		if result.TCPSocket != nil {
+			t.Error("expected TCPSocket to be nil after conversion")
+		}
+	})
+
+	t.Run("GRPC probe converted to HTTP", func(t *testing.T) {
+		probe := &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				GRPC: &corev1.GRPCAction{Port: 50051},
+			},
+		}
+		result := convertAppProber(probe, "/readyz", 15020)
+		if result == nil {
+			t.Fatal("expected GRPC probe to be converted")
+		}
+		if result.HTTPGet == nil {
+			t.Error("expected GRPC to be converted to HTTPGet")
+		}
+		if result.GRPC != nil {
+			t.Error("expected GRPC to be nil after conversion")
+		}
+	})
+
+	t.Run("unsupported probe type returns nil", func(t *testing.T) {
+		// A probe with no handler fields
+		probe := &corev1.Probe{}
+		result := convertAppProber(probe, "/readyz", 15020)
+		if result != nil {
+			t.Errorf("expected nil for unsupported probe, got %v", result)
+		}
+	})
+}
+
+func TestConvertAppLifecycleHandler(t *testing.T) {
+	t.Run("nil handler returns nil", func(t *testing.T) {
+		if result := convertAppLifecycleHandler(nil, "/prestopz", 15020); result != nil {
+			t.Errorf("expected nil, got %v", result)
+		}
+	})
+
+	t.Run("HTTPGet handler converted", func(t *testing.T) {
+		h := &corev1.LifecycleHandler{
+			HTTPGet: &corev1.HTTPGetAction{Path: "/shutdown", Port: intstr.FromInt32(8080)},
+		}
+		result := convertAppLifecycleHandler(h, "/prestopz", 15020)
+		if result == nil || result.HTTPGet == nil {
+			t.Fatal("expected HTTPGet to be converted")
+		}
+		if result.HTTPGet.Path != "/prestopz" {
+			t.Errorf("expected path /prestopz, got %s", result.HTTPGet.Path)
+		}
+	})
+
+	t.Run("TCPSocket handler converted to HTTP", func(t *testing.T) {
+		h := &corev1.LifecycleHandler{
+			TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt32(8080)},
+		}
+		result := convertAppLifecycleHandler(h, "/prestopz", 15020)
+		if result == nil || result.HTTPGet == nil {
+			t.Fatal("expected TCPSocket to be converted to HTTPGet")
+		}
+		if result.TCPSocket != nil {
+			t.Error("expected TCPSocket to be nil after conversion")
+		}
+	})
+
+	t.Run("unsupported handler returns nil", func(t *testing.T) {
+		h := &corev1.LifecycleHandler{}
+		result := convertAppLifecycleHandler(h, "/prestopz", 15020)
+		if result != nil {
+			t.Errorf("expected nil for unsupported handler, got %v", result)
+		}
+	})
+}
+
+func TestFormatProberURL(t *testing.T) {
+	readyz, livez, startupz, prestopz, poststartz := formatProberURL("my-app")
+
+	expected := []struct {
+		name string
+		got  string
+	}{
+		{"readyz", readyz},
+		{"livez", livez},
+		{"startupz", startupz},
+		{"prestopz", prestopz},
+		{"poststartz", poststartz},
+	}
+
+	for _, e := range expected {
+		t.Run(e.name, func(t *testing.T) {
+			expectedPath := "/app-health/my-app/" + e.name
+			if e.name == "prestopz" || e.name == "poststartz" {
+				expectedPath = "/app-lifecycle/my-app/" + e.name
+			}
+			if e.got != expectedPath {
+				t.Errorf("expected %q, got %q", expectedPath, e.got)
+			}
+		})
+	}
+}
+
+func TestDumpAppProbers(t *testing.T) {
+	t.Run("pod with no probes returns empty string", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app"}},
+			},
+		}
+		result := dumpAppProbers(pod, 15020)
+		if result != "" {
+			t.Errorf("expected empty string, got %q", result)
+		}
+	})
+
+	t.Run("pod with HTTPGet readiness probe", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromInt32(8080)},
+							},
+						},
+					},
+				},
+			},
+		}
+		result := dumpAppProbers(pod, 15020)
+		if result == "" {
+			t.Fatal("expected non-empty probers JSON")
+		}
+
+		var probers KubeAppProbers
+		if err := json.Unmarshal([]byte(result), &probers); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+
+		readyzKey := "/app-health/app/readyz"
+		if _, ok := probers[readyzKey]; !ok {
+			t.Errorf("expected prober key %q, got keys: %v", readyzKey, probers)
+		}
+	})
+
+	t.Run("named port resolved to integer", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						Ports: []corev1.ContainerPort{
+							{Name: "http", ContainerPort: 8080},
+						},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromString("http")},
+							},
+						},
+					},
+				},
+			},
+		}
+		result := dumpAppProbers(pod, 15020)
+		if result == "" {
+			t.Fatal("expected non-empty probers JSON")
+		}
+
+		var probers KubeAppProbers
+		if err := json.Unmarshal([]byte(result), &probers); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+
+		readyzKey := "/app-health/app/readyz"
+		p, ok := probers[readyzKey]
+		if !ok {
+			t.Fatalf("expected prober key %q", readyzKey)
+		}
+		if p.HTTPGet.Port.IntVal != 8080 {
+			t.Errorf("expected named port resolved to 8080, got %d", p.HTTPGet.Port.IntVal)
+		}
+	})
+
+	t.Run("named port not found returns empty for that probe", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromString("unknown-port")},
+							},
+						},
+					},
+				},
+			},
+		}
+		result := dumpAppProbers(pod, 15020)
+		if result != "" {
+			t.Errorf("expected empty string for unresolved named port, got %q", result)
+		}
+	})
+
+	t.Run("skip istio-proxy container", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: ProxyContainerName,
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromInt32(15020)},
+							},
+						},
+					},
+				},
+			},
+		}
+		result := dumpAppProbers(pod, 15020)
+		if result != "" {
+			t.Errorf("expected empty string (proxy container skipped), got %q", result)
+		}
+	})
+
+	t.Run("liveness and startup probes included", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/live", Port: intstr.FromInt32(8080)},
+							},
+						},
+						StartupProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/startup", Port: intstr.FromInt32(8080)},
+							},
+						},
+					},
+				},
+			},
+		}
+		result := dumpAppProbers(pod, 15020)
+		if result == "" {
+			t.Fatal("expected non-empty probers JSON")
+		}
+
+		var probers KubeAppProbers
+		if err := json.Unmarshal([]byte(result), &probers); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+
+		for _, key := range []string{"/app-health/app/livez", "/app-health/app/startupz"} {
+			if _, ok := probers[key]; !ok {
+				t.Errorf("expected prober key %q, got keys: %v", key, probers)
+			}
+		}
+	})
+
+	t.Run("lifecycle preStop and postStart included", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						Lifecycle: &corev1.Lifecycle{
+							PreStop: &corev1.LifecycleHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/prestop", Port: intstr.FromInt32(8080)},
+							},
+							PostStart: &corev1.LifecycleHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/poststart", Port: intstr.FromInt32(8080)},
+							},
+						},
+					},
+				},
+			},
+		}
+		result := dumpAppProbers(pod, 15020)
+		if result == "" {
+			t.Fatal("expected non-empty probers JSON")
+		}
+
+		var probers KubeAppProbers
+		if err := json.Unmarshal([]byte(result), &probers); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+
+		for _, key := range []string{"/app-lifecycle/app/prestopz", "/app-lifecycle/app/poststartz"} {
+			if _, ok := probers[key]; !ok {
+				t.Errorf("expected prober key %q, got keys: %v", key, probers)
+			}
+		}
+	})
+
+	t.Run("TCP probe serialized as TCPSocket", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt32(8080)},
+							},
+						},
+					},
+				},
+			},
+		}
+		result := dumpAppProbers(pod, 15020)
+		var probers KubeAppProbers
+		if err := json.Unmarshal([]byte(result), &probers); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		p := probers["/app-health/app/readyz"]
+		// DumpAppProbers uses kubeProbeToInternalProber which preserves original type
+		if p.TCPSocket == nil {
+			t.Error("expected TCP probe to be serialized as TCPSocket in prober")
+		}
+	})
+
+	t.Run("GRPC probe serialized as GRPC", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								GRPC: &corev1.GRPCAction{Port: 50051},
+							},
+						},
+					},
+				},
+			},
+		}
+		result := dumpAppProbers(pod, 15020)
+		var probers KubeAppProbers
+		if err := json.Unmarshal([]byte(result), &probers); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		p := probers["/app-health/app/readyz"]
+		// DumpAppProbers preserves GRPC type
+		if p.GRPC == nil {
+			t.Error("expected GRPC probe to be serialized as GRPC in prober")
+		}
+	})
+
+	t.Run("init containers included", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: "init-app",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromInt32(9090)},
+							},
+						},
+					},
+				},
+			},
+		}
+		result := dumpAppProbers(pod, 15020)
+		var probers KubeAppProbers
+		if err := json.Unmarshal([]byte(result), &probers); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if _, ok := probers["/app-health/init-app/readyz"]; !ok {
+			t.Errorf("expected init container prober key, got keys: %v", probers)
+		}
+	})
+
+	t.Run("already rewritten port skipped", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromInt32(15020)},
+							},
+						},
+					},
+				},
+			},
+		}
+		result := dumpAppProbers(pod, 15020)
+		// Port 15020 is the targetPort, so it's considered already rewritten
+		if result != "" {
+			t.Errorf("expected empty string for already-rewritten port, got %q", result)
+		}
+	})
+}
+
+func TestPatchRewriteProbe(t *testing.T) {
+	t.Run("HTTPGet probes rewritten", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/health", Port: intstr.FromInt32(8080), Scheme: corev1.URISchemeHTTPS},
+							},
+						},
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/live", Port: intstr.FromInt32(8080)},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		patchRewriteProbe(pod, 15020)
+
+		c := pod.Spec.Containers[0]
+		if c.ReadinessProbe.HTTPGet.Path != "/app-health/app/readyz" {
+			t.Errorf("readiness path: expected /app-health/app/readyz, got %s", c.ReadinessProbe.HTTPGet.Path)
+		}
+		if c.ReadinessProbe.HTTPGet.Port.IntVal != 15020 {
+			t.Errorf("readiness port: expected 15020, got %d", c.ReadinessProbe.HTTPGet.Port.IntVal)
+		}
+		if c.ReadinessProbe.HTTPGet.Scheme != corev1.URISchemeHTTP {
+			t.Errorf("readiness scheme: expected HTTP, got %s", c.ReadinessProbe.HTTPGet.Scheme)
+		}
+		if c.LivenessProbe.HTTPGet.Path != "/app-health/app/livez" {
+			t.Errorf("liveness path: expected /app-health/app/livez, got %s", c.LivenessProbe.HTTPGet.Path)
+		}
+	})
+
+	t.Run("TCPSocket probes converted to HTTP", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt32(8080)},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		patchRewriteProbe(pod, 15020)
+
+		c := pod.Spec.Containers[0]
+		if c.ReadinessProbe.HTTPGet == nil {
+			t.Error("expected TCP probe converted to HTTPGet")
+		}
+		if c.ReadinessProbe.TCPSocket != nil {
+			t.Error("expected TCPSocket to be nil after conversion")
+		}
+	})
+
+	t.Run("GRPC probes converted to HTTP", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								GRPC: &corev1.GRPCAction{Port: 50051},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		patchRewriteProbe(pod, 15020)
+
+		c := pod.Spec.Containers[0]
+		if c.ReadinessProbe.HTTPGet == nil {
+			t.Error("expected GRPC probe converted to HTTPGet")
+		}
+		if c.ReadinessProbe.GRPC != nil {
+			t.Error("expected GRPC to be nil after conversion")
+		}
+	})
+
+	t.Run("skip proxy container", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: ProxyContainerName,
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/health", Port: intstr.FromInt32(15020)},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		originalPath := pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Path
+		patchRewriteProbe(pod, 15020)
+
+		if pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Path != originalPath {
+			t.Error("proxy container probe should not be rewritten")
+		}
+	})
+
+	t.Run("init containers rewritten", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: "init",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/health", Port: intstr.FromInt32(9090)},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		patchRewriteProbe(pod, 15020)
+
+		c := pod.Spec.InitContainers[0]
+		if c.ReadinessProbe.HTTPGet.Path != "/app-health/init/readyz" {
+			t.Errorf("init readiness path: expected /app-health/init/readyz, got %s", c.ReadinessProbe.HTTPGet.Path)
+		}
+	})
+
+	t.Run("lifecycle handlers converted", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						Lifecycle: &corev1.Lifecycle{
+							PreStop: &corev1.LifecycleHandler{
+								TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt32(8080)},
+							},
+							PostStart: &corev1.LifecycleHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/start", Port: intstr.FromInt32(8080)},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		patchRewriteProbe(pod, 15020)
+
+		c := pod.Spec.Containers[0]
+		if c.Lifecycle.PreStop.HTTPGet == nil {
+			t.Error("expected PreStop TCPSocket converted to HTTPGet")
+		}
+		if c.Lifecycle.PreStop.TCPSocket != nil {
+			t.Error("expected PreStop TCPSocket nil after conversion")
+		}
+		if c.Lifecycle.PostStart.HTTPGet.Path != "/app-lifecycle/app/poststartz" {
+			t.Errorf("PostStart path: expected /app-lifecycle/app/poststartz, got %s", c.Lifecycle.PostStart.HTTPGet.Path)
+		}
+	})
+}
+
+func TestApplyHealthProbeRewrite(t *testing.T) {
+	t.Run("no sidecar - no changes", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HealthProbeRewriteAnnotation: "true",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/health", Port: intstr.FromInt32(8080)},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		originalPath := pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Path
+		err := ApplyHealthProbeRewrite(pod)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Without sidecar, probe should not be rewritten
+		if pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Path != originalPath {
+			t.Error("probe should not be rewritten without sidecar")
+		}
+	})
+
+	t.Run("with sidecar - probe rewritten and env set", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HealthProbeRewriteAnnotation: "true",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/health", Port: intstr.FromInt32(8080)},
+							},
+						},
+					},
+					{
+						Name: ProxyContainerName,
+					},
+				},
+			},
+		}
+
+		err := ApplyHealthProbeRewrite(pod)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Check probe was rewritten
+		c := pod.Spec.Containers[0]
+		if c.ReadinessProbe.HTTPGet.Path != "/app-health/app/readyz" {
+			t.Errorf("probe path: expected /app-health/app/readyz, got %s", c.ReadinessProbe.HTTPGet.Path)
+		}
+
+		// Check env was set on sidecar
+		sidecar := pod.Spec.Containers[1]
+		found := false
+		for _, env := range sidecar.Env {
+			if env.Name == KubeAppProberEnv {
+				found = true
+				if env.Value == "" {
+					t.Error("ISTIO_KUBE_APP_PROBERS env should not be empty")
+				}
+				// Verify it's valid JSON
+				var probers KubeAppProbers
+				if err := json.Unmarshal([]byte(env.Value), &probers); err != nil {
+					t.Errorf("ISTIO_KUBE_APP_PROBERS is not valid JSON: %v", err)
+				}
+			}
+		}
+		if !found {
+			t.Error("expected ISTIO_KUBE_APP_PROBERS env on sidecar")
+		}
+	})
+
+	t.Run("with sidecar but no probes - only rewrite applied", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HealthProbeRewriteAnnotation: "true",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "app"},
+					{Name: ProxyContainerName},
+				},
+			},
+		}
+
+		err := ApplyHealthProbeRewrite(pod)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// No probes to dump, so env should not be set
+		sidecar := pod.Spec.Containers[1]
+		for _, env := range sidecar.Env {
+			if env.Name == KubeAppProberEnv {
+				t.Error("ISTIO_KUBE_APP_PROBERS should not be set when there are no probes")
+			}
+		}
+	})
+
+	t.Run("sidecar as init container", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HealthProbeRewriteAnnotation: "true",
+				},
+			},
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: "app",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/health", Port: intstr.FromInt32(8080)},
+							},
+						},
+					},
+					{
+						Name: ProxyContainerName,
+					},
+				},
+			},
+		}
+
+		err := ApplyHealthProbeRewrite(pod)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Check probe was rewritten
+		c := pod.Spec.InitContainers[0]
+		if c.ReadinessProbe.HTTPGet.Path != "/app-health/app/readyz" {
+			t.Errorf("probe path: expected /app-health/app/readyz, got %s", c.ReadinessProbe.HTTPGet.Path)
+		}
+
+		// Check env was set on sidecar init container
+		sidecar := pod.Spec.InitContainers[1]
+		found := false
+		for _, env := range sidecar.Env {
+			if env.Name == KubeAppProberEnv {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected ISTIO_KUBE_APP_PROBERS env on sidecar init container")
+		}
+	})
+
+	t.Run("annotation disables rewrite", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					HealthProbeRewriteAnnotation: "false",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Path: "/health", Port: intstr.FromInt32(8080)},
+							},
+						},
+					},
+					{
+						Name: ProxyContainerName,
+					},
+				},
+			},
+		}
+
+		originalPath := pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Path
+		originalPort := pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Port.IntVal
+
+		err := ApplyHealthProbeRewrite(pod)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Probe should NOT be rewritten when annotation is "false"
+		if pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Path != originalPath {
+			t.Errorf("probe should not be rewritten with annotation=false, got path %s", pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Path)
+		}
+		if pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Port.IntVal != originalPort {
+			t.Errorf("probe port should not change with annotation=false, got %d", pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Port.IntVal)
+		}
+
+		// Env should not be set on sidecar
+		sidecar := pod.Spec.Containers[1]
+		for _, env := range sidecar.Env {
+			if env.Name == KubeAppProberEnv {
+				t.Error("ISTIO_KUBE_APP_PROBERS should not be set when annotation disables rewrite")
+			}
+		}
+	})
+}
+
+func TestKubeProbeToInternalProber(t *testing.T) {
+	t.Run("nil probe", func(t *testing.T) {
+		if p := kubeProbeToInternalProber(nil); p != nil {
+			t.Errorf("expected nil, got %v", p)
+		}
+	})
+
+	t.Run("HTTPGet probe", func(t *testing.T) {
+		probe := &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{Path: "/health", Port: intstr.FromInt32(8080)},
+			},
+			TimeoutSeconds: 5,
+		}
+		p := kubeProbeToInternalProber(probe)
+		if p == nil || p.HTTPGet == nil {
+			t.Fatal("expected HTTPGet prober")
+		}
+		if p.TimeoutSeconds != 5 {
+			t.Errorf("expected timeout 5, got %d", p.TimeoutSeconds)
+		}
+	})
+
+	t.Run("TCPSocket probe", func(t *testing.T) {
+		probe := &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt32(8080)},
+			},
+			TimeoutSeconds: 3,
+		}
+		p := kubeProbeToInternalProber(probe)
+		if p == nil || p.TCPSocket == nil {
+			t.Fatal("expected TCPSocket prober")
+		}
+		if p.TimeoutSeconds != 3 {
+			t.Errorf("expected timeout 3, got %d", p.TimeoutSeconds)
+		}
+	})
+
+	t.Run("GRPC probe", func(t *testing.T) {
+		probe := &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				GRPC: &corev1.GRPCAction{Port: 50051},
+			},
+			TimeoutSeconds: 10,
+		}
+		p := kubeProbeToInternalProber(probe)
+		if p == nil || p.GRPC == nil {
+			t.Fatal("expected GRPC prober")
+		}
+		if p.TimeoutSeconds != 10 {
+			t.Errorf("expected timeout 10, got %d", p.TimeoutSeconds)
+		}
+	})
+}
+
+func TestKubeLifecycleHandlerToInternalProber(t *testing.T) {
+	t.Run("nil handler", func(t *testing.T) {
+		if p := kubeLifecycleHandlerToInternalProber(nil); p != nil {
+			t.Errorf("expected nil, got %v", p)
+		}
+	})
+
+	t.Run("HTTPGet handler", func(t *testing.T) {
+		h := &corev1.LifecycleHandler{
+			HTTPGet: &corev1.HTTPGetAction{Path: "/shutdown", Port: intstr.FromInt32(8080)},
+		}
+		p := kubeLifecycleHandlerToInternalProber(h)
+		if p == nil || p.HTTPGet == nil {
+			t.Fatal("expected HTTPGet prober")
+		}
+	})
+
+	t.Run("TCPSocket handler", func(t *testing.T) {
+		h := &corev1.LifecycleHandler{
+			TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt32(8080)},
+		}
+		p := kubeLifecycleHandlerToInternalProber(h)
+		if p == nil || p.TCPSocket == nil {
+			t.Fatal("expected TCPSocket prober")
+		}
+	})
+
+	t.Run("empty handler", func(t *testing.T) {
+		h := &corev1.LifecycleHandler{}
+		p := kubeLifecycleHandlerToInternalProber(h)
+		if p != nil {
+			t.Errorf("expected nil for empty handler, got %v", p)
+		}
+	})
+}
+
+func TestAllContainers(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "init-1"}, {Name: "init-2"}},
+			Containers:     []corev1.Container{{Name: "app"}},
+		},
+	}
+
+	result := allContainers(pod)
+	if len(result) != 3 {
+		t.Errorf("expected 3 containers, got %d", len(result))
+	}
+
+	// Verify init containers come first
+	if result[0].Name != "init-1" || result[1].Name != "init-2" {
+		t.Errorf("expected init containers first, got %v", result)
+	}
+	if result[2].Name != "app" {
+		t.Errorf("expected app container last, got %v", result)
+	}
+}

--- a/pkg/utils/sidecarutils/sidecar_config_inject.go
+++ b/pkg/utils/sidecarutils/sidecar_config_inject.go
@@ -19,6 +19,7 @@ package sidecarutils
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -29,21 +30,13 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
+	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/webhookutils"
 )
 
-func enableInjectCsiMountConfig(sandbox *agentsv1alpha1.Sandbox) bool {
+func IsRuntimeEnabled(sandbox *agentsv1alpha1.Sandbox, runtimeName string) bool {
 	for _, runtime := range sandbox.Spec.Runtimes {
-		if runtime.Name == agentsv1alpha1.RuntimeConfigForInjectCsiMount {
-			return true
-		}
-	}
-	return false
-}
-
-func enableInjectAgentRuntimeConfig(sandbox *agentsv1alpha1.Sandbox) bool {
-	for _, runtime := range sandbox.Spec.Runtimes {
-		if runtime.Name == agentsv1alpha1.RuntimeConfigForInjectAgentRuntime {
+		if runtime.Name == runtimeName {
 			return true
 		}
 	}
@@ -171,6 +164,51 @@ func setAgentRuntimeContainer(ctx context.Context, podSpec *corev1.PodSpec, conf
 	setMainContainerConfigWhenInjectRuntimeSidecar(ctx, mainContainer, config)
 
 	podSpec.Volumes = append(podSpec.Volumes, config.Volumes...)
+}
+
+func applyInjectionTemplate(ctx context.Context, pod *corev1.Pod, config SidecarInjectConfig) error {
+	for k, v := range config.Labels {
+		if _, exists := pod.Labels[k]; exists {
+			return fmt.Errorf("label already exists: %s", k)
+		}
+		if pod.Labels == nil {
+			pod.Labels = make(map[string]string)
+		}
+		pod.Labels[k] = v
+	}
+
+	for k, v := range config.Annotations {
+		if _, exists := pod.Annotations[k]; exists {
+			return fmt.Errorf("label already exists: %s", k)
+		}
+		if pod.Annotations == nil {
+			pod.Annotations = make(map[string]string)
+		}
+		pod.Annotations[k] = v
+	}
+
+	for _, ic := range config.InitContainers {
+		if utils.FindContainer(ic.Name, pod.Spec.InitContainers) != nil {
+			return fmt.Errorf("init container already exists: %s", ic.Name)
+		}
+		pod.Spec.InitContainers = append(pod.Spec.InitContainers, ic)
+	}
+
+	for _, c := range config.Containers {
+		if utils.FindContainer(c.Name, pod.Spec.Containers) != nil {
+			return fmt.Errorf("container already exists: %s", c.Name)
+		}
+		pod.Spec.Containers = append(pod.Spec.Containers, c)
+	}
+
+	for _, v := range config.Volumes {
+		if findVolumeByName(pod.Spec.Volumes, v.Name) {
+			return fmt.Errorf("volume already exists: %s", v.Name)
+		}
+		pod.Spec.Volumes = append(pod.Spec.Volumes, v)
+	}
+
+	return nil
 }
 
 func setMainContainerConfigWhenInjectRuntimeSidecar(ctx context.Context, mainContainer *corev1.Container, config SidecarInjectConfig) {

--- a/pkg/utils/sidecarutils/utils.go
+++ b/pkg/utils/sidecarutils/utils.go
@@ -18,6 +18,7 @@ package sidecarutils
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
@@ -25,45 +26,66 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	egresscontrol "github.com/openkruise/agents/pkg/utils/sidecarutils/egress-control"
 )
 
-func InjectPodTemplateCSIAndRuntimeSidecar(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, podSpec *corev1.PodSpec, cli client.Client) error {
+func InjectSandboxRuntimes(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod, cli client.Client) error {
 	logger := logf.FromContext(ctx).WithValues("sandbox", klog.KObj(sandbox))
-	if !enableInjectCsiMountConfig(sandbox) && !enableInjectAgentRuntimeConfig(sandbox) {
+	if len(sandbox.Spec.Runtimes) == 0 {
 		return nil
 	}
+
 	// fetch the custom injection configuration
 	config, err := fetchInjectionConfiguration(ctx, cli)
 	if err != nil {
 		logger.Error(err, "failed to fetch injection configuration")
 		return err
 	}
-	return doSidecarInjection(ctx, sandbox, podSpec, config)
+	return doSidecarInjection(ctx, sandbox, pod, config)
 }
 
-func doSidecarInjection(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, podSpec *corev1.PodSpec, injectConfigMap map[string]string) error {
+func doSidecarInjection(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod, injectConfigMap map[string]string) error {
 	logger := logf.FromContext(ctx).WithValues("sandbox", klog.KObj(sandbox))
-	// set agent runtime sidecar config
-	if enableInjectAgentRuntimeConfig(sandbox) {
-		runTimeInjectConfig, err := parseInjectConfig(ctx, KEY_RUNTIME_INJECTION_CONFIG, injectConfigMap)
+
+	for _, runtime := range sandbox.Spec.Runtimes {
+		// should we return an error when inject config not exists?
+		runtimeInjectConfig, err := parseInjectConfig(ctx, runtime.Name, injectConfigMap)
 		if err != nil {
-			logger.Error(err, "failed to parse agent runtime injection configuration")
+			logger.Error(err, "failed to parse runtime injection configuration")
 			return err
 		}
-		if !isContainersExists(podSpec.InitContainers, runTimeInjectConfig.Sidecars) && !isContainersExists(podSpec.Containers, runTimeInjectConfig.Sidecars) {
-			setAgentRuntimeContainer(ctx, podSpec, runTimeInjectConfig)
+		switch runtime.Name {
+		case agentsv1alpha1.RuntimeConfigForInjectAgentRuntime:
+			if !isContainersExists(pod.Spec.InitContainers, runtimeInjectConfig.Sidecars) && !isContainersExists(pod.Spec.Containers, runtimeInjectConfig.Sidecars) {
+				setAgentRuntimeContainer(ctx, &pod.Spec, runtimeInjectConfig)
+			}
+		case agentsv1alpha1.RuntimeConfigForInjectCsiMount:
+			if !isContainersExists(pod.Spec.InitContainers, runtimeInjectConfig.Sidecars) && !isContainersExists(pod.Spec.Containers, runtimeInjectConfig.Sidecars) {
+				setCSIMountContainer(ctx, &pod.Spec, runtimeInjectConfig)
+			}
+		default:
+			injectConfig, err := parseInjectConfig(ctx, KEY_EGRESS_CONTROL_INJECTION_CONFIG, injectConfigMap)
+			if err != nil {
+				logger.Error(err, "failed to parse egress control injection configuration")
+				return err
+			}
+			// not mute the conflicts
+			if isContainersExists(pod.Spec.InitContainers, injectConfig.InitContainers) || isContainersExists(pod.Spec.Containers, injectConfig.Containers) {
+				return fmt.Errorf("injected container conflicts")
+			}
+			if err := applyInjectionTemplate(ctx, pod, injectConfig); err != nil {
+				return fmt.Errorf("failed to inject runtime %s: %v", runtime.Name, err)
+			}
 		}
 	}
-	// set csi sidecar config
-	if enableInjectCsiMountConfig(sandbox) {
-		csiInjectConfig, err := parseInjectConfig(ctx, KEY_CSI_INJECTION_CONFIG, injectConfigMap)
-		if err != nil {
-			logger.Error(err, "failed to parse csi injection configuration")
+
+	// Enable health probes rewrite if needed.
+	if IsRuntimeEnabled(sandbox, agentsv1alpha1.RuntimeConfigForInjectEgressControl) {
+		if err := egresscontrol.ApplyHealthProbeRewrite(pod); err != nil {
+			logger.Error(err, "failed to apply health probe rewrite")
 			return err
 		}
-		if !isContainersExists(podSpec.InitContainers, csiInjectConfig.Sidecars) && !isContainersExists(podSpec.Containers, csiInjectConfig.Sidecars) {
-			setCSIMountContainer(ctx, podSpec, csiInjectConfig)
-		}
 	}
+
 	return nil
 }

--- a/pkg/utils/sidecarutils/utils_test.go
+++ b/pkg/utils/sidecarutils/utils_test.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -34,13 +35,17 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 	tests := []struct {
 		name                   string
 		sandbox                *agentsv1alpha1.Sandbox
-		podSpecTemplate        *corev1.PodSpec
+		pod                    *corev1.Pod
 		injectionConfigData    map[string]string
 		expectInjection        bool
 		expectRuntimeContainer bool
 		expectCSIContainer     bool
 		expectRuntimeEnvCount  int
 		expectCSIVolumeMounts  int
+		expectEgressContainer  bool
+		expectInitContainers   int // expected InitContainer count after injection
+		expectContainers       int // expected Container count after injection
+		initialContainerCount  int // base Container count before injection (default 1)
 	}{
 		{
 			name: "no injection needed",
@@ -55,9 +60,11 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 					},
 				},
 			},
-			podSpecTemplate: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{Name: "main", Image: "nginx"},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
 				},
 			},
 			expectInjection: false,
@@ -80,9 +87,11 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 					},
 				},
 			},
-			podSpecTemplate: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{Name: "main", Image: "nginx"},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
 				},
 			},
 			injectionConfigData: map[string]string{
@@ -124,9 +133,11 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 					},
 				},
 			},
-			podSpecTemplate: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{Name: "main", Image: "nginx"},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
 				},
 			},
 			injectionConfigData: map[string]string{
@@ -173,9 +184,11 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 					},
 				},
 			},
-			podSpecTemplate: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{Name: "main", Image: "nginx"},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
 				},
 			},
 			injectionConfigData: map[string]string{
@@ -209,6 +222,171 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 			expectRuntimeEnvCount:  1,
 			expectCSIVolumeMounts:  1,
 		},
+		{
+			name: "inject egress control sidecar only",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{},
+					},
+					Runtimes: []agentsv1alpha1.RuntimeConfig{
+						{
+							Name: agentsv1alpha1.RuntimeConfigForInjectEgressControl,
+						},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
+				},
+			},
+			injectionConfigData: map[string]string{
+				KEY_EGRESS_CONTROL_INJECTION_CONFIG: `{
+					"mainContainer": {},
+					"csiSidecar": [],
+					"volume": [{"name": "egress-vol", "emptyDir": {}}],
+					"initContainers": [{"name": "egress-init", "image": "egress-init:v1"}],
+					"containers": [{"name": "egress-sidecar", "image": "egress:v1"}],
+					"labels": {"egress": "enabled"},
+					"annotations": {"egress-control": "true"}
+				}`,
+			},
+			// Note: InjectPodTemplateCSIAndRuntimeSidecar does not return early when only egress is enabled;
+			// it proceeds with egress injection via doSidecarInjection.
+			expectInjection:       true,
+			expectEgressContainer: true,
+			expectContainers:      2, // main + egress sidecar
+		},
+		{
+			name: "inject egress control with health probe rewrite - early return without CSI/runtime",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{},
+					},
+					Runtimes: []agentsv1alpha1.RuntimeConfig{
+						{
+							Name: agentsv1alpha1.RuntimeConfigForInjectEgressControl,
+						},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"networking.agents.kruise.io/health-probe-rewrite": "true",
+						"networking.agents.kruise.io/sidecar-proxy":        "istio-proxy",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "main",
+							Image: "nginx",
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/healthz",
+										Port: intstr.FromInt(8080),
+									},
+								},
+							},
+						},
+						{
+							Name:  "istio-proxy",
+							Image: "istio/proxyv2:latest",
+						},
+					},
+				},
+			},
+			injectionConfigData: map[string]string{
+				KEY_EGRESS_CONTROL_INJECTION_CONFIG: `{
+					"mainContainer": {},
+					"csiSidecar": [],
+					"volume": [],
+					"initContainers": [],
+					"containers": [],
+					"labels": {},
+					"annotations": {}
+				}`,
+			},
+			// Egress injection proceeds but with empty config, so pod remains unchanged.
+			expectInjection:       true,
+			expectEgressContainer: false,
+			initialContainerCount: 2, // main + istio-proxy
+		},
+		{
+			name: "inject all three: runtime, csi, and egress",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{},
+					},
+					Runtimes: []agentsv1alpha1.RuntimeConfig{
+						{
+							Name: agentsv1alpha1.RuntimeConfigForInjectAgentRuntime,
+						},
+						{
+							Name: agentsv1alpha1.RuntimeConfigForInjectCsiMount,
+						},
+						{
+							Name: agentsv1alpha1.RuntimeConfigForInjectEgressControl,
+						},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
+				},
+			},
+			injectionConfigData: map[string]string{
+				KEY_RUNTIME_INJECTION_CONFIG: `{
+					"mainContainer": {"env": [{"name": "RUNTIME", "value": "on"}], "volumeMounts": []},
+					"csiSidecar": [{"name": "runtime-sidecar", "image": "runtime:v1"}],
+					"volume": []
+				}`,
+				KEY_CSI_INJECTION_CONFIG: `{
+					"mainContainer": {"volumeMounts": [{"name": "csi-vol", "mountPath": "/csi"}]},
+					"csiSidecar": [{"name": "csi-sidecar", "image": "csi:v1"}],
+					"volume": [{"name": "csi-vol", "emptyDir": {}}]
+				}`,
+				KEY_EGRESS_CONTROL_INJECTION_CONFIG: `{
+					"mainContainer": {},
+					"csiSidecar": [],
+					"volume": [{"name": "egress-vol", "emptyDir": {}}],
+					"initContainers": [],
+					"containers": [{"name": "egress-sidecar", "image": "egress:v1"}],
+					"labels": {"egress": "enabled"},
+					"annotations": {}
+				}`,
+			},
+			expectInjection:        true,
+			expectRuntimeContainer: true,
+			expectCSIContainer:     true,
+			expectEgressContainer:  true,
+			expectRuntimeEnvCount:  1,
+			expectCSIVolumeMounts:  1,
+			expectInitContainers:   2, // runtime + csi sidecars
+			expectContainers:       2, // main + egress container
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -227,7 +405,7 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithObjects(objs...).Build()
 			ctx := context.Background()
 
-			err := InjectPodTemplateCSIAndRuntimeSidecar(ctx, tt.sandbox, tt.podSpecTemplate, fakeClient)
+			err := InjectSandboxRuntimes(ctx, tt.sandbox, tt.pod, fakeClient)
 			// Verify results
 			if !tt.expectInjection {
 				// Should return early without error
@@ -235,8 +413,12 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 					t.Errorf("expected no error when no injection needed, got: %v", err)
 				}
 				// Pod template should not be modified
-				if len(tt.podSpecTemplate.Containers) != 1 {
-					t.Errorf("expected 1 container, got %d", len(tt.podSpecTemplate.Containers))
+				initialContainers := 1
+				if tt.initialContainerCount > 0 {
+					initialContainers = tt.initialContainerCount
+				}
+				if len(tt.pod.Spec.Containers) != initialContainers {
+					t.Errorf("expected %d containers (unchanged), got %d", initialContainers, len(tt.pod.Spec.Containers))
 				}
 				return
 			}
@@ -249,7 +431,7 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 			csiContainerInjected := false
 			// Check InitContainers for both runtime sidecar and csi sidecar (both are injected to InitContainers)
 			// Use image to distinguish between pre-existing containers and injected containers
-			for _, container := range tt.podSpecTemplate.InitContainers {
+			for _, container := range tt.pod.Spec.InitContainers {
 				// runtime sidecar injection uses image "runtime:v1"
 				if container.Name == "runtime-sidecar" && container.Image == "runtime:v1" {
 					runtimeContainerInjected = true
@@ -261,7 +443,7 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 			}
 			// Check main container in Containers
 			mainContainerFound := false
-			for _, container := range tt.podSpecTemplate.Containers {
+			for _, container := range tt.pod.Spec.Containers {
 				if container.Name == "main" {
 					mainContainerFound = true
 					// Check main container env count (from runtime injection)
@@ -285,17 +467,37 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 			if !mainContainerFound {
 				t.Error("expected main container to still exist")
 			}
-			expectedTotal := 1 // main container
+			// Verify InitContainer and Container counts if specified
+			if tt.expectInitContainers > 0 {
+				if len(tt.pod.Spec.InitContainers) != tt.expectInitContainers {
+					t.Errorf("expected %d InitContainers, got %d", tt.expectInitContainers, len(tt.pod.Spec.InitContainers))
+				}
+			}
+			if tt.expectContainers > 0 {
+				if len(tt.pod.Spec.Containers) != tt.expectContainers {
+					t.Errorf("expected %d Containers, got %d", tt.expectContainers, len(tt.pod.Spec.Containers))
+				}
+			}
+			// Count total containers (InitContainers + Containers)
+			expectedTotal := 1
+			if tt.initialContainerCount > 0 {
+				expectedTotal = tt.initialContainerCount
+			}
 			if tt.expectRuntimeContainer {
 				expectedTotal++
 			}
 			if tt.expectCSIContainer {
 				expectedTotal++
 			}
-			// Count total containers (InitContainers + Containers)
-			totalContainers := len(tt.podSpecTemplate.InitContainers) + len(tt.podSpecTemplate.Containers)
-			if totalContainers != expectedTotal {
-				t.Errorf("expected %d total containers, got %d", expectedTotal, totalContainers)
+			if tt.expectEgressContainer {
+				expectedTotal++
+			}
+			totalContainers := len(tt.pod.Spec.InitContainers) + len(tt.pod.Spec.Containers)
+			if tt.expectInitContainers == 0 && tt.expectContainers == 0 {
+				// Only verify total count when not explicitly checking init/container counts
+				if totalContainers != expectedTotal {
+					t.Errorf("expected %d total containers, got %d", expectedTotal, totalContainers)
+				}
 			}
 		})
 	}
@@ -413,7 +615,7 @@ func TestDoSidecarInjection(t *testing.T) {
 	tests := []struct {
 		name                   string
 		sandbox                *agentsv1alpha1.Sandbox
-		podSpecTemplate        *corev1.PodSpec
+		pod                    *corev1.Pod
 		injectConfigMap        map[string]string
 		expectRuntimeContainer bool
 		expectCSIContainer     bool
@@ -435,9 +637,11 @@ func TestDoSidecarInjection(t *testing.T) {
 					},
 				},
 			},
-			podSpecTemplate: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{Name: "main", Image: "nginx"},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
 				},
 			},
 			injectConfigMap: map[string]string{
@@ -475,9 +679,11 @@ func TestDoSidecarInjection(t *testing.T) {
 					},
 				},
 			},
-			podSpecTemplate: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{Name: "main", Image: "nginx"},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
 				},
 			},
 			injectConfigMap: map[string]string{
@@ -518,9 +724,11 @@ func TestDoSidecarInjection(t *testing.T) {
 					},
 				},
 			},
-			podSpecTemplate: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{Name: "main", Image: "nginx"},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
 				},
 			},
 			injectConfigMap: map[string]string{
@@ -561,9 +769,11 @@ func TestDoSidecarInjection(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			podSpecTemplate: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{Name: "main", Image: "nginx"},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
 				},
 			},
 			injectConfigMap: map[string]string{},
@@ -582,10 +792,12 @@ func TestDoSidecarInjection(t *testing.T) {
 					},
 				},
 			},
-			podSpecTemplate: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{Name: "main", Image: "nginx"},
-					{Name: "runtime-sidecar", Image: "existing:v1"}, // conflict with runtime sidecar in Containers
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+						{Name: "runtime-sidecar", Image: "existing:v1"}, // conflict with runtime sidecar in Containers
+					},
 				},
 			},
 			injectConfigMap: map[string]string{
@@ -618,12 +830,14 @@ func TestDoSidecarInjection(t *testing.T) {
 					},
 				},
 			},
-			podSpecTemplate: &corev1.PodSpec{
-				InitContainers: []corev1.Container{
-					{Name: "runtime-sidecar", Image: "existing-init:v1"}, // conflict in initContainers
-				},
-				Containers: []corev1.Container{
-					{Name: "main", Image: "nginx"},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "runtime-sidecar", Image: "existing-init:v1"}, // conflict in initContainers
+					},
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
 				},
 			},
 			injectConfigMap: map[string]string{
@@ -658,10 +872,12 @@ func TestDoSidecarInjection(t *testing.T) {
 					},
 				},
 			},
-			podSpecTemplate: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{Name: "main", Image: "nginx"},
-					{Name: "csi-sidecar", Image: "existing-csi:v1"}, // conflict with csi sidecar in Containers
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+						{Name: "csi-sidecar", Image: "existing-csi:v1"}, // conflict with csi sidecar in Containers
+					},
 				},
 			},
 			injectConfigMap: map[string]string{
@@ -695,12 +911,14 @@ func TestDoSidecarInjection(t *testing.T) {
 					},
 				},
 			},
-			podSpecTemplate: &corev1.PodSpec{
-				InitContainers: []corev1.Container{
-					{Name: "csi-sidecar", Image: "existing-init-csi:v1"}, // conflict in initContainers
-				},
-				Containers: []corev1.Container{
-					{Name: "main", Image: "nginx"},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "csi-sidecar", Image: "existing-init-csi:v1"}, // conflict in initContainers
+					},
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
 				},
 			},
 			injectConfigMap: map[string]string{
@@ -737,10 +955,12 @@ func TestDoSidecarInjection(t *testing.T) {
 					},
 				},
 			},
-			podSpecTemplate: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{Name: "main", Image: "nginx"},
-					{Name: "runtime-sidecar", Image: "existing:v1"}, // conflict with runtime sidecar
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+						{Name: "runtime-sidecar", Image: "existing:v1"}, // conflict with runtime sidecar
+					},
 				},
 			},
 			injectConfigMap: map[string]string{
@@ -791,10 +1011,12 @@ func TestDoSidecarInjection(t *testing.T) {
 					},
 				},
 			},
-			podSpecTemplate: &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{Name: "main", Image: "nginx"},
-					{Name: "csi-sidecar", Image: "existing-csi:v1"}, // conflict with csi sidecar
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+						{Name: "csi-sidecar", Image: "existing-csi:v1"}, // conflict with csi sidecar
+					},
 				},
 			},
 			injectConfigMap: map[string]string{
@@ -845,13 +1067,15 @@ func TestDoSidecarInjection(t *testing.T) {
 					},
 				},
 			},
-			podSpecTemplate: &corev1.PodSpec{
-				InitContainers: []corev1.Container{
-					{Name: "runtime-sidecar", Image: "existing-init:v1"}, // conflict in initContainers
-					{Name: "csi-sidecar", Image: "existing-init-csi:v1"}, // conflict in initContainers
-				},
-				Containers: []corev1.Container{
-					{Name: "main", Image: "nginx"},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "runtime-sidecar", Image: "existing-init:v1"}, // conflict in initContainers
+						{Name: "csi-sidecar", Image: "existing-init-csi:v1"}, // conflict in initContainers
+					},
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
 				},
 			},
 			injectConfigMap: map[string]string{
@@ -889,7 +1113,7 @@ func TestDoSidecarInjection(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			// Call the function
-			err := doSidecarInjection(ctx, tt.sandbox, tt.podSpecTemplate, tt.injectConfigMap)
+			err := doSidecarInjection(ctx, tt.sandbox, tt.pod, tt.injectConfigMap)
 			// Verify no error
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -899,7 +1123,7 @@ func TestDoSidecarInjection(t *testing.T) {
 			csiContainerInjected := false
 			// Check InitContainers for both runtime sidecar and csi sidecar
 			// Use image to distinguish between pre-existing containers (for conflict tests) and injected containers
-			for _, container := range tt.podSpecTemplate.InitContainers {
+			for _, container := range tt.pod.Spec.InitContainers {
 				// runtime sidecar injection uses image "runtime:v1"
 				if container.Name == "runtime-sidecar" && container.Image == "runtime:v1" {
 					runtimeContainerInjected = true
@@ -910,7 +1134,7 @@ func TestDoSidecarInjection(t *testing.T) {
 				}
 			}
 			// Check main container in Containers
-			for _, container := range tt.podSpecTemplate.Containers {
+			for _, container := range tt.pod.Spec.Containers {
 				if container.Name == "main" {
 					// Check main container env count
 					if tt.expectMainEnvCount > 0 && len(container.Env) != tt.expectMainEnvCount {
@@ -937,14 +1161,14 @@ func TestDoSidecarInjection(t *testing.T) {
 			}
 			// Verify volume injection
 			if tt.expectCSIVolumeCount > 0 {
-				actualVolumeCount := len(tt.podSpecTemplate.Volumes)
+				actualVolumeCount := len(tt.pod.Spec.Volumes)
 				if actualVolumeCount < tt.expectCSIVolumeCount {
 					t.Errorf("expected at least %d volumes, got %d", tt.expectCSIVolumeCount, actualVolumeCount)
 				}
 			}
 			// Main container should always exist
 			mainContainerFound := false
-			for _, container := range tt.podSpecTemplate.Containers {
+			for _, container := range tt.pod.Spec.Containers {
 				if container.Name == "main" {
 					mainContainerFound = true
 					break

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -330,3 +330,13 @@ func GenerateSandboxName(baseName string) string {
 	}
 	return generateName
 }
+
+// FindContainer returns the pointer to the first container whose name matches.
+func FindContainer(name string, containers []corev1.Container) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Add egress-control sidecar injection with automatic health probe rewriting via a new controller-runtime managed Injector, replacing the old inline injection path.

Support strategic merge patch runtime injection, allow us to inject with more flexibility and extensibility.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

