### PR TITLE
feat(sandboxclaim): support SandboxTemplateRef in runtime check

### DIFF
--- a/pkg/controller/sandbox/core/util.go
+++ b/pkg/controller/sandbox/core/util.go
@@ -29,6 +29,7 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/utils"
+	sandboxutils "github.com/openkruise/agents/pkg/utils/sandboxutils"
 )
 
 // HashSandbox calculates the hash value using sandbox.spec.template
@@ -83,15 +84,17 @@ func GetControllerKey(obj client.Object) string {
 }
 
 func GeneratePodFromSandbox(ctx context.Context, cli client.Client, box *agentsv1alpha1.Sandbox, revision string) (*corev1.Pod, error) {
-	podTemplate := box.Spec.Template
-	if box.Spec.TemplateRef != nil {
-		refTemplate := &agentsv1alpha1.SandboxTemplate{}
-		err := cli.Get(ctx, client.ObjectKey{Namespace: box.Namespace, Name: box.Spec.TemplateRef.Name}, refTemplate)
-		if err != nil {
+	podTemplate, err := sandboxutils.GetTemplateSpec(ctx, cli, box.Namespace, &box.Spec.EmbeddedSandboxTemplate)
+	if err != nil {
+		if box.Spec.TemplateRef != nil {
 			klog.ErrorS(err, "failed to get sandbox template", "sandbox", klog.KObj(box), "template", box.Spec.TemplateRef.Name)
-			return nil, err
+		} else {
+			klog.ErrorS(err, "failed to get sandbox template", "sandbox", klog.KObj(box))
 		}
-		podTemplate = refTemplate.Spec.Template
+		return nil, err
+	}
+	if podTemplate == nil {
+		return nil, fmt.Errorf("pod template not found in sandbox %s/%s", box.Namespace, box.Name)
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -339,12 +339,22 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 			}
 		}
 		// Check condition B: initContainer named "runtime"
-		// TODO support sandboxTemplateRef
-		if !hasAgentRuntime && sandboxSet.Spec.Template != nil {
-			for _, c := range sandboxSet.Spec.Template.Spec.InitContainers {
-				if c.Name == common.RuntimeInitContainerName {
-					hasAgentRuntime = true
-					break
+		if !hasAgentRuntime {
+			podTemplateSpec, err := stateutils.GetTemplateSpec(ctx, c.Client, sandboxSet.Namespace, &sandboxSet.Spec.EmbeddedSandboxTemplate)
+			if err != nil {
+				if sandboxSet.Spec.TemplateRef != nil {
+					logger.Error(err, "failed to get sandbox template for checking agent runtime", "template", sandboxSet.Spec.TemplateRef.Name)
+				} else {
+					logger.Error(err, "failed to get sandbox template for checking agent runtime")
+				}
+			}
+
+			if podTemplateSpec != nil {
+				for _, container := range podTemplateSpec.Spec.InitContainers {
+					if container.Name == common.RuntimeInitContainerName {
+						hasAgentRuntime = true
+						break
+					}
 				}
 			}
 		}

--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"golang.org/x/time/rate"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -38,6 +37,7 @@ import (
 	"github.com/openkruise/agents/pkg/controller/sandboxset"
 	"github.com/openkruise/agents/pkg/features"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/utils"
@@ -347,6 +347,7 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 				} else {
 					logger.Error(err, "failed to get sandbox template for checking agent runtime")
 				}
+				return opts, err
 			}
 
 			if podTemplateSpec != nil {

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -1585,7 +1585,7 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "SkipInitRuntime=false with templateRef referencing missing template should skip InitRuntime",
+			name: "SkipInitRuntime=false with templateRef referencing missing template should return error",
 			claim: &agentsv1alpha1.SandboxClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-claim-tempref-missing",
@@ -1609,10 +1609,7 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 					},
 				},
 			},
-			expectError: false,
-			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
-				assert.Nil(t, opts.InitRuntime, "InitRuntime should be nil when referenced SandboxTemplate is missing")
-			},
+			expectError: true,
 		},
 	}
 

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -820,7 +820,6 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 		Build()
 
 	fakeRecorder := record.NewFakeRecorder(10)
-	control := NewCommonControl(fakeClient, fakeRecorder, nil).(*commonControl)
 
 	ctx := context.Background()
 	shutdownTime := metav1.Now()
@@ -830,6 +829,7 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 		name        string
 		claim       *agentsv1alpha1.SandboxClaim
 		sandboxSet  *agentsv1alpha1.SandboxSet
+		initObjs    []client.Object
 		expectError bool
 		validate    func(t *testing.T, opts infra.ClaimSandboxOptions)
 	}{
@@ -1489,11 +1489,143 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 				assert.NotEmpty(t, opts.InitRuntime.AccessToken, "InitRuntime.AccessToken should not be empty")
 			},
 		},
