### PR TITLE
feat: implement sandbox pausing lifecycle

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -243,6 +243,8 @@ const (
 	// SandboxRunning means the pod has been bound to a node and all of the containers have been started.
 	// At least one container is still running or is in the process of being restarted.
 	SandboxRunning SandboxPhase = "Running"
+	// SandboxPausing means the sandbox is pausing and has not completed hibernation yet.
+	SandboxPausing SandboxPhase = "Pausing"
 	// SandboxPaused means the sandbox has entered the paused state.
 	SandboxPaused SandboxPhase = "Paused"
 	// SandboxResuming means the sandbox has entered the resume state

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -165,11 +165,12 @@ func (r *commonControl) EnsureSandboxPaused(ctx context.Context, args EnsureFunc
 		utils.SetSandboxCondition(newStatus, *cond)
 		klog.InfoS("Paused condition initialized", "sandbox", klog.KObj(box))
 	} else if cond.Status == metav1.ConditionTrue {
+		newStatus.Phase = agentsv1alpha1.SandboxPaused
 		klog.InfoS("Paused condition is already true", "sandbox", klog.KObj(box))
 		return nil
 	}
 
-	// The paused phase sets condition ready to false.
+	// The pausing phase sets condition ready to false.
 	if rCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady)); rCond != nil && rCond.Status == metav1.ConditionTrue {
 		rCond.Status = metav1.ConditionFalse
 		rCond.LastTransitionTime = metav1.Now()
@@ -183,6 +184,7 @@ func (r *commonControl) EnsureSandboxPaused(ctx context.Context, args EnsureFunc
 		cond.Status = metav1.ConditionTrue
 		cond.LastTransitionTime = metav1.Now()
 		utils.SetSandboxCondition(newStatus, *cond)
+		newStatus.Phase = agentsv1alpha1.SandboxPaused
 		klog.InfoS("Pod deletion completed, pause phase completed", "sandbox", klog.KObj(box))
 		return nil
 	}

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -484,10 +484,11 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 	_ = agentsv1alpha1.AddToScheme(scheme)
 
 	tests := []struct {
-		name      string
-		args      EnsureFuncArgs
-		podExists bool
-		wantErr   bool
+		name          string
+		args          EnsureFuncArgs
+		podExists     bool
+		wantErr       bool
+		expectedPhase agentsv1alpha1.SandboxPhase
 	}{
 		{
 			name: "pod does not exist, should mark paused",
@@ -500,6 +501,7 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 					},
 				},
 				NewStatus: &agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxPausing,
 					Conditions: []metav1.Condition{
 						{
 							Type:               string(agentsv1alpha1.SandboxConditionReady),
@@ -510,8 +512,9 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 					},
 				},
 			},
-			podExists: false,
-			wantErr:   false,
+			podExists:     false,
+			wantErr:       false,
+			expectedPhase: agentsv1alpha1.SandboxPaused,
 		},
 		{
 			name: "pod exists but being deleted, should wait",
@@ -531,6 +534,7 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 					},
 				},
 				NewStatus: &agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxPausing,
 					Conditions: []metav1.Condition{
 						{
 							Type:               string(agentsv1alpha1.SandboxConditionReady),
@@ -541,8 +545,9 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 					},
 				},
 			},
-			podExists: true,
-			wantErr:   false,
+			podExists:     true,
+			wantErr:       false,
+			expectedPhase: agentsv1alpha1.SandboxPausing,
 		},
 		{
 			name: "pod exists, should delete it",
@@ -560,6 +565,7 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 					},
 				},
 				NewStatus: &agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxPausing,
 					Conditions: []metav1.Condition{
 						{
 							Type:               string(agentsv1alpha1.SandboxConditionReady),
@@ -570,8 +576,9 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 					},
 				},
 			},
-			podExists: true,
-			wantErr:   false,
+			podExists:     true,
+			wantErr:       false,
+			expectedPhase: agentsv1alpha1.SandboxPausing,
 		},
 	}
 
@@ -593,6 +600,9 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("EnsureSandboxPaused() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if tt.args.NewStatus.Phase != tt.expectedPhase {
+				t.Errorf("EnsureSandboxPaused() phase = %s, want %s", tt.args.NewStatus.Phase, tt.expectedPhase)
 			}
 
 			// Verify pod was deleted if it existed initially

