### PR TITLE
refactor(sandboxcr): Checkpoint owns SandboxTemplate (fix TTL leak)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,8 @@ test/              E2E (Go), E2B (Python) tests
 
 ### Testing
 
+- Only run Go tests for packages under `pkg/` via `go test`.
+- Never run any E2E test under the `test/` directory.
 - Table-driven tests with descriptive `name` fields is a must: **ALWAYS** use table-driven tests for consistency and clarity.
 - Reference test methods in same directory for best practices
 - Use shared test helpers

--- a/api/v1alpha1/checkpoint_types.go
+++ b/api/v1alpha1/checkpoint_types.go
@@ -138,6 +138,8 @@ type CheckpointList struct {
 	Items           []Checkpoint `json:"items"`
 }
 
+var CheckpointControllerKind = GroupVersion.WithKind("Checkpoint")
+
 func init() {
 	SchemeBuilder.Register(&Checkpoint{}, &CheckpointList{})
 }

--- a/docs/specs/2026-05-19-checkpoint-owns-sandboxtemplate-design.md
+++ b/docs/specs/2026-05-19-checkpoint-owns-sandboxtemplate-design.md
@@ -145,7 +145,7 @@ and `SandboxTemplateControllerKind`
 | New replica creates snapshot | Produces shape B; old replicas can List/Clone/Delete | compatible |
 
 Rollback to the old image after the new one ran for some time is safe: shape B
-data continues to be servicable by the old code path; TTL behavior is owned by
+data continues to be serviceable by the old code path; TTL behavior is owned by
 the external controller and is not version-coupled.
 
 ## 6. File-level change list

