### PR TITLE
In the scenario of backoff-based token allocation, it still returns the default expiration time of 1 minute.

### DIFF
--- a/pkg/identity/common_provider.go
+++ b/pkg/identity/common_provider.go
@@ -18,6 +18,7 @@ package identity
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"k8s.io/klog/v2"
@@ -44,8 +45,10 @@ func NewDefaultIdentityProvider() IdentityProvider {
 
 func (u *defaultTokenProvider) IssueToken(_ context.Context, _ TokenRequest) (*TokenResponse, error) {
 	return &TokenResponse{
-		RequestID:   uuid.NewString(),
-		AccessToken: uuid.NewString(),
+		RequestID:             uuid.NewString(),
+		AccessToken:           uuid.NewString(),
+		SandboxClientID:       uuid.NewString(),
+		AccessTokenExpiration: time.Now().UTC().Add(time.Minute).Format(time.RFC3339),
 	}, nil
 }
 


### PR DESCRIPTION
…he default expiration time of 1 minute.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