--- a/pkg/controller/sandbox/core/interface.go
+++ b/pkg/controller/sandbox/core/interface.go
@@ -48,7 +48,7 @@ type SandboxControl interface {
 	// EnsureSandboxUpdated handle sandbox with status phase = Running
 	EnsureSandboxUpdated(ctx context.Context, args EnsureFuncArgs) error
 
-	// EnsureSandboxPaused handle sandbox with status phase = Paused
+	// EnsureSandboxPaused handle sandbox with status phase = Pausing or Paused.
 	EnsureSandboxPaused(ctx context.Context, args EnsureFuncArgs) error
 
 	// EnsureSandboxResumed handle sandbox with status phase = Resuming

--- a/pkg/controller/sandbox/core/rateLimiter.go
+++ b/pkg/controller/sandbox/core/rateLimiter.go
@@ -165,7 +165,8 @@ func isCreatingSandbox(box *agentsv1alpha1.Sandbox) bool {
 	if !box.DeletionTimestamp.IsZero() {
 		return false
 	}
-	if box.Status.Phase == agentsv1alpha1.SandboxPaused || box.Status.Phase == agentsv1alpha1.SandboxResuming ||
+	if box.Status.Phase == agentsv1alpha1.SandboxPausing || box.Status.Phase == agentsv1alpha1.SandboxPaused ||
+		box.Status.Phase == agentsv1alpha1.SandboxResuming ||
 		box.Status.Phase == agentsv1alpha1.SandboxSucceeded || box.Status.Phase == agentsv1alpha1.SandboxFailed {
 		return false
 	}

--- a/pkg/controller/sandbox/core/rateLimiter_test.go
+++ b/pkg/controller/sandbox/core/rateLimiter_test.go
@@ -147,6 +147,11 @@ func TestIsCreatingSandbox(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "phase Pausing is not creating",
+			box:      newSandbox("default", "box1", agentsv1alpha1.SandboxPausing),
+			expected: false,
+		},
+		{
 			name:     "phase Paused is not creating",
 			box:      newSandbox("default", "box1", agentsv1alpha1.SandboxPaused),
 			expected: false,

--- a/pkg/controller/sandbox/metrics.go
+++ b/pkg/controller/sandbox/metrics.go
@@ -241,6 +241,7 @@ var (
 	allPhases = []agentsv1alpha1.SandboxPhase{
 		agentsv1alpha1.SandboxPending,
 		agentsv1alpha1.SandboxRunning,
+		agentsv1alpha1.SandboxPausing,
 		agentsv1alpha1.SandboxPaused,
 		agentsv1alpha1.SandboxResuming,
 		agentsv1alpha1.SandboxSucceeded,

--- a/pkg/controller/sandbox/metrics_test.go
+++ b/pkg/controller/sandbox/metrics_test.go
@@ -127,6 +127,7 @@ func TestRecordSandboxMetrics_StatusPhase(t *testing.T) {
 	}{
 		{name: "Pending phase", phase: agentsv1alpha1.SandboxPending},
 		{name: "Running phase", phase: agentsv1alpha1.SandboxRunning},
+		{name: "Pausing phase", phase: agentsv1alpha1.SandboxPausing},
 		{name: "Paused phase", phase: agentsv1alpha1.SandboxPaused},
 		{name: "Resuming phase", phase: agentsv1alpha1.SandboxResuming},
 		{name: "Succeeded phase", phase: agentsv1alpha1.SandboxSucceeded},

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -231,7 +231,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 		requeueAfter, err = r.getControl(args.Pod).EnsureSandboxRunning(ctx, args)
 	case agentsv1alpha1.SandboxRunning:
 		err = r.getControl(args.Pod).EnsureSandboxUpdated(ctx, args)
-	case agentsv1alpha1.SandboxPaused:
+	case agentsv1alpha1.SandboxPausing, agentsv1alpha1.SandboxPaused:
 		err = r.EnsureSandboxPaused(ctx, args)
 	case agentsv1alpha1.SandboxResuming:
 		err = r.getControl(args.Pod).EnsureSandboxResumed(ctx, args)
@@ -318,6 +318,10 @@ func calculateStatus(args core.EnsureFuncArgs) (*agentsv1alpha1.SandboxStatus, b
 	switch newStatus.Phase {
 	case agentsv1alpha1.SandboxPending:
 		updateStatusIfPodCompleted(pod, newStatus)
+		if box.Spec.Paused {
+			utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionResumed))
+			newStatus.Phase = agentsv1alpha1.SandboxPausing
+		}
 		if isSandboxCompletedPhase(newStatus.Phase) {
 			return newStatus, true
 		}
@@ -333,12 +337,12 @@ func calculateStatus(args core.EnsureFuncArgs) (*agentsv1alpha1.SandboxStatus, b
 			return newStatus, true
 		}
 
-		// If it is paused, first set the sandbox to the Paused state.
-		// To prevent loss of state information, the state immediately before Paused must currently be Running.
+		// If it is paused, first set the sandbox to the Pausing state.
+		// To prevent loss of state information, the state immediately before Pausing must currently be Running.
 		if box.Spec.Paused {
 			// The paused and resumed condition are exclusive
 			utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionResumed))
-			newStatus.Phase = agentsv1alpha1.SandboxPaused
+			newStatus.Phase = agentsv1alpha1.SandboxPausing
 			// Check for upgrade: if template has changed (hash mismatch), transition to Upgrading phase
 		} else if pod != nil && pod.Labels[agentsv1alpha1.PodLabelTemplateHash] != newStatus.UpdateRevision &&
 			box.Spec.UpgradePolicy != nil && box.Spec.UpgradePolicy.Type == agentsv1alpha1.SandboxUpgradePolicyRecreate {
@@ -349,10 +353,18 @@ func calculateStatus(args core.EnsureFuncArgs) (*agentsv1alpha1.SandboxStatus, b
 			utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionUpgrading))
 		}
 
+	case agentsv1alpha1.SandboxPausing:
+		cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
+		if cond != nil && cond.Status == metav1.ConditionTrue {
+			newStatus.Phase = agentsv1alpha1.SandboxPaused
+		} else if !box.Spec.Paused {
+			klog.InfoS("sandbox pause not completed, cannot enter resume state temporarily", "sandbox", klog.KObj(box))
+		}
+
 	case agentsv1alpha1.SandboxPaused:
 		cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
 		// sandbox will only enter the resuming state after successful paused
-		if cond.Status == metav1.ConditionTrue && !box.Spec.Paused {
+		if cond != nil && cond.Status == metav1.ConditionTrue && !box.Spec.Paused {
 			// delete paused condition
 			utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
 			newStatus.Phase = agentsv1alpha1.SandboxResuming
@@ -363,7 +375,7 @@ func calculateStatus(args core.EnsureFuncArgs) (*agentsv1alpha1.SandboxStatus, b
 				LastTransitionTime: metav1.Now(),
 			}
 			utils.SetSandboxCondition(newStatus, rCond)
-		} else if !box.Spec.Paused && cond.Status == metav1.ConditionFalse {
+		} else if cond != nil && !box.Spec.Paused && cond.Status == metav1.ConditionFalse {
 			klog.InfoS("sandbox pause not completed, cannot enter resume state temporarily", "sandbox", klog.KObj(box))
 		}
 

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -348,7 +348,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 					Phase: corev1.PodRunning,
 				},
 			},
-			expectedPhase: agentsv1alpha1.SandboxPaused,
+			expectedPhase: agentsv1alpha1.SandboxPausing,
 			wantErr:       false,
 		},
 		{
@@ -1482,7 +1482,7 @@ func TestCalculateStatus(t *testing.T) {
 			expectedShouldReq: true,
 		},
 		{
-			name: "running phase with paused spec should set to paused",
+			name: "running phase with paused spec should set to pausing",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -1518,7 +1518,7 @@ func TestCalculateStatus(t *testing.T) {
 					},
 				},
 			},
-			expectedPhase:     agentsv1alpha1.SandboxPaused,
+			expectedPhase:     agentsv1alpha1.SandboxPausing,
 			expectedShouldReq: false,
 			checkConditions: func(t *testing.T, status *agentsv1alpha1.SandboxStatus) {
 				// Should remove resumed condition
@@ -1528,6 +1528,150 @@ func TestCalculateStatus(t *testing.T) {
 					}
 				}
 			},