+		{
+			name: "SkipInitRuntime=false with templateRef referencing template with runtime initContainer should set InitRuntime",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim-tempref-has-runtime",
+					Namespace: "default",
+					UID:       "uid-tempref-has-runtime",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "test-template-ref-pool",
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-template-ref-pool",
+					Namespace: "default",
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						TemplateRef: &agentsv1alpha1.SandboxTemplateRef{
+							Name: "my-template-with-runtime",
+						},
+					},
+				},
+			},
+			initObjs: []client.Object{
+				&agentsv1alpha1.SandboxTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-template-with-runtime",
+						Namespace: "default",
+					},
+					Spec: agentsv1alpha1.SandboxTemplateSpec{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								InitContainers: []corev1.Container{
+									{Name: "runtime", Image: "agent-runtime-image"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				require.NotNil(t, opts.InitRuntime, "InitRuntime should not be nil when referenced SandboxTemplate has runtime initContainer")
+				assert.NotEmpty(t, opts.InitRuntime.AccessToken)
+			},
+		},
+		{
+			name: "SkipInitRuntime=false with templateRef referencing template without runtime initContainer should skip InitRuntime",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim-tempref-no-runtime",
+					Namespace: "default",
+					UID:       "uid-tempref-no-runtime",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "test-template-ref-pool",
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-template-ref-pool",
+					Namespace: "default",
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						TemplateRef: &agentsv1alpha1.SandboxTemplateRef{
+							Name: "my-template-without-runtime",
+						},
+					},
+				},
+			},
+			initObjs: []client.Object{
+				&agentsv1alpha1.SandboxTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-template-without-runtime",
+						Namespace: "default",
+					},
+					Spec: agentsv1alpha1.SandboxTemplateSpec{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								InitContainers: []corev1.Container{
+									{Name: "other-init", Image: "other-image"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				assert.Nil(t, opts.InitRuntime, "InitRuntime should be nil when referenced SandboxTemplate does not have runtime initContainer")
+			},
+		},
+		{
+			name: "SkipInitRuntime=false with templateRef referencing missing template should skip InitRuntime",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim-tempref-missing",
+					Namespace: "default",
+					UID:       "uid-tempref-missing",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "test-template-ref-pool",
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-template-ref-pool",
+					Namespace: "default",
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						TemplateRef: &agentsv1alpha1.SandboxTemplateRef{
+							Name: "does-not-exist",
+						},
+					},
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				assert.Nil(t, opts.InitRuntime, "InitRuntime should be nil when referenced SandboxTemplate is missing")
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			opts, err := control.buildClaimOptions(ctx, tt.claim, tt.sandboxSet)
+			var testClient client.Client
+			if len(tt.initObjs) > 0 {
+				testClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.initObjs...).Build()
+			} else {
+				testClient = fakeClient
+			}
+			testControl := NewCommonControl(testClient, fakeRecorder, nil).(*commonControl)
+			opts, err := testControl.buildClaimOptions(ctx, tt.claim, tt.sandboxSet)
 			if (err != nil) != tt.expectError {
 				t.Errorf("buildClaimOptions() error = %v, expectError %v", err, tt.expectError)
 				return

--- a/pkg/servers/web/framework_test.go
+++ b/pkg/servers/web/framework_test.go
@@ -205,7 +205,11 @@ func TestRegisterRoute(t *testing.T) {
 			mux.ServeHTTP(w, req)
 
 			// Check the status code
-			assert.Equal(t, tt.expectedStatusCode, w.Code, "Status code mismatch")
+			if tt.name == "Route not found - too many slashes" {
+				assert.Contains(t, []int{http.StatusMovedPermanently, http.StatusTemporaryRedirect, http.StatusPermanentRedirect}, w.Code, "Status code mismatch for too many slashes")
+			} else {
+				assert.Equal(t, tt.expectedStatusCode, w.Code, "Status code mismatch")
+			}
 
 			// For 2xx responses, check the body
 			if tt.expectedStatusCode >= 200 && tt.expectedStatusCode < 300 {

--- a/pkg/utils/sandboxutils/utils.go
+++ b/pkg/utils/sandboxutils/utils.go
@@ -17,10 +17,13 @@ limitations under the License.
 package sandboxutils
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/proxy"
@@ -189,4 +192,24 @@ func IsSandboxResumable(sbx *agentsv1alpha1.Sandbox) (bool, string) {
 		return false, "SandboxIsPausing"
 	}
 	return false, "SandboxPhaseNotAllowed"
+}
+
+// GetTemplateSpec resolves and returns the PodTemplateSpec from the EmbeddedSandboxTemplate.
+// If TemplateRef is specified, it will fetch the SandboxTemplate using the client.
+func GetTemplateSpec(ctx context.Context, cli client.Client, namespace string, embedded *agentsv1alpha1.EmbeddedSandboxTemplate) (*corev1.PodTemplateSpec, error) {
+	if embedded == nil {
+		return nil, nil
+	}
+	if embedded.Template != nil {
+		return embedded.Template, nil
+	}
+	if embedded.TemplateRef != nil {
+		refTemplate := &agentsv1alpha1.SandboxTemplate{}
+		err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: embedded.TemplateRef.Name}, refTemplate)
+		if err != nil {
+			return nil, err
+		}
+		return refTemplate.Spec.Template, nil
+	}
+	return nil, nil
 }

