### PR TITLE
sandbox: resume upgrades from previous failed step

### DIFF
--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -419,22 +419,48 @@ func (r *SandboxReconciler) calculateStatus(ctx context.Context, args core.Ensur
 
 	case agentsv1alpha1.SandboxUpgrading:
 		// This indicates the podTemplate has changed again during an ongoing upgrade.
-		// Therefore, the Upgrading condition reason must be reset to PreUpgrade to restart the upgrade lifecycle.
+		// Determine the resume step after the desired template changes during an ongoing upgrade.
 		if newStatus.UpdateRevision != box.Status.UpdateRevision {
 			upgradeCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionUpgrading))
 			if upgradeCond != nil {
-				klog.InfoS("podTemplate changed during upgrade, resetting condition Upgrading reason to PreUpgrade",
+				resumeReason := determineUpgradeResumeReason(pod, newStatus, upgradeCond)
+				klog.InfoS("podTemplate changed during upgrade, resetting condition Upgrading reason",
 					"sandbox", klog.KObj(box),
 					"previousReason", upgradeCond.Reason,
 					"oldRevision", box.Status.UpdateRevision,
-					"newRevision", newStatus.UpdateRevision)
-				upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonPreUpgrade
+					"newRevision", newStatus.UpdateRevision,
+					"resumeReason", resumeReason)
+				upgradeCond.Reason = resumeReason
 				upgradeCond.Message = ""
 				utils.SetSandboxCondition(newStatus, *upgradeCond)
 			}
 		}
 	}
 	return newStatus, false
+}
+
+func determineUpgradeResumeReason(
+	pod *corev1.Pod,
+	newStatus *agentsv1alpha1.SandboxStatus,
+	upgradeCond *metav1.Condition,
+) string {
+	if upgradeCond == nil || !utilfeature.DefaultFeatureGate.Enabled(features.SandboxUpgradeResumeFromFailedStepGate) {
+		return agentsv1alpha1.SandboxUpgradingReasonPreUpgrade
+	}
+
+	switch upgradeCond.Reason {
+	case agentsv1alpha1.SandboxUpgradingReasonPreUpgradeFailed:
+		return agentsv1alpha1.SandboxUpgradingReasonPreUpgrade
+	case agentsv1alpha1.SandboxUpgradingReasonUpgradePodFailed:
+		return agentsv1alpha1.SandboxUpgradingReasonUpgradePod
+	case agentsv1alpha1.SandboxUpgradingReasonPostUpgradeFailed:
+		if pod != nil && pod.Labels[agentsv1alpha1.PodLabelTemplateHash] == newStatus.UpdateRevision {
+			return agentsv1alpha1.SandboxUpgradingReasonPostUpgrade
+		}
+		return agentsv1alpha1.SandboxUpgradingReasonUpgradePod
+	default:
+		return agentsv1alpha1.SandboxUpgradingReasonPreUpgrade
+	}
 }
 
 func updateStatusIfPodCompleted(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus) {

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -42,6 +42,7 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/controller/sandbox/core"
+	"github.com/openkruise/agents/pkg/features"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
@@ -2869,7 +2870,7 @@ func TestReconcile_SandboxNotFoundCleanup(t *testing.T) {
 		}),
 		checkpointControl: core.NewCheckpointControl(fakeClient, fakeRecorder),
 		rateLimiter:       rl,
-		metricsCleanup: &fakeEnqueuer{},
+		metricsCleanup:    &fakeEnqueuer{},
 	}
 
 	// Set up expectations for a sandbox that will not be found