--- a/docs/specs/2026-05-19-checkpoint-owns-sandboxtemplate-design.md
+++ b/docs/specs/2026-05-19-checkpoint-owns-sandboxtemplate-design.md
@@ -1,0 +1,275 @@
+# Checkpoint Owns SandboxTemplate — Design
+
+- Date: 2026-05-19
+- Branch: `refactor/cp-owner-260519`
+- Scope: `pkg/sandbox-manager/infra/sandboxcr/`, `api/v1alpha1/checkpoint_types.go`
+
+## 1. Problem
+
+`pkg/sandbox-manager/infra/sandboxcr/clone.go:299` (`CreateCheckpoint`) sets the
+new `Checkpoint` CR as a dependent of the freshly-created `SandboxTemplate` via
+`OwnerReferences`. As a consequence, when the `Checkpoint` is later deleted by
+the external Checkpoint TTL controller (driven by `CheckpointSpec.TtlAfterFinished`),
+Kubernetes garbage collection does not reach the `SandboxTemplate`, and the
+template leaks indefinitely.
+
+The leak is observable on snapshots created through
+`POST /sandboxes/{sandboxID}/snapshots` (handler at
+`pkg/servers/e2b/snapshot.go:33-75`).
+
+## 2. Goal & Non-goals
+
+### Goal
+
+Make the deletion of a `Checkpoint` — through any channel, including the external
+TTL controller — cascade-delete the matching `SandboxTemplate`, while preserving
+strict compatibility with all existing data and API behaviors.
+
+### Non-goals
+
+- Do not modify the external Checkpoint TTL controller (lives outside this repo).
+- Do not migrate or clean up legacy orphan `SandboxTemplate` resources that
+  already leaked under today's behavior. New code must not regress existing
+  resources, but it also will not retroactively fix them.
+- Do not introduce a new in-cluster controller, finalizer, or annotation.
+- Do not break E2B HTTP API behavior (status codes, response shape, idempotency).
+
+## 3. Constraints (compatibility envelope)
+
+- New code must not write to existing `Checkpoint` / `SandboxTemplate` resources
+  on disk; only newly created snapshots adopt the new ownership shape.
+- All API surfaces (`POST /sandboxes/{id}/snapshots`, `POST /sandboxes` clone
+  path, `GET /v2/sandboxes`, `GET /snapshots`, `DELETE /templates/{id}`) must
+  remain functionally identical to callers.
+- Both the legacy ownership shape and the new ownership shape must remain
+  fully serviceable (List, Clone, Delete) by both old and new sandbox-manager
+  binaries during rolling upgrade and rollback windows.
+
+## 4. Approach
+
+### 4.1 Reverse the ownership direction for new snapshots
+
+`CreateCheckpoint` will be reordered to:
+
+1. Create the `Checkpoint` first using `GenerateName: sbx.Name + "-"`. The
+   `Checkpoint` carries no `OwnerReferences`. Its `Spec.PersistentContents`
+   fallback source switches from `tmpl.Spec.PersistentContents` to
+   `sbx.Spec.PersistentContents` (the data is equivalent — `SandboxTemplate`
+   itself copies from the same `Sandbox`).
+2. Create the `SandboxTemplate` with `Name: cp.Name` and a single
+   `OwnerReference` pointing back at the `Checkpoint`:
+   ```go
+   {
+       APIVersion:         v1alpha1.CheckpointControllerKind.GroupVersion().String(),
+       Kind:               v1alpha1.CheckpointControllerKind.Kind,
+       Name:               cp.Name,
+       UID:                cp.UID,
+       Controller:         ptr.To(true),
+       BlockOwnerDeletion: ptr.To(true),
+   }
+   ```
+3. Wait for `Checkpoint` to reach `Succeeded` via the existing
+   `cache.NewCheckpointTask(...).Wait(...)` and refresh logic.
+
+This order improves failure semantics over today's code:
+
+| Step that fails | New approach (Checkpoint then Template) | Today (Template then Checkpoint) |
+|---|---|---|
+| Step 1 | Nothing created. Clean error. | Same. |
+| Step 2 | Orphan `Checkpoint` only — drained naturally by TTL. | Orphan `SandboxTemplate` — leaks until manually cleaned. |
+| Step 3 (wait) | Both exist; `Checkpoint` owns `SandboxTemplate`; external TTL on `Checkpoint` cascades both. | Both exist; external TTL deletes `Checkpoint` but `SandboxTemplate` persists as the orphan owner — today's headline bug. |
+
+### 4.2 Flip the deletion path to align
+
+`pkg/sandbox-manager/infra/sandboxcr/infra.go:216` `DeleteCheckpoint` will:
+
+1. Keep Step 1 (`findCheckpointAndTemplateById`) and Step 2 (`AnnotationOwner`
+   verification) unchanged.
+2. Step 3: delete the `Checkpoint` first via `DefaultDeleteCheckpointCR`. For
+   new-shape data, GC cascades the `SandboxTemplate` after the
+   `agents.kruise.io/checkpoint` finalizer is processed.
+3. Step 4: invert the legacy guard from `IsControlledBy(cp, tmpl)` to
+   `IsControlledBy(tmpl, cp)`. When the `SandboxTemplate` is *not* controlled
+   by the `Checkpoint` (legacy shape), explicitly delete the
+   `SandboxTemplate` via `DefaultDeleteSandboxTemplate`.
+
+| Data shape | Step 3 outcome | `IsControlledBy(tmpl, cp)` | Step 4 |
+|---|---|---|---|
+| New (Checkpoint owns Template) | Checkpoint enters Terminating; GC will sweep Template after finalizer | `true` | skip |
+| Legacy (Template owns Checkpoint) | Checkpoint deletion is independent | `false` | explicitly delete Template |
+
+Both shapes converge to "Checkpoint and Template are both removed".
+
+### 4.3 New constant `CheckpointControllerKind`
+
+`api/v1alpha1/checkpoint_types.go` gains:
+
+```go
+var CheckpointControllerKind = GroupVersion.WithKind("Checkpoint")
+```
+
+This mirrors `SandboxSetControllerKind` (`api/v1alpha1/sandboxset_types.go:54`)
+and `SandboxTemplateControllerKind`
+(`api/v1alpha1/sandboxtemplate_types.go:74`), avoiding string literals at
+`OwnerReference` construction sites.
+
+## 5. Compatibility Matrix
+
+### 5.1 Data shapes coexisting at upgrade time
+
+| Shape | OwnerReferences | Origin |
+|---|---|---|
+| A. Legacy Checkpoint+Template | Checkpoint owned by Template; Template has no owner | Pre-upgrade snapshots |
+| B. New Checkpoint+Template | Template owned by Checkpoint; Checkpoint has no owner | Post-upgrade snapshots created by this design |
+| C. Orphan Template (legacy leak) | Template has no owner; matching Checkpoint already TTL'd | Pre-upgrade external-TTL leak (out of scope) |
+| D. SandboxSet-backed Template | Template owned by SandboxSet | Unrelated to this design |
+
+### 5.2 API surfaces × data shapes
+
+| API path | A | B | C | D |
+|---|---|---|---|---|
+| `POST /sandboxes/{id}/snapshots` (CreateCheckpoint) | never touches A | new flow | never touches | never touches |
+| `POST /sandboxes` clone via Checkpoint | name-based pairing, works | works | NotFound (today's behavior) | uses SandboxSet claim path |
+| `GET /v2/sandboxes`, `GET /snapshots` | reads only Checkpoint Phase | same | Checkpoint absent, naturally hidden | not in ListSnapshots scope |
+| `DELETE /templates/{id}` → `DeleteCheckpoint` | Step 4 explicitly deletes Template | GC cascade-deletes Template | Step 1 returns NotFound, handler returns 204 | rejected by `HasTemplate` guard with 401 |
+| `GET /templates`, `GET /templates/{id}` | not in ListTemplates scope | not in scope | not in scope | works |
+| External Checkpoint TTL controller | deletes Checkpoint, leaks Template (today's behavior preserved) | deletes Checkpoint, GC cascades Template | N/A | N/A |
+
+### 5.3 Rolling upgrade and rollback
+
+| Operator → Data | Behavior | Outcome |
+|---|---|---|
+| Old replica deletes B | Old code: deletes Template (the dependent) → `IsControlledBy(cp, tmpl)` = false → explicitly deletes Checkpoint | both removed |
+| New replica deletes A | New code: deletes Checkpoint (the dependent) → `IsControlledBy(tmpl, cp)` = false → explicitly deletes Template | both removed |
+| Old replica creates snapshot | Produces shape A; new replicas can List/Clone/Delete | compatible |
+| New replica creates snapshot | Produces shape B; old replicas can List/Clone/Delete | compatible |
+
+Rollback to the old image after the new one ran for some time is safe: shape B
+data continues to be servicable by the old code path; TTL behavior is owned by
+the external controller and is not version-coupled.
+
+## 6. File-level change list
+
+### 6.1 `api/v1alpha1/checkpoint_types.go`
+
+Add `var CheckpointControllerKind = GroupVersion.WithKind("Checkpoint")` near
+the existing constant block. No CRD schema impact.
+
+### 6.2 `pkg/sandbox-manager/infra/sandboxcr/clone.go` (`CreateCheckpoint`)
+
+- Reorder: build and create `Checkpoint` first, then `SandboxTemplate`.
+- `Checkpoint.ObjectMeta` uses `GenerateName: sbx.Name + "-"`, no
+  `OwnerReferences`.
+- `Checkpoint.Spec.PersistentContents` fallback source: `sbx.Spec.PersistentContents`
+  filtered by `CheckpointPersistentContent{Memory,Filesystem}`.
+- `SandboxTemplate.ObjectMeta.Name` = `cp.Name`; `OwnerReferences` set to a
+  single controller ref pointing at the `Checkpoint`.
+- Continue to call `checkpointUtils.PropagateAnnotationsToCheckpoint(sbx, cp)`
+  before creating the `Checkpoint`.
+- Preserve `DefaultCreateSandboxTemplate` and `DefaultCreateCheckpoint` package
+  variables (test seams; required by directory `AGENTS.md`).
+- Preserve `cache.NewCheckpointTask(ctx, cp).Wait(opts.WaitSuccessTimeout)` and
+  the post-wait `Get` to refresh `Status.CheckpointId`.
+
+### 6.3 `pkg/sandbox-manager/infra/sandboxcr/infra.go` (`DeleteCheckpoint`)
+
+- Step 3: replace `DefaultDeleteSandboxTemplate(...)` with
+  `DefaultDeleteCheckpointCR(ctx, i.Cache.GetClient(), cp.Namespace, cp.Name)`.
+- Step 4: change guard from `if !metav1.IsControlledBy(cp, tmpl)` to
+  `if !metav1.IsControlledBy(tmpl, cp)`; in the body, call
+  `DefaultDeleteSandboxTemplate(...)`.
+- Update inline comments to describe both ownership directions.
+
+### 6.4 `pkg/sandbox-manager/infra/sandboxcr/clone_test.go`
+
+- `TestCreateCheckPoint` (line 955): switch the fake-client name/UID priming
+  hook from `DefaultCreateSandboxTemplate` to `DefaultCreateCheckpoint` (the
+  first object created is now the `Checkpoint`).
+- For each successful case (lines 1022, 1049, 1085): drop assertions that
+  `cp.OwnerReferences[0].Kind == "SandboxTemplate"`; assert
+  `cp.OwnerReferences` is empty; load the `SandboxTemplate` and assert its
+  `OwnerReferences[0]` has `Kind == "Checkpoint"`, `Name == cp.Name`,
+  `UID == cp.UID`.
+- Add a new case "template create fails after checkpoint create": inject error
+  on `DefaultCreateSandboxTemplate`, assert `CreateCheckpoint` returns an
+  error and the `Checkpoint` exists in the fake store while `SandboxTemplate`
+  does not.
+
+### 6.5 `pkg/sandbox-manager/infra/sandboxcr/infra_test.go`
+
+- `TestInfra_DeleteCheckpointWithOptions_NamespaceScoped` (line 301): existing
+  fixture is shape A (no `OwnerReferences`), still valid; assertions remain.
+- Add a "new-data-shape delete" mirror case where `SandboxTemplate.OwnerReferences`
+  points at the `Checkpoint`. Stub or count `DefaultDeleteSandboxTemplate`
+  invocations to verify Step 4 is skipped (the fake client does not simulate
+  GC cascade by default; verifying skip is the contract under test).
+- `TestInfra_DeleteCheckpoint_OwnerVerification` (line 335): orthogonal,
+  unchanged. Optionally add a new-shape variant for parity.
+
+### 6.6 Files explicitly not modified
+
+| File | Reason |
+|---|---|
+| `pkg/servers/e2b/snapshot.go` | Calls `CreateCheckpoint`, signature/return unchanged |
+| `pkg/servers/e2b/templates.go` | Calls `DeleteCheckpoint`, HTTP status mapping unchanged |
+| `pkg/servers/e2b/list.go` | Reads only Checkpoint state, owner-direction agnostic |
+| `pkg/cache/...` | Phase-based logic, owner-direction agnostic |
+| External Checkpoint controller | Out of repo |
+
+## 7. Risks & mitigations
+
+| Risk | Trigger | Mitigation |
+|---|---|---|
+| Orphan Checkpoint after Template create fails | Process restart / API throttling / network blip between Step 1 and Step 2 | Accepted. Drained naturally by external TTL. Strictly better than today's orphan-Template failure mode (which never self-heals). |
+| Wrong field in `OwnerReference` (Kind / APIVersion / UID / Name) | Code typo | Centralize via `CheckpointControllerKind`; assert `Kind == "Checkpoint"` and UID/Name pairing in unit tests. |
+| Mixed-version replicas during rolling upgrade write inconsistent data | Canary deploy window | Verified in §5.3 — all four cross-operations close cleanly. |
+| External Checkpoint controller starts work before Template exists | Fast watch | Verified in §4.1 — the controller reads only `Checkpoint` + `Sandbox`/`Pod`, never the sibling `SandboxTemplate`. |
+| `BlockOwnerDeletion: true` blocks under foregroundDeletion | Caller misuse of foreground propagation | All in-repo deletes use background propagation; field setting kept identical to today's. |
+| Test fixture hook relocation breaks unrelated tests | Shared test seam | Verified by `grep -n "DefaultCreateSandboxTemplate" pkg/sandbox-manager/infra/sandboxcr/` during review. |
+
+## 8. Rollback
+
+Revert the sandbox-manager image to the pre-change tag. No CR migration is
+required: shape-B resources written by the new image remain serviceable by the
+old image (clone, list, delete). TTL behavior is governed by the external
+controller and Kubernetes GC, not by the sandbox-manager version. Shape-B
+`SandboxTemplate.OwnerReferences` persists after rollback; this is harmless
+and re-engages on the next forward deploy.
+
+## 9. Verification
+
+### 9.1 Pre-merge
+
+- [ ] `make generate manifests` (sanity; no schema change expected)
+- [ ] `go vet ./...`, `go build ./...` succeed
+- [ ] `golangci-lint run` passes; cyclomatic complexity of `CreateCheckpoint`
+      does not exceed 32
+- [ ] `go test ./pkg/sandbox-manager/infra/sandboxcr/...` green, including the
+      new cases listed in §6.4 and §6.5
+- [ ] `go test ./pkg/servers/e2b/...` green (regression check, no source change)
+- [ ] PR diff inspected for any string-literal `"Checkpoint"` /
+      `"SandboxTemplate"` in `OwnerReference` blocks
+- [ ] `grep -n "IsControlledBy" pkg/sandbox-manager/infra/sandboxcr/` shows
+      exactly one occurrence with argument order `(tmpl, cp)`
+
+### 9.2 Post-deploy
+
+- [ ] Create a new snapshot via `POST /sandboxes/{id}/snapshots`.
+      `kubectl get checkpoint <name> -o yaml` shows empty `ownerReferences`;
+      `kubectl get sbt <name> -o yaml` shows
+      `ownerReferences[0].kind == Checkpoint`.
+- [ ] Clone from the new snapshot via `POST /sandboxes`; the resulting sandbox
+      reaches Ready.
+- [ ] `DELETE /templates/{checkpointID}` removes both objects within the
+      finalizer + GC sweep window.
+- [ ] Repeat clone / delete against a known pre-upgrade legacy snapshot;
+      behavior unchanged.
+- [ ] Allow a fresh snapshot to expire via the external TTL controller and
+      confirm the `SandboxTemplate` is cascade-deleted (the headline goal of
+      this design).
+
+## 10. Metrics
+
+No new metrics. Existing counters / histograms (`snapshotTotal`,
+`snapshotDuration` at `pkg/servers/e2b/snapshot.go:62,67`) continue to cover
+the create path with unchanged label dimensions.

--- a/pkg/sandbox-manager/api_test.go
+++ b/pkg/sandbox-manager/api_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
@@ -1422,7 +1423,7 @@ func TestSandboxManager_DeleteCheckpoint(t *testing.T) {
 			checkpointID:       "cp-tmpl-fail",
 			user:               "test-user",
 			setup:              true,
-			withOwnerRef:       true,
+			withOwnerRef:       false,
 			mockDeleteTemplate: fmt.Errorf("mock template delete error"),
 			expectError:        "mock template delete error",
 		},
@@ -1450,6 +1451,27 @@ func TestSandboxManager_DeleteCheckpoint(t *testing.T) {
 			manager, client := setupTestManager(t)
 
 			if tt.setup {
+				// Create Checkpoint with owner annotation.
+				cp := &agentsv1alpha1.Checkpoint{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tt.checkpointID,
+						Namespace: namespace,
+						Annotations: map[string]string{
+							agentsv1alpha1.AnnotationOwner: "test-user",
+						},
+					},
+				}
+				if tt.withOwnerRef {
+					cp.UID = types.UID("uid-" + tt.checkpointID)
+				}
+				err := client.Create(t.Context(), cp)
+				require.NoError(t, err)
+
+				// Update status with checkpointId.
+				cp.Status.CheckpointId = tt.checkpointID
+				err = client.Status().Update(t.Context(), cp)
+				require.NoError(t, err)
+
 				// Create SandboxTemplate
 				tmpl := &agentsv1alpha1.SandboxTemplate{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1466,37 +1488,19 @@ func TestSandboxManager_DeleteCheckpoint(t *testing.T) {
 						},
 					},
 				}
-				err := client.Create(t.Context(), tmpl)
-				require.NoError(t, err)
-
-				// Create Checkpoint with owner annotation
-				cp := &agentsv1alpha1.Checkpoint{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      tt.checkpointID,
-						Namespace: namespace,
-						Annotations: map[string]string{
-							agentsv1alpha1.AnnotationOwner: "test-user",
-						},
-					},
-				}
 				if tt.withOwnerRef {
-					cp.OwnerReferences = []metav1.OwnerReference{
+					tmpl.OwnerReferences = []metav1.OwnerReference{
 						{
-							APIVersion:         agentsv1alpha1.SandboxTemplateControllerKind.GroupVersion().String(),
-							Kind:               agentsv1alpha1.SandboxTemplateControllerKind.Kind,
-							Name:               tmpl.Name,
-							UID:                tmpl.UID,
+							APIVersion:         agentsv1alpha1.CheckpointControllerKind.GroupVersion().String(),
+							Kind:               agentsv1alpha1.CheckpointControllerKind.Kind,
+							Name:               cp.Name,
+							UID:                cp.UID,
 							Controller:         ptr.To(true),
 							BlockOwnerDeletion: ptr.To(true),
 						},
 					}
 				}
-				err = client.Create(t.Context(), cp)
-				require.NoError(t, err)
-
-				// Update status with checkpointId
-				cp.Status.CheckpointId = tt.checkpointID
-				err = client.Status().Update(t.Context(), cp)
+				err = client.Create(t.Context(), tmpl)
 				require.NoError(t, err)
 
 				// Wait for informer sync

--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -376,6 +376,7 @@ func CreateCheckpoint(ctx context.Context, sbx *v1alpha1.Sandbox, cache infracac
 	log.Info("template created")
 
 	// Step 3: Wait for the Checkpoint to reach Succeeded.
+	// In the future, we can delete the failed Checkpoint and retry like ClaimSandbox
 	if err = cache.NewCheckpointTask(ctx, cp).Wait(opts.WaitSuccessTimeout); err != nil {
 		log.Error(err, "failed to wait checkpoint ready")
 		return "", fmt.Errorf("failed to wait checkpoint ready: %w", err)

--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -298,44 +298,17 @@ func createCheckpoint(ctx context.Context, c client.Client, cp *v1alpha1.Checkpo
 
 func CreateCheckpoint(ctx context.Context, sbx *v1alpha1.Sandbox, cache infracache.Provider, opts infra.CreateCheckpointOptions) (string, error) {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
-	log.Info("creating sandbox template")
-	tmpl := &v1alpha1.SandboxTemplate{
+
+	// Step 1: Build the Checkpoint with GenerateName. The Checkpoint is the new
+	// owner of the SandboxTemplate; it carries no OwnerReferences itself.
+	cp := &v1alpha1.Checkpoint{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: sbx.Name + "-",
 			Namespace:    sbx.Namespace,
-		},
-		Spec: v1alpha1.SandboxTemplateSpec{
-			PersistentContents:   sbx.Spec.PersistentContents,
-			Template:             sbx.Spec.Template,
-			VolumeClaimTemplates: sbx.Spec.VolumeClaimTemplates,
-			Runtimes:             sbx.Spec.Runtimes,
-		},
-	}
-	tmpl, err := DefaultCreateSandboxTemplate(ctx, cache.GetClient(), tmpl)
-	if err != nil {
-		log.Error(err, "failed to create sandbox template")
-		return "", fmt.Errorf("failed to create sandbox template: %w", err)
-	}
-	log = log.WithValues("template", klog.KObj(tmpl))
-	log.Info("template created")
-	cp := &v1alpha1.Checkpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      tmpl.Name,
-			Namespace: sbx.Namespace,
 			Annotations: map[string]string{
 				v1alpha1.AnnotationInitRuntimeRequest: sbx.Annotations[v1alpha1.AnnotationInitRuntimeRequest],
 				v1alpha1.AnnotationOwner:              sbx.Annotations[v1alpha1.AnnotationOwner],
 				v1alpha1.AnnotationSandboxID:          stateutils.GetSandboxID(sbx),
-			},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         v1alpha1.SandboxTemplateControllerKind.GroupVersion().String(),
-					Kind:               v1alpha1.SandboxTemplateControllerKind.Kind,
-					Name:               tmpl.Name,
-					UID:                tmpl.UID,
-					Controller:         ptr.To(true),
-					BlockOwnerDeletion: ptr.To(true),
-				},
 			},
 		},
 		Spec: v1alpha1.CheckpointSpec{
@@ -347,21 +320,62 @@ func CreateCheckpoint(ctx context.Context, sbx *v1alpha1.Sandbox, cache infracac
 	if len(opts.PersistentContents) > 0 {
 		cp.Spec.PersistentContents = opts.PersistentContents
 	} else {
-		for _, pc := range tmpl.Spec.PersistentContents {
+		// Source falls back to the Sandbox itself (the same data the
+		// SandboxTemplate would copy from), filtered to the persistent-content
+		// values the Checkpoint understands.
+		for _, pc := range sbx.Spec.PersistentContents {
 			if pc == v1alpha1.CheckpointPersistentContentFilesystem || pc == v1alpha1.CheckpointPersistentContentMemory {
 				cp.Spec.PersistentContents = append(cp.Spec.PersistentContents, pc)
 			}
 		}
 	}
-	// to make sure the sandbox annotations are propagated to the checkpoint
+	// Propagate sandbox annotations (e.g., csi mount config) to the Checkpoint
+	// before creation.
 	checkpointUtils.PropagateAnnotationsToCheckpoint(sbx, cp)
-	cp, err = DefaultCreateCheckpoint(ctx, cache.GetClient(), cp)
+	log.Info("creating checkpoint")
+	cp, err := DefaultCreateCheckpoint(ctx, cache.GetClient(), cp)
 	if err != nil {
 		log.Error(err, "failed to create checkpoint")
 		return "", fmt.Errorf("failed to create checkpoint: %w", err)
 	}
 	log = log.WithValues("checkpoint", klog.KObj(cp))
-	log.Info("checkpoint creating")
+	log.Info("checkpoint created")
+
+	// Step 2: Build the SandboxTemplate with the Checkpoint's name and an
+	// OwnerReference pointing back at the Checkpoint, so deletion of the
+	// Checkpoint cascades to the SandboxTemplate via Kubernetes GC.
+	tmpl := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cp.Name,
+			Namespace: sbx.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         v1alpha1.CheckpointControllerKind.GroupVersion().String(),
+					Kind:               v1alpha1.CheckpointControllerKind.Kind,
+					Name:               cp.Name,
+					UID:                cp.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			PersistentContents:   sbx.Spec.PersistentContents,
+			Template:             sbx.Spec.Template,
+			VolumeClaimTemplates: sbx.Spec.VolumeClaimTemplates,
+			Runtimes:             sbx.Spec.Runtimes,
+		},
+	}
+	log.Info("creating sandbox template")
+	tmpl, err = DefaultCreateSandboxTemplate(ctx, cache.GetClient(), tmpl)
+	if err != nil {
+		log.Error(err, "failed to create sandbox template")
+		return "", fmt.Errorf("failed to create sandbox template: %w", err)
+	}
+	log = log.WithValues("template", klog.KObj(tmpl))
+	log.Info("template created")
+
+	// Step 3: Wait for the Checkpoint to reach Succeeded.
 	if err = cache.NewCheckpointTask(ctx, cp).Wait(opts.WaitSuccessTimeout); err != nil {
 		log.Error(err, "failed to wait checkpoint ready")
 		return "", fmt.Errorf("failed to wait checkpoint ready: %w", err)
@@ -371,7 +385,7 @@ func CreateCheckpoint(ctx context.Context, sbx *v1alpha1.Sandbox, cache infracac
 		log.Error(err, "failed to refresh checkpoint after wait")
 		return "", fmt.Errorf("failed to refresh checkpoint: %w", err)
 	}
-	log.Info("checkpoint created")
+	log.Info("checkpoint ready")
 	return fresh.Status.CheckpointId, nil
 }
 

--- a/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
@@ -1352,6 +1352,31 @@ func TestCreateCheckPoint(t *testing.T) {
 				assert.Equal(t, []string{"filesystem"}, cp.Spec.PersistentContents, "checkpoint should inherit template's PersistentContents when opts is empty")
 			},
 		},
+		{
+			name:    "template creation failure leaves checkpoint orphan for TTL drainage",
+			sandbox: newTestSandbox("test-sbx-tmpl-fail-after-cp"),
+			cpStatus: v1alpha1.CheckpointStatus{
+				Phase:        v1alpha1.CheckpointSucceeded,
+				CheckpointId: "cp-id-orphan",
+			},
+			tmplOverride: tmplOverride{Name: "tmpl-orphan", UID: "uid-orphan"},
+			opts: infra.CreateCheckpointOptions{
+				WaitSuccessTimeout: 5 * time.Second,
+			},
+			injectErr:   injectErrTemplate,
+			expectError: "failed to create sandbox template",
+			postCheck: func(t *testing.T, id string, c client.Client) {
+				// Checkpoint was created before the SandboxTemplate failed; it must remain
+				// in the fake store so the external TTL controller can drain it later.
+				var cp v1alpha1.Checkpoint
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "tmpl-orphan"}, &cp),
+					"checkpoint must exist after template create failed")
+				assert.Empty(t, cp.OwnerReferences, "orphan checkpoint must not have owner references")
+				// SandboxTemplate must NOT exist (creation was injected to fail).
+				err := c.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "tmpl-orphan"}, &v1alpha1.SandboxTemplate{})
+				require.Error(t, err, "sandbox template must not exist after injected failure")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1375,9 +1400,9 @@ func TestCreateCheckPoint(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.expectError)
 			} else {
 				require.NoError(t, err)
-				if tt.postCheck != nil {
-					tt.postCheck(t, id, fc)
-				}
+			}
+			if tt.postCheck != nil {
+				tt.postCheck(t, id, fc)
 			}
 		})
 	}