+		},
+		{
+			name: "pausing phase with paused condition false should stay pausing",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-sandbox",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused: true,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+							},
+						},
+					},
+				},
+			},
+			initStatus: &agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPausing,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(agentsv1alpha1.SandboxConditionPaused),
+						Status: metav1.ConditionFalse,
+					},
+				},
+			},
+			expectedPhase:     agentsv1alpha1.SandboxPausing,
+			expectedShouldReq: false,
+		},
+		{
+			name: "pausing phase with paused condition true should set to paused",
+			pod:  nil,
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-sandbox",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused: true,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+							},
+						},
+					},
+				},
+			},
+			initStatus: &agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPausing,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(agentsv1alpha1.SandboxConditionPaused),
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+			expectedPhase:     agentsv1alpha1.SandboxPaused,
+			expectedShouldReq: false,
+		},
+		{
+			name: "pausing phase with resume requested should stay pausing until paused condition true",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-sandbox",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused: false,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+							},
+						},
+					},
+				},
+			},
+			initStatus: &agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPausing,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(agentsv1alpha1.SandboxConditionPaused),
+						Status: metav1.ConditionFalse,
+					},
+				},
+			},
+			expectedPhase:     agentsv1alpha1.SandboxPausing,
+			expectedShouldReq: false,
+		},
+		{
+			name: "pausing phase with resume requested and paused condition true should set to paused first",
+			pod:  nil,
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-sandbox",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused: false,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+							},
+						},
+					},
+				},
+			},
+			initStatus: &agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPausing,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(agentsv1alpha1.SandboxConditionPaused),
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+			expectedPhase:     agentsv1alpha1.SandboxPaused,
+			expectedShouldReq: false,
 		},
 		{
 			name: "paused phase with paused condition true and not paused spec should set to resuming",

--- a/pkg/utils/sandboxutils/utils.go
+++ b/pkg/utils/sandboxutils/utils.go
@@ -51,7 +51,7 @@ func GetSandboxState(sbx *agentsv1alpha1.Sandbox) (state string, reason string) 
 	if sbx.Spec.ShutdownTime != nil && time.Since(sbx.Spec.ShutdownTime.Time) > 0 {
 		return agentsv1alpha1.SandboxStateDead, "ShutdownTimeReached"
 	}
-	if sbx.Status.Phase == agentsv1alpha1.SandboxPending {
+	if sbx.Status.Phase == agentsv1alpha1.SandboxPending || sbx.Status.Phase == "" {
 		return agentsv1alpha1.SandboxStateCreating, "ResourcePending"
 	}
 	if sbx.Status.Phase == agentsv1alpha1.SandboxSucceeded {
@@ -82,9 +82,12 @@ func GetSandboxState(sbx *agentsv1alpha1.Sandbox) (state string, reason string) 
 					return agentsv1alpha1.SandboxStateDead, "RunningResourceClaimedButNotReady"
 				}
 			}
+		} else if sbx.Status.Phase == agentsv1alpha1.SandboxPausing || sbx.Status.Phase == agentsv1alpha1.SandboxPaused || sbx.Status.Phase == agentsv1alpha1.SandboxResuming {
+			return agentsv1alpha1.SandboxStatePaused, "PausedOrResumingResourceClaimed"
+		} else if sbx.Status.Phase == agentsv1alpha1.SandboxUpgrading {
+			return agentsv1alpha1.SandboxStateRunning, "UpgradingResourceClaimed"
 		} else {
-			// Paused and Resuming phases are both treated as paused state
-			return agentsv1alpha1.SandboxStatePaused, "NotRunningResourceClaimed"
+			return agentsv1alpha1.SandboxStateDead, "UnknownPhaseResourceClaimed"
 		}
 	}
 }
