### PR TITLE
refactor(identity): extract IssueSandboxToken helper for shared use

### DIFF
--- a/pkg/identity/interface.go
+++ b/pkg/identity/interface.go
@@ -30,7 +30,8 @@ import (
 //   - PropagateSecurityToken: no-op (no propagators registered).
 //
 // Enterprise deployment (secureIdentityProvider):
-//   - IssueToken: calls HTTPS identity provider service with default fallback.
+//   - IssueToken: calls HTTPS identity provider service; errors are surfaced
+//     directly (no silent degradation to UUID).
 //   - PropagateSecurityToken: executes registered propagators (e.g., write credential files).
 type IdentityProvider interface {
 	// IssueToken generates an access token for the given token request.

--- a/pkg/identity/sandbox_token_helper.go
+++ b/pkg/identity/sandbox_token_helper.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/utils"
+)
+
+// IssueSandboxToken issues a security token for the given sandbox using the
+// registered identity provider.
+//
+// It collects all sandbox labels prefixed with utils.SecurityMetadataPrefix as
+// request metadata, builds a TokenRequest of type TokenTypeAgent, and delegates
+// to the package-level IssueToken entry. The returned cost reflects the total
+// duration spent issuing the token (including metadata collection), which
+// callers can record on their own metrics structures.
+//
+// The function is intentionally side-effect free: it does NOT mutate the
+// sandbox object or persist the response. Callers are responsible for
+// persisting the returned TokenResponse into the appropriate place
+// (e.g. ClaimSandboxOptions, sandbox annotations, or runtime credentials).
+func IssueSandboxToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (*TokenResponse, time.Duration, error) {
+	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx), "action", "IssueSandboxToken")
+	start := time.Now()
+
+	metadata := make(map[string]string)
+	for k, v := range sbx.GetLabels() {
+		if strings.HasPrefix(k, utils.SecurityMetadataPrefix) {
+			metadata[k] = v
+		}
+	}
+
+	tokenResp, err := IssueToken(ctx, TokenRequest{
+		TokenType: TokenTypeAgent,
+		Sandbox: &SandboxInfo{
+			PodName:      sbx.Name,
+			PodNamespace: sbx.Namespace,
+			SandboxID:    fmt.Sprintf("%s/%s/%s", sbx.Namespace, sbx.Name, sbx.UID),
+			SandboxName:  sbx.Name,
+			SandboxUID:   string(sbx.UID),
+		},
+		Metadata: metadata,
+	})
+	cost := time.Since(start)
+	if err != nil {
+		log.Error(err, "failed to issue sandbox security token", "cost", cost)
+		return nil, cost, fmt.Errorf("failed to issue security token: %w", err)
+	}
+	log.Info("sandbox security token issued", "cost", cost)
+	return tokenResp, cost, nil
+}

