### PR TITLE
fix(sandboxupdateops): fail fast when failed sandboxes block all maxUnavailable slots

### DIFF
--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
@@ -184,6 +184,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		} else {
 			newStatus.Phase = agentsv1alpha1.SandboxUpdateOpsCompleted
 		}
+
+	case failed > 0 && updating == 0 && len(candidates) > 0 &&
+		int(calculateMaxUnavailable(ops.Spec.UpdateStrategy.MaxUnavailable, total)) <= int(failed):
+		newStatus.Phase = agentsv1alpha1.SandboxUpdateOpsFailed
 	}
 
 	// Only initiate new upgrades when in Updating phase, not paused, and there are candidates

--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
@@ -949,6 +949,63 @@ func TestHandleDeletion_UpdateFinalizerRemovalError(t *testing.T) {
 	assert.Contains(t, err.Error(), "simulated update error")
 }
 
+func TestReconcile_FailedBlocksAllSlotsLeadsToFailed(t *testing.T) {
+	maxUnavail := intstrutil.FromInt32(1)
+	ops := newSandboxUpdateOps("test-ops", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, &maxUnavail)
+	// 1 failed sandbox (occupies the only maxUnavailable slot), 2 candidates remain
+	sbx1 := newSandbox("sbx-1", "default", "test-ops", agentsv1alpha1.SandboxRunning, []metav1.Condition{
+		{Type: string(agentsv1alpha1.SandboxConditionUpgrading), Reason: agentsv1alpha1.SandboxUpgradingReasonPreUpgradeFailed, Status: metav1.ConditionFalse},
+	})
+	sbx2 := newSandbox("sbx-2", "default", "", agentsv1alpha1.SandboxRunning, nil)
+	sbx3 := newSandbox("sbx-3", "default", "", agentsv1alpha1.SandboxRunning, nil)
+	r := newTestReconciler(ops, sbx1, sbx2, sbx3)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-ops", Namespace: "default"},
+	})
+	assert.NoError(t, err)
+
+	updatedOps := &agentsv1alpha1.SandboxUpdateOps{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "test-ops", Namespace: "default"}, updatedOps)
+	assert.NoError(t, err)
+	assert.Equal(t, agentsv1alpha1.SandboxUpdateOpsFailed, updatedOps.Status.Phase)
+	assert.Equal(t, int32(1), updatedOps.Status.FailedReplicas)
+	// Candidates should NOT have been patched
+	for _, name := range []string{"sbx-2", "sbx-3"} {
+		sbx := &agentsv1alpha1.Sandbox{}
+		err = r.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "default"}, sbx)
+		assert.NoError(t, err)
+		assert.Empty(t, sbx.Labels[agentsv1alpha1.LabelSandboxUpdateOps])
+	}
+}
+
+func TestReconcile_FailedBelowMaxUnavailableContinuesUpdating(t *testing.T) {
+	maxUnavail := intstrutil.FromInt32(2)
+	ops := newSandboxUpdateOps("test-ops", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, &maxUnavail)
+	// 1 failed, maxUnavailable=2 -> still has capacity to start 1 more
+	sbx1 := newSandbox("sbx-1", "default", "test-ops", agentsv1alpha1.SandboxRunning, []metav1.Condition{
+		{Type: string(agentsv1alpha1.SandboxConditionUpgrading), Reason: agentsv1alpha1.SandboxUpgradingReasonPreUpgradeFailed, Status: metav1.ConditionFalse},
+	})
+	sbx2 := newSandbox("sbx-2", "default", "", agentsv1alpha1.SandboxRunning, nil)
+	r := newTestReconciler(ops, sbx1, sbx2)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-ops", Namespace: "default"},
+	})
+	assert.NoError(t, err)
+
+	updatedOps := &agentsv1alpha1.SandboxUpdateOps{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "test-ops", Namespace: "default"}, updatedOps)
+	assert.NoError(t, err)
+	assert.Equal(t, agentsv1alpha1.SandboxUpdateOpsUpdating, updatedOps.Status.Phase)
+
+	// Candidate should have been patched (2-0-1=1 slot available)
+	sbx := &agentsv1alpha1.Sandbox{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "sbx-2", Namespace: "default"}, sbx)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-ops", sbx.Labels[agentsv1alpha1.LabelSandboxUpdateOps])
+}
+
 func TestUpdateStatus_NoChange(t *testing.T) {
 	ops := newSandboxUpdateOps("test-ops", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil)
 	ops.Status.Replicas = 5

--- a/test/e2e/sandboxupdateops_test.go
+++ b/test/e2e/sandboxupdateops_test.go
@@ -449,8 +449,8 @@ var _ = Describe("SandboxUpdateOps E2E", func() {
 
 			By("Verifying MaxUnavailable=1 limited the blast radius")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ops1.Name, Namespace: ops1.Namespace}, ops1)).To(Succeed())
-			Expect(ops1.Status.Phase).To(Equal(agentsv1alpha1.SandboxUpdateOpsUpdating),
-				"ops should remain in Updating phase since failed occupies maxUnavailable quota")
+			Expect(ops1.Status.Phase).To(Equal(agentsv1alpha1.SandboxUpdateOpsFailed),
+				"ops should transition to Failed when failed sandboxes block all maxUnavailable slots")
 			Expect(ops1.Status.Replicas).To(Equal(int32(2)),
 				"total replicas should be 2")
 			Expect(ops1.Status.FailedReplicas).To(Equal(int32(1)),
@@ -726,8 +726,8 @@ var _ = Describe("SandboxUpdateOps E2E", func() {
 
 			By("Verifying ops status with MaxUnavailable=1")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ops1.Name, Namespace: ops1.Namespace}, ops1)).To(Succeed())
-			Expect(ops1.Status.Phase).To(Equal(agentsv1alpha1.SandboxUpdateOpsUpdating),
-				"ops should remain in Updating phase since failed occupies maxUnavailable quota")
+			Expect(ops1.Status.Phase).To(Equal(agentsv1alpha1.SandboxUpdateOpsFailed),
+				"ops should transition to Failed when failed sandboxes block all maxUnavailable slots")
 			Expect(ops1.Status.Replicas).To(Equal(int32(2)))
 			Expect(ops1.Status.FailedReplicas).To(Equal(int32(1)))
 			Expect(ops1.Status.UpdatingReplicas).To(Equal(int32(0)))


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Adds a phase transition case in the SandboxUpdateOps controller: when `failed >= maxUnavailable`, no sandboxes are actively updating, and candidates remain, the SUO transitions directly to `Failed` instead of staying stuck in `Updating`.

Previously, the SUO would block indefinitely because `toUpgrade = maxUnavailable - updating - failed` evaluates to 0 while the terminal condition `updated+failed == total` is never satisfied. This made it impossible to create recovery SUOs in the same namespace without delete permissions.

### Ⅱ. Does this pull request fix one issue?

fixes #425

### Ⅲ. Describe how to verify it

1. `go test ./pkg/controller/sandboxupdateops/...`
2. New test `TestReconcile_FailedBlocksAllSlotsLeadsToFailed`: maxUnavailable=1, 1 failed + 2 candidates → SUO transitions to Failed
3. New test `TestReconcile_FailedBelowMaxUnavailableContinuesUpdating`: maxUnavailable=2, 1 failed + 1 candidate → SUO stays Updating, candidate gets patched

### Ⅳ. Special notes for reviews

- The new case is ordered after the existing `updated+failed == total` case so it only triggers when there are still unprocessed candidates
- `updating == 0` guard ensures we don't prematurely fail while in-flight upgrades could still succeed and free up slots
