### PR TITLE
fix(keys): replace ticker with informer-driven refresh for secret-backed key storage

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -357,6 +357,10 @@ func (c *Cache) GetAPIReader() ctrlclient.Reader {
 	return c.reader
 }
 
+func (c *Cache) GetCache() ctrlcache.Cache {
+	return c.mgr.GetCache()
+}
+
 // GetWaitHooks returns the internal waitHooks map used for wait simulation.
 // This is only intended for test infrastructure use.
 func (c *Cache) GetWaitHooks() *sync.Map {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1284,3 +1284,11 @@ func TestBuildCacheConfig(t *testing.T) {
 }
 
 func boolPtr(b bool) *bool { return &b }
+
+func TestCache_GetCache_ReturnsManagerCache(t *testing.T) {
+	c, _, err := cachetest.NewTestCache(t)
+	require.NoError(t, err)
+
+	require.Equal(t, c.GetMockManager().GetCache(), c.GetCache(),
+		"GetCache must return the underlying manager's cache")
+}

--- a/pkg/cache/controllers/test_helpers.go
+++ b/pkg/cache/controllers/test_helpers.go
@@ -45,6 +45,38 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 )
 
+// stubCtrlCache is a no-op placeholder for ctrlcache.Cache returned by
+// MockManager.GetCache(). Returning a non-nil value is required so production
+// code that injects the cache into downstream consumers (e.g., the e2b
+// key-storage factory) does not reject the test wiring as if no cache were
+// configured. The only methods exercised by the production cache lifecycle
+// in tests are IndexField and WaitForCacheSync; both are no-ops because the
+// fake client built alongside MockManager already has indexes wired through
+// fake.WithIndex, and tests never block on real informer sync. Any other
+// method falls through to the embedded nil interface and panics, which is
+// the desired loud-failure behavior for paths the tests should not reach.
+type stubCtrlCache struct {
+	ctrlcache.Cache // embedded nil interface
+}
+
+// IndexField is a no-op; cache.AddIndexesToCache forwards the field config
+// here, but the fake client already carries the same indexes from
+// cache.GetIndexFuncs.
+func (*stubCtrlCache) IndexField(_ context.Context, _ client.Object, _ string, _ client.IndexerFunc) error {
+	return nil
+}
+
+// WaitForCacheSync returns true so cache.Run does not block on a fake
+// informer that will never sync.
+func (*stubCtrlCache) WaitForCacheSync(_ context.Context) bool { return true }
+
+// Start blocks until ctx is done so cache.Run's mgr.Start goroutine has
+// something to exit cleanly when the test cancels its context.
+func (*stubCtrlCache) Start(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
 // MockManager implements manager.Manager for unit testing.
 // It provides controllable Add() behavior to allow error injection on specific calls.
 type MockManager struct {
@@ -126,7 +158,7 @@ func (b *MockManagerBuilder) Build() *MockManager {
 
 func (m *MockManager) GetHTTPClient() *http.Client          { return nil }
 func (m *MockManager) GetConfig() *rest.Config              { return nil }
-func (m *MockManager) GetCache() ctrlcache.Cache            { return nil }
+func (m *MockManager) GetCache() ctrlcache.Cache            { return &stubCtrlCache{} }
 func (m *MockManager) GetScheme() *runtime.Scheme           { return m.scheme }
 func (m *MockManager) GetClient() client.Client             { return m.client }
 func (m *MockManager) GetAPIReader() client.Reader          { return m.apiReader }

--- a/pkg/cache/interface.go
+++ b/pkg/cache/interface.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"context"
 
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
@@ -97,6 +98,11 @@ type Provider interface {
 	// Prefer GetClient() for most operations; use this only when cache staleness
 	// is unacceptable (e.g., validating critical state transitions).
 	GetAPIReader() client.Reader
+
+	// GetCache returns the underlying controller-runtime cache. Use this only
+	// when you need to register informer event handlers; for normal Get/List,
+	// prefer GetClient().
+	GetCache() ctrlcache.Cache
 }
 
 type GetClaimedSandboxOptions struct {

--- a/pkg/servers/e2b/adapters/unified_e2b_test.go
+++ b/pkg/servers/e2b/adapters/unified_e2b_test.go
@@ -27,12 +27,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 )
 
 var adminKey = "admin-key"
+
+// stubAdapterCache is a no-op ctrlcache.Cache used solely so the keys factory
+// validation passes during adapter test setup. The keystore built here is not
+// exercised by any adapter test; it only needs to construct successfully.
+type stubAdapterCache struct {
+	ctrlcache.Cache // embedded nil interface; unused methods will panic
+}
 
 func SetUpE2BAdapter(t *testing.T) *E2BAdapter {
 	scheme := runtime.NewScheme()
@@ -52,6 +60,7 @@ func SetUpE2BAdapter(t *testing.T) *E2BAdapter {
 		AdminKey:  adminKey,
 		Client:    fc,
 		APIReader: fc,
+		Cache:     &stubAdapterCache{},
 	})
 	require.NoError(t, err)
 	assert.NoError(t, keyStore.Init(context.Background()))

--- a/pkg/servers/e2b/api_key_test.go
+++ b/pkg/servers/e2b/api_key_test.go
@@ -90,6 +90,7 @@ func TestListTeams(t *testing.T) {
 	require.NoError(t, err)
 	_, err = controller.keys.CreateKey(ctx, adminUser, keys.CreateKeyOptions{Name: "team-b-key", TeamName: "team-b"})
 	require.NoError(t, err)
+	refreshKeyStorageForTest(t, controller)
 
 	tests := []struct {
 		name        string
@@ -185,6 +186,7 @@ func TestCreateAPIKey(t *testing.T) {
 				rawKey, decoded := keys.DecodeFromE2BSDKCompatible(resp.Body.Key)
 				require.True(t, decoded)
 				assert.NotEqual(t, rawKey, resp.Body.Key)
+				refreshKeyStorageForTest(t, controller)
 				stored, found := controller.keys.LoadByID(t.Context(), resp.Body.ID.String())
 				require.True(t, found)
 				assert.Equal(t, rawKey, stored.Key)
@@ -213,6 +215,7 @@ func TestCompatibleAPIKeyEndpoint(t *testing.T) {
 	}
 	regularUser, err := controller.keys.CreateKey(ctx, adminUser, keys.CreateKeyOptions{Name: "regular-user", TeamName: "regular-team"})
 	require.NoError(t, err)
+	refreshKeyStorageForTest(t, controller)
 	compatibleKey := keys.EncodeForE2BSDK(regularUser.Key)
 
 	tests := []struct {
@@ -268,6 +271,7 @@ func TestCreateAPIKeyPermissionMiddleware(t *testing.T) {
 	}
 	teamAKey, err := controller.keys.CreateKey(ctx, adminUser, keys.CreateKeyOptions{Name: "team-a-key", TeamName: "team-a"})
 	require.NoError(t, err)
+	refreshKeyStorageForTest(t, controller)
 	require.NoError(t, fc.Create(t.Context(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: "team-a"},
 	}))
@@ -380,6 +384,7 @@ func TestDeleteAPIKeyPermissionMiddleware(t *testing.T) {
 	require.NoError(t, err)
 	teamBKey, err := controller.keys.CreateKey(ctx, adminUser, keys.CreateKeyOptions{Name: "team-b-key", TeamName: "team-b"})
 	require.NoError(t, err)
+	refreshKeyStorageForTest(t, controller)
 
 	tests := []struct {
 		name                  string

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -142,6 +142,7 @@ func (sc *Controller) initKeyStorage(ctx context.Context) error {
 		if sc.cache != nil {
 			sc.keyCfg.Client = sc.cache.GetClient()
 			sc.keyCfg.APIReader = sc.cache.GetAPIReader()
+			sc.keyCfg.Cache = sc.cache.GetCache()
 		}
 		if sc.keys, err = keys.NewKeyStorage(*sc.keyCfg); err != nil {
 			return err

--- a/pkg/servers/e2b/core_test.go
+++ b/pkg/servers/e2b/core_test.go
@@ -76,6 +76,11 @@ func Setup(t *testing.T) (*Controller, ctrlclient.Client, func()) {
 	return SetupWithMinResumeTimeout(t, models.DefaultMinResumeTimeoutSeconds)
 }
 
+func refreshKeyStorageForTest(t *testing.T, controller *Controller) {
+	t.Helper()
+	require.NoError(t, controller.keys.Init(t.Context()))
+}
+
 // SetupWithMinResumeTimeout mirrors Setup but lets the caller override
 // Controller.minResumeTimeout so floor-enforcement assertions can use a
 // non-default value (e.g., 120s with a 60s request to observe the bump).

--- a/pkg/servers/e2b/keys/AGENTS.md
+++ b/pkg/servers/e2b/keys/AGENTS.md
@@ -7,6 +7,26 @@ This directory owns E2B API-key persistence behind the `KeyStorage` interface. K
 - `secretKeyStorage` is the compatibility baseline for API behavior.
 - `mysqlKeyStorage` is the database backend. Keep the concrete type unexported; expose it only through `KeyStorage` and `NewKeyStorage`.
 
+## Secret Backend Refresh Semantics
+
+`secretKeyStorage` keeps its in-memory indexes in sync with the backing
+`e2b-key-store` Secret via an informer event handler installed on the shared
+`pkg/cache.Cache`. There is no periodic poller. Cross-replica propagation
+delay for key create/delete is bounded by informer push latency (typically
+sub-second).
+
+- `Config.Cache` is required for secret mode and is validated in
+  `NewKeyStorage`. `NewSecretKeyStorage` itself does not validate, allowing
+  unit tests to construct the storage without a cache as long as they do not
+  call `Run()`.
+- `Run()` registers the handler and starts a single-worker goroutine that
+  drains a coalescing channel and calls `refresh()` against the cached
+  client. `Stop()` removes the handler and waits for the worker to exit.
+- Cross-replica visibility (including the historical `retryCreateKey` case
+  where a retry re-reads a Secret revision containing concurrent writes
+  from another replica) is healed by the next informer event reaching the
+  affected replica — typically within a few hundred milliseconds.
+
 ## Interface And Callers
 
 - Keep `KeyStorage` signatures in sync with current callers in `pkg/servers/e2b/api_key.go` and `pkg/servers/e2b/routes.go`.

--- a/pkg/servers/e2b/keys/factory.go
+++ b/pkg/servers/e2b/keys/factory.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -41,16 +42,17 @@ type Config struct {
 	DisableAutoMigrate bool   // mysql mode
 	Client             client.Client
 	APIReader          client.Reader
+	Cache              ctrlcache.Cache // required for secret mode; ignored for mysql mode
 }
 
 // NewKeyStorage returns a KeyStorage implementation for the given config.
 func NewKeyStorage(cfg Config) (KeyStorage, error) {
 	switch cfg.Mode {
 	case "", StorageModeSecret:
-		if cfg.Client == nil || cfg.APIReader == nil {
-			return nil, errors.New("secret key storage requires controller-runtime client and api-reader")
+		if cfg.Client == nil || cfg.APIReader == nil || cfg.Cache == nil {
+			return nil, errors.New("secret key storage requires controller-runtime client, api-reader, and cache")
 		}
-		return NewSecretKeyStorage(cfg.Client, cfg.APIReader, cfg.Namespace, cfg.AdminKey), nil
+		return NewSecretKeyStorage(cfg.Client, cfg.APIReader, cfg.Cache, cfg.Namespace, cfg.AdminKey), nil
 	case StorageModeMySQL:
 		if cfg.DSN == "" {
 			return nil, errors.New("mysql key storage requires a DSN")

--- a/pkg/servers/e2b/keys/factory_test.go
+++ b/pkg/servers/e2b/keys/factory_test.go
@@ -47,9 +47,23 @@ func TestNewKeyStorage(t *testing.T) {
 				AdminKey:  "admin",
 				Client:    fc,
 				APIReader: fc,
+				Cache:     newStubCache(),
 			},
 			wantErr:  false,
 			wantType: &secretKeyStorage{},
+		},
+		{
+			name: "secret mode requires cache",
+			config: Config{
+				Mode:      StorageModeSecret,
+				Namespace: "default",
+				AdminKey:  "admin",
+				Client:    fc,
+				APIReader: fc,
+				Cache:     nil,
+			},
+			wantErr:     true,
+			errContains: "cache",
 		},
 		{
 			name:        "mysql mode requires dsn",

--- a/pkg/servers/e2b/keys/secret.go
+++ b/pkg/servers/e2b/keys/secret.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openkruise/agents/pkg/sandbox-manager/logs"
@@ -60,21 +61,24 @@ type secretKeyStorage struct {
 	Client client.Client
 	// APIReader is used for reading secrets before cache is started (e.g., during Init).
 	APIReader client.Reader
-	stop      chan struct{}
-	done      chan struct{}
-	stopOnce  sync.Once
+	Cache     ctrlcache.Cache
+
+	stop     chan struct{}
+	done     chan struct{}
+	stopOnce sync.Once
 
 	idxByKey  sync.Map
 	idxByID   sync.Map
 	idxByTeam sync.Map // teamName -> *models.Team
 }
 
-func NewSecretKeyStorage(client client.Client, apiReader client.Reader, namespace, adminKey string) KeyStorage {
+func NewSecretKeyStorage(client client.Client, apiReader client.Reader, cache ctrlcache.Cache, namespace, adminKey string) KeyStorage {
 	return &secretKeyStorage{
 		Namespace: namespace,
 		AdminKey:  adminKey,
 		Client:    client,
 		APIReader: apiReader,
+		Cache:     cache,
 		stop:      make(chan struct{}),
 		done:      make(chan struct{}),
 	}

--- a/pkg/servers/e2b/keys/secret.go
+++ b/pkg/servers/e2b/keys/secret.go
@@ -46,7 +46,7 @@ var (
 	marshalAPIKey = json.Marshal
 )
 
-const secretKeyStorageRefreshInterval = 15 * time.Second
+const secretKeyStorageRefreshInterval = 10 * time.Minute
 
 func init() {
 	AdminKeyID = uuid.MustParse("550e8400-e29b-41d4-a716-446655440000") // no means, just a const
@@ -169,6 +169,9 @@ func (k *secretKeyStorage) refresh(ctx context.Context, reader client.Reader) er
 	return nil
 }
 
+// triggerRefresh uses refreshC, which is a buffered channel (cap=1), to coalesce refresh signals.
+// Multiple events between refresh cycles are collapsed into a single refresh,
+// preventing redundant Secret reads when the informer delivers a burst of events.
 func (k *secretKeyStorage) triggerRefresh() {
 	select {
 	case k.refreshC <- struct{}{}:

--- a/pkg/servers/e2b/keys/secret.go
+++ b/pkg/servers/e2b/keys/secret.go
@@ -46,6 +46,8 @@ var (
 	marshalAPIKey = json.Marshal
 )
 
+const secretKeyStorageRefreshInterval = 15 * time.Second
+
 func init() {
 	AdminKeyID = uuid.MustParse("550e8400-e29b-41d4-a716-446655440000") // no means, just a const
 }
@@ -67,6 +69,8 @@ type secretKeyStorage struct {
 	refreshC chan struct{}
 	wg       sync.WaitGroup
 
+	refreshInterval time.Duration
+
 	idxByKey  sync.Map
 	idxByID   sync.Map
 	idxByTeam sync.Map // teamName -> *models.Team
@@ -74,14 +78,15 @@ type secretKeyStorage struct {
 
 func NewSecretKeyStorage(client client.Client, apiReader client.Reader, cache ctrlcache.Cache, namespace, adminKey string) KeyStorage {
 	return &secretKeyStorage{
-		Namespace: namespace,
-		AdminKey:  adminKey,
-		Client:    client,
-		APIReader: apiReader,
-		Cache:     cache,
-		stop:      make(chan struct{}),
-		done:      make(chan struct{}),
-		refreshC:  make(chan struct{}, 1),
+		Namespace:       namespace,
+		AdminKey:        adminKey,
+		Client:          client,
+		APIReader:       apiReader,
+		Cache:           cache,
+		stop:            make(chan struct{}),
+		done:            make(chan struct{}),
+		refreshC:        make(chan struct{}, 1),
+		refreshInterval: secretKeyStorageRefreshInterval,
 	}
 }
 
@@ -121,6 +126,11 @@ func (k *secretKeyStorage) refresh(ctx context.Context, reader client.Reader) er
 	if err := reader.Get(ctx, client.ObjectKey{Namespace: k.Namespace, Name: KeySecretName}, secret); err != nil {
 		return err
 	}
+	// refresh is the only path that mutates the in-memory indexes. CreateKey
+	// and DeleteKey intentionally only update the Secret and then wait for an
+	// informer-backed refresh to publish the change locally. Mixing writer-side
+	// index updates with queued stale informer refreshes can briefly revoke a
+	// newly created key or restore a newly deleted key on the auth path.
 	var ids, keys, teamNames = sets.NewString(), sets.NewString(), sets.NewString()
 	for id, bytes := range secret.Data {
 		var apiKey models.CreatedTeamAPIKey
@@ -169,9 +179,19 @@ func (k *secretKeyStorage) triggerRefresh() {
 func (k *secretKeyStorage) refreshWorker(ctx context.Context) {
 	defer k.wg.Done()
 	log := klog.FromContext(ctx)
+	refreshInterval := k.refreshInterval
+	if refreshInterval <= 0 {
+		refreshInterval = secretKeyStorageRefreshInterval
+	}
+	ticker := time.NewTicker(refreshInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-k.refreshC:
+			if err := k.refresh(ctx, k.Client); err != nil {
+				log.Error(err, "failed to refresh key store")
+			}
+		case <-ticker.C:
 			if err := k.refresh(ctx, k.Client); err != nil {
 				log.Error(err, "failed to refresh key store")
 			}
@@ -402,7 +422,6 @@ func (k *secretKeyStorage) CreateKey(ctx context.Context, key *models.CreatedTea
 		log.Error(err, "failed to update api-key")
 		return nil, err
 	}
-	k.storeKey(createdKey)
 	return createdKey, nil
 }
 
@@ -417,8 +436,6 @@ func (k *secretKeyStorage) DeleteKey(ctx context.Context, key *models.CreatedTea
 	if err != nil {
 		return err
 	}
-	k.idxByKey.Delete(key.Key)
-	k.idxByID.Delete(key.ID.String())
 	return nil
 }
 

--- a/pkg/servers/e2b/keys/secret.go
+++ b/pkg/servers/e2b/keys/secret.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
@@ -39,13 +40,10 @@ import (
 )
 
 var (
-	KeySecretName    = "e2b-key-store"
-	AdminKeyID       uuid.UUID
-	generateUUID     = uuid.New
-	marshalAPIKey    = json.Marshal
-	newRefreshTicker = func() *time.Ticker {
-		return time.NewTicker(10 * time.Minute)
-	}
+	KeySecretName = "e2b-key-store"
+	AdminKeyID    uuid.UUID
+	generateUUID  = uuid.New
+	marshalAPIKey = json.Marshal
 )
 
 func init() {
@@ -66,6 +64,8 @@ type secretKeyStorage struct {
 	stop     chan struct{}
 	done     chan struct{}
 	stopOnce sync.Once
+	refreshC chan struct{}
+	wg       sync.WaitGroup
 
 	idxByKey  sync.Map
 	idxByID   sync.Map
@@ -81,6 +81,7 @@ func NewSecretKeyStorage(client client.Client, apiReader client.Reader, cache ct
 		Cache:     cache,
 		stop:      make(chan struct{}),
 		done:      make(chan struct{}),
+		refreshC:  make(chan struct{}, 1),
 	}
 }
 
@@ -158,32 +159,80 @@ func (k *secretKeyStorage) refresh(ctx context.Context, reader client.Reader) er
 	return nil
 }
 
-func (k *secretKeyStorage) Run() {
-	// Capture newRefreshTicker synchronously in the calling goroutine to avoid
-	// a data race between the background goroutine reading newRefreshTicker and
-	// test cleanup code writing to it after the test function returns.
-	tickerFactory := newRefreshTicker
-	go func() {
-		defer close(k.done)
-		ticker := tickerFactory()
-		ctx := logs.NewContext()
-		log := klog.FromContext(ctx)
-		for {
-			select {
-			case <-ticker.C:
-				if err := k.refresh(ctx, k.Client); err != nil {
-					log.Error(err, "failed to refresh key store")
-				}
-			case <-k.stop:
-				ticker.Stop()
-				log.Info("api-key refreshing stopped")
-				return
+func (k *secretKeyStorage) triggerRefresh() {
+	select {
+	case k.refreshC <- struct{}{}:
+	default:
+	}
+}
+
+func (k *secretKeyStorage) refreshWorker(ctx context.Context) {
+	defer k.wg.Done()
+	log := klog.FromContext(ctx)
+	for {
+		select {
+		case <-k.refreshC:
+			if err := k.refresh(ctx, k.Client); err != nil {
+				log.Error(err, "failed to refresh key store")
 			}
+		case <-k.stop:
+			return
 		}
+	}
+}
+
+func (k *secretKeyStorage) onSecretEvent(obj any) {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		if t, isTombstone := obj.(toolscache.DeletedFinalStateUnknown); isTombstone {
+			secret, ok = t.Obj.(*corev1.Secret)
+		}
+		if !ok {
+			return
+		}
+	}
+	if secret.Namespace != k.Namespace || secret.Name != KeySecretName {
+		return
+	}
+	k.triggerRefresh()
+}
+
+func (k *secretKeyStorage) Run() {
+	ctx := logs.NewContext()
+	log := klog.FromContext(ctx)
+
+	informer, err := k.Cache.GetInformer(ctx, &corev1.Secret{})
+	if err != nil {
+		log.Error(err, "failed to get Secret informer; key store will not refresh")
+		close(k.done)
+		return
+	}
+
+	reg, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+		AddFunc:    k.onSecretEvent,
+		UpdateFunc: func(_, newObj any) { k.onSecretEvent(newObj) },
+		DeleteFunc: k.onSecretEvent,
+	})
+	if err != nil {
+		log.Error(err, "failed to register Secret event handler")
+		close(k.done)
+		return
+	}
+
+	k.wg.Add(1)
+	go k.refreshWorker(ctx)
+
+	go func() {
+		<-k.stop
+		if removeErr := informer.RemoveEventHandler(reg); removeErr != nil {
+			log.Error(removeErr, "failed to remove Secret event handler")
+		}
+		k.wg.Wait()
+		close(k.done)
 	}()
 }
 
-// Stop signals the background refresh goroutine to exit and waits for it to finish.
+// Stop signals the background refresh worker to exit and waits for it to finish.
 func (k *secretKeyStorage) Stop() {
 	k.stopOnce.Do(func() {
 		close(k.stop)

--- a/pkg/servers/e2b/keys/secret_test.go
+++ b/pkg/servers/e2b/keys/secret_test.go
@@ -68,7 +68,7 @@ func newSecretStorageForTest(t *testing.T, data map[string][]byte) (*secretKeySt
 		ObjectMeta: metav1.ObjectMeta{Name: KeySecretName, Namespace: "default"},
 		Data:       data,
 	}).Build()
-	return NewSecretKeyStorage(c, c, "default", "admin-key").(*secretKeyStorage), c
+	return NewSecretKeyStorage(c, c, nil, "default", "admin-key").(*secretKeyStorage), c
 }
 
 func getSecretForTest(t *testing.T, c client.Client) *corev1.Secret {
@@ -142,7 +142,7 @@ func TestSecretKeyStorage_Init(t *testing.T) {
 			name: "secret not found",
 			prepare: func(t *testing.T) (*secretKeyStorage, client.Client) {
 				c := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
-				return NewSecretKeyStorage(c, c, "default", "admin-key").(*secretKeyStorage), c
+				return NewSecretKeyStorage(c, c, nil, "default", "admin-key").(*secretKeyStorage), c
 			},
 			expectError: "not found",
 		},
@@ -192,7 +192,7 @@ func TestSecretKeyStorage_Init(t *testing.T) {
 						return nil
 					},
 				}
-				return NewSecretKeyStorage(hookClient, hookClient, "default", "admin-key").(*secretKeyStorage), c
+				return NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage), c
 			},
 		},
 		{
@@ -205,7 +205,7 @@ func TestSecretKeyStorage_Init(t *testing.T) {
 						return errors.New("update failed")
 					},
 				}
-				return NewSecretKeyStorage(hookClient, hookClient, "default", "admin-key").(*secretKeyStorage), c
+				return NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage), c
 			},
 			expectError: "update failed",
 		},
@@ -264,7 +264,7 @@ func TestSecretKeyStorage_UpdateAndRetry(t *testing.T) {
 			name: "update get error",
 			run: func(t *testing.T) error {
 				c := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
-				storage := NewSecretKeyStorage(c, c, "default", "admin-key").(*secretKeyStorage)
+				storage := NewSecretKeyStorage(c, c, nil, "default", "admin-key").(*secretKeyStorage)
 				return storage.updateSecret(context.Background(), "id", &models.CreatedTeamAPIKey{ID: uuid.New(), Key: "x"})
 			},
 			expectError: "not found",
@@ -322,7 +322,7 @@ func TestSecretKeyStorage_UpdateAndRetry(t *testing.T) {
 						return nil
 					},
 				}
-				storage := NewSecretKeyStorage(hookClient, hookClient, "default", "admin-key").(*secretKeyStorage)
+				storage := NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage)
 				err := storage.retryUpdateSecret(context.Background(), uuid.NewString(), &models.CreatedTeamAPIKey{ID: uuid.New(), Key: "x"})
 				if err == nil {
 					assert.GreaterOrEqual(t, atomic.LoadInt32(&updated), int32(2))
@@ -410,7 +410,7 @@ func TestSecretKeyStorage_CreateKey(t *testing.T) {
 						return errors.New("update failed")
 					},
 				}
-				storageErr := NewSecretKeyStorage(hookClient, hookClient, "default", "admin-key").(*secretKeyStorage)
+				storageErr := NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage)
 				_, err := storageErr.CreateKey(context.Background(), user, CreateKeyOptions{Name: "name"})
 				return err
 			},
@@ -457,7 +457,7 @@ func TestSecretKeyStorage_CreateKey(t *testing.T) {
 						return apierrors.NewConflict(schema.GroupResource{Group: "", Resource: "secrets"}, KeySecretName, errors.New("conflict"))
 					},
 				}
-				storage := NewSecretKeyStorage(hookClient, hookClient, "default", "admin-key").(*secretKeyStorage)
+				storage := NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage)
 
 				useGeneratedUUIDsForTest(t,
 					uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
@@ -596,7 +596,7 @@ func TestSecretKeyStorage_DeleteAndList(t *testing.T) {
 			return errors.New("delete failed")
 		},
 	}
-	storageWithDeleteError := NewSecretKeyStorage(hookClient, hookClient, "default", "admin-key").(*secretKeyStorage)
+	storageWithDeleteError := NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage)
 	require.Error(t, storageWithDeleteError.DeleteKey(context.Background(), key2))
 }
 

--- a/pkg/servers/e2b/keys/secret_test.go
+++ b/pkg/servers/e2b/keys/secret_test.go
@@ -71,6 +71,48 @@ func (c *getHookClient) Get(ctx context.Context, key client.ObjectKey, obj clien
 	return c.Client.Get(ctx, key, obj, opts...)
 }
 
+type staleSecretReadClient struct {
+	client.Client
+
+	mu       sync.Mutex
+	secret   *corev1.Secret
+	getCount int32
+}
+
+func (c *staleSecretReadClient) SetSecret(secret *corev1.Secret) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.secret = secret.DeepCopy()
+}
+
+func (c *staleSecretReadClient) ClearSecret() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.secret = nil
+}
+
+func (c *staleSecretReadClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	atomic.AddInt32(&c.getCount, 1)
+	c.mu.Lock()
+	var secret *corev1.Secret
+	if c.secret != nil {
+		secret = c.secret.DeepCopy()
+	}
+	c.mu.Unlock()
+	if secret != nil && key.Namespace == secret.Namespace && key.Name == secret.Name {
+		target, ok := obj.(*corev1.Secret)
+		if ok {
+			secret.DeepCopyInto(target)
+			return nil
+		}
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func (c *staleSecretReadClient) GetCount() int32 {
+	return atomic.LoadInt32(&c.getCount)
+}
+
 func newTestScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	scheme := runtime.NewScheme()
@@ -385,7 +427,7 @@ func TestSecretKeyStorage_CreateKey(t *testing.T) {
 		{
 			name: "success",
 			run: func(t *testing.T) error {
-				storage, _ := newSecretStorageForTest(t, map[string][]byte{})
+				storage, c := newSecretStorageForTest(t, map[string][]byte{})
 				userTeam := &models.Team{Name: "user-team"}
 				user := &models.CreatedTeamAPIKey{ID: uuid.New(), Team: userTeam, CreatedBy: &models.TeamUser{ID: uuid.New()}}
 				key, err := storage.CreateKey(context.Background(), user, CreateKeyOptions{Name: "name"})
@@ -395,7 +437,10 @@ func TestSecretKeyStorage_CreateKey(t *testing.T) {
 					require.NotNil(t, key.CreatedBy)
 					require.Equal(t, user.ID, key.CreatedBy.ID)
 					_, found := storage.LoadByID(context.Background(), key.ID.String())
-					assert.True(t, found)
+					assert.False(t, found, "created key should wait for informer-backed refresh before entering the index")
+
+					secret := getSecretForTest(t, c)
+					require.Contains(t, secret.Data, key.ID.String())
 				}
 				return err
 			},
@@ -487,9 +532,6 @@ func TestSecretKeyStorage_CreateKey(t *testing.T) {
 					return err
 				}
 				require.Equal(t, existingTeam, key.Team)
-				stored, found := storage.LoadByID(context.Background(), key.ID.String())
-				require.True(t, found)
-				require.Equal(t, existingTeam, stored.Team)
 
 				secret := getSecretForTest(t, c)
 				require.Contains(t, secret.Data, key.ID.String())
@@ -690,6 +732,9 @@ func TestSecretKeyStorage_DeleteAndList(t *testing.T) {
 
 	key, err := storage.CreateKey(context.Background(), user, CreateKeyOptions{Name: "name"})
 	require.NoError(t, err)
+	// This test exercises list/delete behavior. Seed the created key into the
+	// index explicitly because CreateKey no longer mutates informer-owned state.
+	storage.storeKey(key)
 
 	// Same-team key should be visible even if CreatedBy does not match.
 	otherKey := &models.CreatedTeamAPIKey{ID: other, Key: uuid.NewString(), Name: "other", Team: teamA, CreatedBy: &models.TeamUser{ID: uuid.New()}}
@@ -710,6 +755,9 @@ func TestSecretKeyStorage_DeleteAndList(t *testing.T) {
 	require.NoError(t, storage.DeleteKey(context.Background(), nil))
 	require.NoError(t, storage.DeleteKey(context.Background(), key))
 	_, found := storage.LoadByID(context.Background(), key.ID.String())
+	assert.True(t, found, "deleted key should wait for informer-backed refresh before leaving the index")
+	require.NoError(t, storage.refresh(context.Background(), storage.APIReader))
+	_, found = storage.LoadByID(context.Background(), key.ID.String())
 	assert.False(t, found)
 
 	secret := getSecretForTest(t, c)
@@ -1156,6 +1204,170 @@ func TestSecretKeyStorage_Run_HandlerEventTriggersRefresh(t *testing.T) {
 		_, ok := storage.LoadByKey(t.Context(), keyStr)
 		return ok
 	}, time.Second, 5*time.Millisecond, "expected refreshWorker to repopulate the index")
+}
+
+func TestSecretKeyStorage_Run_PeriodicRefreshTriggersRefresh(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "refreshes from cached reader without an event"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			id := uuid.New()
+			keyStr := uuid.NewString()
+			apiKey := &models.CreatedTeamAPIKey{
+				ID: id, Key: keyStr, Name: "periodic", Team: models.AdminTeam(), CreatedAt: time.Now(),
+			}
+			apiKeyJSON, err := json.Marshal(apiKey)
+			require.NoError(t, err)
+
+			storage, _ := newSecretStorageForTest(t, map[string][]byte{id.String(): apiKeyJSON})
+			stub := newStubCache()
+			storage.Cache = stub
+			storage.refreshInterval = 10 * time.Millisecond
+			storage.idxByKey = sync.Map{}
+			storage.idxByID = sync.Map{}
+			storage.idxByTeam = sync.Map{}
+
+			storage.Run()
+			t.Cleanup(storage.Stop)
+
+			require.Eventually(t, func() bool {
+				_, ok := storage.LoadByKey(t.Context(), keyStr)
+				return ok
+			}, time.Second, 5*time.Millisecond, "expected periodic refresh to repopulate the index")
+		})
+	}
+}
+
+func TestSecretKeyStorage_CreateKeyWaitsForInformerRefresh(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "pending stale refresh keeps create waiting for informer-owned index"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			apiClient := fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: KeySecretName, Namespace: "default"},
+				Data:       map[string][]byte{},
+			}).Build()
+			cachedClient := &staleSecretReadClient{Client: apiClient}
+			cachedClient.SetSecret(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: KeySecretName, Namespace: "default"},
+				Data:       map[string][]byte{},
+			})
+			storage := NewSecretKeyStorage(cachedClient, apiClient, nil, "default", "admin-key").(*secretKeyStorage)
+			storage.triggerRefresh()
+
+			newID := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+			newKey := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+			useGeneratedUUIDsForTest(t, newID, newKey)
+			creator := &models.CreatedTeamAPIKey{
+				ID:        uuid.New(),
+				Team:      &models.Team{Name: "team-a"},
+				CreatedBy: &models.TeamUser{ID: uuid.New()},
+			}
+
+			created, err := storage.CreateKey(context.Background(), creator, CreateKeyOptions{Name: "created"})
+			require.NoError(t, err)
+			require.Equal(t, newID, created.ID)
+			require.Equal(t, newKey.String(), created.Key)
+
+			_, found := storage.LoadByID(context.Background(), created.ID.String())
+			require.False(t, found, "CreateKey must not update the in-memory index before informer refresh")
+			_, found = storage.LoadByKey(context.Background(), created.Key)
+			require.False(t, found, "CreateKey must not update the in-memory index before informer refresh")
+
+			storage.wg.Add(1)
+			go storage.refreshWorker(t.Context())
+			t.Cleanup(func() {
+				close(storage.stop)
+				storage.wg.Wait()
+			})
+
+			require.Eventually(t, func() bool {
+				return cachedClient.GetCount() > 0
+			}, time.Second, 5*time.Millisecond)
+			_, found = storage.LoadByID(context.Background(), created.ID.String())
+			require.False(t, found, "stale queued refresh should keep the informer-owned index unchanged")
+
+			cachedClient.ClearSecret()
+			storage.triggerRefresh()
+			require.Eventually(t, func() bool {
+				_, ok := storage.LoadByID(context.Background(), created.ID.String())
+				return ok
+			}, time.Second, 5*time.Millisecond, "expected fresh informer refresh to publish created key")
+			_, found = storage.LoadByKey(context.Background(), created.Key)
+			require.True(t, found)
+		})
+	}
+}
+
+func TestSecretKeyStorage_DeleteKeyWaitsForInformerRefresh(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "pending stale refresh keeps delete waiting for informer-owned index"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			apiKey := &models.CreatedTeamAPIKey{
+				ID:   uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+				Key:  "key-to-delete",
+				Name: "delete-me",
+				Team: &models.Team{Name: "team-a"},
+			}
+			apiKeyJSON, err := json.Marshal(apiKey)
+			require.NoError(t, err)
+			staleSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: KeySecretName, Namespace: "default"},
+				Data:       map[string][]byte{apiKey.ID.String(): apiKeyJSON},
+			}
+			apiClient := fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(staleSecret.DeepCopy()).Build()
+			cachedClient := &staleSecretReadClient{Client: apiClient}
+			cachedClient.SetSecret(staleSecret)
+			storage := NewSecretKeyStorage(cachedClient, apiClient, nil, "default", "admin-key").(*secretKeyStorage)
+			storage.storeKey(apiKey)
+			storage.triggerRefresh()
+
+			require.NoError(t, storage.DeleteKey(context.Background(), apiKey))
+
+			_, found := storage.LoadByID(context.Background(), apiKey.ID.String())
+			require.True(t, found, "DeleteKey must not update the in-memory index before informer refresh")
+			_, found = storage.LoadByKey(context.Background(), apiKey.Key)
+			require.True(t, found, "DeleteKey must not update the in-memory index before informer refresh")
+
+			storage.wg.Add(1)
+			go storage.refreshWorker(t.Context())
+			t.Cleanup(func() {
+				close(storage.stop)
+				storage.wg.Wait()
+			})
+
+			require.Eventually(t, func() bool {
+				return cachedClient.GetCount() > 0
+			}, time.Second, 5*time.Millisecond)
+			_, found = storage.LoadByID(context.Background(), apiKey.ID.String())
+			require.True(t, found, "stale queued refresh should keep the informer-owned index unchanged")
+
+			cachedClient.ClearSecret()
+			storage.triggerRefresh()
+			require.Eventually(t, func() bool {
+				_, ok := storage.LoadByID(context.Background(), apiKey.ID.String())
+				return !ok
+			}, time.Second, 5*time.Millisecond, "expected fresh informer refresh to remove deleted key")
+			_, found = storage.LoadByKey(context.Background(), apiKey.Key)
+			require.False(t, found)
+		})
+	}
 }
 
 func TestSecretKeyStorage_Run_FilteredEventDoesNotTriggerRefresh(t *testing.T) {

--- a/pkg/servers/e2b/keys/secret_test.go
+++ b/pkg/servers/e2b/keys/secret_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -35,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	toolscache "k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -53,6 +55,20 @@ func (c *updateHookClient) Update(ctx context.Context, obj client.Object, opts .
 		}
 	}
 	return c.Client.Update(ctx, obj, opts...)