--- a/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
@@ -970,20 +970,12 @@ func TestCreateCheckPoint(t *testing.T) {
 		injectErrCheckpoint injectErrTarget = "checkpoint"
 	)
 
-	// Decorator 1: DefaultCreateSandboxTemplate
+	// Decorator 1: DefaultCreateSandboxTemplate (only for error injection now;
+	// after the flip, the SandboxTemplate inherits its Name from the Checkpoint).
 	origCreateSandboxTemplate := DefaultCreateSandboxTemplate
 	DefaultCreateSandboxTemplate = func(ctx context.Context, c client.Client, tmpl *v1alpha1.SandboxTemplate) (*v1alpha1.SandboxTemplate, error) {
-		// Check for error injection
 		if target, ok := ctx.Value(injectErrKey{}).(injectErrTarget); ok && target == injectErrTemplate {
 			return nil, fmt.Errorf("injected error: template creation failed")
-		}
-		if override, ok := ctx.Value(tmplOverrideKey{}).(tmplOverride); ok {
-			if override.Name != "" {
-				tmpl.Name = override.Name
-			}
-			if override.UID != "" {
-				tmpl.UID = override.UID
-			}
 		}
 		return origCreateSandboxTemplate(ctx, c, tmpl)
 	}
@@ -992,9 +984,20 @@ func TestCreateCheckPoint(t *testing.T) {
 	// Decorator 2: DefaultCreateCheckpoint
 	origCreateCheckpoint := DefaultCreateCheckpoint
 	DefaultCreateCheckpoint = func(ctx context.Context, c client.Client, cp *v1alpha1.Checkpoint) (*v1alpha1.Checkpoint, error) {
-		// Check for error injection
 		if target, ok := ctx.Value(injectErrKey{}).(injectErrTarget); ok && target == injectErrCheckpoint {
 			return nil, fmt.Errorf("injected error: checkpoint creation failed")
+		}
+		// After the flip the Checkpoint is the first object created (with GenerateName).
+		// Apply the test override here so the rest of the flow sees a deterministic
+		// Name and UID.
+		if override, ok := ctx.Value(tmplOverrideKey{}).(tmplOverride); ok {
+			if override.Name != "" {
+				cp.Name = override.Name
+				cp.GenerateName = ""
+			}
+			if override.UID != "" {
+				cp.UID = override.UID
+			}
 		}
 		if status, ok := ctx.Value(cpStatusKey{}).(v1alpha1.CheckpointStatus); ok {
 			cp.Status = status
@@ -1035,13 +1038,14 @@ func TestCreateCheckPoint(t *testing.T) {
 				require.NoError(t, c.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "tmpl-1"}, &cp))
 				assert.Equal(t, "tmpl-1", cp.Name)
 				assert.Equal(t, "test-sandbox-1", *cp.Spec.PodName)
-				require.Len(t, cp.OwnerReferences, 1)
-				assert.Equal(t, "SandboxTemplate", cp.OwnerReferences[0].Kind)
-				assert.Equal(t, "tmpl-1", cp.OwnerReferences[0].Name)
-				assert.Equal(t, types.UID("uid-1"), cp.OwnerReferences[0].UID)
-				// Verify PersistentContents: sandbox has no PersistentContents, so both template and checkpoint should be empty
+				assert.Empty(t, cp.OwnerReferences, "checkpoint should have no owner references")
 				var tmpl v1alpha1.SandboxTemplate
 				require.NoError(t, c.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "tmpl-1"}, &tmpl))