@@ -118,8 +121,8 @@ func IsSandboxPausable(sbx *agentsv1alpha1.Sandbox) (bool, string) {
 		}
 	}
 	switch sbx.Status.Phase {
-	case agentsv1alpha1.SandboxRunning, agentsv1alpha1.SandboxPaused:
-		return true, "SandboxIsRunningOrPaused"
+	case agentsv1alpha1.SandboxPending, agentsv1alpha1.SandboxRunning, agentsv1alpha1.SandboxPausing, agentsv1alpha1.SandboxPaused, agentsv1alpha1.SandboxResuming:
+		return true, "SandboxIsPausablePhase"
 	default:
 		return false, "SandboxPhaseNotAllowed"
 	}

--- a/pkg/utils/sandboxutils/utils_test.go
+++ b/pkg/utils/sandboxutils/utils_test.go
@@ -245,14 +245,44 @@ func TestGetSandboxState(t *testing.T) {
 			expectedReason: "RunningResourceClaimedButNotReady",
 		},
 		{
-			name: "Not Running Sandbox claimed",
+			name: "Pausing Sandbox claimed",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxPausing,
+				},
+			},
+			expectedState:  agentsv1alpha1.SandboxStatePaused,
+			expectedReason: "PausedOrResumingResourceClaimed",
+		},
+		{
+			name: "Paused Sandbox claimed",
 			sandbox: &agentsv1alpha1.Sandbox{
 				Status: agentsv1alpha1.SandboxStatus{
 					Phase: agentsv1alpha1.SandboxPaused,
 				},
 			},
 			expectedState:  agentsv1alpha1.SandboxStatePaused,
-			expectedReason: "NotRunningResourceClaimed",
+			expectedReason: "PausedOrResumingResourceClaimed",
+		},
+		{
+			name: "Resuming Sandbox claimed",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxResuming,
+				},
+			},
+			expectedState:  agentsv1alpha1.SandboxStatePaused,
+			expectedReason: "PausedOrResumingResourceClaimed",
+		},
+		{
+			name: "Upgrading Sandbox claimed",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxUpgrading,
+				},
+			},
+			expectedState:  agentsv1alpha1.SandboxStateRunning,
+			expectedReason: "UpgradingResourceClaimed",
 		},
 	}
 
