### PR TITLE
refactor: remove SandboxInPlaceResourceResizeGate from sandbox-manager layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,9 @@ client/            Generated clientset (DO NOT edit)
 config/            CRD, RBAC, manifests (generated)
 pkg/
   controller/      Controllers (sandbox, set, claim)
-  sandbox-manager/ Manager logic (infra, errors, logs)
-  servers/         E2B API, web framework
+  features/        Feature gates for controller (controller-only, MUST NOT be imported by sandbox-manager or servers)
+  sandbox-manager/ Manager logic (infra, errors, logs). MUST NOT import pkg/features.
+  servers/         E2B API, web framework. MUST NOT import pkg/features.
   proxy/           Envoy ext_proc gRPC server
   sandbox-gateway/ Envoy Go filter, route controller
   webhook/         Admission webhooks

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -28,14 +28,12 @@ import (
 	"k8s.io/klog/v2"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
-	"github.com/openkruise/agents/pkg/features"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/csiutils"
-	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 	"github.com/openkruise/agents/pkg/utils/sandboxutils"
 	"github.com/openkruise/agents/pkg/utils/timeout"
 )
@@ -109,12 +107,6 @@ func (sc *Controller) createSandboxWithClaim(ctx context.Context, request models
 			Image: extension.Image,
 		}
 		if extension.Resources != nil && (len(extension.Resources.Requests) > 0 || len(extension.Resources.Limits) > 0) {
-			if !utilfeature.DefaultFeatureGate.Enabled(features.SandboxInPlaceResourceResizeGate) {
-				return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
-					Code:    http.StatusBadRequest,
-					Message: fmt.Sprintf("in-place resource resize is disabled by feature gate %s", features.SandboxInPlaceResourceResizeGate),
-				}
-			}
 			opts.InplaceUpdate.Resources = &config.InplaceUpdateResourcesOptions{
 				Requests: extension.Resources.Requests,
 				Limits:   extension.Resources.Limits,

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -29,16 +29,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openkruise/agents/api/v1alpha1"
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
-	"github.com/openkruise/agents/pkg/features"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
-	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 )
 
 // TestCsiMountOptionsConfigRecord tests the csiMountOptionsConfigRecord function
@@ -383,103 +379,6 @@ func TestCreateSandboxWithClone_CSIMount(t *testing.T) {
 	}
 }
 
-func TestCreateSandboxWithClaim_CPUResizeFeatureGate(t *testing.T) {
-	user := &models.CreatedTeamAPIKey{ID: uuid.New(), Name: "test-user"}
-
-	t.Run("feature gate disabled rejects CPU resize with requests", func(t *testing.T) {
-		err := utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
-			string(features.SandboxInPlaceResourceResizeGate): false,
-		})
-		assert.NoError(t, err)
-		defer func() {
-			_ = utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
-				string(features.SandboxInPlaceResourceResizeGate): true,
-			})
-		}()
-
-		ctrl := &Controller{}
-		request := models.NewSandboxRequest{
-			TemplateID: "test-template",
-			Extensions: models.NewSandboxRequestExtension{
-				SkipInitRuntime: true,
-				InplaceUpdate: models.InplaceUpdateExtension{
-					Resources: &models.InplaceUpdateResourcesExtension{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU: resource.MustParse("500m"),
-						},
-					},
-				},
-			},
-		}
-		_, apiErr := ctrl.createSandboxWithClaim(context.Background(), request, user)
-		assert.NotNil(t, apiErr)
-		assert.Equal(t, http.StatusBadRequest, apiErr.Code)
-		assert.Contains(t, apiErr.Message, "feature gate")
-	})
-
-	t.Run("feature gate disabled rejects CPU resize with limits", func(t *testing.T) {
-		err := utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
-			string(features.SandboxInPlaceResourceResizeGate): false,
-		})
-		assert.NoError(t, err)
-		defer func() {
-			_ = utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
-				string(features.SandboxInPlaceResourceResizeGate): true,
-			})
-		}()
-
-		ctrl := &Controller{}
-		request := models.NewSandboxRequest{
-			TemplateID: "test-template",
-			Extensions: models.NewSandboxRequestExtension{
-				SkipInitRuntime: true,
-				InplaceUpdate: models.InplaceUpdateExtension{
-					Resources: &models.InplaceUpdateResourcesExtension{
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU: resource.MustParse("1000m"),
-						},
-					},
-				},
-			},
-		}
-		_, apiErr := ctrl.createSandboxWithClaim(context.Background(), request, user)
-		assert.NotNil(t, apiErr)
-		assert.Equal(t, http.StatusBadRequest, apiErr.Code)
-		assert.Contains(t, apiErr.Message, "feature gate")
-	})
-
-	t.Run("feature gate disabled rejects mixed image and cpu resize", func(t *testing.T) {
-		err := utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
-			string(features.SandboxInPlaceResourceResizeGate): false,
-		})
-		assert.NoError(t, err)
-		defer func() {
-			_ = utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
-				string(features.SandboxInPlaceResourceResizeGate): true,
-			})
-		}()
-
-		ctrl := &Controller{}
-		request := models.NewSandboxRequest{
-			TemplateID: "test-template",
-			Extensions: models.NewSandboxRequestExtension{
-				SkipInitRuntime: true,
-				InplaceUpdate: models.InplaceUpdateExtension{
-					Image: "nginx:latest",
-					Resources: &models.InplaceUpdateResourcesExtension{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU: resource.MustParse("500m"),
-						},
-					},
-				},
-			},
-		}
-		_, apiErr := ctrl.createSandboxWithClaim(context.Background(), request, user)
-		assert.NotNil(t, apiErr)
-		assert.Equal(t, http.StatusBadRequest, apiErr.Code)
-		assert.Contains(t, apiErr.Message, "feature gate")
-	})
-}
 
 func TestCreateSandboxWithClone_InplaceUpdateRejected(t *testing.T) {
 	ctrl := &Controller{}


### PR DESCRIPTION
## Summary
- Remove `SandboxInPlaceResourceResizeGate` feature gate check from E2B create handler (`pkg/servers/e2b/create.go`)
- Remove corresponding unit tests (`TestCreateSandboxWithClaim_CPUResizeFeatureGate`)
- Document in `AGENTS.md` that `pkg/sandbox-manager/` and `pkg/servers/` must not import `pkg/features`

## Test plan
- [x] `go vet ./pkg/servers/e2b/...` passes
- [ ] Verify existing E2B create tests still pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)