### PR TITLE
feat(e2b): return pod ip metadata

### DIFF
--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/features"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
@@ -302,6 +303,9 @@ func (sc *Controller) basicSandboxCreateModifier(ctx context.Context, sbx infra.
 	}
 	for k, v := range request.Metadata {
 		annotations[k] = v
+	}
+	if request.Extensions.ReturnPodIP {
+		annotations[models.ExtensionKeyReturnPodIP] = agentsv1alpha1.True
 	}
 	sbx.SetAnnotations(annotations)
 

--- a/pkg/servers/e2b/models/extensions.go
+++ b/pkg/servers/e2b/models/extensions.go
@@ -58,6 +58,8 @@ const (
 	ExtensionKeyReserveFailedSandboxFor       = v1alpha1.E2BPrefix + "reserve-failed-sandbox-for"
 	ExtensionKeyCreateOnNoStock               = v1alpha1.E2BPrefix + "create-on-no-stock"
 	ExtensionKeyNeverTimeout                  = v1alpha1.E2BPrefix + "never-timeout"
+	ExtensionKeyReturnPodIP                   = v1alpha1.E2BPrefix + "return-pod-ip"
+	MetadataKeyPodIP                          = v1alpha1.E2BPrefix + "pod-ip"
 )
 
 const (
@@ -102,10 +104,12 @@ func (r *NewSandboxRequest) parseCommonExtensions() error {
 	}
 	r.Extensions.CreateOnNoStock = r.Metadata[ExtensionKeyCreateOnNoStock] != v1alpha1.False
 	r.Extensions.NeverTimeout = r.Metadata[ExtensionKeyNeverTimeout] == v1alpha1.True
+	r.Extensions.ReturnPodIP = r.Metadata[ExtensionKeyReturnPodIP] == v1alpha1.True
 	delete(r.Metadata, ExtensionKeySkipInitRuntime)
 	delete(r.Metadata, ExtensionKeyReserveFailedSandbox)
 	delete(r.Metadata, ExtensionKeyCreateOnNoStock)
 	delete(r.Metadata, ExtensionKeyNeverTimeout)
+	delete(r.Metadata, ExtensionKeyReturnPodIP)
 	if r.Extensions.TimeoutSeconds, err = r.parseAndRemoveIntExtension(ExtensionKeyClaimTimeout); err != nil {
 		return err
 	}

--- a/pkg/servers/e2b/models/extensions.go
+++ b/pkg/servers/e2b/models/extensions.go
@@ -58,8 +58,8 @@ const (
 	ExtensionKeyReserveFailedSandboxFor       = v1alpha1.E2BPrefix + "reserve-failed-sandbox-for"
 	ExtensionKeyCreateOnNoStock               = v1alpha1.E2BPrefix + "create-on-no-stock"
 	ExtensionKeyNeverTimeout                  = v1alpha1.E2BPrefix + "never-timeout"
-	ExtensionKeyReturnPodIP                   = v1alpha1.E2BPrefix + "return-pod-ip"
-	MetadataKeyPodIP                          = v1alpha1.E2BPrefix + "pod-ip"
+	ExtensionKeyReturnPodIP                   = v1alpha1.E2BPrefix + "return-sandbox-ip"
+	MetadataKeyPodIP                          = v1alpha1.E2BPrefix + "sandbox-ip"
 )
 
 const (

--- a/pkg/servers/e2b/models/extensions_test.go
+++ b/pkg/servers/e2b/models/extensions_test.go
@@ -169,6 +169,27 @@ func TestParseExtensions(t *testing.T) {
 			},
 		},
 		{
+			name: "return pod ip == true",
+			metadata: map[string]string{
+				ExtensionKeyReturnPodIP: v1alpha1.True,
+			},
+			wantErr: false,
+			expectExtension: NewSandboxRequestExtension{
+				CreateOnNoStock: true,
+				ReturnPodIP:     true,
+			},
+		},
+		{
+			name: "return pod ip == false",
+			metadata: map[string]string{
+				ExtensionKeyReturnPodIP: v1alpha1.False,
+			},
+			wantErr: false,
+			expectExtension: NewSandboxRequestExtension{
+				CreateOnNoStock: true,
+			},
+		},
+		{
 			name: "invalid image extension",
 			metadata: map[string]string{
 				ExtensionKeyClaimWithImage: "invalid:image:name",

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -69,6 +69,7 @@ type NewSandboxRequestExtension struct {
 	WaitReadySeconds        int
 	TimeoutSeconds          int
 	NeverTimeout            bool
+	ReturnPodIP             bool
 	Labels                  map[string]string
 }
 

--- a/pkg/servers/e2b/sandbox.go
+++ b/pkg/servers/e2b/sandbox.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
@@ -97,6 +98,11 @@ func (sc *Controller) convertToE2BSandbox(sbx infra.Sandbox, accessToken string)
 	for key, val := range annotations {
 		if ValidateMetadataKey(key) {
 			sandbox.Metadata[key] = val
+		}
+	}
+	if annotations[models.ExtensionKeyReturnPodIP] == agentsv1alpha1.True {
+		if ip := sbx.GetRoute().IP; ip != "" {
+			sandbox.Metadata[models.MetadataKeyPodIP] = ip
 		}
 	}
 

--- a/pkg/servers/e2b/sandbox_test.go
+++ b/pkg/servers/e2b/sandbox_test.go
@@ -18,10 +18,14 @@ package e2b
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 )
 
@@ -94,6 +98,76 @@ func TestGetNamespaceOfUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.namespace, controller.getNamespaceOfUser(tt.user))
+		})
+	}
+}
+
+func TestConvertToE2BSandboxPodIPMetadata(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		podIP       string
+		expectKey   bool
+		expectValue string
+	}{
+		{
+			name:  "disabled does not return pod ip metadata",
+			podIP: "1.2.3.4",
+		},
+		{
+			name: "enabled returns pod ip metadata",
+			annotations: map[string]string{
+				models.ExtensionKeyReturnPodIP: agentsv1alpha1.True,
+			},
+			podIP:       "1.2.3.4",
+			expectKey:   true,
+			expectValue: "1.2.3.4",
+		},
+		{
+			name: "enabled skips pod ip metadata when pod ip is empty",
+			annotations: map[string]string{
+				models.ExtensionKeyReturnPodIP: agentsv1alpha1.True,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotations := map[string]string{
+				agentsv1alpha1.AnnotationClaimTime: now.Format(time.RFC3339),
+			}
+			for k, v := range tt.annotations {
+				annotations[k] = v
+			}
+			sbx := &sandboxcr.Sandbox{
+				Sandbox: &agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "sandbox-1",
+						Namespace:   "default",
+						Annotations: annotations,
+					},
+					Status: agentsv1alpha1.SandboxStatus{
+						Phase: agentsv1alpha1.SandboxRunning,
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(agentsv1alpha1.SandboxConditionReady),
+								Status: metav1.ConditionTrue,
+							},
+						},
+						PodInfo: agentsv1alpha1.PodInfo{
+							PodIP: tt.podIP,
+						},
+					},
+				},
+			}
+
+			got := (&Controller{}).convertToE2BSandbox(sbx, "")
+			value, exists := got.Metadata[models.MetadataKeyPodIP]
+			assert.Equal(t, tt.expectKey, exists)
+			if tt.expectKey {
+				assert.Equal(t, tt.expectValue, value)
+			}
 		})
 	}
 }

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -252,7 +252,7 @@ func TestCreateSandbox(t *testing.T) {
 				},
 			},
 			postCheck: func(t *testing.T, resp *models.Sandbox) {
-				assert.Empty(t, resp.EndAt)
+				assert.Equal(t, "0001-01-01T00:00:00Z", resp.EndAt)
 				sbx, err := controller.manager.GetClaimedSandbox(t.Context(), keys.AdminKeyID.String(), infra.GetClaimedSandboxOptions{
 					SandboxID: resp.SandboxID,
 				})
@@ -446,6 +446,24 @@ func TestCreateSandbox(t *testing.T) {
 				assert.NotContains(t, sbx.Spec.Template.Labels, "another-metadata")
 			},
 		},
