### PR TITLE
fix(sandbox-manager): prevent ClaimSandbox returning (nil, nil) on context cancel

### DIFF
--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -2232,6 +2233,99 @@ func TestTryClaimSandbox_LockConflict(t *testing.T) {
 
 			// Clean up expectation state
 			expectationutils.ResourceVersionExpectationDelete(sbx)
+		})
+	}
+}
+
+//goland:noinspection GoDeprecation
+func TestInfraClaimSandboxReturnsErrorWhenLockContextCanceled(t *testing.T) {
+	utils.InitLogOutput()
+	existTemplate := "test-template"
+	user := "test-user"
+
+	tests := []struct {
+		name        string
+		lockError   error
+		expectError string
+	}{
+		{
+			name: "context canceled during sandbox lock",
+			lockError: &url.Error{
+				Op:  "Put",
+				URL: "https://apiserver.example/apis/agents.kruise.io/v1alpha1/namespaces/default/sandboxes/test-sbx",
+				Err: context.Canceled,
+			},
+			expectError: "context canceled",
+		},
+		{
+			name:        "context canceled returned directly",
+			lockError:   context.Canceled,
+			expectError: "context canceled",
+		},
+		{
+			name: "context deadline exceeded during sandbox lock",
+			lockError: &url.Error{
+				Op:  "Put",
+				URL: "https://apiserver.example/apis/agents.kruise.io/v1alpha1/namespaces/default/sandboxes/test-sbx",
+				Err: context.DeadlineExceeded,
+			},
+			expectError: "context deadline exceeded",
+		},
+		{
+			name:        "context deadline exceeded returned directly",
+			lockError:   context.DeadlineExceeded,
+			expectError: "context deadline exceeded",
+		},
+		{
+			name:        "wait timeout returned directly",
+			lockError:   wait.ErrorInterrupted(fmt.Errorf("wait interrupted by test")),
+			expectError: "wait interrupted by test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testInfra, fc := NewTestInfra(t, config.SandboxManagerOptions{
+				DisableRouteReconciliation: true,
+			})
+
+			origCreateSandbox := DefaultCreateSandbox
+			DefaultCreateSandbox = func(context.Context, *v1alpha1.Sandbox, client.Client) (*v1alpha1.Sandbox, error) {
+				return nil, tt.lockError
+			}
+			t.Cleanup(func() {
+				DefaultCreateSandbox = origCreateSandbox
+			})
+
+			sbs := &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      existTemplate,
+					Namespace: "default",
+				},
+				Spec: v1alpha1.SandboxSetSpec{
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "main", Image: "test-image"}},
+							},
+						},
+					},
+				},
+			}
+			require.NoError(t, fc.Create(t.Context(), sbs))
+
+			got, metrics, err := testInfra.ClaimSandbox(t.Context(), infra.ClaimSandboxOptions{
+				User:            user,
+				Template:        existTemplate,
+				CreateOnNoStock: true,
+				ClaimTimeout:    100 * time.Millisecond,
+			})
+
+			require.Nil(t, got)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+			require.NotNil(t, metrics.LastError)
+			assert.Contains(t, metrics.LastError.Error(), tt.expectError)
 		})
 	}
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -168,6 +168,13 @@ func (i *Infra) ClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions
 		} else {
 			metrics.RetryCost += tryMetrics.Total
 		}
+		// client-go retry.OnError rewrites interrupted errors to the last
+		// retriable error. Context cancellation is interrupted but non-retriable,
+		// so keep its message while intentionally avoiding %w; wrapping would
+		// still let wait.Interrupted identify and rewrite it.
+		if wait.Interrupted(claimErr) {
+			return fmt.Errorf("%v", claimErr)
+		}
 		return claimErr
 	})
 	return claimedSandbox, metrics, buildClaimError(err, metrics.LastError, metrics.PickSandboxFailures)


### PR DESCRIPTION
## Summary

- Fixes a panic in `SandboxManager.ClaimSandbox` when the underlying sandbox lock fails with `context.Canceled` / `context.DeadlineExceeded` (or any other `wait.Interrupted`-matched error) on the first retry attempt.
- Root cause: `client-go`'s `retry.OnError` rewrites the final error to `lastErr` whenever `wait.Interrupted(err)` is true. When the first iteration returns an interrupted error and no prior retriable error has been recorded, `lastErr` is still `nil`, so `retry.OnError` returns `nil`. `Infra.ClaimSandbox` then returns `(nil sandbox, nil error)` and the caller in `pkg/sandbox-manager/api.go` panics on `sandbox.GetState()` / `sandbox.GetNamespace()`.
- Fix: detect `wait.Interrupted(claimErr)` inside the retry callback and re-emit the error via `fmt.Errorf(\"%v\", claimErr)` so the error chain no longer matches `errors.Is` checks used by `wait.Interrupted`, preventing the silent rewrite. Original message is preserved so logs and metrics still carry the underlying cause.

## Test plan

- [x] `go test ./pkg/sandbox-manager/infra/sandboxcr/ -count=1` passes locally.
- [x] New table-driven test `TestInfraClaimSandboxReturnsErrorWhenLockContextCanceled` covers:
  - `context.Canceled` wrapped in `url.Error` (typical apiserver client shape)
  - bare `context.Canceled`
  - `context.DeadlineExceeded` wrapped in `url.Error`
  - bare `context.DeadlineExceeded`
  - `wait.ErrorInterrupted(...)` (the third path matched by `wait.Interrupted`)
- [x] All sub-cases assert both the returned `err` and `metrics.LastError` carry the expected message and that the returned sandbox is `nil`.