### PR TITLE
fix(e2b): allow pause sandboxes in state pausing

### DIFF
--- a/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
@@ -608,7 +608,7 @@ func TestSandbox_PauseRefreshesBeforePreconditionChecks(t *testing.T) {
 	}
 }
 
-func TestSandbox_PauseConflictsWithActiveResumeWaitHook(t *testing.T) {
+func TestSandbox_PauseAlreadyPausedShortCircuitsWithActiveResumeWaitHook(t *testing.T) {
 	sandbox := &v1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-sandbox",
@@ -660,12 +660,14 @@ func TestSandbox_PauseConflictsWithActiveResumeWaitHook(t *testing.T) {
 
 	s := AsSandbox(sandbox, cache)
 	err = s.Pause(t.Context(), infra.PauseOptions{})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "another action(Resume)'s wait task already exists")
+	require.NoError(t, err)
 
-	if val, ok := cache.GetWaitHooks().Load(key); ok {
-		val.(*cacheutils.WaitEntry[*v1alpha1.Sandbox]).Close()
-	}
+	// Synthetic guard: production should not keep a Resume hook after the sandbox is already paused.
+	val, ok := cache.GetWaitHooks().Load(key)
+	require.True(t, ok)
+	entry := val.(*cacheutils.WaitEntry[*v1alpha1.Sandbox])
+	assert.Equal(t, cacheutils.WaitActionResume, entry.Action)
+	entry.Close()
 	select {
 	case <-waitDone:
 	case <-time.After(2 * time.Second):

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -309,11 +309,6 @@ func (s *Sandbox) Pause(ctx context.Context, opts infra.PauseOptions) error {
 	if pausable, reason := stateutils.IsSandboxPausable(s.Sandbox); !pausable {
 		return errors.NewError(errors.ErrorConflict, "sandbox is not pausable, reason: %s", reason)
 	}
-	pauseTask, err := s.Cache.NewSandboxPauseTask(ctx, s.Sandbox)
-	if err != nil {
-		return err
-	}
-	defer pauseTask.Release()
 
 	cond := GetSandboxCondition(s.Sandbox, agentsv1alpha1.SandboxConditionPaused)
 	if s.Status.Phase == agentsv1alpha1.SandboxPaused {
@@ -322,6 +317,12 @@ func (s *Sandbox) Pause(ctx context.Context, opts infra.PauseOptions) error {
 			return nil
 		}
 	}
+
+	pauseTask, err := s.Cache.NewSandboxPauseTask(ctx, s.Sandbox)
+	if err != nil {
+		return err
+	}
+	defer pauseTask.Release()
 	updated, err := s.retryUpdate(ctx, func(sbx *agentsv1alpha1.Sandbox) (bool, error) {
 		if sbx.Spec.Paused {
 			// Pause is first-writer-wins: only the request that flips

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -18,11 +18,12 @@ package e2b
 
 import (
 	"context"
-	stderrors "errors"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 
 	"github.com/openkruise/agents/api/v1alpha1"
@@ -59,8 +60,11 @@ func (sc *Controller) PauseSandbox(r *http.Request) (web.ApiResponse[struct{}], 
 }
 
 func pauseSandboxErrorCode(err error) int {
+	if apierrors.IsNotFound(err) {
+		return http.StatusNotFound
+	}
 	if managererrors.GetErrCode(err) == managererrors.ErrorConflict ||
-		stderrors.Is(err, cacheutils.ErrWaitTaskConflict) {
+		errors.Is(err, cacheutils.ErrWaitTaskConflict) {
 		return http.StatusConflict
 	}
 	return http.StatusInternalServerError

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -18,6 +18,7 @@ package e2b
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -25,7 +26,8 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openkruise/agents/api/v1alpha1"
-	"github.com/openkruise/agents/pkg/sandbox-manager/errors"
+	cacheutils "github.com/openkruise/agents/pkg/cache/utils"
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
@@ -41,18 +43,12 @@ func (sc *Controller) PauseSandbox(r *http.Request) (web.ApiResponse[struct{}], 
 	if apiErr != nil {
 		return web.ApiResponse[struct{}]{}, apiErr
 	}
-	if state, reason := sbx.GetState(); state != v1alpha1.SandboxStateRunning {
-		log.Info("skip pause sandbox: sandbox is not running", "state", state, "reason", reason)
-		return web.ApiResponse[struct{}]{}, &web.ApiError{
-			Code:    http.StatusConflict,
-			Message: fmt.Sprintf("Sandbox %s is not running", id),
-		}
-	}
 	timeoutOptions := sc.buildPauseTimeoutOptions(sbx, time.Now())
 	if err := sc.manager.PauseSandbox(ctx, sbx, infra.PauseOptions{
 		Timeout: &timeoutOptions,
 	}); err != nil {
 		return web.ApiResponse[struct{}]{}, &web.ApiError{
+			Code:    pauseSandboxErrorCode(err),
 			Message: fmt.Sprintf("Failed to pause sandbox: %v", err),
 		}
 	}
@@ -60,6 +56,14 @@ func (sc *Controller) PauseSandbox(r *http.Request) (web.ApiResponse[struct{}], 
 	return web.ApiResponse[struct{}]{
 		Code: http.StatusNoContent,
 	}, nil
+}
+
+func pauseSandboxErrorCode(err error) int {
+	if managererrors.GetErrCode(err) == managererrors.ErrorConflict ||
+		stderrors.Is(err, cacheutils.ErrWaitTaskConflict) {
+		return http.StatusConflict
+	}
+	return http.StatusInternalServerError
 }
 
 func (sc *Controller) buildPauseTimeoutOptions(sbx infra.Sandbox, now time.Time) timeout.Options {
@@ -112,7 +116,7 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 	log.Info("resuming sandbox")
 	if err := sc.manager.ResumeSandbox(ctx, sbx, infra.ResumeOptions{}); err != nil {
 		code := http.StatusInternalServerError
-		if errors.GetErrCode(err) == errors.ErrorBadRequest {
+		if managererrors.GetErrCode(err) == managererrors.ErrorBadRequest {
 			code = http.StatusBadRequest
 		}
 		return web.ApiResponse[struct{}]{}, &web.ApiError{
@@ -172,7 +176,7 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 		if err := sc.manager.ResumeSandbox(ctx, sbx, infra.ResumeOptions{}); err != nil {
 			log.Error(err, "failed to resume sandbox")
 			code := http.StatusInternalServerError
-			if errors.GetErrCode(err) == errors.ErrorConflict {
+			if managererrors.GetErrCode(err) == managererrors.ErrorConflict {
 				code = http.StatusBadRequest
 			}
 			return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package e2b
 
 import (
-	stderrors "errors"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -26,7 +26,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	cacheutils "github.com/openkruise/agents/pkg/cache/utils"
@@ -534,8 +536,13 @@ func TestPauseSandboxErrorCode(t *testing.T) {
 			expectStatus: http.StatusConflict,
 		},
 		{
+			name:         "kubernetes not found returns not found",
+			err:          apierrors.NewNotFound(schema.GroupResource{Group: agentsv1alpha1.GroupVersion.Group, Resource: "sandboxes"}, "sandbox-id"),
+			expectStatus: http.StatusNotFound,
+		},
+		{
 			name:         "unknown error returns internal server error",
-			err:          stderrors.New("pause failed"),
+			err:          errors.New("pause failed"),
 			expectStatus: http.StatusInternalServerError,
 		},
 	}

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -74,13 +74,11 @@ func TestPauseSandbox(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, pauseResp.Code)
 	assert.Equal(t, models.SandboxStatePaused, describeResp.Body.State)
 
-	// pause again
+	// pause again — should be idempotent (sandbox already paused)
 	start := time.Now()
 	pauseResp, err = controller.PauseSandbox(req)
-	assert.NotNil(t, err)
-	if err != nil {
-		assert.Equal(t, http.StatusConflict, err.Code)
-	}
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusNoContent, pauseResp.Code)
 	describeResp, err = controller.DescribeSandbox(req)
 	assert.Nil(t, err)
 	assert.Equal(t, models.SandboxStatePaused, describeResp.Body.State)
@@ -88,6 +86,61 @@ func TestPauseSandbox(t *testing.T) {
 	assert.NoError(t, parseErr)
 	expectEndAt := start.AddDate(1000, 0, 0)
 	assert.WithinDuration(t, expectEndAt, endAt, 5*time.Second, "expect end at: %s, but got %s", expectEndAt, endAt)
+}
+
+func TestPauseSandboxConflict(t *testing.T) {
+	tests := []struct {
+		name          string
+		prepare       func(t *testing.T, controller *Controller, sandboxID string) func()
+		expectStatus  int
+		expectMessage string
+	}{
+		{
+			name: "active resume wait returns conflict",
+			prepare: func(t *testing.T, controller *Controller, sandboxID string) func() {
+				sbx := GetSandbox(t, sandboxID, controller.cache.GetClient())
+				task, err := controller.cache.NewSandboxResumeTask(t.Context(), sbx)
+				require.NoError(t, err)
+				return task.Release
+			},
+			expectStatus:  http.StatusConflict,
+			expectMessage: "another action(Resume)'s wait task already exists",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			templateName := "test-template-pause-conflict"
+			controller, _, teardown := Setup(t)
+			defer teardown()
+			cleanup := CreateSandboxPool(t, controller, templateName, 1)
+			defer cleanup()
+			user := &models.CreatedTeamAPIKey{
+				ID:   keys.AdminKeyID,
+				Key:  InitKey,
+				Name: "admin",
+			}
+			createResp, err := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+				TemplateID: templateName,
+				Metadata: map[string]string{
+					models.ExtensionKeySkipInitRuntime: agentsv1alpha1.True,
+				},
+			}, nil, user))
+			require.Nil(t, err)
+			require.Equal(t, models.SandboxStateRunning, createResp.Body.State)
+
+			release := tt.prepare(t, controller, createResp.Body.SandboxID)
+			if release != nil {
+				defer release()
+			}
+			_, apiErr := controller.PauseSandbox(NewRequest(t, nil, nil, map[string]string{
+				"sandboxID": createResp.Body.SandboxID,
+			}, user))
+			require.NotNil(t, apiErr)
+			assert.Equal(t, tt.expectStatus, apiErr.Code)
+			assert.Contains(t, apiErr.Message, tt.expectMessage)
+		})
+	}
 }
 
 func pauseSandboxHelper(t *testing.T, controller *Controller, client client.Client, sandboxID string, pausing, resuming bool, user *models.CreatedTeamAPIKey) {

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2b
 
 import (
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -29,6 +30,7 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	cacheutils "github.com/openkruise/agents/pkg/cache/utils"
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -511,6 +513,36 @@ func TestConnectSandboxConcurrentPausedTimeouts(t *testing.T) {
 				assert.WithinDuration(t, expectedEndAt, updated.Spec.ShutdownTime.Time, 5*time.Second)
 				assert.Nil(t, updated.Spec.PauseTime)
 			}
+		})
+	}
+}
+
+func TestPauseSandboxErrorCode(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		expectStatus int
+	}{
+		{
+			name:         "manager conflict returns conflict",
+			err:          managererrors.NewError(managererrors.ErrorConflict, "pause conflict"),
+			expectStatus: http.StatusConflict,
+		},
+		{
+			name:         "wait task conflict returns conflict",
+			err:          fmt.Errorf("pause failed: %w", cacheutils.ErrWaitTaskConflict),
+			expectStatus: http.StatusConflict,
+		},
+		{
+			name:         "unknown error returns internal server error",
+			err:          stderrors.New("pause failed"),
+			expectStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectStatus, pauseSandboxErrorCode(tt.err))
 		})
 	}
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Make the E2B `PauseSandbox` endpoint idempotent for already-paused sandboxes and concurrent pause requests.

- Delegate pause state handling to the sandbox manager/infra layer so an already-paused sandbox returns `204 No Content`.
- Preserve `409 Conflict` for real pause conflicts, including active opposite wait tasks such as an in-flight resume operation.
- Add regression coverage for both repeated pause and pause-vs-resume wait conflict behavior.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

```bash
gofmt -w pkg/servers/e2b/pause_resume.go pkg/servers/e2b/pause_resume_test.go
git diff --check
go test -mod=readonly ./pkg/servers/e2b
```

### Ⅳ. Special notes for reviews

Please focus review on the HTTP status mapping for pause conflicts. The handler now maps both sandbox-manager domain conflicts and cache wait-task conflicts to `409 Conflict`.
