### PR TITLE
feat: wake-on-traffic auto-resume for paused sandboxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,7 @@ cython_debug/
 .pearai/
 .trae/
 .agents/
+docs/plans
 
 REVIEW.md
 

--- a/api/v1alpha1/annotations.go
+++ b/api/v1alpha1/annotations.go
@@ -21,6 +21,7 @@ package v1alpha1
 const (
 	AnnotationRuntimeURL         = InternalPrefix + "runtime-url"
 	AnnotationRuntimeAccessToken = InternalPrefix + "runtime-access-token"
+	AnnotationWakeOnTraffic      = InternalPrefix + "wake-on-traffic"
 )
 
 // E2B annotations

--- a/cmd/sandbox-gateway/main.go
+++ b/cmd/sandbox-gateway/main.go
@@ -33,13 +33,16 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-gateway/controller"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/filter"
 	peerserver "github.com/openkruise/agents/pkg/sandbox-gateway/server"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/wake"
 )
 
 func init() {
+	gatewayConfig := filter.DefaultConfig()
+	wakeModule := wake.NewModule(gatewayConfig.GetManagerURL())
 	envoyhttp.RegisterHttpFilterFactoryAndConfigParser(
 		"sandbox-gateway",
 		filter.FilterFactory,
-		&filter.ConfigParser{},
+		filter.NewConfigParserWithWakeClient(gatewayConfig.GetManagerURL(), wakeModule),
 	)
 
 	go func() {

--- a/config/network-policy/kustomization.yaml
+++ b/config/network-policy/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
 - allow-metrics-traffic.yaml
+- sandbox-manager-internal.yaml

--- a/config/network-policy/sandbox-manager-internal.yaml
+++ b/config/network-policy/sandbox-manager-internal.yaml
@@ -1,0 +1,43 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: sandbox-manager
+    app.kubernetes.io/managed-by: kustomize
+  name: sandbox-manager-internal
+  namespace: sandbox-system
+spec:
+  podSelector:
+    matchLabels:
+      component: sandbox-manager
+      app.kubernetes.io/name: sandbox-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # 7788 intentionally has no source selector because it serves ingress and
+    # business traffic through the manager proxy. The wake path uses 7789 below.
+    - ports:
+        - port: 7788
+          protocol: TCP
+    - from:
+        - podSelector:
+            matchLabels:
+              component: sandbox-manager
+              app.kubernetes.io/name: sandbox-gateway
+        - podSelector:
+            matchLabels:
+              component: sandbox-manager
+              app.kubernetes.io/name: sandbox-manager
+      ports:
+        - port: 7789
+          protocol: TCP
+    - from:
+        - podSelector:
+            matchLabels:
+              component: sandbox-manager
+              app.kubernetes.io/name: sandbox-manager
+      ports:
+        - port: 7946
+          protocol: TCP
+        - port: 7946
+          protocol: UDP

--- a/config/sandbox-manager/service.yaml
+++ b/config/sandbox-manager/service.yaml
@@ -14,6 +14,10 @@ spec:
       targetPort: 7788
       protocol: TCP
       name: http-envoy
+    - port: 7789
+      targetPort: 7789
+      protocol: TCP
+      name: internal
   selector:
     component: sandbox-manager
     app.kubernetes.io/name: sandbox-manager

--- a/docs/specs/2026-05-14-wake-on-traffic-design.md
+++ b/docs/specs/2026-05-14-wake-on-traffic-design.md
@@ -1,0 +1,614 @@
+# Wake-on-Traffic Auto-Resume
+
+## Context
+
+Today, a paused sandbox returns to running only when an SDK explicitly issues `/sandboxes/{id}/connect` or `/sandboxes/{id}/resume`. Data-plane traffic to a paused sandbox is rejected by `pkg/sandbox-gateway/filter/filter.go:95-105` with a 502 `sandbox_not_running`. The peer-refresh handler `pkg/sandbox-gateway/server/server.go:174-177` removes any non-Running route from the registry, so a paused entry can briefly disappear from a gateway replica between the manager push and the local informer write-back.
+
+E2B's `POST /sandboxes` create API exposes `autoResume: SandboxAutoResumeConfig { enabled: bool }`, and the [auto-resume feature documentation](https://e2b.dev/docs/sandbox/auto-resume) defines the wake semantics: any HTTP traffic or SDK operation against a paused sandbox transparently resumes it; on resume, the timeout restarts with a 5-minute minimum, or the original duration if it was longer; the lifecycle configuration persists across pause/resume cycles.
+
+The project does not implement these semantics. Adding them requires producing a wake event from the gateway data-plane filter, executing the resume in sandbox-manager, restoring an appropriate timeout, and forwarding the original request to the now-running pod.
+
+## Goals
+
+- Auto-resume any paused sandbox whose CR carries `agents.kruise.io/wake-on-traffic` when data-plane traffic arrives at the gateway.
+- Mirror E2B `autoResume` semantics: enabled at create time via the top-level `autoResume.enabled` wire field; resume restores the timeout that was last set by create / connect / set-timeout; finite resume timeouts are clamped to a 5-minute minimum.
+- Support a K8S-direct workflow: a user can patch the annotation on a Sandbox CR plus `spec.paused=true` and obtain wake-on-traffic without going through the E2B API.
+- Single-PR scope; touch only the components needed to thread the wake path end-to-end.
+- Cross-replica correct on both gateway side (multi-replica deployment) and manager side (existing first-writer-wins resume).
+
+## Non-goals
+
+- No CRD changes. The protocol is annotation-only.
+- No new admission webhook. Annotation validation lives in the manager wake handler; non-wake paths do not validate.
+- No owner/tenant identity check on the new internal endpoint. JWT/access-token-to-owner mapping is a separate workstream and is explicitly deferred.
+- No changes to sandbox-controller. Auto-pause via `spec.PauseTime` and auto-shutdown via `spec.ShutdownTime` continue unchanged.
+- No idle-detection or activity-tracking. "Wake on traffic" is wake-from-paused, not refresh-on-traffic; running sandboxes are forwarded without timeout side-effects.
+- No changes to existing `/sandboxes/{id}/connect` and `/sandboxes/{id}/timeout` semantics other than an additive annotation-sync side-effect.
+- No async upgrade for non-wake filter paths. The async pattern is added only on the wake branch of `DecodeHeaders`.
+
+## Design
+
+### Annotation protocol
+
+A single annotation `agents.kruise.io/wake-on-traffic` carries the wake policy. Values use a `<kind>:<payload>` form so future kinds can be added without breaking the parser. Only one kind, `timeout`, is defined now.
+
+```go
+// api/v1alpha1/annotations.go
+const AnnotationWakeOnTraffic = InternalPrefix + "wake-on-traffic"
+```
+
+Value grammar:
+
+| Value | Meaning |
+|---|---|
+| absent | wake-on-traffic disabled; gateway returns existing 502 on paused traffic |
+| `"timeout:never"` | enabled; on wake, do not write any new `ShutdownTime` or `PauseTime` |
+| `"timeout:<duration>"` where duration is a Go duration ≥ 1s, lower-case (`"timeout:300s"`, `"timeout:5m"`, `"timeout:2h30m"`) | enabled; on wake, set the new deadline to `now + duration` |
+| anything else (unknown kind, unparsable payload, etc.) | invalid; manager returns InvalidAutoResumePolicy; gateway falls back to 502 |
+
+Parsing rules for the `timeout` kind:
+
+- `never` is matched literally (case-sensitive). No leading/trailing whitespace tolerated.
+- Duration: parsed via `time.ParseDuration`; reject `≤ 0` and anything below 1s.
+- The parser tries `never` first, then duration. The two forms are textually disjoint.
+
+The `<duration>` payload is exactly the wire form `metav1.Duration` uses across Kubernetes (`5m`, `300s`, `2h30m` — anything `time.ParseDuration` accepts). Hand-patched annotations therefore look indistinguishable from `metav1.Duration` fields in any other CR, which is the reason for choosing this form over an absolute-time alternative.
+
+Strict parsing rejects `""`, `"true"`, `"0"`, `"timeout:"`, `"timeout:0"`, `"timeout:0s"`, `"timeout:-1s"`, `"timeout:500ms"`, `"timeout:Never"`, `"timeout: 300s"`, and any value whose kind is not `timeout`. No silent trim, no case folding, no minimum-floor clamp at parse time (the 5-minute floor is applied later, in `WakeSandbox`).
+
+The `agents.kruise.io/` prefix is already on `BlackListPrefix` (`pkg/servers/e2b/metadata.go:24`), so E2B users cannot inject this key through the public `metadata` field; only the manager itself or a cluster admin via `kubectl` can write it.
+
+### E2B create wire mapping
+
+`models.NewSandboxRequest` (`pkg/servers/e2b/models/sandbox.go:50`) gains the field defined by E2B:
+
+```go
+type NewSandboxRequest struct {
+    // ... existing fields ...
+    AutoResume *AutoResumeConfig `json:"autoResume,omitempty"`
+    // ...
+}
+
+type AutoResumeConfig struct {
+    Enabled bool `json:"enabled"`
+}
+```
+
+Pointer keeps "user did not send `autoResume` at all" distinguishable from `{enabled: false}` and matches E2B's nullable shape. The manager does not parse the SDK-side `lifecycle` wrapper; both stock E2B Python and JS SDKs flatten it to the wire shape before sending.
+
+Annotation write decision in `basicSandboxCreateModifier` (`pkg/servers/e2b/create.go:269-296`):
+
+```go
+if request.AutoResume != nil && request.AutoResume.Enabled {
+    var payload string
+    if request.Extensions.NeverTimeout {
+        payload = "timeout:never"
+    } else {
+        payload = fmt.Sprintf("timeout:%ds", request.Timeout)
+    }
+    sbx.SetAnnotation(v1alpha1.AnnotationWakeOnTraffic, payload)
+}
+```
+
+`autoPause` and `autoResume.enabled` are orthogonal. `autoPause=false` + `autoResume.enabled=true` is legal: the sandbox is deleted on timeout in the auto-shutdown path, but a manual pause leaves the sandbox alive and wake-on-traffic restores it.
+
+### Annotation updates piggyback on `SaveTimeoutWithPolicy`
+
+Connect, set-timeout, and wake all need to update the wake-on-traffic annotation in lockstep with the timeout fields they write. Doing this as a separate `retryUpdate` adds an extra round trip, an extra conflict-retry surface, and a second observability point. Instead, `SaveTimeoutWithPolicy` is the single place that mutates the annotation alongside `Spec.ShutdownTime` / `Spec.PauseTime`.
+
+`timeout.Options` gains a `SetAnnotations` field:
+
+```go
+// pkg/utils/timeout/types.go
+type Options struct {
+    ShutdownTime time.Time
+    PauseTime    time.Time
+    Baseline     *Options          `json:"-"`
+    // SetAnnotations is applied to metadata.annotations inside the same retryUpdate
+    // modifier that writes ShutdownTime / PauseTime. Empty-string values delete the key.
+    SetAnnotations map[string]string `json:"-"`
+}
+```
+
+Inside `Sandbox.SaveTimeoutWithPolicy`'s modifier, after the policy decides `shouldUpdate == true`, the modifier:
+
+1. Calls `setTimeout(sbx, opts)` (existing behavior).
+2. Iterates `opts.SetAnnotations`. For each key, sets `sbx.Annotations[key] = value`, or `delete(sbx.Annotations, key)` if value is empty string.
+3. Returns `(true, nil)`.
+
+When `shouldUpdate == false`, the annotation is also not changed — i.e., annotation drift never outpaces the timeout it describes.
+
+This keeps the annotation atomic with the timeout from the K8s API server's perspective, simplifies the call sites, and gives `BaselineAware` / `ExtendOnly` a single decision point that covers both fields.
+
+### E2B connect / set-timeout annotation sync rules
+
+Handler logic for both `ConnectSandbox` and `SetSandboxTimeout`:
+
+- If the sandbox carries no `wake-on-traffic` annotation, the handler does not put anything in `opts.SetAnnotations`. The handlers never silently enable wake-on-traffic.
+- If the sandbox carries the annotation, the handler builds `opts.SetAnnotations[v1alpha1.AnnotationWakeOnTraffic] = "timeout:<request.TimeoutSeconds>s"` and passes it through `SaveTimeoutWithPolicy`. The policy machinery then decides whether to write both fields together.
+- The handler does not need to special-case "annotation update should not happen on a no-op timeout write" — the modifier's `shouldUpdate == false` branch covers that automatically.
+
+`Pause` does not touch the annotation. `Resume` does not touch the annotation. `WakeSandbox` does not touch the annotation either (see below). The annotation is set only at create and updated only at connect / set-timeout.
+
+### Shared connect/wake core
+
+`ConnectSandbox` and the new `WakeSandbox` share a manager-level helper that runs resume-if-paused plus the single timeout/annotation write. Auth, request parsing, the 5-minute clamp, and any handler-specific computation stay in the callers.
+
+```go
+// pkg/sandbox-manager/connect_core.go
+
+// ConnectOrWakeInput describes the shared resume + timeout-write request.
+// Exported only because callers live in other packages (pkg/servers/e2b for
+// ConnectSandbox, this package for WakeSandbox); semantically it is an internal
+// building block and should not be invoked by anything outside those handlers.
+type ConnectOrWakeInput struct {
+    // Snapshot fields captured by the caller before Resume:
+    PreState   string                  // sbx.GetState() return at handler entry
+    AutoPause  bool                    // ParseTimeout result at handler entry
+    PreEndAt   time.Time               // ParseTimeout result at handler entry
+    Baseline   timeout.Options         // sbx.GetTimeout() at handler entry
+
+    // Caller-computed target deadline:
+    NewEndAt   time.Time               // zero ⇒ leave timeouts cleared (never policy or never-timeout sandbox)
+
+    // Annotations to set/delete atomically with the timeout write:
+    SetAnnotations map[string]string
+}
+
+// ConnectOrWake is exported so the e2b ConnectSandbox handler can call it from
+// pkg/servers/e2b. WakeSandbox in this package calls it directly.
+func (m *SandboxManager) ConnectOrWake(ctx context.Context, sbx infra.Sandbox, in ConnectOrWakeInput) error {
+    // 1. If paused, run Resume (first-writer-wins, shared task wait).
+    if in.PreState == v1alpha1.SandboxStatePaused {
+        if err := m.ResumeSandbox(ctx, sbx, infra.ResumeOptions{}); err != nil {
+            return err
+        }
+    }
+
+    // 2. Never-timeout sandbox stays never-timeout — skip the write entirely.
+    //    This preserves the existing Rule 1 from updateConnectTimeout.
+    if in.PreEndAt.IsZero() && in.NewEndAt.IsZero() && len(in.SetAnnotations) == 0 {
+        return nil
+    }
+
+    // 3. Build the timeout payload from NewEndAt + autoPause.
+    //    m.maxTimeout is the manager's hard upper bound on shutdown time, mirrored
+    //    from the existing e2b Controller config; routing it through the manager
+    //    is part of this refactor (see Code Impact).
+    var opts timeout.Options
+    if !in.NewEndAt.IsZero() {
+        if in.AutoPause {
+            opts.PauseTime    = in.NewEndAt
+            opts.ShutdownTime = time.Now().Add(m.maxTimeout)
+        } else {
+            opts.ShutdownTime = in.NewEndAt
+        }
+    }
+    opts.Baseline       = &in.Baseline
+    opts.SetAnnotations = in.SetAnnotations
+
+    // 4. Pick policy: BaselineAware for paused→resumed paths, ExtendOnly for running.
+    policy := timeout.UpdatePolicyExtendOnly
+    if in.PreState == v1alpha1.SandboxStatePaused {
+        policy = timeout.UpdatePolicyBaselineAware
+    }
+
+    _, err := sbx.SaveTimeoutWithPolicy(ctx, opts, policy)
+    return err
+}
+```
+
+Both callers funnel into `ConnectOrWake`. The annotation update piggybacks on `SaveTimeoutWithPolicy` via `opts.SetAnnotations` (see the previous subsection). The "should we write at all" decision is centralised in two places: this function (the never-timeout fast return) and `SaveTimeoutWithPolicy`'s policy switch (extend-only / baseline-aware degrade).
+
+The legacy `ResumeSandbox` HTTP handler in `pkg/servers/e2b/pause_resume.go` is left as-is (deprecated; old SDK only); it is not migrated to `ConnectOrWake` because its behavior is "always overwrite" rather than the policy-aware path connect/wake share.
+
+### Manager `WakeSandbox`
+
+A new entry point `WakeSandbox` on `*SandboxManager` consumes the annotation, computes the wake-specific target deadline (including the 5-minute floor), and dispatches to `ConnectOrWake`.
+
+```
+1. sbx := m.infra.GetClaimedSandbox(...)        // informer + APIReader fallback
+2. policy := ParseWakeOnTrafficPolicy(sbx.Annotations)
+     absent  → return AutoResumeDisabled (no write)
+     invalid → return InvalidAutoResumePolicy (no write)
+3. state, _ := sbx.GetState()
+     running → return AlreadyRunning (no write)
+     other than paused → map to Pausing / BadState / Gone / NotFound (no write)
+4. if !sandboxutils.IsSandboxPausable(sbx) → return BadState (no write)
+   // Filters out resuming/pending/terminating sandboxes that share the
+   // "paused" gateway state but cannot be safely resumed yet.
+5. autoPause, currentEndAt := ParseTimeout(sbx)
+6. baseline := sbx.GetTimeout()
+7. Compute newEndAt:
+     - never policy           → zero time
+     - never-timeout sandbox  → zero time (preserved by ConnectOrWake)
+     - duration policy        → now + max(duration, wakeMinimumTimeout)
+8. m.ConnectOrWake(ctx, sbx, ConnectOrWakeInput{
+       PreState:       v1alpha1.SandboxStatePaused,
+       AutoPause:      autoPause,
+       PreEndAt:       currentEndAt,
+       Baseline:       baseline,
+       NewEndAt:       newEndAt,
+       SetAnnotations: nil,                     // wake never rewrites the annotation
+   })
+9. m.syncRoute(ctx, sbx, true)                  // push running state to peers
+10. return WakeResult{Action: Resumed, State: running, ResourceVersion: ...}
+```
+
+`WakeResult.ResourceVersion` is the manager replica's best-effort observed Sandbox version after the wake attempt. The gateway must not use it as a correctness gate; convergence still comes from polling the local registry until the route is observed as `Running`.
+
+The 5-minute floor is a manager package-level constant `wakeMinimumTimeout = 5 * time.Minute`, applied only inside `WakeSandbox` and only on the duration form. The never policy bypasses it (no deadline written). `ConnectSandbox` does not see this constant.
+
+`WakeSandbox` does not write the wake-on-traffic annotation. Annotation maintenance is the create / connect / set-timeout responsibility (per the previous section).
+
+### `ConnectSandbox` refactor
+
+`ConnectSandbox` after this change:
+
+1. Auth + parse `request.TimeoutSeconds` (existing).
+2. Get user's sandbox (existing).
+3. Snapshot `state`, `autoPause`, `currentEndAt`, `baseline` (existing).
+4. Build the desired `newEndAt` from `request.TimeoutSeconds` (relative to `now`); apply the existing extend-only "Rule 2" guard at this point if `state == running`, by skipping the call when the requested end-at would not extend.
+5. Build `SetAnnotations` for the wake-on-traffic key only when the existing annotation is present (per the previous section).
+6. Call `m.ConnectOrWake(...)` with the input above. Return its error to the SDK.
+
+The existing `updateConnectTimeout` helper is removed; its Rule 1 (never-timeout) lives in `ConnectOrWake`, its Rule 2 (extend-only on running) becomes a guard in step 4 above (the policy degrade in `SaveTimeoutWithPolicy` would also catch it, but doing the check before the call avoids an unnecessary `retryUpdate` round-trip in the common no-op case).
+
+### Internal HTTP endpoint
+
+`POST /wake/{sandboxID}` is registered on the existing internal mux owned by `pkg/proxy/server.go` (port `proxy.SystemPort = 7789`), alongside the existing `/refresh`. The handler is anonymous, the same trust model `/refresh` already uses: protection comes from the network boundary (cluster-internal port, no Ingress, NetworkPolicy), not from request-level credentials.
+
+Request body: empty.
+
+Response body:
+
+```json
+{
+  "action": "Resumed | AlreadyRunning | AutoResumeDisabled | InvalidAutoResumePolicy | NotFound | Pausing | BadState | Gone",
+  "message": "...",
+  "state": "running | paused | creating | dead",
+  "resourceVersion": "..."
+}
+```
+
+HTTP status mapping:
+
+| Action | Status |
+|---|---|
+| Resumed, AlreadyRunning | 200 |
+| AutoResumeDisabled, InvalidAutoResumePolicy | 422 |
+| Pausing, BadState | 409 |
+| Gone | 410 |
+| NotFound | 404 |
+| any infra failure | 500 |
+
+A request-level shared token / mTLS / SA-token verification is **explicitly out of scope** for v1. If a future threat model demands it (operators auditing in-cluster blast radius, hostile co-tenancy, etc.), it lives in a follow-up ticket. The wake handler is one deny rule away from being unreachable, and that deny rule is the v1 boundary.
+
+### Gateway Route extension
+
+`proxy.Route` (`pkg/proxy/routes.go:39-46`) gains two fields:
+
+- `WakeOnTraffic string` — raw annotation value verbatim; the gateway parses it on the wake path.
+- `Pausable bool` — `sandboxutils.IsSandboxPausable(sbx)` evaluated at Route construction. The gateway uses this as the gate for triggering a wake call (see the filter section below). Computing it once at Route construction avoids re-walking conditions / phase fields per request.
+
+JSON encoding for both fields is forward-compatible: old peers ignore unknown fields on inbound, new peers see zero values when receiving from old peers — both safe.
+
+`proxyutils.DefaultGetRouteFunc` (`pkg/utils/sandbox-manager/proxyutils/default.go`) reads `sandbox.Annotations[v1alpha1.AnnotationWakeOnTraffic]` and `sandboxutils.IsSandboxPausable(sandbox)` and copies them to the Route. The gateway controller `pkg/sandbox-gateway/controller/gateway_controller.go:61-63` populates Route via this helper, so both fields flow from the CR to every replica's local registry through both the local informer and the manager's `SyncRouteWithPeers` push.
+
+### Refresh handler relaxation
+
+`pkg/sandbox-gateway/server/server.go:174-177` currently deletes any non-Running route. This was a defensive measure to avoid routing to unhealthy sandboxes; with wake-on-traffic, paused entries must remain visible so the filter can find them. The handler is relaxed to:
+
+```go
+switch route.State {
+case v1alpha1.SandboxStateDead, "":
+    registry.GetRegistry().Delete(route.ID)
+default:
+    registry.GetRegistry().Update(route.ID, route)
+}
+```
+
+This matches the local controller's path (`gateway_controller.go:61-63`), which already keeps non-Running routes via `Update`.
+
+### Gateway async filter
+
+`pkg/sandbox-gateway/filter/filter.go` extends `DecodeHeaders` with an async branch on the paused + wake-on-traffic path. The non-wake paths remain synchronous and unchanged.
+
+```
+DecodeHeaders:
+  parse / lookup registry / extract sandboxID, port (existing)
+
+  if route.State == Running:
+    set dynamic metadata (existing)
+    return api.Continue
+
+  // Wake gate: must satisfy ALL three:
+  //   - State is paused (route.State == "paused")
+  //   - The sandbox is in a state we can resume from (route.Pausable)
+  //   - wake-on-traffic is configured on the CR (route.WakeOnTraffic != "")
+  // Any other combination falls through to the existing 502 path.
+  if !(route.State == Paused && route.Pausable && route.WakeOnTraffic != ""):
+    SendLocalReply 502 (existing)
+    return api.LocalReply
+
+  spawn goroutine (parented to filter context — cancelled on OnDestroy):
+    defer recover() — turn panics into SendLocalReply 500
+    err := wakeAndWait(filterCtx, sandboxID)
+    f.completeOnce.Do(func() {
+      if err != nil:
+        SendLocalReply with mapped status, no extraHeaders
+      else:
+        re-read registry, set extraHeaders + dynamic metadata, Continue
+    })
+  return api.Running
+```
+
+Invariants:
+
+- `f.completeOnce sync.Once` guards `Continue` and `SendLocalReply`. Calling either twice on the same stream panics inside Envoy.
+- `OnDestroy` (`api.StreamFilter.OnDestroy`) cancels the filter context and disables the `completeOnce` block, preventing callbacks on a destroyed stream. The client closing the TCP connection is what bounds the wait.
+- The gateway does **not** apply its own wake-side timeout. Production wake operations regularly take tens of seconds (image pull, pod scheduling, runtime re-init) and a hardcoded gateway timeout would convert healthy slow waking into 503 storms. The bounding signals are: (a) the client connection going away (OnDestroy → ctx cancellation), (b) Envoy's listener-level `stream_idle_timeout` / route `timeout` configured in `config/sandbox-gateway/configmap.yaml` (currently 600s), (c) the manager's own `Resume` task wait inside `Sandbox.Resume` (1 minute hard cap). Any of these is sufficient to terminate a hopeless wake.
+- `wakeAndWait` runs under a per-replica `singleflight.Group` keyed by sandbox ID. Concurrent requests against the same paused sandbox in the same replica share one manager call and one wait loop. Cross-replica deduplication is not attempted; manager-side `Resume`'s first-writer-wins handles it.
+- `wakeAndWait` returns either nil (after observing `route.State == Running` in the registry) or a typed error mapped to HTTP. Manager response codes flow through.
+- Header mutation happens only after the goroutine completes; the original `header` map's lifetime ends with the synchronous return from `DecodeHeaders`. The goroutine uses `f.callbacks` to set headers and dynamic metadata.
+
+`wakeAndWait` body:
+
+```
+1. POST :7789/wake/{id} (no token); HTTP client timeout follows ctx, no extra deadline
+2. on 422/410/404 → return mapped error immediately
+3. on 200 → enter registry poll:
+     for !ctx.Done():
+       r := registry.Get(id)
+       if r.State == Running: return nil
+       sleep backoff (50ms → 100ms → 200ms → 500ms cap)
+4. on ctx.Done() → return ctx.Err() (client cancelled or filter destroyed)
+```
+
+Error-to-status mapping at the gateway:
+
+| wake error | HTTP | `Retry-After` |
+|---|---|---|
+| AutoResumeDisabled | 502 sandbox_not_running | none |
+| InvalidAutoResumePolicy | 503 | 0 |
+| Pausing | 503 | 5 |
+| BadState (creating, etc.) | 503 | 15 |
+| Gone | 502 sandbox_not_found | none |
+| NotFound | 502 sandbox_not_found | none |
+| transport / 5xx | 503 | 5 |
+| ctx cancelled (client disconnect) | no reply emitted — Envoy already cleaning up | — |
+
+`AutoResumeDisabled` is mapped to the existing 502 to keep the no-wake response shape stable for clients; this case only arises in races where the route says wake-on-traffic is set but the manager observes it absent.
+
+### Network boundary
+
+The wake endpoint has no application-level authentication; protection comes entirely from the network layer. This is consistent with the existing `/refresh` endpoint on the same port.
+
+A new NetworkPolicy in `config/network-policy/` is required (or, if a manager NetworkPolicy already exists, the gateway label is added to its `:7789` allow rules). Allowed sources for `:7789`:
+
+- Manager-to-manager peer mesh — existing rule, unchanged.
+- Pods matching the gateway's `metadata.labels` (specific selector to be confirmed against `config/sandbox-gateway/deployment.yaml` at implementation).
+
+Other in-cluster pods cannot reach `:7789`. The Service does not expose this port via Ingress.
+
+A ClusterIP Service exposing `:7789` for cluster DNS resolution from the gateway is added if one does not already exist (port name: `internal`). The existing manager Service used by `/kruise/api/*` proxy traffic is at `:7788` and is unaffected.
+
+## State machine and concurrency
+
+### Wake outcomes by sandbox state
+
+The `IsSandboxPausable` gate at the manager (and on the gateway via `Route.Pausable`) keeps the wake path narrow: only `Phase ∈ {Running, Paused}` qualifies, plus the additional rules below.
+
+| Observed CR shape | gateway state | `IsSandboxPausable` | `IsSandboxResumable` | wake action | manager response |
+|---|---|---|---|---|---|
+| Phase=Running, Spec.Paused=false, Ready=true | running | true | true | no-op | AlreadyRunning |
+| Phase=Running, Spec.Paused=true (pause in flight, controller has not yet deleted pod) | paused | true | true | Resume (fast path: Ready may already be true → no-op; else flips Spec.Paused=false) + ConnectOrWake (BaselineAware) | Resumed |
+| Phase=Paused, cond[SandboxPaused]=True (pause completed) | paused | true | true | Resume + ConnectOrWake (BaselineAware) | Resumed |
+| Phase=Paused, cond[SandboxPaused]=False (pod still terminating) | paused | true | false | reject inside Resume's `IsSandboxResumable` pre-check | Pausing (409) |
+| Phase=Resuming | paused | false | true | reject at `IsSandboxPausable` gate (gateway pre-filtered; manager defensive) | BadState (409) |
+| Phase=Pending / state=creating | creating | false | false | reject | BadState (409) |
+| state=dead, `DeletionTimestamp != nil`, or `Phase ∈ {Failed, Succeeded, Terminating}` | dead | false | false | reject | Gone (410) |
+| not found / not claimed | n/a | n/a | n/a | reject | NotFound (404) |
+
+Phases for which both gateway and manager agree to reject without a Resume attempt are filtered at the gateway by the `route.Pausable` check; the manager-side `IsSandboxPausable` is a defensive double-check for direct K8S-driven traffic that bypasses the gateway.
+
+### Concurrent wake / connect on same sandbox
+
+- Two wake calls (different gateway replicas, both routed to one manager replica or split): both enter `Sandbox.Resume`. The `retryUpdate` modifier is `if !sbx.Spec.Paused { return false }`, so the second caller is `resumeUpdated == false` and skips post-resume `InitRuntime` / CSI. Both wait on the shared `resumeTask`. Both proceed to `ConnectOrWake` → `SaveTimeoutWithPolicy(BaselineAware)` with identical baselines (informer view at request entry).
+- The first `SaveTimeoutWithPolicy` call sees `current == baseline` and (because `BaselineAware` falls through to `Always` semantics in this branch) writes its computed timeout. The second call sees `current != baseline` and degrades to `ExtendOnly`. For two finite values, the longer one survives.
+- Connect concurrent with wake: connect captures its own baseline and threads through the same `ConnectOrWake`. The first writer applies `Always` semantics; the second degrades to `ExtendOnly`. For finite-vs-finite the longer survives.
+- Cross-form race (one writer finite, the other `never` ⇒ zero-time): the first writer always wins. The first writer's `BaselineAware` matches and writes via `Always` semantics. The second writer's `BaselineAware` mismatches, degrades to `ExtendOnly`, and `ShouldExtendTimeout` treats either side being zero as "no comparable end-time" and returns false — so the second write is a no-op regardless of which form it carries. This is a deliberate property of the existing policy machinery: it never silently shrinks an already-extended timeout, and it never silently demotes "no deadline" to a finite one. The same property applies today to never-timeout sandboxes — connect and set-timeout's existing Rule 1 short-circuits the call when `currentEndAt.IsZero()`. Users who need to override a once-applied `never` reset the wake-on-traffic annotation and pause/resume cycle the sandbox; this is not a new constraint introduced by wake-on-traffic.
+
+### Annotation drift
+
+If `ConnectSandbox` succeeds in `Resume` but fails in `SaveTimeoutWithPolicy` (network glitch, conflict storm), the annotation is also not updated. The annotation remains consistent with the spec timeout. The handler returns 5xx and the client retries.
+
+If `ConnectSandbox` succeeds in both timeout write and annotation update but the SDK never receives the response (network drop after manager commit), the next request finds a Running sandbox with the new timeout and matching annotation. No reconciliation is needed.
+
+### Cross-replica correctness
+
+- Per-replica gateway `singleflight` deduplicates within one replica. Multi-replica gateway: each replica independently calls manager, manager handles concurrency.
+- Manager resume is first-writer-wins with shared wait. Manager `SaveTimeoutWithPolicy` is `BaselineAware` and resolves any concurrent timeout writes via "longest timeout wins" semantics.
+- The baseline travels with the request, captured at the manager replica handling that request. The k8s API server is the only authoritative source consulted under conflict (via `retryUpdate`'s API-reader refresh).
+- Informer staleness on the gateway can produce a transient `paused` Route after manager has resumed. The wake call then returns `AlreadyRunning`; the gateway retries the registry poll and converges once its own informer catches up. Worst case is a ~1s delay; never an incorrect routing decision.
+
+## Behavior under existing flows
+
+### Auto-pause (controller-driven via `Spec.PauseTime`)
+
+The controller flips `Spec.Paused = true` without writing any timeout. The wake annotation, if present, was set at create / connect / set-timeout and is preserved. When traffic later arrives, gateway invokes manager wake; the manager observes the annotation, runs Resume, and writes the new timeout. Identical to manual-pause behavior from the wake perspective.
+
+### Manual pause (E2B `/pause`)
+
+Manual pause sets `Spec.Paused = true` and rewrites both `ShutdownTime` and `PauseTime` to `now+1000y` (`buildPauseTimeoutOptions`, `pause_resume.go:65-77`), so the controller does not auto-shutdown the paused sandbox. The annotation is untouched. Wake reads the annotation, calls Resume (which now lifts `Spec.Paused = false` but leaves the 1000y deadlines in spec), then `SaveTimeoutWithPolicy(BaselineAware)` overwrites them with `now + effective` (or clears them for `never`). The 1000y baseline matches what the handler observed pre-Resume, so `BaselineAware` uses `Always` semantics and the overwrite proceeds.
+
+### Never-timeout sandbox (`Extensions.NeverTimeout=true` at create)
+
+`Spec.PauseTime` and `Spec.ShutdownTime` are nil at all times. `ParseTimeout` returns `currentEndAt.IsZero() == true`. Connect, set-timeout, and wake all skip timeout writes for these sandboxes. The annotation, if present, is `"timeout:never"`. The pre-write guards work as follows:
+
+- `WakeSandbox` produces `NewEndAt = zero` for never policy and for never-timeout sandboxes (the duration form only matters when the sandbox actually had a deadline before pause).
+- `ConnectOrWake` then sees `PreEndAt.IsZero() && NewEndAt.IsZero() && len(SetAnnotations) == 0`, returns nil without calling `SaveTimeoutWithPolicy`.
+- For the never-policy-on-previously-finite case, `PreEndAt` is non-zero and `NewEndAt` is zero, which falls through to `SaveTimeoutWithPolicy` with `opts` containing zero times; `setTimeout` then clears `Spec.PauseTime` / `Spec.ShutdownTime` to nil. This is the only path through which paused 1000y deadlines get reset to "no deadline".
+
+### Wake on running sandbox (defensive)
+
+Gateway only triggers wake when `route.State != Running`. Manager wake on a running sandbox (from informer races or admin debug) returns AlreadyRunning without touching timeout or annotation. No write.
+
+## Code Impact
+
+### New files
+
+- `pkg/sandbox-manager/wakeontraffic.go` — `ParseWakeOnTrafficPolicy` (handles `timeout:never` / `timeout:<duration>`) and the resulting `Policy` type.
+- `pkg/sandbox-manager/wake.go` — `WakeSandbox` orchestration plus the 5-minute floor constant.
+- `pkg/sandbox-manager/connect_core.go` — exported `ConnectOrWake` helper plus `ConnectOrWakeInput` shared by `WakeSandbox` (same package) and the e2b connect handler (in `pkg/servers/e2b`).
+- `pkg/proxy/wake_handler.go` — internal anonymous HTTP handler for `/wake/{id}`.
+- `pkg/sandbox-gateway/wake/wake.go` — `wakeAndWait`, `singleflight.Group`, manager HTTP client (no auth header).
+- `pkg/sandbox-gateway/filter/async.go` — async `DecodeHeaders` glue, `completeOnce`, `OnDestroy` integration.
+- `config/network-policy/sandbox-manager-internal.yaml` — ingress allow rule for the gateway → manager `:7789` path.
+
+### Modified files
+
+- `api/v1alpha1/annotations.go` — `AnnotationWakeOnTraffic` constant.
+- `pkg/proxy/routes.go` — `Route.WakeOnTraffic string`, `Route.Pausable bool` fields.
+- `pkg/utils/timeout/types.go` — `Options.SetAnnotations map[string]string` field.
+- `pkg/sandbox-manager/infra/sandboxcr/sandbox.go` — `SaveTimeoutWithPolicy` modifier applies `opts.SetAnnotations` together with `setTimeout`.
+- `pkg/sandbox-manager/core.go` — `SandboxManager` gains a `maxTimeout time.Duration` field (mirrored from the CLI flag previously consumed only by the e2b Controller); `ConnectOrWake` reads it for the auto-pause `ShutdownTime` upper-bound. The e2b Controller continues to hold its own copy for request validation; the value is passed in once at builder time.
+- `pkg/utils/sandbox-manager/proxyutils/default.go` — `DefaultGetRouteFunc` populates `WakeOnTraffic` and `Pausable`.
+- `pkg/sandbox-gateway/server/server.go` — `handleRefresh` keeps non-Dead routes (the existing delete-on-non-Running guard is relaxed).
+- `pkg/sandbox-gateway/filter/filter.go` — async branch with the three-condition wake gate.
+- `pkg/sandbox-gateway/filter/config.go` — manager URL config (no token).
+- `cmd/sandbox-gateway/main.go` — init wake module.
+- `pkg/proxy/server.go` — register anonymous `/wake/{id}` on the internal mux.
+- `pkg/servers/e2b/models/sandbox.go` — `AutoResume *AutoResumeConfig`, `AutoResumeConfig` type.
+- `pkg/servers/e2b/create.go` — `basicSandboxCreateModifier` writes the annotation in `timeout:<seconds>s` / `timeout:never` form.
+- `pkg/servers/e2b/pause_resume.go` — `ConnectSandbox` reshapes around `m.ConnectOrWake`; `updateConnectTimeout` is removed; annotation update is carried through `opts.SetAnnotations`.
+- `pkg/servers/e2b/timeout.go` — `setSandboxTimeout` carries annotation update through `opts.SetAnnotations`.
+- `config/sandbox-manager/service.yaml` — expose `:7789` (or add a new internal Service) for cluster DNS resolution from the gateway.
+
+### Not modified
+
+- `api/v1alpha1/sandbox_types.go` — no CRD field changes.
+- `config/crd/bases/agents.kruise.io_sandboxes.yaml` — no CRD schema changes.
+- `pkg/controller/sandbox/...` — no controller behavior changes.
+- `config/rbac/...` — gateway already has read-only access to Sandbox CRs; manager already has full access. No new permissions needed.
+- No new K8s Secret. No `KRUISE_INTERNAL_TOKEN` env var. No `Makefile` token target.
+
+## Test Plan
+
+### Annotation parser (`pkg/sandbox-manager/wakeontraffic_test.go`)
+
+- Disabled: annotation absent on a populated map.
+- Never: exact `"timeout:never"` string.
+- Duration form: `"timeout:1s"`, `"timeout:30s"`, `"timeout:5m"`, `"timeout:2h30m"`.
+- Absolute timestamp rejected: `"timeout:2099-01-01T00:00:00Z"` and other RFC3339-looking payloads return InvalidPolicy.
+- Invalid kind: `"foo:300s"`, `"timeout"` (no colon), `":300s"`.
+- Invalid duration payload: `""`, `"true"`, `"false"`, `"timeout:"`, `"timeout:0"`, `"timeout:0s"`, `"timeout:-1s"`, `"timeout:500ms"`, `"timeout:abc"`, `"timeout:5"`, `"timeout:Never"`, `"timeout:NEVER"`, `"timeout: 300s"`, `"timeout:300s\n"`.
+- Boundary: `"timeout:1s"` accepted, `"timeout:999ms"` rejected.
+- Round-trip: `"timeout:300s"` → Policy with Duration=300s and Form=duration; `"timeout:never"` → Policy with Form=never.
+
+### Manager wake (`pkg/sandbox-manager/wake_test.go`)
+
+- WakeSandbox(paused, duration, autoPause=false) writes ShutdownTime = now + max(duration, 5min); no PauseTime.
+- WakeSandbox(paused, duration, autoPause=true) writes PauseTime = now + max(duration, 5min); ShutdownTime = now + maxTimeout.
+- WakeSandbox(paused, never) clears both timeouts.
+- WakeSandbox(paused, duration < 5min) clamps to 5min.
+- WakeSandbox(paused, duration >= 5min) preserves duration.
+- WakeSandbox(running) returns AlreadyRunning, asserts no Update was issued.
+- WakeSandbox(annotation absent) returns AutoResumeDisabled.
+- WakeSandbox(annotation invalid) returns InvalidAutoResumePolicy.
+- WakeSandbox(deletionTimestamp set) returns Gone.
+- WakeSandbox(Spec.Paused && cond Paused == False) returns Pausing — both via state and via `IsSandboxPausable` returning false.
+- WakeSandbox(state=creating) returns BadState.
+- WakeSandbox(state=resuming, IsSandboxPausable=false) returns BadState.
+- WakeSandbox(not found) returns NotFound.
+- WakeSandbox does NOT mutate the wake-on-traffic annotation.
+- Concurrent wake + wake: second caller skips post-resume init, both succeed; longest timeout survives.
+- Cross-form race (driven by SaveTimeoutWithPolicy ordering, asserted in two sub-cases):
+  - Connect (finite 300s) writes first, then wake (never) writes second → spec keeps the 300s deadline; wake's no-op is observed via `TimeoutUpdateResult.Updated == false`.
+  - Wake (never) writes first, then connect (finite 300s) writes second → spec keeps the cleared (zero) deadline; connect's no-op is observed via `TimeoutUpdateResult.Updated == false`.
+  Both sub-cases verify the "first writer wins, second is a no-op" property of `BaselineAware` + `ExtendOnly` against zero-time semantics.
+
+### Shared `ConnectOrWake` core (`pkg/sandbox-manager/connect_core_test.go`)
+
+- Paused input: triggers Resume; SaveTimeoutWithPolicy with BaselineAware.
+- Running input: skips Resume; SaveTimeoutWithPolicy with ExtendOnly.
+- Never-timeout sandbox + zero NewEndAt + empty SetAnnotations → no write.
+- Never-timeout sandbox + zero NewEndAt + non-empty SetAnnotations → annotation update still flows through.
+- AutoPause=true + finite NewEndAt → PauseTime + ShutdownTime=now+maxTimeout.
+- AutoPause=false + finite NewEndAt → only ShutdownTime.
+- Empty NewEndAt + non-empty SetAnnotations → annotation written, timeouts cleared by `setTimeout(opts)` (the empty-time path).
+
+### `SaveTimeoutWithPolicy.SetAnnotations` (`pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go`)
+
+- SetAnnotations with non-empty values writes them on the same `retryUpdate` round.
+- SetAnnotations with empty-string value deletes the annotation key.
+- shouldUpdate=false (policy degrade / no-op): SetAnnotations are NOT applied.
+- Conflict-retry: a 409 in the middle of `retryUpdate` re-runs the modifier, applying SetAnnotations against the refreshed object.
+
+### E2B handler annotation sync (`pkg/servers/e2b/create_test.go`, `pause_resume_test.go`, `timeout_test.go`)
+
+- Create with `autoResume.enabled=true` + finite Timeout → annotation written as `"timeout:<seconds>s"`.
+- Create with `autoResume.enabled=true` + `never-timeout=true` extension → annotation = `"timeout:never"`.
+- Create with `autoResume=nil` → no annotation.
+- Create with `autoResume.enabled=false` → no annotation.
+- Connect on sandbox without annotation → no annotation added; `opts.SetAnnotations` empty.
+- Connect on sandbox with annotation, paused→resumed branch, request timeout=600 → annotation = `"timeout:600s"` written via SetAnnotations.
+- Connect on sandbox with annotation, running branch, request timeout extends → annotation updated.
+- Connect on sandbox with annotation, running branch, request timeout shorter (extend-only no-op) → annotation unchanged.
+- Connect on never-timeout sandbox (skip per ConnectOrWake guard) → annotation unchanged.
+- SetTimeout on running sandbox without annotation → no annotation added.
+- SetTimeout on running sandbox with annotation → annotation updated.
+- SetTimeout on never-timeout sandbox → annotation unchanged.
+
+### Gateway filter (`pkg/sandbox-gateway/filter/filter_test.go`, `wake/wake_test.go`)
+
+- Wake gate matrix:
+  - paused + Pausable=true + WakeOnTraffic="" → 502 (existing).
+  - paused + Pausable=false + WakeOnTraffic non-empty → 502 (existing; never call manager).
+  - non-paused + Pausable=true + WakeOnTraffic non-empty → 502 (existing).
+  - paused + Pausable=true + WakeOnTraffic non-empty → wake.
+- Paused + all three conditions met: returns `api.Running`; goroutine calls manager; on 200 + registry converges, calls Continue with new dynamic metadata.
+- Manager 422 InvalidPolicy: SendLocalReply 503.
+- Manager 409 Pausing: SendLocalReply 503 with `Retry-After: 5`.
+- Manager 410 Gone: SendLocalReply 502 sandbox_not_found.
+- Manager transport error: SendLocalReply 503.
+- Concurrent in-replica wake (singleflight): two parallel requests to same paused sandbox produce one manager call; both receive Continue.
+- OnDestroy after returning Running: filter context cancelled; in-flight wake goroutine sees ctx.Err() and exits; Continue/SendLocalReply not invoked on the destroyed stream.
+- panic in goroutine: caught, mapped to SendLocalReply 500.
+- Registry update arrives before manager response: still continues.
+- No gateway-side wake timeout: assert that the goroutine does not impose its own deadline; only ctx cancellation (from OnDestroy) terminates it.
+
+### Refresh handler (`pkg/sandbox-gateway/server/server_test.go`)
+
+- /refresh paused: registry retains entry, State="paused".
+- /refresh dead: registry removes entry.
+- /refresh terminating: registry removes entry.
+
+### Route mapping (`pkg/utils/sandbox-manager/proxyutils/default_test.go`)
+
+- Sandbox with annotation: Route.WakeOnTraffic populated; Route.Pausable reflects `IsSandboxPausable(sbx)`.
+- Sandbox without annotation: Route.WakeOnTraffic empty string.
+- Sandbox in resuming/pending/terminating phase: Route.Pausable=false.
+- JSON round-trip Route old→new: missing fields decode to zero values.
+- JSON round-trip Route new→old: extra fields ignored.
+
+### Integration
+
+A single happy-path integration test under `test/e2e/` (or the project's existing integration suite):
+
+- Bootstrap envtest with manager + gateway controller + sandbox controller stubs.
+- Create sandbox with `autoResume.enabled=true`, `timeout=60s`.
+- Pause via E2B handler.
+- Send HTTP request through gateway filter.
+- Assert: filter returns `api.Running`, eventually calls Continue; Sandbox CR has `Spec.Paused=false`; `Spec.ShutdownTime ≈ now + 5min` (clamped from 60s).
+- Annotation remains `"timeout:60s"` (the original create value).
+
+End-to-end SDK tests (real E2B SDK against a running cluster) are deferred to a follow-up.
+
+## Open Decisions
+
+- **Exact NetworkPolicy label selector** for sandbox-gateway pods. To be confirmed against the gateway Deployment's `metadata.labels` at implementation time. Whether a manager-side NetworkPolicy already exists (and we extend it) or whether a new NetworkPolicy is created is a deployment-shape detail to verify in `config/network-policy/`.
+- **Manager internal Service shape**. Whether `:7789` is exposed by extending the existing `sandbox-manager` Service with a new port, or by creating a new dedicated Service, is a kustomize/Helm preference to be confirmed during implementation.
+- **Wake metrics naming.** Manager-side wake metrics should align with the existing `sandbox{Resume,Pause,Delete}Responses` / `Duration` histograms in `pkg/sandbox-manager/metrics.go`. V1 includes a counter of wake responses by action code and a histogram of wake total duration. Gateway-side metrics for singleflight-coalesced calls and `wakeAndWait` duration are deferred to a follow-up because the sandbox-gateway currently exposes Envoy admin stats on `:9090`, while controller-runtime Go metrics are disabled to avoid port conflicts.
+- **Future request-level auth on `/wake`.** Out of scope for v1 (network policy is sufficient given the trust model). If hostile co-tenancy or stricter compliance forces this later, the cleanest hook is an SA-token + TokenReview check on the manager handler; placement is at the entry of `pkg/proxy/wake_handler.go`. This spec does not pre-add the hook to keep the path symmetric with `/refresh`.
+- **Future JWT/access-token owner check.** Tracking a separate workstream that maps an envd `X-Access-Token` to the sandbox owner. Not in this scope; no placeholder header is added to the wake path because such a header would only be meaningful once the verification machinery exists.

--- a/hack/run-e2b-e2e-test.sh
+++ b/hack/run-e2b-e2e-test.sh
@@ -146,7 +146,10 @@ cd "$PROJECT_ROOT"
 if [ "$WITH_GATEWAY" = "true" ]; then
     pytest -v -s -x --tb=short "$TEST_DIR"
 else
-    pytest -v -s -x --tb=short --ignore="$TEST_DIR/test_gateway.py" "$TEST_DIR"
+    pytest -v -s -x --tb=short \
+        --ignore="$TEST_DIR/test_gateway.py" \
+        --ignore="$TEST_DIR/test_wake_on_traffic.py" \
+        "$TEST_DIR"
 fi
 retVal=$?
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -62,6 +62,24 @@ func TestCache_GetClaimedSandbox(t *testing.T) {
 		assert.Equal(t, "test-sbx", got.Name)
 	})
 
+	t.Run("canonical sandbox id can be queried without namespace and wrong namespace does not match", func(t *testing.T) {
+		c, _, err := cachetest.NewTestCache(t, sbx)
+		require.NoError(t, err)
+		sandboxID := sandboxutils.GetSandboxID(sbx)
+
+		got, err := c.GetClaimedSandbox(t.Context(), cache.GetClaimedSandboxOptions{SandboxID: sandboxID})
+		require.NoError(t, err)
+		assert.Equal(t, "default", got.Namespace)
+		assert.Equal(t, "test-sbx", got.Name)
+
+		_, err = c.GetClaimedSandbox(t.Context(), cache.GetClaimedSandboxOptions{
+			Namespace: "wrong-namespace",
+			SandboxID: sandboxID,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in cache")
+	})
+
 	t.Run("not found", func(t *testing.T) {
 		c, _, err := cachetest.NewTestCache(t)
 		require.NoError(t, err)

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -43,6 +43,8 @@ type Route struct {
 	Owner           string    `json:"owner"`
 	State           string    `json:"state"`
 	ResourceVersion string    `json:"resourceVersion"`
+	WakeOnTraffic   string    `json:"wakeOnTraffic"`
+	Pausable        bool      `json:"pausable"`
 }
 
 func (s *Server) SetRoute(ctx context.Context, route Route) {

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -42,6 +42,7 @@ import (
 
 const (
 	RefreshAPI = "/refresh"
+	WakeAPI    = "/wake/{sandboxID}"
 	SystemPort = 7789
 )
 
@@ -78,6 +79,7 @@ type Server struct {
 	// internal
 	routes  sync.Map
 	adapter RequestAdapter
+	wake    WakeFunc
 	LBEntry string // entry of load balancer, usually a service
 	// peers - now managed by Peers
 	peersManager peers.Peers
@@ -97,6 +99,10 @@ func (s *Server) SetRequestAdapter(adapter RequestAdapter) {
 	s.LBEntry = adapter.Entry()
 }
 
+func (s *Server) SetWakeFunc(wake WakeFunc) {
+	s.wake = wake
+}
+
 func (s *Server) SetPeersManager(p peers.Peers) {
 	s.peersManager = p
 }
@@ -108,6 +114,7 @@ func (s *Server) Run() error {
 	// HTTP
 	mux := http.NewServeMux()
 	web.RegisterRoute(mux, http.MethodPost, RefreshAPI, s.handleRefresh)
+	web.RegisterRoute(mux, http.MethodPost, WakeAPI, s.handleWake)
 	s.httpSrv = &http.Server{
 		Addr:              fmt.Sprintf(":%d", SystemPort),
 		Handler:           mux,
@@ -163,7 +170,7 @@ func (s *Server) handleRefresh(r *http.Request) (web.ApiResponse[struct{}], *web
 			Message: fmt.Sprintf("failed to unmarshal body: %s", err.Error()),
 		}
 	}
-	if route.State == v1alpha1.SandboxStateDead {
+	if route.State == "" || route.State == v1alpha1.SandboxStateDead {
 		s.DeleteRoute(route.ID)
 		log.Info("route deleted")
 	} else {

--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -66,7 +66,7 @@ func TestHealthServer_Watch(t *testing.T) {
 func TestHandleRefresh_Success(t *testing.T) {
 	s := newTestServer(nil)
 
-	route := Route{ID: "sb-refresh", IP: "10.0.0.1", ResourceVersion: "1", Owner: "user1"}
+	route := Route{ID: "sb-refresh", IP: "10.0.0.1", ResourceVersion: "1", Owner: "user1", State: v1alpha1.SandboxStateRunning}
 	body, err := json.Marshal(route)
 	require.NoError(t, err)
 
@@ -106,7 +106,7 @@ func TestHandleRefresh_EmptyBody(t *testing.T) {
 func TestHandleRefresh_ContextPropagated(t *testing.T) {
 	s := newTestServer(nil)
 
-	route := Route{ID: "sb-ctx", IP: "9.9.9.9", ResourceVersion: "1"}
+	route := Route{ID: "sb-ctx", IP: "9.9.9.9", ResourceVersion: "1", State: v1alpha1.SandboxStateRunning}
 	body, err := json.Marshal(route)
 	require.NoError(t, err)
 
@@ -128,7 +128,7 @@ func TestHandleRefresh_OverwritesExistingRoute(t *testing.T) {
 	s.SetRoute(ctx, Route{ID: "sb-over", IP: "1.1.1.1", ResourceVersion: "1"})
 
 	// Send a newer route via handleRefresh
-	newer := Route{ID: "sb-over", IP: "2.2.2.2", ResourceVersion: "2"}
+	newer := Route{ID: "sb-over", IP: "2.2.2.2", ResourceVersion: "2", State: v1alpha1.SandboxStateRunning}
 	body, _ := json.Marshal(newer)
 	req := httptest.NewRequest(http.MethodPost, RefreshAPI, bytes.NewReader(body))
 	_, apiErr := s.handleRefresh(req)
@@ -160,6 +160,18 @@ func TestServer_handleRefresh(t *testing.T) {
 				IP:              "10.0.0.1",
 				State:           v1alpha1.SandboxStateDead,
 				ResourceVersion: "1",
+			}),
+			expectedCode:  http.StatusNoContent,
+			expectedError: false,
+			expectDeleted: true,
+		},
+		{
+			name: "empty state should delete route",
+			body: mustMarshal(Route{
+				ID:              "sandbox-empty-state",
+				IP:              "10.0.0.4",
+				State:           "",
+				ResourceVersion: "2",
 			}),
 			expectedCode:  http.StatusNoContent,
 			expectedError: false,
@@ -198,8 +210,10 @@ func TestServer_handleRefresh(t *testing.T) {
 
 			// Pre-set a route for delete test
 			if tt.expectDeleted {
+				var incoming Route
+				require.NoError(t, json.Unmarshal([]byte(tt.body), &incoming))
 				route := Route{
-					ID:              "sandbox-1",
+					ID:              incoming.ID,
 					IP:              "10.0.0.1",
 					State:           v1alpha1.SandboxStateRunning,
 					ResourceVersion: "1",
@@ -224,7 +238,9 @@ func TestServer_handleRefresh(t *testing.T) {
 
 			// Verify route deletion
 			if tt.expectDeleted {
-				_, loaded := s.routes.Load("sandbox-1")
+				var incoming Route
+				require.NoError(t, json.Unmarshal([]byte(tt.body), &incoming))
+				_, loaded := s.routes.Load(incoming.ID)
 				assert.False(t, loaded, "route should be deleted")
 			}
 

--- a/pkg/proxy/wake.go
+++ b/pkg/proxy/wake.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+type WakeAction string
+
+const (
+	WakeActionResumed                 WakeAction = "Resumed"
+	WakeActionAlreadyRunning          WakeAction = "AlreadyRunning"
+	WakeActionAutoResumeDisabled      WakeAction = "AutoResumeDisabled"
+	WakeActionInvalidAutoResumePolicy WakeAction = "InvalidAutoResumePolicy"
+	WakeActionNotFound                WakeAction = "NotFound"
+	WakeActionPausing                 WakeAction = "Pausing"
+	WakeActionBadState                WakeAction = "BadState"
+	WakeActionGone                    WakeAction = "Gone"
+)
+
+type WakeResult struct {
+	Action WakeAction `json:"action"`
+	State  string     `json:"state"`
+	// ResourceVersion is the manager's best-effort observed Sandbox version.
+	// Gateways do not depend on it; wake convergence is based on registry polling.
+	ResourceVersion string `json:"resourceVersion"`
+	Message         string `json:"message"`
+}

--- a/pkg/proxy/wake_handler.go
+++ b/pkg/proxy/wake_handler.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/openkruise/agents/pkg/servers/web"
+)
+
+type WakeFunc func(ctx context.Context, id string) (WakeResult, error)
+
+func (s *Server) handleWake(r *http.Request) (web.ApiResponse[WakeResult], *web.ApiError) {
+	if s.wake == nil {
+		return web.ApiResponse[WakeResult]{}, &web.ApiError{
+			Code:    http.StatusInternalServerError,
+			Message: "wake function is not configured",
+		}
+	}
+
+	result, err := s.wake(r.Context(), r.PathValue("sandboxID"))
+	if err != nil {
+		return web.ApiResponse[WakeResult]{}, &web.ApiError{
+			Code:    http.StatusInternalServerError,
+			Message: fmt.Sprintf("wake sandbox failed: %v", err),
+		}
+	}
+
+	status, ok := wakeActionHTTPStatus(result.Action)
+	if !ok {
+		return web.ApiResponse[WakeResult]{}, &web.ApiError{
+			Code:    http.StatusInternalServerError,
+			Message: fmt.Sprintf("unsupported wake action: %s", result.Action),
+		}
+	}
+	return web.ApiResponse[WakeResult]{
+		Code: status,
+		Body: result,
+	}, nil
+}
+
+func wakeActionHTTPStatus(action WakeAction) (int, bool) {
+	switch action {
+	case WakeActionResumed, WakeActionAlreadyRunning:
+		return http.StatusOK, true
+	case WakeActionAutoResumeDisabled, WakeActionInvalidAutoResumePolicy:
+		return http.StatusUnprocessableEntity, true
+	case WakeActionPausing, WakeActionBadState:
+		return http.StatusConflict, true
+	case WakeActionGone:
+		return http.StatusGone, true
+	case WakeActionNotFound:
+		return http.StatusNotFound, true
+	default:
+		return 0, false
+	}
+}

--- a/pkg/proxy/wake_handler_test.go
+++ b/pkg/proxy/wake_handler_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+	"github.com/openkruise/agents/pkg/servers/web"
+)
+
+func TestHandleWakeActionStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		action     WakeAction
+		expectCode int
+	}{
+		{
+			name:       "resumed returns ok",
+			action:     WakeActionResumed,
+			expectCode: http.StatusOK,
+		},
+		{
+			name:       "already running returns ok",
+			action:     WakeActionAlreadyRunning,
+			expectCode: http.StatusOK,
+		},
+		{
+			name:       "auto resume disabled returns unprocessable entity",
+			action:     WakeActionAutoResumeDisabled,
+			expectCode: http.StatusUnprocessableEntity,
+		},
+		{
+			name:       "invalid auto resume policy returns unprocessable entity",
+			action:     WakeActionInvalidAutoResumePolicy,
+			expectCode: http.StatusUnprocessableEntity,
+		},
+		{
+			name:       "pausing returns conflict",
+			action:     WakeActionPausing,
+			expectCode: http.StatusConflict,
+		},
+		{
+			name:       "bad state returns conflict",
+			action:     WakeActionBadState,
+			expectCode: http.StatusConflict,
+		},
+		{
+			name:       "gone returns gone",
+			action:     WakeActionGone,
+			expectCode: http.StatusGone,
+		},
+		{
+			name:       "not found returns not found",
+			action:     WakeActionNotFound,
+			expectCode: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewServer(config.SandboxManagerOptions{})
+			s.SetWakeFunc(func(ctx context.Context, id string) (WakeResult, error) {
+				assert.Equal(t, "sandbox-1", id)
+				return WakeResult{
+					Action:          tt.action,
+					Message:         "wake result",
+					State:           "paused",
+					ResourceVersion: "10",
+				}, nil
+			})
+			mux := http.NewServeMux()
+			web.RegisterRoute(mux, http.MethodPost, WakeAPI, s.handleWake)
+
+			req := httptest.NewRequest(http.MethodPost, "/wake/sandbox-1", nil)
+			rr := httptest.NewRecorder()
+
+			mux.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.expectCode, rr.Code)
+			var body WakeResult
+			require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
+			assert.Equal(t, tt.action, body.Action)
+			assert.Equal(t, "wake result", body.Message)
+			assert.Equal(t, "paused", body.State)
+			assert.Equal(t, "10", body.ResourceVersion)
+		})
+	}
+}
+
+func TestHandleWakeJSONIncludesEmptyFields(t *testing.T) {
+	s := NewServer(config.SandboxManagerOptions{})
+	s.SetWakeFunc(func(ctx context.Context, id string) (WakeResult, error) {
+		assert.Equal(t, "sandbox-empty-fields", id)
+		return WakeResult{Action: WakeActionAlreadyRunning}, nil
+	})
+	mux := http.NewServeMux()
+	web.RegisterRoute(mux, http.MethodPost, WakeAPI, s.handleWake)
+
+	req := httptest.NewRequest(http.MethodPost, "/wake/sandbox-empty-fields", nil)
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
+	assert.Equal(t, string(WakeActionAlreadyRunning), body["action"])
+	assert.Contains(t, body, "message")
+	assert.Contains(t, body, "state")
+	assert.Contains(t, body, "resourceVersion")
+	assert.Equal(t, "", body["message"])
+	assert.Equal(t, "", body["state"])
+	assert.Equal(t, "", body["resourceVersion"])
+}
+
+func TestHandleWakeUnsupportedAction(t *testing.T) {
+	s := NewServer(config.SandboxManagerOptions{})
+	s.SetWakeFunc(func(ctx context.Context, id string) (WakeResult, error) {
+		assert.Equal(t, "sandbox-unknown", id)
+		return WakeResult{Action: WakeAction("Unknown")}, nil
+	})
+	mux := http.NewServeMux()
+	web.RegisterRoute(mux, http.MethodPost, WakeAPI, s.handleWake)
+
+	req := httptest.NewRequest(http.MethodPost, "/wake/sandbox-unknown", nil)
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	var body web.ApiError
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
+	assert.Contains(t, body.Message, "unsupported wake action")
+}
+
+func TestHandleWakeEmptyBodyWorksThroughMux(t *testing.T) {
+	s := NewServer(config.SandboxManagerOptions{})
+	s.SetWakeFunc(func(ctx context.Context, id string) (WakeResult, error) {
+		assert.Equal(t, "sandbox-empty-body", id)
+		return WakeResult{
+			Action:          WakeActionResumed,
+			Message:         "resumed",
+			State:           "running",
+			ResourceVersion: "11",
+		}, nil
+	})
+	mux := http.NewServeMux()
+	web.RegisterRoute(mux, http.MethodPost, "/wake/{sandboxID}", s.handleWake)
+
+	req := httptest.NewRequest(http.MethodPost, "/wake/sandbox-empty-body", nil)
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var body WakeResult
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
+	assert.Equal(t, WakeActionResumed, body.Action)
+	assert.Equal(t, "resumed", body.Message)
+	assert.Equal(t, "running", body.State)
+	assert.Equal(t, "11", body.ResourceVersion)
+}
+
+func TestHandleWakeError(t *testing.T) {
+	s := NewServer(config.SandboxManagerOptions{})
+	s.SetWakeFunc(func(ctx context.Context, id string) (WakeResult, error) {
+		return WakeResult{}, errors.New("wake failed")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/wake/sandbox-1", strings.NewReader(""))
+	req.SetPathValue("sandboxID", "sandbox-1")
+
+	resp, apiErr := s.handleWake(req)
+
+	assert.Empty(t, resp.Code)
+	require.NotNil(t, apiErr)
+	assert.Equal(t, http.StatusInternalServerError, apiErr.Code)
+	assert.Contains(t, apiErr.Message, "wake failed")
+}
+
+func TestHandleWakeMissingWakeFunc(t *testing.T) {
+	s := NewServer(config.SandboxManagerOptions{})
+	req := httptest.NewRequest(http.MethodPost, "/wake/sandbox-1", nil)
+	req.SetPathValue("sandboxID", "sandbox-1")
+
+	resp, apiErr := s.handleWake(req)
+
+	assert.Empty(t, resp.Code)
+	require.NotNil(t, apiErr)
+	assert.Equal(t, http.StatusInternalServerError, apiErr.Code)
+	assert.Contains(t, apiErr.Message, "wake function is not configured")
+}

--- a/pkg/sandbox-gateway/filter/async.go
+++ b/pkg/sandbox-gateway/filter/async.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
+)
+
+func (f *sandboxFilter) wakeContext() context.Context {
+	f.contextMu.Lock()
+	defer f.contextMu.Unlock()
+
+	if f.cancel == nil {
+		f.context, f.cancel = context.WithCancel(context.Background())
+	}
+	return f.context
+}
+
+func (f *sandboxFilter) OnDestroy(api.DestroyReason) {
+	// Claim the completeOnce slot so any in-flight wake goroutine that finishes
+	// after Envoy destroys the filter cannot invoke callbacks on freed memory.
+	f.completeOnce.Do(func() {})
+	f.cancelWakeContext()
+}
+
+func (f *sandboxFilter) cancelWakeContext() {
+	f.contextMu.Lock()
+	cancel := f.cancel
+	f.contextMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (f *sandboxFilter) completeWithReply(status int, body string, headers map[string]string, code string) {
+	if status == 0 {
+		return
+	}
+	f.completeOnce.Do(func() {
+		f.callbacks.DecoderFilterCallbacks().SendLocalReply(status, body, toReplyHeaders(headers), -1, code)
+	})
+}
+
+func (f *sandboxFilter) completeWithContinue(upstreamHost string) {
+	f.completeOnce.Do(func() {
+		f.callbacks.StreamInfo().DynamicMetadata().Set("envoy.lb.original_dst", "host", upstreamHost)
+		f.callbacks.DecoderFilterCallbacks().Continue(api.Continue)
+	})
+}
+
+func toRetryAfterHeader(retryAfter int) map[string]string {
+	if retryAfter < 0 {
+		return nil
+	}
+	return map[string]string{"Retry-After": strconv.Itoa(retryAfter)}
+}
+
+func toReplyHeaders(headers map[string]string) map[string][]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	result := make(map[string][]string, len(headers))
+	for k, v := range headers {
+		result[k] = []string{v}
+	}
+	return result
+}

--- a/pkg/sandbox-gateway/filter/config.go
+++ b/pkg/sandbox-gateway/filter/config.go
@@ -17,14 +17,17 @@ limitations under the License.
 package filter
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 
 	v3 "github.com/cncf/xds/go/xds/type/v3"
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	"github.com/openkruise/agents/pkg/sandbox-gateway/wake"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 )
 
@@ -33,6 +36,10 @@ const (
 	DefaultSandboxHeaderName = "e2b-sandbox-id"
 	DefaultSandboxPortHeader = "e2b-sandbox-port"
 	DefaultSandboxPort       = "49983"
+	DefaultManagerNamespace  = "sandbox-system"
+	DefaultManagerPort       = "7789"
+	EnvSandboxManagerURL     = "SANDBOX_MANAGER_URL"
+	EnvPeerNamespace         = "PEER_NAMESPACE"
 )
 
 // Config holds the filter configuration
@@ -45,6 +52,8 @@ type Config struct {
 	HostHeaderName string `json:"host-header-name,omitempty"`
 	// DefaultPort is the default port if not specified
 	DefaultPort string `json:"default-port,omitempty"`
+	// ManagerURL is the sandbox-manager internal URL used for wake-on-traffic.
+	ManagerURL string `json:"manager-url,omitempty"`
 }
 
 // DefaultConfig returns default configuration
@@ -54,6 +63,7 @@ func DefaultConfig() *Config {
 		SandboxPortHeader: DefaultSandboxPortHeader,
 		HostHeaderName:    DefaultHostHeaderName,
 		DefaultPort:       DefaultSandboxPort,
+		ManagerURL:        defaultManagerURL(),
 	}
 }
 
@@ -97,14 +107,41 @@ func (c *Config) GetDefaultPort() int {
 	return p
 }
 
+func (c *Config) GetManagerURL() string {
+	if c.ManagerURL != "" {
+		return c.ManagerURL
+	}
+	return defaultManagerURL()
+}
+
+func defaultManagerURL() string {
+	if managerURL := os.Getenv(EnvSandboxManagerURL); managerURL != "" {
+		return managerURL
+	}
+	namespace := os.Getenv(EnvPeerNamespace)
+	if namespace == "" {
+		namespace = DefaultManagerNamespace
+	}
+	return fmt.Sprintf("http://sandbox-manager.%s.svc.cluster.local:%s", namespace, DefaultManagerPort)
+}
+
+type WakeClient interface {
+	WakeAndWait(ctx context.Context, sandboxID string) error
+}
+
 // FilterConfig wraps Config and holds the adapter created from the config
 type FilterConfig struct {
 	*Config
-	Adapter *adapters.E2BAdapter
+	Adapter    *adapters.E2BAdapter
+	WakeClient WakeClient
 }
 
 // NewFilterConfig creates a FilterConfig with an adapter built from the config values
 func NewFilterConfig(cfg *Config) *FilterConfig {
+	return NewFilterConfigWithWakeClient(cfg, wake.NewModule(cfg.GetManagerURL()))
+}
+
+func NewFilterConfigWithWakeClient(cfg *Config, wakeClient WakeClient) *FilterConfig {
 	adapter := adapters.NewE2BAdapterWithOptions(
 		0, // port not used by gateway
 		adapters.E2BAdapterOptions{
@@ -115,12 +152,23 @@ func NewFilterConfig(cfg *Config) *FilterConfig {
 		},
 	)
 	return &FilterConfig{
-		Config:  cfg,
-		Adapter: adapter,
+		Config:     cfg,
+		Adapter:    adapter,
+		WakeClient: wakeClient,
 	}
 }
 
-type ConfigParser struct{}
+type ConfigParser struct {
+	defaultManagerURL string
+	defaultWakeClient WakeClient
+}
+
+func NewConfigParserWithWakeClient(managerURL string, wakeClient WakeClient) *ConfigParser {
+	return &ConfigParser{
+		defaultManagerURL: managerURL,
+		defaultWakeClient: wakeClient,
+	}
+}
 
 func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {
 	cfg := DefaultConfig()
@@ -135,7 +183,7 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 	valueStruct := typedStruct.GetValue()
 	if valueStruct == nil {
 		// No value field, use defaults
-		return NewFilterConfig(cfg), nil
+		return p.newFilterConfig(cfg), nil
 	}
 
 	// Convert the struct to JSON
@@ -156,7 +204,7 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 		return nil, err
 	}
 
-	return NewFilterConfig(cfg), nil
+	return p.newFilterConfig(cfg), nil
 }
 
 func (p *ConfigParser) Merge(parent interface{}, child interface{}) interface{} {
@@ -179,6 +227,23 @@ func (p *ConfigParser) Merge(parent interface{}, child interface{}) interface{} 
 	if childCfg.DefaultPort != "" {
 		merged.DefaultPort = childCfg.DefaultPort
 	}
+	if childCfg.ManagerURL != "" {
+		merged.ManagerURL = childCfg.ManagerURL
+	}
 
-	return NewFilterConfig(merged)
+	return parentCfg.newRelatedFilterConfig(merged)
+}
+
+func (p *ConfigParser) newFilterConfig(cfg *Config) *FilterConfig {
+	if p != nil && p.defaultWakeClient != nil && cfg.GetManagerURL() == p.defaultManagerURL {
+		return NewFilterConfigWithWakeClient(cfg, p.defaultWakeClient)
+	}
+	return NewFilterConfig(cfg)
+}
+
+func (fc *FilterConfig) newRelatedFilterConfig(cfg *Config) *FilterConfig {
+	if fc != nil && fc.WakeClient != nil && cfg.GetManagerURL() == fc.GetManagerURL() {
+		return NewFilterConfigWithWakeClient(cfg, fc.WakeClient)
+	}
+	return NewFilterConfig(cfg)
 }

--- a/pkg/sandbox-gateway/filter/config_test.go
+++ b/pkg/sandbox-gateway/filter/config_test.go
@@ -133,6 +133,9 @@ func TestGetHostHeaderName(t *testing.T) {
 }
 
 func TestDefaultConfig(t *testing.T) {
+	t.Setenv(EnvSandboxManagerURL, "")
+	t.Setenv(EnvPeerNamespace, DefaultManagerNamespace)
+
 	cfg := DefaultConfig()
 	if cfg.SandboxHeaderName != "e2b-sandbox-id" {
 		t.Errorf("DefaultConfig().SandboxHeaderName = %q, want %q", cfg.SandboxHeaderName, "e2b-sandbox-id")
@@ -145,6 +148,44 @@ func TestDefaultConfig(t *testing.T) {
 	}
 	if cfg.DefaultPort != "49983" {
 		t.Errorf("DefaultConfig().DefaultPort = %q, want %q", cfg.DefaultPort, "49983")
+	}
+	if cfg.ManagerURL != "http://sandbox-manager.sandbox-system.svc.cluster.local:7789" {
+		t.Errorf("DefaultConfig().ManagerURL = %q, want %q", cfg.ManagerURL, "http://sandbox-manager.sandbox-system.svc.cluster.local:7789")
+	}
+}
+
+func TestDefaultConfigManagerURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		manager   string
+		namespace string
+		want      string
+	}{
+		{
+			name:    "manager url env overrides namespace fallback",
+			manager: "http://manager.internal:7789",
+			want:    "http://manager.internal:7789",
+		},
+		{
+			name:      "namespace fallback",
+			namespace: "custom-system",
+			want:      "http://sandbox-manager.custom-system.svc.cluster.local:7789",
+		},
+		{
+			name: "default namespace fallback",
+			want: "http://sandbox-manager.sandbox-system.svc.cluster.local:7789",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(EnvSandboxManagerURL, tt.manager)
+			t.Setenv(EnvPeerNamespace, tt.namespace)
+
+			if got := DefaultConfig().ManagerURL; got != tt.want {
+				t.Fatalf("ManagerURL = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -167,6 +208,9 @@ func helperTypedStructAny(t *testing.T, fields map[string]interface{}) *anypb.An
 }
 
 func TestConfigParserParse(t *testing.T) {
+	t.Setenv(EnvSandboxManagerURL, "")
+	t.Setenv(EnvPeerNamespace, DefaultManagerNamespace)
+
 	parser := &ConfigParser{}
 
 	tests := []struct {
@@ -177,6 +221,7 @@ func TestConfigParserParse(t *testing.T) {
 		wantHostHeader    string
 		wantPortHeader    string
 		wantDefaultPort   string
+		wantManagerURL    string
 	}{
 		{
 			name:              "nil value in TypedStruct returns defaults",
@@ -185,6 +230,7 @@ func TestConfigParserParse(t *testing.T) {
 			wantHostHeader:    DefaultHostHeaderName,
 			wantPortHeader:    DefaultSandboxPortHeader,
 			wantDefaultPort:   DefaultSandboxPort,
+			wantManagerURL:    "http://sandbox-manager.sandbox-system.svc.cluster.local:7789",
 		},
 		{
 			name:              "empty struct returns defaults",
@@ -193,6 +239,7 @@ func TestConfigParserParse(t *testing.T) {
 			wantHostHeader:    DefaultHostHeaderName,
 			wantPortHeader:    DefaultSandboxPortHeader,
 			wantDefaultPort:   DefaultSandboxPort,
+			wantManagerURL:    "http://sandbox-manager.sandbox-system.svc.cluster.local:7789",
 		},
 		{
 			name:              "custom sandbox header",
@@ -201,6 +248,7 @@ func TestConfigParserParse(t *testing.T) {
 			wantHostHeader:    DefaultHostHeaderName,
 			wantPortHeader:    DefaultSandboxPortHeader,
 			wantDefaultPort:   DefaultSandboxPort,
+			wantManagerURL:    "http://sandbox-manager.sandbox-system.svc.cluster.local:7789",
 		},
 		{
 			name:              "all custom values",
@@ -209,6 +257,7 @@ func TestConfigParserParse(t *testing.T) {
 			wantHostHeader:    "X-Forwarded-Host",
 			wantPortHeader:    "x-port",
 			wantDefaultPort:   "8080",
+			wantManagerURL:    "http://custom-manager:7789",
 		},
 	}
 
@@ -229,6 +278,7 @@ func TestConfigParserParse(t *testing.T) {
 		"host-header-name":    "X-Forwarded-Host",
 		"sandbox-port-header": "x-port",
 		"default-port":        "8080",
+		"manager-url":         "http://custom-manager:7789",
 	})
 
 	for _, tt := range tests {
@@ -256,8 +306,14 @@ func TestConfigParserParse(t *testing.T) {
 			if fc.DefaultPort != tt.wantDefaultPort && tt.wantDefaultPort != "" {
 				t.Errorf("DefaultPort = %q, want %q", fc.DefaultPort, tt.wantDefaultPort)
 			}
+			if got := fc.GetManagerURL(); got != tt.wantManagerURL {
+				t.Errorf("ManagerURL = %q, want %q", got, tt.wantManagerURL)
+			}
 			if fc.Adapter == nil {
 				t.Error("Parse() returned FilterConfig with nil Adapter")
+			}
+			if fc.WakeClient == nil {
+				t.Error("Parse() returned FilterConfig with nil WakeClient")
 			}
 		})
 	}
@@ -279,6 +335,9 @@ func TestConfigParserParseInvalidAny(t *testing.T) {
 }
 
 func TestConfigParserMerge(t *testing.T) {
+	t.Setenv(EnvSandboxManagerURL, "")
+	t.Setenv(EnvPeerNamespace, DefaultManagerNamespace)
+
 	parser := &ConfigParser{}
 
 	tests := []struct {
@@ -289,24 +348,27 @@ func TestConfigParserMerge(t *testing.T) {
 		wantHostHeader    string
 		wantPortHeader    string
 		wantDefaultPort   string
+		wantManagerURL    string
 	}{
 		{
 			name:              "child overrides all parent fields",
 			parent:            DefaultConfig(),
-			child:             &Config{SandboxHeaderName: "child-sbx", HostHeaderName: "child-host", SandboxPortHeader: "child-port", DefaultPort: "9999"},
+			child:             &Config{SandboxHeaderName: "child-sbx", HostHeaderName: "child-host", SandboxPortHeader: "child-port", DefaultPort: "9999", ManagerURL: "http://child-manager:7789"},
 			wantSandboxHeader: "child-sbx",
 			wantHostHeader:    "child-host",
 			wantPortHeader:    "child-port",
 			wantDefaultPort:   "9999",
+			wantManagerURL:    "http://child-manager:7789",
 		},
 		{
 			name:              "empty child preserves parent",
-			parent:            &Config{SandboxHeaderName: "parent-sbx", HostHeaderName: "parent-host", SandboxPortHeader: "parent-port", DefaultPort: "1234"},
+			parent:            &Config{SandboxHeaderName: "parent-sbx", HostHeaderName: "parent-host", SandboxPortHeader: "parent-port", DefaultPort: "1234", ManagerURL: "http://parent-manager:7789"},
 			child:             &Config{},
 			wantSandboxHeader: "parent-sbx",
 			wantHostHeader:    "parent-host",
 			wantPortHeader:    "parent-port",
 			wantDefaultPort:   "1234",
+			wantManagerURL:    "http://parent-manager:7789",
 		},
 		{
 			name:              "partial child override",
@@ -316,6 +378,7 @@ func TestConfigParserMerge(t *testing.T) {
 			wantHostHeader:    DefaultHostHeaderName,
 			wantPortHeader:    DefaultSandboxPortHeader,
 			wantDefaultPort:   DefaultSandboxPort,
+			wantManagerURL:    "http://sandbox-manager.sandbox-system.svc.cluster.local:7789",
 		},
 		{
 			name:              "both defaults",
@@ -325,6 +388,7 @@ func TestConfigParserMerge(t *testing.T) {
 			wantHostHeader:    DefaultHostHeaderName,
 			wantPortHeader:    DefaultSandboxPortHeader,
 			wantDefaultPort:   DefaultSandboxPort,
+			wantManagerURL:    "http://sandbox-manager.sandbox-system.svc.cluster.local:7789",
 		},
 	}
 
@@ -350,8 +414,14 @@ func TestConfigParserMerge(t *testing.T) {
 			if fc.DefaultPort != tt.wantDefaultPort {
 				t.Errorf("DefaultPort = %q, want %q", fc.DefaultPort, tt.wantDefaultPort)
 			}
+			if got := fc.GetManagerURL(); got != tt.wantManagerURL {
+				t.Errorf("ManagerURL = %q, want %q", got, tt.wantManagerURL)
+			}
 			if fc.Adapter == nil {
 				t.Error("Merge() returned FilterConfig with nil Adapter")
+			}
+			if fc.WakeClient == nil {
+				t.Error("Merge() returned FilterConfig with nil WakeClient")
 			}
 		})
 	}

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -17,14 +17,19 @@ limitations under the License.
 package filter
 
 import (
-	"fmt"
+	"context"
+	"net"
+	"strconv"
+	"sync"
 
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/proxy"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/wake"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 )
 
@@ -42,28 +47,31 @@ func FilterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.Strea
 		callbacks: callbacks,
 		config:    cfg.Config,
 		adapter:   cfg.Adapter,
+		wake:      cfg.WakeClient,
 	}
 }
 
 type sandboxFilter struct {
 	api.PassThroughStreamFilter
-	callbacks api.FilterCallbackHandler
-	config    *Config
-	adapter   *adapters.E2BAdapter
+	callbacks    api.FilterCallbackHandler
+	config       *Config
+	adapter      *adapters.E2BAdapter
+	wake         WakeClient
+	completeOnce sync.Once
+	contextMu    sync.Mutex
+	context      context.Context
+	cancel       context.CancelFunc
 }
 
-func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream bool) api.StatusType {
-	// Step 1: Build flat headers map from the request, including pseudo-headers
+func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, _ bool) api.StatusType {
 	headers := make(map[string]string)
 	header.Range(func(key, value string) bool {
 		headers[key] = value
 		return true
 	})
 
-	// Step 2: Use adapter.ParseRequest to normalize the request
 	parsed := f.adapter.ParseRequest(headers)
 
-	// Step 3: Use the unified adapter to extract sandbox ID and port
 	sandboxID, sandboxPort, extraHeaders, err := f.adapter.Map(parsed)
 	if err != nil {
 		logger.Debug("Adapter could not extract sandbox info, continuing",
@@ -75,8 +83,7 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 
 	logger.Debug("DecodeHeaders: adapter mapped request",
 		zap.String("sandboxID", sandboxID),
-		zap.Int("sandboxPort", sandboxPort),
-		zap.Any("extraHeaders", extraHeaders))
+		zap.Int("sandboxPort", sandboxPort))
 
 	// Look up the pod IP from registry
 	route, ok := registry.GetRegistry().Get(sandboxID)
@@ -92,7 +99,12 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 		return api.LocalReply
 	}
 
-	if route.State != agentsv1alpha1.SandboxStateRunning {
+	if route.State == agentsv1alpha1.SandboxStateRunning {
+		f.applyRoute(header, extraHeaders, route, sandboxPort)
+		return api.Continue
+	}
+
+	if !(route.State == agentsv1alpha1.SandboxStatePaused && route.Pausable && route.WakeOnTraffic != "") {
 		logger.Warn("Sandbox is not running", zap.String("sandboxID", sandboxID), zap.String("state", route.State))
 		f.callbacks.DecoderFilterCallbacks().SendLocalReply(
 			502,
@@ -104,14 +116,69 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 		return api.LocalReply
 	}
 
-	// Apply extra headers from the adapter (e.g., :path rewrite for kruise custom protocol)
+	if f.wake == nil {
+		logger.Error("Wake client is not configured", zap.String("sandboxID", sandboxID))
+		f.callbacks.DecoderFilterCallbacks().SendLocalReply(
+			503,
+			"failed to wake sandbox",
+			toReplyHeaders(toRetryAfterHeader(5)),
+			-1,
+			"sandbox_wake_failed",
+		)
+		return api.LocalReply
+	}
+
 	for k, v := range extraHeaders {
 		header.Set(k, v)
 	}
 
-	upstreamHost := fmt.Sprintf("%s:%d", route.IP, sandboxPort)
+	filterCtx := f.wakeContext()
+	go f.wakeAndContinue(filterCtx, sandboxID, sandboxPort)
+
+	return api.Running
+}
+
+func (f *sandboxFilter) wakeAndContinue(ctx context.Context, sandboxID string, sandboxPort int) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			f.cancelWakeContext()
+			logger.Error("Wake goroutine panicked", zap.String("sandboxID", sandboxID), zap.Any("panic", recovered))
+			f.completeWithReply(500, "wake filter panic", nil, "sandbox_wake_panic")
+		}
+	}()
+
+	if err := f.wake.WakeAndWait(ctx, sandboxID); err != nil {
+		status, body, retryAfter, code := wake.MapErrToReply(err)
+		f.completeWithReply(status, body, toRetryAfterHeader(retryAfter), code)
+		return
+	}
+
+	route, ok := registry.GetRegistry().Get(sandboxID)
+	if !ok {
+		f.completeWithReply(502, "sandbox not found: "+sandboxID, nil, "sandbox_not_found")
+		return
+	}
+	if route.State != agentsv1alpha1.SandboxStateRunning {
+		f.completeWithReply(502, "healthy sandbox not found: "+sandboxID, nil, "sandbox_not_running")
+		return
+	}
+
+	upstreamHost := upstreamHost(route.IP, sandboxPort)
+	logger.Debug("Upstream override set successfully", zap.String("upstreamHost", upstreamHost))
+	f.completeWithContinue(upstreamHost)
+}
+
+func (f *sandboxFilter) applyRoute(header api.RequestHeaderMap, extraHeaders map[string]string, route proxy.Route, sandboxPort int) {
+	for k, v := range extraHeaders {
+		header.Set(k, v)
+	}
+
+	upstreamHost := upstreamHost(route.IP, sandboxPort)
 	f.callbacks.StreamInfo().DynamicMetadata().Set("envoy.lb.original_dst", "host", upstreamHost)
 
 	logger.Debug("Upstream override set successfully", zap.String("upstreamHost", upstreamHost))
-	return api.Continue
+}
+
+func upstreamHost(ip string, port int) string {
+	return net.JoinHostPort(ip, strconv.Itoa(port))
 }

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -17,14 +17,23 @@ limitations under the License.
 package filter
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/proxy"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/wake"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 )
 
@@ -193,6 +202,7 @@ func defaultTestAdapter() *adapters.E2BAdapter {
 
 // mockDynamicMetadata implements api.DynamicMetadata for testing
 type mockDynamicMetadata struct {
+	mu   sync.Mutex
 	data map[string]map[string]interface{}
 }
 
@@ -201,14 +211,27 @@ func newMockDynamicMetadata() *mockDynamicMetadata {
 }
 
 func (m *mockDynamicMetadata) Get(filterName string) map[string]interface{} {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.data[filterName]
 }
 
 func (m *mockDynamicMetadata) Set(filterName string, key string, value interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.data[filterName] == nil {
 		m.data[filterName] = make(map[string]interface{})
 	}
 	m.data[filterName][key] = value
+}
+
+func (m *mockDynamicMetadata) Value(filterName string, key string) interface{} {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.data[filterName] == nil {
+		return nil
+	}
+	return m.data[filterName][key]
 }
 
 // mockStreamInfo implements api.StreamInfo for testing
@@ -241,28 +264,62 @@ func (m *mockStreamInfo) WorkerID() uint32                      { return 0 }
 
 // mockDecoderFilterCallbacks implements api.DecoderFilterCallbacks for testing
 type mockDecoderFilterCallbacks struct {
+	mu                   sync.Mutex
 	sendLocalReplyCalled bool
 	replyStatusCode      int
 	replyBody            string
 	replyDetails         string
+	replyHeaders         map[string][]string
+	continueCalled       bool
+	continueStatus       api.StatusType
 }
 
-func (m *mockDecoderFilterCallbacks) Continue(statusType api.StatusType) {}
+func (m *mockDecoderFilterCallbacks) Continue(statusType api.StatusType) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.continueCalled = true
+	m.continueStatus = statusType
+}
 
-func (m *mockDecoderFilterCallbacks) SendLocalReply(responseCode int, bodyText string, headers map[string][]string, grpcStatus int64, details string) {
+func (m *mockDecoderFilterCallbacks) SendLocalReply(responseCode int, bodyText string, headers map[string][]string, _ int64, details string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.sendLocalReplyCalled = true
 	m.replyStatusCode = responseCode
 	m.replyBody = bodyText
 	m.replyDetails = details
+	m.replyHeaders = headers
+}
+
+func (m *mockDecoderFilterCallbacks) HasContinued() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.continueCalled
+}
+
+func (m *mockDecoderFilterCallbacks) HasLocalReply() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.sendLocalReplyCalled
+}
+
+func (m *mockDecoderFilterCallbacks) Snapshot() (bool, int, string, string, map[string][]string, bool, api.StatusType) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	headers := make(map[string][]string, len(m.replyHeaders))
+	for k, values := range m.replyHeaders {
+		headers[k] = append([]string(nil), values...)
+	}
+	return m.sendLocalReplyCalled, m.replyStatusCode, m.replyBody, m.replyDetails, headers, m.continueCalled, m.continueStatus
 }
 
 func (m *mockDecoderFilterCallbacks) RecoverPanic() {}
 
-func (m *mockDecoderFilterCallbacks) AddData(data []byte, isStreaming bool) {}
+func (m *mockDecoderFilterCallbacks) AddData([]byte, bool) {}
 
-func (m *mockDecoderFilterCallbacks) InjectData(data []byte) {}
+func (m *mockDecoderFilterCallbacks) InjectData([]byte) {}
 
-func (m *mockDecoderFilterCallbacks) SetUpstreamOverrideHost(host string, strict bool) error {
+func (m *mockDecoderFilterCallbacks) SetUpstreamOverrideHost(string, bool) error {
 	return nil
 }
 
@@ -287,11 +344,11 @@ func (m *mockFilterCallbackHandler) ClearRouteCache() {}
 
 func (m *mockFilterCallbackHandler) RefreshRouteCache() {}
 
-func (m *mockFilterCallbackHandler) Log(level api.LogType, msg string) {}
+func (m *mockFilterCallbackHandler) Log(api.LogType, string) {}
 
 func (m *mockFilterCallbackHandler) LogLevel() api.LogType { return api.Info }
 
-func (m *mockFilterCallbackHandler) GetProperty(key string) (string, error) {
+func (m *mockFilterCallbackHandler) GetProperty(string) (string, error) {
 	return "", nil
 }
 
@@ -303,6 +360,39 @@ func (m *mockFilterCallbackHandler) DecoderFilterCallbacks() api.DecoderFilterCa
 
 func (m *mockFilterCallbackHandler) EncoderFilterCallbacks() api.EncoderFilterCallbacks {
 	return nil
+}
+
+type fakeWakeModule struct {
+	err        error
+	panic      bool
+	calls      atomic.Int32
+	onCall     func(ctx context.Context, sandboxID string) error
+	called     chan struct{}
+	calledOnce sync.Once
+	release    chan struct{}
+}
+
+func (m *fakeWakeModule) WakeAndWait(ctx context.Context, sandboxID string) error {
+	m.calls.Add(1)
+	if m.called != nil {
+		m.calledOnce.Do(func() {
+			close(m.called)
+		})
+	}
+	if m.panic {
+		panic("wake panic")
+	}
+	if m.onCall != nil {
+		return m.onCall(ctx, sandboxID)
+	}
+	if m.release != nil {
+		select {
+		case <-m.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return m.err
 }
 
 // TestDecodeHeadersSandboxHeaderPriority tests that sandbox header takes priority over host header
@@ -640,7 +730,7 @@ func TestDecodeHeadersWithIPv6(t *testing.T) {
 	// Verify dynamic metadata was set correctly
 	metadata := mockCallbacks.streamInfo.dynamicMetadata.data["envoy.lb.original_dst"]
 	assert.NotNil(t, metadata)
-	assert.Equal(t, "2001:db8::1:49983", metadata["host"])
+	assert.Equal(t, "[2001:db8::1]:49983", metadata["host"])
 }
 
 // TestDecodeHeadersWithIPv6HostFallback tests IPv6 via host header
@@ -669,7 +759,7 @@ func TestDecodeHeadersWithIPv6HostFallback(t *testing.T) {
 	// Verify dynamic metadata was set correctly
 	metadata := mockCallbacks.streamInfo.dynamicMetadata.data["envoy.lb.original_dst"]
 	assert.NotNil(t, metadata)
-	assert.Equal(t, "2001:db8::1:8080", metadata["host"])
+	assert.Equal(t, "[2001:db8::1]:8080", metadata["host"])
 }
 
 // TestDecodeHeadersEmptySandboxID tests the case when sandbox-id header is empty string
@@ -929,4 +1019,402 @@ func TestDecodeHeadersKruiseCustomProtocolInvalidPath(t *testing.T) {
 	// Should pass through since adapter returns error
 	assert.Equal(t, api.Continue, status)
 	assert.False(t, mockCallbacks.decoderCallbacks.sendLocalReplyCalled)
+}
+
+func TestDecodeHeadersWakeGateMatrix(t *testing.T) {
+	tests := []struct {
+		name          string
+		state         string
+		pausable      bool
+		wakeOnTraffic string
+		wantStatus    api.StatusType
+		wantWakeCall  bool
+	}{
+		{
+			name:          "paused pausable with wake policy starts async wake",
+			state:         agentsv1alpha1.SandboxStatePaused,
+			pausable:      true,
+			wakeOnTraffic: "timeout:5m",
+			wantStatus:    api.Running,
+			wantWakeCall:  true,
+		},
+		{
+			name:          "paused but not pausable stays local reply",
+			state:         agentsv1alpha1.SandboxStatePaused,
+			pausable:      false,
+			wakeOnTraffic: "timeout:5m",
+			wantStatus:    api.LocalReply,
+		},
+		{
+			name:         "paused without wake policy stays local reply",
+			state:        agentsv1alpha1.SandboxStatePaused,
+			pausable:     true,
+			wantStatus:   api.LocalReply,
+			wantWakeCall: false,
+		},
+		{
+			name:          "non-paused state stays local reply",
+			state:         agentsv1alpha1.SandboxStateCreating,
+			pausable:      true,
+			wakeOnTraffic: "timeout:5m",
+			wantStatus:    api.LocalReply,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := registry.GetRegistry()
+			defer r.Clear()
+			sandboxID := "default--wake-gate"
+			r.Update(sandboxID, proxy.Route{
+				IP:              "10.0.0.9",
+				State:           tt.state,
+				ResourceVersion: "1",
+				Pausable:        tt.pausable,
+				WakeOnTraffic:   tt.wakeOnTraffic,
+			})
+
+			wakeClient := &fakeWakeModule{
+				onCall: func(ctx context.Context, sandboxID string) error {
+					r.Update(sandboxID, proxy.Route{
+						IP:              "10.0.0.10",
+						State:           agentsv1alpha1.SandboxStateRunning,
+						ResourceVersion: "2",
+					})
+					return nil
+				},
+			}
+			mockCallbacks := newMockFilterCallbackHandler()
+			filter := &sandboxFilter{callbacks: mockCallbacks, config: DefaultConfig(), adapter: defaultTestAdapter(), wake: wakeClient}
+			header := newMockRequestHeaderMap()
+			header.Set(DefaultSandboxHeaderName, sandboxID)
+
+			status := filter.DecodeHeaders(header, true)
+			assert.Equal(t, tt.wantStatus, status)
+
+			if tt.wantWakeCall {
+				require.Eventually(t, func() bool {
+					return mockCallbacks.decoderCallbacks.HasContinued()
+				}, time.Second, 10*time.Millisecond)
+				assert.Equal(t, int32(1), wakeClient.calls.Load())
+				sendLocalReplyCalled, _, _, _, _, _, _ := mockCallbacks.decoderCallbacks.Snapshot()
+				assert.False(t, sendLocalReplyCalled)
+				assert.Equal(t, "10.0.0.10:49983", mockCallbacks.streamInfo.dynamicMetadata.Value("envoy.lb.original_dst", "host"))
+				return
+			}
+
+			assert.True(t, mockCallbacks.decoderCallbacks.sendLocalReplyCalled)
+			assert.Equal(t, 502, mockCallbacks.decoderCallbacks.replyStatusCode)
+			assert.Equal(t, "sandbox_not_running", mockCallbacks.decoderCallbacks.replyDetails)
+			assert.Equal(t, int32(0), wakeClient.calls.Load())
+		})
+	}
+}
+
+func TestDecodeHeadersWakeErrorReplies(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            error
+		wantStatus     int
+		wantRetryAfter string
+		wantDetails    string
+	}{
+		{
+			name:        "auto resume disabled",
+			err:         wake.ErrAutoResumeDisabled,
+			wantStatus:  http.StatusBadGateway,
+			wantDetails: "sandbox_not_running",
+		},
+		{
+			name:           "invalid policy",
+			err:            wake.ErrInvalidPolicy,
+			wantStatus:     http.StatusServiceUnavailable,
+			wantRetryAfter: "0",
+			wantDetails:    "sandbox_wake_invalid_policy",
+		},
+		{
+			name:           "pausing",
+			err:            wake.ErrPausing,
+			wantStatus:     http.StatusServiceUnavailable,
+			wantRetryAfter: "5",
+			wantDetails:    "sandbox_wake_pausing",
+		},
+		{
+			name:           "bad state",
+			err:            wake.ErrBadState,
+			wantStatus:     http.StatusServiceUnavailable,
+			wantRetryAfter: "15",
+			wantDetails:    "sandbox_wake_bad_state",
+		},
+		{
+			name:        "gone",
+			err:         wake.ErrGone,
+			wantStatus:  http.StatusBadGateway,
+			wantDetails: "sandbox_not_found",
+		},
+		{
+			name:           "transport",
+			err:            wake.ErrTransport,
+			wantStatus:     http.StatusServiceUnavailable,
+			wantRetryAfter: "5",
+			wantDetails:    "sandbox_wake_failed",
+		},
+		{
+			name:           "unknown error",
+			err:            errors.New("boom"),
+			wantStatus:     http.StatusServiceUnavailable,
+			wantRetryAfter: "5",
+			wantDetails:    "sandbox_wake_failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := registry.GetRegistry()
+			defer r.Clear()
+			sandboxID := "default--wake-error"
+			r.Update(sandboxID, proxy.Route{
+				IP:              "10.0.0.9",
+				State:           agentsv1alpha1.SandboxStatePaused,
+				ResourceVersion: "1",
+				Pausable:        true,
+				WakeOnTraffic:   "timeout:5m",
+			})
+
+			mockCallbacks := newMockFilterCallbackHandler()
+			filter := &sandboxFilter{
+				callbacks: mockCallbacks,
+				config:    DefaultConfig(),
+				adapter:   defaultTestAdapter(),
+				wake:      &fakeWakeModule{err: tt.err},
+			}
+			header := newMockRequestHeaderMap()
+			header.Set(DefaultSandboxHeaderName, sandboxID)
+
+			status := filter.DecodeHeaders(header, true)
+			require.Equal(t, api.Running, status)
+			require.Eventually(t, func() bool {
+				return mockCallbacks.decoderCallbacks.HasLocalReply()
+			}, time.Second, 10*time.Millisecond)
+			_, replyStatusCode, _, replyDetails, replyHeaders, _, _ := mockCallbacks.decoderCallbacks.Snapshot()
+			assert.Equal(t, tt.wantStatus, replyStatusCode)
+			assert.Equal(t, tt.wantDetails, replyDetails)
+			if tt.wantRetryAfter == "" {
+				assert.Empty(t, replyHeaders)
+				return
+			}
+			assert.Equal(t, []string{tt.wantRetryAfter}, replyHeaders["Retry-After"])
+		})
+	}
+}
+
+func TestDecodeHeadersWakeOnDestroyCancelsWithoutReply(t *testing.T) {
+	r := registry.GetRegistry()
+	defer r.Clear()
+	sandboxID := "default--wake-destroy"
+	r.Update(sandboxID, proxy.Route{
+		IP:              "10.0.0.9",
+		State:           agentsv1alpha1.SandboxStatePaused,
+		ResourceVersion: "1",
+		Pausable:        true,
+		WakeOnTraffic:   "timeout:5m",
+	})
+
+	called := make(chan struct{})
+	wakeClient := &fakeWakeModule{
+		called: called,
+		onCall: func(ctx context.Context, sandboxID string) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+	mockCallbacks := newMockFilterCallbackHandler()
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: DefaultConfig(), adapter: defaultTestAdapter(), wake: wakeClient}
+	header := newMockRequestHeaderMap()
+	header.Set(DefaultSandboxHeaderName, sandboxID)
+
+	status := filter.DecodeHeaders(header, true)
+	require.Equal(t, api.Running, status)
+	<-called
+
+	require.Never(t, func() bool {
+		return mockCallbacks.decoderCallbacks.HasContinued() || mockCallbacks.decoderCallbacks.HasLocalReply()
+	}, 150*time.Millisecond, 10*time.Millisecond)
+
+	filter.OnDestroy(api.Terminate)
+	require.Never(t, func() bool {
+		return mockCallbacks.decoderCallbacks.HasContinued() || mockCallbacks.decoderCallbacks.HasLocalReply()
+	}, 150*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestDecodeHeadersWakePanicRecovered(t *testing.T) {
+	r := registry.GetRegistry()
+	defer r.Clear()
+	sandboxID := "default--wake-panic"
+	r.Update(sandboxID, proxy.Route{
+		IP:              "10.0.0.9",
+		State:           agentsv1alpha1.SandboxStatePaused,
+		ResourceVersion: "1",
+		Pausable:        true,
+		WakeOnTraffic:   "timeout:5m",
+	})
+
+	var wakeCtx context.Context
+	wakeClient := &fakeWakeModule{
+		onCall: func(ctx context.Context, sandboxID string) error {
+			wakeCtx = ctx
+			panic("wake panic")
+		},
+	}
+	mockCallbacks := newMockFilterCallbackHandler()
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: DefaultConfig(), adapter: defaultTestAdapter(), wake: wakeClient}
+	header := newMockRequestHeaderMap()
+	header.Set(DefaultSandboxHeaderName, sandboxID)
+
+	status := filter.DecodeHeaders(header, true)
+	require.Equal(t, api.Running, status)
+	require.Eventually(t, func() bool {
+		return mockCallbacks.decoderCallbacks.HasLocalReply()
+	}, time.Second, 10*time.Millisecond)
+	_, replyStatusCode, _, replyDetails, _, _, _ := mockCallbacks.decoderCallbacks.Snapshot()
+	assert.Equal(t, 500, replyStatusCode)
+	assert.Equal(t, "sandbox_wake_panic", replyDetails)
+	require.NotNil(t, wakeCtx)
+	assert.ErrorIs(t, wakeCtx.Err(), context.Canceled)
+}
+
+func TestDecodeHeadersWakeContinuationWithIPv6(t *testing.T) {
+	r := registry.GetRegistry()
+	defer r.Clear()
+	sandboxID := "default--wake-ipv6"
+	r.Update(sandboxID, proxy.Route{
+		IP:              "2001:db8::1",
+		State:           agentsv1alpha1.SandboxStatePaused,
+		ResourceVersion: "1",
+		Pausable:        true,
+		WakeOnTraffic:   "timeout:5m",
+	})
+
+	wakeClient := &fakeWakeModule{
+		onCall: func(ctx context.Context, sandboxID string) error {
+			r.Update(sandboxID, proxy.Route{
+				IP:              "2001:db8::2",
+				State:           agentsv1alpha1.SandboxStateRunning,
+				ResourceVersion: "2",
+			})
+			return nil
+		},
+	}
+	mockCallbacks := newMockFilterCallbackHandler()
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: DefaultConfig(), adapter: defaultTestAdapter(), wake: wakeClient}
+	header := newMockRequestHeaderMap()
+	header.Set(DefaultSandboxHeaderName, sandboxID)
+	header.Set(DefaultSandboxPortHeader, "8080")
+
+	status := filter.DecodeHeaders(header, true)
+	require.Equal(t, api.Running, status)
+	require.Eventually(t, func() bool {
+		return mockCallbacks.decoderCallbacks.HasContinued()
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, "[2001:db8::2]:8080", mockCallbacks.streamInfo.dynamicMetadata.Value("envoy.lb.original_dst", "host"))
+}
+
+func TestDecodeHeadersWakeCustomProtocolAppliesPathRewriteBeforeAsyncWait(t *testing.T) {
+	r := registry.GetRegistry()
+	defer r.Clear()
+	sandboxID := "ns--wake-path"
+	r.Update(sandboxID, proxy.Route{
+		IP:              "10.0.0.9",
+		State:           agentsv1alpha1.SandboxStatePaused,
+		ResourceVersion: "1",
+		Pausable:        true,
+		WakeOnTraffic:   "timeout:5m",
+	})
+
+	called := make(chan struct{})
+	wakeClient := &fakeWakeModule{
+		called: called,
+		onCall: func(ctx context.Context, sandboxID string) error {
+			r.Update(sandboxID, proxy.Route{
+				IP:              "10.0.0.21",
+				State:           agentsv1alpha1.SandboxStateRunning,
+				ResourceVersion: "2",
+			})
+			return nil
+		},
+	}
+	mockCallbacks := newMockFilterCallbackHandler()
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: DefaultConfig(), adapter: defaultTestAdapter(), wake: wakeClient}
+	header := &mockRequestHeaderMapCustom{
+		mockRequestHeaderMap: *newMockRequestHeaderMap(),
+		pathValue:            "/kruise/ns--wake-path/3000/api/v1/data",
+	}
+
+	status := filter.DecodeHeaders(header, true)
+	require.Equal(t, api.Running, status)
+	assert.Equal(t, "/api/v1/data", header.headers[":path"])
+	<-called
+	require.Eventually(t, func() bool {
+		return mockCallbacks.decoderCallbacks.HasContinued()
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, "10.0.0.21:3000", mockCallbacks.streamInfo.dynamicMetadata.Value("envoy.lb.original_dst", "host"))
+}
+
+func TestDecodeHeadersWakeSingleflightContinuesBothStreams(t *testing.T) {
+	r := registry.GetRegistry()
+	defer r.Clear()
+	sandboxID := "default--wake-shared"
+	r.Update(sandboxID, proxy.Route{
+		IP:              "10.0.0.9",
+		State:           agentsv1alpha1.SandboxStatePaused,
+		ResourceVersion: "1",
+		Pausable:        true,
+		WakeOnTraffic:   "timeout:5m",
+	})
+
+	var posts atomic.Int32
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		posts.Add(1)
+		<-release
+		registry.GetRegistry().Update(sandboxID, proxy.Route{
+			IP:              "10.0.0.20",
+			State:           agentsv1alpha1.SandboxStateRunning,
+			ResourceVersion: "2",
+		})
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	wakeClient := wake.NewModuleWithClient(server.URL, server.Client())
+	mockCallbacks1 := newMockFilterCallbackHandler()
+	mockCallbacks2 := newMockFilterCallbackHandler()
+	filter1 := &sandboxFilter{callbacks: mockCallbacks1, config: DefaultConfig(), adapter: defaultTestAdapter(), wake: wakeClient}
+	filter2 := &sandboxFilter{callbacks: mockCallbacks2, config: DefaultConfig(), adapter: defaultTestAdapter(), wake: wakeClient}
+	header1 := newMockRequestHeaderMap()
+	header1.Set(DefaultSandboxHeaderName, sandboxID)
+	header2 := newMockRequestHeaderMap()
+	header2.Set(DefaultSandboxHeaderName, sandboxID)
+
+	status1 := filter1.DecodeHeaders(header1, true)
+	status2 := filter2.DecodeHeaders(header2, true)
+	require.Equal(t, api.Running, status1)
+	require.Equal(t, api.Running, status2)
+	require.Eventually(t, func() bool {
+		return posts.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+	require.Never(t, func() bool {
+		return posts.Load() > 1
+	}, 50*time.Millisecond, 10*time.Millisecond)
+	close(release)
+
+	require.Eventually(t, func() bool {
+		return mockCallbacks1.decoderCallbacks.HasContinued() && mockCallbacks2.decoderCallbacks.HasContinued()
+	}, time.Second, 10*time.Millisecond)
+	sendLocalReplyCalled1, _, _, _, _, _, _ := mockCallbacks1.decoderCallbacks.Snapshot()
+	sendLocalReplyCalled2, _, _, _, _, _, _ := mockCallbacks2.decoderCallbacks.Snapshot()
+	assert.False(t, sendLocalReplyCalled1)
+	assert.False(t, sendLocalReplyCalled2)
+	assert.Equal(t, "10.0.0.20:49983", mockCallbacks1.streamInfo.dynamicMetadata.Value("envoy.lb.original_dst", "host"))
+	assert.Equal(t, "10.0.0.20:49983", mockCallbacks2.streamInfo.dynamicMetadata.Value("envoy.lb.original_dst", "host"))
 }

--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -163,17 +163,15 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 
 	log.V(consts.DebugLogLevel).Info("Received route refresh", "route", route)
 
-	// Handle based on state
-	if route.State == v1alpha1.SandboxStateRunning {
-		// Update the route
+	switch route.State {
+	case v1alpha1.SandboxStateDead, "":
+		registry.GetRegistry().Delete(route.ID)
+	default:
 		if registry.GetRegistry().Update(route.ID, route) {
 			log.Info("Route updated via refresh", "id", route.ID, "ip", route.IP)
 		} else {
 			log.V(consts.DebugLogLevel).Info("Route update skipped due to older resourceVersion", "id", route.ID)
 		}
-	} else {
-		// Delete the route if the sandbox is dead
-		registry.GetRegistry().Delete(route.ID)
 	}
 
 	w.WriteHeader(http.StatusNoContent)

--- a/pkg/sandbox-gateway/server/server_test.go
+++ b/pkg/sandbox-gateway/server/server_test.go
@@ -184,72 +184,6 @@ func TestHandleRefresh_RunningState(t *testing.T) {
 	assert.Equal(t, "test-owner", got.Owner)
 }
 
-func TestHandleRefresh_NonRunningState(t *testing.T) {
-	// Clear registry and add a route first
-	registry.GetRegistry().Clear()
-	registry.GetRegistry().Update("test-sandbox-2", proxy.Route{
-		ID:              "test-sandbox-2",
-		IP:              "10.0.0.2",
-		State:           v1alpha1.SandboxStateRunning,
-		ResourceVersion: "1",
-	})
-
-	s := &Server{}
-
-	// Send a dead state route
-	route := proxy.Route{
-		ID:              "test-sandbox-2",
-		IP:              "10.0.0.2",
-		State:           v1alpha1.SandboxStateDead,
-		ResourceVersion: "2",
-	}
-	body, _ := json.Marshal(route)
-
-	req := httptest.NewRequest(http.MethodPost, proxy.RefreshAPI, bytes.NewReader(body))
-	rr := httptest.NewRecorder()
-
-	s.handleRefresh(rr, req)
-
-	assert.Equal(t, http.StatusNoContent, rr.Code)
-
-	// Verify route was deleted from registry
-	_, ok := registry.GetRegistry().Get("test-sandbox-2")
-	assert.False(t, ok)
-}
-
-func TestHandleRefresh_AvailableState(t *testing.T) {
-	// Clear registry and add a route first
-	registry.GetRegistry().Clear()
-	registry.GetRegistry().Update("test-sandbox-3", proxy.Route{
-		ID:              "test-sandbox-3",
-		IP:              "10.0.0.3",
-		State:           v1alpha1.SandboxStateRunning,
-		ResourceVersion: "1",
-	})
-
-	s := &Server{}
-
-	// Available state is treated as non-running and will delete the route
-	route := proxy.Route{
-		ID:              "test-sandbox-3",
-		IP:              "10.0.0.3",
-		State:           v1alpha1.SandboxStateAvailable,
-		ResourceVersion: "2",
-	}
-	body, _ := json.Marshal(route)
-
-	req := httptest.NewRequest(http.MethodPost, proxy.RefreshAPI, bytes.NewReader(body))
-	rr := httptest.NewRecorder()
-
-	s.handleRefresh(rr, req)
-
-	assert.Equal(t, http.StatusNoContent, rr.Code)
-
-	// Verify route was deleted (only Running state keeps routes)
-	_, ok := registry.GetRegistry().Get("test-sandbox-3")
-	assert.False(t, ok)
-}
-
 func TestHandleRefresh_UpdateExistingRoute(t *testing.T) {
 	// Clear registry and add initial route
 	registry.GetRegistry().Clear()
@@ -282,6 +216,75 @@ func TestHandleRefresh_UpdateExistingRoute(t *testing.T) {
 	got, ok := registry.GetRegistry().Get("test-sandbox-4")
 	assert.True(t, ok)
 	assert.Equal(t, "10.0.0.5", got.IP)
+}
+
+func TestHandleRefresh_StateActions(t *testing.T) {
+	tests := []struct {
+		name        string
+		state       string
+		expectFound bool
+	}{
+		{
+			name:        "paused state retains route",
+			state:       v1alpha1.SandboxStatePaused,
+			expectFound: true,
+		},
+		{
+			name:        "available state retains route",
+			state:       v1alpha1.SandboxStateAvailable,
+			expectFound: true,
+		},
+		{
+			name:        "dead state removes route",
+			state:       v1alpha1.SandboxStateDead,
+			expectFound: false,
+		},
+		{
+			name:        "empty state removes route",
+			state:       "",
+			expectFound: false,
+		},
+		{
+			name:        "running state updates route",
+			state:       v1alpha1.SandboxStateRunning,
+			expectFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry.GetRegistry().Clear()
+			registry.GetRegistry().Update("test-sandbox-refresh", proxy.Route{
+				ID:              "test-sandbox-refresh",
+				IP:              "10.0.0.1",
+				State:           v1alpha1.SandboxStateRunning,
+				ResourceVersion: "1",
+			})
+
+			s := &Server{}
+			route := proxy.Route{
+				ID:              "test-sandbox-refresh",
+				IP:              "10.0.0.2",
+				State:           tt.state,
+				ResourceVersion: "2",
+			}
+			body, err := json.Marshal(route)
+			assert.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, proxy.RefreshAPI, bytes.NewReader(body))
+			rr := httptest.NewRecorder()
+
+			s.handleRefresh(rr, req)
+
+			assert.Equal(t, http.StatusNoContent, rr.Code)
+			got, ok := registry.GetRegistry().Get("test-sandbox-refresh")
+			assert.Equal(t, tt.expectFound, ok)
+			if tt.expectFound {
+				assert.Equal(t, "10.0.0.2", got.IP)
+				assert.Equal(t, tt.state, got.State)
+			}
+		})
+	}
 }
 
 func TestHandleRefresh_EmptyBody(t *testing.T) {

--- a/pkg/sandbox-gateway/wake/wake.go
+++ b/pkg/sandbox-gateway/wake/wake.go
@@ -1,0 +1,275 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wake
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/proxy"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
+)
+
+const (
+	minPollBackoff = 50 * time.Millisecond
+	maxPollBackoff = 500 * time.Millisecond
+)
+
+var (
+	ErrAutoResumeDisabled = errors.New("auto-resume disabled")
+	ErrInvalidPolicy      = errors.New("invalid auto-resume policy")
+	ErrPausing            = errors.New("sandbox is pausing")
+	ErrBadState           = errors.New("sandbox is not resumable")
+	ErrGone               = errors.New("sandbox is gone")
+	ErrNotFound           = errors.New("sandbox not found")
+	ErrTransport          = errors.New("wake transport error")
+)
+
+// Module calls sandbox-manager's internal wake endpoint and waits for the local
+// gateway registry to observe the sandbox as Running.
+type Module struct {
+	managerURL string
+	httpClient *http.Client
+	sf         singleflight.Group
+	flightsMu  sync.Mutex
+	flights    map[string]*flight
+}
+
+type flight struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	waiters int
+	done    bool
+}
+
+func NewModule(managerURL string) *Module {
+	return &Module{
+		managerURL: strings.TrimRight(managerURL, "/"),
+		httpClient: http.DefaultClient,
+	}
+}
+
+func NewModuleWithClient(managerURL string, client *http.Client) *Module {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &Module{
+		managerURL: strings.TrimRight(managerURL, "/"),
+		httpClient: client,
+	}
+}
+
+func (m *Module) ManagerURL() string {
+	if m == nil {
+		return ""
+	}
+	return m.managerURL
+}
+
+func (m *Module) WakeAndWait(ctx context.Context, sandboxID string) error {
+	if m == nil || m.managerURL == "" || m.httpClient == nil {
+		return ErrTransport
+	}
+
+	flight := m.acquireFlight(sandboxID)
+	result := m.sf.DoChan(sandboxID, func() (any, error) {
+		defer m.finishFlight(sandboxID, flight)
+		if err := m.callManager(flight.ctx, sandboxID); err != nil {
+			return nil, err
+		}
+		return nil, waitUntilRunning(flight.ctx, sandboxID)
+	})
+
+	select {
+	case r := <-result:
+		m.releaseFlight(sandboxID, flight)
+		return r.Err
+	case <-ctx.Done():
+		if m.releaseFlight(sandboxID, flight) {
+			<-result
+		}
+		return ctx.Err()
+	}
+}
+
+func (m *Module) acquireFlight(sandboxID string) *flight {
+	m.flightsMu.Lock()
+	defer m.flightsMu.Unlock()
+
+	if m.flights == nil {
+		m.flights = make(map[string]*flight)
+	}
+	f := m.flights[sandboxID]
+	if f == nil || f.done {
+		ctx, cancel := context.WithCancel(context.Background())
+		f = &flight{ctx: ctx, cancel: cancel}
+		m.flights[sandboxID] = f
+	}
+	f.waiters++
+	return f
+}
+
+func (m *Module) releaseFlight(sandboxID string, f *flight) bool {
+	m.flightsMu.Lock()
+	defer m.flightsMu.Unlock()
+
+	if current := m.flights[sandboxID]; current != f || f.done {
+		return false
+	}
+	if f.waiters > 0 {
+		f.waiters--
+	}
+	if f.waiters == 0 {
+		f.cancel()
+		f.done = true
+		delete(m.flights, sandboxID)
+		m.sf.Forget(sandboxID)
+		return true
+	}
+	return false
+}
+
+func (m *Module) finishFlight(sandboxID string, f *flight) {
+	m.flightsMu.Lock()
+	defer m.flightsMu.Unlock()
+
+	if current := m.flights[sandboxID]; current != f {
+		return
+	}
+	f.done = true
+	delete(m.flights, sandboxID)
+	f.cancel()
+}
+
+func (m *Module) callManager(ctx context.Context, sandboxID string) error {
+	endpoint := m.managerURL + "/wake/" + url.PathEscape(sandboxID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrTransport, err)
+	}
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return fmt.Errorf("%w: %v", ErrTransport, err)
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
+
+	result, decodeErr := decodeWakeResult(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusUnprocessableEntity:
+		if decodeErr != nil {
+			return fmt.Errorf("%w: decode wake result: %v", ErrTransport, decodeErr)
+		}
+		if result.Action == proxy.WakeActionInvalidAutoResumePolicy {
+			return ErrInvalidPolicy
+		}
+		if result.Action == proxy.WakeActionAutoResumeDisabled {
+			return ErrAutoResumeDisabled
+		}
+		return fmt.Errorf("%w: unexpected wake action %q", ErrTransport, result.Action)
+	case http.StatusConflict:
+		if decodeErr == nil && result.Action == proxy.WakeActionPausing {
+			return ErrPausing
+		}
+		return ErrBadState
+	case http.StatusGone:
+		return ErrGone
+	case http.StatusNotFound:
+		return ErrNotFound
+	default:
+		return fmt.Errorf("%w: manager returned %d", ErrTransport, resp.StatusCode)
+	}
+}
+
+func decodeWakeResult(body io.Reader) (proxy.WakeResult, error) {
+	var result proxy.WakeResult
+	if body == nil {
+		return result, io.EOF
+	}
+	err := json.NewDecoder(body).Decode(&result)
+	return result, err
+}
+
+func waitUntilRunning(ctx context.Context, sandboxID string) error {
+	backoff := minPollBackoff
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		route, ok := registry.GetRegistry().Get(sandboxID)
+		if ok && route.State == agentsv1alpha1.SandboxStateRunning {
+			return nil
+		}
+
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+
+		if backoff < maxPollBackoff {
+			backoff *= 2
+			if backoff > maxPollBackoff {
+				backoff = maxPollBackoff
+			}
+		}
+	}
+}
+
+func MapErrToReply(err error) (status int, body string, retryAfter int, code string) {
+	switch {
+	case err == nil:
+		return 0, "", -1, ""
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return 0, "", -1, ""
+	case errors.Is(err, ErrAutoResumeDisabled):
+		return http.StatusBadGateway, "healthy sandbox not found", -1, "sandbox_not_running"
+	case errors.Is(err, ErrInvalidPolicy):
+		return http.StatusServiceUnavailable, "invalid auto-resume policy", 0, "sandbox_wake_invalid_policy"
+	case errors.Is(err, ErrPausing):
+		return http.StatusServiceUnavailable, "sandbox is pausing", 5, "sandbox_wake_pausing"
+	case errors.Is(err, ErrBadState):
+		return http.StatusServiceUnavailable, "sandbox is not resumable", 15, "sandbox_wake_bad_state"
+	case errors.Is(err, ErrGone), errors.Is(err, ErrNotFound):
+		return http.StatusBadGateway, "sandbox not found", -1, "sandbox_not_found"
+	default:
+		return http.StatusServiceUnavailable, "failed to wake sandbox", 5, "sandbox_wake_failed"
+	}
+}

--- a/pkg/sandbox-gateway/wake/wake_test.go
+++ b/pkg/sandbox-gateway/wake/wake_test.go
@@ -1,0 +1,421 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wake
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/proxy"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
+)
+
+func TestWakeAndWait(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		action      proxy.WakeAction
+		setup       func(sandboxID string)
+		afterServer func(sandboxID string)
+		rawBody     string
+		expectError error
+	}{
+		{
+			name:   "manager 200 and registry already running",
+			status: http.StatusOK,
+			setup: func(sandboxID string) {
+				setRoute(sandboxID, agentsv1alpha1.SandboxStateRunning, "2")
+			},
+		},
+		{
+			name:   "manager 200 and registry transitions to running",
+			status: http.StatusOK,
+			setup: func(sandboxID string) {
+				setRoute(sandboxID, agentsv1alpha1.SandboxStatePaused, "1")
+			},
+			afterServer: func(sandboxID string) {
+				go func() {
+					time.Sleep(80 * time.Millisecond)
+					setRoute(sandboxID, agentsv1alpha1.SandboxStateRunning, "2")
+				}()
+			},
+		},
+		{
+			name:        "manager 422 invalid policy",
+			status:      http.StatusUnprocessableEntity,
+			action:      proxy.WakeActionInvalidAutoResumePolicy,
+			expectError: ErrInvalidPolicy,
+		},
+		{
+			name:        "manager 422 auto resume disabled",
+			status:      http.StatusUnprocessableEntity,
+			action:      proxy.WakeActionAutoResumeDisabled,
+			expectError: ErrAutoResumeDisabled,
+		},
+		{
+			name:        "manager 422 unknown action is transport",
+			status:      http.StatusUnprocessableEntity,
+			action:      proxy.WakeActionBadState,
+			expectError: ErrTransport,
+		},
+		{
+			name:        "manager 422 invalid json is transport",
+			status:      http.StatusUnprocessableEntity,
+			rawBody:     "{",
+			expectError: ErrTransport,
+		},
+		{
+			name:        "manager 422 empty body is transport",
+			status:      http.StatusUnprocessableEntity,
+			expectError: ErrTransport,
+		},
+		{
+			name:        "manager 409 pausing",
+			status:      http.StatusConflict,
+			action:      proxy.WakeActionPausing,
+			expectError: ErrPausing,
+		},
+		{
+			name:        "manager 409 bad state",
+			status:      http.StatusConflict,
+			action:      proxy.WakeActionBadState,
+			expectError: ErrBadState,
+		},
+		{
+			name:        "manager 410 gone",
+			status:      http.StatusGone,
+			action:      proxy.WakeActionGone,
+			expectError: ErrGone,
+		},
+		{
+			name:        "manager 404 not found",
+			status:      http.StatusNotFound,
+			action:      proxy.WakeActionNotFound,
+			expectError: ErrNotFound,
+		},
+		{
+			name:        "manager 5xx",
+			status:      http.StatusInternalServerError,
+			expectError: ErrTransport,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := registry.GetRegistry()
+			r.Clear()
+			t.Cleanup(r.Clear)
+
+			sandboxID := "default--wake-test"
+			if tt.setup != nil {
+				tt.setup(sandboxID)
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("method = %s, want %s", r.Method, http.MethodPost)
+				}
+				if !strings.HasSuffix(r.URL.Path, "/wake/"+sandboxID) {
+					t.Errorf("path = %s, want suffix /wake/%s", r.URL.Path, sandboxID)
+				}
+				w.WriteHeader(tt.status)
+				if tt.rawBody != "" {
+					_, _ = w.Write([]byte(tt.rawBody))
+				} else if tt.action != "" {
+					_ = json.NewEncoder(w).Encode(proxy.WakeResult{Action: tt.action})
+				}
+			}))
+			defer server.Close()
+
+			if tt.afterServer != nil {
+				tt.afterServer(sandboxID)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			err := NewModuleWithClient(server.URL, server.Client()).WakeAndWait(ctx, sandboxID)
+			if tt.expectError == nil {
+				if err != nil {
+					t.Fatalf("WakeAndWait() error = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.expectError) {
+				t.Fatalf("WakeAndWait() error = %v, want %v", err, tt.expectError)
+			}
+		})
+	}
+}
+
+func TestWakeAndWaitSingleflight(t *testing.T) {
+	tests := []struct {
+		name       string
+		sandboxIDs []string
+		wantPosts  int32
+	}{
+		{
+			name:       "same sandbox shares one manager request",
+			sandboxIDs: []string{"default--shared", "default--shared"},
+			wantPosts:  1,
+		},
+		{
+			name:       "different sandboxes do not coalesce",
+			sandboxIDs: []string{"default--one", "default--two"},
+			wantPosts:  2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := registry.GetRegistry()
+			r.Clear()
+			t.Cleanup(r.Clear)
+
+			for _, sandboxID := range tt.sandboxIDs {
+				setRoute(sandboxID, agentsv1alpha1.SandboxStatePaused, "1")
+			}
+
+			var posts atomic.Int32
+			release := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				posts.Add(1)
+				<-release
+				sandboxID := strings.TrimPrefix(r.URL.Path, "/wake/")
+				setRoute(sandboxID, agentsv1alpha1.SandboxStateRunning, "2")
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			module := NewModuleWithClient(server.URL, server.Client())
+			var wg sync.WaitGroup
+			errs := make([]error, len(tt.sandboxIDs))
+			for i, sandboxID := range tt.sandboxIDs {
+				wg.Add(1)
+				go func(i int, sandboxID string) {
+					defer wg.Done()
+					ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+					defer cancel()
+					errs[i] = module.WakeAndWait(ctx, sandboxID)
+				}(i, sandboxID)
+			}
+
+			deadline := time.After(2 * time.Second)
+			for posts.Load() < tt.wantPosts {
+				select {
+				case <-deadline:
+					t.Fatalf("manager posts = %d, want %d", posts.Load(), tt.wantPosts)
+				default:
+					time.Sleep(10 * time.Millisecond)
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			if got := posts.Load(); got != tt.wantPosts {
+				t.Fatalf("manager posts before release = %d, want %d", got, tt.wantPosts)
+			}
+			close(release)
+			wg.Wait()
+
+			for i, err := range errs {
+				if err != nil {
+					t.Fatalf("WakeAndWait(%s) error = %v", tt.sandboxIDs[i], err)
+				}
+			}
+		})
+	}
+}
+
+func TestWakeAndWaitLeaderCancelKeepsFollowerAlive(t *testing.T) {
+	r := registry.GetRegistry()
+	r.Clear()
+	t.Cleanup(r.Clear)
+
+	sandboxID := "default--leader-cancel"
+	setRoute(sandboxID, agentsv1alpha1.SandboxStatePaused, "1")
+
+	var posts atomic.Int32
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		posts.Add(1)
+		<-release
+		setRoute(sandboxID, agentsv1alpha1.SandboxStateRunning, "2")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	module := NewModuleWithClient(server.URL, server.Client())
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderDone := make(chan error, 1)
+	go func() {
+		leaderDone <- module.WakeAndWait(leaderCtx, sandboxID)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for posts.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("manager did not receive leader POST")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	followerDone := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		followerDone <- module.WakeAndWait(ctx, sandboxID)
+	}()
+	requireFlightWaiters(t, module, sandboxID, 2)
+
+	cancelLeader()
+	if err := <-leaderDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("leader error = %v, want context.Canceled", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if got := posts.Load(); got != 1 {
+		t.Fatalf("manager posts = %d, want 1", got)
+	}
+	close(release)
+
+	if err := <-followerDone; err != nil {
+		t.Fatalf("follower error = %v, want nil", err)
+	}
+}
+
+func requireFlightWaiters(t *testing.T, module *Module, sandboxID string, want int) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		module.flightsMu.Lock()
+		got := 0
+		if module.flights != nil && module.flights[sandboxID] != nil {
+			got = module.flights[sandboxID].waiters
+		}
+		module.flightsMu.Unlock()
+		if got == want {
+			return
+		}
+
+		select {
+		case <-deadline:
+			t.Fatalf("flight waiters = %d, want %d", got, want)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+func TestWakeAndWaitContextCancelledMidPoll(t *testing.T) {
+	r := registry.GetRegistry()
+	r.Clear()
+	t.Cleanup(r.Clear)
+
+	sandboxID := "default--cancelled"
+	setRoute(sandboxID, agentsv1alpha1.SandboxStatePaused, "1")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		cancel()
+	}()
+
+	err := NewModuleWithClient(server.URL, server.Client()).WakeAndWait(ctx, sandboxID)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WakeAndWait() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestWakeAndWaitSlowManagerUsesCallerContextOnly(t *testing.T) {
+	sandboxID := "default--slow-manager"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- NewModuleWithClient(server.URL, server.Client()).WakeAndWait(ctx, sandboxID)
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("WakeAndWait returned before caller cancellation: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("WakeAndWait() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestMapErrToReply(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            error
+		wantStatus     int
+		wantRetryAfter int
+		wantCode       string
+	}{
+		{"auto resume disabled", ErrAutoResumeDisabled, http.StatusBadGateway, -1, "sandbox_not_running"},
+		{"invalid policy", ErrInvalidPolicy, http.StatusServiceUnavailable, 0, "sandbox_wake_invalid_policy"},
+		{"pausing", ErrPausing, http.StatusServiceUnavailable, 5, "sandbox_wake_pausing"},
+		{"bad state", ErrBadState, http.StatusServiceUnavailable, 15, "sandbox_wake_bad_state"},
+		{"gone", ErrGone, http.StatusBadGateway, -1, "sandbox_not_found"},
+		{"not found", ErrNotFound, http.StatusBadGateway, -1, "sandbox_not_found"},
+		{"transport", ErrTransport, http.StatusServiceUnavailable, 5, "sandbox_wake_failed"},
+		{"cancelled", context.Canceled, 0, -1, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, _, retryAfter, code := MapErrToReply(tt.err)
+			if status != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", status, tt.wantStatus)
+			}
+			if retryAfter != tt.wantRetryAfter {
+				t.Fatalf("retryAfter = %d, want %d", retryAfter, tt.wantRetryAfter)
+			}
+			if code != tt.wantCode {
+				t.Fatalf("code = %q, want %q", code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func setRoute(sandboxID string, state string, resourceVersion string) {
+	registry.GetRegistry().Update(sandboxID, proxy.Route{
+		IP:              "10.0.0.1",
+		State:           state,
+		ResourceVersion: resourceVersion,
+	})
+}

--- a/pkg/sandbox-manager/connect_core.go
+++ b/pkg/sandbox-manager/connect_core.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandbox_manager
+
+import (
+	"context"
+	"time"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/utils/timeout"
+)
+
+type ConnectOrWakeInput struct {
+	PreState       string
+	AutoPause      bool
+	PreEndAt       time.Time
+	Baseline       timeout.Options
+	NewEndAt       time.Time
+	SetAnnotations map[string]string
+}
+
+func (m *SandboxManager) ConnectOrWake(ctx context.Context, sbx infra.Sandbox, in ConnectOrWakeInput) error {
+	if in.PreState == v1alpha1.SandboxStatePaused {
+		if err := m.ResumeSandbox(ctx, sbx, infra.ResumeOptions{}); err != nil {
+			return err
+		}
+	}
+
+	if in.PreEndAt.IsZero() && in.NewEndAt.IsZero() && len(in.SetAnnotations) == 0 {
+		return nil
+	}
+
+	opts := timeout.Options{
+		Baseline:       &in.Baseline,
+		SetAnnotations: in.SetAnnotations,
+	}
+	if !in.NewEndAt.IsZero() {
+		if in.AutoPause {
+			opts.PauseTime = in.NewEndAt
+			opts.ShutdownTime = time.Now().Add(m.maxTimeout)
+		} else {
+			opts.ShutdownTime = in.NewEndAt
+		}
+	}
+
+	policy := timeout.UpdatePolicyExtendOnly
+	if in.PreState == v1alpha1.SandboxStatePaused {
+		policy = timeout.UpdatePolicyBaselineAware
+	}
+	_, err := sbx.SaveTimeoutWithPolicy(ctx, opts, policy)
+	return err
+}

--- a/pkg/sandbox-manager/connect_core_test.go
+++ b/pkg/sandbox-manager/connect_core_test.go
@@ -1,0 +1,519 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandbox_manager
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/cache"
+	"github.com/openkruise/agents/pkg/proxy"
+	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/utils/timeout"
+)
+
+func TestSandboxManagerBuilder_WithMaxTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+	}{
+		{
+			name: "sets max timeout",
+			d:    10 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewSandboxManagerBuilder(testManagerOptions())
+			got := builder.WithMaxTimeout(tt.d)
+
+			assert.Same(t, builder, got)
+			assert.Equal(t, tt.d, builder.instance.maxTimeout)
+		})
+	}
+}
+
+func TestSandboxManager_ConnectOrWake(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	baseline := timeout.Options{ShutdownTime: now.Add(10 * time.Minute)}
+	annotation := map[string]string{v1alpha1.AnnotationWakeOnTraffic: "timeout:300s"}
+	resumeErr := errors.New("resume failed")
+
+	tests := []struct {
+		name                 string
+		input                ConnectOrWakeInput
+		resumeErr            error
+		expectResumeCalls    int
+		expectSaveCalls      int
+		expectPolicy         timeout.UpdatePolicy
+		expectPauseTime      time.Time
+		expectShutdownTime   time.Time
+		expectBaseline       timeout.Options
+		expectSetAnnotations map[string]string
+		expectError          string
+	}{
+		{
+			name: "paused resumes then writes baseline aware timeout",
+			input: ConnectOrWakeInput{
+				PreState: v1alpha1.SandboxStatePaused,
+				PreEndAt: baseline.ShutdownTime,
+				Baseline: baseline,
+				NewEndAt: now.Add(5 * time.Minute),
+			},
+			expectResumeCalls:  1,
+			expectSaveCalls:    1,
+			expectPolicy:       timeout.UpdatePolicyBaselineAware,
+			expectShutdownTime: now.Add(5 * time.Minute),
+			expectBaseline:     baseline,
+		},
+		{
+			name: "running writes extend only timeout",
+			input: ConnectOrWakeInput{
+				PreState: v1alpha1.SandboxStateRunning,
+				PreEndAt: baseline.ShutdownTime,
+				Baseline: baseline,
+				NewEndAt: now.Add(15 * time.Minute),
+			},
+			expectSaveCalls:    1,
+			expectPolicy:       timeout.UpdatePolicyExtendOnly,
+			expectShutdownTime: now.Add(15 * time.Minute),
+			expectBaseline:     baseline,
+		},
+		{
+			name: "never timeout with no annotation fast returns",
+			input: ConnectOrWakeInput{
+				PreState: v1alpha1.SandboxStateRunning,
+				Baseline: timeout.Options{},
+			},
+		},
+		{
+			name: "running annotation-only write uses extend only",
+			input: ConnectOrWakeInput{
+				PreState:       v1alpha1.SandboxStateRunning,
+				Baseline:       timeout.Options{},
+				SetAnnotations: annotation,
+			},
+			expectSaveCalls:      1,
+			expectPolicy:         timeout.UpdatePolicyExtendOnly,
+			expectSetAnnotations: annotation,
+		},
+		{
+			name: "auto pause finite timeout sets pause and max shutdown",
+			input: ConnectOrWakeInput{
+				PreState:  v1alpha1.SandboxStateRunning,
+				AutoPause: true,
+				PreEndAt:  baseline.ShutdownTime,
+				Baseline:  baseline,
+				NewEndAt:  now.Add(5 * time.Minute),
+			},
+			expectSaveCalls:    1,
+			expectPolicy:       timeout.UpdatePolicyExtendOnly,
+			expectPauseTime:    now.Add(5 * time.Minute),
+			expectShutdownTime: now.Add(30 * time.Minute),
+			expectBaseline:     baseline,
+		},
+		{
+			name: "manual finite timeout sets only shutdown",
+			input: ConnectOrWakeInput{
+				PreState: v1alpha1.SandboxStateRunning,
+				PreEndAt: baseline.ShutdownTime,
+				Baseline: baseline,
+				NewEndAt: now.Add(5 * time.Minute),
+			},
+			expectSaveCalls:    1,
+			expectPolicy:       timeout.UpdatePolicyExtendOnly,
+			expectShutdownTime: now.Add(5 * time.Minute),
+			expectBaseline:     baseline,
+		},
+		{
+			name: "running zero new end with annotation uses extend only",
+			input: ConnectOrWakeInput{
+				PreState:       v1alpha1.SandboxStateRunning,
+				PreEndAt:       baseline.ShutdownTime,
+				Baseline:       baseline,
+				SetAnnotations: annotation,
+			},
+			expectSaveCalls:      1,
+			expectPolicy:         timeout.UpdatePolicyExtendOnly,
+			expectBaseline:       baseline,
+			expectSetAnnotations: annotation,
+		},
+		{
+			name: "resume error propagates and skips save",
+			input: ConnectOrWakeInput{
+				PreState: v1alpha1.SandboxStatePaused,
+				PreEndAt: baseline.ShutdownTime,
+				Baseline: baseline,
+				NewEndAt: now.Add(5 * time.Minute),
+			},
+			resumeErr:         resumeErr,
+			expectResumeCalls: 1,
+			expectError:       "resume failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := newFakeSandbox("sandbox")
+			sbx.resumeErr = tt.resumeErr
+			manager := &SandboxManager{
+				proxy:      proxy.NewServer(testManagerOptions()),
+				maxTimeout: 30 * time.Minute,
+			}
+
+			start := time.Now()
+			err := manager.ConnectOrWake(t.Context(), sbx, tt.input)
+			end := time.Now()
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectResumeCalls, sbx.resumeCalls)
+			assert.Equal(t, tt.expectSaveCalls, sbx.saveCalls)
+			if tt.expectSaveCalls == 0 {
+				return
+			}
+			assert.Equal(t, tt.expectPolicy, sbx.lastPolicy)
+			require.NotNil(t, sbx.lastOptions.Baseline)
+			assert.Equal(t, tt.expectBaseline, *sbx.lastOptions.Baseline)
+			assert.Equal(t, tt.expectSetAnnotations, sbx.lastOptions.SetAnnotations)
+			if !tt.expectPauseTime.IsZero() {
+				assert.WithinDuration(t, tt.expectPauseTime, sbx.lastOptions.PauseTime, 2*time.Second)
+			} else {
+				assert.True(t, sbx.lastOptions.PauseTime.IsZero())
+			}
+			if tt.input.AutoPause && !tt.input.NewEndAt.IsZero() {
+				assert.True(t, !sbx.lastOptions.ShutdownTime.Before(start.Add(manager.maxTimeout)))
+				assert.True(t, !sbx.lastOptions.ShutdownTime.After(end.Add(manager.maxTimeout+2*time.Second)))
+			} else if !tt.expectShutdownTime.IsZero() {
+				assert.WithinDuration(t, tt.expectShutdownTime, sbx.lastOptions.ShutdownTime, 2*time.Second)
+			} else {
+				assert.True(t, sbx.lastOptions.ShutdownTime.IsZero())
+			}
+		})
+	}
+}
+
+func TestSandboxManager_ConnectOrWakeZeroNewEndPolicySemantics(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	annotation := map[string]string{v1alpha1.AnnotationWakeOnTraffic: "timeout:300s"}
+
+	tests := []struct {
+		name            string
+		initialTimeout  timeout.Options
+		input           ConnectOrWakeInput
+		expectUpdated   bool
+		expectFinalZero bool
+	}{
+		{
+			name:           "finite running annotation-only write does not clear timeout",
+			initialTimeout: timeout.Options{ShutdownTime: now.Add(10 * time.Minute)},
+			input: ConnectOrWakeInput{
+				PreState:       v1alpha1.SandboxStateRunning,
+				PreEndAt:       now.Add(10 * time.Minute),
+				Baseline:       timeout.Options{ShutdownTime: now.Add(10 * time.Minute)},
+				SetAnnotations: annotation,
+			},
+			expectUpdated:   false,
+			expectFinalZero: false,
+		},
+		{
+			name:           "never-timeout annotation-only write calls save but policy skips update",
+			initialTimeout: timeout.Options{},
+			input: ConnectOrWakeInput{
+				PreState:       v1alpha1.SandboxStateRunning,
+				Baseline:       timeout.Options{},
+				SetAnnotations: annotation,
+			},
+			expectUpdated:   false,
+			expectFinalZero: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := newPolicyTimeoutState(tt.initialTimeout)
+			sbx := newFakeSandbox("sandbox")
+			sbx.timeout = tt.initialTimeout
+			sbx.saveFn = state.save
+			manager := &SandboxManager{
+				proxy:      proxy.NewServer(testManagerOptions()),
+				maxTimeout: 30 * time.Minute,
+			}
+
+			err := manager.ConnectOrWake(t.Context(), sbx, tt.input)
+			require.NoError(t, err)
+
+			assert.Equal(t, 1, sbx.saveCalls)
+			results := state.results()
+			require.Len(t, results, 1)
+			assert.Equal(t, tt.expectUpdated, results[0].Updated)
+			finalTimeout := state.get()
+			if tt.expectFinalZero {
+				assert.True(t, finalTimeout.ShutdownTime.IsZero())
+				assert.True(t, finalTimeout.PauseTime.IsZero())
+			} else {
+				assert.Equal(t, tt.initialTimeout, finalTimeout)
+			}
+		})
+	}
+}
+
+func testManagerOptions() config.SandboxManagerOptions {
+	return config.SandboxManagerOptions{}
+}
+
+type fakeSandbox struct {
+	mu sync.Mutex
+
+	metav1.ObjectMeta
+
+	id       string
+	state    string
+	reason   string
+	raw      *v1alpha1.Sandbox
+	route    proxy.Route
+	timeout  timeout.Options
+	resource infra.SandboxResource
+
+	resumeErr  error
+	saveErr    error
+	refreshErr error
+	getClaimAt time.Time
+
+	resumeFn     func(context.Context) error
+	saveFn       func(context.Context, timeout.Options, timeout.UpdatePolicy) (infra.TimeoutUpdateResult, error)
+	getTimeoutFn func() timeout.Options
+	refreshFn    func(context.Context, bool) error
+
+	resumeCalls  int
+	saveCalls    int
+	refreshCalls int
+	lastOptions  timeout.Options
+	lastPolicy   timeout.UpdatePolicy
+}
+
+func newFakeSandbox(id string) *fakeSandbox {
+	raw := &v1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            id,
+			Namespace:       "default",
+			Annotations:     map[string]string{},
+			ResourceVersion: "1",
+		},
+	}
+	return &fakeSandbox{
+		ObjectMeta: raw.ObjectMeta,
+		id:         id,
+		state:      v1alpha1.SandboxStateRunning,
+		raw:        raw,
+		route: proxy.Route{
+			ID:              id,
+			State:           v1alpha1.SandboxStateRunning,
+			ResourceVersion: "1",
+		},
+		getClaimAt: time.Now(),
+	}
+}
+
+func (f *fakeSandbox) Pause(context.Context, infra.PauseOptions) error {
+	return nil
+}
+
+func (f *fakeSandbox) Resume(ctx context.Context, _ infra.ResumeOptions) error {
+	f.mu.Lock()
+	f.resumeCalls++
+	resumeFn := f.resumeFn
+	resumeErr := f.resumeErr
+	f.mu.Unlock()
+	if resumeFn != nil {
+		return resumeFn(ctx)
+	}
+	return resumeErr
+}
+
+func (f *fakeSandbox) GetSandboxID() string {
+	return f.id
+}
+
+func (f *fakeSandbox) GetRoute() proxy.Route {
+	return f.route
+}
+
+func (f *fakeSandbox) GetState() (string, string) {
+	return f.state, f.reason
+}
+
+func (f *fakeSandbox) GetTemplate() string {
+	return "template"
+}
+
+func (f *fakeSandbox) GetResource() infra.SandboxResource {
+	return f.resource
+}
+
+func (f *fakeSandbox) SetImage(string) {
+}
+
+func (f *fakeSandbox) GetImage() string {
+	return "image"
+}
+
+func (f *fakeSandbox) SetPodLabels(map[string]string) {
+}
+
+func (f *fakeSandbox) GetPodLabels() map[string]string {
+	return nil
+}
+
+func (f *fakeSandbox) SetTimeout(opts timeout.Options) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.timeout = opts
+}
+
+func (f *fakeSandbox) SaveTimeoutWithPolicy(ctx context.Context, opts timeout.Options, policy timeout.UpdatePolicy) (infra.TimeoutUpdateResult, error) {
+	f.mu.Lock()
+	f.saveCalls++
+	f.lastOptions = opts
+	f.lastPolicy = policy
+	saveFn := f.saveFn
+	saveErr := f.saveErr
+	f.mu.Unlock()
+	if saveFn != nil {
+		return saveFn(ctx, opts, policy)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.timeout = opts
+	if saveErr != nil {
+		return infra.TimeoutUpdateResult{}, saveErr
+	}
+	return infra.TimeoutUpdateResult{Updated: true}, nil
+}
+
+func (f *fakeSandbox) GetTimeout() timeout.Options {
+	if f.getTimeoutFn != nil {
+		return f.getTimeoutFn()
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.timeout
+}
+
+func (f *fakeSandbox) GetClaimTime() (time.Time, error) {
+	return f.getClaimAt, nil
+}
+
+func (f *fakeSandbox) Kill(context.Context) error {
+	return nil
+}
+
+func (f *fakeSandbox) InplaceRefresh(ctx context.Context, refreshEndpoints bool) error {
+	f.mu.Lock()
+	f.refreshCalls++
+	refreshFn := f.refreshFn
+	refreshErr := f.refreshErr
+	f.mu.Unlock()
+	if refreshFn != nil {
+		return refreshFn(ctx, refreshEndpoints)
+	}
+	return refreshErr
+}
+
+func (f *fakeSandbox) Request(context.Context, string, string, int, io.Reader) (*http.Response, error) {
+	return nil, nil
+}
+
+func (f *fakeSandbox) CSIMount(context.Context, string, string) error {
+	return nil
+}
+
+func (f *fakeSandbox) CreateCheckpoint(context.Context, infra.CreateCheckpointOptions) (string, error) {
+	return "", nil
+}
+
+func (f *fakeSandbox) GetSandboxCR() *v1alpha1.Sandbox {
+	return f.raw
+}
+
+type fakeInfrastructure struct {
+	sandbox infra.Sandbox
+	err     error
+}
+
+func (f *fakeInfrastructure) Run(context.Context) error {
+	return nil
+}
+
+func (f *fakeInfrastructure) Stop(context.Context) {
+}
+
+func (f *fakeInfrastructure) HasTemplate(context.Context, infra.HasTemplateOptions) bool {
+	return true
+}
+
+func (f *fakeInfrastructure) HasCheckpoint(context.Context, infra.HasCheckpointOptions) bool {
+	return true
+}
+
+func (f *fakeInfrastructure) GetCache() cache.Provider {
+	return nil
+}
+
+func (f *fakeInfrastructure) LoadDebugInfo() map[string]any {
+	return nil
+}
+
+func (f *fakeInfrastructure) SelectSandboxes(context.Context, infra.SelectSandboxesOptions) ([]infra.Sandbox, error) {
+	return nil, nil
+}
+
+func (f *fakeInfrastructure) GetClaimedSandbox(context.Context, infra.GetClaimedSandboxOptions) (infra.Sandbox, error) {
+	return f.sandbox, f.err
+}
+
+func (f *fakeInfrastructure) SelectSucceededCheckpoints(context.Context, infra.SelectSucceededCheckpointsOptions) ([]infra.CheckpointInfo, error) {
+	return nil, nil
+}
+
+func (f *fakeInfrastructure) ClaimSandbox(context.Context, infra.ClaimSandboxOptions) (infra.Sandbox, infra.ClaimMetrics, error) {
+	return nil, infra.ClaimMetrics{}, nil
+}
+
+func (f *fakeInfrastructure) CloneSandbox(context.Context, infra.CloneSandboxOptions) (infra.Sandbox, infra.CloneMetrics, error) {
+	return nil, infra.CloneMetrics{}, nil
+}
+
+func (f *fakeInfrastructure) DeleteCheckpoint(context.Context, infra.DeleteCheckpointOptions) error {
+	return nil
+}

--- a/pkg/sandbox-manager/core.go
+++ b/pkg/sandbox-manager/core.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/google/uuid"
 	"k8s.io/klog/v2"
@@ -112,7 +113,15 @@ func (b *SandboxManagerBuilder) WithRequestAdapter(adapter proxy.RequestAdapter)
 	return b
 }
 
+func (b *SandboxManagerBuilder) WithMaxTimeout(d time.Duration) *SandboxManagerBuilder {
+	b.instance.maxTimeout = d
+	return b
+}
+
 func (b *SandboxManagerBuilder) Build() (*SandboxManager, error) {
+	if b.instance.maxTimeout <= 0 {
+		return nil, errors.NewError(errors.ErrorInternal, "max timeout must be greater than zero: call WithMaxTimeout before Build")
+	}
 	// Build infra
 	if b.buildInfraFunc == nil {
 		return nil, errors.NewError(errors.ErrorInternal, "infra builder is not configured: call WithSandboxInfra or WithCustomInfra before Build")
@@ -122,6 +131,7 @@ func (b *SandboxManagerBuilder) Build() (*SandboxManager, error) {
 		return nil, errors.NewError(errors.ErrorInternal, "failed to get infra builder: %v", err)
 	}
 	b.instance.infra = builder.Build()
+	b.instance.proxy.SetWakeFunc(b.instance.WakeSandbox)
 	reader := b.instance.infra.GetCache().GetAPIReader()
 
 	// Build peers manager
@@ -145,6 +155,7 @@ func (b *SandboxManagerBuilder) Build() (*SandboxManager, error) {
 type SandboxManager struct {
 	peersManager       peers.Peers
 	memberlistBindPort int
+	maxTimeout         time.Duration
 
 	infra infra.Infrastructure
 	proxy *proxy.Server

--- a/pkg/sandbox-manager/core_test.go
+++ b/pkg/sandbox-manager/core_test.go
@@ -19,6 +19,7 @@ package sandbox_manager
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 	"github.com/stretchr/testify/assert"
@@ -32,6 +33,8 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 )
+
+const testBuilderMaxTimeout = 30 * time.Minute
 
 func TestNewSandboxManagerBuilder(t *testing.T) {
 	tests := []struct {
@@ -90,7 +93,8 @@ func TestSandboxManagerBuilder_WithSandboxInfra(t *testing.T) {
 		opts := config.SandboxManagerOptions{}
 
 		builder := NewSandboxManagerBuilder(opts).
-			WithSandboxInfra()
+			WithSandboxInfra().
+			WithMaxTimeout(testBuilderMaxTimeout)
 
 		assert.NotNil(t, builder.buildInfraFunc, "buildInfraFunc should be set")
 
@@ -127,7 +131,8 @@ func TestSandboxManagerBuilder_WithCustomInfra(t *testing.T) {
 					WithCache(cache).
 					WithAPIReader(fc).
 					WithProxy(proxyServer), nil
-			})
+			}).
+			WithMaxTimeout(testBuilderMaxTimeout)
 
 		manager, err := builder.Build()
 		require.NoError(t, err)
@@ -221,7 +226,8 @@ func TestSandboxManagerBuilder_WithMemberlistPeers(t *testing.T) {
 						WithAPIReader(fc).
 						WithProxy(proxyServer), nil
 				}).
-				WithMemberlistPeers()
+				WithMemberlistPeers().
+				WithMaxTimeout(testBuilderMaxTimeout)
 
 			if tt.expectError != "" {
 				_, err := builder.Build()
@@ -271,6 +277,26 @@ func TestSandboxManagerBuilder_WithRequestAdapter(t *testing.T) {
 }
 
 func TestSandboxManagerBuilder_Build(t *testing.T) {
+	t.Run("should fail when max timeout is not configured", func(t *testing.T) {
+		opts := config.SandboxManagerOptions{}
+		cache, fc, err := cachetest.NewTestCache(t)
+		require.NoError(t, err)
+
+		builder := NewSandboxManagerBuilder(opts).
+			WithCustomInfra(func() (infra.Builder, error) {
+				proxyServer := proxy.NewServer(opts)
+				return sandboxcr.NewInfraBuilder(opts).
+					WithCache(cache).
+					WithAPIReader(fc).
+					WithProxy(proxyServer), nil
+			})
+
+		_, err = builder.Build()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "max timeout")
+		assert.Equal(t, errors.ErrorInternal, errors.GetErrCode(err))
+	})
+
 	t.Run("should build complete SandboxManager with all components", func(t *testing.T) {
 		opts := config.SandboxManagerOptions{
 			SystemNamespace:  "test-namespace",
@@ -290,7 +316,8 @@ func TestSandboxManagerBuilder_Build(t *testing.T) {
 					WithAPIReader(fc).
 					WithProxy(proxyServer), nil
 			}).
-			WithRequestAdapter(mockAdapter)
+			WithRequestAdapter(mockAdapter).
+			WithMaxTimeout(testBuilderMaxTimeout)
 
 		manager, err := builder.Build()
 		require.NoError(t, err)
@@ -321,7 +348,8 @@ func TestSandboxManagerBuilder_Build(t *testing.T) {
 					WithAPIReader(fc).
 					WithProxy(proxyServer), nil
 			}).
-			WithMemberlistPeers()
+			WithMemberlistPeers().
+			WithMaxTimeout(testBuilderMaxTimeout)
 
 		manager, err := builder.Build()
 		require.NoError(t, err)
@@ -346,7 +374,8 @@ func TestSandboxManagerBuilder_Build(t *testing.T) {
 					WithCache(cache).
 					WithAPIReader(fc).
 					WithProxy(proxyServer), nil
-			})
+			}).
+			WithMaxTimeout(testBuilderMaxTimeout)
 
 		_, err = builder.Build()
 		require.NoError(t, err)
@@ -369,7 +398,8 @@ func TestSandboxManagerBuilder_Build(t *testing.T) {
 			}).
 			WithCustomPeers(func(args NewPeerArgs) (peers.Peers, error) {
 				return nil, assert.AnError
-			})
+			}).
+			WithMaxTimeout(testBuilderMaxTimeout)
 
 		_, err = builder.Build()
 		require.Error(t, err)
@@ -401,7 +431,8 @@ func TestSandboxManagerBuilder_Build(t *testing.T) {
 					WithProxy(proxyServer), nil
 			}).
 			WithMemberlistPeers().
-			WithRequestAdapter(mockAdapter)
+			WithRequestAdapter(mockAdapter).
+			WithMaxTimeout(testBuilderMaxTimeout)
 
 		manager, err := builder.Build()
 		require.NoError(t, err)
@@ -444,6 +475,9 @@ func TestSandboxManagerBuilder_Chaining(t *testing.T) {
 
 		result3 := builder.WithRequestAdapter(mockAdapter)
 		assert.Same(t, builder, result3)
+
+		result4 := builder.WithMaxTimeout(testBuilderMaxTimeout)
+		assert.Same(t, builder, result4)
 
 		// Should be able to build
 		manager, err := builder.Build()

--- a/pkg/sandbox-manager/infra/interface.go
+++ b/pkg/sandbox-manager/infra/interface.go
@@ -24,6 +24,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/proxy"
 	"github.com/openkruise/agents/pkg/utils/timeout"
@@ -103,6 +104,8 @@ type Sandbox interface {
 	Pause(ctx context.Context, opts PauseOptions) error   // Pause a Sandbox
 	Resume(ctx context.Context, opts ResumeOptions) error // Resume a paused Sandbox
 	GetSandboxID() string
+	// GetSandboxCR returns the backing Sandbox custom resource. Callers should treat it as read-only.
+	GetSandboxCR() *v1alpha1.Sandbox
 	GetRoute() proxy.Route
 	GetState() (string, string)   // Get Sandbox State (pending, running, paused, killing, etc.)
 	GetTemplate() string          // Get the template name of the Sandbox

--- a/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
@@ -281,6 +281,13 @@ func TestInfra_GetClaimedSandboxWithOptions_NamespaceScoped(t *testing.T) {
 	sandboxID := stateutils.GetSandboxID(sbx)
 
 	got, err := infraInstance.GetClaimedSandbox(t.Context(), infra.GetClaimedSandboxOptions{
+		SandboxID: sandboxID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "team-a", got.GetNamespace())
+	assert.Equal(t, "sandbox-a", got.GetName())
+
+	got, err = infraInstance.GetClaimedSandbox(t.Context(), infra.GetClaimedSandboxOptions{
 		Namespace: "team-a",
 		SandboxID: sandboxID,
 	})

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -71,6 +71,10 @@ func (s *Sandbox) GetTemplate() string {
 	return utils.GetTemplateFromSandbox(s.Sandbox)
 }
 
+func (s *Sandbox) GetSandboxCR() *agentsv1alpha1.Sandbox {
+	return s.Sandbox
+}
+
 func (s *Sandbox) InplaceRefresh(ctx context.Context, deepcopy bool) error {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(s.Sandbox)).V(consts.DebugLogLevel)
 	fetchFromApiServer := false
@@ -201,6 +205,19 @@ func setTimeout(s *agentsv1alpha1.Sandbox, opts timeout.Options) {
 	}
 }
 
+func setAnnotations(s *agentsv1alpha1.Sandbox, annotations map[string]string) {
+	for key, value := range annotations {
+		if value == "" {
+			delete(s.Annotations, key)
+			continue
+		}
+		if s.Annotations == nil {
+			s.Annotations = map[string]string{}
+		}
+		s.Annotations[key] = value
+	}
+}
+
 func (s *Sandbox) SetTimeout(opts timeout.Options) {
 	setTimeout(s.Sandbox, opts)
 }
@@ -276,6 +293,7 @@ func (s *Sandbox) SaveTimeoutWithPolicy(ctx context.Context, opts timeout.Option
 			return false, nil
 		}
 		setTimeout(sbx, opts)
+		setAnnotations(sbx, opts.SetAnnotations)
 		return true, nil
 	})
 	if err != nil {
@@ -428,7 +446,8 @@ func (s *Sandbox) Resume(ctx context.Context, _ infra.ResumeOptions) error {
 		// Concurrent same-action Resume callers share the Sandbox resume wait.
 		// Once the Sandbox reaches Ready, losing callers return success without
 		// running or waiting for the transitional E2B post-resume initialization
-		// below. ReInit and CSI remount are not part of the loser success contract.
+		// below. This is general Resume behavior, not wake-specific behavior.
+		// ReInit and CSI remount are not part of the loser success contract.
 		log.Info("sandbox resume already won by another request, skipping post-resume operations")
 		return nil
 	}

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
@@ -96,14 +96,17 @@ func TestSandbox_SaveTimeoutWithPolicy(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		current       timeout.Options
-		baseline      *timeout.Options
-		requested     timeout.Options
-		policy        timeout.UpdatePolicy
-		expectUpdated bool
-		expectTimeout timeout.Options
-		expectError   string
+		name                  string
+		current               timeout.Options
+		baseline              *timeout.Options
+		requested             timeout.Options
+		policy                timeout.UpdatePolicy
+		expectUpdated         bool
+		expectTimeout         timeout.Options
+		initialAnnotations    map[string]string
+		nilInitialAnnotations bool
+		expectAnnotations     map[string]string
+		expectError           string
 	}{
 		{
 			name: "always updates when requested timeout differs",
@@ -241,6 +244,88 @@ func TestSandbox_SaveTimeoutWithPolicy(t *testing.T) {
 				ShutdownTime: base.Add(10 * time.Minute),
 			},
 		},
+		{
+			name: "always updates timeout and annotations together",
+			current: timeout.Options{
+				ShutdownTime: base.Add(10 * time.Minute),
+			},
+			requested: timeout.Options{
+				ShutdownTime: base.Add(20 * time.Minute),
+				SetAnnotations: map[string]string{
+					v1alpha1.AnnotationWakeOnTraffic: "timeout:300s",
+				},
+			},
+			policy:        timeout.UpdatePolicyAlways,
+			expectUpdated: true,
+			expectTimeout: timeout.Options{ShutdownTime: base.Add(20 * time.Minute)},
+			initialAnnotations: map[string]string{
+				v1alpha1.AnnotationWakeOnTraffic: "timeout:never",
+			},
+			expectAnnotations: map[string]string{
+				v1alpha1.AnnotationWakeOnTraffic: "timeout:300s",
+			},
+		},
+		{
+			name: "empty annotation value deletes existing key",
+			current: timeout.Options{
+				ShutdownTime: base.Add(10 * time.Minute),
+			},
+			requested: timeout.Options{
+				ShutdownTime: base.Add(20 * time.Minute),
+				SetAnnotations: map[string]string{
+					v1alpha1.AnnotationWakeOnTraffic: "",
+				},
+			},
+			policy:        timeout.UpdatePolicyAlways,
+			expectUpdated: true,
+			expectTimeout: timeout.Options{ShutdownTime: base.Add(20 * time.Minute)},
+			initialAnnotations: map[string]string{
+				v1alpha1.AnnotationWakeOnTraffic: "timeout:never",
+			},
+			expectAnnotations: map[string]string{
+				v1alpha1.AnnotationWakeOnTraffic: "",
+			},
+		},
+		{
+			name: "extend only no-op leaves annotations untouched",
+			current: timeout.Options{
+				ShutdownTime: base.Add(25 * time.Minute),
+			},
+			requested: timeout.Options{
+				ShutdownTime: base.Add(10 * time.Minute),
+				SetAnnotations: map[string]string{
+					v1alpha1.AnnotationWakeOnTraffic: "timeout:300s",
+				},
+			},
+			policy:        timeout.UpdatePolicyExtendOnly,
+			expectUpdated: false,
+			expectTimeout: timeout.Options{ShutdownTime: base.Add(25 * time.Minute)},
+			initialAnnotations: map[string]string{
+				v1alpha1.AnnotationWakeOnTraffic: "timeout:never",
+			},
+			expectAnnotations: map[string]string{
+				v1alpha1.AnnotationWakeOnTraffic: "timeout:never",
+			},
+		},
+		{
+			name: "non empty annotation write initializes nil annotations map",
+			current: timeout.Options{
+				ShutdownTime: base.Add(10 * time.Minute),
+			},
+			requested: timeout.Options{
+				ShutdownTime: base.Add(20 * time.Minute),
+				SetAnnotations: map[string]string{
+					"example.com/new": "value",
+				},
+			},
+			policy:                timeout.UpdatePolicyAlways,
+			expectUpdated:         true,
+			expectTimeout:         timeout.Options{ShutdownTime: base.Add(20 * time.Minute)},
+			nilInitialAnnotations: true,
+			expectAnnotations: map[string]string{
+				"example.com/new": "value",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -249,6 +334,11 @@ func TestSandbox_SaveTimeoutWithPolicy(t *testing.T) {
 
 			sbx := createTestSandboxWithDefaults("test-sandbox", "default")
 			setTimeout(sbx, tt.current)
+			if tt.nilInitialAnnotations {
+				sbx.Annotations = nil
+			} else if tt.initialAnnotations != nil {
+				sbx.Annotations = tt.initialAnnotations
+			}
 			CreateSandboxWithStatus(t, fc, sbx)
 
 			var sandbox infra.Sandbox
@@ -278,6 +368,13 @@ func TestSandbox_SaveTimeoutWithPolicy(t *testing.T) {
 			var updated v1alpha1.Sandbox
 			require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: sbx.Namespace, Name: sbx.Name}, &updated))
 			assert.True(t, timeout.Equal(tt.expectTimeout, timeout.GetTimeoutFromSandbox(&updated)))
+			for key, value := range tt.expectAnnotations {
+				if value == "" {
+					assert.NotContains(t, updated.Annotations, key)
+					continue
+				}
+				assert.Equal(t, value, updated.Annotations[key])
+			}
 		})
 	}
 }
@@ -470,6 +567,87 @@ func TestSandbox_SaveTimeoutWithPolicy_BaselineAwareUsesAPIReaderAfterConflict(t
 	updated := &v1alpha1.Sandbox{}
 	require.NoError(t, fc.Get(t.Context(), client.ObjectKeyFromObject(initial), updated))
 	assert.True(t, timeout.Equal(winnerTimeout, timeout.GetTimeoutFromSandbox(updated)))
+}
+
+func TestSandbox_SaveTimeoutWithPolicy_SetAnnotationsReappliedAfterConflict(t *testing.T) {
+	scheme := k8sruntime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+
+	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	current := timeout.Options{ShutdownTime: base.Add(10 * time.Minute)}
+	requested := timeout.Options{
+		ShutdownTime: base.Add(20 * time.Minute),
+		SetAnnotations: map[string]string{
+			v1alpha1.AnnotationWakeOnTraffic: "timeout:300s",
+		},
+	}
+
+	initial := createTestSandboxWithDefaults("test-sandbox", "default")
+	setTimeout(initial, current)
+	initial.Annotations = map[string]string{
+		v1alpha1.AnnotationWakeOnTraffic: "timeout:never",
+		"example.com/existing":           "keep",
+	}
+	stale := initial.DeepCopy()
+
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.Sandbox{}).
+		WithObjects(initial).
+		Build()
+
+	provider := &retryUpdateTestProvider{
+		apiReader:      &countingReader{Reader: fc},
+		claimedSandbox: initial,
+	}
+	var updateCalls atomic.Int32
+	provider.client = interceptor.NewClient(fc, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			provider.clientGetCalls.Add(1)
+			if key == client.ObjectKeyFromObject(stale) {
+				stale.DeepCopyInto(obj.(*v1alpha1.Sandbox))
+				return nil
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if updateCalls.Add(1) == 1 {
+				latest := &v1alpha1.Sandbox{}
+				if err := c.Get(ctx, client.ObjectKeyFromObject(stale), latest); err != nil {
+					return err
+				}
+				winner := latest.DeepCopy()
+				setTimeout(winner, timeout.Options{ShutdownTime: base.Add(12 * time.Minute)})
+				winner.Annotations[v1alpha1.AnnotationWakeOnTraffic] = "timeout:120s"
+				if err := c.Update(ctx, winner); err != nil {
+					return err
+				}
+				return apierrors.NewConflict(
+					schema.GroupResource{Group: v1alpha1.GroupVersion.Group, Resource: "sandboxes"},
+					obj.GetName(),
+					errors.New("simulated conflict"),
+				)
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+	})
+
+	sandbox := AsSandbox(stale.DeepCopy(), provider)
+	result, err := sandbox.SaveTimeoutWithPolicy(t.Context(), requested, timeout.UpdatePolicyAlways)
+	require.NoError(t, err)
+	assert.True(t, result.Updated)
+	assert.Equal(t, int32(1), provider.clientGetCalls.Load())
+	assert.Equal(t, int32(1), provider.apiReader.Calls())
+	assert.Equal(t, int32(2), updateCalls.Load())
+	assert.True(t, timeout.Equal(requested, sandbox.GetTimeout()))
+	assert.Equal(t, "timeout:300s", sandbox.GetAnnotations()[v1alpha1.AnnotationWakeOnTraffic])
+
+	updated := &v1alpha1.Sandbox{}
+	require.NoError(t, fc.Get(t.Context(), client.ObjectKeyFromObject(initial), updated))
+	assert.True(t, timeout.Equal(requested, timeout.GetTimeoutFromSandbox(updated)))
+	assert.Equal(t, "timeout:300s", updated.Annotations[v1alpha1.AnnotationWakeOnTraffic])
+	assert.Equal(t, "keep", updated.Annotations["example.com/existing"])
 }
 
 type countingReader struct {
@@ -1254,10 +1432,11 @@ func TestSandbox_GetRoute(t *testing.T) {
 				},
 			},
 			expectedRoute: proxy.Route{
-				IP:    "10.0.0.2",
-				ID:    "default--running-sandbox",
-				Owner: "",
-				State: v1alpha1.SandboxStateRunning,
+				IP:       "10.0.0.2",
+				ID:       "default--running-sandbox",
+				Owner:    "",
+				State:    v1alpha1.SandboxStateRunning,
+				Pausable: true,
 			},
 		},
 	}

--- a/pkg/sandbox-manager/metrics.go
+++ b/pkg/sandbox-manager/metrics.go
@@ -62,6 +62,26 @@ var (
 		[]string{"result"},
 	)
 
+	// sandboxWakeDuration tracks the total time of wake-on-traffic operations
+	sandboxWakeDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:        "sandbox_wake_duration_seconds",
+			Help:        "Total duration of wake-on-traffic operations in seconds",
+			ConstLabels: prometheus.Labels{"source": "gateway"},
+			Buckets:     prometheus.ExponentialBuckets(0.02, 2, 12), // 20ms -> ~41s
+		},
+	)
+
+	// sandboxWakeResponses tracks wake-on-traffic requests by returned action
+	sandboxWakeResponses = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "sandbox_wake_responses",
+			Help:        "Total number of wake-on-traffic requests by returned action",
+			ConstLabels: prometheus.Labels{"source": "gateway"},
+		},
+		[]string{"action"},
+	)
+
 	// sandboxDeleteResponses tracks total delete requests and their results
 	sandboxDeleteResponses = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -175,6 +195,7 @@ func init() {
 	metrics.Registry.MustRegister(sandboxClaimCreationResponses,
 		sandboxPauseDuration, sandboxPauseResponses,
 		sandboxResumeDuration, sandboxResumeResponses,
+		sandboxWakeDuration, sandboxWakeResponses,
 		sandboxDeleteResponses,
 		// Claim
 		sandboxClaimDuration, sandboxClaimTotal, sandboxClaimRetries,

--- a/pkg/sandbox-manager/wake.go
+++ b/pkg/sandbox-manager/wake.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandbox_manager
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/proxy"
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/utils"
+	sandboxutils "github.com/openkruise/agents/pkg/utils/sandboxutils"
+)
+
+const wakeMinimumTimeout = 5 * time.Minute
+
+func (m *SandboxManager) WakeSandbox(ctx context.Context, sandboxID string) (result proxy.WakeResult, err error) {
+	start := time.Now()
+	defer func() {
+		action := string(result.Action)
+		if action == "" {
+			action = "error"
+		}
+		sandboxWakeResponses.WithLabelValues(action).Inc()
+		sandboxWakeDuration.Observe(time.Since(start).Seconds())
+	}()
+
+	// Wake uses only the canonical sandbox ID (`namespace--name`) from the URL.
+	// The request does not carry or trust a separate namespace field.
+	sbx, err := m.infra.GetClaimedSandbox(ctx, infra.GetClaimedSandboxOptions{SandboxID: sandboxID})
+	if err != nil {
+		if isSandboxNotFound(err) {
+			return proxy.WakeResult{Action: proxy.WakeActionNotFound, Message: err.Error()}, nil
+		}
+		return proxy.WakeResult{}, err
+	}
+
+	policy, err := ParseWakeOnTrafficPolicy(sbx.GetAnnotations())
+	if err != nil {
+		if errors.Is(err, ErrAutoResumeDisabled) {
+			return wakeResult(sbx, proxy.WakeActionAutoResumeDisabled, err.Error()), nil
+		}
+		if errors.Is(err, ErrInvalidAutoResumePolicy) {
+			return wakeResult(sbx, proxy.WakeActionInvalidAutoResumePolicy, err.Error()), nil
+		}
+		return proxy.WakeResult{}, err
+	}
+
+	state, reason := sbx.GetState()
+	if state == v1alpha1.SandboxStateRunning {
+		return wakeResult(sbx, proxy.WakeActionAlreadyRunning, reason), nil
+	}
+	if state == v1alpha1.SandboxStateDead || sbx.GetDeletionTimestamp() != nil {
+		return wakeResult(sbx, proxy.WakeActionGone, reason), nil
+	}
+	if state != v1alpha1.SandboxStatePaused {
+		return wakeResult(sbx, proxy.WakeActionBadState, reason), nil
+	}
+
+	action, ok := classifyPausedWakeSandbox(sbx)
+	if !ok {
+		return wakeResult(sbx, action, reason), nil
+	}
+
+	baseline := sbx.GetTimeout()
+	autoPause := !baseline.PauseTime.IsZero()
+	currentEndAt := baseline.ShutdownTime
+	if autoPause {
+		currentEndAt = baseline.PauseTime
+	}
+	newEndAt := wakeNewEndAt(policy, currentEndAt, time.Now())
+
+	err = m.ConnectOrWake(ctx, sbx, ConnectOrWakeInput{
+		PreState:  v1alpha1.SandboxStatePaused,
+		AutoPause: autoPause,
+		PreEndAt:  currentEndAt,
+		Baseline:  baseline,
+		NewEndAt:  newEndAt,
+	})
+	if err != nil {
+		action, actionErr := wakeActionForConnectError(ctx, err, sbx)
+		if actionErr != nil {
+			return proxy.WakeResult{}, actionErr
+		}
+		if action != "" {
+			return wakeResult(sbx, action, err.Error()), nil
+		}
+		return proxy.WakeResult{}, err
+	}
+	if err = m.syncRoute(ctx, sbx, true); err != nil {
+		klog.FromContext(ctx).Error(err, "failed to sync route with peers after wake", "sandbox", klog.KObj(sbx))
+	}
+	return wakeResult(sbx, proxy.WakeActionResumed, ""), nil
+}
+
+func isSandboxNotFound(err error) bool {
+	return apierrors.IsNotFound(err) ||
+		managererrors.GetErrCode(err) == managererrors.ErrorNotFound ||
+		strings.Contains(err.Error(), "not found in cache")
+}
+
+func classifyPausedWakeSandbox(sbx infra.Sandbox) (proxy.WakeAction, bool) {
+	raw := sbx.GetSandboxCR()
+	if raw == nil {
+		return proxy.WakeActionBadState, false
+	}
+	if raw.DeletionTimestamp != nil {
+		return proxy.WakeActionGone, false
+	}
+	if raw.Status.Phase == v1alpha1.SandboxResuming {
+		return proxy.WakeActionBadState, false
+	}
+	if raw.Status.Phase == v1alpha1.SandboxPaused {
+		pauseCond := utils.GetSandboxCondition(&raw.Status, string(v1alpha1.SandboxConditionPaused))
+		if pauseCond == nil || pauseCond.Status != metav1.ConditionTrue {
+			return proxy.WakeActionPausing, false
+		}
+	}
+	if resumable, _ := sandboxutils.IsSandboxResumable(raw); !resumable {
+		return proxy.WakeActionBadState, false
+	}
+	return "", true
+}
+
+func wakeNewEndAt(policy Policy, currentEndAt time.Time, now time.Time) time.Time {
+	if policy.Form == PolicyFormNever || currentEndAt.IsZero() {
+		return time.Time{}
+	}
+	duration := policy.Duration
+	if duration < wakeMinimumTimeout {
+		duration = wakeMinimumTimeout
+	}
+	return now.Add(duration)
+}
+
+func wakeActionForConnectError(ctx context.Context, err error, sbx infra.Sandbox) (proxy.WakeAction, error) {
+	if managererrors.GetErrCode(err) != managererrors.ErrorConflict {
+		return "", err
+	}
+	if refreshErr := sbx.InplaceRefresh(ctx, false); refreshErr != nil {
+		return "", refreshErr
+	}
+	state, _ := sbx.GetState()
+	if state == v1alpha1.SandboxStateRunning {
+		return proxy.WakeActionAlreadyRunning, nil
+	}
+	if state == v1alpha1.SandboxStateDead || sbx.GetDeletionTimestamp() != nil {
+		return proxy.WakeActionGone, nil
+	}
+	action, ok := classifyPausedWakeSandbox(sbx)
+	if !ok && action != "" {
+		return action, nil
+	}
+	return proxy.WakeActionBadState, nil
+}
+
+func wakeResult(sbx infra.Sandbox, action proxy.WakeAction, message string) proxy.WakeResult {
+	state, _ := sbx.GetState()
+	return proxy.WakeResult{
+		Action:          action,
+		State:           state,
+		ResourceVersion: sbx.GetResourceVersion(),
+		Message:         message,
+	}
+}

--- a/pkg/sandbox-manager/wake_test.go
+++ b/pkg/sandbox-manager/wake_test.go
@@ -1,0 +1,879 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandbox_manager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/peers"
+	"github.com/openkruise/agents/pkg/proxy"
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/utils/timeout"
+)
+
+func TestSandboxManager_WakeSandbox(t *testing.T) {
+	tests := []struct {
+		name                  string
+		state                 string
+		phase                 v1alpha1.SandboxPhase
+		annotations           map[string]string
+		initialTimeout        timeout.Options
+		deleting              bool
+		pausedCondition       metav1.ConditionStatus
+		readyCondition        metav1.ConditionStatus
+		infraErr              error
+		syncPeerIP            string
+		expectAction          proxy.WakeAction
+		expectSaveCalls       int
+		expectResumeCalls     int
+		expectPauseTime       bool
+		expectShutdownTime    bool
+		expectClearedTimeouts bool
+		expectDuration        time.Duration
+		expectAnnotation      string
+	}{
+		{
+			name:               "paused duration manual timeout writes shutdown",
+			state:              v1alpha1.SandboxStatePaused,
+			phase:              v1alpha1.SandboxPaused,
+			annotations:        map[string]string{v1alpha1.AnnotationWakeOnTraffic: "timeout:10m"},
+			initialTimeout:     timeout.Options{ShutdownTime: time.Now().Add(time.Hour)},
+			pausedCondition:    metav1.ConditionTrue,
+			expectAction:       proxy.WakeActionResumed,
+			expectSaveCalls:    1,
+			expectResumeCalls:  1,
+			expectShutdownTime: true,
+			expectDuration:     10 * time.Minute,
+			expectAnnotation:   "timeout:10m",
+		},
+		{
+			name:        "paused duration auto pause writes pause and max shutdown",
+			state:       v1alpha1.SandboxStatePaused,
+			phase:       v1alpha1.SandboxPaused,
+			annotations: map[string]string{v1alpha1.AnnotationWakeOnTraffic: "timeout:10m"},
+			initialTimeout: timeout.Options{
+				PauseTime:    time.Now().Add(time.Hour),
+				ShutdownTime: time.Now().Add(24 * time.Hour),
+			},
+			pausedCondition:    metav1.ConditionTrue,
+			expectAction:       proxy.WakeActionResumed,
+			expectSaveCalls:    1,
+			expectResumeCalls:  1,
+			expectPauseTime:    true,
+			expectShutdownTime: true,
+			expectDuration:     10 * time.Minute,
+			expectAnnotation:   "timeout:10m",
+		},
+		{
+			name:                  "paused never policy clears timeouts",
+			state:                 v1alpha1.SandboxStatePaused,
+			phase:                 v1alpha1.SandboxPaused,
+			annotations:           map[string]string{v1alpha1.AnnotationWakeOnTraffic: "timeout:never"},
+			initialTimeout:        timeout.Options{ShutdownTime: time.Now().Add(time.Hour)},
+			pausedCondition:       metav1.ConditionTrue,
+			expectAction:          proxy.WakeActionResumed,
+			expectSaveCalls:       1,
+			expectResumeCalls:     1,
+			expectClearedTimeouts: true,
+			expectAnnotation:      "timeout:never",
+		},
+		{
+			name:               "duration below minimum clamps to five minutes",
+			state:              v1alpha1.SandboxStatePaused,
+			phase:              v1alpha1.SandboxPaused,
+			annotations:        map[string]string{v1alpha1.AnnotationWakeOnTraffic: "timeout:30s"},
+			initialTimeout:     timeout.Options{ShutdownTime: time.Now().Add(time.Hour)},
+			pausedCondition:    metav1.ConditionTrue,
+			expectAction:       proxy.WakeActionResumed,
+			expectSaveCalls:    1,
+			expectResumeCalls:  1,
+			expectShutdownTime: true,
+			expectDuration:     5 * time.Minute,
+			expectAnnotation:   "timeout:30s",
+		},
+		{
+			name:             "running returns already running",
+			state:            v1alpha1.SandboxStateRunning,
+			phase:            v1alpha1.SandboxRunning,
+			annotations:      map[string]string{v1alpha1.AnnotationWakeOnTraffic: "timeout:10m"},
+			expectAction:     proxy.WakeActionAlreadyRunning,
+			expectAnnotation: "timeout:10m",
+		},
+		{
+			name:            "absent annotation disables auto resume",
+			state:           v1alpha1.SandboxStatePaused,
+			phase:           v1alpha1.SandboxPaused,
+			pausedCondition: metav1.ConditionTrue,
+			expectAction:    proxy.WakeActionAutoResumeDisabled,
+		},
+		{
+			name:             "invalid annotation returns invalid policy",
+			state:            v1alpha1.SandboxStatePaused,
+			phase:            v1alpha1.SandboxPaused,
+			annotations:      map[string]string{v1alpha1.AnnotationWakeOnTraffic: "true"},
+			pausedCondition:  metav1.ConditionTrue,
+			expectAction:     proxy.WakeActionInvalidAutoResumePolicy,
+			expectAnnotation: "true",
+		},
+		{
+			name:             "deleting sandbox is gone",
+			state:            v1alpha1.SandboxStateDead,
+			phase:            v1alpha1.SandboxPaused,
+			annotations:      map[string]string{v1alpha1.AnnotationWakeOnTraffic: "timeout:10m"},
+			deleting:         true,
+			expectAction:     proxy.WakeActionGone,
+			expectAnnotation: "timeout:10m",
+		},
+		{
+			name:             "paused phase with false paused condition is pausing",
+			state:            v1alpha1.SandboxStatePaused,
+			phase:            v1alpha1.SandboxPaused,
+			annotations:      map[string]string{v1alpha1.AnnotationWakeOnTraffic: "timeout:10m"},
+			pausedCondition:  metav1.ConditionFalse,
+			expectAction:     proxy.WakeActionPausing,
+			expectAnnotation: "timeout:10m",
+		},
+		{
+			name:             "creating state is bad state",
+			state:            v1alpha1.SandboxStateCreating,
+			phase:            v1alpha1.SandboxPending,
+			annotations:      map[string]string{v1alpha1.AnnotationWakeOnTraffic: "timeout:10m"},
+			expectAction:     proxy.WakeActionBadState,
+			expectAnnotation: "timeout:10m",
+		},
+		{
+			name:             "resuming phase is bad state",
+			state:            v1alpha1.SandboxStatePaused,
+			phase:            v1alpha1.SandboxResuming,
+			annotations:      map[string]string{v1alpha1.AnnotationWakeOnTraffic: "timeout:10m"},
+			expectAction:     proxy.WakeActionBadState,
+			expectAnnotation: "timeout:10m",
+		},
+		{
+			name:         "not found maps to not found action",
+			infraErr:     managererrors.NewError(managererrors.ErrorNotFound, "missing"),
+			expectAction: proxy.WakeActionNotFound,
+		},
+		{
+			name:         "cache not found maps to not found action",
+			infraErr:     fmt.Errorf("sandbox sandbox not found in cache"),
+			expectAction: proxy.WakeActionNotFound,
+		},
+		{
+			name:               "route sync failure still reports resumed",
+			state:              v1alpha1.SandboxStatePaused,
+			phase:              v1alpha1.SandboxPaused,
+			annotations:        map[string]string{v1alpha1.AnnotationWakeOnTraffic: "timeout:10m"},
+			initialTimeout:     timeout.Options{ShutdownTime: time.Now().Add(time.Hour)},
+			pausedCondition:    metav1.ConditionTrue,
+			syncPeerIP:         "%",
+			expectAction:       proxy.WakeActionResumed,
+			expectSaveCalls:    1,
+			expectResumeCalls:  1,
+			expectShutdownTime: true,
+			expectDuration:     10 * time.Minute,
+			expectAnnotation:   "timeout:10m",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := newWakeFakeSandbox(tt)
+			manager := &SandboxManager{
+				infra:      &fakeInfrastructure{sandbox: sbx, err: tt.infraErr},
+				proxy:      proxy.NewServer(testManagerOptions()),
+				maxTimeout: 30 * time.Minute,
+			}
+			if tt.syncPeerIP != "" {
+				manager.proxy.SetPeersManager(&wakeTestPeers{members: []peers.Peer{{IP: tt.syncPeerIP}}})
+			}
+
+			start := time.Now()
+			result, err := manager.WakeSandbox(t.Context(), "sandbox")
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectAction, result.Action)
+			if sbx != nil {
+				assert.Equal(t, tt.expectResumeCalls, sbx.resumeCalls)
+				assert.Equal(t, tt.expectSaveCalls, sbx.saveCalls)
+				assert.Equal(t, tt.expectAnnotation, sbx.GetAnnotations()[v1alpha1.AnnotationWakeOnTraffic])
+			}
+			if tt.expectSaveCalls == 0 {
+				return
+			}
+			if tt.expectClearedTimeouts {
+				assert.True(t, sbx.lastOptions.PauseTime.IsZero())
+				assert.True(t, sbx.lastOptions.ShutdownTime.IsZero())
+				return
+			}
+			if tt.expectPauseTime {
+				assert.WithinDuration(t, start.Add(tt.expectDuration), sbx.lastOptions.PauseTime, 5*time.Second)
+				assert.WithinDuration(t, start.Add(30*time.Minute), sbx.lastOptions.ShutdownTime, 5*time.Second)
+				return
+			}
+			if tt.expectShutdownTime {
+				assert.True(t, sbx.lastOptions.PauseTime.IsZero())
+				assert.WithinDuration(t, start.Add(tt.expectDuration), sbx.lastOptions.ShutdownTime, 5*time.Second)
+			}
+		})
+	}
+}
+
+func TestSandboxManager_WakeSandboxMetrics(t *testing.T) {
+	tests := []struct {
+		name         string
+		setup        func() *fakeSandbox
+		expectAction proxy.WakeAction
+	}{
+		{
+			name: "records resumed action and duration",
+			setup: func() *fakeSandbox {
+				return newWakeMetricsSandbox(v1alpha1.SandboxStatePaused, v1alpha1.SandboxPaused,
+					map[string]string{v1alpha1.AnnotationWakeOnTraffic: "timeout:10m"})
+			},
+			expectAction: proxy.WakeActionResumed,
+		},
+		{
+			name: "records disabled action and duration",
+			setup: func() *fakeSandbox {
+				return newWakeMetricsSandbox(v1alpha1.SandboxStatePaused, v1alpha1.SandboxPaused, nil)
+			},
+			expectAction: proxy.WakeActionAutoResumeDisabled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := tt.setup()
+			manager := &SandboxManager{
+				infra:      &fakeInfrastructure{sandbox: sbx},
+				proxy:      proxy.NewServer(testManagerOptions()),
+				maxTimeout: 30 * time.Minute,
+			}
+			beforeResponses := testutil.ToFloat64(sandboxWakeResponses.WithLabelValues(string(tt.expectAction)))
+			beforeDurationCount := wakeDurationSampleCount(t)
+
+			result, err := manager.WakeSandbox(t.Context(), "sandbox")
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectAction, result.Action)
+			assert.Equal(t, float64(1), testutil.ToFloat64(sandboxWakeResponses.WithLabelValues(string(tt.expectAction)))-beforeResponses)
+			assert.Equal(t, uint64(1), wakeDurationSampleCount(t)-beforeDurationCount)
+		})
+	}
+}
+
+func wakeDurationSampleCount(t *testing.T) uint64 {
+	t.Helper()
+	metric := &dto.Metric{}
+	require.NoError(t, sandboxWakeDuration.Write(metric))
+	require.NotNil(t, metric.Histogram)
+	return metric.GetHistogram().GetSampleCount()
+}
+
+func newWakeMetricsSandbox(state string, phase v1alpha1.SandboxPhase, annotations map[string]string) *fakeSandbox {
+	sbx := newFakeSandbox("sandbox")
+	sbx.state = state
+	sbx.timeout = timeout.Options{ShutdownTime: time.Now().Add(time.Hour)}
+	sbx.raw.Annotations = map[string]string{}
+	for key, value := range annotations {
+		sbx.raw.Annotations[key] = value
+	}
+	sbx.SetAnnotations(sbx.raw.Annotations)
+	sbx.raw.Status.Phase = phase
+	sbx.raw.Status.Conditions = append(sbx.raw.Status.Conditions, metav1.Condition{
+		Type:   string(v1alpha1.SandboxConditionPaused),
+		Status: metav1.ConditionTrue,
+	})
+	return sbx
+}
+
+func TestSandboxManager_WakeSandboxRunningPhasePausedSpecResumes(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "running phase with paused spec resumes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initial := timeout.Options{ShutdownTime: time.Now().Add(time.Hour)}
+			sharedTimeout := newPolicyTimeoutState(initial)
+			sbx := newPolicyWakeFakeSandbox("sandbox", "timeout:10m", sharedTimeout)
+			sbx.raw.Status.Phase = v1alpha1.SandboxRunning
+			sbx.raw.Spec.Paused = true
+			manager := &SandboxManager{
+				infra:      &fakeInfrastructure{sandbox: sbx},
+				proxy:      proxy.NewServer(testManagerOptions()),
+				maxTimeout: 30 * time.Minute,
+			}
+
+			start := time.Now()
+			result, err := manager.WakeSandbox(t.Context(), "sandbox")
+			require.NoError(t, err)
+
+			assert.Equal(t, proxy.WakeActionResumed, result.Action)
+			assert.Equal(t, 1, sbx.resumeCalls)
+			assert.Equal(t, 1, sbx.saveCalls)
+			finalTimeout := sharedTimeout.get()
+			assert.True(t, finalTimeout.PauseTime.IsZero())
+			assert.WithinDuration(t, start.Add(10*time.Minute), finalTimeout.ShutdownTime, 5*time.Second)
+		})
+	}
+}
+
+func TestWakeActionForConnectErrorReclassifiesSandbox(t *testing.T) {
+	tests := []struct {
+		name         string
+		refreshState string
+		phase        v1alpha1.SandboxPhase
+		pausedStatus metav1.ConditionStatus
+		deleting     bool
+		expectAction proxy.WakeAction
+		expectError  string
+	}{
+		{
+			name:         "conflict with refreshed running state is already running",
+			refreshState: v1alpha1.SandboxStateRunning,
+			phase:        v1alpha1.SandboxRunning,
+			expectAction: proxy.WakeActionAlreadyRunning,
+		},
+		{
+			name:         "conflict with refreshed dead state is gone",
+			refreshState: v1alpha1.SandboxStateDead,
+			phase:        v1alpha1.SandboxFailed,
+			expectAction: proxy.WakeActionGone,
+		},
+		{
+			name:         "conflict with paused phase and false paused condition is pausing",
+			refreshState: v1alpha1.SandboxStatePaused,
+			phase:        v1alpha1.SandboxPaused,
+			pausedStatus: metav1.ConditionFalse,
+			expectAction: proxy.WakeActionPausing,
+		},
+		{
+			name:         "conflict with resuming phase is bad state",
+			refreshState: v1alpha1.SandboxStatePaused,
+			phase:        v1alpha1.SandboxResuming,
+			expectAction: proxy.WakeActionBadState,
+		},
+		{
+			name:         "conflict with deleted sandbox is gone",
+			refreshState: v1alpha1.SandboxStatePaused,
+			phase:        v1alpha1.SandboxPaused,
+			pausedStatus: metav1.ConditionTrue,
+			deleting:     true,
+			expectAction: proxy.WakeActionGone,
+		},
+		{
+			name:        "non-conflict bubbles error",
+			expectError: "resume failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := newPolicyWakeFakeSandbox("sandbox", "timeout:10m", newPolicyTimeoutState(timeout.Options{}))
+			sbx.refreshFn = func(context.Context, bool) error {
+				sbx.state = tt.refreshState
+				sbx.raw.Status.Phase = tt.phase
+				sbx.raw.Status.Conditions = nil
+				if tt.pausedStatus != "" {
+					sbx.raw.Status.Conditions = append(sbx.raw.Status.Conditions, metav1.Condition{
+						Type:   string(v1alpha1.SandboxConditionPaused),
+						Status: tt.pausedStatus,
+					})
+				}
+				if tt.deleting {
+					deletionTimestamp := metav1.Now()
+					sbx.raw.DeletionTimestamp = &deletionTimestamp
+				}
+				return nil
+			}
+			var err error = managererrors.NewError(managererrors.ErrorConflict, "conflict without internal reason string")
+			if tt.expectError != "" {
+				err = errors.New(tt.expectError)
+			}
+
+			action, actionErr := wakeActionForConnectError(t.Context(), err, sbx)
+
+			if tt.expectError != "" {
+				require.Error(t, actionErr)
+				assert.Contains(t, actionErr.Error(), tt.expectError)
+				assert.Empty(t, action)
+				return
+			}
+			require.NoError(t, actionErr)
+			assert.Equal(t, tt.expectAction, action)
+			assert.Equal(t, 1, sbx.refreshCalls)
+		})
+	}
+}
+
+func TestSandboxManager_WakeSandboxResumeConflictReclassifiesCurrentSandbox(t *testing.T) {
+	tests := []struct {
+		name         string
+		currentPhase v1alpha1.SandboxPhase
+		pausedStatus metav1.ConditionStatus
+		expectAction proxy.WakeAction
+	}{
+		{
+			name:         "current sandbox is still pausing",
+			currentPhase: v1alpha1.SandboxPaused,
+			pausedStatus: metav1.ConditionFalse,
+			expectAction: proxy.WakeActionPausing,
+		},
+		{
+			name:         "current sandbox is not pausing",
+			currentPhase: v1alpha1.SandboxResuming,
+			expectAction: proxy.WakeActionBadState,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initial := timeout.Options{ShutdownTime: time.Now().Add(time.Hour)}
+			sbx := newPolicyWakeFakeSandbox("sandbox", "timeout:10m", newPolicyTimeoutState(initial))
+			sbx.resumeFn = func(context.Context) error {
+				sbx.raw.Status.Phase = tt.currentPhase
+				sbx.raw.Status.Conditions = nil
+				if tt.pausedStatus != "" {
+					sbx.raw.Status.Conditions = append(sbx.raw.Status.Conditions, metav1.Condition{
+						Type:   string(v1alpha1.SandboxConditionPaused),
+						Status: tt.pausedStatus,
+					})
+				}
+				return managererrors.NewError(managererrors.ErrorConflict, "conflict without internal reason string")
+			}
+			manager := &SandboxManager{
+				infra:      &fakeInfrastructure{sandbox: sbx},
+				proxy:      proxy.NewServer(testManagerOptions()),
+				maxTimeout: 30 * time.Minute,
+			}
+
+			result, err := manager.WakeSandbox(t.Context(), "sandbox")
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectAction, result.Action)
+			assert.Equal(t, 1, sbx.resumeCalls)
+			assert.Equal(t, 1, sbx.refreshCalls)
+			assert.Equal(t, 0, sbx.saveCalls)
+		})
+	}
+}
+
+func TestSandboxManager_WakeSandboxConcurrentWakeWake(t *testing.T) {
+	tests := []struct {
+		name                string
+		annotations         []string
+		expectLongestOffset time.Duration
+	}{
+		{
+			name:                "two paused wake callers both succeed and longest timeout survives",
+			annotations:         []string{"timeout:5m", "timeout:15m"},
+			expectLongestOffset: 15 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initial := timeout.Options{ShutdownTime: time.Now().Add(time.Hour)}
+			sharedTimeout := newPolicyTimeoutState(initial)
+			timeoutReads := make(chan struct{}, len(tt.annotations))
+			releaseTimeoutReads := make(chan struct{})
+			resumeTracker := &firstWriterResumeTracker{}
+
+			sandboxes := make([]infra.Sandbox, 0, len(tt.annotations))
+			for i, annotation := range tt.annotations {
+				sbx := newPolicyWakeFakeSandbox("sandbox", annotation, sharedTimeout)
+				sbx.getTimeoutFn = func() timeout.Options {
+					snapshot := sharedTimeout.get()
+					timeoutReads <- struct{}{}
+					<-releaseTimeoutReads
+					return snapshot
+				}
+				sbx.resumeFn = resumeTracker.resume
+				sandboxes = append(sandboxes, sbx)
+				_ = i
+			}
+			manager := &SandboxManager{
+				infra:      &sequenceInfrastructure{sandboxes: sandboxes},
+				proxy:      proxy.NewServer(testManagerOptions()),
+				maxTimeout: 30 * time.Minute,
+			}
+
+			results := make(chan proxy.WakeResult, len(tt.annotations))
+			errs := make(chan error, len(tt.annotations))
+			var wg sync.WaitGroup
+			start := time.Now()
+			for range tt.annotations {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					result, err := manager.WakeSandbox(t.Context(), "sandbox")
+					results <- result
+					errs <- err
+				}()
+			}
+			for range tt.annotations {
+				select {
+				case <-timeoutReads:
+				case <-time.After(5 * time.Second):
+					t.Fatal("timed out waiting for concurrent wake timeout snapshots")
+				}
+			}
+			close(releaseTimeoutReads)
+			wg.Wait()
+			close(results)
+			close(errs)
+
+			for err := range errs {
+				require.NoError(t, err)
+			}
+			for result := range results {
+				assert.Equal(t, proxy.WakeActionResumed, result.Action)
+			}
+			assert.Equal(t, len(tt.annotations), resumeTracker.attempts())
+			assert.Equal(t, 1, resumeTracker.updates())
+			finalTimeout := sharedTimeout.get()
+			assert.True(t, finalTimeout.PauseTime.IsZero())
+			assert.WithinDuration(t, start.Add(tt.expectLongestOffset), finalTimeout.ShutdownTime, 5*time.Second)
+		})
+	}
+}
+
+func TestSandboxManager_WakeSandboxCrossFormZeroTimeRaces(t *testing.T) {
+	tests := []struct {
+		name              string
+		wakeFirst         bool
+		expectFinalZero   bool
+		expectLoserResult int
+	}{
+		{
+			name:              "connect finite wins before stale wake never and deadline remains",
+			wakeFirst:         false,
+			expectFinalZero:   false,
+			expectLoserResult: 1,
+		},
+		{
+			name:              "wake never wins before stale connect finite and timeout remains cleared",
+			wakeFirst:         true,
+			expectFinalZero:   true,
+			expectLoserResult: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initial := timeout.Options{ShutdownTime: time.Now().Add(time.Hour)}
+			sharedTimeout := newPolicyTimeoutState(initial)
+			manager := &SandboxManager{
+				proxy:      proxy.NewServer(testManagerOptions()),
+				maxTimeout: 30 * time.Minute,
+			}
+			connectSbx := newPolicyWakeFakeSandbox("sandbox", "timeout:300s", sharedTimeout)
+			connectEndAt := time.Now().Add(300 * time.Second)
+
+			if tt.wakeFirst {
+				wakeSbx := newPolicyWakeFakeSandbox("sandbox", "timeout:never", sharedTimeout)
+				manager.infra = &fakeInfrastructure{sandbox: wakeSbx}
+				result, err := manager.WakeSandbox(t.Context(), "sandbox")
+				require.NoError(t, err)
+				assert.Equal(t, proxy.WakeActionResumed, result.Action)
+
+				err = manager.ConnectOrWake(t.Context(), connectSbx, ConnectOrWakeInput{
+					PreState: v1alpha1.SandboxStatePaused,
+					PreEndAt: initial.ShutdownTime,
+					Baseline: initial,
+					NewEndAt: connectEndAt,
+				})
+				require.NoError(t, err)
+			} else {
+				wakeObserved := make(chan struct{})
+				releaseWakeResume := make(chan struct{})
+				var closeObserved sync.Once
+				wakeSbx := newPolicyWakeFakeSandbox("sandbox", "timeout:never", sharedTimeout)
+				wakeSbx.getTimeoutFn = func() timeout.Options {
+					closeObserved.Do(func() {
+						close(wakeObserved)
+					})
+					return sharedTimeout.get()
+				}
+				wakeSbx.resumeFn = func(ctx context.Context) error {
+					select {
+					case <-releaseWakeResume:
+						return nil
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				}
+				manager.infra = &fakeInfrastructure{sandbox: wakeSbx}
+				wakeResult := make(chan proxy.WakeResult, 1)
+				wakeErr := make(chan error, 1)
+				go func() {
+					result, err := manager.WakeSandbox(t.Context(), "sandbox")
+					wakeResult <- result
+					wakeErr <- err
+				}()
+				select {
+				case <-wakeObserved:
+				case <-time.After(5 * time.Second):
+					t.Fatal("timed out waiting for wake timeout snapshot")
+				}
+
+				err := manager.ConnectOrWake(t.Context(), connectSbx, ConnectOrWakeInput{
+					PreState: v1alpha1.SandboxStatePaused,
+					PreEndAt: initial.ShutdownTime,
+					Baseline: initial,
+					NewEndAt: connectEndAt,
+				})
+				require.NoError(t, err)
+				close(releaseWakeResume)
+				require.NoError(t, <-wakeErr)
+				assert.Equal(t, proxy.WakeActionResumed, (<-wakeResult).Action)
+			}
+
+			results := sharedTimeout.results()
+			require.Len(t, results, 2)
+			assert.True(t, results[0].Updated)
+			assert.False(t, results[tt.expectLoserResult].Updated)
+			finalTimeout := sharedTimeout.get()
+			if tt.expectFinalZero {
+				assert.True(t, finalTimeout.ShutdownTime.IsZero())
+				assert.True(t, finalTimeout.PauseTime.IsZero())
+			} else {
+				assert.True(t, finalTimeout.PauseTime.IsZero())
+				assert.WithinDuration(t, connectEndAt, finalTimeout.ShutdownTime, 5*time.Second)
+			}
+		})
+	}
+}
+
+func newWakeFakeSandbox(tt struct {
+	name                  string
+	state                 string
+	phase                 v1alpha1.SandboxPhase
+	annotations           map[string]string
+	initialTimeout        timeout.Options
+	deleting              bool
+	pausedCondition       metav1.ConditionStatus
+	readyCondition        metav1.ConditionStatus
+	infraErr              error
+	syncPeerIP            string
+	expectAction          proxy.WakeAction
+	expectSaveCalls       int
+	expectResumeCalls     int
+	expectPauseTime       bool
+	expectShutdownTime    bool
+	expectClearedTimeouts bool
+	expectDuration        time.Duration
+	expectAnnotation      string
+}) *fakeSandbox {
+	if tt.infraErr != nil {
+		return nil
+	}
+	sbx := newFakeSandbox("sandbox")
+	sbx.state = tt.state
+	sbx.timeout = tt.initialTimeout
+	sbx.raw.Annotations = map[string]string{}
+	for key, value := range tt.annotations {
+		sbx.raw.Annotations[key] = value
+	}
+	sbx.SetAnnotations(sbx.raw.Annotations)
+	sbx.raw.Status.Phase = tt.phase
+	if tt.pausedCondition != "" {
+		sbx.raw.Status.Conditions = append(sbx.raw.Status.Conditions, metav1.Condition{
+			Type:   string(v1alpha1.SandboxConditionPaused),
+			Status: tt.pausedCondition,
+		})
+	}
+	if tt.readyCondition != "" {
+		sbx.raw.Status.Conditions = append(sbx.raw.Status.Conditions, metav1.Condition{
+			Type:   string(v1alpha1.SandboxConditionReady),
+			Status: tt.readyCondition,
+		})
+	}
+	if tt.deleting {
+		deletionTimestamp := metav1.Now()
+		sbx.raw.DeletionTimestamp = &deletionTimestamp
+		sbx.SetDeletionTimestamp(&deletionTimestamp)
+	}
+	return sbx
+}
+
+func newPolicyWakeFakeSandbox(id string, annotation string, state *policyTimeoutState) *fakeSandbox {
+	sbx := newFakeSandbox(id)
+	sbx.state = v1alpha1.SandboxStatePaused
+	sbx.timeout = state.get()
+	sbx.raw.Status.Phase = v1alpha1.SandboxPaused
+	sbx.raw.Status.Conditions = []metav1.Condition{
+		{
+			Type:   string(v1alpha1.SandboxConditionPaused),
+			Status: metav1.ConditionTrue,
+		},
+	}
+	sbx.raw.Annotations = map[string]string{
+		v1alpha1.AnnotationWakeOnTraffic: annotation,
+	}
+	sbx.SetAnnotations(map[string]string{
+		v1alpha1.AnnotationWakeOnTraffic: annotation,
+	})
+	sbx.saveFn = state.save
+	sbx.getTimeoutFn = state.get
+	return sbx
+}
+
+type firstWriterResumeTracker struct {
+	mu             sync.Mutex
+	resumeAttempts int
+	resumeUpdates  int
+	resumed        bool
+}
+
+func (t *firstWriterResumeTracker) resume(context.Context) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.resumeAttempts++
+	if !t.resumed {
+		t.resumed = true
+		t.resumeUpdates++
+	}
+	return nil
+}
+
+func (t *firstWriterResumeTracker) attempts() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.resumeAttempts
+}
+
+func (t *firstWriterResumeTracker) updates() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.resumeUpdates
+}
+
+type policyTimeoutState struct {
+	mu      sync.Mutex
+	current timeout.Options
+	updates []infra.TimeoutUpdateResult
+}
+
+func newPolicyTimeoutState(initial timeout.Options) *policyTimeoutState {
+	return &policyTimeoutState{current: timeout.Options{
+		ShutdownTime: initial.ShutdownTime,
+		PauseTime:    initial.PauseTime,
+	}}
+}
+
+func (s *policyTimeoutState) get() timeout.Options {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return timeout.Options{
+		ShutdownTime: s.current.ShutdownTime,
+		PauseTime:    s.current.PauseTime,
+	}
+}
+
+func (s *policyTimeoutState) results() []infra.TimeoutUpdateResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	results := make([]infra.TimeoutUpdateResult, len(s.updates))
+	copy(results, s.updates)
+	return results
+}
+
+func (s *policyTimeoutState) save(_ context.Context, opts timeout.Options, policy timeout.UpdatePolicy) (infra.TimeoutUpdateResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	shouldUpdate := false
+	switch policy {
+	case timeout.UpdatePolicyAlways:
+		shouldUpdate = !timeout.Equal(s.current, opts)
+	case timeout.UpdatePolicyExtendOnly:
+		shouldUpdate = timeout.ShouldExtendTimeout(s.current, opts)
+	case timeout.UpdatePolicyBaselineAware:
+		if opts.Baseline == nil {
+			return infra.TimeoutUpdateResult{}, fmt.Errorf("BaselineAware policy requires opts.Baseline to be set")
+		}
+		if timeout.Equal(s.current, *opts.Baseline) {
+			shouldUpdate = !timeout.Equal(s.current, opts)
+		} else {
+			shouldUpdate = timeout.ShouldExtendTimeout(s.current, opts)
+		}
+	default:
+		return infra.TimeoutUpdateResult{}, fmt.Errorf("unsupported timeout update policy %q", policy)
+	}
+	result := infra.TimeoutUpdateResult{Updated: shouldUpdate}
+	if shouldUpdate {
+		s.current = timeout.Options{
+			ShutdownTime: opts.ShutdownTime,
+			PauseTime:    opts.PauseTime,
+		}
+	}
+	s.updates = append(s.updates, result)
+	return result, nil
+}
+
+type sequenceInfrastructure struct {
+	fakeInfrastructure
+	mu        sync.Mutex
+	sandboxes []infra.Sandbox
+	next      int
+}
+
+func (f *sequenceInfrastructure) GetClaimedSandbox(context.Context, infra.GetClaimedSandboxOptions) (infra.Sandbox, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.next >= len(f.sandboxes) {
+		return nil, managererrors.NewError(managererrors.ErrorNotFound, "sandbox not found")
+	}
+	sbx := f.sandboxes[f.next]
+	f.next++
+	return sbx, nil
+}
+
+type wakeTestPeers struct {
+	members []peers.Peer
+}
+
+func (p *wakeTestPeers) Start(context.Context, int) error { return nil }
+func (p *wakeTestPeers) Stop() error                      { return nil }
+func (p *wakeTestPeers) GetPeers() []peers.Peer           { return p.members }
+func (p *wakeTestPeers) GetAllMembers() []peers.Peer      { return p.members }
+func (p *wakeTestPeers) WaitForPeers(context.Context, int) error {
+	return nil
+}
+func (p *wakeTestPeers) LocalAddr() net.IP { return net.ParseIP("127.0.0.1") }
+func (p *wakeTestPeers) LocalPort() int    { return 0 }

