### PR TITLE
fix: secure unauthenticated route refresh endpoint and fix PauseTime calculation

### DIFF
--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -216,7 +216,10 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 			modified.Spec.Paused = true
 			return ctrl.Result{}, r.Patch(ctx, modified, patch)
 		}
-		requeueAfter = min(requeueAfter, box.Spec.PauseTime.Sub(now.Time))
+		pauseDuration := box.Spec.PauseTime.Sub(now.Time)
+		if requeueAfter == 0 || pauseDuration < requeueAfter {
+			requeueAfter = pauseDuration
+		}
 	}
 
 	// calculate sandbox status

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -156,6 +157,19 @@ func (s *Server) Stop(ctx context.Context) {
 func (s *Server) handleRefresh(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
 	ctx := r.Context()
 	log := klog.FromContext(ctx)
+
+	// Authenticate the request if PEER_AUTH_TOKEN is set
+	if expectedToken := os.Getenv("PEER_AUTH_TOKEN"); expectedToken != "" {
+		token := r.Header.Get("X-Peer-Auth-Token")
+		if token != expectedToken {
+			log.Error(nil, "unauthorized route refresh request", "token", token)
+			return web.ApiResponse[struct{}]{}, &web.ApiError{
+				Code:    http.StatusUnauthorized,
+				Message: "unauthorized",
+			}
+		}
+	}
+
 	var route Route
 	if err := json.NewDecoder(r.Body).Decode(&route); err != nil {
 		return web.ApiResponse[struct{}]{}, &web.ApiError{

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -156,6 +157,17 @@ func (s *Server) Stop(ctx context.Context) {
 func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := klog.FromContext(ctx)
+
+	// Authenticate the request if PEER_AUTH_TOKEN is set
+	if expectedToken := os.Getenv("PEER_AUTH_TOKEN"); expectedToken != "" {
+		token := r.Header.Get("X-Peer-Auth-Token")
+		if token != expectedToken {
+			log.Error(nil, "unauthorized route refresh request", "token", token)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
+
 	var route Route
 	if err := json.NewDecoder(r.Body).Decode(&route); err != nil {
 		log.Error(err, "failed to unmarshal refresh request body")

--- a/pkg/proxy/utils.go
+++ b/pkg/proxy/utils.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 )
@@ -37,6 +38,10 @@ func requestPeer(method, ip, path string, body []byte) error {
 	request, err := http.NewRequest(method, fmt.Sprintf("http://%s:%d%s", ip, SystemPort, path), buf)
 	if err != nil {
 		return err
+	}
+
+	if token := os.Getenv("PEER_AUTH_TOKEN"); token != "" {
+		request.Header.Set("X-Peer-Auth-Token", token)
 	}
 
 	resp, err := requestPeerClient.Do(request)

--- a/pkg/proxy/utils.go
+++ b/pkg/proxy/utils.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -40,6 +41,10 @@ func requestPeer(method, ip, path string, body []byte) error {
 	request, err := http.NewRequest(method, fmt.Sprintf("http://%s:%d%s", ip, SystemPort, path), buf)
 	if err != nil {
 		return err
+	}
+
+	if token := os.Getenv("PEER_AUTH_TOKEN"); token != "" {
+		request.Header.Set("X-Peer-Auth-Token", token)
 	}
 
 	resp, err := requestPeerClient.Do(request)

--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -154,6 +154,16 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := klog.FromContext(ctx)
 
+	// Authenticate the request if PEER_AUTH_TOKEN is set
+	if expectedToken := os.Getenv("PEER_AUTH_TOKEN"); expectedToken != "" {
+		token := r.Header.Get("X-Peer-Auth-Token")
+		if token != expectedToken {
+			log.Error(nil, "unauthorized route refresh request", "token", token)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
+
 	var route proxy.Route
 	if err := json.NewDecoder(r.Body).Decode(&route); err != nil {
 		log.Error(err, "Failed to decode refresh request")

--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -207,6 +207,16 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := klog.FromContext(ctx)
 
+	// Authenticate the request if PEER_AUTH_TOKEN is set
+	if expectedToken := os.Getenv("PEER_AUTH_TOKEN"); expectedToken != "" {
+		token := r.Header.Get("X-Peer-Auth-Token")
+		if token != expectedToken {
+			log.Error(nil, "unauthorized route refresh request", "token", token)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
+
 	var route proxy.Route
 	if err := json.NewDecoder(r.Body).Decode(&route); err != nil {
 		log.Error(err, "Failed to decode refresh request")


### PR DESCRIPTION
### PR Title
fix: secure unauthenticated route refresh endpoint and fix PauseTime calculation

### PR Description
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

This PR addresses a critical security vulnerability and a core functional bug in the Sandbox controller:
1. **Unauthenticated Route Hijacking (Security)**: The `/refresh` endpoint on `proxy.SystemPort` (7789) used for peer-to-peer route synchronization was previously unauthenticated. This allowed any pod in the cluster to send spoofed route mappings to the Gateway/Manager, hijacking traffic meant for other sandboxes. This PR injects a lightweight `X-Peer-Auth-Token` header derived from the `PEER_AUTH_TOKEN` environment variable. If configured, the receiver validates the token and returns a `401 Unauthorized` response on mismatch.
2. **Broken `PauseTime` Behavior (Bug)**: The `PauseTime` calculation in the Sandbox controller previously initialized `requeueAfter` to `0` and then used `min(requeueAfter, pauseDuration)`. This incorrectly evaluated to `0`, preventing the controller from ever requeuing based on the `PauseTime`. This PR corrects the logic to properly assign the `pauseDuration` when `requeueAfter` is `0` or less than the `pauseDuration`.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#427 
### Ⅲ. Describe how to verify it

**Security Fix Verification:**
1. Send an unauthenticated POST request to the Gateway pod:
   ```bash
   curl -X POST http://<gateway-pod-ip>:7789/refresh -H "Content-Type: application/json" -d '{"ID":"test", "IP":"10.0.0.1", "State":"Running"}
   ```
 2.If PEER_AUTH_TOKEN is set, verify that it is rejected with 401 Unauthorized.
 3.Provide the correct header X-Peer-Auth-Token: <token> and verify it returns 204 No Content.

**PauseTime Fix Verification:**
1.Create a Sandbox with a PauseTime set to 5 minutes in the future.
2.Observe the Sandbox transitions into the Paused state exactly at the defined PauseTime without requiring manual intervention.
### Ⅳ. Special notes for reviews
For Operators: To fully enable the security fix, cluster administrators must ensure that the PEER_AUTH_TOKEN environment variable is identically injected into the Pod specs of both the sandbox-manager and sandbox-gateway deployments. If left unset, the endpoints fallback to the previous unauthenticated behavior to preserve backward compatibility during upgrades.