### PR TITLE
fix(pagination): keep list pages stable so sandboxes with the same claim time aren't skipped

### DIFF
--- a/pkg/servers/e2b/list.go
+++ b/pkg/servers/e2b/list.go
@@ -143,6 +143,9 @@ func (sc *Controller) ListSandboxes(r *http.Request) (web.ApiResponse[[]*models.
 		GetKey: func(sbx infra.Sandbox) string {
 			return sbx.GetAnnotations()[agentsv1alpha1.AnnotationClaimTime]
 		},
+		GetUniqueKey: func(sbx infra.Sandbox) string {
+			return sbx.GetSandboxID()
+		},
 	})
 	var headers map[string]string
 	if nextToken != "" {
@@ -284,6 +287,9 @@ func (sc *Controller) listCheckpointsForUser(ctx context.Context, user *models.C
 		NextToken: nextTokenParam,
 		GetKey: func(cp infra.CheckpointInfo) string {
 			return cp.CreationTimestamp // Sort by creation timestamp
+		},
+		GetUniqueKey: func(cp infra.CheckpointInfo) string {
+			return cp.CheckpointID
 		},
 		Filter: filter,
 	})

--- a/pkg/servers/e2b/list_test.go
+++ b/pkg/servers/e2b/list_test.go
@@ -18,6 +18,7 @@ package e2b
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"sort"
@@ -456,8 +457,15 @@ func TestListSandboxes_Pagination(t *testing.T) {
 			},
 		},
 		{
-			name:  "start with nextToken",
-			query: map[string]string{"limit": "2", "nextToken": "2024-01-01T00:00:02Z"},
+			// The page token is opaque: it encodes the sort key (claim time) plus a
+			// unique tiebreaker (sandbox ID) so equal-timestamp sandboxes are not
+			// skipped at a page boundary. Resuming from the token for sandbox idx 1
+			// must return the following sandboxes (idx 2,3).
+			name: "start with nextToken",
+			query: map[string]string{
+				"limit":     "2",
+				"nextToken": base64.RawURLEncoding.EncodeToString([]byte(claimTimes[1] + "\x00" + createdSandboxIDs[1])),
+			},
 			pages: []pageExpectation{
 				{count: 2, hasNextToken: true, startedAtIdxs: []int{2, 3}},
 			},

--- a/pkg/utils/sandbox-manager/pagination.go
+++ b/pkg/utils/sandbox-manager/pagination.go
@@ -17,8 +17,15 @@ limitations under the License.
 package utils
 
 import (
+	"encoding/base64"
 	"sort"
 )
+
+// cursorSep separates the sort key from the unique tiebreaker inside a composite
+// cursor. It is the NUL byte so that the tiebreaker always orders after the sort
+// key but before any printable continuation of a longer key (e.g. "1\x00z" sorts
+// before "10\x00a"), keeping the composite order consistent with (key, unique).
+const cursorSep = "\x00"
 
 // Paginator pages the selected objects.
 type Paginator[T any] struct {
@@ -26,6 +33,18 @@ type Paginator[T any] struct {
 	NextToken string
 	// All objects are sorted by the key, and the key of the last object is used as next token. If the key is empty, the object is not included.
 	GetKey func(T) string
+	// GetUniqueKey, when set, returns a stable per-object discriminator (for
+	// example the sandbox or checkpoint ID) that is appended to GetKey to form
+	// the ordering/cursor. GetKey values are not guaranteed unique — claim and
+	// creation timestamps are formatted at RFC3339 (one-second) granularity, so
+	// many objects can share a key. Paging on GetKey alone resumes at the first
+	// item strictly greater than the previous page's last key, which skips every
+	// other item that shares that key, so those objects never appear on any page.
+	// With GetUniqueKey set, ordering and the page cursor use the composite
+	// (GetKey, GetUniqueKey), which is unique, so no item is dropped at a page
+	// boundary. If nil, GetKey alone is used and the caller must guarantee GetKey
+	// uniqueness.
+	GetUniqueKey func(T) string
 	// Return true if the object should be included
 	Filter func(T) bool
 }
@@ -42,19 +61,52 @@ func (p *Paginator[T]) Apply(objs []T) ([]T, string) {
 	return p.paginateResults(sorted)
 }
 
-// sortObjects retrieves objects from informer and sorts them by annotation.
+// cursor returns the ordering key for an object: the bare sort key when no
+// tiebreaker is configured, or the composite (GetKey, GetUniqueKey) otherwise.
+func (p *Paginator[T]) cursor(obj T) string {
+	if p.GetUniqueKey == nil {
+		return p.GetKey(obj)
+	}
+	return p.GetKey(obj) + cursorSep + p.GetUniqueKey(obj)
+}
+
+// encodeToken renders a cursor as an opaque page token. Composite cursors carry
+// a NUL separator that is not valid in an HTTP header, so they are base64url
+// encoded; bare-key cursors are returned verbatim to preserve the existing token
+// format for callers that do not set GetUniqueKey.
+func (p *Paginator[T]) encodeToken(cursor string) string {
+	if p.GetUniqueKey == nil {
+		return cursor
+	}
+	return base64.RawURLEncoding.EncodeToString([]byte(cursor))
+}
+
+// decodeToken reverses encodeToken. A token that does not decode (legacy or
+// malformed) is used as-is so the list call degrades to a best-effort resume
+// rather than failing.
+func (p *Paginator[T]) decodeToken(token string) string {
+	if p.GetUniqueKey == nil {
+		return token
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return token
+	}
+	return string(decoded)
+}
+
+// sortObjects sorts items by their cursor so that equal sort keys are ordered by
+// the unique tiebreaker when one is configured.
 func (p *Paginator[T]) sortObjects(items []T) []T {
-	// Sort by annotation value (string comparison, RFC3339 format is lexicographically sortable)
+	// Sort by cursor (string comparison, RFC3339 format is lexicographically sortable)
 	sort.Slice(items, func(i, j int) bool {
-		iSortKey := p.GetKey(items[i])
-		jSortKey := p.GetKey(items[j])
-		return iSortKey < jSortKey
+		return p.cursor(items[i]) < p.cursor(items[j])
 	})
 
 	return items
 }
 
-// paginateResults applies pagination to a sorted slice of items. The sortKey of the last item is used as next token.
+// paginateResults applies pagination to a sorted slice of items. The cursor of the last item is used as next token.
 func (p *Paginator[T]) paginateResults(items []T) ([]T, string) {
 	// If limit <= 0, return all items without pagination
 	if p.Limit <= 0 {
@@ -64,9 +116,10 @@ func (p *Paginator[T]) paginateResults(items []T) ([]T, string) {
 	// Find start index using binary search
 	startIdx := 0
 	if p.NextToken != "" {
-		// Find the first item with sortKey > startSortKey(nextToken) in O(log n)
+		startCursor := p.decodeToken(p.NextToken)
+		// Find the first item with cursor > startCursor(nextToken) in O(log n)
 		startIdx = sort.Search(len(items), func(i int) bool {
-			return p.GetKey(items[i]) > p.NextToken
+			return p.cursor(items[i]) > startCursor
 		})
 	}
 
@@ -86,7 +139,7 @@ func (p *Paginator[T]) paginateResults(items []T) ([]T, string) {
 	// Generate next token if there are more items
 	var nextToken string
 	if endIdx < len(items) && len(paged) > 0 {
-		nextToken = p.GetKey(paged[len(paged)-1])
+		nextToken = p.encodeToken(p.cursor(paged[len(paged)-1]))
 	}
 
 	return paged, nextToken

--- a/pkg/utils/sandbox-manager/pagination_test.go
+++ b/pkg/utils/sandbox-manager/pagination_test.go
@@ -185,3 +185,94 @@ func TestPaginator_Apply(t *testing.T) {
 		})
 	}
 }
+
+// sandboxWithKey builds a sandbox whose name is the unique tiebreaker and whose
+// "key" annotation is the (possibly shared) sort key, mirroring how the e2b list
+// API sorts by a coarse claim/creation timestamp while paging by a unique ID.
+func sandboxWithKey(name, key string) *v1alpha1.Sandbox {
+	return &v1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: map[string]string{"key": key},
+		},
+	}
+}
+
+// TestPaginator_Apply_DuplicateSortKeys is a regression test for silent item
+// loss: when more than `limit` items share the same sort key at a page boundary,
+// a key-only cursor (resume at first key strictly greater than the last key)
+// skips every shared-key item after the first. With GetUniqueKey set, paging
+// over the whole set must return every item exactly once.
+func TestPaginator_Apply_DuplicateSortKeys(t *testing.T) {
+	getKey := func(sbx *v1alpha1.Sandbox) string { return sbx.GetAnnotations()["key"] }
+	getUnique := func(sbx *v1alpha1.Sandbox) string { return sbx.GetName() }
+	filter := func(*v1alpha1.Sandbox) bool { return true }
+
+	// Five sandboxes, three of them sharing the same one-second timestamp "t1".
+	input := []*v1alpha1.Sandbox{
+		sandboxWithKey("a", "t0"),
+		sandboxWithKey("b", "t1"),
+		sandboxWithKey("c", "t1"),
+		sandboxWithKey("d", "t1"),
+		sandboxWithKey("e", "t2"),
+	}
+
+	var got []string
+	token := ""
+	for i := 0; i < 10; i++ { // bounded to avoid an infinite loop on regression
+		p := &Paginator[*v1alpha1.Sandbox]{
+			Limit:        2,
+			NextToken:    token,
+			GetKey:       getKey,
+			GetUniqueKey: getUnique,
+			Filter:       filter,
+		}
+		page, next := p.Apply(input)
+		for _, sbx := range page {
+			got = append(got, sbx.GetName())
+		}
+		if next == "" {
+			break
+		}
+		token = next
+	}
+
+	// Every item is returned exactly once, in (key, name) order — none skipped.
+	assert.Equal(t, []string{"a", "b", "c", "d", "e"}, got)
+}
+
+// TestPaginator_Apply_UniqueKeyTokenRoundTrips verifies the composite token is a
+// header-safe opaque string that the next page decodes back to the same cursor.
+func TestPaginator_Apply_UniqueKeyTokenRoundTrips(t *testing.T) {
+	getKey := func(sbx *v1alpha1.Sandbox) string { return sbx.GetAnnotations()["key"] }
+	getUnique := func(sbx *v1alpha1.Sandbox) string { return sbx.GetName() }
+	filter := func(*v1alpha1.Sandbox) bool { return true }
+
+	input := []*v1alpha1.Sandbox{
+		sandboxWithKey("b", "t1"),
+		sandboxWithKey("c", "t1"),
+		sandboxWithKey("d", "t2"),
+	}
+
+	p := &Paginator[*v1alpha1.Sandbox]{
+		Limit:        2,
+		GetKey:       getKey,
+		GetUniqueKey: getUnique,
+		Filter:       filter,
+	}
+	page, token := p.Apply(input)
+	assert.Equal(t, []string{"b", "c"}, []string{page[0].GetName(), page[1].GetName()})
+	assert.NotEmpty(t, token)
+	assert.NotContains(t, token, "\x00", "token must be header-safe")
+
+	p2 := &Paginator[*v1alpha1.Sandbox]{
+		Limit:        2,
+		NextToken:    token,
+		GetKey:       getKey,
+		GetUniqueKey: getUnique,
+		Filter:       filter,
+	}
+	page2, token2 := p2.Apply(input)
+	assert.Equal(t, []string{"d"}, []string{page2[0].GetName()})
+	assert.Empty(t, token2)
+}


### PR DESCRIPTION
## fix(pagination): keep list pages stable so sandboxes with the same claim time aren't skipped

fixes #439

### Ⅰ. What this PR does

When you list sandboxes or snapshots, the results are paged by `utils.Paginator`.
It remembered where a page ended by saving the last item's timestamp as the
`nextToken`, and started the next page at the first item *strictly after* that
timestamp.

The catch: that timestamp isn't unique. Sandboxes sort by their `claim-timestamp`
annotation, which is `time.Now().Format(time.RFC3339)` — only one-second
precision. Snapshots sort by checkpoint creation time, same story. So when more
than `limit` items were claimed in the same second and a page boundary landed in
the middle of them, the leftovers got skipped and never appeared on any page.
Since sandboxes are claimed in batches, same-second groups are common, so this
shows up as real, running sandboxes silently missing from the list — especially
under load.

The fix is to make the page marker unique by adding a tiebreaker:

- `Paginator` gets an optional `GetUniqueKey`. When it's set, sorting and the
  page cursor use the pair `(GetKey, GetUniqueKey)` instead of just `GetKey`.
  Because the pair is unique, two items with the same timestamp can no longer
  straddle a page boundary and get lost.
- The continuation token now carries both parts, so it's base64url-encoded (the
  combined value uses a separator that isn't valid in an HTTP header). A token
  that doesn't decode is just used as-is, so a stale/old token degrades to a
  best-effort resume instead of erroring the whole call.
- The two list call sites pass a tiebreaker: sandbox ID for sandboxes, checkpoint
  ID for snapshots.

If `GetUniqueKey` isn't set, everything — order, behavior, and token format —
stays exactly as before, so existing callers are untouched.

### Ⅱ. Does this pull request fix one issue?

fixes #<issue-number>

### Ⅲ. How to verify it

- `go test ./pkg/utils/sandbox-manager/...` — green, including two new tests:
  - `TestPaginator_Apply_DuplicateSortKeys`: pages over five items where three
    share one timestamp (`limit=2`) and checks every item comes back exactly
    once, none skipped. This fails on the old timestamp-only cursor.
  - `TestPaginator_Apply_UniqueKeyTokenRoundTrips`: the token is header-safe (no
    raw separator) and the next page decodes it back to the same position.
  - the existing `TestPaginator_Apply` cases still pass unchanged.
- `go test ./pkg/servers/e2b/...` — `TestListSandboxes_Pagination` and
  `TestListSnapshots` pass; the "start with nextToken" case now uses the encoded
  token.
- `go build ./...`, `go vet`, and `gofmt` are all clean.

### Ⅳ. Notes for reviewers

Contained change: the generic paginator plus the two e2b list call sites. It
doesn't change what's listed or the sort order (still claim/creation time) — only
the page boundary marker is made unique. The token is opaque to clients, so the
encoding change needs nothing on the client side.
