### PR TITLE
feat(e2b): support setting pod annotations via metadata

### DIFF
--- a/api/v1alpha1/annotations.go
+++ b/api/v1alpha1/annotations.go
@@ -26,8 +26,9 @@ const (
 // E2B annotations
 
 const (
-	E2BPrefix      = "e2b." + InternalPrefix
-	E2BLabelPrefix = "label:"
+	E2BPrefix           = "e2b." + InternalPrefix
+	E2BLabelPrefix      = "label:"
+	E2BAnnotationPrefix = "annotation:"
 
 	AnnotationEnvdAccessToken = E2BPrefix + "envd-access-token"
 	AnnotationEnvdURL         = E2BPrefix + "envd-url"

--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -291,6 +291,18 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 			}
 			sbx.SetPodLabels(labels)
 
+			// propagate annotations to podtemplate
+			if len(claim.Spec.Annotations) > 0 {
+				podAnnotations := sbx.GetPodAnnotations()
+				if podAnnotations == nil {
+					podAnnotations = make(map[string]string)
+				}
+				for k, v := range claim.Spec.Annotations {
+					podAnnotations[k] = v
+				}
+				sbx.SetPodAnnotations(podAnnotations)
+			}
+
 			// apply shutdownTime
 			if claim.Spec.ShutdownTime != nil {
 				sbx.SetTimeout(timeout.Options{

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -826,6 +826,11 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 								"existing-label": "existing-value",
 							},
 						},
+						Spec: agentsv1alpha1.SandboxSpec{
+							EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+								Template: &corev1.PodTemplateSpec{},
+							},
+						},
 					},
 				}
 				opts.Modifier(mockSandbox)
@@ -836,6 +841,13 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 				assert.Equal(t, "platform", mockSandbox.Labels["team"], "team label mismatch")
 				assert.Equal(t, "existing-value", mockSandbox.Labels["existing-label"], "existing-label should be preserved")
 				assert.Equal(t, "test annotation", mockSandbox.Annotations["description"], "description annotation mismatch")