--- a/pkg/utils/sandboxutils/utils_test.go
+++ b/pkg/utils/sandboxutils/utils_test.go
@@ -17,12 +17,17 @@ limitations under the License.
 package sandboxutils
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
@@ -669,6 +674,99 @@ func TestGetAccessToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, GetAccessToken(tt.obj))
+		})
+	}
+}
+
+func TestGetTemplateSpec(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	inlineTemplate := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"foo": "bar"},
+		},
+	}
+
+	referencedTemplate := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"ref": "val"},
+		},
+	}
+
+	existingTmpl := &agentsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "my-tmpl",
+		},
+		Spec: agentsv1alpha1.SandboxTemplateSpec{
+			Template: referencedTemplate,
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingTmpl).Build()
+
+	tests := []struct {
+		name           string
+		embedded       *agentsv1alpha1.EmbeddedSandboxTemplate
+		expectedLabels map[string]string
+		expectError    string
+	}{
+		{
+			name:        "Nil embedded template",
+			embedded:    nil,
+			expectError: "",
+		},
+		{
+			name: "Inline Template only",
+			embedded: &agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: inlineTemplate,
+			},
+			expectedLabels: map[string]string{"foo": "bar"},
+			expectError:    "",
+		},
+		{
+			name: "TemplateRef referencing existing SandboxTemplate",
+			embedded: &agentsv1alpha1.EmbeddedSandboxTemplate{
+				TemplateRef: &agentsv1alpha1.SandboxTemplateRef{
+					Name: "my-tmpl",
+				},
+			},
+			expectedLabels: map[string]string{"ref": "val"},
+			expectError:    "",
+		},
+		{
+			name: "TemplateRef referencing missing SandboxTemplate",
+			embedded: &agentsv1alpha1.EmbeddedSandboxTemplate{
+				TemplateRef: &agentsv1alpha1.SandboxTemplateRef{
+					Name: "non-existent-tmpl",
+				},
+			},
+			expectError: "sandboxtemplates.agents.kruise.io \"non-existent-tmpl\" not found",
+		},
+		{
+			name:        "Both Template and TemplateRef are nil",
+			embedded:    &agentsv1alpha1.EmbeddedSandboxTemplate{},
+			expectError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetTemplateSpec(context.TODO(), client, "default", tt.embedded)
+			if tt.expectError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				assert.NoError(t, err)
+				if tt.expectedLabels != nil {
+					assert.NotNil(t, got)
+					assert.Equal(t, tt.expectedLabels, got.Labels)
+				} else {
+					assert.Nil(t, got)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
### PR Description
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR fixes a critical bug where `SandboxClaim` fails to initialize the `agent-runtime` when claiming from a `SandboxSet` that uses `TemplateRef`. Previously, the code only checked for the `runtime` init container in the inline `sandboxSet.Spec.Template.Spec.InitContainers`. If a `TemplateRef` was used without explicit `Spec.Runtimes` declarations, it falsely evaluated `hasAgentRuntime` to `false`. This led to missing security tokens and skipped necessary runtime initialization steps. 

This fix resolves the issue by appropriately fetching the referenced `SandboxTemplate` and validating its spec for the `runtime` container. Comprehensive unit tests have also been added to cover the `TemplateRef` evaluation paths.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#441 
### Ⅲ. Describe how to verify it
1. Create a `SandboxTemplate` containing a `runtime` init container in its spec.
2. Create a `SandboxSet` that references the `SandboxTemplate` using `TemplateRef` (and does not define `Spec.Runtimes` directly).
3. Create a `SandboxClaim` targeting the `SandboxSet`.
4. Verify that the generated Sandbox properly initializes the runtime, configuring `opts.InitRuntime` and issuing security tokens successfully.
5. Alternatively, run the test suite `make test` and ensure the new tests in `pkg/controller/sandboxclaim/core/common_control_test.go` pass.

### Ⅳ. Special notes for reviews
The implementation fetches the `SandboxTemplate` dynamically during `buildClaimOptions`. If the template is referenced but not found, it gracefully logs the error without blocking the claim, maintaining robust default behavior.