@@ -3955,6 +3956,193 @@ func TestUpdateSandboxStatus_Upgrading_RevisionUnchanged_NoReset(t *testing.T) {
 	}
 	if upgradeCond.Message != "upgrading pod" {
 		t.Errorf("Expected Message %q, got %q", "upgrading pod", upgradeCond.Message)
+	}
+}
+
+func TestUpdateSandboxStatus_Upgrading_RevisionChanged_ResumeFromFailedStep(t *testing.T) {
+	_ = utilfeature.DefaultMutableFeatureGate.Set(string(features.SandboxUpgradeResumeFromFailedStepGate) + "=true")
+	defer func() {
+		_ = utilfeature.DefaultMutableFeatureGate.Set(string(features.SandboxUpgradeResumeFromFailedStepGate) + "=true")
+	}()
+
+	tests := []struct {
+		name           string
+		pod            *corev1.Pod
+		reason         string
+		expectReason   string
+		updateRevision string
+	}{
+		{
+			name:           "pre upgrade failed resumes from preUpgrade",
+			reason:         agentsv1alpha1.SandboxUpgradingReasonPreUpgradeFailed,
+			expectReason:   agentsv1alpha1.SandboxUpgradingReasonPreUpgrade,
+			updateRevision: "old-revision",
+		},
+		{
+			name:           "upgrade pod failed resumes from upgradePod",
+			reason:         agentsv1alpha1.SandboxUpgradingReasonUpgradePodFailed,
+			expectReason:   agentsv1alpha1.SandboxUpgradingReasonUpgradePod,
+			updateRevision: "old-revision",
+		},
+		{
+			name: "post upgrade failed with matching pod revision resumes from postUpgrade",
+			pod: func() *corev1.Pod {
+				p := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}}}
+				return p
+			}(),
+			reason:         agentsv1alpha1.SandboxUpgradingReasonPostUpgradeFailed,
+			expectReason:   agentsv1alpha1.SandboxUpgradingReasonPostUpgrade,
+			updateRevision: "old-revision",
+		},
+		{
+			name:           "post upgrade failed with mismatched pod revision resumes from upgradePod",
+			reason:         agentsv1alpha1.SandboxUpgradingReasonPostUpgradeFailed,
+			expectReason:   agentsv1alpha1.SandboxUpgradingReasonUpgradePod,
+			updateRevision: "old-revision",
+		},
+		{
+			name:           "non failed reason still resets to preUpgrade",
+			reason:         agentsv1alpha1.SandboxUpgradingReasonUpgradePod,
+			expectReason:   agentsv1alpha1.SandboxUpgradingReasonPreUpgrade,
+			updateRevision: "old-revision",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			box := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-sandbox",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+							},
+						},
+					},
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					UpdateRevision: tt.updateRevision,
+				},
+			}
+
+			hash, _ := core.HashSandbox(box)
+			if tt.pod != nil {
+				tt.pod = tt.pod.DeepCopy()
+				tt.pod.Labels[agentsv1alpha1.PodLabelTemplateHash] = hash
+			}
+
+			initStatus := &agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxUpgrading,
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionUpgrading),
+						Status:             metav1.ConditionFalse,
+						Reason:             tt.reason,
+						Message:            "needs reset",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			}
+
+			args := core.EnsureFuncArgs{
+				Pod:       tt.pod,
+				Box:       box,
+				NewStatus: initStatus,
+			}
+
+			scheme := runtime.NewScheme()
+			_ = clientgoscheme.AddToScheme(scheme)
+			_ = agentsv1alpha1.AddToScheme(scheme)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			reconciler := &SandboxReconciler{
+				checkpointControl: core.NewCheckpointControl(fakeClient, record.NewFakeRecorder(10)),
+			}
+			newStatus, _ := reconciler.calculateStatus(context.Background(), args)
+			upgradeCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionUpgrading))
+			if upgradeCond == nil {
+				t.Fatal("Expected Upgrading condition to exist")
+			}
+			if upgradeCond.Reason != tt.expectReason {
+				t.Errorf("Expected Reason %s, got %s", tt.expectReason, upgradeCond.Reason)
+			}
+			if upgradeCond.Message != "" {
+				t.Errorf("Expected Message to be empty, got %q", upgradeCond.Message)
+			}
+		})
+	}
+}
+
+func TestUpdateSandboxStatus_Upgrading_RevisionChanged_FeatureGateDisabled_ResetsToPreUpgrade(t *testing.T) {
+	_ = utilfeature.DefaultMutableFeatureGate.Set(string(features.SandboxUpgradeResumeFromFailedStepGate) + "=false")
+	defer func() {
+		_ = utilfeature.DefaultMutableFeatureGate.Set(string(features.SandboxUpgradeResumeFromFailedStepGate) + "=true")
+	}()
+
+	box := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-sandbox",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: agentsv1alpha1.SandboxSpec{
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+					},
+				},
+			},
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			UpdateRevision: "old-revision",
+		},
+	}
+
+	initStatus := &agentsv1alpha1.SandboxStatus{
+		Phase: agentsv1alpha1.SandboxUpgrading,
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(agentsv1alpha1.SandboxConditionUpgrading),
+				Status:             metav1.ConditionFalse,
+				Reason:             agentsv1alpha1.SandboxUpgradingReasonPostUpgradeFailed,
+				Message:            "post failed",
+				LastTransitionTime: metav1.Now(),
+			},
+		},
+	}
+
+	args := core.EnsureFuncArgs{
+		Pod: &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+			},
+		},
+		Box:       box,
+		NewStatus: initStatus,
+	}
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := &SandboxReconciler{
+		checkpointControl: core.NewCheckpointControl(fakeClient, record.NewFakeRecorder(10)),
+	}
+	newStatus, _ := reconciler.calculateStatus(context.Background(), args)
+	upgradeCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionUpgrading))
+	if upgradeCond == nil {
+		t.Fatal("Expected Upgrading condition to exist")
+	}
+	if upgradeCond.Reason != agentsv1alpha1.SandboxUpgradingReasonPreUpgrade {
+		t.Errorf("Expected Reason %s, got %s", agentsv1alpha1.SandboxUpgradingReasonPreUpgrade, upgradeCond.Reason)
+	}
+	if upgradeCond.Message != "" {
+		t.Errorf("Expected Message to be empty, got %q", upgradeCond.Message)
 	}
 }
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -50,6 +50,11 @@ const (
 	// to prevent naming collisions across multiple clusters.
 	SandboxMultiClusterNaming featuregate.Feature = "SandboxMultiClusterNaming"
 
+	// SandboxUpgradeResumeFromFailedStepGate enables phase-aware resume behavior for sandbox upgrades.
+	// When enabled, the sandbox controller resumes from the previously failed upgrade step instead of
+	// always restarting from PreUpgrade after a template change.
+	SandboxUpgradeResumeFromFailedStepGate featuregate.Feature = "SandboxUpgradeResumeFromFailedStep"
+
 	// SecurityIdentityProviderGate enables issuing sandbox access tokens via an external
 	// identity provider service instead of random UUID generation.
 	SecurityIdentityProviderGate featuregate.Feature = "SecurityIdentityProvider"
@@ -60,16 +65,17 @@ const (
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	SandboxGate:                      {Default: true, PreRelease: featuregate.Alpha},
-	SandboxSetGate:                   {Default: true, PreRelease: featuregate.Alpha},
-	SandboxClaimGate:                 {Default: true, PreRelease: featuregate.Alpha},
-	SandboxCreatePodRateLimitGate:    {Default: false, PreRelease: featuregate.Alpha},
-	SandboxCreatePodInjectConfigGate: {Default: false, PreRelease: featuregate.Alpha},
-	CachePodLabelSelectorGate:        {Default: true, PreRelease: featuregate.Alpha},
-	SandboxInPlaceResourceResizeGate: {Default: true, PreRelease: featuregate.Alpha},
-	SandboxMultiClusterNaming:        {Default: false, PreRelease: featuregate.Alpha},
-	SecurityIdentityProviderGate:     {Default: false, PreRelease: featuregate.Alpha},
-	SandboxPauseCheckpointGate:       {Default: false, PreRelease: featuregate.Alpha},
+	SandboxGate:                            {Default: true, PreRelease: featuregate.Alpha},
+	SandboxSetGate:                         {Default: true, PreRelease: featuregate.Alpha},
+	SandboxClaimGate:                       {Default: true, PreRelease: featuregate.Alpha},
+	SandboxCreatePodRateLimitGate:          {Default: false, PreRelease: featuregate.Alpha},
+	SandboxCreatePodInjectConfigGate:       {Default: false, PreRelease: featuregate.Alpha},
+	CachePodLabelSelectorGate:              {Default: true, PreRelease: featuregate.Alpha},
+	SandboxInPlaceResourceResizeGate:       {Default: true, PreRelease: featuregate.Alpha},
+	SandboxMultiClusterNaming:              {Default: false, PreRelease: featuregate.Alpha},
+	SandboxUpgradeResumeFromFailedStepGate: {Default: true, PreRelease: featuregate.Alpha},
+	SecurityIdentityProviderGate:           {Default: false, PreRelease: featuregate.Alpha},
+	SandboxPauseCheckpointGate:             {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/test/e2e/sandboxupdateops_test.go
+++ b/test/e2e/sandboxupdateops_test.go
@@ -188,6 +188,32 @@ var _ = Describe("SandboxUpdateOps E2E", func() {
 		})
 	}
 
+	getUpgradingCondition := func(sbx *agentsv1alpha1.Sandbox) *metav1.Condition {
+		for i := range sbx.Status.Conditions {
+			if sbx.Status.Conditions[i].Type == string(agentsv1alpha1.SandboxConditionUpgrading) {
+				return &sbx.Status.Conditions[i]
+			}
+		}
+		return nil
+	}
+
+	waitSandboxUpgradeReason := func(sbx *agentsv1alpha1.Sandbox, reason string, timeout time.Duration) {
+		Eventually(func() string {
+			_ = k8sClient.Get(ctx, types.NamespacedName{Name: sbx.Name, Namespace: sbx.Namespace}, sbx)
+			cond := getUpgradingCondition(sbx)
+			if cond == nil {
+				return ""
+			}
+			return cond.Reason
+		}, timeout, time.Second).Should(Equal(reason))
+	}
+
+	waitOpsDeleted := func(ops *agentsv1alpha1.SandboxUpdateOps) {
+		Eventually(func() bool {
+			return errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: ops.Name, Namespace: ops.Namespace}, ops))
+		}, 30*time.Second, time.Second).Should(BeTrue())
+	}
+
 	Context("Webhook Validation", func() {
 		It("should reject Update that modifies Lifecycle field", func() {
 			By("Creating a Sandbox and waiting for Running")
@@ -854,5 +880,303 @@ var _ = Describe("SandboxUpdateOps E2E", func() {
 					"sandbox %s should not have ops label since template already matched", sbx.Name)
 			}
 		})
+
+		It("should recover previous UpgradePodFailed sandboxes without rerunning preUpgrade", func() {
+			labelValue := fmt.Sprintf("recover-upgradepod-%d", time.Now().UnixNano())
+			sbx := newOpsSandbox(
+				fmt.Sprintf("ops-recover-upgradepod-%s", labelValue[:10]),
+				labelValue, nil, nil,
+			)
+
+			By("Creating a Sandbox and waiting for Running")
+			Expect(k8sClient.Create(ctx, sbx)).To(Succeed())
+			waitSandboxRunning(sbx)
+
+			By("Creating a SandboxUpdateOps that succeeds preUpgrade and fails in UpgradePod")
+			ops1 := &agentsv1alpha1.SandboxUpdateOps{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("ops-recover-upgradepod-1-%s", labelValue[:10]),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxUpdateOpsSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{batchLabel: labelValue},
+					},
+					Patch: mustMarshalPatch(corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "test-container", Image: badImage},
+							},
+						},
+					}),
+					Lifecycle: &agentsv1alpha1.SandboxLifecycle{
+						PreUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec:           &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "exit 0"}},
+							TimeoutSeconds: 30,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ops1)).To(Succeed())
+
+			By("Waiting for the sandbox to stop at UpgradePodFailed")
+			waitSandboxUpgradeReason(sbx, agentsv1alpha1.SandboxUpgradingReasonUpgradePodFailed, 3*time.Minute)
+
+			By("Deleting the failed SandboxUpdateOps and waiting for label cleanup")
+			Expect(k8sClient.Delete(ctx, ops1)).To(Succeed())
+			waitOpsDeleted(ops1)
+			Eventually(func() bool {
+				updated := &agentsv1alpha1.Sandbox{}
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), updated); err != nil {
+					return false
+				}
+				return updated.Labels[agentsv1alpha1.LabelSandboxUpdateOps] == ""
+			}, 30*time.Second, time.Second).Should(BeTrue())
+
+			By("Creating a recovery SandboxUpdateOps with failing preUpgrade")
+			ops2 := &agentsv1alpha1.SandboxUpdateOps{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("ops-recover-upgradepod-2-%s", labelValue[:10]),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxUpdateOpsSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{batchLabel: labelValue},
+					},
+					Patch: mustMarshalPatch(corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "test-container", Image: updateImage},
+							},
+						},
+					}),
+					Lifecycle: &agentsv1alpha1.SandboxLifecycle{
+						PreUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec:           &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "exit 1"}},
+							TimeoutSeconds: 30,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ops2)).To(Succeed())
+
+			By("Waiting for recovery to complete, which proves preUpgrade was skipped")
+			waitOpsPhase(ops2, agentsv1alpha1.SandboxUpdateOpsCompleted, 3*time.Minute)
+			waitSandboxRunning(sbx)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ops2.Name, Namespace: ops2.Namespace}, ops2)).To(Succeed())
+			Expect(ops2.Status.UpdatedReplicas).To(Equal(int32(1)))
+
+			updatedPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: sbx.Name, Namespace: sbx.Namespace}, updatedPod)).To(Succeed())
+			Expect(updatedPod.Spec.Containers[0].Image).To(Equal(updateImage))
+		})
+
+		It("should recover previous PostUpgradeFailed sandboxes without rerunning preUpgrade or recreating pod when patch is unchanged", func() {
+			labelValue := fmt.Sprintf("recover-postupgrade-%d", time.Now().UnixNano())
+			sbx := newOpsSandbox(
+				fmt.Sprintf("ops-recover-postupgrade-%s", labelValue[:10]),
+				labelValue, nil, nil,
+			)
+
+			By("Creating a Sandbox and waiting for Running")
+			Expect(k8sClient.Create(ctx, sbx)).To(Succeed())
+			waitSandboxRunning(sbx)
+
+			By("Creating a SandboxUpdateOps that fails in postUpgrade after upgrading the pod")
+			ops1 := &agentsv1alpha1.SandboxUpdateOps{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("ops-recover-postupgrade-1-%s", labelValue[:10]),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxUpdateOpsSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{batchLabel: labelValue},
+					},
+					Patch: mustMarshalPatch(corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "test-container", Image: updateImage},
+							},
+						},
+					}),
+					Lifecycle: &agentsv1alpha1.SandboxLifecycle{
+						PreUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec:           &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "exit 0"}},
+							TimeoutSeconds: 30,
+						},
+						PostUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec:           &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "exit 1"}},
+							TimeoutSeconds: 30,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ops1)).To(Succeed())
+
+			By("Waiting for the sandbox to stop at PostUpgradeFailed")
+			waitSandboxUpgradeReason(sbx, agentsv1alpha1.SandboxUpgradingReasonPostUpgradeFailed, 3*time.Minute)
+
+			By("Recording pod UID after the failed postUpgrade")
+			failedPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: sbx.Name, Namespace: sbx.Namespace}, failedPod)).To(Succeed())
+			failedPodUID := failedPod.UID
+
+			By("Deleting the failed SandboxUpdateOps and waiting for label cleanup")
+			Expect(k8sClient.Delete(ctx, ops1)).To(Succeed())
+			waitOpsDeleted(ops1)
+			Eventually(func() bool {
+				updated := &agentsv1alpha1.Sandbox{}
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), updated); err != nil {
+					return false
+				}
+				return updated.Labels[agentsv1alpha1.LabelSandboxUpdateOps] == ""
+			}, 30*time.Second, time.Second).Should(BeTrue())
+
+			By("Creating a recovery SandboxUpdateOps with unchanged patch, failing preUpgrade, and fixed postUpgrade")
+			ops2 := &agentsv1alpha1.SandboxUpdateOps{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("ops-recover-postupgrade-2-%s", labelValue[:10]),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxUpdateOpsSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{batchLabel: labelValue},
+					},
+					Patch: mustMarshalPatch(corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "test-container", Image: updateImage},
+							},
+						},
+					}),
+					Lifecycle: &agentsv1alpha1.SandboxLifecycle{
+						PreUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec:           &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "exit 1"}},
+							TimeoutSeconds: 30,
+						},
+						PostUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec:           &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "exit 0"}},
+							TimeoutSeconds: 30,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ops2)).To(Succeed())
+
+			By("Waiting for recovery to complete, which proves preUpgrade was skipped")
+			waitOpsPhase(ops2, agentsv1alpha1.SandboxUpdateOpsCompleted, 3*time.Minute)
+			waitSandboxRunning(sbx)
+
+			By("Verifying the pod UID stays the same because the patch did not change")
+			recoveredPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: sbx.Name, Namespace: sbx.Namespace}, recoveredPod)).To(Succeed())
+			Expect(recoveredPod.UID).To(Equal(failedPodUID))
+			Expect(recoveredPod.Spec.Containers[0].Image).To(Equal(updateImage))
+		})
+
+		It("should recover previous PostUpgradeFailed sandboxes by rerunning UpgradePod when the recovery patch changes", func() {
+			labelValue := fmt.Sprintf("recover-postupgrade-changed-%d", time.Now().UnixNano())
+			sbx := newOpsSandbox(
+				fmt.Sprintf("ops-recover-postupgrade-changed-%s", labelValue[:10]),
+				labelValue, nil, nil,
+			)
+
+			By("Creating a Sandbox and waiting for Running")
+			Expect(k8sClient.Create(ctx, sbx)).To(Succeed())
+			waitSandboxRunning(sbx)
+
+			By("Creating a SandboxUpdateOps that fails in postUpgrade after upgrading the pod")
+			ops1 := &agentsv1alpha1.SandboxUpdateOps{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("ops-recover-postupgrade-changed-1-%s", labelValue[:10]),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxUpdateOpsSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{batchLabel: labelValue},
+					},
+					Patch: mustMarshalPatch(corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "test-container", Image: updateImage},
+							},
+						},
+					}),
+					Lifecycle: &agentsv1alpha1.SandboxLifecycle{
+						PreUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec:           &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "exit 0"}},
+							TimeoutSeconds: 30,
+						},
+						PostUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec:           &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "exit 1"}},
+							TimeoutSeconds: 30,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ops1)).To(Succeed())
+
+			By("Waiting for the sandbox to stop at PostUpgradeFailed")
+			waitSandboxUpgradeReason(sbx, agentsv1alpha1.SandboxUpgradingReasonPostUpgradeFailed, 3*time.Minute)
+
+			By("Recording pod UID after the failed postUpgrade")
+			failedPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: sbx.Name, Namespace: sbx.Namespace}, failedPod)).To(Succeed())
+			failedPodUID := failedPod.UID
+			Expect(failedPod.Spec.Containers[0].Image).To(Equal(updateImage))
+
+			By("Deleting the failed SandboxUpdateOps and waiting for label cleanup")
+			Expect(k8sClient.Delete(ctx, ops1)).To(Succeed())
+			waitOpsDeleted(ops1)
+			Eventually(func() bool {
+				updated := &agentsv1alpha1.Sandbox{}
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), updated); err != nil {
+					return false
+				}
+				return updated.Labels[agentsv1alpha1.LabelSandboxUpdateOps] == ""
+			}, 30*time.Second, time.Second).Should(BeTrue())
+
+			By("Creating a recovery SandboxUpdateOps with a changed patch, failing preUpgrade, and fixed postUpgrade")
+			ops2 := &agentsv1alpha1.SandboxUpdateOps{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("ops-recover-postupgrade-changed-2-%s", labelValue[:10]),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxUpdateOpsSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{batchLabel: labelValue},
+					},
+					Patch: mustMarshalPatch(corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "test-container", Image: initialImage},
+							},
+						},
+					}),
+					Lifecycle: &agentsv1alpha1.SandboxLifecycle{
+						PreUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec:           &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "exit 1"}},
+							TimeoutSeconds: 30,
+						},
+						PostUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec:           &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "exit 0"}},
+							TimeoutSeconds: 30,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ops2)).To(Succeed())
+
+			By("Waiting for recovery to complete, which proves preUpgrade was skipped and UpgradePod reran")
+			waitOpsPhase(ops2, agentsv1alpha1.SandboxUpdateOpsCompleted, 3*time.Minute)
+			waitSandboxRunning(sbx)
+
+			By("Verifying the pod UID changed because the recovery patch changed the image")
+			recoveredPod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: sbx.Name, Namespace: sbx.Namespace}, recoveredPod)).To(Succeed())
+			Expect(recoveredPod.UID).NotTo(Equal(failedPodUID))
+			Expect(recoveredPod.Spec.Containers[0].Image).To(Equal(initialImage))
+		})
+
 	})
 })


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds phase-aware resume behavior for sandboxes left in a failed upgrade state from a previous `SandboxUpdateOps`.