--- a/pkg/sandbox-manager/wakeontraffic.go
+++ b/pkg/sandbox-manager/wakeontraffic.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandbox_manager
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+var (
+	ErrAutoResumeDisabled      = errors.New("auto resume disabled")
+	ErrInvalidAutoResumePolicy = errors.New("invalid auto resume policy")
+)
+
+const wakeTimeoutNeverValue = "timeout:never"
+
+type Policy struct {
+	Form     PolicyForm
+	Duration time.Duration
+}
+
+type PolicyForm string
+
+const (
+	PolicyFormNever    PolicyForm = "never"
+	PolicyFormDuration PolicyForm = "duration"
+)
+
+func ParseWakeOnTrafficPolicy(annotations map[string]string) (Policy, error) {
+	value, ok := annotations[agentsv1alpha1.AnnotationWakeOnTraffic]
+	if !ok {
+		return Policy{}, ErrAutoResumeDisabled
+	}
+	if value == wakeTimeoutNeverValue {
+		return Policy{Form: PolicyFormNever}, nil
+	}
+
+	kind, payload, ok := strings.Cut(value, ":")
+	if !ok || kind != "timeout" {
+		return Policy{}, ErrInvalidAutoResumePolicy
+	}
+	duration, err := time.ParseDuration(payload)
+	if err != nil || duration < time.Second {
+		return Policy{}, ErrInvalidAutoResumePolicy
+	}
+	return Policy{Form: PolicyFormDuration, Duration: duration}, nil
+}
+
+// FormatNeverWakeOnTrafficPolicy returns the annotation value for the
+// no-shutdown-timeout wake-on-traffic policy. The output is parseable by
+// ParseWakeOnTrafficPolicy.
+func FormatNeverWakeOnTrafficPolicy() string {
+	return wakeTimeoutNeverValue
+}
+
+// FormatTimeoutWakeOnTrafficPolicy returns the annotation value for a
+// timeout-based wake-on-traffic policy. The output is parseable by
+// ParseWakeOnTrafficPolicy.
+func FormatTimeoutWakeOnTrafficPolicy(seconds int) string {
+	return fmt.Sprintf("timeout:%ds", seconds)
+}