+
+				// Verify modifier propagated labels to pod template
+				assert.Equal(t, "test", mockSandbox.GetPodLabels()["env"], "pod template env label mismatch")
+				assert.Equal(t, "platform", mockSandbox.GetPodLabels()["team"], "pod template team label mismatch")
+
+				// Verify modifier propagated annotations to pod template
+				assert.Equal(t, "test annotation", mockSandbox.GetPodAnnotations()["description"], "pod template description annotation mismatch")
 			},
 		},
 		{

--- a/pkg/sandbox-manager/infra/interface.go
+++ b/pkg/sandbox-manager/infra/interface.go
@@ -111,6 +111,8 @@ type Sandbox interface {
 	GetImage() string
 	SetPodLabels(labels map[string]string)
 	GetPodLabels() map[string]string
+	SetPodAnnotations(annotations map[string]string)
+	GetPodAnnotations() map[string]string
 	SetTimeout(opts timeout.Options)
 	SaveTimeoutWithPolicy(ctx context.Context, opts timeout.Options, policy timeout.UpdatePolicy) (TimeoutUpdateResult, error)
 	GetTimeout() timeout.Options

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -218,6 +218,19 @@ func (s *Sandbox) SetPodLabels(labels map[string]string) {
 	}
 }
 
+func (s *Sandbox) GetPodAnnotations() map[string]string {
+	if s.Spec.Template != nil {
+		return s.Spec.Template.Annotations
+	}
+	return nil
+}
+
+func (s *Sandbox) SetPodAnnotations(annotations map[string]string) {
+	if s.Spec.Template != nil {
+		s.Spec.Template.Annotations = annotations
+	}
+}
+
 // SetImage sets the image of the first container
 func (s *Sandbox) SetImage(image string) {
 	if s.Spec.Template != nil {

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
@@ -1037,6 +1037,67 @@ func TestSandbox_SetImageAndGetImage(t *testing.T) {
 	})
 }
 
+func TestSandbox_SetPodAnnotationsAndGetPodAnnotations(t *testing.T) {
+	t.Run("set and get annotations with template", func(t *testing.T) {
+		s := &Sandbox{
+			Sandbox: &v1alpha1.Sandbox{
+				Spec: v1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{},
+					},
+				},
+			},
+		}
+
+		assert.Nil(t, s.GetPodAnnotations())
+
+		annotations := map[string]string{"app.io/owner": "team-a", "app.io/env": "prod"}
+		s.SetPodAnnotations(annotations)
+		assert.Equal(t, annotations, s.GetPodAnnotations())
+	})
+
+	t.Run("overwrite existing annotations", func(t *testing.T) {
+		s := &Sandbox{
+			Sandbox: &v1alpha1.Sandbox{
+				Spec: v1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{"old-key": "old-value"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, map[string]string{"old-key": "old-value"}, s.GetPodAnnotations())
+
+		newAnnotations := map[string]string{"new-key": "new-value"}
+		s.SetPodAnnotations(newAnnotations)
+		assert.Equal(t, newAnnotations, s.GetPodAnnotations())
+		assert.NotContains(t, s.GetPodAnnotations(), "old-key")
+	})
+
+	t.Run("set and get annotations with nil template", func(t *testing.T) {
+		s := &Sandbox{
+			Sandbox: &v1alpha1.Sandbox{
+				Spec: v1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: nil,
+					},
+				},
+			},
+		}
+
+		assert.Nil(t, s.GetPodAnnotations())
+		assert.NotPanics(t, func() {
+			s.SetPodAnnotations(map[string]string{"key": "value"})
+		})
+		assert.Nil(t, s.GetPodAnnotations())
+	})
+}
+
 func TestSandbox_GetSandboxID(t *testing.T) {
 	s := &Sandbox{
 		Sandbox: &v1alpha1.Sandbox{

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -253,6 +253,15 @@ func (sc *Controller) parseCreateSandboxRequest(r *http.Request) (models.NewSand
 		}
 	}
 
+	for k := range request.Extensions.Annotations {
+		if !ValidateMetadataKey(k) {
+			return request, &web.ApiError{
+				Code:    http.StatusBadRequest,
+				Message: fmt.Sprintf("Forbidden annotation key [%s]: cannot contain prefixes: %v", k, BlackListPrefix),
+			}
+		}
+	}
+
 	if request.Timeout == 0 {
 		request.Timeout = models.DefaultTimeoutSeconds
 	}
@@ -315,7 +324,7 @@ func (sc *Controller) basicSandboxCreateModifier(ctx context.Context, sbx infra.
 	}
 	sbx.SetLabels(labels)
 
-	// propagate annotations to podtemplate
+	// propagate labels to podtemplate
 	labels = sbx.GetPodLabels()
 	if labels == nil {
 		labels = make(map[string]string)
@@ -324,6 +333,16 @@ func (sc *Controller) basicSandboxCreateModifier(ctx context.Context, sbx infra.
 		labels[k] = v
 	}
 	sbx.SetPodLabels(labels)
+
+	// propagate annotations to podtemplate
+	podAnnotations := sbx.GetPodAnnotations()
+	if podAnnotations == nil {
+		podAnnotations = make(map[string]string)
+	}
+	for k, v := range request.Extensions.Annotations {
+		podAnnotations[k] = v
+	}
+	sbx.SetPodAnnotations(podAnnotations)
 }
 
 func (sc *Controller) csiMountOptionsConfigRecord(ctx context.Context, sbx infra.Sandbox, request models.NewSandboxRequest) {

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -551,6 +551,66 @@ func TestParseCreateSandboxRequest(t *testing.T) {
 		assert.Contains(t, apiErr.Message, "Forbidden metadata key")
 	})
 
+	t.Run("annotation metadata validation", func(t *testing.T) {
+		tests := []struct {
+			name              string
+			metadata          map[string]string
+			expectError       string
+			expectAnnotations map[string]string
+		}{
+			{
+				name: "annotation value with spaces is allowed",
+				metadata: map[string]string{
+					v1alpha1.E2BAnnotationPrefix + "description": "value with spaces",
+				},
+				expectAnnotations: map[string]string{"description": "value with spaces"},
+			},
+			{
+				name: "annotation value with json is allowed",
+				metadata: map[string]string{
+					v1alpha1.E2BAnnotationPrefix + "config": `{"enabled":true,"mode":"test"}`,
+				},
+				expectAnnotations: map[string]string{"config": `{"enabled":true,"mode":"test"}`},
+			},
+			{
+				name: "forbidden internal annotation key prefix",
+				metadata: map[string]string{
+					v1alpha1.E2BAnnotationPrefix + v1alpha1.InternalPrefix + "inplace-update-state": "user-value",
+				},
+				expectError: "Forbidden annotation key",
+			},
+			{
+				name: "forbidden e2b annotation key prefix",
+				metadata: map[string]string{
+					v1alpha1.E2BAnnotationPrefix + v1alpha1.E2BPrefix + "envd-url": "user-value",
+				},
+				expectError: "Forbidden annotation key",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				raw, err := json.Marshal(models.NewSandboxRequest{
+					TemplateID: "t1",
+					Metadata:   tt.metadata,
+				})
+				require.NoError(t, err)
+
+				req := httptest.NewRequest(http.MethodPost, "/sandboxes", bytes.NewReader(raw))
+				got, apiErr := ctrl.parseCreateSandboxRequest(req)
+				if tt.expectError != "" {
+					require.NotNil(t, apiErr)
+					assert.Equal(t, http.StatusBadRequest, apiErr.Code)
+					assert.Contains(t, apiErr.Message, tt.expectError)
+					return
+				}
+
+				require.Nil(t, apiErr)
+				assert.Equal(t, tt.expectAnnotations, got.Extensions.Annotations)
+			})
+		}
+	})
+
 	t.Run("timeout defaults when omitted", func(t *testing.T) {
 		raw, err := json.Marshal(models.NewSandboxRequest{
 			TemplateID: "t1",

--- a/pkg/servers/e2b/models/extensions.go
+++ b/pkg/servers/e2b/models/extensions.go
@@ -27,7 +27,9 @@ import (
 	"github.com/distribution/reference"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/validation"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
 	"github.com/openkruise/agents/api/v1alpha1"
@@ -100,6 +102,9 @@ func (r *NewSandboxRequest) parseCommonExtensions() error {
 	if err = r.parseExtensionLabels(); err != nil {
 		return err
 	}
+	if err = r.parseExtensionAnnotations(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -113,15 +118,41 @@ func (r *NewSandboxRequest) parseExtensionLabels() error {
 		if r.Extensions.Labels == nil {
 			r.Extensions.Labels = make(map[string]string)
 		}
-		if len(validation.IsQualifiedName(key)) != 0 {
+		if len(utilvalidation.IsQualifiedName(key)) != 0 {
 			return fmt.Errorf("invalid label name [%s]", key)
 		}
 
-		if len(validation.IsValidLabelValue(v)) != 0 {
+		if len(utilvalidation.IsValidLabelValue(v)) != 0 {
 			return fmt.Errorf("invalid label value [%s]", v)
 		}
 
 		r.Extensions.Labels[key] = v
+		delete(r.Metadata, k)
+	}
+	return nil
+}
+
+func (r *NewSandboxRequest) parseExtensionAnnotations() error {
+	annotationsToDelete := make([]string, 0)
+	for k, v := range r.Metadata {
+		key := strings.TrimPrefix(k, v1alpha1.E2BAnnotationPrefix)
+		if key == k {
+			// not an annotation
+			continue
+		}
+		if r.Extensions.Annotations == nil {
+			r.Extensions.Annotations = make(map[string]string)
+		}
+		r.Extensions.Annotations[key] = v
+		annotationsToDelete = append(annotationsToDelete, k)
+	}
+	if len(r.Extensions.Annotations) == 0 {
+		return nil
+	}
+	if errList := apivalidation.ValidateAnnotations(r.Extensions.Annotations, field.NewPath("metadata").Child("annotations")); len(errList) != 0 {
+		return fmt.Errorf("invalid annotation: %v", errList.ToAggregate())
+	}
+	for _, k := range annotationsToDelete {
 		delete(r.Metadata, k)
 	}
 	return nil

--- a/pkg/servers/e2b/models/extensions_test.go
+++ b/pkg/servers/e2b/models/extensions_test.go
@@ -18,6 +18,7 @@ package models
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -738,6 +739,132 @@ func TestParseExtensionLabels(t *testing.T) {
 					}
 				}
 			}
+		})
+	}
+}
+
+func TestParseExtensionAnnotations(t *testing.T) {
+	tests := []struct {
+		name                string
+		metadata            map[string]string
+		expectError         string
+		expectedAnnotations map[string]string
+	}{
+		{
+			name:                "no annotations in metadata",
+			metadata:            map[string]string{},
+			expectedAnnotations: nil,
+		},
+		{
+			name: "no valid annotations in metadata",
+			metadata: map[string]string{
+				"app": "myapp",
+			},
+			expectedAnnotations: nil,
+		},
+		{
+			name: "single valid annotation",
+			metadata: map[string]string{
+				"annotation:app": "myapp",
+			},
+			expectedAnnotations: map[string]string{"app": "myapp"},
+		},
+		{
+			name: "multiple valid annotations",
+			metadata: map[string]string{
+				"annotation:app":  "myapp",
+				"annotation:env":  "production",
+				"annotation:tier": "backend",
+			},
+			expectedAnnotations: map[string]string{"app": "myapp", "env": "production", "tier": "backend"},
+		},
+		{
+			name: "invalid annotation name",
+			metadata: map[string]string{
+				"annotation:invalid-app{}": "myapp",
+			},
+			expectError: "invalid annotation",
+		},
+		{
+			name: "annotation value with spaces is allowed",
+			metadata: map[string]string{
+				"annotation:description": "value with spaces",
+			},
+			expectedAnnotations: map[string]string{"description": "value with spaces"},
+		},
+		{
+			name: "annotation value with json is allowed",
+			metadata: map[string]string{
+				"annotation:config": `{"enabled":true,"mode":"test"}`,
+			},
+			expectedAnnotations: map[string]string{"config": `{"enabled":true,"mode":"test"}`},
+		},
+		{
+			name: "annotation value longer than label value is allowed",
+			metadata: map[string]string{
+				"annotation:description": "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-extra",
+			},
+			expectedAnnotations: map[string]string{"description": "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-extra"},
+		},
+		{
+			name: "annotation value with newline is allowed",
+			metadata: map[string]string{
+				"annotation:description": "line one\nline two",
+			},
+			expectedAnnotations: map[string]string{"description": "line one\nline two"},
+		},
+		{
+			name: "annotation total size above kubernetes limit is rejected",
+			metadata: map[string]string{
+				"annotation:description": strings.Repeat("a", 256*1024),
+			},
+			expectError: "Too long",
+		},
+		{
+			name: "annotation with special characters in value",
+			metadata: map[string]string{
+				"annotation:app": "my-app_v1.0",
+			},
+			expectedAnnotations: map[string]string{"app": "my-app_v1.0"},
+		},
+		{
+			name: "kubernetes style annotation name",
+			metadata: map[string]string{
+				"annotation:kubernetes.io/app": "myapp",
+			},
+			expectedAnnotations: map[string]string{"kubernetes.io/app": "myapp"},
+		},
+		{
+			name: "annotations are removed from metadata after parsing",
+			metadata: map[string]string{
+				"annotation:app":   "myapp",
+				"regular-metadata": "should-remain",
+			},
+			expectedAnnotations: map[string]string{"app": "myapp"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &NewSandboxRequest{
+				Metadata: tt.metadata,
+			}
+
+			err := req.parseExtensionAnnotations()
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.expectedAnnotations == nil {
+				assert.Nil(t, req.Extensions.Annotations)
+				return
+			}
+			require.NotNil(t, req.Extensions.Annotations)
+			assert.Equal(t, tt.expectedAnnotations, req.Extensions.Annotations)
 		})
 	}
 }

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -68,6 +68,7 @@ type NewSandboxRequestExtension struct {
 	TimeoutSeconds       int
 	NeverTimeout         bool
 	Labels               map[string]string
+	Annotations          map[string]string
 }
 
 type InplaceUpdateExtension struct {

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -446,6 +446,86 @@ func TestCreateSandbox(t *testing.T) {
 				assert.NotContains(t, sbx.Spec.Template.Labels, "another-metadata")
 			},
 		},
+		{
+			name:      "success with custom annotations",
+			available: 2,
+			userName:  "test-user",
+			request: models.NewSandboxRequest{
+				TemplateID: templateName,
+				Timeout:    600,
+				Metadata: map[string]string{
+					v1alpha1.E2BAnnotationPrefix + "app.io/owner": "team-a",
+					v1alpha1.E2BAnnotationPrefix + "app.io/env":   "prod",
+					"regular-metadata-key":                        "should-remain-in-metadata",
+				},
+			},
+			postCheck: func(t *testing.T, resp *models.Sandbox) {
+				sbx := GetSandbox(t, resp.SandboxID, fc)
+				assert.NotNil(t, sbx.Spec.Template)
+				assert.NotNil(t, sbx.Spec.Template.Annotations)
+
+				assert.Equal(t, "team-a", sbx.Spec.Template.Annotations["app.io/owner"])
+				assert.Equal(t, "prod", sbx.Spec.Template.Annotations["app.io/env"])
+
+				assert.NotContains(t, sbx.Spec.Template.Annotations, "regular-metadata-key")
+
+				sandboxFromManager, err := controller.manager.GetClaimedSandbox(t.Context(), keys.AdminKeyID.String(), infra.GetClaimedSandboxOptions{
+					SandboxID: resp.SandboxID,
+				})
+				assert.NoError(t, err)
+				assert.NotNil(t, sandboxFromManager.GetPodAnnotations())
+				assert.Equal(t, "team-a", sandboxFromManager.GetPodAnnotations()["app.io/owner"])
+				assert.Equal(t, "prod", sandboxFromManager.GetPodAnnotations()["app.io/env"])
+			},
+		},
+		{
+			name:      "fail with invalid annotation name",
+			available: 2,
+			userName:  "test-user",
+			request: models.NewSandboxRequest{
+				TemplateID: templateName,
+				Metadata: map[string]string{
+					v1alpha1.E2BAnnotationPrefix + "invalid@annotation": "value",
+				},
+			},
+			expectError: &web.ApiError{
+				Code:    http.StatusBadRequest,
+				Message: "invalid annotation",
+			},
+		},
+		{
+			name:      "success with kubernetes annotation value",
+			available: 2,
+			userName:  "test-user",
+			request: models.NewSandboxRequest{
+				TemplateID: templateName,
+				Timeout:    600,
+				Metadata: map[string]string{
+					v1alpha1.E2BAnnotationPrefix + "valid-annotation": "value with spaces!",
+				},
+			},
+			postCheck: func(t *testing.T, resp *models.Sandbox) {
+				sbx := GetSandbox(t, resp.SandboxID, fc)
+				assert.NotNil(t, sbx.Spec.Template)
+				assert.NotNil(t, sbx.Spec.Template.Annotations)
+				assert.Equal(t, "value with spaces!", sbx.Spec.Template.Annotations["valid-annotation"])
+			},
+		},
+		{
+			name:      "fail with forbidden annotation key prefix",
+			available: 2,
+			userName:  "test-user",
+			request: models.NewSandboxRequest{
+				TemplateID: templateName,
+				Metadata: map[string]string{
+					v1alpha1.E2BAnnotationPrefix + v1alpha1.InternalPrefix + "inplace-update-state": "user-value",
+				},
+			},
+			expectError: &web.ApiError{
+				Code:    http.StatusBadRequest,
+				Message: "Forbidden annotation key",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -496,6 +576,9 @@ func TestCreateSandbox(t *testing.T) {
 						continue
 					}
 					if strings.HasPrefix(k, v1alpha1.E2BLabelPrefix) {
+						continue
+					}
+					if strings.HasPrefix(k, v1alpha1.E2BAnnotationPrefix) {
 						continue
 					}
 					assert.Equal(t, v, sbx.Metadata[k], fmt.Sprintf("metadata key: %s", k))

--- a/pkg/utils/inplaceupdate/inplace_update.go
+++ b/pkg/utils/inplaceupdate/inplace_update.go
@@ -201,7 +201,20 @@ func DefaultGeneratePatchBodyFunc(opts InPlaceUpdateOptions) string {
 		annotationsPatch[PodAnnotationInPlaceUpdateStateKey] = utils.DumpJson(state)
 	}
 	for k, v := range extensionAnnotations {
+		if k == PodAnnotationInPlaceUpdateStateKey {
+			continue
+		}
 		annotationsPatch[k] = v
+	}
+	if box.Spec.Template != nil {
+		for k, v := range box.Spec.Template.Annotations {
+			if k == PodAnnotationInPlaceUpdateStateKey {
+				continue
+			}
+			if pod.Annotations[k] != v {
+				annotationsPatch[k] = v
+			}
+		}
 	}
 
 	if len(labelsPatch) == 0 && len(annotationsPatch) == 0 && len(patchSpec.Containers) == 0 {

--- a/pkg/utils/inplaceupdate/inplace_update_test.go
+++ b/pkg/utils/inplaceupdate/inplace_update_test.go
@@ -2026,6 +2026,233 @@ func TestDefaultGeneratePatchBodyFunc_ExtensionAnnotations(t *testing.T) {
 	}
 }
 
+func TestDefaultGeneratePatchBodyFunc_ReservedInPlaceStateAnnotation(t *testing.T) {
+	tests := []struct {
+		name                 string
+		extensionAnnotations map[string]string
+		templateAnnotations  map[string]string
+		expectAnnotation     map[string]string
+	}{
+		{
+			name: "extension annotation cannot override generated state",
+			extensionAnnotations: map[string]string{
+				PodAnnotationInPlaceUpdateStateKey: "user-state",
+				"custom.annotation/key":            "from-extension",
+			},
+			expectAnnotation: map[string]string{
+				"custom.annotation/key": "from-extension",
+			},
+		},
+		{
+			name: "template annotation cannot override generated state",
+			templateAnnotations: map[string]string{
+				PodAnnotationInPlaceUpdateStateKey: "template-state",
+				"custom.annotation/key":            "from-template",
+			},
+			expectAnnotation: map[string]string{
+				"custom.annotation/key": "from-template",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := InPlaceUpdateOptions{
+				Box: &agentsv1alpha1.Sandbox{
+					Spec: agentsv1alpha1.SandboxSpec{
+						EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+							Template: &corev1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: tt.templateAnnotations,
+								},
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  "container1",
+											Image: "nginx:new",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-pod",
+						Namespace:   "default",
+						Annotations: map[string]string{},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "container1",
+								Image: "nginx:old",
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:    "container1",
+								ImageID: "nginx@sha256:old",
+							},
+						},
+					},
+				},
+				Revision:             "rev-reserved",
+				ExtensionAnnotations: tt.extensionAnnotations,
+			}
+
+			patchBody := DefaultGeneratePatchBodyFunc(opts)
+			if patchBody == "" {
+				t.Fatalf("expected non-empty patch body")
+			}
+
+			var patch map[string]interface{}
+			if err := json.Unmarshal([]byte(patchBody), &patch); err != nil {
+				t.Fatalf("failed to unmarshal patch body: %v", err)
+			}
+
+			metadata, ok := patch["metadata"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("patch body should have metadata")
+			}
+
+			annotations, ok := metadata["annotations"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("metadata should have annotations")
+			}
+
+			stateStr, ok := annotations[PodAnnotationInPlaceUpdateStateKey].(string)
+			if !ok {
+				t.Fatalf("annotations should have generated in-place update state")
+			}
+			var state InPlaceUpdateState
+			if err := json.Unmarshal([]byte(stateStr), &state); err != nil {
+				t.Fatalf("generated in-place update state should be valid json: %v", err)
+			}
+			if state.Revision != "rev-reserved" {
+				t.Errorf("expected revision rev-reserved, got %s", state.Revision)
+			}
+			if !state.UpdateImages {
+				t.Errorf("expected generated state to track image update")
+			}
+			for k, v := range tt.expectAnnotation {
+				if annotations[k] != v {
+					t.Errorf("expected annotation %s=%s in patch, got %v", k, v, annotations[k])
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultGeneratePatchBodyFunc_TemplateAnnotations(t *testing.T) {
+	tests := []struct {
+		name               string
+		templateAnnotation map[string]string
+		podAnnotations     map[string]string
+		expectInPatch      map[string]string
+		expectNotInPatch   []string
+	}{
+		{
+			name:               "new annotations added to pod",
+			templateAnnotation: map[string]string{"app.io/owner": "team-a", "app.io/env": "prod"},
+			podAnnotations:     map[string]string{},
+			expectInPatch:      map[string]string{"app.io/owner": "team-a", "app.io/env": "prod"},
+		},
+		{
+			name:               "already synced annotations not patched",
+			templateAnnotation: map[string]string{"app.io/owner": "team-a"},
+			podAnnotations:     map[string]string{"app.io/owner": "team-a"},
+			expectNotInPatch:   []string{"app.io/owner"},
+		},
+		{
+			name:               "changed annotation value is patched",
+			templateAnnotation: map[string]string{"app.io/owner": "team-b"},
+			podAnnotations:     map[string]string{"app.io/owner": "team-a"},
+			expectInPatch:      map[string]string{"app.io/owner": "team-b"},
+		},
+		{
+			name:               "nil template annotations produce no annotation patch",
+			templateAnnotation: nil,
+			podAnnotations:     map[string]string{"existing": "value"},
+			expectNotInPatch:   []string{"existing"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			box := &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels:      map[string]string{},
+								Annotations: tt.templateAnnotation,
+							},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "c", Image: "img:v1"}},
+							},
+						},
+					},
+				},
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "p",
+					Namespace:   "default",
+					Labels:      map[string]string{},
+					Annotations: tt.podAnnotations,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "img:v1"}},
+				},
+			}
+
+			body := DefaultGeneratePatchBodyFunc(InPlaceUpdateOptions{
+				Box:      box,
+				Pod:      pod,
+				Revision: "rev-anno",
+			})
+
+			if len(tt.expectInPatch) == 0 && len(tt.expectNotInPatch) > 0 {
+				// Patch may be empty or have no annotation section
+				if body == "" {
+					return
+				}
+				var decoded map[string]any
+				if err := json.Unmarshal([]byte(body), &decoded); err != nil {
+					t.Fatalf("unmarshal patch: %v", err)
+				}
+				metadata, _ := decoded["metadata"].(map[string]any)
+				annotations, _ := metadata["annotations"].(map[string]any)
+				for _, k := range tt.expectNotInPatch {
+					if _, exists := annotations[k]; exists {
+						t.Errorf("annotation %s should not be in patch", k)
+					}
+				}
+				return
+			}
+
+			if body == "" {
+				t.Fatalf("expected non-empty body")
+			}
+			var decoded map[string]any
+			if err := json.Unmarshal([]byte(body), &decoded); err != nil {
+				t.Fatalf("unmarshal patch: %v", err)
+			}
+			metadata, _ := decoded["metadata"].(map[string]any)
+			annotations, _ := metadata["annotations"].(map[string]any)
+			for k, v := range tt.expectInPatch {
+				if annotations[k] != v {
+					t.Errorf("expected annotation %s=%s in patch, got %v", k, v, annotations[k])
+				}
+			}
+		})
+	}
+}
+
 func TestCheckResizeQoSChange(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary
- Add `annotation:` prefix support in E2B metadata to set pod-level annotations, mirroring existing `label:` prefix behavior
- Validate annotation keys against blacklisted prefixes and Kubernetes annotation rules
- Propagate annotations to pod templates during sandbox create, claim, and in-place update flows

## Test plan
- [x] Unit tests for `parseExtensionAnnotations` with valid/invalid inputs
- [x] Unit tests for `SetPodAnnotations`/`GetPodAnnotations` on Sandbox CR
- [x] Integration tests in `services_test.go` for create sandbox with annotations
- [x] Unit tests for in-place update annotation sync and reserved key protection
- [x] Unit tests for claim controller annotation propagation