### PR TITLE
fix: reject resume during pausing state and return 400 for conflict

### DIFF
--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -171,8 +171,12 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 		log.Info("sandbox is paused, will resume it", "reason", pauseResumeReason)
 		if err := sc.manager.ResumeSandbox(ctx, sbx, infra.ResumeOptions{}); err != nil {
 			log.Error(err, "failed to resume sandbox")
+			code := http.StatusInternalServerError
+			if errors.GetErrCode(err) == errors.ErrorConflict {
+				code = http.StatusBadRequest
+			}
 			return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
-				Code:    http.StatusInternalServerError,
+				Code:    code,
 				Message: fmt.Sprintf("Failed to resume sandbox: %v", err),
 			}
 		}

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -28,10 +28,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	cacheutils "github.com/openkruise/agents/pkg/cache/utils"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+type waitHooksCache interface {
+	GetWaitHooks() *sync.Map
+}
 
 func TestPauseSandbox(t *testing.T) {
 	templateName := "test-template"
@@ -105,7 +110,7 @@ func pauseSandboxHelper(t *testing.T, controller *Controller, client client.Clie
 			return sbx.Spec.Paused == true
 		}, DoSetSandboxStatus(agentsv1alpha1.SandboxPaused, metav1.ConditionFalse, ""))
 	} else if resuming {
-		// Set resuming state: Spec.Paused=false, Phase=Running, Ready=false
+		// Set resuming state: Spec.Paused=false, Phase=Resuming, Ready=false
 		// This means sandbox is transitioning from paused to running
 		sbx := GetSandbox(t, sandboxID, client)
 		sbx.Spec.Paused = false
@@ -114,6 +119,27 @@ func pauseSandboxHelper(t *testing.T, controller *Controller, client client.Clie
 		UpdateSandboxWhen(t, client, sandboxID, func(sbx *agentsv1alpha1.Sandbox) bool {
 			return sbx.Spec.Paused == false
 		}, DoSetSandboxStatus(agentsv1alpha1.SandboxResuming, "", metav1.ConditionFalse))
+	}
+}
+
+func waitForResumeUpdate(controller *Controller, waitForResumeHook bool) WhenFunc {
+	return func(sbx *agentsv1alpha1.Sandbox) bool {
+		if sbx.Spec.Paused {
+			return false
+		}
+		if !waitForResumeHook {
+			return true
+		}
+		cache, ok := controller.cache.(waitHooksCache)
+		if !ok || cache.GetWaitHooks() == nil {
+			return false
+		}
+		value, ok := cache.GetWaitHooks().Load(cacheutils.WaitHookKey[*agentsv1alpha1.Sandbox](sbx))
+		if !ok {
+			return false
+		}
+		entry, ok := value.(*cacheutils.WaitEntry[*agentsv1alpha1.Sandbox])
+		return ok && entry.Action == cacheutils.WaitActionResume
 	}
 }
 
