### PR TITLE
fix(e2b): atomic Resume with placeholder pausetime and min timeout floor

### DIFF
--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"net/http"         // Added for pprof server
 	_ "net/http/pprof" // Added to register pprof handlers
 	"os"
@@ -44,6 +45,22 @@ const (
 	E2BKeyHashPepperEnvVar = "E2B_KEY_HASH_PEPPER"
 )
 
+// validateE2BTimeoutFlags rejects misconfigurations that would either
+// (a) make floor enforcement no-op or pathological (min <= 0), or
+// (b) push effectiveTimeout past the user-facing maxTimeout ceiling.
+func validateE2BTimeoutFlags(minResumeTimeout, maxTimeout int) error {
+	if minResumeTimeout <= 0 {
+		return fmt.Errorf("--e2b-min-resume-timeout must be greater than 0, got %d", minResumeTimeout)
+	}
+	if minResumeTimeout > maxTimeout {
+		return fmt.Errorf(
+			"--e2b-min-resume-timeout (%d) must not exceed --e2b-max-timeout (%d); "+
+				"otherwise floor enforcement could bump a valid request past the API ceiling",
+			minResumeTimeout, maxTimeout)
+	}
+	return nil
+}
+
 func main() {
 	// Define variables for pprof configuration
 	var enablePprof bool
@@ -55,6 +72,7 @@ func main() {
 	var e2bEnableAuth bool
 	var domain string
 	var e2bMaxTimeout int
+	var e2bMinResumeTimeout int
 	var sysNs string
 	var peerSelector string
 	var sandboxNamespace string
@@ -80,6 +98,10 @@ func main() {
 	pflag.BoolVar(&e2bEnableAuth, "e2b-enable-auth", true, "Enable E2B authentication")
 	pflag.StringVar(&domain, "e2b-domain", "localhost", "E2B domain")
 	pflag.IntVar(&e2bMaxTimeout, "e2b-max-timeout", models.DefaultMaxTimeout, "E2B maximum timeout in seconds")
+	pflag.IntVar(&e2bMinResumeTimeout, "e2b-min-resume-timeout", models.DefaultMinResumeTimeoutSeconds,
+		"Minimum effective timeout (seconds) applied to Connect / Resume requests that trigger Resume on a Paused sandbox. "+
+			"Requests shorter than this are bumped up so the Resume placeholder cannot expire mid-Resume. "+
+			"Should be set above the production worst-case Resume duration.")
 	pflag.StringVar(&sysNs, "system-namespace", utils.DefaultSandboxDeployNamespace, "The namespace where the sandbox manager is running (required)")
 	pflag.StringVar(&peerSelector, "peer-selector", "", "Peer selector for sandbox manager (required)")
 	pflag.StringVar(&sandboxNamespace, "sandbox-namespace", "", "Namespace to filter sandbox-related custom resources (Sandbox, SandboxSet, Checkpoint, SandboxTemplate). Defaults to all.")
@@ -139,6 +161,10 @@ func main() {
 		klog.Fatalf("--e2b-max-timeout must be greater than 0")
 	}
 
+	if err := validateE2BTimeoutFlags(e2bMinResumeTimeout, e2bMaxTimeout); err != nil {
+		klog.Fatalf("invalid e2b timeout flags: %v", err)
+	}
+
 	if maxClaimWorkers < 0 {
 		klog.Fatalf("--max-claim-workers must be non-negative")
 	}
@@ -195,7 +221,7 @@ func main() {
 		}
 	}
 
-	sandboxController := e2b.NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSelector, e2bMaxTimeout, maxClaimWorkers, maxCreateQPS, uint32(extProcMaxConcurrency),
+	sandboxController := e2b.NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSelector, e2bMaxTimeout, e2bMinResumeTimeout, maxClaimWorkers, maxCreateQPS, uint32(extProcMaxConcurrency),
 		port, memberlistBindPort, keyCfg, clientConfig)
 
 	if err := sandboxController.Init(); err != nil {

--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -99,9 +99,8 @@ func main() {
 	pflag.StringVar(&domain, "e2b-domain", "localhost", "E2B domain")
 	pflag.IntVar(&e2bMaxTimeout, "e2b-max-timeout", models.DefaultMaxTimeout, "E2B maximum timeout in seconds")
 	pflag.IntVar(&e2bMinResumeTimeout, "e2b-min-resume-timeout", models.DefaultMinResumeTimeoutSeconds,
-		"Minimum effective timeout (seconds) applied to Connect / Resume requests that trigger Resume on a Paused sandbox. "+
-			"Requests shorter than this are bumped up so the Resume placeholder cannot expire mid-Resume. "+
-			"Should be set above the production worst-case Resume duration.")
+		"Floor timeout (seconds) for resuming a Paused sandbox; shorter requests are raised to this value "+
+			"to prevent the sandbox from being deleted or hibernated mid-Resume. Set above worst-case Resume latency.")
 	pflag.StringVar(&sysNs, "system-namespace", utils.DefaultSandboxDeployNamespace, "The namespace where the sandbox manager is running (required)")
 	pflag.StringVar(&peerSelector, "peer-selector", "", "Peer selector for sandbox manager (required)")
 	pflag.StringVar(&sandboxNamespace, "sandbox-namespace", "", "Namespace to filter sandbox-related custom resources (Sandbox, SandboxSet, Checkpoint, SandboxTemplate). Defaults to all.")

--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -99,8 +99,8 @@ func main() {
 	pflag.StringVar(&domain, "e2b-domain", "localhost", "E2B domain")
 	pflag.IntVar(&e2bMaxTimeout, "e2b-max-timeout", models.DefaultMaxTimeout, "E2B maximum timeout in seconds")
 	pflag.IntVar(&e2bMinResumeTimeout, "e2b-min-resume-timeout", models.DefaultMinResumeTimeoutSeconds,
-		"Floor timeout (seconds) for resuming a Paused sandbox; shorter requests are raised to this value "+
-			"to prevent the sandbox from being deleted or hibernated mid-Resume. Set above worst-case Resume latency.")
+		"Minimum value (seconds) for the timeout parameter carried by the E2B connect API; "+
+			"timeout values below this floor will be raised to this value.")
 	pflag.StringVar(&sysNs, "system-namespace", utils.DefaultSandboxDeployNamespace, "The namespace where the sandbox manager is running (required)")
 	pflag.StringVar(&peerSelector, "peer-selector", "", "Peer selector for sandbox manager (required)")
 	pflag.StringVar(&sandboxNamespace, "sandbox-namespace", "", "Namespace to filter sandbox-related custom resources (Sandbox, SandboxSet, Checkpoint, SandboxTemplate). Defaults to all.")

--- a/cmd/sandbox-manager/main_test.go
+++ b/cmd/sandbox-manager/main_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateE2BTimeoutFlags(t *testing.T) {
+	cases := []struct {
+		name             string
+		minResumeTimeout int
+		maxTimeout       int
+		expectError      string
+	}{
+		{name: "ok-default", minResumeTimeout: 300, maxTimeout: 2592000, expectError: ""},
+		{name: "ok-equal", minResumeTimeout: 60, maxTimeout: 60, expectError: ""},
+		{name: "zero-min", minResumeTimeout: 0, maxTimeout: 2592000, expectError: "--e2b-min-resume-timeout must be greater than 0"},
+		{name: "negative-min", minResumeTimeout: -1, maxTimeout: 2592000, expectError: "--e2b-min-resume-timeout must be greater than 0"},
+		{name: "min-exceeds-max", minResumeTimeout: 120, maxTimeout: 60, expectError: "must not exceed --e2b-max-timeout"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateE2BTimeoutFlags(tc.minResumeTimeout, tc.maxTimeout)
+			if tc.expectError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectError)
+			}
+		})
+	}
+}

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -209,14 +209,25 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 		requeueAfter = box.Spec.ShutdownTime.Sub(now.Time)
 	}
 	if box.Spec.PauseTime != nil && !box.Spec.Paused {
-		if box.Spec.PauseTime.Before(&now) {
-			klog.InfoS("sandbox pause time reached, will be paused", "sandbox", klog.KObj(box))
+		if pauseTimeReached(box.Spec.PauseTime, now) {
+			klog.InfoS("sandbox pause time reached", "sandbox", klog.KObj(box))
 			modified := box.DeepCopy()
-			patch := client.MergeFrom(box)
+			// Optimistic-lock so concurrent writers surface as 409 instead of
+			// silently winning a last-writer race.
+			patch := client.MergeFromWithOptions(box, client.MergeFromWithOptimisticLock{})
 			modified.Spec.Paused = true
-			return ctrl.Result{}, r.Patch(ctx, modified, patch)
+			if err := r.Patch(ctx, modified, patch); err != nil {
+				if errors.IsConflict(err) {
+					return ctrl.Result{Requeue: true}, nil
+				}
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
 		}
-		requeueAfter = min(requeueAfter, box.Spec.PauseTime.Sub(now.Time))
+		pauseDelta := box.Spec.PauseTime.Sub(now.Time)
+		if pauseDelta > 0 && (requeueAfter == 0 || pauseDelta < requeueAfter) {
+			requeueAfter = pauseDelta
+		}
 	}
 
 	// calculate sandbox status
@@ -261,6 +272,10 @@ func (r *SandboxReconciler) handleTerminating(ctx context.Context, args core.Ens
 
 func isSandboxCompletedPhase(phase agentsv1alpha1.SandboxPhase) bool {
 	return phase == agentsv1alpha1.SandboxFailed || phase == agentsv1alpha1.SandboxSucceeded
+}
+
+func pauseTimeReached(pauseTime *metav1.Time, now metav1.Time) bool {
+	return pauseTime != nil && !pauseTime.After(now.Time)
 }
 
 func (r *SandboxReconciler) addSandboxFinalizerAndHash(ctx context.Context, box *agentsv1alpha1.Sandbox) (*agentsv1alpha1.Sandbox, error) {

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sandbox
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -994,6 +995,214 @@ func TestSandboxReconciler_ShutdownTime(t *testing.T) {
 	err = client.Get(context.TODO(), req.NamespacedName, updatedSandbox)
 	if err == nil && updatedSandbox.DeletionTimestamp.IsZero() {
 		t.Errorf("Expected sandbox to be deleted, but it still exists")
+	}
+}
+
+func TestSandboxReconciler_AutoPauseOCCConflict(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	pauseTime := metav1.NewTime(time.Now().Add(-1 * time.Minute).Truncate(time.Second))
+	shutdownTime := metav1.NewTime(time.Now().Add(1 * time.Hour).Truncate(time.Second))
+	sandbox := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "auto-pause-conflict-sandbox",
+			Namespace:       "default",
+			Finalizers:      []string{utils.SandboxFinalizer},
+			ResourceVersion: "42",
+		},
+		Spec: agentsv1alpha1.SandboxSpec{
+			Paused:       false,
+			PauseTime:    &pauseTime,
+			ShutdownTime: &shutdownTime,
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+					},
+				},
+			},
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxRunning,
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(agentsv1alpha1.SandboxConditionReady),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+					Reason:             "Test",
+				},
+			},
+		},
+	}
+
+	patchConflicts := 0
+	optimisticLockPatchSeen := false
+	fakeRecorder := record.NewFakeRecorder(100)
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&agentsv1alpha1.Sandbox{}).
+		WithObjects(sandbox).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if _, ok := obj.(*agentsv1alpha1.Sandbox); ok {
+					patchData, err := patch.Data(obj)
+					if err != nil {
+						t.Fatalf("failed to render sandbox patch: %v", err)
+					}
+					if !bytes.Contains(patchData, []byte(`"spec":{"paused":true}`)) {
+						t.Fatalf("expected auto-pause patch to set spec.paused=true, got %s", patchData)
+					}
+					if !bytes.Contains(patchData, []byte(`"resourceVersion"`)) {
+						t.Fatalf("expected auto-pause patch to include optimistic-lock resourceVersion, got %s", patchData)
+					}
+					optimisticLockPatchSeen = true
+					patchConflicts++
+					return apierrors.NewConflict(schema.GroupResource{Group: agentsv1alpha1.GroupVersion.Group, Resource: "sandboxes"}, obj.GetName(), fmt.Errorf("simulated conflict"))
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+	rl := core.NewRateLimiter()
+	reconciler := &SandboxReconciler{
+		Client: cli,
+		Scheme: scheme,
+		controls: core.NewSandboxControl(core.SandboxControlArgs{
+			Client:      cli,
+			Recorder:    fakeRecorder,
+			RateLimiter: rl,
+		}),
+		rateLimiter: rl,
+	}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace},
+	}
+	result, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected reconcile error: %v", err)
+	}
+	if !result.Requeue {
+		t.Fatalf("expected conflict to request requeue, got result=%+v", result)
+	}
+	if patchConflicts != 1 {
+		t.Fatalf("expected one simulated patch conflict, got %d", patchConflicts)
+	}
+	if !optimisticLockPatchSeen {
+		t.Fatalf("expected auto-pause patch to use optimistic locking")
+	}
+
+	updated := &agentsv1alpha1.Sandbox{}
+	if err := cli.Get(context.TODO(), req.NamespacedName, updated); err != nil {
+		t.Fatalf("failed to get sandbox after reconcile: %v", err)
+	}
+	if updated.Spec.Paused {
+		t.Fatalf("expected Spec.Paused to remain false after conflict")
+	}
+	if updated.Spec.PauseTime == nil || !updated.Spec.PauseTime.Time.Equal(pauseTime.Time) {
+		t.Fatalf("expected Spec.PauseTime unchanged at %v, got %v", pauseTime, updated.Spec.PauseTime)
+	}
+	if updated.Spec.ShutdownTime == nil || !updated.Spec.ShutdownTime.Time.Equal(shutdownTime.Time) {
+		t.Fatalf("expected Spec.ShutdownTime unchanged at %v, got %v", shutdownTime, updated.Spec.ShutdownTime)
+	}
+}
+
+func TestSandboxReconciler_PauseTimeOnlyRequeue(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	pauseDelta := 10 * time.Second
+	pauseTime := metav1.NewTime(time.Now().Add(pauseDelta))
+	sandbox := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "pause-time-only-sandbox",
+			Namespace:  "default",
+			Finalizers: []string{utils.SandboxFinalizer},
+		},
+		Spec: agentsv1alpha1.SandboxSpec{
+			Paused:    false,
+			PauseTime: &pauseTime,
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+					},
+				},
+			},
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxPhase("NoControlAction"),
+		},
+	}
+
+	fakeRecorder := record.NewFakeRecorder(100)
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&agentsv1alpha1.Sandbox{}).
+		WithObjects(sandbox).
+		Build()
+	rl := core.NewRateLimiter()
+	reconciler := &SandboxReconciler{
+		Client: cli,
+		Scheme: scheme,
+		controls: core.NewSandboxControl(core.SandboxControlArgs{
+			Client:      cli,
+			Recorder:    fakeRecorder,
+			RateLimiter: rl,
+		}),
+		rateLimiter: rl,
+	}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace},
+	}
+	result, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected reconcile error: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatalf("expected non-zero RequeueAfter for future PauseTime, got result=%+v", result)
+	}
+	if delta := result.RequeueAfter - pauseDelta; delta < -2*time.Second || delta > 2*time.Second {
+		t.Fatalf("expected RequeueAfter within 2s of %v, got %v", pauseDelta, result.RequeueAfter)
+	}
+}
+
+func TestPauseTimeReached(t *testing.T) {
+	now := metav1.NewTime(time.Now().Truncate(time.Second))
+	cases := []struct {
+		name      string
+		pauseTime metav1.Time
+		now       metav1.Time
+		expectDue bool
+	}{
+		{
+			name:      "past pause time is due",
+			pauseTime: metav1.NewTime(now.Add(-time.Second)),
+			now:       now,
+			expectDue: true,
+		},
+		{
+			name:      "exact pause time is due",
+			pauseTime: now,
+			now:       now,
+			expectDue: true,
+		},
+		{
+			name:      "future pause time is not due",
+			pauseTime: metav1.NewTime(now.Add(time.Second)),
+			now:       now,
+			expectDue: false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pauseTimeReached(&tt.pauseTime, tt.now); got != tt.expectDue {
+				t.Fatalf("pauseTimeReached() = %v, want %v", got, tt.expectDue)
+			}
+		})
 	}
 }
 

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -998,174 +998,194 @@ func TestSandboxReconciler_ShutdownTime(t *testing.T) {
 	}
 }
 