The behavior is implemented in the sandbox controller lifecycle and guarded by the `SandboxUpgradeResumeFromFailedStep` feature gate. When a sandbox is still in `Phase=Upgrading` and a new update changes its desired revision again, the controller now derives the resume step from the sandbox's recorded failed upgrade reason instead of always resetting back to `PreUpgrade`.

This keeps recovery on the existing upgrade flow while avoiding duplicate `preUpgrade` execution for sandboxes whose previous attempt had already passed that step.

Behavior:
- `PreUpgradeFailed`: resume from `PreUpgrade`
- `UpgradePodFailed`: resume from `UpgradePod`
- `PostUpgradeFailed`: resume from `PostUpgrade` when the current pod already matches the desired revision, otherwise resume from `UpgradePod`

This simplifies recovery for failed upgrade batches:
- users do not need to split selectors by failed step
- users do not need to craft a special recovery SUO without `preUpgrade` just to avoid overwriting backups
- users can reuse the normal SUO flow after deleting the previous failed operation

Implementation note:
- this PR does not add a new field to `SandboxUpdateOps`
- `SandboxUpdateOps` still patches the full lifecycle onto sandboxes as before
- the sandbox controller decides which upgrade step to resume from by rewriting the `Upgrading` condition reason when the desired revision changes during an ongoing upgrade
- the existing upgrade flow is reused, while duplicate `preUpgrade` execution is avoided by resuming from the correct step instead of trimming lifecycle hooks

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