--- a/pkg/identity/sandbox_token_helper_test.go
+++ b/pkg/identity/sandbox_token_helper_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/utils"
+)
+
+// fakeIdentityProvider is a minimal IdentityProvider stub used to capture the
+// TokenRequest passed to IssueToken and to deterministically control the
+// returned TokenResponse / error. Only the IssueToken path is exercised by
+// IssueSandboxToken; PropagateSecurityToken is implemented as a no-op.
+type fakeIdentityProvider struct {
+	gotReq TokenRequest
+	called int
+
+	resp *TokenResponse
+	err  error
+}
+
+func (f *fakeIdentityProvider) IssueToken(_ context.Context, req TokenRequest) (*TokenResponse, error) {
+	f.gotReq = req
+	f.called++
+	return f.resp, f.err
+}
+
+func (f *fakeIdentityProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse) error {
+	return nil
+}
+
+// withFakeProvider swaps the package-level provider with the given fake for the
+// duration of the test, restoring the original on cleanup.
+func withFakeProvider(t *testing.T, fake *fakeIdentityProvider) {
+	t.Helper()
+	saved := provider
+	RegisterProvider(fake)
+	t.Cleanup(func() { RegisterProvider(saved) })
+}
+
+// TestIssueSandboxToken_Success exercises the happy path: the helper must
+// project the sandbox identity into the TokenRequest, propagate security-prefixed
+// labels into Metadata, and return the provider's response unchanged together
+// with a non-negative cost and a nil error.
+func TestIssueSandboxToken_Success(t *testing.T) {
+	wantResp := &TokenResponse{
+		RequestID:             "req-1",
+		AccessToken:           "tok-1",
+		SandboxClientID:       "client-1",
+		AccessTokenExpiration: "2099-01-01T00:00:00Z",
+	}
+	fake := &fakeIdentityProvider{resp: wantResp}
+	withFakeProvider(t, fake)
+
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sbx-a",
+			Namespace: "ns-a",
+			UID:       types.UID("uid-a"),
+			Labels: map[string]string{
+				utils.SecurityMetadataPrefix + "tenant":  "t1",
+				utils.SecurityMetadataPrefix + "project": "p1",
+				"app":                                    "demo",         // non-security label, must be filtered out
+				"kubernetes.io/managed-by":               "sandbox-mgr",  // non-security label, must be filtered out
+			},
+		},
+	}
+
+	gotResp, cost, err := IssueSandboxToken(context.Background(), sbx)
+	require.NoError(t, err)
+	require.NotNil(t, gotResp)
+	assert.Same(t, wantResp, gotResp, "response must be returned as-is from the provider")
+	assert.GreaterOrEqual(t, int64(cost), int64(0), "cost should be non-negative")
+	assert.Equal(t, 1, fake.called, "underlying provider must be called exactly once")
+
+	// Verify the TokenRequest projection.
+	gotReq := fake.gotReq
+	assert.Equal(t, TokenTypeAgent, gotReq.TokenType, "TokenType must be Agent for sandbox issuance")
+	require.NotNil(t, gotReq.Sandbox)
+	assert.Equal(t, "sbx-a", gotReq.Sandbox.PodName)
+	assert.Equal(t, "ns-a", gotReq.Sandbox.PodNamespace)
+	assert.Equal(t, "ns-a/sbx-a/uid-a", gotReq.Sandbox.SandboxID,
+		"SandboxID must follow the canonical namespace/name/uid layout")
+	assert.Equal(t, "sbx-a", gotReq.Sandbox.SandboxName)
+	assert.Equal(t, "uid-a", gotReq.Sandbox.SandboxUID)
+
+	// Only labels prefixed with utils.SecurityMetadataPrefix must flow into Metadata.
+	assert.Equal(t, map[string]string{
+		utils.SecurityMetadataPrefix + "tenant":  "t1",
+		utils.SecurityMetadataPrefix + "project": "p1",
+	}, gotReq.Metadata)
+}
+
+// TestIssueSandboxToken_NoLabels guarantees that a sandbox without any labels
+// still produces a non-nil (empty) Metadata map. This matters because downstream
+// providers may type-assert on a non-nil map and the helper documents that the
+// caller does not need to pre-populate Metadata.
+func TestIssueSandboxToken_NoLabels(t *testing.T) {
+	fake := &fakeIdentityProvider{resp: &TokenResponse{AccessToken: "tok"}}
+	withFakeProvider(t, fake)
+
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sbx-empty",
+			Namespace: "ns",
+			UID:       types.UID("uid-empty"),
+		},
+	}
+
+	_, _, err := IssueSandboxToken(context.Background(), sbx)
+	require.NoError(t, err)
+	require.NotNil(t, fake.gotReq.Metadata, "Metadata must be a non-nil map even when no labels are present")
+	assert.Empty(t, fake.gotReq.Metadata)
+}
+
+// TestIssueSandboxToken_OnlyNonSecurityLabels verifies the prefix filter rejects
+// every label that is not under utils.SecurityMetadataPrefix, even when label
+// values look plausible (e.g. share a substring with the prefix).
+func TestIssueSandboxToken_OnlyNonSecurityLabels(t *testing.T) {
+	fake := &fakeIdentityProvider{resp: &TokenResponse{AccessToken: "tok"}}
+	withFakeProvider(t, fake)
+
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sbx",
+			Namespace: "ns",
+			UID:       types.UID("uid"),
+			Labels: map[string]string{
+				"app":                            "demo",
+				"agents.kruise.io/team":          "infra",                      // shares root domain but lacks "security." prefix
+				"security-fake.agents.kruise.io": "no",                         // close-but-not-equal prefix
+				"x-security.agents.kruise.io/y":  "no",                         // prefix is not at the start
+			},
+		},
+	}
+
+	_, _, err := IssueSandboxToken(context.Background(), sbx)
+	require.NoError(t, err)
+	assert.Empty(t, fake.gotReq.Metadata, "labels without the SecurityMetadataPrefix must be filtered out")
+}
+
+// TestIssueSandboxToken_ProviderError guarantees the helper surfaces provider
+// errors wrapped with the documented message and returns a nil response so that
+// callers never accidentally persist a stale or zero-value token.
+func TestIssueSandboxToken_ProviderError(t *testing.T) {
+	rootErr := errors.New("identity provider unavailable")
+	fake := &fakeIdentityProvider{err: rootErr}
+	withFakeProvider(t, fake)
+
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sbx-err",
+			Namespace: "ns",
+			UID:       types.UID("uid-err"),
+		},
+	}
+
+	gotResp, cost, err := IssueSandboxToken(context.Background(), sbx)
+	require.Error(t, err)
+	assert.Nil(t, gotResp, "response must be nil on error to prevent persisting a zero-value token")
+	assert.GreaterOrEqual(t, int64(cost), int64(0), "cost must still be reported even on failure for metric accounting")
+
+	// Wrap message must remain stable; downstream code matches against this prefix.
+	assert.Contains(t, err.Error(), "failed to issue security token")
+	assert.True(t, errors.Is(err, rootErr), "wrapped error must preserve the original cause via errors.Is")
+}
+
+// TestIssueSandboxToken_DefaultProviderIntegration sanity-checks the helper
+// against the real defaultTokenProvider (no fake), to ensure the integration
+// with the package-level provider variable is wired correctly when tests do
+// not replace the provider explicitly.
+func TestIssueSandboxToken_DefaultProviderIntegration(t *testing.T) {
+	// Reset to the community default for this test so prior tests cannot leak
+	// state via the package-level provider variable.
+	saved := provider
+	RegisterProvider(NewDefaultIdentityProvider())
+	t.Cleanup(func() { RegisterProvider(saved) })
+
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sbx-default",
+			Namespace: "ns-default",
+			UID:       types.UID("uid-default"),
+		},
+	}
+
+	resp, _, err := IssueSandboxToken(context.Background(), sbx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.AccessToken, "default provider must mint a non-empty access token")
+	assert.NotEmpty(t, resp.RequestID, "default provider must mint a non-empty request id")
+}
+
+// Compile-time guard: fakeIdentityProvider must satisfy IdentityProvider so it
+// is accepted by RegisterProvider.
+var _ IdentityProvider = (*fakeIdentityProvider)(nil)

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -483,41 +483,17 @@ func pickFromCandidates(ctx context.Context, candidates []*v1alpha1.Sandbox, pic
 	return nil, errors.New("all candidates are picked")
 }
 
