### PR TITLE
refactor(sandbox-manager): move SecurityTokenOptions from config to infra to break import cycle

### DIFF
--- a/pkg/sandbox-manager/config/infra.go
+++ b/pkg/sandbox-manager/config/infra.go
@@ -19,8 +19,6 @@ package config
 import (
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
-
-	"github.com/openkruise/agents/pkg/identity"
 )
 
 type InitRuntimeOptions struct {
@@ -41,10 +39,6 @@ type CSIMountOptions struct {
 	MountOptionList    []MountConfig `json:"mountOptionList"`
 	MountOptionListRaw string        `json:"mountOptionListRaw"`    // the raw json string for mount options
 	Concurrency        int           `json:"concurrency,omitempty"` // max concurrent CSI mount operations, 0 or negative means unlimited, default is DefaultCSIMountConcurrency
-}
-
-type SecurityTokenOptions struct {
-	identity.TokenResponse
 }
 
 type MountConfig struct {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -42,7 +42,6 @@ import (
 	"github.com/openkruise/agents/pkg/controller/sandboxset"
 	"github.com/openkruise/agents/pkg/features"
 	"github.com/openkruise/agents/pkg/identity"
-	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/logs"
@@ -238,7 +237,7 @@ func TryClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions, pickCa
 	// We deliberately do NOT degrade to a UUID token on issuance failure: a UUID carries no identity and would
 	// be propagated to the runtime as a meaningless credential, masking real provider outages.
 	if utilfeature.DefaultFeatureGate.Enabled(features.SecurityIdentityProviderGate) {
-		opts.SecurityToken = &config.SecurityTokenOptions{}
+		opts.SecurityToken = &infra.SecurityTokenOptions{}
 		log.Info("starting to issue security token via identity provider")
 		metrics.SecurityToken, err = issueSecurityToken(ctx, sbx, opts.SecurityToken)
 		if err != nil {
@@ -486,7 +485,7 @@ func pickFromCandidates(ctx context.Context, candidates []*v1alpha1.Sandbox, pic
 
 // issueSecurityToken issues a security token for the given sandbox using the registered identity provider.
 // The issued access token is written into the sandbox's SecurityToken option for downstream consumption.
-func issueSecurityToken(ctx context.Context, sbx *Sandbox, opts *config.SecurityTokenOptions) (time.Duration, error) {
+func issueSecurityToken(ctx context.Context, sbx *Sandbox, opts *infra.SecurityTokenOptions) (time.Duration, error) {
 	ctx = logs.Extend(ctx, "action", "issueSecurityToken")
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx.Sandbox))
 	start := time.Now()

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -2161,7 +2161,7 @@ func TestRecordSecurityTokenRefreshStatus(t *testing.T) {
 		{
 			name: "with security token and expiration",
 			opts: infra.ClaimSandboxOptions{
-				SecurityToken: &config.SecurityTokenOptions{
+				SecurityToken: &infra.SecurityTokenOptions{
 					TokenResponse: identity.TokenResponse{
 						AccessToken:           "security-access-token",
 						AccessTokenExpiration: "2026-12-31T23:59:59Z",
@@ -2175,7 +2175,7 @@ func TestRecordSecurityTokenRefreshStatus(t *testing.T) {
 		{
 			name: "with security token without expiration",
 			opts: infra.ClaimSandboxOptions{
-				SecurityToken: &config.SecurityTokenOptions{
+				SecurityToken: &infra.SecurityTokenOptions{
 					TokenResponse: identity.TokenResponse{
 						AccessToken: "at-456",
 					},
@@ -2263,7 +2263,7 @@ func TestRecordSecurityTokenRefreshStatus_NilAnnotations(t *testing.T) {
 			name:         "nil annotations map is created",
 			initialAnnos: nil,
 			opts: infra.ClaimSandboxOptions{
-				SecurityToken: &config.SecurityTokenOptions{
+				SecurityToken: &infra.SecurityTokenOptions{
 					TokenResponse: identity.TokenResponse{
 						AccessToken:           "token-1",
 						AccessTokenExpiration: "2026-06-01T00:00:00Z",
@@ -2278,7 +2278,7 @@ func TestRecordSecurityTokenRefreshStatus_NilAnnotations(t *testing.T) {
 				"existing-key": "existing-value",
 			},
 			opts: infra.ClaimSandboxOptions{
-				SecurityToken: &config.SecurityTokenOptions{
+				SecurityToken: &infra.SecurityTokenOptions{
 					TokenResponse: identity.TokenResponse{
 						AccessToken:           "token-2",
 						AccessTokenExpiration: "2026-07-01T00:00:00Z",
@@ -2411,7 +2411,7 @@ func TestRecordSecurityTokenRefreshStatus_PatchErrors(t *testing.T) {
 			fakeClient := builder.Build()
 
 			opts := infra.ClaimSandboxOptions{
-				SecurityToken: &config.SecurityTokenOptions{
+				SecurityToken: &infra.SecurityTokenOptions{
 					TokenResponse: identity.TokenResponse{
 						AccessToken:           "at-err",
 						AccessTokenExpiration: "2027-01-01T00:00:00Z",
@@ -2463,7 +2463,7 @@ func TestRecordSecurityTokenRefreshStatus_Overwrite(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sbx.Sandbox.DeepCopy()).Build()
 
 	opts := infra.ClaimSandboxOptions{
-		SecurityToken: &config.SecurityTokenOptions{
+		SecurityToken: &infra.SecurityTokenOptions{
 			TokenResponse: identity.TokenResponse{
 				AccessToken:           "at-new",
 				AccessTokenExpiration: "2027-06-01T00:00:00Z",
@@ -3508,7 +3508,7 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				InitRuntime: &config.InitRuntimeOptions{
 					AccessToken: "original-uuid-token",
 				},
-				SecurityToken: &config.SecurityTokenOptions{
+				SecurityToken: &infra.SecurityTokenOptions{
 					TokenResponse: identity.TokenResponse{AccessToken: "placeholder"},
 				},
 			},
@@ -3541,7 +3541,7 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				InitRuntime: &config.InitRuntimeOptions{
 					AccessToken: "original-uuid-token",
 				},
-				SecurityToken: &config.SecurityTokenOptions{
+				SecurityToken: &infra.SecurityTokenOptions{
 					TokenResponse: identity.TokenResponse{AccessToken: "placeholder"},
 				},
 			},
@@ -3564,7 +3564,7 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				InitRuntime: &config.InitRuntimeOptions{
 					AccessToken: "original-uuid-token",
 				},
-				SecurityToken: &config.SecurityTokenOptions{
+				SecurityToken: &infra.SecurityTokenOptions{
 					TokenResponse: identity.TokenResponse{AccessToken: "placeholder"},
 				},
 			},

--- a/pkg/sandbox-manager/infra/types.go
+++ b/pkg/sandbox-manager/infra/types.go
@@ -24,8 +24,19 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 )
+
+// SecurityTokenOptions wraps the issued security token response for downstream
+// consumers in the claim pipeline. It lives here (rather than in
+// pkg/sandbox-manager/config) to avoid an import cycle:
+// pkg/identity -> pkg/utils/runtime -> pkg/sandbox-manager/config -> pkg/identity.
+// pkg/sandbox-manager/infra is allowed to depend on pkg/identity because it is
+// not transitively imported by pkg/identity.
+type SecurityTokenOptions struct {
+	identity.TokenResponse
+}
 
 type ClaimSandboxOptions struct {
 	Namespace string `json:"namespace,omitempty"`
@@ -56,7 +67,7 @@ type ClaimSandboxOptions struct {
 	// Set CSIMount to non-nil value to mount a CSI volume
 	CSIMount *config.CSIMountOptions `json:"CSIMount"`
 	// Set SecurityToken value in runtime
-	SecurityToken *config.SecurityTokenOptions `json:"securityToken"`
+	SecurityToken *SecurityTokenOptions `json:"securityToken"`
 	// Max ClaimTimeout duration
 	ClaimTimeout time.Duration `json:"claimTimeout"`
 	// Max WaitReadyTimeout duration


### PR DESCRIPTION
…nfra to break import cycle

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

