### PR TITLE
docs(AGENTS.md) add multi-agent development limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,19 @@ test/              E2E (Go), E2B (Python) tests
   string means no error is expected; a non-empty string means an error is expected and the actual error message must
   contain that string (verified with `assert.Contains(t, err.Error(), tt.expectError)`).
 
+### Multi-Agent Development Limits
+
+- Core goal: accelerate development as much as possible while still delivering high-quality code.
+- Sub-agents executing a specific task, including implementer and task reviewer agents, must not run all unit tests
+  such as `go test ./pkg/...`.
+- Implementer agents may run unit tests when necessary, such as during TDD or after implementation, but the test scope
+  must stay focused on the changed behavior and must not include unnecessary packages.
+- Reviewer agents must assume unit tests are already passing. They may run unit tests only when the code has an obvious
+  issue that needs verification.
+- Sub-agents must never run `go build`.
+- The main agent, or the final global review agent, may run full package tests sparingly. `go build` must be reserved
+  for final verification after the implementation is considered fully safe.
+
 ## Behavioral Rules
 
 - Read related files before modifying code


### PR DESCRIPTION
## What changed

- Added a new `Multi-Agent Development Limits` section to the root `AGENTS.md`.
- Documented constraints for implementer and reviewer sub-agents around unit test scope and `go build` usage.
- Clarified that full package tests and final `go build` are reserved for the main agent or final global review agent.

## Why

The goal is to speed up multi-agent development while keeping code quality expectations explicit. Sub-agents should avoid expensive broad validation unless it is directly needed for their focused task, while final validation remains centralized.

## Validation

- Reviewed the `AGENTS.md` diff.
- No Go tests or `go build` were run because this is a documentation-only change.