Local verification:
- `go test -vet=off ./pkg/controller/sandbox -count=1`
- `go test -vet=off ./pkg/controller/sandboxupdateops`
- `go test -vet=off ./pkg/webhook/sandboxupdateops/validating`

CI / E2E verification:
- GitHub Actions E2E should cover recovery from previous failed upgrade steps end to end

Added tests:
- sandbox controller unit tests for phase-aware resume behavior in `pkg/controller/sandbox/sandbox_controller_test.go`
- `SandboxUpdateOps` E2E coverage for:
  - recovering previous `UpgradePodFailed` sandboxes
  - recovering previous `PostUpgradeFailed` sandboxes without recreating the pod when the patch is unchanged
  - recovering previous `PostUpgradeFailed` sandboxes by rerunning `UpgradePod` when the recovery patch changes

### Ⅳ. Special notes for reviews

A recovery SUO still goes through the existing sandbox upgrade state machine.

For sandboxes that previously failed in `UpgradePodFailed` or `PostUpgradeFailed`, this PR avoids rerunning `preUpgrade` by resuming from the correct lifecycle step in the sandbox controller. This is the key mechanism that prevents backup overwrite during recovery.

If a recovery SUO also changes the sandbox template or patch, the existing controller behavior may still recreate the pod as part of the normal upgrade flow. This PR keeps that behavior unchanged and only changes how the controller chooses the resume step for sandboxes that were already left in a failed upgrading state.