+}
+
+type getHookClient struct {
+	client.Client
+	getHook func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error
+}
+
+func (c *getHookClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if c.getHook != nil {
+		if err := c.getHook(ctx, key, obj, opts...); err != nil {
+			return err
+		}
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
 }
 
 func newTestScheme(t *testing.T) *runtime.Scheme {
@@ -551,6 +567,118 @@ func TestSecretKeyStorage_CreateKey(t *testing.T) {
 	}
 }
 
+func TestSecretKeyStorage_CreateKeyInSecretErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		run         func(t *testing.T) error
+		expectError string
+	}{
+		{
+			name: "get secret error",
+			run: func(t *testing.T) error {
+				c := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
+				storage := NewSecretKeyStorage(c, c, nil, "default", "admin-key").(*secretKeyStorage)
+				_, err := storage.createKeyInSecret(t.Context(), uuid.NewString(), &models.CreatedTeamAPIKey{
+					ID:   uuid.New(),
+					Key:  uuid.NewString(),
+					Name: "new",
+				})
+				return err
+			},
+			expectError: "not found",
+		},
+		{
+			name: "marshal error",
+			run: func(t *testing.T) error {
+				storage, _ := newSecretStorageForTest(t, map[string][]byte{})
+				oldMarshal := marshalAPIKey
+				marshalAPIKey = func(v any) ([]byte, error) { return nil, fmt.Errorf("marshal failed") }
+				t.Cleanup(func() { marshalAPIKey = oldMarshal })
+				_, err := storage.createKeyInSecret(t.Context(), uuid.NewString(), &models.CreatedTeamAPIKey{
+					ID:   uuid.New(),
+					Key:  uuid.NewString(),
+					Name: "new",
+				})
+				return err
+			},
+			expectError: "failed to marshal",
+		},
+		{
+			name: "update error",
+			run: func(t *testing.T) error {
+				_, c := newSecretStorageForTest(t, map[string][]byte{})
+				hookClient := &updateHookClient{
+					Client: c,
+					updateHook: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+						return errors.New("update failed")
+					},
+				}
+				storage := NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage)
+				_, err := storage.createKeyInSecret(t.Context(), uuid.NewString(), &models.CreatedTeamAPIKey{
+					ID:   uuid.New(),
+					Key:  uuid.NewString(),
+					Name: "new",
+				})
+				return err
+			},
+			expectError: "update failed",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run(t)
+			assertExpectedError(t, err, tt.expectError)
+		})
+	}
+}
+
+func TestFindTeamByNameInSecret(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      map[string][]byte
+		teamName  string
+		expectHit bool
+	}{
+		{
+			name:      "invalid data is skipped",
+			data:      map[string][]byte{"invalid": []byte("not-json")},
+			teamName:  "team-a",
+			expectHit: false,
+		},
+		{
+			name: "matching team is cloned",
+			data: func() map[string][]byte {
+				key := &models.CreatedTeamAPIKey{
+					ID:   uuid.New(),
+					Key:  uuid.NewString(),
+					Name: "existing",
+					Team: &models.Team{Name: "team-a"},
+				}
+				b, err := json.Marshal(key)
+				require.NoError(t, err)
+				return map[string][]byte{key.ID.String(): b}
+			}(),
+			teamName:  "team-a",
+			expectHit: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			secret := &corev1.Secret{Data: tt.data}
+			team, found := findTeamByNameInSecret(secret, tt.teamName)
+			assert.Equal(t, tt.expectHit, found)
+			if tt.expectHit {
+				require.NotNil(t, team)
+				assert.Equal(t, tt.teamName, team.Name)
+			}
+		})
+	}
+}
+
 func TestSecretKeyStorage_DeleteAndList(t *testing.T) {
 	storage, c := newSecretStorageForTest(t, map[string][]byte{})
 	owner := uuid.New()
@@ -598,6 +726,58 @@ func TestSecretKeyStorage_DeleteAndList(t *testing.T) {
 	}
 	storageWithDeleteError := NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage)
 	require.Error(t, storageWithDeleteError.DeleteKey(context.Background(), key2))
