### PR TITLE
followup updates for egress control

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -47,9 +47,9 @@ const (
 	// RuntimeConfigForInjectAgentRuntime is a valid value for RuntimeConfig.Name.
 	// When set, enables agent runtime sidecar injection for the sandbox.
 	RuntimeConfigForInjectAgentRuntime = "agent-runtime"
-	// RuntimeConfigForInjectEgressControl is a valid value for RuntimeConfig.Name.
-	// When set, enables egress control sidecar injection for the sandbox.
-	RuntimeConfigForInjectEgressControl = "egress-control"
+	// RuntimeConfigForInjectTrafficProxy is a valid value for RuntimeConfig.Name.
+	// When set, enables traffic proxy sidecar injection for the sandbox.
+	RuntimeConfigForInjectTrafficProxy = "traffic-proxy"
 )
 
 type RuntimeConfig struct {

--- a/pkg/controller/sandbox/core/upgrade_control_test.go
+++ b/pkg/controller/sandbox/core/upgrade_control_test.go
@@ -155,8 +155,8 @@ func TestExecuteUpgradeAction(t *testing.T) {
 			expectContains: "command not found",
 		},
 		{
-			name: "message truncated when exceeding max length",
-			hookFunc: mockLifecycleHookFunc(-1, "", strings.Repeat("x", 1100), fmt.Errorf("exec failed")),
+			name:           "message truncated when exceeding max length",
+			hookFunc:       mockLifecycleHookFunc(-1, "", strings.Repeat("x", 1100), fmt.Errorf("exec failed")),
 			expectSuccess:  false,
 			expectContains: "...",
 		},

--- a/pkg/controller/sandbox/metrics_test.go
+++ b/pkg/controller/sandbox/metrics_test.go
@@ -1873,10 +1873,10 @@ func TestSandboxDeletionDuration(t *testing.T) {
 
 func TestSandboxStatusAbnormal(t *testing.T) {
 	tests := []struct {
-		name              string
-		phase             agentsv1alpha1.SandboxPhase
-		conditions        []metav1.Condition
-		wantPauseAbnormal float64
+		name               string
+		phase              agentsv1alpha1.SandboxPhase
+		conditions         []metav1.Condition
+		wantPauseAbnormal  float64
 		wantResumeAbnormal float64
 	}{
 		{
@@ -1933,9 +1933,9 @@ func TestSandboxStatusAbnormal(t *testing.T) {
 			wantResumeAbnormal: 0,
 		},
 		{
-			name:  "Phase=Paused with no Paused condition is abnormal",
-			phase: agentsv1alpha1.SandboxPaused,
-			conditions: nil,
+			name:               "Phase=Paused with no Paused condition is abnormal",
+			phase:              agentsv1alpha1.SandboxPaused,
+			conditions:         nil,
 			wantPauseAbnormal:  1,
 			wantResumeAbnormal: 0,
 		},

--- a/pkg/controller/sandboxset/metrics_test.go
+++ b/pkg/controller/sandboxset/metrics_test.go
@@ -167,8 +167,8 @@ func TestSandboxSetSandboxesClaimedTotal(t *testing.T) {
 
 func TestSandboxSetSandboxesClaimedTotalMultipleSandboxSets(t *testing.T) {
 	tests := []struct {
-		name        string
-		sets        []struct {
+		name string
+		sets []struct {
 			namespace string
 			sbsName   string
 			count     int

--- a/pkg/utils/sidecarutils/config_types.go
+++ b/pkg/utils/sidecarutils/config_types.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	KEY_CSI_INJECTION_CONFIG            = "csi"
-	KEY_EGRESS_CONTROL_INJECTION_CONFIG = "egress-control"
-	KEY_RUNTIME_INJECTION_CONFIG        = "agent-runtime"
+	KEY_CSI_INJECTION_CONFIG           = "csi"
+	KEY_TRAFFIC_PROXY_INJECTION_CONFIG = "traffic-proxy"
+	KEY_RUNTIME_INJECTION_CONFIG       = "agent-runtime"
 
 	SandboxInjectionConfigName = "sandbox-injection-config"
 )

--- a/pkg/utils/sidecarutils/sidecar_config_inject.go
+++ b/pkg/utils/sidecarutils/sidecar_config_inject.go
@@ -28,20 +28,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/webhookutils"
 )
-
-func IsRuntimeEnabled(sandbox *agentsv1alpha1.Sandbox, runtimeName string) bool {
-	for _, runtime := range sandbox.Spec.Runtimes {
-		if runtime.Name == runtimeName {
-			return true
-		}
-	}
-	return false
-}
 
 func fetchInjectionConfiguration(ctx context.Context, cli client.Client) (map[string]string, error) {
 	logger := logf.FromContext(ctx)
@@ -167,45 +157,63 @@ func setAgentRuntimeContainer(ctx context.Context, podSpec *corev1.PodSpec, conf
 }
 
 func applyInjectionTemplate(ctx context.Context, pod *corev1.Pod, config SidecarInjectConfig) error {
+	if pod.Labels == nil {
+		pod.Labels = make(map[string]string)
+	}
 	for k, v := range config.Labels {
-		if _, exists := pod.Labels[k]; exists {
-			return fmt.Errorf("label already exists: %s", k)
+		// not override user-defined labels
+		if _, exists := pod.Labels[k]; !exists {
+			pod.Labels[k] = v
 		}
-		if pod.Labels == nil {
-			pod.Labels = make(map[string]string)
-		}
-		pod.Labels[k] = v
 	}
 
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
 	for k, v := range config.Annotations {
-		if _, exists := pod.Annotations[k]; exists {
-			return fmt.Errorf("label already exists: %s", k)
+		// not override user-defined annotations
+		if _, exists := pod.Annotations[k]; !exists {
+			pod.Annotations[k] = v
 		}
-		if pod.Annotations == nil {
-			pod.Annotations = make(map[string]string)
-		}
-		pod.Annotations[k] = v
 	}
 
 	for _, ic := range config.InitContainers {
-		if utils.FindContainer(ic.Name, pod.Spec.InitContainers) != nil {
-			return fmt.Errorf("init container already exists: %s", ic.Name)
-		}
 		pod.Spec.InitContainers = append(pod.Spec.InitContainers, ic)
 	}
 
 	for _, c := range config.Containers {
-		if utils.FindContainer(c.Name, pod.Spec.Containers) != nil {
-			return fmt.Errorf("container already exists: %s", c.Name)
-		}
 		pod.Spec.Containers = append(pod.Spec.Containers, c)
 	}
 
 	for _, v := range config.Volumes {
-		if findVolumeByName(pod.Spec.Volumes, v.Name) {
-			return fmt.Errorf("volume already exists: %s", v.Name)
-		}
 		pod.Spec.Volumes = append(pod.Spec.Volumes, v)
+	}
+
+	return nil
+}
+
+// injectConflicts checks if injection config conflicts with the pod. Only configuration below are checked:
+// 1. Containers
+// 2. Init containers
+// 3. Volumes
+// Annotations and Labels are not checked and user-defined values may override the injected values.
+func injectConflicts(pod *corev1.Pod, config SidecarInjectConfig) error {
+	for _, ic := range config.InitContainers {
+		if conflicted := utils.FindContainer(ic.Name, pod.Spec.InitContainers); conflicted != nil {
+			return fmt.Errorf("inject conflicting with init container: %s", ic.Name)
+		}
+	}
+
+	for _, c := range config.Containers {
+		if conflicted := utils.FindContainer(c.Name, pod.Spec.Containers); conflicted != nil {
+			return fmt.Errorf("inject conflicting with container: %s", c.Name)
+		}
+	}
+
+	for _, v := range config.Volumes {
+		if findVolumeByName(pod.Spec.Volumes, v.Name) {
+			return fmt.Errorf("inject conflicting with volume: %s", v.Name)
+		}
 	}
 
 	return nil

--- a/pkg/utils/sidecarutils/sidecar_config_inject.go
+++ b/pkg/utils/sidecarutils/sidecar_config_inject.go
@@ -156,7 +156,7 @@ func setAgentRuntimeContainer(ctx context.Context, podSpec *corev1.PodSpec, conf
 	podSpec.Volumes = append(podSpec.Volumes, config.Volumes...)
 }
 
-func applyInjectionTemplate(ctx context.Context, pod *corev1.Pod, config SidecarInjectConfig) error {
+func applyInjectionTemplate(pod *corev1.Pod, config SidecarInjectConfig) {
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)
 	}
@@ -188,16 +188,14 @@ func applyInjectionTemplate(ctx context.Context, pod *corev1.Pod, config Sidecar
 	for _, v := range config.Volumes {
 		pod.Spec.Volumes = append(pod.Spec.Volumes, v)
 	}
-
-	return nil
 }
 
-// injectConflicts checks if injection config conflicts with the pod. Only configuration below are checked:
+// checkInjectionConflicts checks if injection config conflicts with the pod. Only configuration below are checked:
 // 1. Containers
 // 2. Init containers
 // 3. Volumes
 // Annotations and Labels are not checked and user-defined values may override the injected values.
-func injectConflicts(pod *corev1.Pod, config SidecarInjectConfig) error {
+func checkInjectionConflicts(pod *corev1.Pod, config SidecarInjectConfig) error {
 	for _, ic := range config.InitContainers {
 		if conflicted := utils.FindContainer(ic.Name, pod.Spec.InitContainers); conflicted != nil {
 			return fmt.Errorf("inject conflicting with init container: %s", ic.Name)

--- a/pkg/utils/sidecarutils/traffic-proxy/health_probe.go
+++ b/pkg/utils/sidecarutils/traffic-proxy/health_probe.go
@@ -1,12 +1,20 @@
-package egresscontrol
+/*
+Copyright 2026.
 
-// Package egresscontrol provides Istio sidecar health probe rewriting.
-//
-// When Istio's envoy proxy intercepts all pod traffic, Kubernetes probes (readiness,
-// liveness, startup) must be redirected through the pilot agent on port 15020.
-// This package converts the original probes into HTTP probes pointing at the
-// pilot agent's /app-health/* endpoints, and serializes the original probe
-// definitions into the ISTIO_KUBE_APP_PROBERS env var on the istio-proxy container.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trafficproxy
 
 import (
 	"encoding/json"
@@ -26,11 +34,7 @@ const (
 )
 
 // findSidecar returns the pointer to the first container whose name matches the "istio-proxy".
-func findSidecar(pod *corev1.Pod) *corev1.Container {
-	proxyContainerName := pod.Annotations[SidecarProxyAnnotation]
-	if proxyContainerName == "" {
-		proxyContainerName = ProxyContainerName
-	}
+func findSidecar(pod *corev1.Pod, proxyContainerName string) *corev1.Container {
 	return findContainerFromPod(proxyContainerName, pod)
 }
 
@@ -143,7 +147,7 @@ type Prober struct {
 
 // dumpAppProbers returns a json encoded string as `status.KubeAppProbers`.
 // Also update the probers so that all usages of named port will be resolved to integer.
-func dumpAppProbers(pod *corev1.Pod, targetPort int32) string {
+func dumpAppProbers(pod *corev1.Pod, targetPort int32, proxyContainerName string) string {
 	out := KubeAppProbers{}
 	updateNamedPort := func(p *Prober, portMap map[string]int32) *Prober {
 		if p == nil {
@@ -177,7 +181,7 @@ func dumpAppProbers(pod *corev1.Pod, targetPort int32) string {
 		return p
 	}
 	for _, c := range allContainers(pod) {
-		if c.Name == ProxyContainerName {
+		if c.Name == proxyContainerName {
 			continue
 		}
 		readyz, livez, startupz, prestopz, poststartz := formatProberURL(c.Name)
@@ -221,11 +225,11 @@ func allContainers(pod *corev1.Pod) []corev1.Container {
 }
 
 // patchRewriteProbe generates the patch for webhook.
-func patchRewriteProbe(pod *corev1.Pod, defaultPort int32) {
+func patchRewriteProbe(pod *corev1.Pod, defaultPort int32, proxyContainerName string) {
 	statusPort := int(defaultPort)
 	for i, c := range pod.Spec.Containers {
 		// Skip sidecar container.
-		if c.Name == ProxyContainerName {
+		if c.Name == proxyContainerName {
 			continue
 		}
 		convertProbe(&c, statusPort)
@@ -233,7 +237,7 @@ func patchRewriteProbe(pod *corev1.Pod, defaultPort int32) {
 	}
 	for i, c := range pod.Spec.InitContainers {
 		// Skip sidecar container.
-		if c.Name == ProxyContainerName {
+		if c.Name == proxyContainerName {
 			continue
 		}
 		convertProbe(&c, statusPort)
@@ -325,14 +329,19 @@ func ApplyHealthProbeRewrite(pod *corev1.Pod) error {
 	if pod.Annotations[HealthProbeRewriteAnnotation] != "true" {
 		return nil
 	}
-	sidecar := findSidecar(pod)
+	proxyContainerName := pod.Annotations[SidecarProxyAnnotation]
+	if proxyContainerName == "" {
+		proxyContainerName = ProxyContainerName
+	}
+
+	sidecar := findSidecar(pod, proxyContainerName)
 	if sidecar == nil {
 		return nil
 	}
 
-	if prober := dumpAppProbers(pod, 15020); prober != "" {
+	if prober := dumpAppProbers(pod, 15020, proxyContainerName); prober != "" {
 		sidecar.Env = append(sidecar.Env, corev1.EnvVar{Name: KubeAppProberEnv, Value: prober})
 	}
-	patchRewriteProbe(pod, 15020)
+	patchRewriteProbe(pod, 15020, proxyContainerName)
 	return nil
 }

--- a/pkg/utils/sidecarutils/traffic-proxy/health_probe_test.go
+++ b/pkg/utils/sidecarutils/traffic-proxy/health_probe_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package egresscontrol
+package trafficproxy
 
 import (
 	"encoding/json"
@@ -89,7 +89,7 @@ func TestFindSidecar(t *testing.T) {
 				Containers: []corev1.Container{{Name: ProxyContainerName}},
 			},
 		}
-		c := findSidecar(pod)
+		c := findSidecar(pod, ProxyContainerName)
 		if c == nil || c.Name != ProxyContainerName {
 			t.Errorf("expected to find %q, got %v", ProxyContainerName, c)
 		}
@@ -101,7 +101,7 @@ func TestFindSidecar(t *testing.T) {
 				InitContainers: []corev1.Container{{Name: ProxyContainerName}},
 			},
 		}
-		c := findSidecar(pod)
+		c := findSidecar(pod, ProxyContainerName)
 		if c == nil || c.Name != ProxyContainerName {
 			t.Errorf("expected to find %q, got %v", ProxyContainerName, c)
 		}
@@ -113,7 +113,7 @@ func TestFindSidecar(t *testing.T) {
 				Containers: []corev1.Container{{Name: "app"}},
 			},
 		}
-		if c := findSidecar(pod); c != nil {
+		if c := findSidecar(pod, ProxyContainerName); c != nil {
 			t.Errorf("expected nil, got %q", c.Name)
 		}
 	})
@@ -321,7 +321,7 @@ func TestDumpAppProbers(t *testing.T) {
 				Containers: []corev1.Container{{Name: "app"}},
 			},
 		}
-		result := dumpAppProbers(pod, 15020)
+		result := dumpAppProbers(pod, 15020, ProxyContainerName)
 		if result != "" {
 			t.Errorf("expected empty string, got %q", result)
 		}
@@ -342,7 +342,7 @@ func TestDumpAppProbers(t *testing.T) {
 				},
 			},
 		}
-		result := dumpAppProbers(pod, 15020)
+		result := dumpAppProbers(pod, 15020, ProxyContainerName)
 		if result == "" {
 			t.Fatal("expected non-empty probers JSON")
 		}
@@ -376,7 +376,7 @@ func TestDumpAppProbers(t *testing.T) {
 				},
 			},
 		}
-		result := dumpAppProbers(pod, 15020)
+		result := dumpAppProbers(pod, 15020, ProxyContainerName)
 		if result == "" {
 			t.Fatal("expected non-empty probers JSON")
 		}
@@ -411,7 +411,7 @@ func TestDumpAppProbers(t *testing.T) {
 				},
 			},
 		}
-		result := dumpAppProbers(pod, 15020)
+		result := dumpAppProbers(pod, 15020, ProxyContainerName)
 		if result != "" {
 			t.Errorf("expected empty string for unresolved named port, got %q", result)
 		}
@@ -432,7 +432,7 @@ func TestDumpAppProbers(t *testing.T) {
 				},
 			},
 		}
-		result := dumpAppProbers(pod, 15020)
+		result := dumpAppProbers(pod, 15020, ProxyContainerName)
 		if result != "" {
 			t.Errorf("expected empty string (proxy container skipped), got %q", result)
 		}
@@ -458,7 +458,7 @@ func TestDumpAppProbers(t *testing.T) {
 				},
 			},
 		}
-		result := dumpAppProbers(pod, 15020)
+		result := dumpAppProbers(pod, 15020, ProxyContainerName)
 		if result == "" {
 			t.Fatal("expected non-empty probers JSON")
 		}
@@ -493,7 +493,7 @@ func TestDumpAppProbers(t *testing.T) {
 				},
 			},
 		}
-		result := dumpAppProbers(pod, 15020)
+		result := dumpAppProbers(pod, 15020, ProxyContainerName)
 		if result == "" {
 			t.Fatal("expected non-empty probers JSON")
 		}
@@ -525,7 +525,7 @@ func TestDumpAppProbers(t *testing.T) {
 				},
 			},
 		}
-		result := dumpAppProbers(pod, 15020)
+		result := dumpAppProbers(pod, 15020, ProxyContainerName)
 		var probers KubeAppProbers
 		if err := json.Unmarshal([]byte(result), &probers); err != nil {
 			t.Fatalf("invalid JSON: %v", err)
@@ -552,7 +552,7 @@ func TestDumpAppProbers(t *testing.T) {
 				},
 			},
 		}
-		result := dumpAppProbers(pod, 15020)
+		result := dumpAppProbers(pod, 15020, ProxyContainerName)
 		var probers KubeAppProbers
 		if err := json.Unmarshal([]byte(result), &probers); err != nil {
 			t.Fatalf("invalid JSON: %v", err)
@@ -579,7 +579,7 @@ func TestDumpAppProbers(t *testing.T) {
 				},
 			},
 		}
-		result := dumpAppProbers(pod, 15020)
+		result := dumpAppProbers(pod, 15020, ProxyContainerName)
 		var probers KubeAppProbers
 		if err := json.Unmarshal([]byte(result), &probers); err != nil {
 			t.Fatalf("invalid JSON: %v", err)
@@ -604,7 +604,7 @@ func TestDumpAppProbers(t *testing.T) {
 				},
 			},
 		}
-		result := dumpAppProbers(pod, 15020)
+		result := dumpAppProbers(pod, 15020, ProxyContainerName)
 		// Port 15020 is the targetPort, so it's considered already rewritten
 		if result != "" {
 			t.Errorf("expected empty string for already-rewritten port, got %q", result)
@@ -634,7 +634,7 @@ func TestPatchRewriteProbe(t *testing.T) {
 			},
 		}
 
-		patchRewriteProbe(pod, 15020)
+		patchRewriteProbe(pod, 15020, ProxyContainerName)
 
 		c := pod.Spec.Containers[0]
 		if c.ReadinessProbe.HTTPGet.Path != "/app-health/app/readyz" {
@@ -667,7 +667,7 @@ func TestPatchRewriteProbe(t *testing.T) {
 			},
 		}
 
-		patchRewriteProbe(pod, 15020)
+		patchRewriteProbe(pod, 15020, ProxyContainerName)
 
 		c := pod.Spec.Containers[0]
 		if c.ReadinessProbe.HTTPGet == nil {
@@ -694,7 +694,7 @@ func TestPatchRewriteProbe(t *testing.T) {
 			},
 		}
 
-		patchRewriteProbe(pod, 15020)
+		patchRewriteProbe(pod, 15020, ProxyContainerName)
 
 		c := pod.Spec.Containers[0]
 		if c.ReadinessProbe.HTTPGet == nil {
@@ -722,7 +722,7 @@ func TestPatchRewriteProbe(t *testing.T) {
 		}
 
 		originalPath := pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Path
-		patchRewriteProbe(pod, 15020)
+		patchRewriteProbe(pod, 15020, ProxyContainerName)
 
 		if pod.Spec.Containers[0].ReadinessProbe.HTTPGet.Path != originalPath {
 			t.Error("proxy container probe should not be rewritten")
@@ -745,7 +745,7 @@ func TestPatchRewriteProbe(t *testing.T) {
 			},
 		}
 
-		patchRewriteProbe(pod, 15020)
+		patchRewriteProbe(pod, 15020, ProxyContainerName)
 
 		c := pod.Spec.InitContainers[0]
 		if c.ReadinessProbe.HTTPGet.Path != "/app-health/init/readyz" {
@@ -772,7 +772,7 @@ func TestPatchRewriteProbe(t *testing.T) {
 			},
 		}
 
-		patchRewriteProbe(pod, 15020)
+		patchRewriteProbe(pod, 15020, ProxyContainerName)
 
 		c := pod.Spec.Containers[0]
 		if c.Lifecycle.PreStop.HTTPGet == nil {

--- a/pkg/utils/sidecarutils/utils.go
+++ b/pkg/utils/sidecarutils/utils.go
@@ -48,20 +48,20 @@ func InjectSandboxRuntimes(ctx context.Context, sandbox *agentsv1alpha1.Sandbox,
 func doSidecarInjection(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod, injectConfigMap map[string]string) error {
 	logger := logf.FromContext(ctx).WithValues("sandbox", klog.KObj(sandbox))
 
-	runtimes := sets.New[string]()
+	injectedRuntimes := sets.NewString()
 	for _, runtime := range sandbox.Spec.Runtimes {
-		if runtime.Name != "" {
-			runtimes.Insert(runtime.Name)
+		if injectedRuntimes.Has(runtime.Name) {
+			logger.V(5).Info("skipping duplicate runtime, already processed", "runtime", runtime.Name)
+			continue
 		}
-	}
+		injectedRuntimes.Insert(runtime.Name)
 
-	for runtime := range runtimes {
-		runtimeInjectConfig, err := parseInjectConfig(ctx, runtime, injectConfigMap)
+		runtimeInjectConfig, err := parseInjectConfig(ctx, runtime.Name, injectConfigMap)
 		if err != nil {
 			logger.Error(err, "failed to parse runtime injection configuration")
 			return err
 		}
-		switch runtime {
+		switch runtime.Name {
 		case agentsv1alpha1.RuntimeConfigForInjectAgentRuntime:
 			if !isContainersExists(pod.Spec.InitContainers, runtimeInjectConfig.Sidecars) && !isContainersExists(pod.Spec.Containers, runtimeInjectConfig.Sidecars) {
 				setAgentRuntimeContainer(ctx, &pod.Spec, runtimeInjectConfig)
@@ -73,17 +73,15 @@ func doSidecarInjection(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, po
 		default:
 			logger.V(5).Info("injecting runtime", "name", runtime)
 			// not mute the conflicts
-			if conflictErr := injectConflicts(pod, runtimeInjectConfig); conflictErr != nil {
+			if conflictErr := checkInjectionConflicts(pod, runtimeInjectConfig); conflictErr != nil {
 				return fmt.Errorf("failed to inject runtime %s: %v", runtime, conflictErr)
 			}
-			if err := applyInjectionTemplate(ctx, pod, runtimeInjectConfig); err != nil {
-				return fmt.Errorf("failed to inject runtime %s: %v", runtime, err)
-			}
+			applyInjectionTemplate(pod, runtimeInjectConfig)
 		}
 	}
 
 	// Enable health probes rewrite if needed.
-	if runtimes.Has(agentsv1alpha1.RuntimeConfigForInjectTrafficProxy) {
+	if injectedRuntimes.Has(agentsv1alpha1.RuntimeConfigForInjectTrafficProxy) {
 		if err := trafficproxy.ApplyHealthProbeRewrite(pod); err != nil {
 			logger.Error(err, "failed to apply health probe rewrite")
 			return err

--- a/pkg/utils/sidecarutils/utils.go
+++ b/pkg/utils/sidecarutils/utils.go
@@ -21,12 +21,13 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
-	egresscontrol "github.com/openkruise/agents/pkg/utils/sidecarutils/egress-control"
+	trafficproxy "github.com/openkruise/agents/pkg/utils/sidecarutils/traffic-proxy"
 )
 
 func InjectSandboxRuntimes(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod, cli client.Client) error {
@@ -47,14 +48,20 @@ func InjectSandboxRuntimes(ctx context.Context, sandbox *agentsv1alpha1.Sandbox,
 func doSidecarInjection(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod, injectConfigMap map[string]string) error {
 	logger := logf.FromContext(ctx).WithValues("sandbox", klog.KObj(sandbox))
 
+	runtimes := sets.New[string]()
 	for _, runtime := range sandbox.Spec.Runtimes {
-		// should we return an error when inject config not exists?
-		runtimeInjectConfig, err := parseInjectConfig(ctx, runtime.Name, injectConfigMap)
+		if runtime.Name != "" {
+			runtimes.Insert(runtime.Name)
+		}
+	}
+
+	for runtime := range runtimes {
+		runtimeInjectConfig, err := parseInjectConfig(ctx, runtime, injectConfigMap)
 		if err != nil {
 			logger.Error(err, "failed to parse runtime injection configuration")
 			return err
 		}
-		switch runtime.Name {
+		switch runtime {
 		case agentsv1alpha1.RuntimeConfigForInjectAgentRuntime:
 			if !isContainersExists(pod.Spec.InitContainers, runtimeInjectConfig.Sidecars) && !isContainersExists(pod.Spec.Containers, runtimeInjectConfig.Sidecars) {
 				setAgentRuntimeContainer(ctx, &pod.Spec, runtimeInjectConfig)
@@ -64,24 +71,20 @@ func doSidecarInjection(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, po
 				setCSIMountContainer(ctx, &pod.Spec, runtimeInjectConfig)
 			}
 		default:
-			injectConfig, err := parseInjectConfig(ctx, KEY_EGRESS_CONTROL_INJECTION_CONFIG, injectConfigMap)
-			if err != nil {
-				logger.Error(err, "failed to parse egress control injection configuration")
-				return err
-			}
+			logger.V(5).Info("injecting runtime", "name", runtime)
 			// not mute the conflicts
-			if isContainersExists(pod.Spec.InitContainers, injectConfig.InitContainers) || isContainersExists(pod.Spec.Containers, injectConfig.Containers) {
-				return fmt.Errorf("injected container conflicts")
+			if conflictErr := injectConflicts(pod, runtimeInjectConfig); conflictErr != nil {
+				return fmt.Errorf("failed to inject runtime %s: %v", runtime, conflictErr)
 			}
-			if err := applyInjectionTemplate(ctx, pod, injectConfig); err != nil {
-				return fmt.Errorf("failed to inject runtime %s: %v", runtime.Name, err)
+			if err := applyInjectionTemplate(ctx, pod, runtimeInjectConfig); err != nil {
+				return fmt.Errorf("failed to inject runtime %s: %v", runtime, err)
 			}
 		}
 	}
 
 	// Enable health probes rewrite if needed.
-	if IsRuntimeEnabled(sandbox, agentsv1alpha1.RuntimeConfigForInjectEgressControl) {
-		if err := egresscontrol.ApplyHealthProbeRewrite(pod); err != nil {
+	if runtimes.Has(agentsv1alpha1.RuntimeConfigForInjectTrafficProxy) {
+		if err := trafficproxy.ApplyHealthProbeRewrite(pod); err != nil {
 			logger.Error(err, "failed to apply health probe rewrite")
 			return err
 		}

--- a/pkg/utils/sidecarutils/utils_test.go
+++ b/pkg/utils/sidecarutils/utils_test.go
@@ -223,7 +223,7 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 			expectCSIVolumeMounts:  1,
 		},
 		{
-			name: "inject egress control sidecar only",
+			name: "inject traffic proxy sidecar only",
 			sandbox: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -235,7 +235,7 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 					},
 					Runtimes: []agentsv1alpha1.RuntimeConfig{
 						{
-							Name: agentsv1alpha1.RuntimeConfigForInjectEgressControl,
+							Name: agentsv1alpha1.RuntimeConfigForInjectTrafficProxy,
 						},
 					},
 				},
@@ -248,14 +248,14 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 				},
 			},
 			injectionConfigData: map[string]string{
-				KEY_EGRESS_CONTROL_INJECTION_CONFIG: `{
+				KEY_TRAFFIC_PROXY_INJECTION_CONFIG: `{
 					"mainContainer": {},
 					"csiSidecar": [],
 					"volume": [{"name": "egress-vol", "emptyDir": {}}],
 					"initContainers": [{"name": "egress-init", "image": "egress-init:v1"}],
 					"containers": [{"name": "egress-sidecar", "image": "egress:v1"}],
 					"labels": {"egress": "enabled"},
-					"annotations": {"egress-control": "true"}
+					"annotations": {"traffic-proxy": "true"}
 				}`,
 			},
 			// Note: InjectPodTemplateCSIAndRuntimeSidecar does not return early when only egress is enabled;
@@ -265,7 +265,7 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 			expectContainers:      2, // main + egress sidecar
 		},
 		{
-			name: "inject egress control with health probe rewrite - early return without CSI/runtime",
+			name: "inject traffic proxy with health probe rewrite - early return without CSI/runtime",
 			sandbox: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -277,7 +277,7 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 					},
 					Runtimes: []agentsv1alpha1.RuntimeConfig{
 						{
-							Name: agentsv1alpha1.RuntimeConfigForInjectEgressControl,
+							Name: agentsv1alpha1.RuntimeConfigForInjectTrafficProxy,
 						},
 					},
 				},
@@ -311,7 +311,7 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 				},
 			},
 			injectionConfigData: map[string]string{
-				KEY_EGRESS_CONTROL_INJECTION_CONFIG: `{
+				KEY_TRAFFIC_PROXY_INJECTION_CONFIG: `{
 					"mainContainer": {},
 					"csiSidecar": [],
 					"volume": [],
@@ -327,7 +327,7 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 			initialContainerCount: 2, // main + istio-proxy
 		},
 		{
-			name: "inject all three: runtime, csi, and egress",
+			name: "inject all three: runtime, csi, and traffic proxy",
 			sandbox: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -345,7 +345,7 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 							Name: agentsv1alpha1.RuntimeConfigForInjectCsiMount,
 						},
 						{
-							Name: agentsv1alpha1.RuntimeConfigForInjectEgressControl,
+							Name: agentsv1alpha1.RuntimeConfigForInjectTrafficProxy,
 						},
 					},
 				},
@@ -368,7 +368,7 @@ func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
 					"csiSidecar": [{"name": "csi-sidecar", "image": "csi:v1"}],
 					"volume": [{"name": "csi-vol", "emptyDir": {}}]
 				}`,
-				KEY_EGRESS_CONTROL_INJECTION_CONFIG: `{
+				KEY_TRAFFIC_PROXY_INJECTION_CONFIG: `{
 					"mainContainer": {},
 					"csiSidecar": [],
 					"volume": [{"name": "egress-vol", "emptyDir": {}}],
@@ -1176,6 +1176,267 @@ func TestDoSidecarInjection(t *testing.T) {
 			}
 			if !mainContainerFound {
 				t.Error("expected main container to still exist")
+			}
+		})
+	}
+}
+
+func TestInjectConflicts(t *testing.T) {
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		config        SidecarInjectConfig
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "no conflicts",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers:     []corev1.Container{{Name: "main", Image: "nginx"}},
+					InitContainers: []corev1.Container{{Name: "init-main", Image: "busybox"}},
+					Volumes:        []corev1.Volume{{Name: "data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+				},
+			},
+			config: SidecarInjectConfig{
+				Containers:     []corev1.Container{{Name: "sidecar", Image: "proxy:v1"}},
+				InitContainers: []corev1.Container{{Name: "init-sidecar", Image: "init:v1"}},
+				Volumes:        []corev1.Volume{{Name: "sidecar-vol", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+			},
+			expectError: false,
+		},
+		{
+			name: "container name conflict",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "nginx"}},
+				},
+			},
+			config: SidecarInjectConfig{
+				Containers: []corev1.Container{{Name: "main", Image: "proxy:v1"}},
+			},
+			expectError:   true,
+			errorContains: "inject conflicting with container: main",
+		},
+		{
+			name: "init container name conflict",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers:     []corev1.Container{{Name: "main", Image: "nginx"}},
+					InitContainers: []corev1.Container{{Name: "init-setup", Image: "busybox"}},
+				},
+			},
+			config: SidecarInjectConfig{
+				InitContainers: []corev1.Container{{Name: "init-setup", Image: "init:v1"}},
+			},
+			expectError:   true,
+			errorContains: "inject conflicting with init container: init-setup",
+		},
+		{
+			name: "volume name conflict",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "nginx"}},
+					Volumes:    []corev1.Volume{{Name: "shared-data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+				},
+			},
+			config: SidecarInjectConfig{
+				Volumes: []corev1.Volume{{Name: "shared-data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+			},
+			expectError:   true,
+			errorContains: "inject conflicting with volume: shared-data",
+		},
+		{
+			name: "multiple conflicts - reports first init container conflict",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers:     []corev1.Container{{Name: "app", Image: "nginx"}},
+					InitContainers: []corev1.Container{{Name: "init-app", Image: "busybox"}},
+					Volumes:        []corev1.Volume{{Name: "vol-a", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+				},
+			},
+			config: SidecarInjectConfig{
+				InitContainers: []corev1.Container{{Name: "init-app", Image: "init:v1"}},
+				Containers:     []corev1.Container{{Name: "app", Image: "proxy:v1"}},
+				Volumes:        []corev1.Volume{{Name: "vol-a", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+			},
+			expectError:   true,
+			errorContains: "init container: init-app",
+		},
+		{
+			name: "empty config - no conflicts",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "nginx"}},
+				},
+			},
+			config:      SidecarInjectConfig{},
+			expectError: false,
+		},
+		{
+			name: "empty pod - no conflicts",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{},
+			},
+			config: SidecarInjectConfig{
+				Containers:     []corev1.Container{{Name: "sidecar", Image: "proxy:v1"}},
+				InitContainers: []corev1.Container{{Name: "init-sidecar", Image: "init:v1"}},
+				Volumes:        []corev1.Volume{{Name: "vol", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := injectConflicts(tt.pod, tt.config)
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errorContains, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestDoSidecarInjectionConflicts(t *testing.T) {
+	tests := []struct {
+		name            string
+		sandbox         *agentsv1alpha1.Sandbox
+		pod             *corev1.Pod
+		injectConfigMap map[string]string
+		expectError     bool
+		errorContains   string
+	}{
+		{
+			name: "traffic-proxy container conflict returns error",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Runtimes: []agentsv1alpha1.RuntimeConfig{
+						{Name: agentsv1alpha1.RuntimeConfigForInjectTrafficProxy},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+						{Name: "istio-proxy", Image: "existing-proxy:v1"},
+					},
+				},
+			},
+			injectConfigMap: map[string]string{
+				KEY_TRAFFIC_PROXY_INJECTION_CONFIG: `{
+					"mainContainer": {"name": ""},
+					"csiSidecar": [],
+					"volume": [],
+					"containers": [{"name": "istio-proxy", "image": "istio:v1"}]
+				}`,
+			},
+			expectError:   true,
+			errorContains: "istio-proxy",
+		},
+		{
+			name: "traffic-proxy init container conflict returns error",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Runtimes: []agentsv1alpha1.RuntimeConfig{
+						{Name: agentsv1alpha1.RuntimeConfigForInjectTrafficProxy},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers:     []corev1.Container{{Name: "main", Image: "nginx"}},
+					InitContainers: []corev1.Container{{Name: "istio-init", Image: "existing:v1"}},
+				},
+			},
+			injectConfigMap: map[string]string{
+				KEY_TRAFFIC_PROXY_INJECTION_CONFIG: `{
+					"mainContainer": {"name": ""},
+					"csiSidecar": [],
+					"volume": [],
+					"initContainers": [{"name": "istio-init", "image": "istio-init:v1"}],
+					"containers": [{"name": "istio-proxy", "image": "istio:v1"}]
+				}`,
+			},
+			expectError:   true,
+			errorContains: "istio-init",
+		},
+		{
+			name: "traffic-proxy no conflict succeeds and injects correctly",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Runtimes: []agentsv1alpha1.RuntimeConfig{
+						{Name: agentsv1alpha1.RuntimeConfigForInjectTrafficProxy},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"networking.agents.kruise.io/health-probe-rewrite": "false",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "nginx"}},
+				},
+			},
+			injectConfigMap: map[string]string{
+				KEY_TRAFFIC_PROXY_INJECTION_CONFIG: `{
+					"mainContainer": {"name": ""},
+					"csiSidecar": [],
+					"volume": [],
+					"initContainers": [{"name": "istio-init", "image": "istio-init:v1"}],
+					"containers": [{"name": "istio-proxy", "image": "istio:v1"}],
+					"annotations": {"sidecar.istio.io/status": "injected"},
+					"labels": {"app.mesh": "true"}
+				}`,
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			err := doSidecarInjection(ctx, tt.sandbox, tt.pod, tt.injectConfigMap)
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errorContains, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				// Verify successful injection applied correctly
+				if tt.name == "traffic-proxy no conflict succeeds and injects correctly" {
+					if utils.FindContainer("istio-proxy", tt.pod.Spec.Containers) == nil {
+						t.Error("expected istio-proxy container to be injected")
+					}
+					if utils.FindContainer("istio-init", tt.pod.Spec.InitContainers) == nil {
+						t.Error("expected istio-init init container to be injected")
+					}
+					if tt.pod.Labels["app.mesh"] != "true" {
+						t.Error("expected label app.mesh=true to be injected")
+					}
+					if tt.pod.Annotations["sidecar.istio.io/status"] != "injected" {
+						t.Error("expected annotation sidecar.istio.io/status=injected to be injected")
+					}
+				}
 			}
 		})
 	}

--- a/pkg/utils/sidecarutils/utils_test.go
+++ b/pkg/utils/sidecarutils/utils_test.go
@@ -1289,7 +1289,7 @@ func TestInjectConflicts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := injectConflicts(tt.pod, tt.config)
+			err := checkInjectionConflicts(tt.pod, tt.config)
 			if tt.expectError {
 				if err == nil {
 					t.Fatalf("expected error but got nil")
@@ -1436,6 +1436,221 @@ func TestDoSidecarInjectionConflicts(t *testing.T) {
 					if tt.pod.Annotations["sidecar.istio.io/status"] != "injected" {
 						t.Error("expected annotation sidecar.istio.io/status=injected to be injected")
 					}
+				}
+			}
+		})
+	}
+}
+
+func TestDoSidecarInjectionDuplicateRuntimes(t *testing.T) {
+	tests := []struct {
+		name                   string
+		sandbox                *agentsv1alpha1.Sandbox
+		pod                    *corev1.Pod
+		injectConfigMap        map[string]string
+		expectRuntimeContainer bool
+		expectCSIContainer     bool
+		expectEgressContainer  bool
+		expectInitContainers   int
+		expectContainers       int
+	}{
+		{
+			name: "duplicate runtime names - only first runtime processed",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Runtimes: []agentsv1alpha1.RuntimeConfig{
+						{Name: agentsv1alpha1.RuntimeConfigForInjectAgentRuntime},
+						{Name: agentsv1alpha1.RuntimeConfigForInjectAgentRuntime},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "nginx"}},
+				},
+			},
+			injectConfigMap: map[string]string{
+				KEY_RUNTIME_INJECTION_CONFIG: `{
+					"mainContainer": {"env": [{"name": "RUNTIME_ENV", "value": "test"}], "volumeMounts": []},
+					"csiSidecar": [{"name": "runtime-sidecar", "image": "runtime:v1"}],
+					"volume": []
+				}`,
+			},
+			expectRuntimeContainer: true,
+			expectInitContainers:   1, // only one runtime-sidecar, not duplicated
+		},
+		{
+			name: "duplicate csi runtime names - only first csi processed",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Runtimes: []agentsv1alpha1.RuntimeConfig{
+						{Name: agentsv1alpha1.RuntimeConfigForInjectCsiMount},
+						{Name: agentsv1alpha1.RuntimeConfigForInjectCsiMount},
+						{Name: agentsv1alpha1.RuntimeConfigForInjectCsiMount},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "nginx"}},
+				},
+			},
+			injectConfigMap: map[string]string{
+				KEY_CSI_INJECTION_CONFIG: `{
+					"mainContainer": {"volumeMounts": [{"name": "csi-vol", "mountPath": "/csi"}]},
+					"csiSidecar": [{"name": "csi-sidecar", "image": "csi:v1"}],
+					"volume": [{"name": "csi-vol", "emptyDir": {}}]
+				}`,
+			},
+			expectCSIContainer:   true,
+			expectInitContainers: 1, // only one csi-sidecar despite 3 runtime entries
+		},
+		{
+			name: "duplicate traffic-proxy runtime names - only first processed",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Runtimes: []agentsv1alpha1.RuntimeConfig{
+						{Name: agentsv1alpha1.RuntimeConfigForInjectTrafficProxy},
+						{Name: agentsv1alpha1.RuntimeConfigForInjectTrafficProxy},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "nginx"}},
+				},
+			},
+			injectConfigMap: map[string]string{
+				KEY_TRAFFIC_PROXY_INJECTION_CONFIG: `{
+					"mainContainer": {},
+					"csiSidecar": [],
+					"volume": [{"name": "egress-vol", "emptyDir": {}}],
+					"initContainers": [],
+					"containers": [{"name": "egress-sidecar", "image": "egress:v1"}],
+					"labels": {"egress": "enabled"},
+					"annotations": {}
+				}`,
+			},
+			expectEgressContainer: true,
+			expectContainers:       2, // main + egress sidecar
+		},
+		{
+			name: "mixed unique and duplicate runtimes - order preserved, first wins",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Runtimes: []agentsv1alpha1.RuntimeConfig{
+						{Name: agentsv1alpha1.RuntimeConfigForInjectAgentRuntime},
+						{Name: agentsv1alpha1.RuntimeConfigForInjectCsiMount},
+						{Name: agentsv1alpha1.RuntimeConfigForInjectAgentRuntime}, // duplicate, should skip
+						{Name: agentsv1alpha1.RuntimeConfigForInjectTrafficProxy},
+						{Name: agentsv1alpha1.RuntimeConfigForInjectCsiMount}, // duplicate, should skip
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "nginx"}},
+				},
+			},
+			injectConfigMap: map[string]string{
+				KEY_RUNTIME_INJECTION_CONFIG: `{
+					"mainContainer": {"env": [{"name": "RUNTIME", "value": "on"}], "volumeMounts": []},
+					"csiSidecar": [{"name": "runtime-sidecar", "image": "runtime:v1"}],
+					"volume": []
+				}`,
+				KEY_CSI_INJECTION_CONFIG: `{
+					"mainContainer": {"volumeMounts": [{"name": "csi-vol", "mountPath": "/csi"}]},
+					"csiSidecar": [{"name": "csi-sidecar", "image": "csi:v1"}],
+					"volume": [{"name": "csi-vol", "emptyDir": {}}]
+				}`,
+				KEY_TRAFFIC_PROXY_INJECTION_CONFIG: `{
+					"mainContainer": {},
+					"csiSidecar": [],
+					"volume": [{"name": "egress-vol", "emptyDir": {}}],
+					"initContainers": [],
+					"containers": [{"name": "egress-sidecar", "image": "egress:v1"}],
+					"labels": {},
+					"annotations": {}
+				}`,
+			},
+			expectRuntimeContainer: true,
+			expectCSIContainer:     true,
+			expectEgressContainer:  true,
+			expectInitContainers:   2, // runtime-sidecar + csi-sidecar (no duplicates)
+			expectContainers:       2, // main + egress-sidecar
+		},
+		{
+			name: "empty runtime list - no injection",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec:       agentsv1alpha1.SandboxSpec{},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "nginx"}},
+				},
+			},
+			injectConfigMap:  map[string]string{},
+			expectContainers: 1, // unchanged
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			err := doSidecarInjection(ctx, tt.sandbox, tt.pod, tt.injectConfigMap)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			runtimeContainerInjected := false
+			csiContainerInjected := false
+			for _, container := range tt.pod.Spec.InitContainers {
+				if container.Name == "runtime-sidecar" && container.Image == "runtime:v1" {
+					runtimeContainerInjected = true
+				}
+				if container.Name == "csi-sidecar" && container.Image == "csi:v1" {
+					csiContainerInjected = true
+				}
+			}
+			egressContainerInjected := false
+			for _, container := range tt.pod.Spec.Containers {
+				if container.Name == "egress-sidecar" && container.Image == "egress:v1" {
+					egressContainerInjected = true
+				}
+			}
+
+			if tt.expectRuntimeContainer && !runtimeContainerInjected {
+				t.Error("expected runtime sidecar to be injected, but not found")
+			}
+			if !tt.expectRuntimeContainer && runtimeContainerInjected {
+				t.Error("expected NO runtime sidecar injection, but injection occurred")
+			}
+			if tt.expectCSIContainer && !csiContainerInjected {
+				t.Error("expected csi sidecar to be injected, but not found")
+			}
+			if !tt.expectCSIContainer && csiContainerInjected {
+				t.Error("expected NO csi sidecar injection, but injection occurred")
+			}
+			if tt.expectEgressContainer && !egressContainerInjected {
+				t.Error("expected egress sidecar to be injected, but not found")
+			}
+			if !tt.expectEgressContainer && egressContainerInjected {
+				t.Error("expected NO egress sidecar injection, but injection occurred")
+			}
+
+			if tt.expectInitContainers > 0 {
+				if len(tt.pod.Spec.InitContainers) != tt.expectInitContainers {
+					t.Errorf("expected %d InitContainers, got %d", tt.expectInitContainers, len(tt.pod.Spec.InitContainers))
+				}
+			}
+			if tt.expectContainers > 0 {
+				if len(tt.pod.Spec.Containers) != tt.expectContainers {
+					t.Errorf("expected %d Containers, got %d", tt.expectContainers, len(tt.pod.Spec.Containers))
 				}
 			}
 		})

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -192,9 +192,9 @@ func TestTruncateConditionMessage_EnvOverride(t *testing.T) {
 	defer func() { MaxConditionMessageLen = original }()
 
 	tests := []struct {
-		name     string
-		envVal   string
-		wantLen  int
+		name    string
+		envVal  string
+		wantLen int
 	}{
 		{
 			name:    "valid env value",


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This is a followup fix for egress control. The changes can be concluded as:
1. rename egress control to traffic proxy
2. not override user-defined pod labels and annotations
3. fixed some health probe issues

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