+				require.Len(t, tmpl.OwnerReferences, 1)
+				assert.Equal(t, "Checkpoint", tmpl.OwnerReferences[0].Kind)
+				assert.Equal(t, "tmpl-1", tmpl.OwnerReferences[0].Name)
+				assert.Equal(t, types.UID("uid-1"), tmpl.OwnerReferences[0].UID)
+				// Verify PersistentContents: sandbox has no PersistentContents, so both template and checkpoint should be empty
 				assert.Empty(t, tmpl.Spec.PersistentContents, "template PersistentContents should be empty when sandbox has no PersistentContents")
 				assert.Empty(t, cp.Spec.PersistentContents, "checkpoint PersistentContents should be empty when sandbox has no PersistentContents")
 			},
@@ -1066,18 +1070,19 @@ func TestCreateCheckPoint(t *testing.T) {
 				require.NoError(t, c.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "tmpl-2"}, &cp))
 				assert.Equal(t, "tmpl-2", cp.Name)
 				assert.Equal(t, "test-sandbox-2", *cp.Spec.PodName)
-				require.Len(t, cp.OwnerReferences, 1)
-				assert.Equal(t, "SandboxTemplate", cp.OwnerReferences[0].Kind)
-				assert.Equal(t, "tmpl-2", cp.OwnerReferences[0].Name)
-				assert.Equal(t, types.UID("uid-2"), cp.OwnerReferences[0].UID)
+				assert.Empty(t, cp.OwnerReferences, "checkpoint should have no owner references")
+				var tmpl v1alpha1.SandboxTemplate
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "tmpl-2"}, &tmpl))
+				require.Len(t, tmpl.OwnerReferences, 1)
+				assert.Equal(t, "Checkpoint", tmpl.OwnerReferences[0].Kind)
+				assert.Equal(t, "tmpl-2", tmpl.OwnerReferences[0].Name)
+				assert.Equal(t, types.UID("uid-2"), tmpl.OwnerReferences[0].UID)
 				// Verify options
 				require.NotNil(t, cp.Spec.KeepRunning)
 				assert.True(t, *cp.Spec.KeepRunning)
 				require.NotNil(t, cp.Spec.TtlAfterFinished)
 				assert.Equal(t, "30m", *cp.Spec.TtlAfterFinished)
 				// Verify PersistentContents: opts.PersistentContents should override template's PersistentContents