+}
+
+func TestSecretKeyStorage_ListNilUsers(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T, storage *secretKeyStorage)
+	}{
+		{
+			name: "nil owner returns nil keys",
+			run: func(t *testing.T, storage *secretKeyStorage) {
+				keys, err := storage.ListByOwnerTeam(t.Context(), nil)
+				require.NoError(t, err)
+				assert.Nil(t, keys)
+			},
+		},
+		{
+			name: "nil user returns nil teams",
+			run: func(t *testing.T, storage *secretKeyStorage) {
+				teams, err := storage.ListTeams(t.Context(), nil)
+				require.NoError(t, err)
+				assert.Nil(t, teams)
+			},
+		},
+		{
+			name: "non-admin skips other teams",
+			run: func(t *testing.T, storage *secretKeyStorage) {
+				storage.storeKey(&models.CreatedTeamAPIKey{
+					ID:   uuid.New(),
+					Key:  uuid.NewString(),
+					Name: "other",
+					Team: &models.Team{Name: "team-b"},
+				})
+
+				teams, err := storage.ListTeams(t.Context(), &models.CreatedTeamAPIKey{
+					ID:   uuid.New(),
+					Key:  uuid.NewString(),
+					Name: "caller",
+					Team: &models.Team{Name: "team-a"},
+				})
+				require.NoError(t, err)
+				assert.Empty(t, teams)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			storage, _ := newSecretStorageForTest(t, map[string][]byte{})
+			tt.run(t, storage)
+		})
+	}
 }
 
 func TestSecretKeyStorage_ListByOwnerMatchesLegacyTeamsByName(t *testing.T) {
@@ -844,26 +1024,248 @@ func TestSecretKeyStorage_IdxByTeamCache(t *testing.T) {
 	}
 }
 