--- a/pkg/sandbox-manager/wakeontraffic_test.go
+++ b/pkg/sandbox-manager/wakeontraffic_test.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandbox_manager
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+func TestParseWakeOnTrafficPolicy(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expect      Policy
+		expectError error
+	}{
+		{
+			name:        "disabled with nil annotations",
+			annotations: nil,
+			expectError: ErrAutoResumeDisabled,
+		},
+		{
+			name:        "disabled with empty annotations",
+			annotations: map[string]string{},
+			expectError: ErrAutoResumeDisabled,
+		},
+		{
+			name: "accepts never policy",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:never",
+			},
+			expect: Policy{Form: PolicyFormNever},
+		},
+		{
+			name: "accepts one second duration",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:1s",
+			},
+			expect: Policy{Form: PolicyFormDuration, Duration: time.Second},
+		},
+		{
+			name: "accepts thirty second duration",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:30s",
+			},
+			expect: Policy{Form: PolicyFormDuration, Duration: 30 * time.Second},
+		},
+		{
+			name: "accepts minute duration",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:5m",
+			},
+			expect: Policy{Form: PolicyFormDuration, Duration: 5 * time.Minute},
+		},
+		{
+			name: "accepts compound hour minute duration",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:2h30m",
+			},
+			expect: Policy{Form: PolicyFormDuration, Duration: 2*time.Hour + 30*time.Minute},
+		},
+		{
+			name: "rejects rfc3339 timestamp payload",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:2099-01-01T00:00:00Z",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects invalid kind",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "foo:300s",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects missing payload separator",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects missing kind",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: ":300s",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects empty value",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects true",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "true",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects false",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "false",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects empty timeout payload",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects zero without unit",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:0",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects zero duration",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:0s",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects negative duration",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:-1s",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects subsecond duration",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:500ms",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects invalid duration text",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:abc",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects duration without unit",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:5",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects capitalized never",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:Never",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects uppercase never",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:NEVER",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects leading space before never",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: " timeout:never",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects trailing space after never",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:never ",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects trailing newline after never",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:never\n",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects leading space before duration",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout: 300s",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects trailing newline",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:300s\n",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+		{
+			name: "rejects just under one second",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:999ms",
+			},
+			expectError: ErrInvalidAutoResumePolicy,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseWakeOnTrafficPolicy(tt.annotations)
+			if tt.expectError != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tt.expectError))
+				assert.Equal(t, Policy{}, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expect, got)
+		})
+	}
+}

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -104,6 +104,7 @@ func (sc *Controller) Init() error {
 		WithSandboxInfra().
 		WithMemberlistPeers().
 		WithRequestAdapter(adapter).
+		WithMaxTimeout(time.Duration(sc.maxTimeout) * time.Second).
 		Build()
 
 	if err != nil {

--- a/pkg/servers/e2b/core_test.go
+++ b/pkg/servers/e2b/core_test.go
@@ -144,6 +144,7 @@ func Setup(t *testing.T) (*Controller, ctrlclient.Client, func()) {
 				WithAPIReader(fc).
 				WithProxy(proxyServer), nil
 		}).
+		WithMaxTimeout(time.Duration(controller.maxTimeout) * time.Second).
 		Build()
 	require.NoError(t, err)
 

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -28,7 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 
+	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/features"
+	sandboxmanager "github.com/openkruise/agents/pkg/sandbox-manager"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
@@ -302,6 +304,13 @@ func (sc *Controller) basicSandboxCreateModifier(ctx context.Context, sbx infra.
 	}
 	for k, v := range request.Metadata {
 		annotations[k] = v
+	}
+	if request.AutoResume != nil && request.AutoResume.Enabled {
+		if request.Extensions.NeverTimeout {
+			annotations[v1alpha1.AnnotationWakeOnTraffic] = sandboxmanager.FormatNeverWakeOnTrafficPolicy()
+		} else {
+			annotations[v1alpha1.AnnotationWakeOnTraffic] = sandboxmanager.FormatTimeoutWakeOnTrafficPolicy(request.Timeout)
+		}
 	}
 	sbx.SetAnnotations(annotations)
 

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -499,6 +499,74 @@ func TestCreateSandboxWithClone_InplaceUpdateRejected(t *testing.T) {
 	assert.Contains(t, apiErr.Message, "InplaceUpdate is not supported for clone")
 }
 
+func TestBasicSandboxCreateModifierAutoResumeAnnotation(t *testing.T) {
+	tests := []struct {
+		name             string
+		request          models.NewSandboxRequest
+		expectAnnotation string
+		expectPresent    bool
+	}{
+		{
+			name: "auto resume nil does not write annotation",
+			request: models.NewSandboxRequest{
+				Timeout: 600,
+			},
+		},
+		{
+			name: "auto resume disabled does not write annotation",
+			request: models.NewSandboxRequest{
+				Timeout:    600,
+				AutoResume: &models.AutoResumeConfig{Enabled: false},
+			},
+		},
+		{
+			name: "auto resume enabled writes finite timeout annotation",
+			request: models.NewSandboxRequest{
+				Timeout:    600,
+				AutoResume: &models.AutoResumeConfig{Enabled: true},
+			},
+			expectAnnotation: "timeout:600s",
+			expectPresent:    true,
+		},
+		{
+			name: "auto resume enabled with never timeout writes never annotation",
+			request: models.NewSandboxRequest{
+				Timeout:    600,
+				AutoResume: &models.AutoResumeConfig{Enabled: true},
+				Extensions: models.NewSandboxRequestExtension{
+					NeverTimeout: true,
+				},
+			},
+			expectAnnotation: "timeout:never",
+			expectPresent:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSbx := &sandboxcr.Sandbox{
+				Sandbox: &agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-sandbox",
+						Namespace: "default",
+					},
+				},
+			}
+			ctrl := &Controller{maxTimeout: 3600}
+
+			ctrl.basicSandboxCreateModifier(context.Background(), mockSbx, tt.request)
+
+			got, ok := mockSbx.GetAnnotations()[v1alpha1.AnnotationWakeOnTraffic]
+			if tt.expectPresent {
+				require.True(t, ok)
+				assert.Equal(t, tt.expectAnnotation, got)
+				return
+			}
+			assert.False(t, ok)
+		})
+	}
+}
+
 func TestParseCreateSandboxRequest(t *testing.T) {
 	ctrl := &Controller{maxTimeout: 3600}
 
@@ -541,6 +609,22 @@ func TestParseCreateSandboxRequest(t *testing.T) {
 		raw, err := json.Marshal(models.NewSandboxRequest{
 			TemplateID: "t1",
 			Metadata:   meta,
+		})
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodPost, "/sandboxes", bytes.NewReader(raw))
+		_, apiErr := ctrl.parseCreateSandboxRequest(req)
+		require.NotNil(t, apiErr)
+		assert.Equal(t, http.StatusBadRequest, apiErr.Code)
+		assert.Contains(t, apiErr.Message, "Forbidden metadata key")
+	})
+
+	t.Run("forbidden wake on traffic metadata key", func(t *testing.T) {
+		raw, err := json.Marshal(models.NewSandboxRequest{
+			TemplateID: "t1",
+			Metadata: map[string]string{
+				v1alpha1.AnnotationWakeOnTraffic: "timeout:never",
+			},
 		})
 		require.NoError(t, err)
 

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -51,11 +51,16 @@ type NewSandboxRequest struct {
 	TemplateID string            `json:"templateID"`
 	Timeout    int               `json:"timeout,omitempty"`
 	AutoPause  bool              `json:"autoPause,omitempty"`
+	AutoResume *AutoResumeConfig `json:"autoResume,omitempty"`
 	Secure     bool              `json:"secure,omitempty"`
 	Metadata   map[string]string `json:"metadata,omitempty"`
 	EnvVars    EnvVars           `json:"envVars,omitempty"`
 
 	Extensions NewSandboxRequestExtension `json:"-"`
+}
+
+type AutoResumeConfig struct {
+	Enabled bool `json:"enabled"`
 }
 
 type NewSandboxRequestExtension struct {

--- a/pkg/servers/e2b/models/sandbox_test.go
+++ b/pkg/servers/e2b/models/sandbox_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNewSandboxRequestAutoResumeUnmarshal(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		expectNil     bool
+		expectEnabled bool
+	}{
+		{
+			name:      "omitted auto resume",
+			body:      `{"templateID":"t1"}`,
+			expectNil: true,
+		},
+		{
+			name:      "null auto resume",
+			body:      `{"templateID":"t1","autoResume":null}`,
+			expectNil: true,
+		},
+		{
+			name:          "enabled auto resume",
+			body:          `{"templateID":"t1","autoResume":{"enabled":true}}`,
+			expectEnabled: true,
+		},
+		{
+			name: "disabled auto resume",
+			body: `{"templateID":"t1","autoResume":{"enabled":false}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var request NewSandboxRequest
+			if err := json.Unmarshal([]byte(tt.body), &request); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+
+			if tt.expectNil {
+				if request.AutoResume != nil {
+					t.Fatalf("AutoResume = %#v, want nil", request.AutoResume)
+				}
+				return
+			}
+
+			if request.AutoResume == nil {
+				t.Fatal("AutoResume = nil, want non-nil")
+			}
+			if request.AutoResume.Enabled != tt.expectEnabled {
+				t.Fatalf("AutoResume.Enabled = %v, want %v", request.AutoResume.Enabled, tt.expectEnabled)
+			}
+		})
+	}
+}

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2b
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -25,6 +24,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openkruise/agents/api/v1alpha1"
+	sandboxmanager "github.com/openkruise/agents/pkg/sandbox-manager"
 	"github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
@@ -165,82 +165,47 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 	// It is only consumed when preConnectState == Paused (BaselineAware policy).
 	baseline := sbx.GetTimeout()
 
-	// Step 1: Resuming the sandbox if it is paused
+	var requestedEndAt time.Time
+	if !currentEndAt.IsZero() {
+		requestedEndAt = TimeAfterSeconds(time.Now(), request.TimeoutSeconds)
+	}
+	if state == v1alpha1.SandboxStateRunning && !currentEndAt.IsZero() && !requestedEndAt.After(currentEndAt) {
+		log.Info("skip connect timeout update because requested timeout does not extend current timeout",
+			"state", state, "reason", pauseResumeReason, "currentEndAt", currentEndAt, "requestedEndAt", requestedEndAt)
+		return web.ApiResponse[*models.Sandbox]{
+			Code: http.StatusOK,
+			Body: sc.convertToE2BSandbox(sbx, runtime.GetAccessToken(sbx)),
+		}, nil
+	}
+
+	var setAnnotations map[string]string
+	if !currentEndAt.IsZero() && sbx.GetAnnotations()[v1alpha1.AnnotationWakeOnTraffic] != "" {
+		setAnnotations = map[string]string{
+			v1alpha1.AnnotationWakeOnTraffic: sandboxmanager.FormatTimeoutWakeOnTrafficPolicy(request.TimeoutSeconds),
+		}
+	}
+
+	if err := sc.manager.ConnectOrWake(ctx, sbx, sandboxmanager.ConnectOrWakeInput{
+		PreState:       state,
+		AutoPause:      autoPause,
+		PreEndAt:       currentEndAt,
+		Baseline:       baseline,
+		NewEndAt:       requestedEndAt,
+		SetAnnotations: setAnnotations,
+	}); err != nil {
+		log.Error(err, "failed to connect sandbox")
+		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
+			Code:    http.StatusInternalServerError,
+			Message: fmt.Sprintf("Failed to connect sandbox: %v", err),
+		}
+	}
+
 	statusCode := http.StatusOK
 	if state == v1alpha1.SandboxStatePaused {
-		log.Info("sandbox is paused, will resume it", "reason", pauseResumeReason)
-		if err := sc.manager.ResumeSandbox(ctx, sbx, infra.ResumeOptions{}); err != nil {
-			log.Error(err, "failed to resume sandbox")
-			return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
-				Code:    http.StatusInternalServerError,
-				Message: fmt.Sprintf("Failed to resume sandbox: %v", err),
-			}
-		}
 		statusCode = http.StatusCreated
-		log.Info("sandbox resumed", "timeout", sbx.GetTimeout())
-	} else {
-		log.Info("sandbox is not paused, skip resuming", "state", state, "reason", pauseResumeReason)
 	}
-
-	// Step 2: Update the sandbox timeout
-	log.Info("updating sandbox timeout")
-	if err := sc.updateConnectTimeout(ctx, sbx, request.TimeoutSeconds, state, autoPause, currentEndAt, baseline); err != nil {
-		log.Error(err, "failed to update sandbox timeout")
-		return web.ApiResponse[*models.Sandbox]{}, err
-	}
-	log.Info("sandbox timeout updated")
-
 	return web.ApiResponse[*models.Sandbox]{
 		Code: statusCode,
 		Body: sc.convertToE2BSandbox(sbx, runtime.GetAccessToken(sbx)),
 	}, nil
-}
-
-// updateConnectTimeout updates the sandbox timeout after a Connect or Resume.
-//
-// Policy selection is based on preConnectState:
-//   - Paused  → BaselineAware: the baseline captured at handler entry is guaranteed to be a
-//     pre-resume value because SaveTimeoutWithPolicy is only reachable after Resume() returns,
-//     and Resume() blocks until status.Phase == Running. Therefore any observation of
-//     state ∈ {Paused, Resuming} proves no prior resumer has written a new timeout yet.
-//     BaselineAware compares the current spec timeout against the baseline: if they match,
-//     no concurrent writer has acted and the request may freely overwrite (Always semantics);
-//     if they diverge, a concurrent writer already wrote, so we degrade to ExtendOnly to
-//     preserve the longest timeout.
-//   - Otherwise → ExtendOnly: the sandbox was already running, so we only allow extending
-//     the existing timeout, never shrinking it.
-func (sc *Controller) updateConnectTimeout(ctx context.Context, sbx infra.Sandbox, timeoutSeconds int, preConnectState string, autoPause bool, currentEndAt time.Time, baseline timeout.Options) *web.ApiError {
-	log := klog.FromContext(ctx).WithValues("sandboxID", sbx.GetSandboxID())
-
-	// Rule 1: Sandboxes without endAt are never-timeout, should not have their timeout updated
-	if currentEndAt.IsZero() {
-		log.Info("skip resetting timeout for never-timeout sandbox")
-		return nil
-	}
-
-	now := time.Now()
-	policy := timeout.UpdatePolicyExtendOnly
-	opts := sc.buildSetTimeoutOptions(autoPause, now, timeoutSeconds)
-	if preConnectState == v1alpha1.SandboxStatePaused {
-		policy = timeout.UpdatePolicyBaselineAware
-		opts.Baseline = &baseline
-	}
-
-	log.Info("saving timeout to sandbox", "timeout", opts, "currentEndAt", currentEndAt,
-		"requestedEndAt", TimeAfterSeconds(now, timeoutSeconds), "requestedTimeoutSeconds", timeoutSeconds, "policy", policy)
-	result, err := sbx.SaveTimeoutWithPolicy(ctx, opts, policy)
-	if err != nil {
-		return &web.ApiError{
-			Message: fmt.Sprintf("Failed to set sandbox timeout: %v", err),
-		}
-	}
-	if !result.Updated {
-		log.Info("skip resetting timeout according to timeout update policy",
-			"currentEndAt", currentEndAt,
-			"requestedTimeoutSeconds", timeoutSeconds,
-			"policy", policy)
-	} else {
-		log.Info("timeout updated", "requestedTimeoutSeconds", timeoutSeconds)
-	}
-	return nil
 }

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	sandboxmanager "github.com/openkruise/agents/pkg/sandbox-manager"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -321,6 +322,141 @@ func TestConnectSandboxRunningTimeoutGuard(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConnectSandboxWakeOnTrafficAnnotationSync(t *testing.T) {
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+	}
+	tests := []struct {
+		name              string
+		templateName      string
+		initialTimeout    int
+		requestTimeout    int
+		paused            bool
+		neverTimeout      bool
+		initialAnnotation string
+		expectStatus      int
+		expectAnnotation  string
+		expectPause       bool
+	}{
+		{
+			name:             "running no annotation keeps annotation absent",
+			templateName:     "test-connect-annotation-running-absent",
+			initialTimeout:   300,
+			requestTimeout:   600,
+			expectStatus:     http.StatusOK,
+			expectAnnotation: "",
+		},
+		{
+			name:             "paused no annotation keeps annotation absent",
+			templateName:     "test-connect-annotation-paused-absent",
+			initialTimeout:   300,
+			requestTimeout:   600,
+			paused:           true,
+			expectStatus:     http.StatusCreated,
+			expectAnnotation: "",
+		},
+		{
+			name:              "running annotation present rewrites longer timeout",
+			templateName:      "test-connect-annotation-running-longer",
+			initialTimeout:    300,
+			requestTimeout:    600,
+			initialAnnotation: "timeout:300s",
+			expectStatus:      http.StatusOK,
+			expectAnnotation:  "timeout:600s",
+		},
+		{
+			name:              "running annotation present shorter timeout short circuits unchanged",
+			templateName:      "test-connect-annotation-running-shorter",
+			initialTimeout:    600,
+			requestTimeout:    300,
+			initialAnnotation: "timeout:600s",
+			expectStatus:      http.StatusOK,
+			expectAnnotation:  "timeout:600s",
+		},
+		{
+			name:              "paused annotation present writes timeout and annotation together",
+			templateName:      "test-connect-annotation-paused-present",
+			initialTimeout:    300,
+			requestTimeout:    600,
+			paused:            true,
+			initialAnnotation: "timeout:300s",
+			expectStatus:      http.StatusCreated,
+			expectAnnotation:  "timeout:600s",
+		},
+		{
+			name:              "never timeout annotation present is unchanged",
+			templateName:      "test-connect-annotation-never-timeout",
+			initialTimeout:    300,
+			requestTimeout:    600,
+			neverTimeout:      true,
+			initialAnnotation: "timeout:300s",
+			expectStatus:      http.StatusOK,
+			expectAnnotation:  "timeout:300s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller, fc, teardown := Setup(t)
+			defer teardown()
+			cleanup := CreateSandboxPool(t, controller, tt.templateName, 1)
+			defer cleanup()
+
+			metadata := map[string]string{
+				models.ExtensionKeySkipInitRuntime: agentsv1alpha1.True,
+			}
+			if tt.neverTimeout {
+				metadata[models.ExtensionKeyNeverTimeout] = agentsv1alpha1.True
+			}
+			createResp, err := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+				TemplateID: tt.templateName,
+				Timeout:    tt.initialTimeout,
+				Metadata:   metadata,
+			}, nil, user))
+			require.Nil(t, err)
+			require.Equal(t, models.SandboxStateRunning, createResp.Body.State)
+
+			if tt.initialAnnotation != "" {
+				setWakeOnTrafficAnnotation(t, fc, createResp.Body.SandboxID, tt.initialAnnotation)
+			}
+			EnableWaitSim(t, controller, createResp.Body.SandboxID)
+			if tt.paused {
+				pauseSandboxHelper(t, controller, fc, createResp.Body.SandboxID, false, false, user)
+				go UpdateSandboxWhen(t, fc, createResp.Body.SandboxID, func(sbx *agentsv1alpha1.Sandbox) bool {
+					return !sbx.Spec.Paused
+				}, DoSetSandboxStatus(agentsv1alpha1.SandboxRunning, metav1.ConditionFalse, metav1.ConditionTrue))
+			}
+
+			resp, apiErr := controller.ConnectSandbox(NewRequest(t, nil, models.SetTimeoutRequest{
+				TimeoutSeconds: tt.requestTimeout,
+			}, map[string]string{
+				"sandboxID": createResp.Body.SandboxID,
+			}, user))
+			require.Nil(t, apiErr)
+			assert.Equal(t, tt.expectStatus, resp.Code)
+
+			updated := GetSandbox(t, createResp.Body.SandboxID, fc)
+			assert.Equal(t, tt.expectAnnotation, updated.Annotations[agentsv1alpha1.AnnotationWakeOnTraffic])
+			if tt.neverTimeout {
+				assert.Nil(t, updated.Spec.PauseTime)
+				assert.Nil(t, updated.Spec.ShutdownTime)
+			}
+		})
+	}
+}
+
+func setWakeOnTrafficAnnotation(t *testing.T, c client.Client, sandboxID string, value string) {
+	t.Helper()
+	sbx := GetSandbox(t, sandboxID, c)
+	if sbx.Annotations == nil {
+		sbx.Annotations = map[string]string{}
+	}
+	sbx.Annotations[agentsv1alpha1.AnnotationWakeOnTraffic] = value
+	require.NoError(t, c.Update(t.Context(), sbx))
 }
 
 func TestConnectSandboxConcurrentPausedTimeouts(t *testing.T) {
@@ -671,9 +807,18 @@ func TestUpdateConnectTimeout(t *testing.T) {
 			}
 
 			beforeCall := time.Now()
-			result := controller.updateConnectTimeout(req.Context(), sbx, tt.timeoutSeconds,
-				tt.preConnectState, tt.autoPause, currentEndAt, baseline)
-			require.Nil(t, result)
+			var newEndAt time.Time
+			if !currentEndAt.IsZero() {
+				newEndAt = TimeAfterSeconds(time.Now(), tt.timeoutSeconds)
+			}
+			connectErr := controller.manager.ConnectOrWake(req.Context(), sbx, sandboxmanager.ConnectOrWakeInput{
+				PreState:  tt.preConnectState,
+				AutoPause: tt.autoPause,
+				PreEndAt:  currentEndAt,
+				Baseline:  baseline,
+				NewEndAt:  newEndAt,
+			})
+			require.NoError(t, connectErr)
 
 			updatedSbx := GetSandbox(t, createResp.Body.SandboxID, fc)
 

--- a/pkg/servers/e2b/templates_test.go
+++ b/pkg/servers/e2b/templates_test.go
@@ -535,6 +535,7 @@ func TestListTemplatesUsesCacheProvider(t *testing.T) {
 				WithAPIReader(spyCache.GetAPIReader()).
 				WithProxy(proxy.NewServer(opts)), nil
 		}).
+		WithMaxTimeout(30 * time.Minute).
 		Build()
 	require.NoError(t, err)
 

--- a/pkg/servers/e2b/timeout.go
+++ b/pkg/servers/e2b/timeout.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openkruise/agents/api/v1alpha1"
+	sandboxmanager "github.com/openkruise/agents/pkg/sandbox-manager"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
 	timeoututils "github.com/openkruise/agents/pkg/utils/timeout"
@@ -73,6 +74,11 @@ func (sc *Controller) setSandboxTimeout(r *http.Request) *web.ApiError {
 	autoPause, timeout := ParseTimeout(sbx)
 	if !timeout.IsZero() {
 		opts := sc.buildSetTimeoutOptions(autoPause, now, request.TimeoutSeconds)
+		if sbx.GetAnnotations()[v1alpha1.AnnotationWakeOnTraffic] != "" {
+			opts.SetAnnotations = map[string]string{
+				v1alpha1.AnnotationWakeOnTraffic: sandboxmanager.FormatTimeoutWakeOnTrafficPolicy(request.TimeoutSeconds),
+			}
+		}
 		if _, err := sbx.SaveTimeoutWithPolicy(ctx, opts, timeoututils.UpdatePolicyAlways); err != nil {
 			return &web.ApiError{
 				Message: fmt.Sprintf("Failed to set sandbox timeout: %v", err),

--- a/pkg/servers/e2b/timeout_test.go
+++ b/pkg/servers/e2b/timeout_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openkruise/agents/api/v1alpha1"
+	sandboxmanager "github.com/openkruise/agents/pkg/sandbox-manager"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 )
@@ -293,6 +294,85 @@ func TestSetSandboxTimeoutStillShortensRunningSandbox(t *testing.T) {
 	assert.WithinDuration(t, beforeSet.Add(time.Duration(shorterSeconds)*time.Second), sbx.Spec.ShutdownTime.Time, 5*time.Second)
 }
 
+func TestSetSandboxTimeoutWakeOnTrafficAnnotationSync(t *testing.T) {
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+	}
+	tests := []struct {
+		name              string
+		templateName      string
+		neverTimeout      bool
+		initialAnnotation string
+		requestTimeout    int
+		expectAnnotation  string
+	}{
+		{
+			name:             "running without annotation leaves annotation absent",
+			templateName:     "test-timeout-annotation-absent",
+			requestTimeout:   600,
+			expectAnnotation: "",
+		},
+		{
+			name:              "running with annotation updates annotation",
+			templateName:      "test-timeout-annotation-present",
+			initialAnnotation: "timeout:300s",
+			requestTimeout:    600,
+			expectAnnotation:  "timeout:600s",
+		},
+		{
+			name:              "never timeout with annotation leaves annotation unchanged",
+			templateName:      "test-timeout-annotation-never",
+			neverTimeout:      true,
+			initialAnnotation: "timeout:300s",
+			requestTimeout:    600,
+			expectAnnotation:  "timeout:300s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller, client, teardown := Setup(t)
+			defer teardown()
+			cleanup := CreateSandboxPool(t, controller, tt.templateName, 1)
+			defer cleanup()
+
+			metadata := map[string]string{
+				models.ExtensionKeySkipInitRuntime: v1alpha1.True,
+			}
+			if tt.neverTimeout {
+				metadata[models.ExtensionKeyNeverTimeout] = v1alpha1.True
+			}
+			createResp, err := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+				TemplateID: tt.templateName,
+				Timeout:    300,
+				Metadata:   metadata,
+			}, nil, user))
+			require.Nil(t, err)
+			require.Equal(t, models.SandboxStateRunning, createResp.Body.State)
+
+			if tt.initialAnnotation != "" {
+				setWakeOnTrafficAnnotation(t, client, createResp.Body.SandboxID, tt.initialAnnotation)
+			}
+
+			_, apiError := controller.SetSandboxTimeout(NewRequest(t, nil, models.SetTimeoutRequest{
+				TimeoutSeconds: tt.requestTimeout,
+			}, map[string]string{
+				"sandboxID": createResp.Body.SandboxID,
+			}, user))
+			require.Nil(t, apiError)
+
+			updated := GetSandbox(t, createResp.Body.SandboxID, client)
+			assert.Equal(t, tt.expectAnnotation, updated.Annotations[v1alpha1.AnnotationWakeOnTraffic])
+			if tt.neverTimeout {
+				assert.Nil(t, updated.Spec.PauseTime)
+				assert.Nil(t, updated.Spec.ShutdownTime)
+			}
+		})
+	}
+}
+
 func TestUpdateConnectTimeoutBaselinePolicy(t *testing.T) {
 	templateName := "test-update-connect-timeout-pause-baseline"
 	user := &models.CreatedTeamAPIKey{
@@ -356,9 +436,13 @@ func TestUpdateConnectTimeoutBaselinePolicy(t *testing.T) {
 			}
 
 			beforeCall := time.Now()
-			errResp := controller.updateConnectTimeout(req.Context(), wrapped, tt.requestTimeout,
-				v1alpha1.SandboxStatePaused, false, beforeCall.Add(time.Duration(tt.currentTimeout)*time.Second), baseline)
-			require.Nil(t, errResp)
+			connectErr := controller.manager.ConnectOrWake(req.Context(), wrapped, sandboxmanager.ConnectOrWakeInput{
+				PreState: v1alpha1.SandboxStatePaused,
+				PreEndAt: beforeCall.Add(time.Duration(tt.currentTimeout) * time.Second),
+				Baseline: baseline,
+				NewEndAt: TimeAfterSeconds(time.Now(), tt.requestTimeout),
+			})
+			require.NoError(t, connectErr)
 
 			updatedSbx := GetSandbox(t, createResp.Body.SandboxID, fc)
 			require.NotNil(t, updatedSbx.Spec.ShutdownTime)
@@ -431,9 +515,13 @@ func TestResumeSandboxBaselinePreventsStaleConnectTimeout(t *testing.T) {
 
 			wrapped, getErr := controller.getSandboxOfUser(req.Context(), createResp.Body.SandboxID)
 			require.Nil(t, getErr)
-			errResp := controller.updateConnectTimeout(req.Context(), wrapped, tt.connectTimeoutSeconds,
-				v1alpha1.SandboxStatePaused, false, afterFirstCall.Spec.ShutdownTime.Time, baseline)
-			require.Nil(t, errResp)
+			connectErr := controller.manager.ConnectOrWake(req.Context(), wrapped, sandboxmanager.ConnectOrWakeInput{
+				PreState: v1alpha1.SandboxStatePaused,
+				PreEndAt: afterFirstCall.Spec.ShutdownTime.Time,
+				Baseline: baseline,
+				NewEndAt: TimeAfterSeconds(time.Now(), tt.connectTimeoutSeconds),
+			})
+			require.NoError(t, connectErr)
 
 			afterSecondCall := GetSandbox(t, createResp.Body.SandboxID, fc)
 			require.NotNil(t, afterSecondCall.Spec.ShutdownTime)

--- a/pkg/utils/sandbox-manager/proxyutils/default_test.go
+++ b/pkg/utils/sandbox-manager/proxyutils/default_test.go
@@ -58,10 +58,11 @@ func TestGetRouteFromSandbox(t *testing.T) {
 				},
 			},
 			expectedRoute: proxy.Route{
-				IP:    "10.0.0.2",
-				ID:    "default--running-sandbox",
-				Owner: "",
-				State: v1alpha1.SandboxStateRunning,
+				IP:       "10.0.0.2",
+				ID:       "default--running-sandbox",
+				Owner:    "",
+				State:    v1alpha1.SandboxStateRunning,
+				Pausable: true,
 			},
 		},
 		{
@@ -83,10 +84,11 @@ func TestGetRouteFromSandbox(t *testing.T) {
 				},
 			},
 			expectedRoute: proxy.Route{
-				IP:    "",
-				ID:    "default--running-sandbox",
-				Owner: "",
-				State: v1alpha1.SandboxStateCreating,
+				IP:       "",
+				ID:       "default--running-sandbox",
+				Owner:    "",
+				State:    v1alpha1.SandboxStateCreating,
+				Pausable: true,
 			},
 		},
 	}

--- a/pkg/utils/sandboxutils/utils.go
+++ b/pkg/utils/sandboxutils/utils.go
@@ -32,6 +32,7 @@ func GetRouteFromSandbox(s *agentsv1alpha1.Sandbox) proxy.Route {
 	if s.Status.PodInfo.PodIP == "" {
 		state = agentsv1alpha1.SandboxStateCreating
 	}
+	pausable, _ := IsSandboxPausable(s)
 	return proxy.Route{
 		IP:              s.Status.PodInfo.PodIP,
 		ID:              GetSandboxID(s),
@@ -39,6 +40,8 @@ func GetRouteFromSandbox(s *agentsv1alpha1.Sandbox) proxy.Route {
 		Owner:           s.GetAnnotations()[agentsv1alpha1.AnnotationOwner],
 		State:           state,
 		ResourceVersion: s.GetResourceVersion(),
+		WakeOnTraffic:   s.GetAnnotations()[agentsv1alpha1.AnnotationWakeOnTraffic],
+		Pausable:        pausable,
 	}
 }
 

--- a/pkg/utils/sandboxutils/utils_test.go
+++ b/pkg/utils/sandboxutils/utils_test.go
@@ -17,13 +17,16 @@ limitations under the License.
 package sandboxutils
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/proxy"
 )
 
 func TestGetSandboxState(t *testing.T) {
@@ -431,6 +434,161 @@ func TestIsSandboxPausable(t *testing.T) {
 			assert.Equal(t, tt.expectedReason, reason)
 		})
 	}
+}
+
+func TestGetRouteFromSandboxWakeOnTraffic(t *testing.T) {
+	tests := []struct {
+		name              string
+		annotations       map[string]string
+		expectWakeTraffic string
+	}{
+		{
+			name: "annotation is copied",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "timeout:300s",
+			},
+			expectWakeTraffic: "timeout:300s",
+		},
+		{
+			name:              "missing annotation defaults empty",
+			annotations:       nil,
+			expectWakeTraffic: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sandbox := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "default",
+					Name:        "sandbox",
+					Annotations: tt.annotations,
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(agentsv1alpha1.SandboxConditionReady),
+							Status: metav1.ConditionTrue,
+						},
+					},
+					PodInfo: agentsv1alpha1.PodInfo{PodIP: "10.0.0.1"},
+				},
+			}
+
+			route := GetRouteFromSandbox(sandbox)
+
+			assert.Equal(t, tt.expectWakeTraffic, route.WakeOnTraffic)
+		})
+	}
+}
+
+func TestGetRouteFromSandboxPausable(t *testing.T) {
+	tests := []struct {
+		name           string
+		phase          agentsv1alpha1.SandboxPhase
+		paused         bool
+		expectPausable bool
+	}{
+		{
+			name:           "resuming sandbox is not pausable",
+			phase:          agentsv1alpha1.SandboxResuming,
+			expectPausable: false,
+		},
+		{
+			name:           "pending sandbox is not pausable",
+			phase:          agentsv1alpha1.SandboxPending,
+			expectPausable: false,
+		},
+		{
+			name:           "terminating sandbox is not pausable",
+			phase:          agentsv1alpha1.SandboxTerminating,
+			expectPausable: false,
+		},
+		{
+			name:           "running unpaused sandbox is pausable",
+			phase:          agentsv1alpha1.SandboxRunning,
+			paused:         false,
+			expectPausable: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sandbox := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "sandbox",
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused: tt.paused,
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: tt.phase,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(agentsv1alpha1.SandboxConditionReady),
+							Status: metav1.ConditionTrue,
+						},
+					},
+					PodInfo: agentsv1alpha1.PodInfo{PodIP: "10.0.0.1"},
+				},
+			}
+
+			route := GetRouteFromSandbox(sandbox)
+
+			assert.Equal(t, tt.expectPausable, route.Pausable)
+		})
+	}
+}
+
+func TestRouteJSONCompatibility(t *testing.T) {
+	type oldRoute struct {
+		IP              string `json:"ip"`
+		ID              string `json:"id"`
+		Owner           string `json:"owner"`
+		State           string `json:"state"`
+		ResourceVersion string `json:"resourceVersion"`
+	}
+
+	t.Run("new route decodes into old route", func(t *testing.T) {
+		body, err := json.Marshal(proxy.Route{
+			IP:              "10.0.0.1",
+			ID:              "sandbox",
+			Owner:           "owner",
+			State:           agentsv1alpha1.SandboxStateRunning,
+			ResourceVersion: "10",
+			WakeOnTraffic:   "timeout:300s",
+			Pausable:        true,
+		})
+		require.NoError(t, err)
+
+		var got oldRoute
+		err = json.Unmarshal(body, &got)
+
+		require.NoError(t, err)
+		assert.Equal(t, "sandbox", got.ID)
+		assert.Equal(t, agentsv1alpha1.SandboxStateRunning, got.State)
+	})
+
+	t.Run("old route decodes into new route with zero values", func(t *testing.T) {
+		body, err := json.Marshal(oldRoute{
+			IP:              "10.0.0.1",
+			ID:              "sandbox",
+			Owner:           "owner",
+			State:           agentsv1alpha1.SandboxStateRunning,
+			ResourceVersion: "10",
+		})
+		require.NoError(t, err)
+
+		var got proxy.Route
+		err = json.Unmarshal(body, &got)
+
+		require.NoError(t, err)
+		assert.Equal(t, "sandbox", got.ID)
+		assert.Empty(t, got.WakeOnTraffic)
+		assert.False(t, got.Pausable)
+	})
 }
 
 func TestIsSandboxResumable(t *testing.T) {

--- a/pkg/utils/timeout/types.go
+++ b/pkg/utils/timeout/types.go
@@ -25,6 +25,9 @@ type Options struct {
 	// Baseline is the timeout state the caller observed before issuing this update.
 	// Consulted only when the policy passed to SaveTimeoutWithPolicy is BaselineAware.
 	Baseline *Options `json:"-"`
+	// SetAnnotations is applied to metadata.annotations inside the same retryUpdate
+	// modifier that writes ShutdownTime / PauseTime. Empty-string values delete the key.
+	SetAnnotations map[string]string `json:"-"`
 }
 
 type UpdatePolicy string

--- a/test/e2b/test_wake_on_traffic.py
+++ b/test/e2b/test_wake_on_traffic.py
@@ -1,0 +1,170 @@
+"""Wake-on-traffic tests driven by the E2B SDK."""
+import json
+import re
+import subprocess
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+import pytest
+from e2b_code_interpreter import Sandbox, SandboxState
+
+from utils import run_code_sandbox
+
+
+WAKE_ON_TRAFFIC_ANNOTATION = "agents.kruise.io/wake-on-traffic"
+KUBERNETES_TIME_RE = re.compile(
+    r"^(?P<prefix>.+?)(?:\.(?P<fraction>\d+))?(?P<offset>Z|[+-]\d{2}:\d{2})$"
+)
+
+
+def kubectl_json(*args: str) -> dict[str, Any]:
+    result = subprocess.run(
+        ["kubectl", *args, "-o", "json"],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def sandbox_object_key(sandbox_id: str) -> tuple[str, str]:
+    parts = sandbox_id.split("--", 1)
+    assert len(parts) == 2, f"unexpected sandbox id format: {sandbox_id}"
+    return parts[0], parts[1]
+
+
+def get_sandbox_resource(sandbox_id: str) -> dict[str, Any]:
+    namespace, name = sandbox_object_key(sandbox_id)
+    return kubectl_json("get", "sbx", name, "-n", namespace)
+
+
+def wait_for_resource(
+    sandbox_id: str,
+    predicate: Callable[[dict[str, Any]], bool],
+    description: str,
+    timeout_seconds: int = 180,
+    interval_seconds: int = 2,
+) -> dict[str, Any]:
+    deadline = time.time() + timeout_seconds
+    last_resource: dict[str, Any] | None = None
+
+    while time.time() < deadline:
+        last_resource = get_sandbox_resource(sandbox_id)
+        if predicate(last_resource):
+            return last_resource
+        time.sleep(interval_seconds)
+
+    raise AssertionError(
+        f"timed out waiting for {description}; "
+        f"last sandbox resource: {json.dumps(last_resource, indent=2, sort_keys=True)}"
+    )
+
+
+def wait_for_sdk_state(
+    sandbox: Sandbox,
+    expected_state: SandboxState,
+    timeout_seconds: int = 180,
+    interval_seconds: int = 2,
+):
+    deadline = time.time() + timeout_seconds
+    last_state = None
+
+    while time.time() < deadline:
+        info = sandbox.get_info()
+        last_state = info.state
+        if last_state == expected_state:
+            return info
+        time.sleep(interval_seconds)
+
+    raise AssertionError(
+        f"timed out waiting for sandbox {sandbox.sandbox_id} to become "
+        f"{expected_state}; last state: {last_state}"
+    )
+
+
+def parse_kubernetes_time(value: str) -> datetime:
+    match = KUBERNETES_TIME_RE.match(value)
+    assert match is not None, f"unexpected Kubernetes timestamp: {value}"
+
+    offset = match.group("offset")
+    if offset == "Z":
+        offset = "+00:00"
+
+    fraction = match.group("fraction")
+    if fraction is None:
+        return datetime.fromisoformat(f"{match.group('prefix')}{offset}")
+
+    return datetime.fromisoformat(
+        f"{match.group('prefix')}.{fraction[:6].ljust(6, '0')}{offset}"
+    )
+
+
+TEST_CASES = [
+    {
+        "name": "run_code_wakes_paused_auto_resume_sandbox",
+        "timeout": 60,
+        "expected_policy": "timeout:60s",
+    },
+]
+
+
+@pytest.mark.parametrize("case", TEST_CASES, ids=[case["name"] for case in TEST_CASES])
+def test_run_code_wakes_paused_auto_resume_sandbox(sandbox_context, case):
+    sandbox: Sandbox = sandbox_context.add(Sandbox.create(
+        template="code-interpreter",
+        timeout=case["timeout"],
+        lifecycle={
+            "auto_resume": True,
+        },
+        metadata={
+            "test_case": "test_run_code_wakes_paused_auto_resume_sandbox",
+        },
+        headers={
+            "x-request-id": sandbox_context.request_id,
+        },
+    ))
+    print(f"sandbox-id: {sandbox.sandbox_id}")
+
+    wait_for_resource(
+        sandbox.sandbox_id,
+        lambda resource: resource.get("metadata", {})
+        .get("annotations", {})
+        .get(WAKE_ON_TRAFFIC_ANNOTATION) == case["expected_policy"],
+        "wake-on-traffic annotation after create",
+    )
+
+    sandbox.beta_pause()
+    wait_for_sdk_state(sandbox, SandboxState.PAUSED)
+    wait_for_resource(
+        sandbox.sandbox_id,
+        lambda resource: resource.get("spec", {}).get("paused") is True
+        and resource.get("metadata", {})
+        .get("annotations", {})
+        .get(WAKE_ON_TRAFFIC_ANNOTATION) == case["expected_policy"],
+        "paused sandbox with wake-on-traffic annotation",
+    )
+
+    # Allow the gateway route cache to observe the paused sandbox before the SDK
+    # sends traffic to the code-interpreter port.
+    time.sleep(3)
+    wake_start = datetime.now(timezone.utc)
+    execution = run_code_sandbox(sandbox, "print('wake-on-traffic')")
+
+    if execution.error:
+        raise Exception(execution.error)
+    assert execution.logs.stdout == ["wake-on-traffic\n"]
+
+    wait_for_sdk_state(sandbox, SandboxState.RUNNING)
+    resource = wait_for_resource(
+        sandbox.sandbox_id,
+        lambda resource: resource.get("spec", {}).get("paused") is False
+        and bool(resource.get("spec", {}).get("shutdownTime"))
+        and resource.get("metadata", {})
+        .get("annotations", {})
+        .get(WAKE_ON_TRAFFIC_ANNOTATION) == case["expected_policy"],
+        "resumed sandbox with refreshed shutdown time",
+    )
+
+    shutdown_time = parse_kubernetes_time(resource["spec"]["shutdownTime"])
+    assert shutdown_time >= wake_start + timedelta(minutes=4)


### PR DESCRIPTION
## Summary

Implements E2B-compatible wake-on-traffic semantics: any HTTP traffic to a paused sandbox transparently resumes it, restoring the timeout that was last set (with a 5-minute minimum floor).

- **Annotation protocol**: `agents.kruise.io/wake-on-traffic` with `timeout:never` / `timeout:<duration>` values
- **E2B wire mapping**: `autoResume.enabled` field on `POST /sandboxes` writes the annotation at create time
- **Manager wake path**: `WakeSandbox` → `ConnectOrWake` shared core (with `ConnectSandbox` refactor)
- **Internal endpoint**: `POST /wake/{sandboxID}` on `:7789` (anonymous, NetworkPolicy-protected)
- **Gateway async filter**: singleflight-coalesced wake calls with `OnDestroy` integration
- **Timeout policy**: `SaveTimeoutWithPolicy` now atomically applies `SetAnnotations` alongside timeout writes
- **Deploy**: NetworkPolicy for gateway→manager `:7789`, manager internal Service

### Key design decisions

- No CRD changes — annotation-only protocol
- No request-level auth on `/wake` — same trust model as existing `/refresh`
- Gateway does not impose its own wake timeout — bounded by client disconnect, Envoy stream timeout, and manager Resume task cap
- `ConnectSandbox` and `WakeSandbox` share `ConnectOrWake` core with `BaselineAware` / `ExtendOnly` policy
- Cross-replica correctness via first-writer-wins Resume + longest-timeout-wins `SaveTimeoutWithPolicy`

## Design

See `docs/specs/2026-05-14-wake-on-traffic-design.md` for the full specification.

## Test plan

- [ ] Annotation parser unit tests (valid/invalid forms, boundary cases)
- [ ] Manager `WakeSandbox` unit tests (all state transitions, 5-min floor, concurrent wake)
- [ ] `ConnectOrWake` core unit tests (paused/running paths, never-timeout, annotation passthrough)
- [ ] `SaveTimeoutWithPolicy.SetAnnotations` unit tests (write/delete/no-op on shouldUpdate=false)
- [ ] E2B handler annotation sync tests (create, connect, set-timeout)
- [ ] Gateway filter wake gate matrix tests
- [ ] Refresh handler relaxation tests (paused retained, dead removed)
- [ ] Route mapping tests (WakeOnTraffic/Pausable fields, JSON round-trip)
- [ ] Integration test (create → pause → traffic → auto-resume → verify CR state)