+		{
+			name:      "success with return pod ip metadata",
+			available: 1,
+			userName:  "test-user",
+			request: models.NewSandboxRequest{
+				TemplateID: templateName,
+				Metadata: map[string]string{
+					models.ExtensionKeyReturnPodIP: v1alpha1.True,
+				},
+			},
+			postCheck: func(t *testing.T, resp *models.Sandbox) {
+				assert.Equal(t, "1.2.3.4", resp.Metadata[models.MetadataKeyPodIP])
+				assert.NotContains(t, resp.Metadata, models.ExtensionKeyReturnPodIP)
+
+				sbx := GetSandbox(t, resp.SandboxID, fc)
+				assert.Equal(t, v1alpha1.True, sbx.Annotations[models.ExtensionKeyReturnPodIP])
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -513,6 +531,9 @@ func TestCreateSandbox(t *testing.T) {
 					assert.WithinDuration(t, startedAt.Add(time.Duration(timeoutSeconds)*time.Second), endAt, 5*time.Second)
 				}
 				assert.Equal(t, models.SandboxStateRunning, sbx.State)
+				if tt.postCheck != nil {
+					tt.postCheck(t, sbx)
+				}
 			}
 		})
 	}

--- a/test/e2b/test_sandbox.py
+++ b/test/e2b/test_sandbox.py
@@ -37,8 +37,8 @@ def _parse_rfc3339_utc(s: str) -> datetime:
     return datetime.fromisoformat(s).astimezone(timezone.utc)
 
 