-func TestSecretKeyStorage_RunStop(t *testing.T) {
+func TestSecretKeyStorage_RunStop_RegistersAndRemovesHandler(t *testing.T) {
 	storage, _ := newSecretStorageForTest(t, map[string][]byte{})
-	oldTicker := newRefreshTicker
-	newRefreshTicker = func() *time.Ticker { return time.NewTicker(2 * time.Millisecond) }
-	t.Cleanup(func() { newRefreshTicker = oldTicker })
+	stub := newStubCache()
+	storage.Cache = stub
+
 	storage.Run()
-	time.Sleep(8 * time.Millisecond)
+	require.NotNil(t, stub.informer.currentHandler(), "Run should register an event handler")
+
 	storage.Stop()
-	require.NotPanics(t, func() { storage.Stop() })
+	require.True(t, stub.informer.wasRemoved(), "Stop should remove the event handler")
+	require.NotPanics(t, func() { storage.Stop() }, "Stop must be idempotent")
 }
 
-func TestSecretKeyStorage_RunRefreshErrorBranch(t *testing.T) {
+func TestSecretKeyStorage_RunErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		stub   func() *stubCache
+		verify func(t *testing.T, storage *secretKeyStorage, stub *stubCache)
+	}{
+		{
+			name: "get informer error closes done",
+			stub: func() *stubCache {
+				stub := newStubCache()
+				stub.getInformerErr = errors.New("get informer failed")
+				return stub
+			},
+			verify: func(t *testing.T, storage *secretKeyStorage, _ *stubCache) {
+				select {
+				case <-storage.done:
+				case <-time.After(time.Second):
+					t.Fatal("expected done to be closed when GetInformer fails")
+				}
+			},
+		},
+		{
+			name: "add event handler error closes done",
+			stub: func() *stubCache {
+				stub := newStubCache()
+				stub.informer.addErr = errors.New("add handler failed")
+				return stub
+			},
+			verify: func(t *testing.T, storage *secretKeyStorage, _ *stubCache) {
+				select {
+				case <-storage.done:
+				case <-time.After(time.Second):
+					t.Fatal("expected done to be closed when AddEventHandler fails")
+				}
+			},
+		},
+		{
+			name: "remove event handler error still stops",
+			stub: func() *stubCache {
+				stub := newStubCache()
+				stub.informer.removeErr = errors.New("remove handler failed")
+				return stub
+			},
+			verify: func(t *testing.T, storage *secretKeyStorage, stub *stubCache) {
+				storage.Stop()
+				assert.True(t, stub.informer.wasRemoved())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			storage, _ := newSecretStorageForTest(t, map[string][]byte{})
+			stub := tt.stub()
+			storage.Cache = stub
+
+			storage.Run()
+			tt.verify(t, storage, stub)
+		})
+	}
+}
+
+func TestSecretKeyStorage_RefreshWorkerLogsRefreshErrorAndContinues(t *testing.T) {
 	storage, c := newSecretStorageForTest(t, map[string][]byte{})
-	require.NoError(t, c.Delete(context.Background(), &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: KeySecretName, Namespace: "default"},
-	}))
-	oldTicker := newRefreshTicker
-	newRefreshTicker = func() *time.Ticker { return time.NewTicker(2 * time.Millisecond) }
-	t.Cleanup(func() { newRefreshTicker = oldTicker })
+	var getCount int32
+	storage.Client = &getHookClient{
+		Client: c,
+		getHook: func(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			atomic.AddInt32(&getCount, 1)
+			return errors.New("refresh failed")
+		},
+	}
+
+	storage.wg.Add(1)
+	go storage.refreshWorker(t.Context())
+
+	storage.triggerRefresh()
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&getCount) > 0
+	}, time.Second, 5*time.Millisecond)
+
+	close(storage.stop)
+	storage.wg.Wait()
+}
+
+func TestSecretKeyStorage_Run_HandlerEventTriggersRefresh(t *testing.T) {
+	// Seed a Secret with a key the storage does not yet know about.
+	id := uuid.New()
+	keyStr := uuid.NewString()
+	apiKey := &models.CreatedTeamAPIKey{
+		ID: id, Key: keyStr, Name: "watched", Team: models.AdminTeam(), CreatedAt: time.Now(),
+	}
+	apiKeyJSON, err := json.Marshal(apiKey)
+	require.NoError(t, err)
+
+	storage, _ := newSecretStorageForTest(t, map[string][]byte{id.String(): apiKeyJSON})
+	stub := newStubCache()
+	storage.Cache = stub
+
+	// Reset the in-memory indexes so we can observe the worker re-populating them.
+	storage.idxByKey = sync.Map{}
+	storage.idxByID = sync.Map{}
+	storage.idxByTeam = sync.Map{}
+	_, ok := storage.LoadByKey(t.Context(), keyStr)
+	require.False(t, ok, "precondition: key should not be in cache before Run")
+
 	storage.Run()
-	time.Sleep(8 * time.Millisecond)
-	storage.Stop()
+	t.Cleanup(storage.Stop)
+
+	// Drive a synthetic event matching the watched Secret.
+	stub.informer.currentHandler().OnUpdate(nil, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: KeySecretName},
+	})
+
+	require.Eventually(t, func() bool {
+		_, ok := storage.LoadByKey(t.Context(), keyStr)
+		return ok
+	}, time.Second, 5*time.Millisecond, "expected refreshWorker to repopulate the index")
+}
+
+func TestSecretKeyStorage_Run_FilteredEventDoesNotTriggerRefresh(t *testing.T) {
+	storage, _ := newSecretStorageForTest(t, map[string][]byte{})
+	stub := newStubCache()
+	storage.Cache = stub
+
+	storage.Run()
+	t.Cleanup(storage.Stop)
+
+	// Event for an unrelated Secret should be filtered out — refreshC stays empty.
+	stub.informer.currentHandler().OnUpdate(nil, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "unrelated"},
+	})
+
+	select {
+	case <-storage.refreshC:
+		t.Fatal("did not expect a refresh signal for unrelated Secret")
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestSecretKeyStorage_TriggerRefresh_Coalesces(t *testing.T) {
+	s := &secretKeyStorage{refreshC: make(chan struct{}, 1)}
+
+	s.triggerRefresh()
+	s.triggerRefresh()
+	s.triggerRefresh()
+
+	select {
+	case <-s.refreshC:
+	default:
+		t.Fatal("expected at least one signal in refreshC")
+	}
+	select {
+	case <-s.refreshC:
+		t.Fatal("expected coalescing; multiple signals queued")
+	default:
+	}
+}
+
+func TestSecretKeyStorage_OnSecretEvent_Match(t *testing.T) {
+	s := &secretKeyStorage{Namespace: "default", refreshC: make(chan struct{}, 1)}
+
+	s.onSecretEvent(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      KeySecretName,
+	}})
+
+	select {
+	case <-s.refreshC:
+	default:
+		t.Fatal("expected refresh signal for matching Secret")
+	}
+}
+
+func TestSecretKeyStorage_OnSecretEvent_Mismatch(t *testing.T) {
+	cases := []struct {
+		name      string
+		namespace string
+		objName   string
+	}{
+		{"wrong namespace", "other-ns", KeySecretName},
+		{"wrong name", "default", "other-secret"},
+		{"both wrong", "other-ns", "other-secret"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &secretKeyStorage{Namespace: "default", refreshC: make(chan struct{}, 1)}
+
+			s.onSecretEvent(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Namespace: tc.namespace,
+				Name:      tc.objName,
+			}})
+
+			select {
+			case <-s.refreshC:
+				t.Fatal("did not expect a refresh signal for non-matching Secret")
+			default:
+			}
+		})
+	}
+}
+
+func TestSecretKeyStorage_OnSecretEvent_Tombstone(t *testing.T) {
+	s := &secretKeyStorage{Namespace: "default", refreshC: make(chan struct{}, 1)}
+
+	s.onSecretEvent(toolscache.DeletedFinalStateUnknown{
+		Key: "default/" + KeySecretName,
+		Obj: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      KeySecretName,
+		}},
+	})
+
+	select {
+	case <-s.refreshC:
+	default:
+		t.Fatal("expected refresh signal from tombstone")
+	}
+}
+
+func TestSecretKeyStorage_OnSecretEvent_UnknownType(t *testing.T) {
+	s := &secretKeyStorage{Namespace: "default", refreshC: make(chan struct{}, 1)}
+
+	s.onSecretEvent("not a secret")
+
+	select {
+	case <-s.refreshC:
+		t.Fatal("did not expect a refresh signal for non-Secret object")
+	default:
+	}
 }

