### PR TITLE
Generate E2B SDK-compatible API keys

### DIFF
--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/spf13/pflag"
 	zapRaw "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -150,9 +149,15 @@ func main() {
 		klog.Fatalf("--peer-selector is required")
 	}
 
-	// Generate admin key if not provided
+	// Generate admin key if not provided; warn if user-provided key has invalid format.
 	if e2bAdminKey == "" {
-		e2bAdminKey = uuid.NewString()
+		generatedKey, err := keys.GenerateAPIKey()
+		if err != nil {
+			klog.Fatalf("failed to generate admin api-key: %v", err)
+		}
+		e2bAdminKey = generatedKey
+	} else if !keys.IsValidAPIKeyFormat(e2bAdminKey) {
+		klog.Warningf("admin api-key does not match standard E2B SDK format (expected e2b_ prefix followed by 40 hex characters)")
 	}
 
 	// Validate positive values

--- a/pkg/servers/e2b/keys/mysql.go
+++ b/pkg/servers/e2b/keys/mysql.go
@@ -331,7 +331,8 @@ func (k *mysqlKeyStorage) CreateKey(ctx context.Context, key *models.CreatedTeam
 		return nil, err
 	}
 
-	var newID, newKey uuid.UUID
+	var newID uuid.UUID
+	var newKeyStr string
 	var entity TeamAPIKeyEntity
 	var team *models.Team
 	if retryErr := retry.OnError(wait.Backoff{
@@ -346,7 +347,11 @@ func (k *mysqlKeyStorage) CreateKey(ctx context.Context, key *models.CreatedTeam
 		default:
 		}
 		newID = generateUUID()
-		newKey = generateUUID()
+		generatedKey, genErr := GenerateAPIKey()
+		if genErr != nil {
+			return fmt.Errorf("failed to generate api-key: %w", genErr)
+		}
+		newKeyStr = generatedKey
 		createdBy := key.ID.String()
 		db := k.db.WithContext(ctx)
 		teamEntity, err := k.getOrCreateTeamDB(ctx, db, teamName)
@@ -360,7 +365,7 @@ func (k *mysqlKeyStorage) CreateKey(ctx context.Context, key *models.CreatedTeam
 		entity = TeamAPIKeyEntity{
 			UID:          newID.String(),
 			Name:         opts.Name,
-			KeyHash:      k.hashKey(newKey.String()),
+			KeyHash:      k.hashKey(newKeyStr),
 			TeamID:       teamEntity.ID,
 			CreatedByUID: &createdBy,
 		}
@@ -381,7 +386,7 @@ func (k *mysqlKeyStorage) CreateKey(ctx context.Context, key *models.CreatedTeam
 	apiKey := &models.CreatedTeamAPIKey{
 		CreatedAt: entity.CreatedAt,
 		ID:        newID,
-		Key:       newKey.String(),
+		Key:       newKeyStr,
 		KeyHash:   entity.KeyHash,
 		Name:      opts.Name,
 		Mask:      models.IdentifierMaskingDetails{},

--- a/pkg/servers/e2b/keys/secret.go
+++ b/pkg/servers/e2b/keys/secret.go
@@ -317,12 +317,17 @@ func (k *secretKeyStorage) CreateKey(ctx context.Context, key *models.CreatedTea
 		team = &models.Team{ID: generateUUID(), Name: teamName}
 	}
 
-	var newID, newKey uuid.UUID
+	var newID uuid.UUID
+	var newKeyStr string
 	for i := 0; i < 100; i++ {
 		newID = generateUUID()
-		newKey = generateUUID()
+		key, err := GenerateAPIKey()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate api-key: %w", err)
+		}
+		newKeyStr = key
 		_, ok1 := k.LoadByID(ctx, newID.String())
-		_, ok2 := k.LoadByKey(ctx, newKey.String())
+		_, ok2 := k.LoadByKey(ctx, newKeyStr)
 		if !ok1 && !ok2 {
 			break
 		}
@@ -334,7 +339,7 @@ func (k *secretKeyStorage) CreateKey(ctx context.Context, key *models.CreatedTea
 	apiKey := &models.CreatedTeamAPIKey{
 		CreatedAt: time.Now(),
 		ID:        newID,
-		Key:       newKey.String(),
+		Key:       newKeyStr,
 		Mask:      models.IdentifierMaskingDetails{},
 		Name:      opts.Name,
 		Team:      cloneTeam(team),

--- a/pkg/servers/e2b/keys/utils.go
+++ b/pkg/servers/e2b/keys/utils.go
@@ -17,10 +17,36 @@ limitations under the License.
 package keys
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
+	"regexp"
 
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 )
+
+// APIKeyPrefix is the prefix required by E2B SDK client-side validation.
+const APIKeyPrefix = "e2b_"
+
+// apiKeyRandBytes is the number of random bytes used to generate a key body (40 hex chars).
+const apiKeyRandBytes = 20
+
+// e2bKeyPattern is the regex enforced by the E2B SDK client-side validation.
+var e2bKeyPattern = regexp.MustCompile(`^e2b_[0-9a-f]+$`)
+
+// GenerateAPIKey generates a cryptographically random E2B-compatible API key: "e2b_" + 40 hex chars.
+func GenerateAPIKey() (string, error) {
+	b := make([]byte, apiKeyRandBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return APIKeyPrefix + hex.EncodeToString(b), nil
+}
+
+// IsValidAPIKeyFormat checks if a key matches the E2B SDK expected format: "e2b_" + 40 hex chars.
+func IsValidAPIKeyFormat(key string) bool {
+	return e2bKeyPattern.MatchString(key)
+}
 
 // TeamForKey returns the team for an API key, defaulting to AdminTeam for legacy keys without team information.
 func TeamForKey(user *models.CreatedTeamAPIKey) *models.Team {

--- a/pkg/servers/e2b/keys/utils_test.go
+++ b/pkg/servers/e2b/keys/utils_test.go
@@ -21,10 +21,72 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 )
 
+
+func TestGenerateAPIKey_HasCorrectPrefix(t *testing.T) {
+	key, err := GenerateAPIKey()
+	require.NoError(t, err)
+	assert.Equal(t, APIKeyPrefix, key[:len(APIKeyPrefix)])
+}
+
+func TestIsValidAPIKeyFormat(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		expect bool
+	}{
+		{
+			name:   "valid 40-char key",
+			key:    "e2b_0123456789abcdef0123456789abcdef01234567",
+			expect: true,
+		},
+		{
+			name:   "valid shorter key",
+			key:    "e2b_abcdef0123456789",
+			expect: true,
+		},
+		{
+			name:   "missing prefix",
+			key:    "sk_0123456789abcdef",
+			expect: false,
+		},
+		{
+			name:   "prefix only without body",
+			key:    "e2b_",
+			expect: false,
+		},
+		{
+			name:   "empty string",
+			key:    "",
+			expect: false,
+		},
+		{
+			name:   "uuid format without prefix",
+			key:    "550e8400-e29b-41d4-a716-446655440000",
+			expect: false,
+		},
+		{
+			name:   "uppercase hex rejected",
+			key:    "e2b_0123456789ABCDEF0123456789abcdef01234567",
+			expect: false,
+		},
+		{
+			name:   "non-hex characters rejected",
+			key:    "e2b_zzzzzzzzzzzzzzzzzzzz",
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, IsValidAPIKeyFormat(tt.key))
+		})
+	}
+}
 func TestTeamForKey(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/sdk/customized_e2b/README.md
+++ b/sdk/customized_e2b/README.md
@@ -39,3 +39,20 @@ if __name__ == "__main__":
     with Sandbox.create() as sbx:
         sbx.run_code("print('hello world')")
 ```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `https` | bool | `True` | Whether to use HTTPS for the API URL. |
+| `bypass_key_validation` | bool | `False` | Set to `True` when using legacy keys that don't match the `e2b_<hex>` format. |
+
+### API Key Format
+
+Starting from E2B SDK v2.25.0, the SDK validates API keys client-side. Keys must match the pattern `e2b_` followed by
+hex characters.
+
+OpenKruise Agents sandbox-manager now generates keys in this format by default. If you have legacy API keys (e.g. UUID
+format), use:
+
+```python
+patch_e2b(https=False, bypass_key_validation=True)
+```

--- a/sdk/customized_e2b/kruise_agents/patch_e2b.py
+++ b/sdk/customized_e2b/kruise_agents/patch_e2b.py
@@ -25,10 +25,24 @@ def __connection_config_get_sandbox_url_http(self, sandbox_id: str, sandbox_doma
 def __jupyter_url_http(self) -> str:
     return f"http://{__sandbox_get_host(self, JUPYTER_PORT)}"
 
-def patch_e2b(https: bool = True):
+def patch_e2b(https: bool = True, bypass_key_validation: bool = False):
+    """Patch E2B SDK to work with OpenKruise Agents.
+
+    Args:
+        https: Whether to use HTTPS for the API URL.
+        bypass_key_validation: If True, disable client-side API key format
+            validation added in newer E2B SDK versions. This allows using
+            keys that don't match the ``e2b_<hex>`` format.
+    """
     os.environ["E2B_API_URL"] = __get_api_url(https)
     SandboxBase.get_host = __sandbox_get_host
     ConnectionConfig.get_host = __connection_config_get_host
     if not https:
         ConnectionConfig.get_sandbox_url = __connection_config_get_sandbox_url_http
         setattr(SandboxSync, '_jupyter_url', property(__jupyter_url_http))
+    if bypass_key_validation:
+        try:
+            import e2b.api as _e2b_api
+            _e2b_api.validate_api_key = lambda _key: None
+        except (ImportError, AttributeError):
+            pass


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Generate E2B SDK-compatible API keys with e2b_ prefix.

[New E2B SDK (>= 2.25.0) versions](https://github.com/e2b-dev/E2B/pull/1356) validate API key format client-side, requiring
keys to match `^e2b_[0-9a-f]+$`. Previously generated keys used raw
UUID format which is now rejected by the SDK.

Changes:

1. Add GenerateAPIKey() using crypto/rand to produce "e2b_" + 40 hex
chars, matching the official E2B key format.
2. Update both secret and mysql key storage to use the new generator.
3. Add bypass_key_validation option to patch_e2b() for backward
compatibility with legacy keys.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

```
[AUTH_FAILED(1002)] Failed to create sandbox: credentials rejected. Che
Ck E2B_API_KEY. Original: Invalid API key format: expected "e2b_" followed by hex characters (e.g. "e2b_0000000000000000000000000000000000000000"). Visit the API Ke
ys tab at https://e2b.dev/dashboard?tab=keys to get your API key.
```

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

