### PR TITLE
fix(inplaceupdate): fix false-positive resource change detection caus…

### DIFF
--- a/pkg/utils/inplaceupdate/inplace_update.go
+++ b/pkg/utils/inplaceupdate/inplace_update.go
@@ -234,6 +234,35 @@ func buildContainerResourcesMap(containers []corev1.Container) map[string]corev1
 	return result
 }
 
+// resourcesEqual compares two ResourceRequirements semantically.
+// It only checks resources specified in 'desired' (the sandbox spec), ignoring extra resources
+// in 'actual' (the pod) injected by the system (e.g., ephemeral-storage).
+// It uses Quantity.Cmp() to handle different unit representations (e.g., "1" vs "1000m").
+func resourcesEqual(desired, actual corev1.ResourceRequirements) bool {
+	if !resourceListContains(actual.Limits, desired.Limits) {
+		return false
+	}
+	if !resourceListContains(actual.Requests, desired.Requests) {
+		return false
+	}
+	return true
+}
+
+// resourceListContains checks that for every resource in 'desired', the 'actual' list
+// contains the same resource with an equal quantity value.
+func resourceListContains(actual, desired corev1.ResourceList) bool {
+	for resName, desiredQty := range desired {
+		actualQty, exists := actual[resName]
+		if !exists {
+			return false
+		}
+		if desiredQty.Cmp(actualQty) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // DefaultGenerateResizeSubresourceBody generates the Pod body for resize subResource update.
 // It compares the current pod's container resources with the sandbox's container resources,
 // and returns a minimal Pod object containing only the fields required by the resize API:
@@ -281,7 +310,7 @@ func DefaultGenerateResizeSubresourceBody(opts InPlaceUpdateOptions) *corev1.Pod
 		if !ok {
 			continue
 		}
-		if reflect.DeepEqual(origin.Resources, container.Resources) {
+		if resourcesEqual(origin.Resources, container.Resources) {
 			continue
 		}
 		container.Resources = origin.Resources

--- a/pkg/utils/inplaceupdate/inplace_update_test.go
+++ b/pkg/utils/inplaceupdate/inplace_update_test.go
@@ -2620,3 +2620,391 @@ func TestInPlaceUpdateControl_Update_ResizeBeforePatch(t *testing.T) {
 			resizeIdx, patchIdx, callOrder)
 	}
 }
+
+func TestResourceListContains(t *testing.T) {
+	tests := []struct {
+		name    string
+		actual  corev1.ResourceList
+		desired corev1.ResourceList
+		expect  bool
+	}{
+		{
+			name:    "both nil",
+			actual:  nil,
+			desired: nil,
+			expect:  true,
+		},
+		{
+			name: "desired nil actual not nil",
+			actual: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			desired: nil,
+			expect:  true,
+		},
+		{
+			name:   "desired not nil actual nil",
+			actual: nil,
+			desired: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("1"),
+			},
+			expect: false,
+		},
+		{
+			name: "exact match",
+			actual: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			desired: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			expect: true,
+		},
+		{
+			name: "actual has extra resources",
+			actual: corev1.ResourceList{
+				corev1.ResourceCPU:              resource.MustParse("1"),
+				corev1.ResourceMemory:           resource.MustParse("1Gi"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("30Gi"),
+			},
+			desired: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			expect: true,
+		},
+		{
+			name: "different unit same value cpu",
+			actual: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("1"),
+			},
+			desired: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("1000m"),
+			},
+			expect: true,
+		},
+		{
+			name: "different unit same value memory",
+			actual: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			desired: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("1024Mi"),
+			},
+			expect: true,
+		},
+		{
+			name: "different value",
+			actual: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("1"),
+			},
+			desired: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("2"),
+			},
+			expect: false,
+		},
+		{
+			name: "desired has resource actual missing",
+			actual: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			desired: corev1.ResourceList{
+				corev1.ResourceCPU:                       resource.MustParse("1"),
+				corev1.ResourceMemory:                    resource.MustParse("1Gi"),
+				corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+			},
+			expect: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resourceListContains(tt.actual, tt.desired)
+			if got != tt.expect {
+				t.Errorf("resourceListContains() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestResourcesEqual(t *testing.T) {
+	tests := []struct {
+		name    string
+		desired corev1.ResourceRequirements
+		actual  corev1.ResourceRequirements
+		expect  bool
+	}{
+		{
+			name: "identical resources",
+			desired: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+			},
+			actual: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "pod has extra ephemeral-storage in requests",
+			desired: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			actual: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:              resource.MustParse("1"),
+					corev1.ResourceMemory:           resource.MustParse("1Gi"),
+					corev1.ResourceEphemeralStorage: resource.MustParse("30Gi"),
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "different cpu unit same value",
+			desired: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1000m"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1000m"),
+				},
+			},
+			actual: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "cpu actually different",
+			desired: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2"),
+				},
+			},
+			actual: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "limits differ",
+			desired: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+			actual: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+			expect: false,
+		},
+		{
+			name:    "both empty",
+			desired: corev1.ResourceRequirements{},
+			actual:  corev1.ResourceRequirements{},
+			expect:  true,
+		},
+		{
+			name: "desired has limits actual missing limits",
+			desired: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+			actual: corev1.ResourceRequirements{},
+			expect: false,
+		},
+		{
+			name: "pod has extra limits sandbox fewer",
+			desired: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			actual: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:                       resource.MustParse("1"),
+					corev1.ResourceMemory:                    resource.MustParse("1Gi"),
+					corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+				},
+			},
+			expect: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resourcesEqual(tt.desired, tt.actual)
+			if got != tt.expect {
+				t.Errorf("resourcesEqual() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestDefaultGenerateResizeSubresourceBody_NoResizeWhenExtraOrUnitDiff(t *testing.T) {
+	tests := []struct {
+		name string
+		box  *agentsv1alpha1.Sandbox
+		pod  *corev1.Pod
+	}{
+		{
+			name: "should NOT resize when pod has extra ephemeral-storage",
+			box: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "main",
+										Image: "busybox",
+										Resources: corev1.ResourceRequirements{
+											Limits: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("1"),
+												corev1.ResourceMemory: resource.MustParse("1Gi"),
+											},
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("1"),
+												corev1.ResourceMemory: resource.MustParse("1Gi"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "default", ResourceVersion: "1"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "main",
+							Image: "busybox",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:              resource.MustParse("1"),
+									corev1.ResourceMemory:           resource.MustParse("1Gi"),
+									corev1.ResourceEphemeralStorage: resource.MustParse("30Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should NOT resize when units differ but values equal",
+			box: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "main",
+										Image: "busybox",
+										Resources: corev1.ResourceRequirements{
+											Limits: corev1.ResourceList{
+												corev1.ResourceCPU: resource.MustParse("1000m"),
+											},
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU: resource.MustParse("1000m"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-2", Namespace: "default", ResourceVersion: "1"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "main",
+							Image: "busybox",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("1"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DefaultGenerateResizeSubresourceBody(InPlaceUpdateOptions{
+				Box: tt.box,
+				Pod: tt.pod,
+			})
+			if result != nil {
+				t.Errorf("expected nil (no resize needed), but got a resize body")
+			}
+		})
+	}
+}


### PR DESCRIPTION

## PR Description

### What

Fix incorrect resource comparison in `DefaultGenerateResizeSubresourceBody` that causes unnecessary pod resize operations.

### Why

The original code uses `reflect.DeepEqual` to compare `ResourceRequirements` between Sandbox spec and Pod. This produces false positives in two common scenarios:

| Scenario | Sandbox Spec | Pod Actual | Expected | Actual (before fix) |
|----------|-------------|-----------|----------|-------------------|
| System-injected resources | `cpu: 1, memory: 1Gi` | `cpu: 1, memory: 1Gi, ephemeral-storage: 30Gi` | Equal ✅ | Not equal ❌ |
| Different unit representation | `cpu: 1000m` | `cpu: "1"` | Equal ✅ | Not equal ❌ |

This leads to unnecessary resize API calls on every reconcile, wasting API server resources and potentially causing resize loops.

### How

- Replace `reflect.DeepEqual(origin.Resources, container.Resources)` with `resourcesEqual(desired, actual)`.
- `resourcesEqual` only checks resources **specified in the Sandbox spec**, ignoring extra resources injected by the system (e.g., kubelet adding `ephemeral-storage`).
- Uses `resource.Quantity.Cmp()` for unit-aware comparison instead of string/struct equality.

### Testing

Added 19 unit test cases:
- `TestResourceListContains` (9 cases)
- `TestResourcesEqual` (8 cases)
- `TestDefaultGenerateResizeSubresourceBody_NoResizeWhenExtraOrUnitDiff` (2 integration cases)

```bash
go test ./pkg/utils/inplaceupdate/ -run "TestResourceListContains|TestResourcesEqual|TestDefaultGenerateResizeSubresourceBody_NoResize" -v
# PASS
```