--- a/pkg/servers/e2b/keys/stub_cache_test.go
+++ b/pkg/servers/e2b/keys/stub_cache_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keys
+
+import (
+	"context"
+	"sync"
+
+	toolscache "k8s.io/client-go/tools/cache"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// stubCache is a minimal ctrlcache.Cache for tests. Only GetInformer is
+// implemented; all other methods are unused by the storage code under test
+// and the embedded nil interface will panic if any test reaches them, which
+// is the desired loud-failure behavior.
+type stubCache struct {
+	ctrlcache.Cache // nil-embedded; methods we don't override panic
+	informer        *stubInformer
+}
+
+func newStubCache() *stubCache {
+	return &stubCache{informer: &stubInformer{}}
+}
+
+func (s *stubCache) GetInformer(_ context.Context, _ client.Object, _ ...ctrlcache.InformerGetOption) (ctrlcache.Informer, error) {
+	return s.informer, nil
+}
+
+// stubInformer records the registered handler so tests can drive events
+// directly. AddEventHandlerWithOptions/AddIndexers are inherited from the
+// embedded nil interface and will panic if called.
+type stubInformer struct {
+	ctrlcache.Informer
+
+	mu      sync.Mutex
+	handler toolscache.ResourceEventHandler
+	removed bool
+}
+
+func (s *stubInformer) AddEventHandler(handler toolscache.ResourceEventHandler) (toolscache.ResourceEventHandlerRegistration, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.handler = handler
+	return stubReg{}, nil
+}
+
+func (s *stubInformer) RemoveEventHandler(_ toolscache.ResourceEventHandlerRegistration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.removed = true
+	s.handler = nil
+	return nil
+}
+
+func (s *stubInformer) currentHandler() toolscache.ResourceEventHandler {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.handler
+}
+
+func (s *stubInformer) wasRemoved() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.removed
+}
+
+type stubReg struct{}
+
+// HasSynced satisfies toolscache.ResourceEventHandlerRegistration. Tests that
+// drive events directly never consult this; returning true is harmless.
+func (stubReg) HasSynced() bool { return true }