-				var tmpl v1alpha1.SandboxTemplate
-				require.NoError(t, c.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "tmpl-2"}, &tmpl))
 				assert.Empty(t, tmpl.Spec.PersistentContents, "template PersistentContents should be empty when sandbox has no PersistentContents")
 				assert.Equal(t, []string{"memory", "filesystem"}, cp.Spec.PersistentContents, "checkpoint PersistentContents should use opts.PersistentContents")
 			},
@@ -1103,10 +1108,13 @@ func TestCreateCheckPoint(t *testing.T) {
 				require.NoError(t, c.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "tmpl-3"}, &cp))
 				assert.Equal(t, "tmpl-3", cp.Name)
 				assert.Equal(t, "test-sandbox-3", *cp.Spec.PodName)
-				require.Len(t, cp.OwnerReferences, 1)
-				assert.Equal(t, "SandboxTemplate", cp.OwnerReferences[0].Kind)
-				assert.Equal(t, "tmpl-3", cp.OwnerReferences[0].Name)
-				assert.Equal(t, types.UID("uid-3"), cp.OwnerReferences[0].UID)
+				assert.Empty(t, cp.OwnerReferences, "checkpoint should have no owner references")
+				var tmpl v1alpha1.SandboxTemplate
+				require.NoError(t, c.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "tmpl-3"}, &tmpl))
+				require.Len(t, tmpl.OwnerReferences, 1)
+				assert.Equal(t, "Checkpoint", tmpl.OwnerReferences[0].Kind)
+				assert.Equal(t, "tmpl-3", tmpl.OwnerReferences[0].Name)
+				assert.Equal(t, types.UID("uid-3"), tmpl.OwnerReferences[0].UID)
 				// Verify init runtime annotation
 				assert.Equal(t, `{"accessToken":"test-token","envVars":{"VAR1":"value1"}}`, cp.Annotations[v1alpha1.AnnotationInitRuntimeRequest])
 			},

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -235,7 +235,7 @@ func (i *Infra) DeleteCheckpoint(ctx context.Context, opts infra.DeleteCheckpoin
 	// SandboxTemplate after the agents.kruise.io/checkpoint finalizer is
 	// processed.
 	log.Info("deleting checkpoint", "checkpoint", klog.KObj(cp))
-	if err := DefaultDeleteCheckpointCR(ctx, i.Cache.GetClient(), cp.Namespace, cp.Name); err != nil {
+	if err := client.IgnoreNotFound(DefaultDeleteCheckpointCR(ctx, i.Cache.GetClient(), cp.Namespace, cp.Name)); err != nil {
 		log.Error(err, "failed to delete checkpoint")
 		return managererrors.NewError(managererrors.ErrorInternal, "%s", err.Error())
 	}
@@ -245,7 +245,7 @@ func (i *Infra) DeleteCheckpoint(ctx context.Context, opts infra.DeleteCheckpoin
 	// SandboxTemplate. Delete it explicitly.
 	if !metav1.IsControlledBy(tmpl, cp) {
 		log.Info("template not controlled by checkpoint, deleting explicitly", "template", klog.KObj(tmpl))
-		if err := DefaultDeleteSandboxTemplate(ctx, i.Cache.GetClient(), tmpl.Namespace, tmpl.Name); err != nil {
+		if err := client.IgnoreNotFound(DefaultDeleteSandboxTemplate(ctx, i.Cache.GetClient(), tmpl.Namespace, tmpl.Name)); err != nil {
 			log.Error(err, "failed to delete sandbox template")
 			return managererrors.NewError(managererrors.ErrorInternal, "%s", err.Error())
 		}

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -230,20 +230,23 @@ func (i *Infra) DeleteCheckpoint(ctx context.Context, opts infra.DeleteCheckpoin
 		return managererrors.NewError(managererrors.ErrorNotAllowed, "checkpoint %s is not owned by user %s", opts.CheckpointID, user)
 	}
 
-	// Step 3: Delete the SandboxTemplate
-	log.Info("deleting sandbox template", "template", klog.KObj(tmpl))
-	if err := DefaultDeleteSandboxTemplate(ctx, i.Cache.GetClient(), tmpl.Namespace, tmpl.Name); err != nil {
-		log.Error(err, "failed to delete sandbox template")
+	// Step 3: Delete the Checkpoint. For new-shape data (SandboxTemplate owned
+	// by Checkpoint), Kubernetes garbage collection cascades the
+	// SandboxTemplate after the agents.kruise.io/checkpoint finalizer is
+	// processed.
+	log.Info("deleting checkpoint", "checkpoint", klog.KObj(cp))
+	if err := DefaultDeleteCheckpointCR(ctx, i.Cache.GetClient(), cp.Namespace, cp.Name); err != nil {
+		log.Error(err, "failed to delete checkpoint")
 		return managererrors.NewError(managererrors.ErrorInternal, "%s", err.Error())
 	}
 
-	// Step 4: Check if checkpoint has OwnerReference to the SandboxTemplate
-	// If yes, Kubernetes garbage collection will handle deletion automatically
-	// If no, explicitly delete the checkpoint
-	if !metav1.IsControlledBy(cp, tmpl) {
-		log.Info("checkpoint has no controller reference to template, deleting explicitly", "checkpoint", klog.KObj(cp))
-		if err := DefaultDeleteCheckpointCR(ctx, i.Cache.GetClient(), cp.Namespace, cp.Name); err != nil {
-			log.Error(err, "failed to delete checkpoint")
+	// Step 4: For legacy-shape data (Checkpoint owned by SandboxTemplate, with
+	// no owner reference on the SandboxTemplate itself), GC will not reach the
+	// SandboxTemplate. Delete it explicitly.
+	if !metav1.IsControlledBy(tmpl, cp) {
+		log.Info("template not controlled by checkpoint, deleting explicitly", "template", klog.KObj(tmpl))
+		if err := DefaultDeleteSandboxTemplate(ctx, i.Cache.GetClient(), tmpl.Namespace, tmpl.Name); err != nil {
+			log.Error(err, "failed to delete sandbox template")
 			return managererrors.NewError(managererrors.ErrorInternal, "%s", err.Error())
 		}
 	}

--- a/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
@@ -25,7 +25,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1076,4 +1078,96 @@ func TestInfra_DeleteCheckpoint_NewShape_SkipsExplicitTemplateDelete(t *testing.
 
 	assert.Equal(t, 1, deleteCpCount, "DefaultDeleteCheckpointCR must be called exactly once")
 	assert.Equal(t, 0, deleteTmplCount, "DefaultDeleteSandboxTemplate must not be called for new-shape data; GC handles cascade")
+}
+
+func TestInfra_DeleteCheckpoint_IgnoresNotFoundDuringDeletes(t *testing.T) {
+	tests := []struct {
+		name             string
+		checkpointID     string
+		deleteCheckpoint error
+		deleteTemplate   error
+		expectCheckpoint int
+		expectTemplate   int
+	}{
+		{
+			name:             "checkpoint delete not found is ignored",
+			checkpointID:     "cp-delete-not-found",
+			deleteCheckpoint: apierrors.NewNotFound(schema.GroupResource{Group: v1alpha1.GroupVersion.Group, Resource: "checkpoints"}, "cp-delete-not-found"),
+			expectCheckpoint: 1,
+			expectTemplate:   1,
+		},
+		{
+			name:             "legacy template delete not found is ignored",
+			checkpointID:     "cp-template-not-found",
+			deleteTemplate:   apierrors.NewNotFound(schema.GroupResource{Group: v1alpha1.GroupVersion.Group, Resource: "sandboxtemplates"}, "cp-template-not-found"),
+			expectCheckpoint: 1,
+			expectTemplate:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			infraInstance, fc := NewTestInfra(t)
+
+			const namespace = "default"
+			cpName := tt.checkpointID
+			cpUID := types.UID(tt.checkpointID + "-uid")
+
+			cp := &v1alpha1.Checkpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        cpName,
+					Namespace:   namespace,
+					UID:         cpUID,
+					Annotations: map[string]string{v1alpha1.AnnotationOwner: "test-user"},
+				},
+				Status: v1alpha1.CheckpointStatus{CheckpointId: cpName},
+			}
+			require.NoError(t, fc.Create(t.Context(), cp))
+			require.NoError(t, fc.Status().Update(t.Context(), cp))
+
+			tmpl := &v1alpha1.SandboxTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cpName,
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.SandboxTemplateSpec{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "main", Image: "test"}},
+						},
+					},
+				},
+			}
+			require.NoError(t, fc.Create(t.Context(), tmpl))
+
+			var deleteCpCount, deleteTmplCount int
+			origDelCp := DefaultDeleteCheckpointCR
+			DefaultDeleteCheckpointCR = func(ctx context.Context, c client.Client, namespace, name string) error {
+				deleteCpCount++
+				if tt.deleteCheckpoint != nil {
+					return tt.deleteCheckpoint
+				}
+				return origDelCp(ctx, c, namespace, name)
+			}
+			t.Cleanup(func() { DefaultDeleteCheckpointCR = origDelCp })
+
+			origDelTmpl := DefaultDeleteSandboxTemplate
+			DefaultDeleteSandboxTemplate = func(ctx context.Context, c client.Client, namespace, name string) error {
+				deleteTmplCount++
+				if tt.deleteTemplate != nil {
+					return tt.deleteTemplate
+				}
+				return origDelTmpl(ctx, c, namespace, name)
+			}
+			t.Cleanup(func() { DefaultDeleteSandboxTemplate = origDelTmpl })
+
+			err := infraInstance.DeleteCheckpoint(t.Context(), infra.DeleteCheckpointOptions{
+				Namespace:    namespace,
+				CheckpointID: cpName,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectCheckpoint, deleteCpCount)
+			assert.Equal(t, tt.expectTemplate, deleteTmplCount)
+		})
+	}
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openkruise/agents/api/v1alpha1"
@@ -1003,4 +1004,76 @@ func TestInfra_startRouteReconciler(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInfra_DeleteCheckpoint_NewShape_SkipsExplicitTemplateDelete(t *testing.T) {
+	infraInstance, fc := NewTestInfra(t)
+
+	var deleteCpCount, deleteTmplCount int
+
+	origDelCp := DefaultDeleteCheckpointCR
+	DefaultDeleteCheckpointCR = func(ctx context.Context, c client.Client, namespace, name string) error {
+		deleteCpCount++
+		return origDelCp(ctx, c, namespace, name)
+	}
+	t.Cleanup(func() { DefaultDeleteCheckpointCR = origDelCp })
+
+	origDelTmpl := DefaultDeleteSandboxTemplate
+	DefaultDeleteSandboxTemplate = func(ctx context.Context, c client.Client, namespace, name string) error {
+		deleteTmplCount++
+		return origDelTmpl(ctx, c, namespace, name)
+	}
+	t.Cleanup(func() { DefaultDeleteSandboxTemplate = origDelTmpl })
+
+	const namespace = "default"
+	const cpName = "cp-new-shape"
+	const cpUID types.UID = "cp-new-shape-uid"
+
+	// Create the Checkpoint first (mirroring production order) with an explicit
+	// UID so the SandboxTemplate's OwnerReference resolves deterministically.
+	cp := &v1alpha1.Checkpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        cpName,
+			Namespace:   namespace,
+			UID:         cpUID,
+			Annotations: map[string]string{v1alpha1.AnnotationOwner: "test-user"},
+		},
+		Status: v1alpha1.CheckpointStatus{CheckpointId: cpName},
+	}
+	require.NoError(t, fc.Create(t.Context(), cp))
+	require.NoError(t, fc.Status().Update(t.Context(), cp))
+
+	tmpl := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cpName,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         v1alpha1.CheckpointControllerKind.GroupVersion().String(),
+					Kind:               v1alpha1.CheckpointControllerKind.Kind,
+					Name:               cpName,
+					UID:                cpUID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
+		},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "test"}},
+				},
+			},
+		},
+	}
+	require.NoError(t, fc.Create(t.Context(), tmpl))
+
+	err := infraInstance.DeleteCheckpoint(t.Context(), infra.DeleteCheckpointOptions{
+		Namespace:    namespace,
+		CheckpointID: cpName,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, deleteCpCount, "DefaultDeleteCheckpointCR must be called exactly once")
+	assert.Equal(t, 0, deleteTmplCount, "DefaultDeleteSandboxTemplate must not be called for new-shape data; GC handles cascade")
 }