-RETURN_POD_IP_METADATA_KEY = "e2b.agents.kruise.io/return-pod-ip"
-POD_IP_METADATA_KEY = "e2b.agents.kruise.io/pod-ip"
+RETURN_POD_IP_METADATA_KEY = "e2b.agents.kruise.io/return-sandbox-ip"
+POD_IP_METADATA_KEY = "e2b.agents.kruise.io/sandbox-ip"
 
 
 def assert_pod_ip_metadata(info, expected_pod_ip: str | None = None) -> str:

--- a/test/e2b/test_sandbox.py
+++ b/test/e2b/test_sandbox.py
@@ -37,6 +37,22 @@ def _parse_rfc3339_utc(s: str) -> datetime:
     return datetime.fromisoformat(s).astimezone(timezone.utc)
 
 
+RETURN_POD_IP_METADATA_KEY = "e2b.agents.kruise.io/return-pod-ip"
+POD_IP_METADATA_KEY = "e2b.agents.kruise.io/pod-ip"
+
+
+def assert_pod_ip_metadata(info, expected_pod_ip: str | None = None) -> str:
+    metadata = info.metadata or {}
+    assert POD_IP_METADATA_KEY in metadata
+    pod_ip = metadata[POD_IP_METADATA_KEY]
+    assert isinstance(pod_ip, str)
+    if expected_pod_ip is None:
+        assert pod_ip != ""
+    else:
+        assert pod_ip == expected_pod_ip
+    return pod_ip
+
+
 # Link: https://e2b.dev/docs/sandbox
 def test_lifecycle(sandbox_context):
     sandbox: Sandbox = sandbox_context.add(Sandbox.create(
@@ -55,6 +71,50 @@ def test_lifecycle(sandbox_context):
     assert info.template_id == "code-interpreter"
     assert info.state == SandboxState.RUNNING
     assert info.metadata["userId"] == "123"
+    assert POD_IP_METADATA_KEY not in info.metadata
+
+
+def test_sandbox_with_pod_ip(sandbox_context):
+    test_case = f"test_sandbox_with_pod_ip-{uuid.uuid4()}"
+    sandbox: Sandbox = sandbox_context.add(Sandbox.create(
+        template="code-interpreter",
+        timeout=6000,
+        metadata={
+            "test_case": test_case,
+            RETURN_POD_IP_METADATA_KEY: "true",
+        },
+        headers={
+            "x-request-id": sandbox_context.request_id
+        }
+    ))
+    print(f"sandbox-id: {sandbox.sandbox_id}")
+
+    info = sandbox.get_info()
+    pod_ip = assert_pod_ip_metadata(info)
+    assert RETURN_POD_IP_METADATA_KEY not in info.metadata
+
+    listed = list_sandbox(
+        query=SandboxQuery(
+            metadata={
+                "test_case": test_case,
+            }
+        ),
+    )
+    matching = [item for item in listed if item.sandbox_id == sandbox.sandbox_id]
+    assert len(matching) == 1
+    assert_pod_ip_metadata(matching[0], pod_ip)
+
+    connected = connect_sandbox(sandbox, timeout=6000)
+    assert connected is not None
+    connected_info = connected.get_info()
+    assert_pod_ip_metadata(connected_info, pod_ip)
+
+    sandbox.beta_pause()
+    resumed = connect_sandbox(sandbox, timeout=6000)
+    assert resumed is not None
+    resumed_info = resumed.get_info()
+    assert resumed_info.state == SandboxState.RUNNING
+    assert_pod_ip_metadata(resumed_info)
 
 
 def test_no_stock(sandbox_context):


### PR DESCRIPTION
## Summary
- Add an E2B metadata extension that lets sandbox creation request Pod IPs in returned sandbox metadata.
- Persist the return-pod-ip flag on claimed sandboxes and include current Pod IP metadata in create, describe, list, and connect responses.
- Cover extension parsing, conversion behavior, create-path assertions, and E2B lifecycle coverage for Pod IP metadata.

## Test Plan
- `GOPATH=/Users/sophon/sdk/gopath GOROOT=/Users/sophon/sdk/gopath/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64 /Users/sophon/Bin/go test -count=1 ./pkg/servers/e2b ./pkg/servers/e2b/models`
- `python3 -m py_compile test/e2b/test_sandbox.py`
- `git diff --check`

Note: per project instructions, E2E tests under `test/e2b` were not run locally.