--- a/pkg/servers/e2b/keys/stub_cache_test.go
+++ b/pkg/servers/e2b/keys/stub_cache_test.go
@@ -32,6 +32,7 @@ import (
 type stubCache struct {
 	ctrlcache.Cache // nil-embedded; methods we don't override panic
 	informer        *stubInformer
+	getInformerErr  error
 }
 
 func newStubCache() *stubCache {
@@ -39,6 +40,9 @@ func newStubCache() *stubCache {
 }
 
 func (s *stubCache) GetInformer(_ context.Context, _ client.Object, _ ...ctrlcache.InformerGetOption) (ctrlcache.Informer, error) {
+	if s.getInformerErr != nil {
+		return nil, s.getInformerErr
+	}
 	return s.informer, nil
 }
 
@@ -48,14 +52,19 @@ func (s *stubCache) GetInformer(_ context.Context, _ client.Object, _ ...ctrlcac
 type stubInformer struct {
 	ctrlcache.Informer
 
-	mu      sync.Mutex
-	handler toolscache.ResourceEventHandler
-	removed bool
+	mu        sync.Mutex
+	handler   toolscache.ResourceEventHandler
+	removed   bool
+	addErr    error
+	removeErr error
 }
 
 func (s *stubInformer) AddEventHandler(handler toolscache.ResourceEventHandler) (toolscache.ResourceEventHandlerRegistration, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.addErr != nil {
+		return nil, s.addErr
+	}
 	s.handler = handler
 	return stubReg{}, nil
 }
@@ -65,7 +74,7 @@ func (s *stubInformer) RemoveEventHandler(_ toolscache.ResourceEventHandlerRegis
 	defer s.mu.Unlock()
 	s.removed = true
 	s.handler = nil
-	return nil
+	return s.removeErr
 }
 
 func (s *stubInformer) currentHandler() toolscache.ResourceEventHandler {

--- a/pkg/servers/e2b/routes_test.go
+++ b/pkg/servers/e2b/routes_test.go
@@ -99,6 +99,7 @@ func TestCheckApiKey_WithRealSetup(t *testing.T) {
 	regularUser, err := controller.keys.CreateKey(ctx, adminUser, keys.CreateKeyOptions{Name: "regular-user", TeamName: "regular-team"})
 	require.NoError(t, err)
 	require.NotNil(t, regularUser)
+	refreshKeyStorageForTest(t, controller)
 
 	tests := []struct {
 		name          string
@@ -284,6 +285,7 @@ func TestCheckApiKey_SandboxOwnership(t *testing.T) {
 	anotherUser, err := controller.keys.CreateKey(ctx, adminUser, keys.CreateKeyOptions{Name: "another-user", TeamName: "another-team"})
 	require.NoError(t, err)
 	require.NotNil(t, anotherUser)
+	refreshKeyStorageForTest(t, controller)
 
 	adminCleanup := CreateSandboxPool(t, controller, templateName, 2)
 	defer adminCleanup()


### PR DESCRIPTION
## Summary

fixes #418 

In multi-replica deployments, the previous secret-backed `KeyStorage` relied on a 10-minute ticker to refresh its in-memory indexes. As a result, a key created or deleted on one replica could take up to 10 minutes to become visible on others. This PR replaces the ticker with an informer-event-driven refresh, bounded by informer push latency (typically sub-second).

### Key changes

- **`pkg/cache`**: expose `ctrlcache.Cache` via `Provider.GetCache()` so downstream components can register informer event handlers on the shared manager cache.
- **`pkg/servers/e2b/keys/secret.go`**:
  - Drop the 10-minute ticker.
  - Register a `Secret` event handler on the shared cache, filtered to the `e2b-key-store` Secret.
  - Coalesce events into a buffered (cap=1) channel and drain them in a single worker goroutine that calls `refresh()`.
  - `Run()` registers the handler and starts the worker; `Stop()` removes the handler and waits for the worker to exit.
- **`pkg/servers/e2b/keys/factory.go`**: `Config.Cache` is now required for secret mode and validated in `NewKeyStorage`. `NewSecretKeyStorage` itself does not validate (allowing unit tests to construct the storage without a cache as long as they do not call `Run()`).
- **`pkg/servers/e2b/core.go`**: wire `cache.Provider.GetCache()` into `keys.Config.Cache`.
- **Docs**: update `pkg/servers/e2b/keys/AGENTS.md` to describe the new watch-driven semantics.

### Why no writer-triggered refresh

An earlier iteration added `triggerRefresh()` calls in `CreateKey` / `DeleteKey` to compress the writer's own propagation latency. Codex review correctly flagged this as a stale-cache race: the worker reads through the controller-runtime cached client, whose local store is populated only by informer watch events. The worker almost always loses the race against its own write and reads a stale Secret revision, briefly removing the just-stored key from the indexes (or re-adding a just-deleted key) until the informer event arrives.

The writer-triggered refresh provided no real benefit — `storeKey()` and `idxBy*.Delete()` already update the auth indexes inline before returning, so the writing replica's authentication path is correct without it. The trigger was removed; cross-replica visibility remains purely informer-driven.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/...` clean
- [x] `go test ./pkg/servers/e2b/keys/...` all green (existing + new tests for `triggerRefresh` coalescing, `onSecretEvent` filtering/tombstone, `Run`/`Stop` lifecycle, factory cache validation)
- [x] `go test ./pkg/servers/e2b/... ./pkg/cache/...` all green
- [ ] (Reviewer) verify multi-replica behavior in a staging cluster: create a key on one replica, confirm the other replica authenticates with it within informer push latency