### PR DESCRIPTION
## Summary
- Reverse `Checkpoint` ↔ `SandboxTemplate` OwnerReference. `Checkpoint` is now the owner of `SandboxTemplate`. External TTL deletion of a `Checkpoint` now cascade-deletes its `SandboxTemplate` via Kubernetes garbage collection, fixing the long-standing template leak triggered when `CheckpointSpec.TtlAfterFinished` fires.
- `CreateCheckpoint` reordered: build `Checkpoint` first (with `GenerateName`), then `SandboxTemplate` with an `OwnerReference` pointing back at the `Checkpoint`. `DeleteCheckpoint` is mirrored: delete the `Checkpoint` first; explicit `SandboxTemplate` delete only fires as a legacy-shape fallback via `metav1.IsControlledBy(tmpl, cp)`. Existing on-disk legacy data is intentionally not migrated.
- Full design + compatibility matrix at `docs/specs/2026-05-19-checkpoint-owns-sandboxtemplate-design.md` (committed as part of this PR). Adds `v1alpha1.CheckpointControllerKind` to centralize OwnerReference construction.

## Test plan
- [ ] `go test ./pkg/...` passes (49 packages, all green)
- [ ] `go vet ./...` and `go build ./...` succeed silently
- [ ] `golangci-lint run pkg/sandbox-manager/infra/sandboxcr/...` reports zero issues
- [ ] `make generate manifests` produces no diff (no CRD field change)
- [ ] Post-deploy: create a new snapshot via `POST /sandboxes/{id}/snapshots`; `kubectl get checkpoint <name> -o yaml` shows empty `ownerReferences`; `kubectl get sbt <name> -o yaml` shows `ownerReferences[0].kind == Checkpoint`
- [ ] Post-deploy: clone the new snapshot via `POST /sandboxes`; resulting sandbox reaches Ready
- [ ] Post-deploy: `DELETE /templates/{id}` on the new snapshot removes both objects within the finalizer + GC sweep window
- [ ] Post-deploy: legacy pre-upgrade snapshot still clones / deletes correctly via the legacy-shape fallback
- [ ] Post-deploy: allow a fresh snapshot to expire via the external TTL controller; confirm the `SandboxTemplate` is cascade-deleted (the headline fix)