### PR TITLE
fix(controller): persist sandbox status during Pending phase

### DIFF
--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -300,7 +300,7 @@ func (r *SandboxReconciler) addSandboxFinalizerAndHash(ctx context.Context, box 
 }
 
 func (r *SandboxReconciler) updateSandboxStatus(ctx context.Context, newStatus agentsv1alpha1.SandboxStatus, box *agentsv1alpha1.Sandbox) error {
-	if reflect.DeepEqual(box.Status, newStatus) || newStatus.Phase == agentsv1alpha1.SandboxPending {
+	if reflect.DeepEqual(box.Status, newStatus) {
 		return nil
 	}
 

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -899,20 +899,17 @@ func TestSandboxReconciler_updateSandboxStatusWithPendingPhase(t *testing.T) {
 			Name:      "test-sandbox",
 			Namespace: "default",
 		},
-		Status: agentsv1alpha1.SandboxStatus{
-			Phase: agentsv1alpha1.SandboxRunning,
-		},
 	}
 
-	// Add the sandbox to the client
 	err := client.Create(context.TODO(), originalSandbox)
 	if err != nil {
 		t.Fatalf("Failed to create sandbox: %v", err)
 	}
 
-	// Try to update with Pending phase (should not update because of early return)
 	pendingStatus := agentsv1alpha1.SandboxStatus{
-		Phase: agentsv1alpha1.SandboxPending,
+		Phase:              agentsv1alpha1.SandboxPending,
+		ObservedGeneration: 1,
+		UpdateRevision:     "abc123",
 	}
 
 	err = reconciler.updateSandboxStatus(context.Background(), pendingStatus, originalSandbox)
@@ -921,13 +918,19 @@ func TestSandboxReconciler_updateSandboxStatusWithPendingPhase(t *testing.T) {
 		return
 	}
 
-	// Status should remain Running because Pending phase updates are skipped
 	updatedSandbox := &agentsv1alpha1.Sandbox{}
 	err = client.Get(context.TODO(), types.NamespacedName{Name: originalSandbox.Name, Namespace: originalSandbox.Namespace}, updatedSandbox)
 	if err != nil {
-		t.Errorf("Failed to get updated sandbox: %v", err)
-	} else if updatedSandbox.Status.Phase != agentsv1alpha1.SandboxRunning {
-		t.Errorf("Expected sandbox phase to remain %v, got %v", agentsv1alpha1.SandboxRunning, updatedSandbox.Status.Phase)
+		t.Fatalf("Failed to get updated sandbox: %v", err)
+	}
+	if updatedSandbox.Status.Phase != agentsv1alpha1.SandboxPending {
+		t.Errorf("Expected sandbox phase %v, got %v", agentsv1alpha1.SandboxPending, updatedSandbox.Status.Phase)
+	}
+	if updatedSandbox.Status.ObservedGeneration != 1 {
+		t.Errorf("Expected ObservedGeneration 1, got %v", updatedSandbox.Status.ObservedGeneration)
+	}
+	if updatedSandbox.Status.UpdateRevision != "abc123" {
+		t.Errorf("Expected UpdateRevision abc123, got %v", updatedSandbox.Status.UpdateRevision)
 	}
 }
 

--- a/test/e2e/sandbox_test.go
+++ b/test/e2e/sandbox_test.go
@@ -103,6 +103,19 @@ var _ = Describe("Sandbox", func() {
 					Namespace: sandbox.Namespace,
 				}, sandbox)
 				return sandbox.Status.Phase
+			}, time.Second*30, time.Millisecond*500).Should(Equal(agentsv1alpha1.SandboxPending))
+
+			By("Verifying ObservedGeneration and UpdateRevision are set in Pending")
+			Expect(sandbox.Status.ObservedGeneration).To(BeNumerically(">", 0))
+			Expect(sandbox.Status.UpdateRevision).NotTo(BeEmpty())
+
+			By("Verifying the sandbox phase transitions to Running")
+			Eventually(func() agentsv1alpha1.SandboxPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      sandbox.Name,
+					Namespace: sandbox.Namespace,
+				}, sandbox)
+				return sandbox.Status.Phase
 			}, time.Second*90, time.Millisecond*500).Should(Equal(agentsv1alpha1.SandboxRunning))
 
 			By("Verifying the sandbox has latest revision")


### PR DESCRIPTION
## Summary

- Remove the `SandboxPending` phase skip in `updateSandboxStatus`, so that `Phase`, `ObservedGeneration`, and `UpdateRevision` are persisted when a sandbox is first reconciled in Pending state.
- Previously, external consumers had no way to know the sandbox had been acknowledged by the controller until it transitioned to Running.

## Changes

| File | Description |
|------|-------------|
| `pkg/controller/sandbox/sandbox_controller.go` | Remove `newStatus.Phase == SandboxPending` from the early-return condition in `updateSandboxStatus` |
| `pkg/controller/sandbox/sandbox_controller_test.go` | Update `TestSandboxReconciler_updateSandboxStatusWithPendingPhase` to assert status IS patched (Phase, ObservedGeneration, UpdateRevision) |
| `test/e2e/sandbox_test.go` | Add intermediate Pending phase assertion before Running, verify ObservedGeneration and UpdateRevision are set |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/controller/sandbox/... -count=1` all tests pass
- [ ] E2E: sandbox creation test verifies Pending → Running lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)