-// issueSecurityToken issues a security token for the given sandbox using the registered identity provider.
-// The issued access token is written into the sandbox's SecurityToken option for downstream consumption.
+// issueSecurityToken issues a security token for the given sandbox via
+// identity.IssueSandboxToken and writes the full issued token response into
+// the sandbox's SecurityToken option for downstream consumption (annotation
+// recording and runtime propagation).
 func issueSecurityToken(ctx context.Context, sbx *Sandbox, opts *infra.SecurityTokenOptions) (time.Duration, error) {
-	ctx = logs.Extend(ctx, "action", "issueSecurityToken")
-	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx.Sandbox))
-	start := time.Now()
-
-	sbxLabels := sbx.GetLabels()
-	metadata := make(map[string]string)
-	for k, v := range sbxLabels {
-		if strings.HasPrefix(k, utils.SecurityMetadataPrefix) {
-			metadata[k] = v
-		}
-	}
-
-	tokenResp, err := identity.IssueToken(ctx, identity.TokenRequest{
-		TokenType: identity.TokenTypeAgent,
-		Sandbox: &identity.SandboxInfo{
-			PodName:      sbx.Name,
-			PodNamespace: sbx.Namespace,
-			SandboxID:    fmt.Sprintf("%s/%s/%s", sbx.Namespace, sbx.Name, sbx.UID),
-			SandboxName:  sbx.Name,
-			SandboxUID:   string(sbx.UID),
-		},
-		Metadata: metadata,
-	})
+	tokenResp, cost, err := identity.IssueSandboxToken(ctx, sbx.Sandbox)
 	if err != nil {
-		log.Error(err, "failed to issue security token")
-		return time.Since(start), fmt.Errorf("failed to issue security token: %w", err)
+		return cost, err
 	}