@@ -400,7 +430,7 @@ func TestIsSandboxPausable(t *testing.T) {
 				},
 			},
 			expectedResult: true,
-			expectedReason: "SandboxIsRunningOrPaused",
+			expectedReason: "SandboxIsPausablePhase",
 		},
 		{
 			name: "Paused sandbox is pausable",
@@ -410,17 +440,17 @@ func TestIsSandboxPausable(t *testing.T) {
 				},
 			},
 			expectedResult: true,
-			expectedReason: "SandboxIsRunningOrPaused",
+			expectedReason: "SandboxIsPausablePhase",
 		},
 		{
-			name: "Pending sandbox is not pausable",
+			name: "Pending sandbox is pausable",
 			sandbox: &agentsv1alpha1.Sandbox{
 				Status: agentsv1alpha1.SandboxStatus{
 					Phase: agentsv1alpha1.SandboxPending,
 				},
 			},
-			expectedResult: false,
-			expectedReason: "SandboxPhaseNotAllowed",
+			expectedResult: true,
+			expectedReason: "SandboxIsPausablePhase",
 		},
 	}
 

--- a/test/e2e/sandbox_test.go
+++ b/test/e2e/sandbox_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -237,7 +238,16 @@ var _ = Describe("Sandbox", func() {
 			originalSandbox.Spec.Paused = true
 			Expect(updateSandboxSpec(ctx, originalSandbox)).To(Succeed())
 
-			By("Verifying sandbox transitions to Paused phase")
+			By("Verifying sandbox transitions to Pausing phase")
+			Eventually(func() agentsv1alpha1.SandboxPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      sandbox.Name,
+					Namespace: sandbox.Namespace,
+				}, sandbox)
+				return sandbox.Status.Phase
+			}, time.Second*30, time.Millisecond*500).Should(Equal(agentsv1alpha1.SandboxPausing))
+
+			By("Verifying sandbox transitions to Paused phase after pause completes")
 			Eventually(func() agentsv1alpha1.SandboxPhase {
 				_ = k8sClient.Get(ctx, types.NamespacedName{
 					Name:      sandbox.Name,
@@ -245,6 +255,9 @@ var _ = Describe("Sandbox", func() {
 				}, sandbox)
 				return sandbox.Status.Phase
 			}, time.Second*30, time.Millisecond*500).Should(Equal(agentsv1alpha1.SandboxPaused))
+			pausedCond := meta.FindStatusCondition(sandbox.Status.Conditions, string(agentsv1alpha1.SandboxConditionPaused))
+			Expect(pausedCond).NotTo(BeNil())
+			Expect(pausedCond.Status).To(Equal(metav1.ConditionTrue))
 
 			By("Verifying the associated pod is deleted when paused")
 			Eventually(func() bool {


### PR DESCRIPTION
Ⅰ. Describe what this PR does
This PR introduces a new transitional lifecycle phase, Pausing, for the Sandbox resource.
Previously, when a Sandbox was set to Paused: true, it would transition directly from Running to Paused while the underlying Pod deletion was still in progress.

Added SandboxPausing to SandboxPhase in the API.
Updated the controller's state machine:
Running -> Pausing (triggered when Spec.Paused is true).
Pausing -> Paused (only after the SandboxPaused condition confirms the Pod is fully deleted).
Updated Prometheus metrics to track the Pausing phase.
Updated the Rate Limiter to treat Pausing as a non-creating phase, ensuring it doesn't block high-priority Sandbox creation.
Ⅱ. Does this pull request fix one issue?
fixes https://github.com/openkruise/agents/issues/250

Ⅲ. Describe how to verify it
Unit Tests: Updated sandbox_controller_test.go, metrics_test.go, and rateLimiter_test.go to cover the new state transitions.
E2E Tests: Verified the Sandbox lifecycle in a Kind cluster. The controller correctly transitions through Pausing before reaching Paused during hibernation.
Manual Verification: Observed Sandbox status transitions using kubectl get sandbox -w while toggling the spec.paused field.