@@ -204,9 +230,9 @@ func TestConnectSandbox(t *testing.T) {
 				tt.sandboxID = createResp.Body.SandboxID
 			}
 			if tt.expectStatus < 300 {
-				go UpdateSandboxWhen(t, fc, createResp.Body.SandboxID, func(sbx *agentsv1alpha1.Sandbox) bool {
-					return sbx.Spec.Paused == false
-				}, DoSetSandboxStatus(agentsv1alpha1.SandboxRunning, "", metav1.ConditionTrue))
+				waitForResumeHook := tt.paused && !tt.pausing
+				go UpdateSandboxWhen(t, fc, createResp.Body.SandboxID, waitForResumeUpdate(controller, waitForResumeHook),
+					DoSetSandboxStatus(agentsv1alpha1.SandboxRunning, "", metav1.ConditionTrue))
 			}
 			now := time.Now()
 			connectResp, err := controller.ConnectSandbox(NewRequest(t, nil, models.SetTimeoutRequest{
@@ -523,9 +549,9 @@ func TestResumeSandbox(t *testing.T) {
 			}
 			if tt.expectStatus < 300 {
 				// Only schedule async update when expecting success
-				go UpdateSandboxWhen(t, fc, createResp.Body.SandboxID, func(sbx *agentsv1alpha1.Sandbox) bool {
-					return sbx.Spec.Paused == false
-				}, DoSetSandboxStatus(agentsv1alpha1.SandboxRunning, "", metav1.ConditionTrue))
+				waitForResumeHook := tt.paused && !tt.pausing
+				go UpdateSandboxWhen(t, fc, createResp.Body.SandboxID, waitForResumeUpdate(controller, waitForResumeHook),
+					DoSetSandboxStatus(agentsv1alpha1.SandboxRunning, "", metav1.ConditionTrue))
 			}
 			now := time.Now()
 			resumeResp, apiErr := controller.ResumeSandbox(NewRequest(t, nil, models.SetTimeoutRequest{

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -146,7 +146,7 @@ func TestConnectSandbox(t *testing.T) {
 			paused:       true,
 			pausing:      true,
 			timeout:      DefaultTimeoutSeconds,
-			expectStatus: http.StatusInternalServerError,
+			expectStatus: http.StatusBadRequest,
 		},
 		{
 			name:         "resume sandbox: resuming",

--- a/pkg/utils/sandboxutils/utils.go
+++ b/pkg/utils/sandboxutils/utils.go
@@ -128,8 +128,13 @@ func IsSandboxPausable(sbx *agentsv1alpha1.Sandbox) (bool, string) {
 // IsSandboxResumable returns true when the resuming operation will not cause any conflict.
 func IsSandboxResumable(sbx *agentsv1alpha1.Sandbox) (bool, string) {
 	switch sbx.Status.Phase {
-	case agentsv1alpha1.SandboxRunning, agentsv1alpha1.SandboxResuming:
-		return true, "SandboxIsRunningOrResuming"
+	case agentsv1alpha1.SandboxRunning:
+		if sbx.Spec.Paused {
+			return false, "SandboxIsPausing"
+		}
+		return true, "SandboxIsRunning"
+	case agentsv1alpha1.SandboxResuming:
+		return true, "SandboxIsResuming"
 	default:
 	}
 	if sbx.Status.Phase == agentsv1alpha1.SandboxPaused {

--- a/pkg/utils/sandboxutils/utils_test.go
+++ b/pkg/utils/sandboxutils/utils_test.go
@@ -448,7 +448,20 @@ func TestIsSandboxResumable(t *testing.T) {
 				},
 			},
 			expectedResult: true,
-			expectedReason: "SandboxIsRunningOrResuming",
+			expectedReason: "SandboxIsRunning",
+		},
+		{
+			name: "Running sandbox with spec.paused=true is not resumable (pausing in progress)",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused: true,
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+				},
+			},
+			expectedResult: false,
+			expectedReason: "SandboxIsPausing",
 		},
 		{
 			name: "Resuming sandbox is resumable",
@@ -458,7 +471,7 @@ func TestIsSandboxResumable(t *testing.T) {
 				},
 			},
 			expectedResult: true,
-			expectedReason: "SandboxIsRunningOrResuming",
+			expectedReason: "SandboxIsResuming",
 		},
 		{
 			name: "Paused sandbox with paused condition is resumable",


### PR DESCRIPTION
## Summary
- `IsSandboxResumable` now splits the combined `Running/Resuming` case into separate branches, adding a `spec.paused` check for Running phase to reject the "pausing in progress" intermediate state (`phase=Running + spec.paused=true`).
- `ConnectSandbox` maps `ErrorConflict` from `ResumeSandbox` to HTTP 400 (BadRequest) instead of 500 (InternalServerError), following the E2B spec pattern.

## Test plan
- [x] `TestIsSandboxResumable` — 6 cases covering Running, Running+paused, Resuming, Paused+condition, Paused-no-condition, Succeeded
- [x] `TestConnectSandbox` — "resume sandbox: pausing" case now expects 400
- [x] Full `pkg/utils/sandboxutils/` and `pkg/servers/e2b/` test suites pass
- [x] `pkg/sandbox-manager/...` regression tests pass