-
-	// Write the full issued token response back into the options for downstream use
 	opts.TokenResponse = *tokenResp
-	log.Info("security token issued", "costTime", time.Since(start))
-	return time.Since(start), nil
+	return cost, nil
 }
 
 var FilteredAnnotationsOnCreation []string


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Extract the sandbox-scoped security-token issuance logic out of
`sandboxcr.issueSecurityToken` into a new package-level helper
`identity.IssueSandboxToken`, so that callers other than the claim flow
(for example a future token-refresh controller) can reuse the same
metadata collection and `TokenRequest` construction without duplicating
the code path.

Behavior is unchanged for the existing claim flow:

- `pkg/identity/sandbox_token_helper.go` (new): `IssueSandboxToken`
  collects all sandbox labels prefixed with `utils.SecurityMetadataPrefix`
  as request metadata, builds a `TokenTypeAgent` `TokenRequest`, delegates
  to the package-level `IssueToken` entry, and returns
  `(*TokenResponse, time.Duration, error)`. The helper is intentionally
  side-effect free — it does **not** mutate the sandbox object or persist
  the response; callers are responsible for storing the result.
- `pkg/sandbox-manager/infra/sandboxcr/claim.go`: rewrite
  `issueSecurityToken` as a thin wrapper that calls
  `identity.IssueSandboxToken` and writes the returned `TokenResponse`
  onto `*infra.SecurityTokenOptions`. Error propagation and
  `ClaimMetrics.SecurityToken` cost recording are preserved.
- `pkg/identity/interface.go`: align the `IdentityProvider` doc comment
  with the post-`5f08f4f1` behavior — `IssueToken` errors are surfaced
  directly (no silent UUID degradation), so the doc no longer mentions
  the removed fallback path.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Build & vet:
   ```
   go build ./pkg/identity/... ./pkg/sandbox-manager/infra/sandboxcr/...
   go vet   ./pkg/identity/... ./pkg/sandbox-manager/infra/sandboxcr/...
   ```
2. Run the affected unit tests:
   ```
   go test -count=1 ./pkg/identity/... ./pkg/sandbox-manager/infra/sandboxcr/...
   ```
3. Manual sanity check (existing behavior preserved):
   - When a `Sandbox` carries labels prefixed with
     `security.agents.kruise.io/`, those labels still flow into
     `TokenRequest.Metadata`.
   - When `IssueToken` fails, `tryClaim` still returns the error and
     records the cost into `ClaimMetrics.SecurityToken`.

### Ⅳ. Special notes for reviews

- This is a pure refactor; no functional change is intended. Reviewers
  may want to focus on:
  - The metadata-collection loop in `IssueSandboxToken` is byte-identical
    to the previous in-place loop in `issueSecurityToken` (same prefix
    filter, same map population).
  - `SandboxID` continues to be formatted as
    `"<namespace>/<name>/<uid>"` to match the previous string layout used
    by the identity provider.
  - The helper returns the elapsed `time.Duration` so the caller can
    keep recording the same metric (`ClaimMetrics.SecurityToken`)
    without changing the metrics surface.
- The doc-comment update in `interface.go` is a documentation-only
  alignment with `5f08f4f1` (UUID-fallback removal); no code path
  changes from this hunk.
