### PR TITLE
fix: return bad request for invalid api key creation

### DIFF
--- a/pkg/servers/e2b/api_key.go
+++ b/pkg/servers/e2b/api_key.go
@@ -70,6 +70,10 @@ func (sc *Controller) CreateAPIKey(r *http.Request) (web.ApiResponse[*models.Cre
 			Message: "User not found",
 		}
 	}
+	if apiErr := validateCreateAPIKeyRequest(request); apiErr != nil {
+		return web.ApiResponse[*models.CreatedTeamAPIKey]{}, apiErr
+	}
+
 	createdAPIKey, err := sc.keys.CreateKey(ctx, user, keys.CreateKeyOptions{
 		Name:     request.Name,
 		TeamName: request.TeamName,
@@ -85,6 +89,16 @@ func (sc *Controller) CreateAPIKey(r *http.Request) (web.ApiResponse[*models.Cre
 		Code: http.StatusCreated,
 		Body: createdAPIKey,
 	}, nil
+}
+
+func validateCreateAPIKeyRequest(request *models.NewTeamAPIKey) *web.ApiError {
+	if request == nil || request.Name == "" {
+		return &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: "api-key name is required",
+		}
+	}
+	return nil
 }
 
 func (sc *Controller) ListTeams(r *http.Request) (web.ApiResponse[[]*models.ListedTeam], *web.ApiError) {

--- a/pkg/servers/e2b/api_key.go
+++ b/pkg/servers/e2b/api_key.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2b
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -49,29 +48,21 @@ func (sc *Controller) ListAPIKeys(r *http.Request) (web.ApiResponse[[]*models.Te
 }
 
 func (sc *Controller) CreateAPIKey(r *http.Request) (web.ApiResponse[*models.CreatedTeamAPIKey], *web.ApiError) {
-	request, ok := GetNewAPIKeyRequestFromContext(r.Context())
+	ctx := r.Context()
+	request, ok := GetNewAPIKeyRequestFromContext(ctx)
 	if !ok {
-		// When CheckCreateAPIKeyPermission middleware is configured, it pre-decodes the request body
-		// and stores it in context. If the middleware is not in the chain (e.g. keys storage is nil),
-		// we fall back to decoding the body directly here. (Which is impossible currently, just in defense for future changes)
-		var decoded models.NewTeamAPIKey
-		if err := json.NewDecoder(r.Body).Decode(&decoded); err != nil {
-			return web.ApiResponse[*models.CreatedTeamAPIKey]{}, &web.ApiError{
-				Message: err.Error(),
-			}
+		// CheckCreateAPIKeyPermission middleware is required but was not in the chain.
+		return web.ApiResponse[*models.CreatedTeamAPIKey]{}, &web.ApiError{
+			Code:    http.StatusInternalServerError,
+			Message: "request not found in context",
 		}
-		request = &decoded
 	}
 
-	ctx := r.Context()
 	user := GetUserFromContext(ctx)
 	if user == nil {
 		return web.ApiResponse[*models.CreatedTeamAPIKey]{}, &web.ApiError{
 			Message: "User not found",
 		}
-	}
-	if apiErr := validateCreateAPIKeyRequest(request); apiErr != nil {
-		return web.ApiResponse[*models.CreatedTeamAPIKey]{}, apiErr
 	}
 
 	createdAPIKey, err := sc.keys.CreateKey(ctx, user, keys.CreateKeyOptions{

--- a/pkg/servers/e2b/api_key_test.go
+++ b/pkg/servers/e2b/api_key_test.go
@@ -174,8 +174,8 @@ func TestCreateAPIKey(t *testing.T) {
 			},
 			request: models.NewTeamAPIKey{Name: ""},
 			expectError: &web.ApiError{
-				Code:    http.StatusInternalServerError,
-				Message: "Failed to create API key",
+				Code:    http.StatusBadRequest,
+				Message: "api-key name is required",
 			},
 		},
 	}
@@ -261,6 +261,13 @@ func TestCreateAPIKeyPermissionMiddleware(t *testing.T) {
 			request:    models.NewTeamAPIKey{Name: "admin-team-default"},
 			expectCode: http.StatusCreated,
 			expectTeam: models.AdminTeamName,
+		},
+		{
+			name:        "missing name fails",
+			user:        adminUser,
+			request:     models.NewTeamAPIKey{},
+			expectCode:  http.StatusBadRequest,
+			expectError: "name",
 		},
 		{
 			name:        "admin targeting missing namespace fails",

--- a/pkg/servers/e2b/api_key_test.go
+++ b/pkg/servers/e2b/api_key_test.go
@@ -165,24 +165,13 @@ func TestCreateAPIKey(t *testing.T) {
 			request:     models.NewTeamAPIKey{Name: "test-key"},
 			expectError: &web.ApiError{Message: "User not found"},
 		},
-		{
-			name: "fail with empty name",
-			user: &models.CreatedTeamAPIKey{
-				ID:   keys.AdminKeyID,
-				Key:  InitKey,
-				Name: "admin",
-			},
-			request: models.NewTeamAPIKey{Name: ""},
-			expectError: &web.ApiError{
-				Code:    http.StatusBadRequest,
-				Message: "api-key name is required",
-			},
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp, apiError := controller.CreateAPIKey(NewRequest(t, nil, tt.request, nil, tt.user))
+			req := NewRequest(t, nil, tt.request, nil, tt.user)
+			ctx := context.WithValue(req.Context(), newAPIKeyRequestContextKey, &tt.request)
+			resp, apiError := controller.CreateAPIKey(req.WithContext(ctx))
 			if tt.expectError != nil {
 				require.NotNil(t, apiError)
 				assert.Equal(t, tt.expectError.Code, apiError.Code)

--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -152,6 +152,9 @@ func (sc *Controller) CheckCreateAPIKeyPermission(ctx context.Context, r *http.R
 			Message: err.Error(),
 		}
 	}
+	if apiErr := validateCreateAPIKeyRequest(&request); apiErr != nil {
+		return ctx, apiErr
+	}
 
 	callerTeam := keys.TeamForKey(user)
 	targetTeamName := request.TeamName


### PR DESCRIPTION
## Summary
- Validate create API key requests before they reach key storage.
- Return HTTP 400 when the request body is valid JSON but missing the required API key name.
- Cover both the normal middleware path and the handler fallback path with unit tests.

## Root Cause
`CheckCreateAPIKeyPermission` decoded `{}` successfully and defaulted the team name, but did not validate the required `name` field. The request then reached `CreateKey`, whose validation returned a plain error that `CreateAPIKey` wrapped as HTTP 500.

## Test Plan
- `GOPATH=/Users/sophon/sdk/gopath GOROOT=/Users/sophon/sdk/gopath/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64 /Users/sophon/Bin/go test ./pkg/servers/e2b -run 'TestCreateAPIKey$|TestCreateAPIKeyPermissionMiddleware$' -count=1`
- `GOPATH=/Users/sophon/sdk/gopath GOROOT=/Users/sophon/sdk/gopath/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64 /Users/sophon/Bin/go test ./pkg/servers/e2b -count=1`