-func TestSandboxReconciler_AutoPauseOCCConflict(t *testing.T) {
+func TestSandboxReconciler_AutoPauseBranch(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = agentsv1alpha1.AddToScheme(scheme)
 
-	pauseTime := metav1.NewTime(time.Now().Add(-1 * time.Minute).Truncate(time.Second))
+	pastPauseTime := metav1.NewTime(time.Now().Add(-1 * time.Minute).Truncate(time.Second))
 	shutdownTime := metav1.NewTime(time.Now().Add(1 * time.Hour).Truncate(time.Second))
-	sandbox := &agentsv1alpha1.Sandbox{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "auto-pause-conflict-sandbox",
-			Namespace:       "default",
-			Finalizers:      []string{utils.SandboxFinalizer},
-			ResourceVersion: "42",
-		},
-		Spec: agentsv1alpha1.SandboxSpec{
-			Paused:       false,
-			PauseTime:    &pauseTime,
-			ShutdownTime: &shutdownTime,
-			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
-				Template: &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+	futurePauseDelta := 10 * time.Second
+	futurePauseTime := metav1.NewTime(time.Now().Add(futurePauseDelta))
+
+	runningSandbox := func(name string, pauseTime metav1.Time) *agentsv1alpha1.Sandbox {
+		return &agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            name,
+				Namespace:       "default",
+				Finalizers:      []string{utils.SandboxFinalizer},
+				ResourceVersion: "42",
+			},
+			Spec: agentsv1alpha1.SandboxSpec{
+				Paused:       false,
+				PauseTime:    &pauseTime,
+				ShutdownTime: &shutdownTime,
+				EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+						},
 					},
 				},
 			},
-		},
-		Status: agentsv1alpha1.SandboxStatus{
-			Phase: agentsv1alpha1.SandboxRunning,
-			Conditions: []metav1.Condition{
-				{
-					Type:               string(agentsv1alpha1.SandboxConditionReady),
-					Status:             metav1.ConditionTrue,
-					LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * time.Minute)),
-					Reason:             "Test",
+			Status: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxRunning,
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionReady),
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+						Reason:             "Test",
+					},
 				},
 			},
+		}
+	}
+
+	noControlSandbox := func(name string, pauseTime metav1.Time) *agentsv1alpha1.Sandbox {
+		return &agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       name,
+				Namespace:  "default",
+				Finalizers: []string{utils.SandboxFinalizer},
+			},
+			Spec: agentsv1alpha1.SandboxSpec{
+				Paused:    false,
+				PauseTime: &pauseTime,
+				EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+						},
+					},
+				},
+			},
+			Status: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPhase("NoControlAction"),
+			},
+		}
+	}
+
+	cases := []struct {
+		name                     string
+		sandbox                  *agentsv1alpha1.Sandbox
+		injectPatchErr           error
+		expectAutoPausePatch     bool
+		expectRequeue            bool
+		expectRequeueAfter       time.Duration
+		expectPausedAfter        bool
+		expectPauseTimeUnchanged bool
+	}{
+		{
+			name:                     "past pause time with patch conflict requeues and leaves spec unchanged",
+			sandbox:                  runningSandbox("auto-pause-conflict", pastPauseTime),
+			injectPatchErr:           apierrors.NewConflict(schema.GroupResource{Group: agentsv1alpha1.GroupVersion.Group, Resource: "sandboxes"}, "auto-pause-conflict", fmt.Errorf("simulated conflict")),
+			expectAutoPausePatch:     true,
+			expectRequeue:            true,
+			expectPausedAfter:        false,
+			expectPauseTimeUnchanged: true,
+		},
+		{
+			name:                 "past pause time with successful patch persists paused=true",
+			sandbox:              runningSandbox("auto-pause-success", pastPauseTime),
+			expectAutoPausePatch: true,
+			expectPausedAfter:    true,
+		},
+		{
+			name:                 "future pause time skips patch and schedules requeue",
+			sandbox:              noControlSandbox("future-pause-sandbox", futurePauseTime),
+			expectAutoPausePatch: false,
+			expectRequeueAfter:   futurePauseDelta,
+			expectPausedAfter:    false,
 		},
 	}
 
-	patchConflicts := 0
-	optimisticLockPatchSeen := false
-	fakeRecorder := record.NewFakeRecorder(100)
-	cli := fake.NewClientBuilder().WithScheme(scheme).
-		WithStatusSubresource(&agentsv1alpha1.Sandbox{}).
-		WithObjects(sandbox).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-				if _, ok := obj.(*agentsv1alpha1.Sandbox); ok {
-					patchData, err := patch.Data(obj)
-					if err != nil {
-						t.Fatalf("failed to render sandbox patch: %v", err)
-					}
-					if !bytes.Contains(patchData, []byte(`"spec":{"paused":true}`)) {
-						t.Fatalf("expected auto-pause patch to set spec.paused=true, got %s", patchData)
-					}
-					if !bytes.Contains(patchData, []byte(`"resourceVersion"`)) {
-						t.Fatalf("expected auto-pause patch to include optimistic-lock resourceVersion, got %s", patchData)
-					}
-					optimisticLockPatchSeen = true
-					patchConflicts++
-					return apierrors.NewConflict(schema.GroupResource{Group: agentsv1alpha1.GroupVersion.Group, Resource: "sandboxes"}, obj.GetName(), fmt.Errorf("simulated conflict"))
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			autoPausePatches := 0
+			optimisticLockSeen := false
+			fakeRecorder := record.NewFakeRecorder(100)
+			cli := fake.NewClientBuilder().WithScheme(scheme).
+				WithStatusSubresource(&agentsv1alpha1.Sandbox{}).
+				WithObjects(tt.sandbox).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if _, ok := obj.(*agentsv1alpha1.Sandbox); ok {
+							patchData, err := patch.Data(obj)
+							if err != nil {
+								t.Fatalf("failed to render sandbox patch: %v", err)
+							}
+							if bytes.Contains(patchData, []byte(`"spec":{"paused":true}`)) {
+								if bytes.Contains(patchData, []byte(`"resourceVersion"`)) {
+									optimisticLockSeen = true
+								}
+								autoPausePatches++
+								if tt.injectPatchErr != nil {
+									return tt.injectPatchErr
+								}
+							}
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+			rl := core.NewRateLimiter()
+			reconciler := &SandboxReconciler{
+				Client: cli,
+				Scheme: scheme,
+				controls: core.NewSandboxControl(core.SandboxControlArgs{
+					Client:      cli,
+					Recorder:    fakeRecorder,
+					RateLimiter: rl,
+				}),
+				rateLimiter: rl,
+			}
+
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: tt.sandbox.Name, Namespace: tt.sandbox.Namespace},
+			}
+			result, err := reconciler.Reconcile(context.Background(), req)
+			if err != nil {
+				t.Fatalf("unexpected reconcile error: %v", err)
+			}
+
+			if tt.expectAutoPausePatch {
+				if autoPausePatches == 0 {
+					t.Fatalf("expected auto-pause patch to be issued")
 				}
-				return c.Patch(ctx, obj, patch, opts...)
-			},
-		}).
-		Build()
-	rl := core.NewRateLimiter()
-	reconciler := &SandboxReconciler{
-		Client: cli,
-		Scheme: scheme,
-		controls: core.NewSandboxControl(core.SandboxControlArgs{
-			Client:      cli,
-			Recorder:    fakeRecorder,
-			RateLimiter: rl,
-		}),
-		rateLimiter: rl,
-	}
+				if !optimisticLockSeen {
+					t.Fatalf("expected auto-pause patch to include optimistic-lock resourceVersion")
+				}
+			} else if autoPausePatches > 0 {
+				t.Fatalf("did not expect auto-pause patch, got %d", autoPausePatches)
+			}
 
-	req := ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace},
-	}
-	result, err := reconciler.Reconcile(context.Background(), req)
-	if err != nil {
-		t.Fatalf("unexpected reconcile error: %v", err)
-	}
-	if !result.Requeue {
-		t.Fatalf("expected conflict to request requeue, got result=%+v", result)
-	}
-	if patchConflicts != 1 {
-		t.Fatalf("expected one simulated patch conflict, got %d", patchConflicts)
-	}
-	if !optimisticLockPatchSeen {
-		t.Fatalf("expected auto-pause patch to use optimistic locking")
-	}
+			if tt.expectRequeue != result.Requeue {
+				t.Fatalf("expected Requeue=%v, got result=%+v", tt.expectRequeue, result)
+			}
+			if tt.expectRequeueAfter != 0 {
+				if delta := result.RequeueAfter - tt.expectRequeueAfter; delta < -2*time.Second || delta > 2*time.Second {
+					t.Fatalf("expected RequeueAfter within 2s of %v, got %v", tt.expectRequeueAfter, result.RequeueAfter)
+				}
+			}
 
-	updated := &agentsv1alpha1.Sandbox{}
-	if err := cli.Get(context.TODO(), req.NamespacedName, updated); err != nil {
-		t.Fatalf("failed to get sandbox after reconcile: %v", err)
-	}
-	if updated.Spec.Paused {
-		t.Fatalf("expected Spec.Paused to remain false after conflict")
-	}
-	if updated.Spec.PauseTime == nil || !updated.Spec.PauseTime.Time.Equal(pauseTime.Time) {
-		t.Fatalf("expected Spec.PauseTime unchanged at %v, got %v", pauseTime, updated.Spec.PauseTime)
-	}
-	if updated.Spec.ShutdownTime == nil || !updated.Spec.ShutdownTime.Time.Equal(shutdownTime.Time) {
-		t.Fatalf("expected Spec.ShutdownTime unchanged at %v, got %v", shutdownTime, updated.Spec.ShutdownTime)
-	}
-}
-
-func TestSandboxReconciler_PauseTimeOnlyRequeue(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = agentsv1alpha1.AddToScheme(scheme)
-
-	pauseDelta := 10 * time.Second
-	pauseTime := metav1.NewTime(time.Now().Add(pauseDelta))
-	sandbox := &agentsv1alpha1.Sandbox{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "pause-time-only-sandbox",
-			Namespace:  "default",
-			Finalizers: []string{utils.SandboxFinalizer},
-		},
-		Spec: agentsv1alpha1.SandboxSpec{
-			Paused:    false,
-			PauseTime: &pauseTime,
-			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
-				Template: &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
-					},
-				},
-			},
-		},
-		Status: agentsv1alpha1.SandboxStatus{
-			Phase: agentsv1alpha1.SandboxPhase("NoControlAction"),
-		},
-	}
-
-	fakeRecorder := record.NewFakeRecorder(100)
-	cli := fake.NewClientBuilder().WithScheme(scheme).
-		WithStatusSubresource(&agentsv1alpha1.Sandbox{}).
-		WithObjects(sandbox).
-		Build()
-	rl := core.NewRateLimiter()
-	reconciler := &SandboxReconciler{
-		Client: cli,
-		Scheme: scheme,
-		controls: core.NewSandboxControl(core.SandboxControlArgs{
-			Client:      cli,
-			Recorder:    fakeRecorder,
-			RateLimiter: rl,
-		}),
-		rateLimiter: rl,
-	}
-
-	req := ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace},
-	}
-	result, err := reconciler.Reconcile(context.Background(), req)
-	if err != nil {
-		t.Fatalf("unexpected reconcile error: %v", err)
-	}
-	if result.RequeueAfter == 0 {
-		t.Fatalf("expected non-zero RequeueAfter for future PauseTime, got result=%+v", result)
-	}
-	if delta := result.RequeueAfter - pauseDelta; delta < -2*time.Second || delta > 2*time.Second {
-		t.Fatalf("expected RequeueAfter within 2s of %v, got %v", pauseDelta, result.RequeueAfter)
+			updated := &agentsv1alpha1.Sandbox{}
+			if err := cli.Get(context.TODO(), req.NamespacedName, updated); err != nil {
+				t.Fatalf("failed to get sandbox after reconcile: %v", err)
+			}
+			if updated.Spec.Paused != tt.expectPausedAfter {
+				t.Fatalf("expected Spec.Paused=%v, got %v", tt.expectPausedAfter, updated.Spec.Paused)
+			}
+			if tt.expectPauseTimeUnchanged {
+				if updated.Spec.PauseTime == nil || !updated.Spec.PauseTime.Time.Equal(tt.sandbox.Spec.PauseTime.Time) {
+					t.Fatalf("expected Spec.PauseTime unchanged at %v, got %v", tt.sandbox.Spec.PauseTime, updated.Spec.PauseTime)
+				}
+				if tt.sandbox.Spec.ShutdownTime != nil &&
+					(updated.Spec.ShutdownTime == nil || !updated.Spec.ShutdownTime.Time.Equal(tt.sandbox.Spec.ShutdownTime.Time)) {
+					t.Fatalf("expected Spec.ShutdownTime unchanged at %v, got %v", tt.sandbox.Spec.ShutdownTime, updated.Spec.ShutdownTime)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/sandbox-manager/infra/interface.go
+++ b/pkg/sandbox-manager/infra/interface.go
@@ -43,8 +43,16 @@ type PauseOptions struct {
 	Timeout *timeout.Options
 }
 
-// ResumeOptions reserves the type for future extensions.
-type ResumeOptions struct{}
+// ResumeOptions configures a Resume operation.
+//
+// Timeout, when non-nil, is written atomically with Spec.Paused=false so
+// the controller's auto-pause action cannot fire on the stale PauseTime
+// between Resume returning and the caller writing the real business
+// timeout. Pass nil to skip the atomic write (the caller accepts that
+// PauseTime may remain stale until the next write).
+type ResumeOptions struct {
+	Timeout *timeout.Options
+}
 
 type HasTemplateOptions struct {
 	Namespace string

--- a/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
@@ -19,6 +19,7 @@ package sandboxcr
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -64,6 +65,36 @@ func (c *apiReaderOverrideCache) GetClient() ctrl.Client {
 		return c.Provider.GetClient()
 	}
 	return c.client
+}
+
+func assertTimePtrEqual(t *testing.T, want, got *metav1.Time, msg string) {
+	t.Helper()
+	if want == nil {
+		assert.Nil(t, got, msg)
+		return
+	}
+	require.NotNil(t, got, msg)
+	wantTime := timeout.NormalizeTime(want.Time)
+	gotTime := timeout.NormalizeTime(got.Time)
+	assert.True(t, wantTime.Equal(gotTime), "%s: want=%s got=%s", msg, wantTime, gotTime)
+}
+
+func timePtrOrNil(t time.Time) *metav1.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &metav1.Time{Time: timeout.NormalizeTime(t)}
+}
+
+func mutateTimeout(ctx context.Context, c ctrl.Client, key types.NamespacedName, opts timeout.Options) error {
+	var current v1alpha1.Sandbox
+	if err := c.Get(ctx, key, &current); err != nil {
+		return err
+	}
+	modified := current.DeepCopy()
+	modified.Spec.PauseTime = timePtrOrNil(opts.PauseTime)
+	modified.Spec.ShutdownTime = timePtrOrNil(opts.ShutdownTime)
+	return c.Patch(ctx, modified, ctrl.MergeFrom(&current))
 }
 
 // TestSandbox_ResumeConcurrent tests concurrent resume operations on the same sandbox
@@ -1428,4 +1459,488 @@ func TestSandbox_ResumePreservesTimeoutOnError(t *testing.T) {
 	require.NotNil(t, updatedSbx.Spec.PauseTime)
 	assert.WithinDuration(t, shutdownTime, updatedSbx.Spec.ShutdownTime.Time, time.Second)
 	assert.WithinDuration(t, pauseTime, updatedSbx.Spec.PauseTime.Time, time.Second)
+}
+
+// TestSandbox_ResumeMutatorAtomicity verifies Resume() writes Spec.Paused=false
+// and the placeholder timeout in the same Update payload across timeout
+// shapes (real / nil / never-timeout / pausetime-only) and across the
+// winner/loser branches of the first-writer-wins guard.
+func TestSandbox_ResumeMutatorAtomicity(t *testing.T) {
+	utils.InitLogOutput()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	realPauseAt := metav1.NewTime(now.Add(10 * time.Minute))
+	realShutdownAt := metav1.NewTime(now.Add(30 * 24 * time.Hour))
+	stalePauseAt := metav1.NewTime(now.Add(-1 * time.Minute))
+
+	type expected struct {
+		paused       bool
+		pauseTime    *metav1.Time // nil means "must be nil"
+		shutdownTime *metav1.Time
+	}
+
+	cases := []struct {
+		name           string
+		initialPaused  bool
+		initialPauseAt *metav1.Time
+		initialShutAt  *metav1.Time
+		optsTimeout    *timeout.Options
+		want           expected
+	}{
+		{
+			name:           "winner-with-realTimeout",
+			initialPaused:  true,
+			initialPauseAt: &stalePauseAt,
+			initialShutAt:  &realShutdownAt,
+			optsTimeout: &timeout.Options{
+				PauseTime:    realPauseAt.Time,
+				ShutdownTime: realShutdownAt.Time,
+			},
+			want: expected{paused: false, pauseTime: &realPauseAt, shutdownTime: &realShutdownAt},
+		},
+		{
+			name:           "winner-no-placeholder",
+			initialPaused:  true,
+			initialPauseAt: &stalePauseAt,
+			initialShutAt:  &realShutdownAt,
+			optsTimeout:    nil,
+			want:           expected{paused: false, pauseTime: &stalePauseAt, shutdownTime: &realShutdownAt},
+		},
+		{
+			name:           "loser-already-flipped",
+			initialPaused:  false,
+			initialPauseAt: &realPauseAt,
+			initialShutAt:  &realShutdownAt,
+			optsTimeout: &timeout.Options{
+				PauseTime:    now.Add(5 * time.Minute),
+				ShutdownTime: now.Add(20 * time.Minute),
+			},
+			want: expected{paused: false, pauseTime: &realPauseAt, shutdownTime: &realShutdownAt},
+		},
+		{
+			name:           "never-timeout",
+			initialPaused:  true,
+			initialPauseAt: nil,
+			initialShutAt:  nil,
+			optsTimeout:    &timeout.Options{}, // zero PauseTime, zero ShutdownTime
+			want:           expected{paused: false, pauseTime: nil, shutdownTime: nil},
+		},
+		{
+			name:           "pausetime-only",
+			initialPaused:  true,
+			initialPauseAt: &stalePauseAt,
+			initialShutAt:  nil,
+			optsTimeout: &timeout.Options{
+				PauseTime: realPauseAt.Time,
+				// ShutdownTime left zero
+			},
+			want: expected{paused: false, pauseTime: &realPauseAt, shutdownTime: nil},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Winners (initialPaused=true): Phase=Paused + ConditionPaused so
+			// IsSandboxResumable passes and the mutator runs (released by the
+			// Ready-flip AfterFunc below). Losers (initialPaused=false):
+			// Phase=Running + ConditionReady so Resume() hits the
+			// "sandbox is already resumed" early-return before retryUpdate.
+			phase := v1alpha1.SandboxPaused
+			conds := []metav1.Condition{
+				{Type: string(v1alpha1.SandboxConditionPaused), Status: metav1.ConditionTrue, Reason: "Paused"},
+			}
+			if !tc.initialPaused {
+				phase = v1alpha1.SandboxRunning
+				conds = []metav1.Condition{
+					{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready"},
+				}
+			}
+
+			sandbox := &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+					Labels:    map[string]string{v1alpha1.LabelSandboxIsClaimed: "true"},
+				},
+				Spec: v1alpha1.SandboxSpec{
+					Paused:       tc.initialPaused,
+					PauseTime:    tc.initialPauseAt,
+					ShutdownTime: tc.initialShutAt,
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase:      phase,
+					Conditions: conds,
+				},
+			}
+
+			cache, fc, err := cachetest.NewTestCache(t)
+			require.NoError(t, err)
+			require.NoError(t, cache.Run(t.Context()))
+			defer cache.Stop(t.Context())
+			CreateSandboxWithStatus(t, fc, sandbox)
+			time.Sleep(10 * time.Millisecond)
+
+			// Winner-only: release the resumeTask.Wait so Resume() returns.
+			if tc.initialPaused {
+				cache.GetMockManager().AddWaitReconcileKey(sandbox)
+				time.AfterFunc(20*time.Millisecond, func() {
+					modified := sandbox.DeepCopy()
+					modified.Status.Phase = v1alpha1.SandboxRunning
+					modified.Status.Conditions = []metav1.Condition{
+						{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready"},
+					}
+					_ = fc.Status().Patch(t.Context(), modified, ctrl.MergeFrom(sandbox))
+				})
+			}
+
+			// Intercept Update calls to capture the payload that crossed the wire.
+			var updatePayloads []*v1alpha1.Sandbox
+			cacheClient, ok := cache.GetClient().(ctrl.WithWatch)
+			require.True(t, ok)
+			interceptedClient := interceptor.NewClient(cacheClient, interceptor.Funcs{
+				Update: func(ctx context.Context, c ctrl.WithWatch, obj ctrl.Object, opts ...ctrl.UpdateOption) error {
+					if sbx, ok := obj.(*v1alpha1.Sandbox); ok {
+						updatePayloads = append(updatePayloads, sbx.DeepCopy())
+					}
+					return c.Update(ctx, obj, opts...)
+				},
+			})
+
+			s := AsSandbox(sandbox.DeepCopy(), &apiReaderOverrideCache{
+				Provider: cache,
+				client:   interceptedClient,
+			})
+
+			err = s.Resume(t.Context(), infra.ResumeOptions{Timeout: tc.optsTimeout})
+			require.NoError(t, err)
+
+			// Loser case: Resume early-returns; no Update should have happened.
+			if !tc.initialPaused {
+				assert.Empty(t, updatePayloads, "loser path must not Update")
+			} else {
+				require.Len(t, updatePayloads, 1, "exactly one Update payload expected")
+				payload := updatePayloads[0]
+				assert.False(t, payload.Spec.Paused, "Paused must be false in the payload")
+				assertTimePtrEqual(t, tc.want.pauseTime, payload.Spec.PauseTime, "PauseTime in payload must match expected")
+				assertTimePtrEqual(t, tc.want.shutdownTime, payload.Spec.ShutdownTime, "ShutdownTime in payload must match expected")
+			}
+
+			// Re-read from fake client and assert the final persisted state.
+			var final v1alpha1.Sandbox
+			require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: sandbox.Namespace, Name: sandbox.Name}, &final))
+			assert.Equal(t, tc.want.paused, final.Spec.Paused)
+			assertTimePtrEqual(t, tc.want.pauseTime, final.Spec.PauseTime, "final PauseTime must match expected")
+			assertTimePtrEqual(t, tc.want.shutdownTime, final.Spec.ShutdownTime, "final ShutdownTime must match expected")
+		})
+	}
+}
+
+func TestSandbox_ResumeExtendOnlyConcurrent(t *testing.T) {
+	utils.InitLogOutput()
+
+	now := time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)
+	staleOpts := timeout.Options{
+		PauseTime:    now.Add(-5 * time.Minute),
+		ShutdownTime: now.Add(24 * time.Hour),
+	}
+	placeholder := timeout.Options{
+		PauseTime:    now.Add(time.Minute),
+		ShutdownTime: now.Add(30 * 24 * time.Hour),
+	}
+	postOpts := timeout.Options{
+		PauseTime:    now.Add(10 * time.Minute),
+		ShutdownTime: now.Add(30 * 24 * time.Hour),
+	}
+	longerOpts := timeout.Options{
+		PauseTime:    now.Add(20 * time.Minute),
+		ShutdownTime: now.Add(30 * 24 * time.Hour),
+	}
+	shorterOpts := timeout.Options{
+		PauseTime:    now.Add(2 * time.Minute),
+		ShutdownTime: now.Add(30 * 24 * time.Hour),
+	}
+
+	cases := []struct {
+		name                 string
+		initialPaused        bool
+		initialTimeout       timeout.Options
+		concurrentTimeout    *timeout.Options
+		postTimeout          timeout.Options
+		expectTimeout        timeout.Options
+		expectSaveWasUpdated bool
+	}{
+		{
+			name:                 "winner-clean",
+			initialPaused:        true,
+			initialTimeout:       staleOpts,
+			postTimeout:          postOpts,
+			expectTimeout:        postOpts,
+			expectSaveWasUpdated: true,
+		},
+		{
+			name:                 "winner-concurrent-longer",
+			initialPaused:        true,
+			initialTimeout:       staleOpts,
+			concurrentTimeout:    &longerOpts,
+			postTimeout:          postOpts,
+			expectTimeout:        longerOpts,
+			expectSaveWasUpdated: false,
+		},
+		{
+			name:                 "winner-concurrent-shorter",
+			initialPaused:        true,
+			initialTimeout:       staleOpts,
+			concurrentTimeout:    &shorterOpts,
+			postTimeout:          postOpts,
+			expectTimeout:        postOpts,
+			expectSaveWasUpdated: true,
+		},
+		{
+			name:                 "loser-after-winner-finalized-shorter-opts",
+			initialPaused:        false,
+			initialTimeout:       longerOpts,
+			postTimeout:          postOpts,
+			expectTimeout:        longerOpts,
+			expectSaveWasUpdated: false,
+		},
+		{
+			name:                 "loser-longer-than-winner",
+			initialPaused:        false,
+			initialTimeout:       shorterOpts,
+			postTimeout:          postOpts,
+			expectTimeout:        postOpts,
+			expectSaveWasUpdated: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			phase := v1alpha1.SandboxPaused
+			conditions := []metav1.Condition{
+				{Type: string(v1alpha1.SandboxConditionPaused), Status: metav1.ConditionTrue, Reason: "Paused"},
+			}
+			if !tc.initialPaused {
+				phase = v1alpha1.SandboxRunning
+				conditions = []metav1.Condition{
+					{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready"},
+				}
+			}
+
+			sandbox := &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+					Labels:    map[string]string{v1alpha1.LabelSandboxIsClaimed: "true"},
+				},
+				Spec: v1alpha1.SandboxSpec{
+					Paused:       tc.initialPaused,
+					PauseTime:    timePtrOrNil(tc.initialTimeout.PauseTime),
+					ShutdownTime: timePtrOrNil(tc.initialTimeout.ShutdownTime),
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase:      phase,
+					Conditions: conditions,
+				},
+			}
+
+			cache, fc, err := cachetest.NewTestCache(t)
+			require.NoError(t, err)
+			require.NoError(t, cache.Run(t.Context()))
+			defer cache.Stop(t.Context())
+			CreateSandboxWithStatus(t, fc, sandbox)
+			time.Sleep(10 * time.Millisecond)
+
+			key := types.NamespacedName{Namespace: sandbox.Namespace, Name: sandbox.Name}
+			if tc.initialPaused {
+				cache.GetMockManager().AddWaitReconcileKey(sandbox)
+				time.AfterFunc(20*time.Millisecond, func() {
+					var current v1alpha1.Sandbox
+					if err := fc.Get(t.Context(), key, &current); err != nil {
+						return
+					}
+					modified := current.DeepCopy()
+					modified.Status.Phase = v1alpha1.SandboxRunning
+					modified.Status.Conditions = []metav1.Condition{
+						{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Resume"},
+					}
+					_ = fc.Status().Patch(t.Context(), modified, ctrl.MergeFrom(&current))
+				})
+			}
+
+			s := AsSandbox(sandbox.DeepCopy(), cache)
+			resumeCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			require.NoError(t, s.Resume(resumeCtx, infra.ResumeOptions{Timeout: &placeholder}))
+
+			if tc.concurrentTimeout != nil {
+				require.NoError(t, mutateTimeout(t.Context(), fc, key, *tc.concurrentTimeout))
+			}
+
+			result, err := s.SaveTimeoutWithPolicy(t.Context(), tc.postTimeout, timeout.UpdatePolicyExtendOnly)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectSaveWasUpdated, result.Updated)
+
+			var final v1alpha1.Sandbox
+			require.NoError(t, fc.Get(t.Context(), key, &final))
+			assert.False(t, final.Spec.Paused)
+			assertTimePtrEqual(t, timePtrOrNil(tc.expectTimeout.PauseTime), final.Spec.PauseTime, "final PauseTime must match expected")
+			assertTimePtrEqual(t, timePtrOrNil(tc.expectTimeout.ShutdownTime), final.Spec.ShutdownTime, "final ShutdownTime must match expected")
+		})
+	}
+}
+
+func TestSandbox_ResumeFailurePathsLeaveRealTimeout(t *testing.T) {
+	utils.InitLogOutput()
+
+	now := time.Date(2026, 5, 22, 11, 0, 0, 0, time.UTC)
+	realTimeout := timeout.Options{
+		PauseTime:    now.Add(5 * time.Minute),
+		ShutdownTime: now.Add(30 * 24 * time.Hour),
+	}
+	atomicTimeout := timeout.Options{
+		PauseTime:    now.Add(2 * time.Minute),
+		ShutdownTime: now.Add(20 * 24 * time.Hour),
+	}
+	injectedErr := fmt.Errorf("injected sandbox update failure")
+
+	cases := []struct {
+		name          string
+		resumeTimeout timeout.Options
+		expectTimeout timeout.Options
+		run           func(t *testing.T, sandbox *v1alpha1.Sandbox, cache *cachepkg.Cache, fc ctrl.Client, resumeTimeout timeout.Options)
+		expectReady   bool
+	}{
+		{
+			name:          "wait-timeout",
+			resumeTimeout: realTimeout,
+			expectTimeout: realTimeout,
+			run: func(t *testing.T, sandbox *v1alpha1.Sandbox, cache *cachepkg.Cache, _ ctrl.Client, resumeTimeout timeout.Options) {
+				s := AsSandbox(sandbox.DeepCopy(), cache)
+				resumeCtx, cancel := context.WithTimeout(t.Context(), 150*time.Millisecond)
+				defer cancel()
+				err := s.Resume(resumeCtx, infra.ResumeOptions{Timeout: &resumeTimeout})
+				require.ErrorIs(t, err, cacheutils.ErrWaitNotSatisfied)
+				var werr *cacheutils.WaitNotSatisfiedError
+				require.ErrorAs(t, err, &werr)
+				assert.True(t, werr.DuringDoubleCheck, "expected double-check failure")
+			},
+		},
+		{
+			name:          "ctx-canceled-post-mutator",
+			resumeTimeout: realTimeout,
+			expectTimeout: realTimeout,
+			run: func(t *testing.T, sandbox *v1alpha1.Sandbox, cache *cachepkg.Cache, _ ctrl.Client, resumeTimeout timeout.Options) {
+				resumeCtx, cancel := context.WithCancel(t.Context())
+				cacheClient, ok := cache.GetClient().(ctrl.WithWatch)
+				require.True(t, ok)
+				var updates atomic.Int32
+				interceptedClient := interceptor.NewClient(cacheClient, interceptor.Funcs{
+					Update: func(ctx context.Context, c ctrl.WithWatch, obj ctrl.Object, opts ...ctrl.UpdateOption) error {
+						err := c.Update(ctx, obj, opts...)
+						if _, ok := obj.(*v1alpha1.Sandbox); ok && updates.Add(1) == 1 {
+							cancel()
+						}
+						return err
+					},
+				})
+				s := AsSandbox(sandbox.DeepCopy(), &apiReaderOverrideCache{
+					Provider: cache,
+					client:   interceptedClient,
+				})
+				err := s.Resume(resumeCtx, infra.ResumeOptions{Timeout: &resumeTimeout})
+				require.ErrorIs(t, err, cacheutils.ErrWaitNotSatisfied)
+				var werr *cacheutils.WaitNotSatisfiedError
+				require.ErrorAs(t, err, &werr)
+				assert.True(t, werr.DuringDoubleCheck, "expected double-check failure")
+			},
+		},
+		{
+			name:          "save-timeout-failure-keeps-atomic-timeout",
+			resumeTimeout: atomicTimeout,
+			expectTimeout: atomicTimeout,
+			run: func(t *testing.T, sandbox *v1alpha1.Sandbox, cache *cachepkg.Cache, fc ctrl.Client, resumeTimeout timeout.Options) {
+				key := types.NamespacedName{Namespace: sandbox.Namespace, Name: sandbox.Name}
+				cache.GetMockManager().AddWaitReconcileKey(sandbox)
+				time.AfterFunc(20*time.Millisecond, func() {
+					var current v1alpha1.Sandbox
+					if err := fc.Get(t.Context(), key, &current); err != nil {
+						return
+					}
+					modified := current.DeepCopy()
+					modified.Status.Phase = v1alpha1.SandboxRunning
+					modified.Status.Conditions = []metav1.Condition{
+						{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Resume"},
+					}
+					_ = fc.Status().Patch(t.Context(), modified, ctrl.MergeFrom(&current))
+				})
+
+				cacheClient, ok := cache.GetClient().(ctrl.WithWatch)
+				require.True(t, ok)
+				var updates atomic.Int32
+				interceptedClient := interceptor.NewClient(cacheClient, interceptor.Funcs{
+					Update: func(ctx context.Context, c ctrl.WithWatch, obj ctrl.Object, opts ...ctrl.UpdateOption) error {
+						if _, ok := obj.(*v1alpha1.Sandbox); ok && updates.Add(1) > 1 {
+							return injectedErr
+						}
+						return c.Update(ctx, obj, opts...)
+					},
+				})
+				s := AsSandbox(sandbox.DeepCopy(), &apiReaderOverrideCache{
+					Provider: cache,
+					client:   interceptedClient,
+				})
+
+				resumeCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+				defer cancel()
+				require.NoError(t, s.Resume(resumeCtx, infra.ResumeOptions{Timeout: &resumeTimeout}))
+
+				_, err := s.SaveTimeoutWithPolicy(t.Context(), realTimeout, timeout.UpdatePolicyExtendOnly)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), injectedErr.Error())
+			},
+			expectReady: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sandbox := &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+					Labels:    map[string]string{v1alpha1.LabelSandboxIsClaimed: "true"},
+				},
+				Spec: v1alpha1.SandboxSpec{
+					Paused:       true,
+					PauseTime:    timePtrOrNil(now.Add(-time.Minute)),
+					ShutdownTime: timePtrOrNil(now.Add(24 * time.Hour)),
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase: v1alpha1.SandboxPaused,
+					Conditions: []metav1.Condition{
+						{Type: string(v1alpha1.SandboxConditionPaused), Status: metav1.ConditionTrue, Reason: "Paused"},
+					},
+				},
+			}
+
+			cache, fc, err := cachetest.NewTestCache(t)
+			require.NoError(t, err)
+			require.NoError(t, cache.Run(t.Context()))
+			defer cache.Stop(t.Context())
+			CreateSandboxWithStatus(t, fc, sandbox)
+			time.Sleep(10 * time.Millisecond)
+
+			tc.run(t, sandbox, cache, fc, tc.resumeTimeout)
+
+			var final v1alpha1.Sandbox
+			require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: sandbox.Namespace, Name: sandbox.Name}, &final))
+			assert.False(t, final.Spec.Paused)
+			assertTimePtrEqual(t, timePtrOrNil(tc.expectTimeout.PauseTime), final.Spec.PauseTime, "final PauseTime must keep expected timeout")
+			assertTimePtrEqual(t, timePtrOrNil(tc.expectTimeout.ShutdownTime), final.Spec.ShutdownTime, "final ShutdownTime must keep expected timeout")
+			if tc.expectReady {
+				state, reason := sandboxutils.GetSandboxState(&final)
+				assert.Equal(t, v1alpha1.SandboxStateRunning, state, reason)
+			}
+		})
+	}
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -233,10 +233,6 @@ func (s *Sandbox) GetImage() string {
 // SaveTimeoutWithPolicy updates timeout with given policy. Available timeout update policies:
 //   - Always: overwrite timeout whenever the requested value differs from current.
 //   - ExtendOnly: only extend to a later effective end time.
-//   - BaselineAware: the caller provides the timeout data it observed before issuing
-//     this update. When current timeout matches baseline, it is treated as
-//     overwrite-allowed; when current timeout differs from baseline, only extension
-//     is allowed.
 func (s *Sandbox) SaveTimeoutWithPolicy(ctx context.Context, opts timeout.Options, policy timeout.UpdatePolicy) (infra.TimeoutUpdateResult, error) {
 	log := klog.FromContext(ctx).V(consts.DebugLogLevel).WithValues("sandbox", klog.KObj(s.Sandbox), "policy", policy)
 	result := infra.TimeoutUpdateResult{}
@@ -251,21 +247,6 @@ func (s *Sandbox) SaveTimeoutWithPolicy(ctx context.Context, opts timeout.Option
 			shouldUpdate = !timeout.Equal(current, opts)
 		case timeout.UpdatePolicyExtendOnly:
 			shouldUpdate = timeout.ShouldExtendTimeout(current, opts)
-		case timeout.UpdatePolicyBaselineAware:
-			if opts.Baseline == nil {
-				return false, fmt.Errorf("BaselineAware policy requires opts.Baseline to be set")
-			}
-			if timeout.Equal(current, *opts.Baseline) {
-				// No concurrent writer has changed the timeout since the caller's observation.
-				// Treat as Always: overwrite if different.
-				shouldUpdate = !timeout.Equal(current, opts)
-				log.Info("baseline matches current, using Always semantics", "shouldUpdate", shouldUpdate)
-			} else {
-				// Some other request has already written a new timeout in this cycle.
-				// Degrade to ExtendOnly so we never shrink an already-extended timeout.
-				shouldUpdate = timeout.ShouldExtendTimeout(current, opts)
-				log.Info("baseline differs from current, using ExtendOnly semantics", "shouldUpdate", shouldUpdate)
-			}
 		default:
 			return false, fmt.Errorf("unsupported timeout update policy %q", policy)
 		}
@@ -357,7 +338,7 @@ func (s *Sandbox) Pause(ctx context.Context, opts infra.PauseOptions) error {
 
 const postResumeOperationTimeout = 30 * time.Second
 
-func (s *Sandbox) Resume(ctx context.Context, _ infra.ResumeOptions) error {
+func (s *Sandbox) Resume(ctx context.Context, opts infra.ResumeOptions) error {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(s.Sandbox))
 
 	if err := s.refreshFromAPIReader(ctx); err != nil {
@@ -383,11 +364,14 @@ func (s *Sandbox) Resume(ctx context.Context, _ infra.ResumeOptions) error {
 	log.Info("try to resume sandbox", "state", state, "reason", reason)
 	resumeUpdated, err := s.retryUpdate(ctx, func(sbx *agentsv1alpha1.Sandbox) (bool, error) {
 		if !sbx.Spec.Paused {
-			// Resume is first-writer-wins: only the request that flips
-			// No need to update if spec.paused is already false.
+			// First-writer-wins: the loser must not overwrite the winner's
+			// fresh PauseTime, otherwise the controller would auto-pause.
 			return false, nil
 		}
 		sbx.Spec.Paused = false
+		if opts.Timeout != nil {
+			setTimeout(sbx, *opts.Timeout)
+		}
 		return true, nil
 	})
 	if err != nil {

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
@@ -91,14 +91,10 @@ func ConvertPodToSandboxCR(pod *corev1.Pod) *v1alpha1.Sandbox {
 
 func TestSandbox_SaveTimeoutWithPolicy(t *testing.T) {
 	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
-	timeoutPtr := func(opts timeout.Options) *timeout.Options {
-		return &opts
-	}
 
 	tests := []struct {
 		name          string
 		current       timeout.Options
-		baseline      *timeout.Options
 		requested     timeout.Options
 		policy        timeout.UpdatePolicy
 		expectUpdated bool
@@ -154,80 +150,6 @@ func TestSandbox_SaveTimeoutWithPolicy(t *testing.T) {
 			expectTimeout: timeout.Options{ShutdownTime: base.Add(25 * time.Minute)},
 		},
 		{
-			name: "baseline aware with matching baseline behaves like always (writes)",
-			current: timeout.Options{
-				ShutdownTime: base.Add(10 * time.Minute),
-			},
-			baseline: timeoutPtr(timeout.Options{
-				ShutdownTime: base.Add(10 * time.Minute),
-			}),
-			requested: timeout.Options{
-				ShutdownTime: base.Add(18 * time.Minute),
-			},
-			policy:        timeout.UpdatePolicyBaselineAware,
-			expectUpdated: true,
-			expectTimeout: timeout.Options{ShutdownTime: base.Add(18 * time.Minute)},
-		},
-		{
-			name: "baseline aware with matching baseline skips when timeout equals current",
-			current: timeout.Options{
-				ShutdownTime: base.Add(10 * time.Minute),
-			},
-			baseline: timeoutPtr(timeout.Options{
-				ShutdownTime: base.Add(10 * time.Minute),
-			}),
-			requested: timeout.Options{
-				ShutdownTime: base.Add(10 * time.Minute),
-			},
-			policy:        timeout.UpdatePolicyBaselineAware,
-			expectUpdated: false,
-			expectTimeout: timeout.Options{ShutdownTime: base.Add(10 * time.Minute)},
-		},
-		{
-			name: "baseline aware with drifted baseline only allows extension",
-			current: timeout.Options{
-				ShutdownTime: base.Add(15 * time.Minute),
-			},
-			baseline: timeoutPtr(timeout.Options{
-				ShutdownTime: base.Add(10 * time.Minute),
-			}),
-			requested: timeout.Options{
-				ShutdownTime: base.Add(30 * time.Minute),
-			},
-			policy:        timeout.UpdatePolicyBaselineAware,
-			expectUpdated: true,
-			expectTimeout: timeout.Options{ShutdownTime: base.Add(30 * time.Minute)},
-		},
-		{
-			name: "baseline aware with drifted baseline rejects non extending timeout",
-			current: timeout.Options{
-				ShutdownTime: base.Add(15 * time.Minute),
-			},
-			baseline: timeoutPtr(timeout.Options{
-				ShutdownTime: base.Add(10 * time.Minute),
-			}),
-			requested: timeout.Options{
-				ShutdownTime: base.Add(12 * time.Minute),
-			},
-			policy:        timeout.UpdatePolicyBaselineAware,
-			expectUpdated: false,
-			expectTimeout: timeout.Options{ShutdownTime: base.Add(15 * time.Minute)},
-		},
-		{
-			name: "baseline aware without baseline returns error",
-			current: timeout.Options{
-				ShutdownTime: base.Add(10 * time.Minute),
-			},
-			requested: timeout.Options{
-				ShutdownTime: base.Add(20 * time.Minute),
-			},
-			policy:      timeout.UpdatePolicyBaselineAware,
-			expectError: "requires opts.Baseline",
-			expectTimeout: timeout.Options{
-				ShutdownTime: base.Add(10 * time.Minute),
-			},
-		},
-		{
 			name: "unsupported policy returns error without mutating timeout",
 			current: timeout.Options{
 				ShutdownTime: base.Add(10 * time.Minute),
@@ -261,11 +183,7 @@ func TestSandbox_SaveTimeoutWithPolicy(t *testing.T) {
 				return err == nil
 			}, time.Second, 10*time.Millisecond)
 
-			requested := tt.requested
-			if tt.baseline != nil {
-				requested.Baseline = tt.baseline
-			}
-			result, err := sandbox.SaveTimeoutWithPolicy(t.Context(), requested, tt.policy)
+			result, err := sandbox.SaveTimeoutWithPolicy(t.Context(), tt.requested, tt.policy)
 			if tt.expectError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectError)
@@ -397,79 +315,6 @@ func TestSandbox_SaveTimeoutWithPolicy_OnConflict(t *testing.T) {
 	var updated v1alpha1.Sandbox
 	require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: sbx.Namespace, Name: sbx.Name}, &updated))
 	assert.True(t, timeout.Equal(requested, timeout.GetTimeoutFromSandbox(&updated)))
-}
-
-func TestSandbox_SaveTimeoutWithPolicy_BaselineAwareUsesAPIReaderAfterConflict(t *testing.T) {
-	scheme := k8sruntime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(v1alpha1.AddToScheme(scheme))
-
-	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
-	baseline := timeout.Options{ShutdownTime: base.Add(10 * time.Minute)}
-	winnerTimeout := timeout.Options{ShutdownTime: base.Add(30 * time.Minute)}
-	requested := timeout.Options{
-		ShutdownTime: base.Add(12 * time.Minute),
-		Baseline:     &baseline,
-	}
-
-	initial := createTestSandboxWithDefaults("test-sandbox", "default")
-	setTimeout(initial, baseline)
-	stale := initial.DeepCopy()
-
-	fc := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithStatusSubresource(&v1alpha1.Sandbox{}).
-		WithObjects(initial).
-		Build()
-
-	provider := &retryUpdateTestProvider{
-		apiReader:      &countingReader{Reader: fc},
-		claimedSandbox: initial,
-	}
-	var updateCalls atomic.Int32
-	provider.client = interceptor.NewClient(fc, interceptor.Funcs{
-		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-			provider.clientGetCalls.Add(1)
-			if key == client.ObjectKeyFromObject(stale) {
-				stale.DeepCopyInto(obj.(*v1alpha1.Sandbox))
-				return nil
-			}
-			return c.Get(ctx, key, obj, opts...)
-		},
-		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-			if updateCalls.Add(1) != 1 {
-				return errors.New("unexpected second update")
-			}
-
-			latest := &v1alpha1.Sandbox{}
-			if err := c.Get(ctx, client.ObjectKeyFromObject(stale), latest); err != nil {
-				return err
-			}
-			winner := latest.DeepCopy()
-			setTimeout(winner, winnerTimeout)
-			if err := c.Update(ctx, winner); err != nil {
-				return err
-			}
-			return apierrors.NewConflict(
-				schema.GroupResource{Group: v1alpha1.GroupVersion.Group, Resource: "sandboxes"},
-				obj.GetName(),
-				errors.New("simulated conflict"),
-			)
-		},
-	})
-
-	sandbox := AsSandbox(stale.DeepCopy(), provider)
-	result, err := sandbox.SaveTimeoutWithPolicy(t.Context(), requested, timeout.UpdatePolicyBaselineAware)
-	require.NoError(t, err)
-	assert.False(t, result.Updated)
-	assert.Equal(t, int32(1), provider.clientGetCalls.Load())
-	assert.Equal(t, int32(1), provider.apiReader.Calls())
-	assert.Equal(t, int32(1), updateCalls.Load())
-	assert.True(t, timeout.Equal(winnerTimeout, sandbox.GetTimeout()))
-
-	updated := &v1alpha1.Sandbox{}
-	require.NoError(t, fc.Get(t.Context(), client.ObjectKeyFromObject(initial), updated))
-	assert.True(t, timeout.Equal(winnerTimeout, timeout.GetTimeoutFromSandbox(updated)))
 }
 
 type countingReader struct {

--- a/pkg/servers/e2b/AGENTS.md
+++ b/pkg/servers/e2b/AGENTS.md
@@ -80,10 +80,17 @@ Every E2B route is registered twice via `RegisterE2BRoute`: once for the native 
 
 ### Timeout Semantics
 - **Pause**: sets timeout far into the future (1000 years) so paused sandboxes are kept indefinitely.
-- **Resume**: sets timeout strictly to the requested value (no extend-only merge).
+- **Resume**: for timed sandboxes, writes an effective timeout while flipping `Spec.Paused=false`; the effective timeout is the request value after the resume floor. Never-timeout sandboxes keep nil timeout fields.
 - **Connect (Running)**: extend-only — never shortens the effective deadline. If the requested deadline is earlier than the current one, the update is silently skipped.
-- **Connect (Paused → Resume)**: sets timeout strictly to the requested value (same as Resume).
+- **Connect (Paused → Resume)**: resumes with an effective timeout placeholder, then applies the post-resume timeout with `UpdatePolicyExtendOnly`.
 - **SetTimeout**: only applies to running sandboxes; conflicts return `409`.
+
+### Connect Timeout Race Handling
+Concurrent `ConnectSandbox` calls intentionally converge by deadline rather than trying to strictly serialize all callers.
+
+For a timed paused sandbox, `ConnectSandbox` first applies the resume floor only when the sandbox is paused and has an existing deadline. `Resume` then updates `Spec.Paused=false` and writes the placeholder timeout in the same Sandbox update, so the controller cannot observe an unpaused sandbox with an already-expired pause deadline. If several callers race, only the first update that flips `Spec.Paused` wins; losing resume callers must not overwrite the winner's placeholder.
+
+After resume, every caller runs `updateConnectTimeout` with `UpdatePolicyExtendOnly`. A later deadline extends the sandbox, while an earlier or stale deadline is skipped. This makes concurrent Connect timeout writes monotonic: final state is the longest effective deadline among the racing requests, and a shorter request cannot shrink a longer timeout even if it finishes later. Running-sandbox Connect also uses `ExtendOnly`, but the resume floor must not apply there.
 
 ### Create Sandbox
 - If `templateID` matches a SandboxSet → claim path (`ClaimSandbox`).
@@ -95,7 +102,7 @@ Every E2B route is registered twice via `RegisterE2BRoute`: once for the native 
 1. **Check E2B spec first**: Read https://github.com/e2b-dev/E2B/blob/main/spec/openapi.yml before changing any endpoint behavior, status codes, or request/response shapes.
 2. **Preserve status code compatibility**: Some E2B endpoints use non-standard codes (e.g. `SetTimeout` returns `500` instead of `400` for validation errors). Do not "fix" these without verifying the E2B spec.
 3. **Keep dual-path registration**: New endpoints must use `RegisterE2BRoute`, not raw `mux.HandleFunc`.
-4. **Timeout rules**: Resume and Connect(Paused→Resume) set timeout strictly to the request value. Connect(Running) is extend-only — cannot shorten. Do not change this unless the product contract changes.
+4. **Timeout rules**: Resume and Connect(Paused→Resume) use the effective timeout after the resume floor, and post-resume Connect timeout writes are extend-only. Connect(Running) is also extend-only and must not apply the resume floor. Do not change this unless the product contract changes.
 5. **Middleware ordering**: `CheckAdminKey` must always come after `CheckApiKey`.
 6. **Model changes**: Request/response types live in `models/`. Keep validation logic in `models/validation.go`.
 

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -41,9 +41,9 @@ import (
 
 // Controller handles sandbox-related operations
 type Controller struct {
-	port             int
-	maxTimeout       int
-	minResumeTimeout int
+	port                  int
+	maxTimeout            int
+	minResumeTimeoutValue int
 
 	// manager params
 	systemNamespace       string // the namespace where the sandbox manager is running
@@ -76,7 +76,7 @@ func NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSe
 		clientConfig:          clientConfig,
 		port:                  port,
 		maxTimeout:            maxTimeout,
-		minResumeTimeout:      minResumeTimeout,
+		minResumeTimeoutValue: minResumeTimeout,
 		systemNamespace:       sysNs, // the namespace where the sandbox manager is running
 		peerSelector:          peerSelector,
 		sandboxNamespace:      sandboxNamespace,

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -41,8 +41,9 @@ import (
 
 // Controller handles sandbox-related operations
 type Controller struct {
-	port       int
-	maxTimeout int
+	port             int
+	maxTimeout       int
+	minResumeTimeout int
 
 	// manager params
 	systemNamespace       string // the namespace where the sandbox manager is running
@@ -68,13 +69,14 @@ type Controller struct {
 }
 
 // NewController creates a new E2B Controller
-func NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSelector string, maxTimeout, maxClaimWorkers, maxCreateQPS int, extProcMaxConcurrency uint32, port, memberlistBindPort int, keyCfg *keys.Config, clientConfig *rest.Config) *Controller {
+func NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSelector string, maxTimeout, minResumeTimeout, maxClaimWorkers, maxCreateQPS int, extProcMaxConcurrency uint32, port, memberlistBindPort int, keyCfg *keys.Config, clientConfig *rest.Config) *Controller {
 	sc := &Controller{
 		mux:                   http.NewServeMux(),
 		domain:                domain,
 		clientConfig:          clientConfig,
 		port:                  port,
 		maxTimeout:            maxTimeout,
+		minResumeTimeout:      minResumeTimeout,
 		systemNamespace:       sysNs, // the namespace where the sandbox manager is running
 		peerSelector:          peerSelector,
 		sandboxNamespace:      sandboxNamespace,

--- a/pkg/servers/e2b/core_test.go
+++ b/pkg/servers/e2b/core_test.go
@@ -72,6 +72,13 @@ func CreateSandboxWithStatus(t *testing.T, c ctrlclient.Client, sbx *agentsv1alp
 }
 
 func Setup(t *testing.T) (*Controller, ctrlclient.Client, func()) {
+	return SetupWithMinResumeTimeout(t, models.DefaultMinResumeTimeoutSeconds)
+}
+
+// SetupWithMinResumeTimeout mirrors Setup but lets the caller override
+// Controller.minResumeTimeout so floor-enforcement assertions can use a
+// non-default value (e.g., 120s with a 60s request to observe the bump).
+func SetupWithMinResumeTimeout(t *testing.T, minResumeTimeout int) (*Controller, ctrlclient.Client, func()) {
 	utils.InitLogOutput()
 	namespace := "sandbox-system"
 
@@ -85,7 +92,7 @@ func Setup(t *testing.T) (*Controller, ctrlclient.Client, func()) {
 	})
 	cache, fc, cacheErr := cachetest.NewTestCache(t)
 	require.NoError(t, cacheErr)
-	controller := NewController("example.com", namespace, "component=sandbox-manager", "", "", models.DefaultMaxTimeout, 10,
+	controller := NewController("example.com", namespace, "component=sandbox-manager", "", "", models.DefaultMaxTimeout, minResumeTimeout, 10,
 		0, 0, TestServerPort, config.DefaultMemberlistBindPort, &keys.Config{
 			Mode:      keys.StorageModeSecret,
 			Namespace: namespace,

--- a/pkg/servers/e2b/models/consts.go
+++ b/pkg/servers/e2b/models/consts.go
@@ -20,6 +20,11 @@ const (
 	DefaultMaxTimeout        = 2592000 // 30 days
 	DefaultMinTimeoutSeconds = 30
 	DefaultTimeoutSeconds    = 300
-	MaxListLimit             = 100
-	MinListLimit             = 1
+	// DefaultMinResumeTimeoutSeconds floors Connect/Resume requests that
+	// trigger Resume on a Paused sandbox, so the placeholder cannot expire
+	// mid-Resume. Tune via --e2b-min-resume-timeout.
+	DefaultMinResumeTimeoutSeconds = 300
+
+	MaxListLimit = 100
+	MinListLimit = 1
 )

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -131,7 +131,7 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 	autoPause, currentEndAt := ParseTimeout(sbx)
 	state, _ := sbx.GetState()
 
-	effectiveTimeout := sc.applyResumeFloor(log, request.TimeoutSeconds, true, !currentEndAt.IsZero())
+	effectiveTimeout := sc.getEffectivePauseTimeSeconds(log, request.TimeoutSeconds, true, !currentEndAt.IsZero())
 	resumeOpts := sc.buildResumeOpts(autoPause, time.Now(), effectiveTimeout, !currentEndAt.IsZero())
 	log.Info("resuming sandbox")
 	if err := sc.manager.ResumeSandbox(ctx, sbx, resumeOpts); err != nil {
@@ -149,12 +149,12 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 	}, nil
 }
 
-// applyResumeFloor bumps `requested` up to sc.minResumeTimeout when the
-// request will trigger Resume on a timed Paused sandbox. The floor prevents
-// the placeholder PauseTime from expiring mid-Resume and triggering an
-// auto-pause race. Never-timeout sandboxes have no PauseTime so the floor
-// is skipped (and would only generate misleading log noise).
-func (sc *Controller) applyResumeFloor(log klog.Logger, requested int, paused, hasDeadline bool) int {
+// getEffectivePauseTimeSeconds enforces a minimum timeout floor when the request
+// will Resume a timed Paused sandbox. Without the floor, a very short timeout
+// could expire while the sandbox is still resuming, causing it to be deleted or
+// hibernated mid-Resume. The floor is skipped for never-timeout sandboxes
+// (hasDeadline == false) since they carry no deadline.
+func (sc *Controller) getEffectivePauseTimeSeconds(log klog.Logger, requested int, paused, hasDeadline bool) int {
 	if !paused || !hasDeadline || requested >= sc.minResumeTimeoutValue {
 		return requested
 	}
@@ -200,7 +200,7 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 	autoPause, currentEndAt := ParseTimeout(sbx)
 
 	paused := state == v1alpha1.SandboxStatePaused
-	effectiveTimeout := sc.applyResumeFloor(log, request.TimeoutSeconds, paused, !currentEndAt.IsZero())
+	effectiveTimeout := sc.getEffectivePauseTimeSeconds(log, request.TimeoutSeconds, paused, !currentEndAt.IsZero())
 
 	// Step 1: Resume the sandbox if it is paused, atomically writing the
 	// placeholder timeout for timed sandboxes.

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -70,6 +70,20 @@ func pauseSandboxErrorCode(err error) int {
 	return http.StatusInternalServerError
 }
 
+// resumeSandboxErrorCode mirrors pauseSandboxErrorCode. The E2B /resume spec
+// permits 401 / 404 / 409 / 500 (no 400), so non-pausable / non-resumable
+// state errors from the infra layer surface as 409 rather than 400.
+func resumeSandboxErrorCode(err error) int {
+	if apierrors.IsNotFound(err) {
+		return http.StatusNotFound
+	}
+	if managererrors.GetErrCode(err) == managererrors.ErrorConflict ||
+		errors.Is(err, cacheutils.ErrWaitTaskConflict) {
+		return http.StatusConflict
+	}
+	return http.StatusInternalServerError
+}
+
 func (sc *Controller) buildPauseTimeoutOptions(sbx infra.Sandbox, now time.Time) timeout.Options {
 	opts := sbx.GetTimeout()
 	// Only set timeout if the sandbox has a timeout configured (not never-timeout)
@@ -91,6 +105,12 @@ func (sc *Controller) buildPauseTimeoutOptions(sbx infra.Sandbox, now time.Time)
 // - Old SDK: first calls SetSandboxTimeout; that path returns 500 on this flow, then falls back to ResumeSandbox.
 //
 // The running-sandbox "extend only" guard is intentionally implemented in ConnectSandbox only.
+//
+// No handler-level state guard is enforced — the infra layer (IsSandboxResumable +
+// first-writer-wins retryUpdate + Ready-cond idempotent short-circuit) is
+// authoritative. A handler guard based on a stale Get would falsely 409 the
+// second of two concurrent Resume requests, mirroring the bug fixed for
+// PauseSandbox in PR #422.
 func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
 	id := r.PathValue("sandboxID")
 	ctx := r.Context()
@@ -107,26 +127,14 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 		return web.ApiResponse[struct{}]{}, apiErr
 	}
 	autoPause, currentEndAt := ParseTimeout(sbx)
-
-	state, reason := sbx.GetState()
-	if state != v1alpha1.SandboxStatePaused {
-		log.Info("skip resume sandbox: sandbox is not paused", "state", state, "reason", reason)
-		return web.ApiResponse[struct{}]{}, &web.ApiError{
-			Code:    http.StatusConflict,
-			Message: fmt.Sprintf("Sandbox %s is not paused", id),
-		}
-	}
+	state, _ := sbx.GetState()
 
 	effectiveTimeout := sc.applyResumeFloor(log, request.TimeoutSeconds, true, !currentEndAt.IsZero())
 	resumeOpts := sc.buildResumeOpts(autoPause, time.Now(), effectiveTimeout, !currentEndAt.IsZero())
 	log.Info("resuming sandbox")
 	if err := sc.manager.ResumeSandbox(ctx, sbx, resumeOpts); err != nil {
-		code := http.StatusInternalServerError
-		if managererrors.GetErrCode(err) == managererrors.ErrorBadRequest {
-			code = http.StatusBadRequest
-		}
 		return web.ApiResponse[struct{}]{}, &web.ApiError{
-			Code:    code,
+			Code:    resumeSandboxErrorCode(err),
 			Message: fmt.Sprintf("Failed to resume sandbox: %v", err),
 		}
 	}
@@ -145,14 +153,14 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 // auto-pause race. Never-timeout sandboxes have no PauseTime so the floor
 // is skipped (and would only generate misleading log noise).
 func (sc *Controller) applyResumeFloor(log klog.Logger, requested int, paused, hasDeadline bool) int {
-	if !paused || !hasDeadline || requested >= sc.minResumeTimeout {
+	if !paused || !hasDeadline || requested >= sc.minResumeTimeoutValue {
 		return requested
 	}
 	log.Info("connect-on-paused timeout floor applied",
 		"requestedSeconds", requested,
-		"effectiveSeconds", sc.minResumeTimeout,
+		"effectiveSeconds", sc.minResumeTimeoutValue,
 		"reason", "request shorter than --e2b-min-resume-timeout")
-	return sc.minResumeTimeout
+	return sc.minResumeTimeoutValue
 }
 
 // buildResumeOpts builds ResumeOptions whose placeholder Timeout is written

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -90,7 +90,6 @@ func (sc *Controller) buildPauseTimeoutOptions(sbx infra.Sandbox, now time.Time)
 // - New SDK: calls ConnectSandbox directly.
 // - Old SDK: first calls SetSandboxTimeout; that path returns 500 on this flow, then falls back to ResumeSandbox.
 //
-// Because ResumeSandbox is only used for the paused->running flow, it always applies the requested timeout directly.
 // The running-sandbox "extend only" guard is intentionally implemented in ConnectSandbox only.
 func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
 	id := r.PathValue("sandboxID")
@@ -108,17 +107,20 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 		return web.ApiResponse[struct{}]{}, apiErr
 	}
 	autoPause, currentEndAt := ParseTimeout(sbx)
-	baseline := sbx.GetTimeout()
 
-	if state, reason := sbx.GetState(); state != v1alpha1.SandboxStatePaused {
+	state, reason := sbx.GetState()
+	if state != v1alpha1.SandboxStatePaused {
 		log.Info("skip resume sandbox: sandbox is not paused", "state", state, "reason", reason)
 		return web.ApiResponse[struct{}]{}, &web.ApiError{
 			Code:    http.StatusConflict,
 			Message: fmt.Sprintf("Sandbox %s is not paused", id),
 		}
 	}
+
+	effectiveTimeout := sc.applyResumeFloor(log, request.TimeoutSeconds, true, !currentEndAt.IsZero())
+	resumeOpts := sc.buildResumeOpts(autoPause, time.Now(), effectiveTimeout, !currentEndAt.IsZero())
 	log.Info("resuming sandbox")
-	if err := sc.manager.ResumeSandbox(ctx, sbx, infra.ResumeOptions{}); err != nil {
+	if err := sc.manager.ResumeSandbox(ctx, sbx, resumeOpts); err != nil {
 		code := http.StatusInternalServerError
 		if managererrors.GetErrCode(err) == managererrors.ErrorBadRequest {
 			code = http.StatusBadRequest
@@ -129,24 +131,40 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 		}
 	}
 
-	// Only set timeout if the sandbox has a timeout configured (not never-timeout).
-	// After resume, the timeout is set strictly to the requested value (no extend-only merge).
-	now := time.Now()
-	if !currentEndAt.IsZero() {
-		opts := sc.buildSetTimeoutOptions(autoPause, now, request.TimeoutSeconds)
-		opts.Baseline = &baseline
-		log.Info("sandbox resumed, resetting sandbox timeout", "timeout", opts)
-		if _, err := sbx.SaveTimeoutWithPolicy(ctx, opts, timeout.UpdatePolicyBaselineAware); err != nil {
-			return web.ApiResponse[struct{}]{}, &web.ApiError{
-				Message: fmt.Sprintf("Failed to set sandbox timeout: %v", err),
-			}
-		}
-	} else {
-		log.Info("skip resetting timeout for never-timeout sandbox")
+	if apiErr := sc.updateConnectTimeout(ctx, sbx, effectiveTimeout, state, autoPause, currentEndAt); apiErr != nil {
+		return web.ApiResponse[struct{}]{}, apiErr
 	}
 	return web.ApiResponse[struct{}]{
 		Code: http.StatusNoContent,
 	}, nil
+}
+
+// applyResumeFloor bumps `requested` up to sc.minResumeTimeout when the
+// request will trigger Resume on a timed Paused sandbox. The floor prevents
+// the placeholder PauseTime from expiring mid-Resume and triggering an
+// auto-pause race. Never-timeout sandboxes have no PauseTime so the floor
+// is skipped (and would only generate misleading log noise).
+func (sc *Controller) applyResumeFloor(log klog.Logger, requested int, paused, hasDeadline bool) int {
+	if !paused || !hasDeadline || requested >= sc.minResumeTimeout {
+		return requested
+	}
+	log.Info("connect-on-paused timeout floor applied",
+		"requestedSeconds", requested,
+		"effectiveSeconds", sc.minResumeTimeout,
+		"reason", "request shorter than --e2b-min-resume-timeout")
+	return sc.minResumeTimeout
+}
+
+// buildResumeOpts builds ResumeOptions whose placeholder Timeout is written
+// atomically with Spec.Paused=false inside Resume() — closing the auto-pause
+// race. Never-timeout sandboxes (hasDeadline == false) get nil so Resume does
+// not convert them into timed sandboxes.
+func (sc *Controller) buildResumeOpts(autoPause bool, now time.Time, effectiveTimeout int, hasDeadline bool) infra.ResumeOptions {
+	if !hasDeadline {
+		return infra.ResumeOptions{}
+	}
+	placeholder := sc.buildSetTimeoutOptions(autoPause, now, effectiveTimeout)
+	return infra.ResumeOptions{Timeout: &placeholder}
 }
 
 func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.Sandbox], *web.ApiError) {
@@ -164,20 +182,23 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 	if apiErr != nil {
 		return web.ApiResponse[*models.Sandbox]{}, apiErr
 	}
-	// `state` is intentionally the pre-connect observation.
-	// We only enforce the extend-only guard for sandboxes that were already running when Connect was called.
-	// Paused->resume requests should always apply the requested timeout directly.
+	// `state` is the pre-connect observation: the extend-only guard at
+	// updateConnectTimeout applies to sandboxes that were already running,
+	// while Paused→resume requests apply the requested timeout (post-floor)
+	// atomically inside Resume.
 	state, pauseResumeReason := sbx.GetState()
 	autoPause, currentEndAt := ParseTimeout(sbx)
-	// Baseline reflects the pre-resume timeout observed in the same Get as `state`.
-	// It is only consumed when preConnectState == Paused (BaselineAware policy).
-	baseline := sbx.GetTimeout()
 
-	// Step 1: Resuming the sandbox if it is paused
+	paused := state == v1alpha1.SandboxStatePaused
+	effectiveTimeout := sc.applyResumeFloor(log, request.TimeoutSeconds, paused, !currentEndAt.IsZero())
+
+	// Step 1: Resume the sandbox if it is paused, atomically writing the
+	// placeholder timeout for timed sandboxes.
 	statusCode := http.StatusOK
-	if state == v1alpha1.SandboxStatePaused {
+	if paused {
 		log.Info("sandbox is paused, will resume it", "reason", pauseResumeReason)
-		if err := sc.manager.ResumeSandbox(ctx, sbx, infra.ResumeOptions{}); err != nil {
+		resumeOpts := sc.buildResumeOpts(autoPause, time.Now(), effectiveTimeout, !currentEndAt.IsZero())
+		if err := sc.manager.ResumeSandbox(ctx, sbx, resumeOpts); err != nil {
 			log.Error(err, "failed to resume sandbox")
 			code := http.StatusInternalServerError
 			if managererrors.GetErrCode(err) == managererrors.ErrorConflict {
@@ -194,9 +215,9 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 		log.Info("sandbox is not paused, skip resuming", "state", state, "reason", pauseResumeReason)
 	}
 
-	// Step 2: Update the sandbox timeout
+	// Step 2: Update the sandbox timeout with the effective (post-floor) value.
 	log.Info("updating sandbox timeout")
-	if err := sc.updateConnectTimeout(ctx, sbx, request.TimeoutSeconds, state, autoPause, currentEndAt, baseline); err != nil {
+	if err := sc.updateConnectTimeout(ctx, sbx, effectiveTimeout, state, autoPause, currentEndAt); err != nil {
 		log.Error(err, "failed to update sandbox timeout")
 		return web.ApiResponse[*models.Sandbox]{}, err
 	}
@@ -208,49 +229,34 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 	}, nil
 }
 
-// updateConnectTimeout updates the sandbox timeout after a Connect or Resume.
-//
-// Policy selection is based on preConnectState:
-//   - Paused  → BaselineAware: the baseline captured at handler entry is guaranteed to be a
-//     pre-resume value because SaveTimeoutWithPolicy is only reachable after Resume() returns,
-//     and Resume() blocks until status.Phase == Running. Therefore any observation of
-//     state ∈ {Paused, Resuming} proves no prior resumer has written a new timeout yet.
-//     BaselineAware compares the current spec timeout against the baseline: if they match,
-//     no concurrent writer has acted and the request may freely overwrite (Always semantics);
-//     if they diverge, a concurrent writer already wrote, so we degrade to ExtendOnly to
-//     preserve the longest timeout.
-//   - Otherwise → ExtendOnly: the sandbox was already running, so we only allow extending
-//     the existing timeout, never shrinking it.
-func (sc *Controller) updateConnectTimeout(ctx context.Context, sbx infra.Sandbox, timeoutSeconds int, preConnectState string, autoPause bool, currentEndAt time.Time, baseline timeout.Options) *web.ApiError {
+// updateConnectTimeout writes the post-Resume / running-sandbox timeout under
+// ExtendOnly so the placeholder written by Resume() naturally extends to the
+// post-Resume value, and concurrent-writer races resolve to the longer
+// timeout. Short-circuits for never-timeout sandboxes.
+func (sc *Controller) updateConnectTimeout(ctx context.Context, sbx infra.Sandbox, timeoutSeconds int, preConnectState string, autoPause bool, currentEndAt time.Time) *web.ApiError {
 	log := klog.FromContext(ctx).WithValues("sandboxID", sbx.GetSandboxID())
 
-	// Rule 1: Sandboxes without endAt are never-timeout, should not have their timeout updated
 	if currentEndAt.IsZero() {
 		log.Info("skip resetting timeout for never-timeout sandbox")
 		return nil
 	}
 
 	now := time.Now()
-	policy := timeout.UpdatePolicyExtendOnly
 	opts := sc.buildSetTimeoutOptions(autoPause, now, timeoutSeconds)
-	if preConnectState == v1alpha1.SandboxStatePaused {
-		policy = timeout.UpdatePolicyBaselineAware
-		opts.Baseline = &baseline
-	}
 
 	log.Info("saving timeout to sandbox", "timeout", opts, "currentEndAt", currentEndAt,
-		"requestedEndAt", TimeAfterSeconds(now, timeoutSeconds), "requestedTimeoutSeconds", timeoutSeconds, "policy", policy)
-	result, err := sbx.SaveTimeoutWithPolicy(ctx, opts, policy)
+		"requestedEndAt", TimeAfterSeconds(now, timeoutSeconds), "requestedTimeoutSeconds", timeoutSeconds,
+		"policy", timeout.UpdatePolicyExtendOnly, "preConnectState", preConnectState)
+	result, err := sbx.SaveTimeoutWithPolicy(ctx, opts, timeout.UpdatePolicyExtendOnly)
 	if err != nil {
 		return &web.ApiError{
 			Message: fmt.Sprintf("Failed to set sandbox timeout: %v", err),
 		}
 	}
 	if !result.Updated {
-		log.Info("skip resetting timeout according to timeout update policy",
+		log.Info("skip resetting timeout according to ExtendOnly policy",
 			"currentEndAt", currentEndAt,
-			"requestedTimeoutSeconds", timeoutSeconds,
-			"policy", policy)
+			"requestedTimeoutSeconds", timeoutSeconds)
 	} else {
 		log.Info("timeout updated", "requestedTimeoutSeconds", timeoutSeconds)
 	}

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -104,7 +104,9 @@ func (sc *Controller) buildPauseTimeoutOptions(sbx infra.Sandbox, now time.Time)
 // - New SDK: calls ConnectSandbox directly.
 // - Old SDK: first calls SetSandboxTimeout; that path returns 500 on this flow, then falls back to ResumeSandbox.
 //
-// The running-sandbox "extend only" guard is intentionally implemented in ConnectSandbox only.
+// The post-Resume timeout write reuses updateConnectTimeout with UpdatePolicyExtendOnly,
+// so the running-sandbox "extend only" semantics apply here as well: a shorter
+// requested timeout never shrinks an existing later deadline.
 //
 // No handler-level state guard is enforced — the infra layer (IsSandboxResumable +
 // first-writer-wins retryUpdate + Ready-cond idempotent short-circuit) is

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -569,6 +569,41 @@ func TestPauseSandboxErrorCode(t *testing.T) {
 	}
 }
 
+func TestResumeSandboxErrorCode(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		expectStatus int
+	}{
+		{
+			name:         "manager conflict returns conflict",
+			err:          managererrors.NewError(managererrors.ErrorConflict, "resume conflict"),
+			expectStatus: http.StatusConflict,
+		},
+		{
+			name:         "wait task conflict returns conflict",
+			err:          fmt.Errorf("resume failed: %w", cacheutils.ErrWaitTaskConflict),
+			expectStatus: http.StatusConflict,
+		},
+		{
+			name:         "kubernetes not found returns not found",
+			err:          apierrors.NewNotFound(schema.GroupResource{Group: agentsv1alpha1.GroupVersion.Group, Resource: "sandboxes"}, "sandbox-id"),
+			expectStatus: http.StatusNotFound,
+		},
+		{
+			name:         "unknown error returns internal server error",
+			err:          errors.New("resume failed"),
+			expectStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectStatus, resumeSandboxErrorCode(tt.err))
+		})
+	}
+}
+
 func TestResumeSandbox(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -580,10 +615,13 @@ func TestResumeSandbox(t *testing.T) {
 		expectStatus int
 	}{
 		{
+			// Running sandboxes succeed idempotently: infra Resume short-circuits
+			// on cond.Ready==True and the handler falls through to ExtendOnly
+			// timeout update (mirrors ConnectSandbox's Running path).
 			name:         "running sandbox",
 			paused:       false,
 			timeout:      300,
-			expectStatus: http.StatusConflict,
+			expectStatus: http.StatusNoContent,
 		},
 		{
 			name:         "resume sandbox: paused",
@@ -594,11 +632,13 @@ func TestResumeSandbox(t *testing.T) {
 			expectStatus: http.StatusNoContent,
 		},
 		{
+			// IsSandboxResumable rejects Paused+!Ready ("SandboxIsPausing") with
+			// ErrorConflict, which resumeSandboxErrorCode maps to 409.
 			name:         "resume sandbox: pausing",
 			paused:       true,
 			pausing:      true,
 			timeout:      300,
-			expectStatus: http.StatusInternalServerError,
+			expectStatus: http.StatusConflict,
 		},
 		{
 			name:         "resume sandbox: resuming",

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -179,6 +179,13 @@ func pauseSandboxHelper(t *testing.T, controller *Controller, client client.Clie
 	}
 }
 
+func setInFlightResumeTimeout(t *testing.T, client client.Client, sandboxID string, endAt time.Time) {
+	sbx := GetSandbox(t, sandboxID, client)
+	sbx.Spec.ShutdownTime = &metav1.Time{Time: endAt}
+	sbx.Spec.PauseTime = nil
+	require.NoError(t, client.Update(t.Context(), sbx))
+}
+
 func waitForResumeUpdate(controller *Controller, waitForResumeHook bool) WhenFunc {
 	return func(sbx *agentsv1alpha1.Sandbox) bool {
 		if sbx.Spec.Paused {
@@ -282,6 +289,11 @@ func TestConnectSandbox(t *testing.T) {
 			if tt.paused {
 				pauseSandboxHelper(t, controller, fc, createResp.Body.SandboxID, tt.pausing, tt.resuming, user)
 			}
+			var inFlightResumeEndAt time.Time
+			if tt.resuming {
+				inFlightResumeEndAt = time.Now().Add(10 * time.Minute).Truncate(time.Second)
+				setInFlightResumeTimeout(t, fc, createResp.Body.SandboxID, inFlightResumeEndAt)
+			}
 
 			if tt.sandboxID == "" {
 				tt.sandboxID = createResp.Body.SandboxID
@@ -311,6 +323,9 @@ func TestConnectSandbox(t *testing.T) {
 				endAt, err := time.Parse(time.RFC3339, connectResp.Body.EndAt)
 				require.NoError(t, err)
 				expectEndAt := now.Add(time.Duration(tt.timeout) * time.Second)
+				if tt.resuming {
+					expectEndAt = inFlightResumeEndAt
+				}
 				assert.WithinDuration(t, expectEndAt, endAt, 5*time.Second,
 					fmt.Sprintf("expect end at: %s, but got %s", expectEndAt, endAt))
 			}
@@ -635,6 +650,11 @@ func TestResumeSandbox(t *testing.T) {
 			if tt.paused {
 				pauseSandboxHelper(t, controller, fc, createResp.Body.SandboxID, tt.pausing, tt.resuming, user)
 			}
+			var inFlightResumeEndAt time.Time
+			if tt.resuming {
+				inFlightResumeEndAt = time.Now().Add(10 * time.Minute).Truncate(time.Second)
+				setInFlightResumeTimeout(t, fc, createResp.Body.SandboxID, inFlightResumeEndAt)
+			}
 
 			if tt.sandboxID == "" {
 				tt.sandboxID = createResp.Body.SandboxID
@@ -670,6 +690,9 @@ func TestResumeSandbox(t *testing.T) {
 				endAt, parseErr := time.Parse(time.RFC3339, describeResp.Body.EndAt)
 				require.NoError(t, parseErr)
 				expectEndAt := now.Add(time.Duration(tt.timeout) * time.Second)
+				if tt.resuming {
+					expectEndAt = inFlightResumeEndAt
+				}
 				assert.WithinDuration(t, expectEndAt, endAt, 5*time.Second,
 					fmt.Sprintf("expect end at: %s, but got %s", expectEndAt, endAt))
 			}
@@ -724,11 +747,11 @@ func TestUpdateConnectTimeout(t *testing.T) {
 			expectUpdated:   true,
 		},
 		{
-			name:            "resumed sandbox (was paused), shorter timeout updates",
+			name:            "resumed sandbox (was paused), shorter timeout is skipped (ExtendOnly)",
 			initialTimeout:  600,
 			timeoutSeconds:  300,
 			preConnectState: agentsv1alpha1.SandboxStatePaused,
-			expectUpdated:   true,
+			expectUpdated:   false,
 		},
 		{
 			name:            "running sandbox with auto-pause, shorter timeout is skipped",
@@ -783,14 +806,13 @@ func TestUpdateConnectTimeout(t *testing.T) {
 			require.NotNil(t, sbx)
 
 			_, currentEndAt := ParseTimeout(sbx)
-			baseline := sbx.GetTimeout()
 			if tt.neverTimeout {
 				currentEndAt = time.Time{}
 			}
 
 			beforeCall := time.Now()
 			result := controller.updateConnectTimeout(req.Context(), sbx, tt.timeoutSeconds,
-				tt.preConnectState, tt.autoPause, currentEndAt, baseline)
+				tt.preConnectState, tt.autoPause, currentEndAt)
 			require.Nil(t, result)
 
 			updatedSbx := GetSandbox(t, createResp.Body.SandboxID, fc)
@@ -827,6 +849,231 @@ func TestUpdateConnectTimeout(t *testing.T) {
 						"ShutdownTime should be unchanged")
 				}
 			}
+		})
+	}
+}
+
+// pickPlaceholderDeadline returns the spec field that buildSetTimeoutOptions
+// populates for a (autoPause) sandbox: PauseTime when auto-pause is enabled,
+// ShutdownTime otherwise.
+func pickPlaceholderDeadline(sbx *agentsv1alpha1.Sandbox, autoPause bool) (*metav1.Time, string) {
+	if autoPause {
+		return sbx.Spec.PauseTime, "PauseTime"
+	}
+	return sbx.Spec.ShutdownTime, "ShutdownTime"
+}
+
+// placeholderAssertion returns the hook the Resume-wait observer fires when
+// it sees Spec.Paused=false. At that instant the Resume mutator has just
+// committed and the e2b handler is still blocked inside Resume's Wait, so the
+// observed payload is the atomic placeholder — proving Resume() wrote
+// Timeout and Spec.Paused=false in the same Update. After asserting the
+// placeholder shape, the hook releases the Wait by flipping Status to Running.
+func placeholderAssertion(beforeT time.Time, neverTimeout, autoPause bool, wantEffective int) func(*testing.T, client.Client, *agentsv1alpha1.Sandbox) {
+	return func(t *testing.T, c client.Client, sbx *agentsv1alpha1.Sandbox) {
+		if neverTimeout {
+			assert.Nil(t, sbx.Spec.PauseTime, "never-timeout sandbox must retain nil PauseTime through Resume")
+			assert.Nil(t, sbx.Spec.ShutdownTime, "never-timeout sandbox must retain nil ShutdownTime through Resume")
+		} else {
+			deadline, field := pickPlaceholderDeadline(sbx, autoPause)
+			if assert.NotNilf(t, deadline, "placeholder %s must be set in the same Update as Paused=false", field) {
+				expectMin := beforeT.Add(time.Duration(wantEffective) * time.Second).Add(-2 * time.Second)
+				expectMax := beforeT.Add(time.Duration(wantEffective) * time.Second).Add(2 * time.Second)
+				assert.False(t, deadline.Time.Before(expectMin),
+					"placeholder %s %s must reflect effectiveTimeout window (>= %s)", field, deadline, expectMin)
+				assert.False(t, deadline.Time.After(expectMax),
+					"placeholder %s %s must reflect effectiveTimeout window (<= %s, before post-Resume slide)", field, deadline, expectMax)
+			}
+		}
+		DoSetSandboxStatus(agentsv1alpha1.SandboxRunning, "", metav1.ConditionTrue)(t, c, sbx)
+	}
+}
+
+// assertFinalDeadline verifies the persisted deadline is bounded by:
+//
+//	beforeT + wantEffective  <= deadline <= beforeT + wantEffective + 30s
+//
+// The lower bound is the placeholder written at Resume entry; the upper
+// bound is the post-Resume ExtendOnly slide (≈ Resume wall-clock duration,
+// with 30s of slack for goroutine scheduling on the fake client).
+func assertFinalDeadline(t *testing.T, final *agentsv1alpha1.Sandbox, autoPause bool, beforeT time.Time, wantEffective int) {
+	t.Helper()
+	expectMin := beforeT.Add(time.Duration(wantEffective) * time.Second).Truncate(time.Second)
+	expectMax := beforeT.Add(time.Duration(wantEffective+30) * time.Second)
+	deadline, _ := pickPlaceholderDeadline(final, autoPause)
+	require.NotNil(t, deadline, "timed sandbox must have the buildSetTimeoutOptions-selected deadline (autoPause=%v)", autoPause)
+	assert.True(t, !deadline.Time.Before(expectMin),
+		"deadline %s must be >= expected min %s (effective=%ds)", deadline, expectMin, wantEffective)
+	assert.True(t, !deadline.Time.After(expectMax),
+		"deadline %s must be <= expected max %s (effective=%ds + ~Resume duration)", deadline, expectMax, wantEffective)
+}
+
+// TestConnectSandbox_ResumeFloorAndPlaceholder covers the four Connect floor
+// + atomic-placeholder scenarios: below-floor / above-floor / never-timeout
+// for paused sandboxes, plus the running case where the floor must not fire.
+func TestConnectSandbox_ResumeFloorAndPlaceholder(t *testing.T) {
+	const minResume = 120
+	templateName := "test-template-floor-connect"
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+	}
+
+	cases := []struct {
+		name           string
+		paused         bool
+		autoPause      bool // false → buildSetTimeoutOptions writes ShutdownTime only
+		neverTimeout   bool // create sandbox as never-timeout via metadata key
+		requestTimeout int
+		// Expected effective timeout after floor enforcement.
+		// For never-timeout this is unused (assertion below skips it).
+		wantEffective int
+		wantStatus    int
+	}{
+		{name: "paused-autopause-below-floor", paused: true, autoPause: true, requestTimeout: 60, wantEffective: minResume, wantStatus: http.StatusCreated},
+		{name: "paused-autopause-above-floor", paused: true, autoPause: true, requestTimeout: 600, wantEffective: 600, wantStatus: http.StatusCreated},
+		{name: "paused-no-autopause-below-floor", paused: true, autoPause: false, requestTimeout: 60, wantEffective: minResume, wantStatus: http.StatusCreated},
+		{name: "paused-never-timeout", paused: true, autoPause: true, neverTimeout: true, requestTimeout: 60, wantStatus: http.StatusCreated},
+		{name: "running-floor-skipped", paused: false, autoPause: true, requestTimeout: 60, wantEffective: 60, wantStatus: http.StatusOK},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			controller, fc, teardown := SetupWithMinResumeTimeout(t, minResume)
+			defer teardown()
+			cleanup := CreateSandboxPool(t, controller, templateName, 1)
+			defer cleanup()
+
+			metadata := map[string]string{
+				models.ExtensionKeySkipInitRuntime: agentsv1alpha1.True,
+			}
+			// Create with a generous timeout so auto-pause is not an issue mid-test.
+			// For never-timeout, set the extension key — Timeout=0 alone falls
+			// back to DefaultTimeoutSeconds in parseCreateSandboxRequest.
+			if tc.neverTimeout {
+				metadata[models.ExtensionKeyNeverTimeout] = agentsv1alpha1.True
+			}
+			createResp, err := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+				Timeout:    600,
+				AutoPause:  tc.autoPause,
+				Metadata:   metadata,
+				TemplateID: templateName,
+			}, nil, user))
+			require.Nil(t, err)
+			sandboxID := createResp.Body.SandboxID
+
+			EnableWaitSim(t, controller, sandboxID)
+
+			if tc.paused {
+				pauseSandboxHelper(t, controller, fc, sandboxID, false, false, user)
+			}
+
+			// beforeConnect must be sampled BEFORE the goroutine launches: the
+			// placeholder assertion compares Spec.PauseTime/ShutdownTime
+			// against (beforeConnect + wantEffective).
+			beforeConnect := time.Now()
+			if tc.paused {
+				hook := placeholderAssertion(beforeConnect, tc.neverTimeout, tc.autoPause, tc.wantEffective)
+				go UpdateSandboxWhen(t, fc, sandboxID, waitForResumeUpdate(controller, true), hook)
+			}
+
+			resp, apiErr := controller.ConnectSandbox(NewRequest(t, nil, models.SetTimeoutRequest{
+				TimeoutSeconds: tc.requestTimeout,
+			}, map[string]string{"sandboxID": sandboxID}, user))
+			require.Nil(t, apiErr)
+			assert.Equal(t, tc.wantStatus, resp.Code)
+
+			final := GetSandbox(t, sandboxID, fc)
+			assert.False(t, final.Spec.Paused, "Spec.Paused must be false after Connect on Paused")
+
+			if tc.neverTimeout {
+				assert.Nil(t, final.Spec.PauseTime, "never-timeout sandbox must retain nil PauseTime")
+				assert.Nil(t, final.Spec.ShutdownTime, "never-timeout sandbox must retain nil ShutdownTime")
+				return
+			}
+			// Running case: the floor is skipped and no Resume occurs;
+			// updateConnectTimeout under ExtendOnly preserves the pre-existing
+			// create-time deadline. "Floor not applied" is already covered by
+			// wantStatus == StatusOK (a Resume would yield 201).
+			if !tc.paused {
+				return
+			}
+			assertFinalDeadline(t, final, tc.autoPause, beforeConnect, tc.wantEffective)
+		})
+	}
+}
+
+// TestResumeSandbox_ResumeFloorAndPlaceholder mirrors
+// TestConnectSandbox_ResumeFloorAndPlaceholder for the legacy ResumeSandbox
+// handler. Non-paused cases are omitted (legacy returns 409). Status code
+// is StatusNoContent.
+func TestResumeSandbox_ResumeFloorAndPlaceholder(t *testing.T) {
+	const minResume = 120
+	templateName := "test-template-floor-resume"
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+	}
+
+	cases := []struct {
+		name           string
+		autoPause      bool
+		neverTimeout   bool
+		requestTimeout int
+		wantEffective  int
+	}{
+		{name: "paused-autopause-below-floor", autoPause: true, requestTimeout: 60, wantEffective: minResume},
+		{name: "paused-autopause-above-floor", autoPause: true, requestTimeout: 600, wantEffective: 600},
+		{name: "paused-no-autopause-below-floor", autoPause: false, requestTimeout: 60, wantEffective: minResume},
+		{name: "paused-never-timeout", autoPause: true, neverTimeout: true, requestTimeout: 60},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			controller, fc, teardown := SetupWithMinResumeTimeout(t, minResume)
+			defer teardown()
+			cleanup := CreateSandboxPool(t, controller, templateName, 1)
+			defer cleanup()
+
+			metadata := map[string]string{
+				models.ExtensionKeySkipInitRuntime: agentsv1alpha1.True,
+			}
+			if tc.neverTimeout {
+				metadata[models.ExtensionKeyNeverTimeout] = agentsv1alpha1.True
+			}
+			createResp, err := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+				Timeout:    600,
+				AutoPause:  tc.autoPause,
+				Metadata:   metadata,
+				TemplateID: templateName,
+			}, nil, user))
+			require.Nil(t, err)
+			sandboxID := createResp.Body.SandboxID
+
+			EnableWaitSim(t, controller, sandboxID)
+			pauseSandboxHelper(t, controller, fc, sandboxID, false, false, user)
+
+			beforeResume := time.Now()
+			hook := placeholderAssertion(beforeResume, tc.neverTimeout, tc.autoPause, tc.wantEffective)
+			go UpdateSandboxWhen(t, fc, sandboxID, waitForResumeUpdate(controller, true), hook)
+
+			resp, apiErr := controller.ResumeSandbox(NewRequest(t, nil, models.SetTimeoutRequest{
+				TimeoutSeconds: tc.requestTimeout,
+			}, map[string]string{"sandboxID": sandboxID}, user))
+			require.Nil(t, apiErr)
+			assert.Equal(t, http.StatusNoContent, resp.Code)
+
+			final := GetSandbox(t, sandboxID, fc)
+			assert.False(t, final.Spec.Paused, "Spec.Paused must be false after Resume")
+
+			if tc.neverTimeout {
+				assert.Nil(t, final.Spec.PauseTime, "never-timeout sandbox must retain nil PauseTime")
+				assert.Nil(t, final.Spec.ShutdownTime, "never-timeout sandbox must retain nil ShutdownTime")
+				return
+			}
+			assertFinalDeadline(t, final, tc.autoPause, beforeResume, tc.wantEffective)
 		})
 	}
 }

--- a/pkg/servers/e2b/timeout_test.go
+++ b/pkg/servers/e2b/timeout_test.go
@@ -293,81 +293,11 @@ func TestSetSandboxTimeoutStillShortensRunningSandbox(t *testing.T) {
 	assert.WithinDuration(t, beforeSet.Add(time.Duration(shorterSeconds)*time.Second), sbx.Spec.ShutdownTime.Time, 5*time.Second)
 }
 
-func TestUpdateConnectTimeoutBaselinePolicy(t *testing.T) {
-	templateName := "test-update-connect-timeout-pause-baseline"
-	user := &models.CreatedTeamAPIKey{
-		ID:   keys.AdminKeyID,
-		Key:  InitKey,
-		Name: "admin",
-	}
-
-	tests := []struct {
-		name               string
-		currentTimeout     int
-		requestTimeout     int
-		changeCurrentAfter bool
-		updatedTimeout     int
-		expectedTimeout    int
-	}{
-		{
-			name:            "matching baseline resets to requested timeout",
-			currentTimeout:  600,
-			requestTimeout:  300,
-			expectedTimeout: 300,
-		},
-		{
-			name:               "mismatched baseline uses extend only and skips shorter timeout",
-			currentTimeout:     600,
-			requestTimeout:     300,
-			changeCurrentAfter: true,
-			updatedTimeout:     900,
-			expectedTimeout:    900,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			controller, fc, teardown := Setup(t)
-			defer teardown()
-
-			cleanup := CreateSandboxPool(t, controller, templateName, 1)
-			defer cleanup()
-
-			createResp, err := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
-				TemplateID: templateName,
-				Timeout:    tt.currentTimeout,
-				Metadata: map[string]string{
-					models.ExtensionKeySkipInitRuntime: v1alpha1.True,
-				},
-			}, nil, user))
-			require.Nil(t, err)
-
-			req := NewRequest(t, nil, nil, map[string]string{
-				"sandboxID": createResp.Body.SandboxID,
-			}, user)
-			wrapped, apiErr := controller.getSandboxOfUser(req.Context(), createResp.Body.SandboxID)
-			require.Nil(t, apiErr)
-			baseline := wrapped.GetTimeout()
-
-			if tt.changeCurrentAfter {
-				sbx := GetSandbox(t, createResp.Body.SandboxID, fc)
-				sbx.Spec.ShutdownTime = &metav1.Time{Time: time.Now().Add(time.Duration(tt.updatedTimeout) * time.Second)}
-				require.NoError(t, fc.Update(t.Context(), sbx))
-			}
-
-			beforeCall := time.Now()
-			errResp := controller.updateConnectTimeout(req.Context(), wrapped, tt.requestTimeout,
-				v1alpha1.SandboxStatePaused, false, beforeCall.Add(time.Duration(tt.currentTimeout)*time.Second), baseline)
-			require.Nil(t, errResp)
-
-			updatedSbx := GetSandbox(t, createResp.Body.SandboxID, fc)
-			require.NotNil(t, updatedSbx.Spec.ShutdownTime)
-			assert.WithinDuration(t, beforeCall.Add(time.Duration(tt.expectedTimeout)*time.Second), updatedSbx.Spec.ShutdownTime.Time, 5*time.Second)
-		})
-	}
-}
-
-func TestResumeSandboxBaselinePreventsStaleConnectTimeout(t *testing.T) {
+// TestResumeSandboxExtendOnlyPreventsStaleConnectTimeout verifies that after
+// Resume sets a longer timeout, a subsequent updateConnectTimeout call with a
+// shorter requested value does NOT shrink the deadline — the ExtendOnly
+// policy (now the only post-Resume policy) preserves the longer timeout.
+func TestResumeSandboxExtendOnlyPreventsStaleConnectTimeout(t *testing.T) {
 	tests := []struct {
 		name                  string
 		templateName          string
@@ -376,8 +306,8 @@ func TestResumeSandboxBaselinePreventsStaleConnectTimeout(t *testing.T) {
 		connectTimeoutSeconds int
 	}{
 		{
-			name:                  "stale paused connect baseline does not shorten timeout set by resume",
-			templateName:          "test-resume-sandbox-baseline-stale-connect-timeout",
+			name:                  "stale paused connect does not shorten timeout set by resume",
+			templateName:          "test-resume-sandbox-stale-connect-timeout",
 			initialTimeoutSeconds: 600,
 			resumeTimeoutSeconds:  900,
 			connectTimeoutSeconds: 300,
@@ -414,9 +344,6 @@ func TestResumeSandboxBaselinePreventsStaleConnectTimeout(t *testing.T) {
 			}, map[string]string{
 				"sandboxID": createResp.Body.SandboxID,
 			}, user)
-			wrappedBeforeResume, getErr := controller.getSandboxOfUser(req.Context(), createResp.Body.SandboxID)
-			require.Nil(t, getErr)
-			baseline := wrappedBeforeResume.GetTimeout()
 
 			go UpdateSandboxWhen(t, fc, createResp.Body.SandboxID, func(sbx *v1alpha1.Sandbox) bool {
 				return sbx.Spec.Paused == false
@@ -432,7 +359,7 @@ func TestResumeSandboxBaselinePreventsStaleConnectTimeout(t *testing.T) {
 			wrapped, getErr := controller.getSandboxOfUser(req.Context(), createResp.Body.SandboxID)
 			require.Nil(t, getErr)
 			errResp := controller.updateConnectTimeout(req.Context(), wrapped, tt.connectTimeoutSeconds,
-				v1alpha1.SandboxStatePaused, false, afterFirstCall.Spec.ShutdownTime.Time, baseline)
+				v1alpha1.SandboxStatePaused, false, afterFirstCall.Spec.ShutdownTime.Time)
 			require.Nil(t, errResp)
 
 			afterSecondCall := GetSandbox(t, createResp.Body.SandboxID, fc)

--- a/pkg/utils/timeout/timeout_test.go
+++ b/pkg/utils/timeout/timeout_test.go
@@ -134,24 +134,6 @@ func TestEqual(t *testing.T) {
 			},
 			want: false,
 		},
-		{
-			name: "Baseline ignored",
-			a: Options{
-				ShutdownTime: base.Add(time.Minute),
-				PauseTime:    base.Add(2 * time.Minute),
-				Baseline: &Options{
-					ShutdownTime: base.Add(3 * time.Minute),
-				},
-			},
-			b: Options{
-				ShutdownTime: base.Add(time.Minute),
-				PauseTime:    base.Add(2 * time.Minute),
-				Baseline: &Options{
-					PauseTime: base.Add(4 * time.Minute),
-				},
-			},
-			want: true,
-		},
 	}
 
 	for _, tt := range tests {
@@ -222,34 +204,22 @@ func TestShouldExtendTimeout(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "Same effective end time with different baselines does not extend",
+			name: "Same effective end time does not extend",
 			current: Options{
 				ShutdownTime: now.Add(time.Minute),
-				Baseline: &Options{
-					ShutdownTime: now.Add(3 * time.Minute),
-				},
 			},
 			requested: Options{
 				ShutdownTime: now.Add(time.Minute),
-				Baseline: &Options{
-					ShutdownTime: now.Add(4 * time.Minute),
-				},
 			},
 			want: false,
 		},
 		{
-			name: "Later effective end time extends despite different baselines",
+			name: "Later effective end time extends",
 			current: Options{
 				ShutdownTime: now.Add(time.Minute),
-				Baseline: &Options{
-					PauseTime: now.Add(3 * time.Minute),
-				},
 			},
 			requested: Options{
 				ShutdownTime: now.Add(2 * time.Minute),
-				Baseline: &Options{
-					PauseTime: now.Add(4 * time.Minute),
-				},
 			},
 			want: true,
 		},

--- a/pkg/utils/timeout/types.go
+++ b/pkg/utils/timeout/types.go
@@ -22,15 +22,11 @@ import "time"
 type Options struct {
 	ShutdownTime time.Time
 	PauseTime    time.Time
-	// Baseline is the timeout state the caller observed before issuing this update.
-	// Consulted only when the policy passed to SaveTimeoutWithPolicy is BaselineAware.
-	Baseline *Options `json:"-"`
 }
 
 type UpdatePolicy string
 
 const (
-	UpdatePolicyAlways        UpdatePolicy = "Always"
-	UpdatePolicyExtendOnly    UpdatePolicy = "ExtendOnly"
-	UpdatePolicyBaselineAware UpdatePolicy = "BaselineAware"
+	UpdatePolicyAlways     UpdatePolicy = "Always"
+	UpdatePolicyExtendOnly UpdatePolicy = "ExtendOnly"
 )

--- a/test/e2b/test_sandbox.py
+++ b/test/e2b/test_sandbox.py
@@ -1,7 +1,9 @@
+import json
+import subprocess
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from dateutil.tz import tzutc
@@ -9,6 +11,24 @@ from e2b.exceptions import NotFoundException
 from e2b_code_interpreter import Sandbox, SandboxQuery, SandboxState
 
 from utils import list_sandbox, connect_sandbox, run_code_sandbox
+
+
+def _get_sandbox_spec(name: str) -> dict:
+    """Fetch the live Spec of a Sandbox CR by name (post `--` portion of sandbox_id)."""
+    result = subprocess.run(
+        ["kubectl", "get", "sbx", name, "-o", "json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout).get("spec", {})
+
+
+def _parse_rfc3339_utc(s: str) -> datetime:
+    """Parse an RFC3339 timestamp (with or without trailing Z) into a UTC-aware datetime."""
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    return datetime.fromisoformat(s).astimezone(timezone.utc)
 
 
 # Link: https://e2b.dev/docs/sandbox
@@ -158,6 +178,91 @@ def test_connect_shorter_timeout(sandbox_context):
 
     # For running sandboxes, connect(timeout=<shorter>) must not shorten endAt.
     assert info_after.end_at == info_before.end_at
+
+
+def test_auto_pause_resume_no_immediate_repause(sandbox_context):
+    """Connect after auto-pause must leave the sandbox running through the
+    stability window: the Connect path replaces the expired PauseTime with
+    the requested running deadline, and the next reconcile must respect it.
+    """
+    auto_pause_timeout_seconds = 30
+    sbx: Sandbox = sandbox_context.add(Sandbox.create(
+        template="code-interpreter",
+        timeout=auto_pause_timeout_seconds,
+        lifecycle={"on_timeout": "pause"},
+        metadata={"test_case": "test_auto_pause_resume_no_immediate_repause"},
+        headers={
+            "x-request-id": sandbox_context.request_id
+        }
+    ))
+    print(f"sandbox-id: {sbx.sandbox_id}")
+    sandbox_name = sbx.sandbox_id.split("--")[1]
+
+    # Step 1: wait for the controller to auto-pause the sandbox.
+    pause_deadline = time.time() + auto_pause_timeout_seconds + 60
+    paused = False
+    while time.time() < pause_deadline:
+        info = sbx.get_info()
+        if info.state == SandboxState.PAUSED:
+            paused = True
+            print(f"sandbox auto-paused: {sandbox_name} state={info.state}")
+            break
+        time.sleep(2)
+    assert paused, f"sandbox {sandbox_name} did not auto-pause within deadline"
+
+    # Step 2: assert auto-pause took effect.
+    spec = _get_sandbox_spec(sandbox_name)
+    assert spec.get("paused") is True, (
+        f"spec.paused must be true after auto-pause; got spec={spec}"
+    )
+    pause_time_str = spec.get("pauseTime")
+    assert pause_time_str, "spec.pauseTime must remain non-nil after auto-pause"
+
+    # Step 3: resume via E2B Connect with an explicit timeout. Record the
+    # wall-clock window that brackets the server's `now`, so we can bound the
+    # post-Connect Spec.PauseTime (= serverNow + connect_timeout for autoPause).
+    connect_timeout_seconds = 600
+    connect_start = datetime.now(timezone.utc)
+    connect_sandbox(sbx, timeout=connect_timeout_seconds)
+    connect_end = datetime.now(timezone.utc)
+
+    info = sbx.get_info()
+    assert info.state == SandboxState.RUNNING, (
+        f"sandbox should be RUNNING after resume; got {info.state}"
+    )
+
+    # Step 4: stability window — controller must NOT immediately re-pause.
+    stability_seconds = 15
+    poll_interval = 2
+    deadline = time.time() + stability_seconds
+    while time.time() < deadline:
+        info = sbx.get_info()
+        assert info.state == SandboxState.RUNNING, (
+            f"sandbox got re-paused unexpectedly during stability window; "
+            f"state={info.state}"
+        )
+        time.sleep(poll_interval)
+
+    # Step 5: confirm final spec is consistent — paused=false and pauseTime
+    # lands in the narrow [connect_start, connect_end] + connect_timeout window
+    # (a stale 5-min-old pauseTime would also be "in the future" — the bound
+    # below proves it's the freshly-written deadline, not a leftover).
+    spec_after = _get_sandbox_spec(sandbox_name)
+    assert not spec_after.get("paused"), (
+        f"spec.paused should be false after resume; got spec={spec_after}"
+    )
+    pause_time_after_str = spec_after.get("pauseTime")
+    assert pause_time_after_str, "spec.pauseTime must remain non-nil after resume"
+    pause_time_after = _parse_rfc3339_utc(pause_time_after_str)
+
+    skew_tolerance = timedelta(seconds=10)
+    expected_min = connect_start + timedelta(seconds=connect_timeout_seconds) - skew_tolerance
+    expected_max = connect_end + timedelta(seconds=connect_timeout_seconds) + skew_tolerance
+    assert expected_min <= pause_time_after <= expected_max, (
+        f"spec.pauseTime should be ~connect_start + {connect_timeout_seconds}s; "
+        f"got {pause_time_after_str}, expected in [{expected_min.isoformat()}, "
+        f"{expected_max.isoformat()}]"
+    )
 
 
 def test_pause_connect_kill(sandbox_context):

--- a/test/e2b/test_sandbox.py
+++ b/test/e2b/test_sandbox.py
@@ -4,6 +4,7 @@ import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
+from importlib.metadata import version as _pkg_version
 
 import pytest
 from dateutil.tz import tzutc
@@ -11,6 +12,11 @@ from e2b.exceptions import NotFoundException
 from e2b_code_interpreter import Sandbox, SandboxQuery, SandboxState
 
 from utils import list_sandbox, connect_sandbox, run_code_sandbox
+
+# e2b-code-interpreter 2.4.x predates the `lifecycle={"on_timeout": "pause"}`
+# parameter, so auto-pause cannot be requested through that SDK.
+_E2B_CODE_INTERPRETER_VERSION = _pkg_version("e2b-code-interpreter")
+_SDK_LACKS_AUTO_PAUSE = _E2B_CODE_INTERPRETER_VERSION.startswith("2.4.")
 
 
 def _get_sandbox_spec(name: str) -> dict:
@@ -180,6 +186,13 @@ def test_connect_shorter_timeout(sandbox_context):
     assert info_after.end_at == info_before.end_at
 
 
+@pytest.mark.skipif(
+    _SDK_LACKS_AUTO_PAUSE,
+    reason=(
+        f"e2b-code-interpreter {_E2B_CODE_INTERPRETER_VERSION} does not support "
+        "lifecycle={'on_timeout': 'pause'}; auto-pause cannot be exercised."
+    ),
+)
 def test_auto_pause_resume_no_immediate_repause(sandbox_context):
     """Connect after auto-pause must leave the sandbox running through the
     stability window: the Connect path replaces the expired PauseTime with

--- a/test/e2b/utils.py
+++ b/test/e2b/utils.py
@@ -36,7 +36,14 @@ def connect_sandbox(sbx: Sandbox, timeout: Optional[int] = None) -> Sandbox | No
                 return sbx.connect()
         except Exception as e:
             error_msg = str(e)
-            if "sandbox is pausing, please wait a moment and try again" in error_msg:
+            # Server-side pausing-state errors. The legacy phrasing predates
+            # commit a83587ed (#358); the current phrasing comes from
+            # IsSandboxResumable returning "SandboxIsPausing".
+            is_pausing = (
+                "sandbox is pausing, please wait a moment and try again" in error_msg
+                or "sandbox is not resumable, reason: SandboxIsPausing" in error_msg
+            )
+            if is_pausing:
                 if attempt < max_retries - 1:
                     print(f"Sandbox is pausing, waiting {retry_interval}s before retry... (attempt {attempt + 1}/{max_retries})")
                     time.sleep(retry_interval)


### PR DESCRIPTION
## Summary

The controller's auto-pause branch used to patch `Spec.Paused=true` without coordinating with the asymmetric `Resume()` in sandbox-manager (which used to flip `Paused=false` first and write the new `PauseTime` later, in a separate update). Between those two writes, the next reconcile observed `{Paused=false, PauseTime=stale}` and immediately re-paused the sandbox, breaking Resume.

This PR closes the race at the source — `Resume()` now writes `Paused=false` together with a placeholder timeout in a single Sandbox update — and tightens the controller-side patch to surface lost races cleanly. With the source-side fix in place, the previously-planned controller grace gate (`canFlipPausedTrue` + 30s Ready-stability window) is no longer needed and the `UpdatePolicyBaselineAware` workaround is removed.

## Changes

### sandbox-manager Resume atomicity (`pkg/sandbox-manager/infra/{interface.go,sandboxcr/sandbox.go}`)

- `ResumeOptions` gains `Timeout *timeout.Options`. When set, `Resume()` writes `Spec.Paused=false` AND the placeholder `Spec.PauseTime` / `Spec.ShutdownTime` in the same `Update` (inside the existing `retryUpdate` mutator). The controller can no longer observe a stale deadline post-Resume.
- Mutator preserves first-writer-wins: only the caller that actually flips `Paused: true→false` writes the placeholder; losing concurrent callers short-circuit and never overwrite the winner's deadline.
- Never-timeout sandboxes pass `Timeout == nil` so Resume does not invent a deadline for them.

### Controller auto-pause patch (`pkg/controller/sandbox/sandbox_controller.go`)

- The auto-pause patch uses `client.MergeFromWithOptimisticLock`. A lost OCC race now surfaces as 409 → `Requeue: true` instead of silently overwriting concurrent state.
- `pauseTimeReached(pauseTime, now)` helper extracted; treats equal-time as due (`<=`).
- Branch only schedules `RequeueAfter` for a future PauseTime; if the time is reached, the patch is the only action — no partial writes.

### E2B handler timeout floor (`pkg/servers/e2b/{pause_resume.go,core.go,models/consts.go}`)

- New `applyResumeFloor`: bumps the requested timeout up to `--e2b-min-resume-timeout` (default 300s) when the request will trigger a Resume on a timed paused sandbox. Skipped for never-timeout sandboxes and for Running-state Connect.
- New `buildResumeOpts`: builds the atomic placeholder for `Resume()`; returns empty opts for never-timeout sandboxes so Resume stays a no-op write on those.
- Post-Resume timeout write goes through `updateConnectTimeout` with `UpdatePolicyExtendOnly`. Concurrent Connect/Resume callers therefore converge to the longest effective deadline; a shorter request cannot shrink a longer in-flight deadline.
- `ResumeSandbox` is now idempotent: an already-Running sandbox returns 204 instead of 409. `resumeSandboxErrorCode` maps NotFound → 404 and infra/cache conflict → 409 per the E2B `/resume` spec (no 400).

### Removed: `UpdatePolicyBaselineAware` (`pkg/utils/timeout/types.go`)

The Baseline-aware policy was introduced earlier to detect concurrent writers on a single timeout update; the atomic Resume placeholder + ExtendOnly post-write supersede it. The policy, the `Options.Baseline` field, and the associated tests are removed.

### CLI flag (`cmd/sandbox-manager/main.go`)

`--e2b-min-resume-timeout` (default 300s) with `validateE2BTimeoutFlags` (must be > 0 and <= `--e2b-max-timeout`).

### Docs

`pkg/servers/e2b/AGENTS.md` updated to match the new timeout semantics (atomic Resume placeholder, ExtendOnly post-Resume, no resume floor for running-state Connect).

## Tests

**Unit**
- `pkg/controller/sandbox/sandbox_controller_test.go`
  - `TestSandboxReconciler_AutoPauseBranch` (table-driven, 3 cases): OCC conflict -> Requeue with spec unchanged; successful patch persists `Paused=true`; future PauseTime -> `RequeueAfter` only.
  - `TestPauseTimeReached` (table-driven, 3 cases): past / equal / future.
- `pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go`
  - `TestSandbox_ResumeMutatorAtomicity`: placeholder + Paused=false are written in the same Update.
  - `TestSandbox_ResumeExtendOnlyConcurrent`: losing caller does not overwrite the winner's deadline.
  - `TestSandbox_ResumeFailurePathsLeaveRealTimeout`: failure paths do not clobber existing timeout state.
- `pkg/servers/e2b/pause_resume_test.go`
  - `TestResumeSandboxErrorCode` (table-driven): 404/409/500 mapping.
  - `TestConnectSandbox_ResumeFloorAndPlaceholder`, `TestResumeSandbox_ResumeFloorAndPlaceholder`: floor application + placeholder build.
- `cmd/sandbox-manager/main_test.go`: `TestValidateE2BTimeoutFlags` (table-driven): boundary cases for the new flag.

**E2E**
- `test/e2b/test_sandbox.py::test_auto_pause_resume_no_immediate_repause`:
  1. Create sandbox with `lifecycle={"on_timeout": "pause"}, timeout=30`.
  2. Wait for `Spec.Paused=true`.
  3. `connect_sandbox(sbx, timeout=600)`.
  4. Assert `state == RUNNING` for 15s after connect (no immediate re-pause).
  5. Assert `Spec.PauseTime ~ connect_start + 600s` (fresh deadline written by Resume, not stale leftover).

## Test plan

- [x] `go test ./pkg/controller/sandbox/... ./pkg/sandbox-manager/infra/sandboxcr/... ./pkg/servers/e2b/... ./pkg/utils/timeout/... ./cmd/sandbox-manager/...`
- [x] `go build ./...`
- [ ] E2E pytest against a Kind cluster (`make test-e2b`)
- [ ] Soak in staging: manual pause/resume and explicit `SetTimeout` paths must remain unaffected

## Out of scope

- Cross-replica route propagation through `syncRoute` gossip on the controller-driven path (separate from this fix).
- Refactoring `SaveTimeoutWithPolicy`'s retry loop to share with `retryUpdate` and switch to `APIReader`-on-conflict (raised in PR #358 review; revisit when the e2b layer adds more policies).
