### PR TITLE
feat(e2b): add E2B >=v2.25.0 SDK-compatible API key encoding layer

### DIFF
--- a/.github/workflows/e2e-e2b-latest.yaml
+++ b/.github/workflows/e2e-e2b-latest.yaml
@@ -126,7 +126,7 @@ jobs:
           export E2B_DOMAIN=localhost
           export E2B_API_KEY=some-api-key
           if [ "${{ matrix.with_gateway }}" = "true" ]; then
-            bash hack/run-e2b-e2e-test.sh --e2b-version 2.24.0 --sdk-version 2.7.0 --with-gateway
+            bash hack/run-e2b-e2e-test.sh --with-gateway
           else
-            bash hack/run-e2b-e2e-test.sh --e2b-version 2.24.0 --sdk-version 2.7.0
+            bash hack/run-e2b-e2e-test.sh
           fi

--- a/.github/workflows/e2e-e2b-mysql-latest.yaml
+++ b/.github/workflows/e2e-e2b-mysql-latest.yaml
@@ -154,7 +154,7 @@ jobs:
           export E2B_DOMAIN=localhost
           export E2B_API_KEY=some-api-key
           if [ "${{ matrix.with_gateway }}" = "true" ]; then
-            bash hack/run-e2b-e2e-test.sh --e2b-version 2.24.0 --sdk-version 2.7.0 --with-gateway
+            bash hack/run-e2b-e2e-test.sh --with-gateway
           else
-            bash hack/run-e2b-e2e-test.sh --e2b-version 2.24.0 --sdk-version 2.7.0
+            bash hack/run-e2b-e2e-test.sh
           fi

--- a/docs/specs/2026-05-28-e2b-api-key-compat-design.md
+++ b/docs/specs/2026-05-28-e2b-api-key-compat-design.md
@@ -1,0 +1,224 @@
+# E2B SDK-Compatible API Key Design
+
+## Context
+
+E2B SDK `>=2.25.0` validates API keys before sending requests. The SDK
+accepts only keys matching:
+
+```text
+e2b_[0-9a-f]+
+```
+
+`sandbox-manager` historically stores and authenticates raw OpenKruise Agents
+keys. Those keys are commonly UUID strings or custom admin keys, such as
+`admin-987654321`, and therefore fail the new SDK-side validation before the
+server can authenticate them.
+
+The compatibility layer must make server-issued and server-accepted keys pass
+the E2B SDK format without changing storage semantics. Existing Secret and
+MySQL backends must continue to store, index, and hash the original raw key.
+
+## Goals
+
+- Accept existing raw API keys exactly as before.
+- Accept SDK-compatible encoded API keys and map them to the same stored raw key.
+- Return SDK-compatible keys from `POST /api-keys`.
+- Provide a protected endpoint for clients to retrieve the SDK-compatible form
+  of the currently authenticated key.
+- Keep Secret storage payloads unchanged.
+- Keep MySQL schema and HMAC input unchanged.
+- Avoid reflecting raw or compatible API keys in authentication failure
+  responses or logs.
+
+## Non-Goals
+
+- Do not change the `keys.KeyStorage` interface.
+- Do not change key generation. Backends still generate raw UUID/custom keys.
+- Do not migrate existing Secret data or MySQL rows.
+- Do not store encoded keys as canonical credentials.
+- Do not make generic `e2b_...` keys valid unless they use the OpenKruise
+  Agents compatibility encoding and checksum.
+
+## Encoded Key Format
+
+The encoded key is lowercase hex and is shaped to satisfy the SDK validator:
+
+```text
+e2b_ + magic + version + length + hex(raw bytes) + checksum
+```
+
+Fields:
+
+- `magic`: `6f6b6167`
+- `version`: `01`
+- `length`: 8 lowercase hex characters, representing the raw byte length
+- `hex(raw bytes)`: lowercase hex encoding of the original raw key bytes
+- `checksum`: first 8 bytes of
+  `SHA256("openkruise-agents/e2b-key-compat/v1" + raw bytes)`, encoded as
+  lowercase hex
+
+Example for a raw key `admin-987654321`:
+
+```text
+e2b_6f6b6167010000000f61646d696e2d393837363534333231...
+```
+
+The checksum prevents accidental decoding of unrelated `e2b_...` values that
+happen to share the prefix and hex-only shape. It is not a security boundary;
+the raw key remains the credential.
+
+## Key Utility API
+
+Add `pkg/servers/e2b/keys/compat.go` with these helpers:
+
+```go
+func IsE2BSDKCompatible(apiKey string) bool
+func EncodeForE2BSDK(raw string) string
+func DecodeFromE2BSDKCompatible(apiKey string) (string, bool)
+func ToStoredRawAPIKey(apiKey string) string
+func ConvertToE2BCompatibleCreatedAPIKey(apiKey *models.CreatedTeamAPIKey) *models.CreatedTeamAPIKey
+```
+
+`ToStoredRawAPIKey` returns the decoded raw key when the presented key is a
+valid OpenKruise-compatible encoded key, and the presented key unchanged
+otherwise.
+
+`ConvertToE2BCompatibleCreatedAPIKey` returns a deep copy of the created API key model with
+`Key` encoded for the SDK. It must not mutate the object returned by storage.
+
+## Authentication Flow
+
+`CheckApiKey` keeps `X-API-KEY` as the only authentication input.
+
+When key storage is enabled:
+
+1. Read the presented `X-API-KEY` header.
+2. Call `keys.ToStoredRawAPIKey` to obtain the lookup key.
+3. Call `sc.keys.LoadByKey(ctx, lookupKey)`.
+4. If lookup fails, return `401` with a generic `Invalid API Key` message.
+5. On success, store the authenticated raw lookup key in request context for
+   later presentation by the compatibility endpoint.
+
+Authentication failure responses and logs must not include either the presented
+key or the decoded raw key.
+
+When key storage is disabled, `AnonymousUser` behavior is unchanged.
+
+## API Key Creation
+
+`CreateAPIKey` continues to call storage with the existing raw-key semantics:
+
+```go
+createdAPIKey, err := sc.keys.CreateKey(ctx, user, keys.CreateKeyOptions{...})
+```
+
+The handler returns:
+
+```go
+keys.ConvertToE2BCompatibleCreatedAPIKey(createdAPIKey)
+```
+
+This means:
+
+- the response `key` field is SDK-compatible;
+- Secret storage still stores the raw key;
+- MySQL still hashes the raw key;
+- cache entries remain based on the raw key or raw-key HMAC;
+- callers cannot authenticate with the encoded key unless the server decodes it
+  back to the raw key first.
+
+## Compatible Key Endpoint
+
+Add a protected endpoint:
+
+```text
+GET /api-keys/compatible
+```
+
+Like other E2B routes, it is registered through `RegisterE2BRoute`, so both the
+native path and customized `/api` prefixed path are available.
+
+Middleware:
+
+```text
+CheckApiKey
+```
+
+Response:
+
+```json
+{
+  "key": "e2b_..."
+}
+```
+
+The endpoint returns the SDK-compatible form of the currently authenticated
+credential. It never returns the raw key. If the request was authenticated with
+an encoded key, the endpoint returns the same canonical encoded representation
+for the decoded raw key.
+
+## Storage Compatibility
+
+Secret backend:
+
+- Keep Secret keys and JSON payloads based on raw keys.
+- Continue loading old raw keys without migration.
+- Continue creating raw UUID keys internally.
+- Remove raw key values from creation logs.
+
+MySQL backend:
+
+- Keep `team_api_keys.key_hash` as `HMAC-SHA256(pepper, rawKey)`.
+- Do not add columns or indexes.
+- Continue returning plaintext only from `CreateKey` once.
+- Continue returning no plaintext key for DB-loaded keys.
+
+The compatibility endpoint uses the authenticated request context rather than
+the storage-returned model's `Key` field. This is required for MySQL, where
+loaded keys normally do not include plaintext.
+
+## Security and Logging
+
+The encoded key is reversible by design. It exists only to satisfy the SDK
+format validator while preserving server-side storage semantics.
+
+Therefore:
+
+- treat encoded keys as credentials;
+- do not log raw keys;
+- do not log encoded keys;
+- do not include raw or encoded keys in unauthorized responses;
+- only log stable non-secret identifiers such as API key ID where needed.
+
+## Compatibility Matrix
+
+| Presented key | Stored credential | Expected result |
+| --- | --- | --- |
+| raw legacy key | same raw key | authenticate |
+| SDK-compatible encoded key | decoded raw key | authenticate |
+| unrelated `e2b_...` value | no matching raw key | reject |
+| malformed key | no matching raw key | reject |
+
+## Tests
+
+Add table-driven unit tests for:
+
+- SDK format detection.
+- Encode/decode round trip for UUID keys, admin keys, empty keys, and UTF-8 byte
+  length handling.
+- Decode rejection for wrong magic, wrong version, wrong length, checksum
+  mismatch, uppercase hex, unrelated `e2b_...`, and trailing bytes.
+- Canonicalization of raw, valid encoded, and invalid encoded keys.
+- `ConvertToE2BCompatibleCreatedAPIKey` returning a copy and preserving the original raw key.
+- `CheckApiKey` authenticating raw keys.
+- `CheckApiKey` authenticating encoded keys by decoded raw lookup.
+- Unauthorized errors not reflecting raw or encoded keys.
+- `POST /api-keys` returning `e2b_[0-9a-f]+` while storage remains raw.
+- `GET /api-keys/compatible` returning a compatible key for raw and encoded
+  authentication.
+
+Run:
+
+```bash
+go test ./pkg/servers/e2b/... ./pkg/servers/e2b/keys/...
+```

--- a/hack/run-e2b-e2e-test.sh
+++ b/hack/run-e2b-e2e-test.sh
@@ -24,6 +24,101 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEST_DIR="$PROJECT_ROOT/test/e2b"
 MANAGER_SELECTOR="app.kubernetes.io/name=sandbox-manager"
+E2B_SDK_COMPAT_MIN_VERSION="2.25.0"
+
+version_part_to_number() {
+    local value="$1"
+    value="${value#v}"
+    value="${value%%[!0-9]*}"
+    if [ -z "$value" ]; then
+        value=0
+    fi
+    echo "$value"
+}
+
+version_ge() {
+    local version="$1"
+    local minimum="$2"
+    local major minor patch min_major min_minor min_patch
+
+    version="${version#v}"
+    minimum="${minimum#v}"
+    IFS=. read -r major minor patch _ <<<"$version"
+    IFS=. read -r min_major min_minor min_patch _ <<<"$minimum"
+
+    major="$(version_part_to_number "$major")"
+    minor="$(version_part_to_number "$minor")"
+    patch="$(version_part_to_number "$patch")"
+    min_major="$(version_part_to_number "$min_major")"
+    min_minor="$(version_part_to_number "$min_minor")"
+    min_patch="$(version_part_to_number "$min_patch")"
+
+    if ((10#$major > 10#$min_major)); then
+        return 0
+    fi
+    if ((10#$major < 10#$min_major)); then
+        return 1
+    fi
+    if ((10#$minor > 10#$min_minor)); then
+        return 0
+    fi
+    if ((10#$minor < 10#$min_minor)); then
+        return 1
+    fi
+    ((10#$patch >= 10#$min_patch))
+}
+
+get_installed_e2b_version() {
+    pip show e2b 2>/dev/null | awk '/^Version:/ {print $2; exit}'
+}
+
+convert_e2b_api_key_for_sdk_if_needed() {
+    local installed_e2b_version="$1"
+    local api_url response compatible_api_key xtrace_enabled
+
+    if ! version_ge "$installed_e2b_version" "$E2B_SDK_COMPAT_MIN_VERSION"; then
+        echo "Installed e2b version $installed_e2b_version does not require SDK-compatible API key conversion"
+        return
+    fi
+
+    echo "Converting E2B_API_KEY for e2b $installed_e2b_version SDK validation..."
+    if [[ $- == *x* ]]; then
+        xtrace_enabled="true"
+        set +x
+    else
+        xtrace_enabled="false"
+    fi
+
+    if [ -z "${E2B_API_KEY:-}" ]; then
+        echo "Error: E2B_API_KEY must be set for e2b >= $E2B_SDK_COMPAT_MIN_VERSION"
+        exit 1
+    fi
+
+    api_url="${E2B_API_URL:-http://${E2B_DOMAIN:-localhost}/kruise/api}"
+    api_url="${api_url%/}"
+
+    response="$(
+        curl --fail --silent --show-error \
+            --retry 30 --retry-delay 1 --retry-connrefused \
+            --connect-timeout 5 --max-time 10 \
+            --header "X-API-Key: ${E2B_API_KEY}" \
+            "${api_url}/api-keys/compatible"
+    )"
+    compatible_api_key="$(
+        printf '%s' "$response" | python3 -c 'import json, sys
+data = json.load(sys.stdin)
+key = data.get("key")
+if not isinstance(key, str) or not key:
+    raise SystemExit("compatible API key response does not contain a non-empty key")
+print(key)'
+    )"
+    export E2B_API_KEY="$compatible_api_key"
+
+    if [ "$xtrace_enabled" = "true" ]; then
+        set -x
+    fi
+    echo "E2B_API_KEY converted to SDK-compatible form"
+}
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -115,7 +210,15 @@ fi
 
 echo "dependencies installed successfully"
 
-# Step 3: Run pytest tests serially
+installed_e2b_version="$(get_installed_e2b_version)"
+if [ -z "$installed_e2b_version" ]; then
+    echo "Error: failed to determine installed e2b version"
+    exit 1
+fi
+convert_e2b_api_key_for_sdk_if_needed "$installed_e2b_version"
+
+# Step 3: Run pytest tests serially (print the key for debug, it's safe to print it in a ci pipeline)
+echo "Using E2B_API_KEY: ${E2B_API_KEY:-}"
 echo "Running E2B pytest tests..."
 set +e
 

--- a/pkg/controller/securitytokenrefresh/predicate_test.go
+++ b/pkg/controller/securitytokenrefresh/predicate_test.go
@@ -24,8 +24,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	"github.com/openkruise/agents/pkg/identity"
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/identity"
 )
 
 // newSandbox builds a *Sandbox with the given knobs. It mirrors the shape of the

--- a/pkg/servers/e2b/api_key.go
+++ b/pkg/servers/e2b/api_key.go
@@ -78,7 +78,21 @@ func (sc *Controller) CreateAPIKey(r *http.Request) (web.ApiResponse[*models.Cre
 
 	return web.ApiResponse[*models.CreatedTeamAPIKey]{
 		Code: http.StatusCreated,
-		Body: createdAPIKey,
+		Body: keys.ConvertToE2BCompatibleCreatedAPIKey(createdAPIKey),
+	}, nil
+}
+
+// GetCompatibleAPIKey returns the E2B SDK-compatible form of the caller's API key.
+//
+// We intentionally read the raw key directly from the request header here instead of
+// retrieving it from a value stashed into the request context by CheckApiKey. Keeping
+// the lookup local to this low-frequency endpoint improves readability and avoids
+// scattering the key-passing logic across the auth middleware and the handler.
+func (sc *Controller) GetCompatibleAPIKey(r *http.Request) (web.ApiResponse[*models.CompatibleAPIKey], *web.ApiError) {
+	rawAPIKey := keys.ToStoredRawAPIKey(r.Header.Get(models.HeaderApiKey))
+
+	return web.ApiResponse[*models.CompatibleAPIKey]{
+		Body: &models.CompatibleAPIKey{Key: keys.EncodeForE2BSDK(rawAPIKey)},
 	}, nil
 }
 

--- a/pkg/servers/e2b/api_key_test.go
+++ b/pkg/servers/e2b/api_key_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/uuid"
@@ -180,12 +181,78 @@ func TestCreateAPIKey(t *testing.T) {
 				require.Nil(t, apiError)
 				assert.Equal(t, tt.expectCode, resp.Code)
 				assert.NotEmpty(t, resp.Body.Key)
+				assert.True(t, keys.IsE2BSDKCompatible(resp.Body.Key))
+				rawKey, decoded := keys.DecodeFromE2BSDKCompatible(resp.Body.Key)
+				require.True(t, decoded)
+				assert.NotEqual(t, rawKey, resp.Body.Key)
+				stored, found := controller.keys.LoadByID(t.Context(), resp.Body.ID.String())
+				require.True(t, found)
+				assert.Equal(t, rawKey, stored.Key)
+				_, found = controller.keys.LoadByKey(t.Context(), resp.Body.Key)
+				assert.False(t, found)
+				_, found = controller.keys.LoadByKey(t.Context(), rawKey)
+				assert.True(t, found)
 				assert.Equal(t, tt.request.Name, resp.Body.Name)
 				require.NotNil(t, resp.Body.CreatedBy)
 				assert.Equal(t, tt.user.ID, resp.Body.CreatedBy.ID)
 			}
 		})
 	}
+}
+
+func TestCompatibleAPIKeyEndpoint(t *testing.T) {
+	controller, _, teardown := Setup(t)
+	defer teardown()
+
+	ctx := logs.NewContext()
+	adminUser := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+		Team: models.AdminTeam(),
+	}
+	regularUser, err := controller.keys.CreateKey(ctx, adminUser, keys.CreateKeyOptions{Name: "regular-user", TeamName: "regular-team"})
+	require.NoError(t, err)
+	compatibleKey := keys.EncodeForE2BSDK(regularUser.Key)
+
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{name: "raw key returns compatible key", header: regularUser.Key, want: compatibleKey},
+		{name: "compatible key returns same compatible key", header: compatibleKey, want: compatibleKey},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api-keys/compatible", nil)
+			req.Header.Set(models.HeaderApiKey, tt.header)
+			rec := httptest.NewRecorder()
+
+			controller.mux.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+			var body map[string]string
+			require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+			assert.Equal(t, tt.want, body["key"])
+			assert.NotEqual(t, regularUser.Key, body["key"])
+			assert.True(t, keys.IsE2BSDKCompatible(body["key"]))
+		})
+	}
+
+	t.Run("invalid key does not appear in unauthorized response", func(t *testing.T) {
+		invalidCompatibleKey := keys.EncodeForE2BSDK("missing-key")
+		req := httptest.NewRequest(http.MethodGet, "/api-keys/compatible", nil)
+		req.Header.Set(models.HeaderApiKey, invalidCompatibleKey)
+		rec := httptest.NewRecorder()
+
+		controller.mux.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.NotContains(t, rec.Body.String(), invalidCompatibleKey)
+		assert.NotContains(t, rec.Body.String(), "missing-key")
+	})
 }
 
 func TestCreateAPIKeyPermissionMiddleware(t *testing.T) {

--- a/pkg/servers/e2b/keys/compat.go
+++ b/pkg/servers/e2b/keys/compat.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keys
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+)
+
+const (
+	e2bSDKPrefix             = "e2b_"
+	e2bSDKCompatMagic        = "6f6b6167"
+	e2bSDKCompatVersion      = "01"
+	e2bSDKCompatChecksumSalt = "openkruise-agents/e2b-key-compat/v1"
+	e2bSDKCompatLengthSize   = 8
+	e2bSDKCompatChecksumSize = 16
+	e2bSDKCompatHeaderSize   = len(e2bSDKCompatMagic) + len(e2bSDKCompatVersion) + e2bSDKCompatLengthSize
+	e2bSDKCompatMaxRawLength = (math.MaxInt32 - e2bSDKCompatHeaderSize - e2bSDKCompatChecksumSize) / 2
+)
+
+var e2bSDKCompatiblePattern = regexp.MustCompile(`^e2b_[0-9a-f]+$`)
+
+// IsE2BSDKCompatible returns whether an API key satisfies the E2B SDK format.
+func IsE2BSDKCompatible(apiKey string) bool {
+	return e2bSDKCompatiblePattern.MatchString(apiKey)
+}
+
+// EncodeForE2BSDK wraps a raw OpenKruise Agents API key in an E2B SDK-compatible form.
+// Callers must pass a regular API key (UUID or admin key, well under 4 GB). Inputs
+// larger than 4 GB would overflow the 8-hex-character length field; such inputs are
+// not produced by any backend in this project, so the function does not guard for them.
+func EncodeForE2BSDK(raw string) string {
+	rawBytes := []byte(raw)
+	return fmt.Sprintf("%s%s%s%08x%s%s",
+		e2bSDKPrefix,
+		e2bSDKCompatMagic,
+		e2bSDKCompatVersion,
+		len(rawBytes),
+		hex.EncodeToString(rawBytes),
+		e2bSDKCompatChecksum(rawBytes),
+	)
+}
+
+// DecodeFromE2BSDKCompatible decodes an OpenKruise Agents-compatible E2B SDK key.
+func DecodeFromE2BSDKCompatible(apiKey string) (string, bool) {
+	if !IsE2BSDKCompatible(apiKey) {
+		return "", false
+	}
+
+	payload := strings.TrimPrefix(apiKey, e2bSDKPrefix)
+	minPayloadSize := e2bSDKCompatHeaderSize + e2bSDKCompatChecksumSize
+	if len(payload) < minPayloadSize {
+		return "", false
+	}
+	if !strings.HasPrefix(payload, e2bSDKCompatMagic+e2bSDKCompatVersion) {
+		return "", false
+	}
+
+	lengthHexStart := len(e2bSDKCompatMagic) + len(e2bSDKCompatVersion)
+	lengthHexEnd := lengthHexStart + e2bSDKCompatLengthSize
+	rawLength, ok := parseE2BSDKCompatRawLength(payload[lengthHexStart:lengthHexEnd])
+	if !ok {
+		return "", false
+	}
+	rawHexStart := lengthHexEnd
+
+	rawHexEnd := rawHexStart + rawLength*2
+	checksumEnd := rawHexEnd + e2bSDKCompatChecksumSize
+	if len(payload) != checksumEnd {
+		return "", false
+	}
+
+	rawBytes, err := hex.DecodeString(payload[rawHexStart:rawHexEnd])
+	if err != nil || len(rawBytes) != rawLength {
+		return "", false
+	}
+	checksum := e2bSDKCompatChecksum(rawBytes)
+	if subtle.ConstantTimeCompare([]byte(payload[rawHexEnd:checksumEnd]), []byte(checksum)) != 1 {
+		return "", false
+	}
+	return string(rawBytes), true
+}
+
+// ToStoredRawAPIKey returns the raw key that storage should use for lookup.
+// If apiKey is a valid OpenKruise-compatible encoded key, the decoded raw key is
+// returned; otherwise the input is returned unchanged.
+func ToStoredRawAPIKey(apiKey string) string {
+	if rawKey, ok := DecodeFromE2BSDKCompatible(apiKey); ok {
+		return rawKey
+	}
+	return apiKey
+}
+
+func parseE2BSDKCompatRawLength(lengthHex string) (int, bool) {
+	rawLength, err := strconv.ParseUint(lengthHex, 16, 31)
+	if err != nil || rawLength > uint64(e2bSDKCompatMaxRawLength) {
+		return 0, false
+	}
+	return int(rawLength), true
+}
+
+// ConvertToE2BCompatibleCreatedAPIKey returns a response copy with Key encoded for the E2B SDK.
+func ConvertToE2BCompatibleCreatedAPIKey(apiKey *models.CreatedTeamAPIKey) *models.CreatedTeamAPIKey {
+	presented := cloneCreatedTeamAPIKey(apiKey)
+	if presented == nil {
+		return nil
+	}
+	presented.Key = EncodeForE2BSDK(apiKey.Key)
+	return presented
+}
+
+func e2bSDKCompatChecksum(raw []byte) string {
+	payload := append([]byte(e2bSDKCompatChecksumSalt), raw...)
+	checksum := sha256.Sum256(payload)
+	return hex.EncodeToString(checksum[:8])
+}

--- a/pkg/servers/e2b/keys/compat_test.go
+++ b/pkg/servers/e2b/keys/compat_test.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keys
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+)
+
+func TestIsE2BSDKCompatible(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want bool
+	}{
+		{name: "e2b prefix with lowercase hex", key: "e2b_abc123", want: true},
+		{name: "encoded compatible key", key: expectedE2BSDKCompatibleKey("admin-987654321"), want: true},
+		{name: "missing prefix", key: "abc123", want: false},
+		{name: "empty suffix", key: "e2b_", want: false},
+		{name: "uppercase prefix", key: "E2B_abc123", want: false},
+		{name: "uppercase hex", key: "e2b_ABC123", want: false},
+		{name: "non hex suffix", key: "e2b_not-hex", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsE2BSDKCompatible(tt.key))
+		})
+	}
+}
+
+func TestEncodeDecodeFromE2BSDKCompatible(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "legacy admin key", raw: "admin-987654321"},
+		{name: "uuid key", raw: uuid.MustParse("11111111-2222-3333-4444-555555555555").String()},
+		{name: "empty key", raw: ""},
+		{name: "utf8 key uses byte length", raw: "key-with-\xe4\xb8\xad"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded := EncodeForE2BSDK(tt.raw)
+
+			require.Equal(t, expectedE2BSDKCompatibleKey(tt.raw), encoded)
+			assert.True(t, IsE2BSDKCompatible(encoded))
+			assert.True(t, strings.HasPrefix(encoded, "e2b_6f6b616701"))
+
+			decoded, ok := DecodeFromE2BSDKCompatible(encoded)
+			require.True(t, ok)
+			assert.Equal(t, tt.raw, decoded)
+		})
+	}
+}
+
+func TestDecodeFromE2BSDKCompatibleRejectsInvalidEncoding(t *testing.T) {
+	valid := EncodeForE2BSDK("raw-key")
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{name: "raw key", key: "raw-key"},
+		{name: "sdk compatible but not openkruise encoding", key: "e2b_abc123"},
+		{name: "wrong magic", key: "e2b_0000000001000000077261772d6b6579" + checksumForTest("raw-key")},
+		{name: "wrong version", key: strings.Replace(valid, "01", "02", 1)},
+		{name: "length mismatch", key: strings.Replace(valid, "00000007", "00000008", 1)},
+		{name: "checksum mismatch", key: flipLastHexForTest(valid)},
+		{name: "uppercase hex", key: strings.ToUpper(valid)},
+		{name: "trailing bytes", key: valid + "00"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decoded, ok := DecodeFromE2BSDKCompatible(tt.key)
+			assert.False(t, ok)
+			assert.Empty(t, decoded)
+		})
+	}
+}
+
+func TestParseE2BSDKCompatRawLength(t *testing.T) {
+	tests := []struct {
+		name       string
+		lengthHex  string
+		wantLength int
+		wantOK     bool
+	}{
+		{name: "valid length", lengthHex: "00000007", wantLength: 7, wantOK: true},
+		{name: "length too large for int safe payload", lengthHex: "40000000", wantOK: false},
+		{name: "invalid hex", lengthHex: "not-hex!", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLength, ok := parseE2BSDKCompatRawLength(tt.lengthHex)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantLength, gotLength)
+		})
+	}
+}
+
+func TestToStoredRawAPIKey(t *testing.T) {
+	encoded := EncodeForE2BSDK("raw-key")
+	tests := []struct {
+		name      string
+		presented string
+		wantKey   string
+	}{
+		{name: "raw key is unchanged", presented: "raw-key", wantKey: "raw-key"},
+		{name: "encoded key returns raw key", presented: encoded, wantKey: "raw-key"},
+		{name: "invalid e2b key is unchanged", presented: "e2b_abc123", wantKey: "e2b_abc123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantKey, ToStoredRawAPIKey(tt.presented))
+		})
+	}
+}
+
+func TestConvertToE2BCompatibleCreatedAPIKeyReturnsCopyWithCompatibleKey(t *testing.T) {
+	rawKey := "raw-admin-key"
+	original := &models.CreatedTeamAPIKey{
+		ID:   uuid.New(),
+		Key:  rawKey,
+		Name: "admin",
+		Team: &models.Team{
+			ID:   uuid.New(),
+			Name: "team-a",
+		},
+		CreatedBy: &models.TeamUser{ID: uuid.New()},
+	}
+
+	presented := ConvertToE2BCompatibleCreatedAPIKey(original)
+
+	require.NotNil(t, presented)
+	assert.NotSame(t, original, presented)
+	assert.Equal(t, rawKey, original.Key)
+	assert.Equal(t, EncodeForE2BSDK(rawKey), presented.Key)
+	assert.NotSame(t, original.Team, presented.Team)
+	assert.NotSame(t, original.CreatedBy, presented.CreatedBy)
+}
+
+func expectedE2BSDKCompatibleKey(raw string) string {
+	rawBytes := []byte(raw)
+	return fmt.Sprintf("e2b_6f6b616701%08x%s%s", len(rawBytes), hex.EncodeToString(rawBytes), checksumForTest(raw))
+}
+
+func checksumForTest(raw string) string {
+	payload := append([]byte("openkruise-agents/e2b-key-compat/v1"), []byte(raw)...)
+	checksum := sha256.Sum256(payload)
+	return hex.EncodeToString(checksum[:8])
+}
+
+func flipLastHexForTest(value string) string {
+	if value[len(value)-1] == '0' {
+		return value[:len(value)-1] + "1"
+	}
+	return value[:len(value)-1] + "0"
+}
+
+// FuzzEncodeDecodeRoundTrip verifies that encoding any raw string with EncodeForE2BSDK
+// and then decoding the result with DecodeFromE2BSDKCompatible always recovers the
+// original value without panicking.
+func FuzzEncodeDecodeRoundTrip(f *testing.F) {
+	f.Add("")
+	f.Add("admin-987654321")
+	f.Add("11111111-2222-3333-4444-555555555555")
+	f.Add("key-with-\xe4\xb8\xad")
+	f.Add(strings.Repeat("a", 1024))
+	f.Add("\x00\x01\x02\xff")
+	f.Add("e2b_abc123")
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		encoded := EncodeForE2BSDK(raw)
+
+		if !IsE2BSDKCompatible(encoded) {
+			t.Fatalf("encoded key %q is not E2B SDK compatible", encoded)
+		}
+
+		decoded, ok := DecodeFromE2BSDKCompatible(encoded)
+		if !ok {
+			t.Fatalf("failed to decode encoded key for raw input %q", raw)
+		}
+		if decoded != raw {
+			t.Fatalf("round-trip mismatch: got %q, want %q", decoded, raw)
+		}
+	})
+}
+
+// FuzzDecodeFromE2BSDKCompatible verifies that DecodeFromE2BSDKCompatible never panics
+// on arbitrary input strings, including malformed, truncated, or random data.
+func FuzzDecodeFromE2BSDKCompatible(f *testing.F) {
+	f.Add("")
+	f.Add("e2b_")
+	f.Add("e2b_abc123")
+	f.Add("e2b_6f6b616701")
+	f.Add("not-a-valid-key")
+	f.Add(EncodeForE2BSDK("valid-key"))
+	f.Add("e2b_" + strings.Repeat("0", 200))
+	f.Add("e2b_6f6b61670100000000")
+	f.Add("e2b_6f6b6167010000000100" + strings.Repeat("f", 16))
+	f.Add("\x00\xff\xfe")
+
+	f.Fuzz(func(t *testing.T, input string) {
+		// Must not panic regardless of input.
+		decoded, ok := DecodeFromE2BSDKCompatible(input)
+		if ok && decoded == "" && input != EncodeForE2BSDK("") {
+			// If decode reports success with empty result, ensure it's actually the
+			// encoding of empty string (legitimate case).
+			reEncoded := EncodeForE2BSDK(decoded)
+			if input != reEncoded {
+				t.Fatalf("decode reported success for input %q but re-encode mismatch: got %q", input, reEncoded)
+			}
+		}
+		if ok {
+			// If decode succeeded, verify consistency: re-encoding the decoded value
+			// and decoding again must yield the same result.
+			reEncoded := EncodeForE2BSDK(decoded)
+			reDecoded, reOK := DecodeFromE2BSDKCompatible(reEncoded)
+			if !reOK {
+				t.Fatalf("re-encode/decode failed for decoded value %q", decoded)
+			}
+			if reDecoded != decoded {
+				t.Fatalf("re-encode/decode mismatch: got %q, want %q", reDecoded, decoded)
+			}
+		}
+	})
+}
+
+// FuzzEncodeForE2BSDK verifies that EncodeForE2BSDK never panics on arbitrary
+// input and always produces a valid E2B SDK compatible key.
+func FuzzEncodeForE2BSDK(f *testing.F) {
+	f.Add("")
+	f.Add("simple")
+	f.Add(strings.Repeat("x", 4096))
+	f.Add("\x00")
+	f.Add("\xff\xfe\xfd")
+	f.Add("emoji-\xf0\x9f\x98\x80")
+	f.Add("e2b_already_prefixed")
+	f.Add("spaces and\ttabs\nnewlines")
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		encoded := EncodeForE2BSDK(raw)
+
+		if !strings.HasPrefix(encoded, "e2b_") {
+			t.Fatalf("encoded key missing e2b_ prefix: %q", encoded)
+		}
+		if !IsE2BSDKCompatible(encoded) {
+			t.Fatalf("encoded key %q failed IsE2BSDKCompatible check", encoded)
+		}
+	})
+}

--- a/pkg/servers/e2b/keys/secret.go
+++ b/pkg/servers/e2b/keys/secret.go
@@ -102,7 +102,7 @@ func (k *secretKeyStorage) Init(ctx context.Context) error {
 		if err := k.retryUpdateSecret(ctx, AdminKeyID.String(), adminKey); err != nil && !apierrors.IsConflict(err) {
 			return err
 		} else if err == nil {
-			log.Info("create admin key success", "key", adminKey.Key)
+			log.Info("create admin key success", "id", adminKey.ID)
 		}
 	}
 
@@ -343,7 +343,7 @@ func (k *secretKeyStorage) CreateKey(ctx context.Context, key *models.CreatedTea
 		},
 	}
 
-	log.Info("api-key generated", "key", apiKey)
+	log.Info("api-key generated", "id", apiKey.ID)
 	createdKey, err := k.retryCreateKey(ctx, newID.String(), apiKey)
 	if err != nil {
 		log.Error(err, "failed to update api-key")

--- a/pkg/servers/e2b/models/api_key.go
+++ b/pkg/servers/e2b/models/api_key.go
@@ -82,6 +82,11 @@ type NewTeamAPIKey struct {
 	TeamName string `json:"teamName,omitempty"`
 }
 
+// CompatibleAPIKey represents the SDK-compatible form of an authenticated API key.
+type CompatibleAPIKey struct {
+	Key string `json:"key"`
+}
+
 // ListedTeam represents a team returned by the upstream-compatible GET /teams API.
 type ListedTeam struct {
 	TeamID    string `json:"teamID"`

--- a/pkg/servers/e2b/models/consts.go
+++ b/pkg/servers/e2b/models/consts.go
@@ -27,4 +27,6 @@ const (
 
 	MaxListLimit = 100
 	MinListLimit = 1
+
+	HeaderApiKey = "X-API-Key"
 )

--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -68,6 +68,7 @@ func (sc *Controller) registerRoutes() {
 	// API Keys management endpoints
 	if sc.keyCfg != nil {
 		RegisterE2BRoute(sc.mux, http.MethodGet, "/teams", sc.ListTeams, sc.CheckApiKey)
+		RegisterE2BRoute(sc.mux, http.MethodGet, "/api-keys/compatible", sc.GetCompatibleAPIKey, sc.CheckApiKey)
 		RegisterE2BRoute(sc.mux, http.MethodGet, "/api-keys", sc.ListAPIKeys, sc.CheckApiKey)
 		RegisterE2BRoute(sc.mux, http.MethodPost, "/api-keys", sc.CreateAPIKey, sc.CheckApiKey, sc.CheckCreateAPIKeyPermission)
 		RegisterE2BRoute(sc.mux, http.MethodDelete, "/api-keys/{apiKeyID}", sc.DeleteAPIKey, sc.CheckApiKey, sc.CheckDeleteAPIKeyPermission)
@@ -93,18 +94,21 @@ var AnonymousUser = &models.CreatedTeamAPIKey{
 func (sc *Controller) CheckApiKey(ctx context.Context, r *http.Request) (context.Context, *web.ApiError) {
 	logger := klog.FromContext(ctx)
 	middleWareLog := logger.WithValues("middleware", "CheckApiKey").V(utils.DebugLogLevel)
-	apiKey := r.Header.Get("X-API-KEY")
+	apiKey := r.Header.Get(models.HeaderApiKey)
 	var user *models.CreatedTeamAPIKey
 	var ok bool
 	if sc.keys == nil {
 		user = AnonymousUser
 	} else {
-		user, ok = sc.keys.LoadByKey(ctx, apiKey)
+		// There's no such an existing key that can be decoded in the world,
+		// so it's unnecessary to fallback to the original api-key. Check raw api-key only.
+		rawAPIKey := keys.ToStoredRawAPIKey(apiKey)
+		user, ok = sc.keys.LoadByKey(ctx, rawAPIKey)
 		if !ok {
 			middleWareLog.Info("failed to load key by API-KEY")
 			return ctx, &web.ApiError{
 				Code:    http.StatusUnauthorized,
-				Message: fmt.Sprintf("Invalid API Key: %s", apiKey),
+				Message: "Invalid API Key",
 			}
 		}
 	}
@@ -125,7 +129,9 @@ func (sc *Controller) CheckApiKey(ctx context.Context, r *http.Request) (context
 			}
 		}
 	}
-	return context.WithValue(klog.NewContext(ctx, logger.WithValues("user", user.Name)), "user", user), nil
+	ctx = klog.NewContext(ctx, logger.WithValues("user", user.Name))
+	ctx = context.WithValue(ctx, "user", user)
+	return ctx, nil
 }
 
 const (

--- a/pkg/servers/e2b/routes_test.go
+++ b/pkg/servers/e2b/routes_test.go
@@ -33,6 +33,50 @@ import (
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 )
 
+type lookupKeyStorage struct {
+	byKey map[string]*models.CreatedTeamAPIKey
+	calls []string
+}
+
+func (s *lookupKeyStorage) Init(context.Context) error { return nil }
+func (s *lookupKeyStorage) Run()                       {}
+func (s *lookupKeyStorage) Stop()                      {}
+
+func (s *lookupKeyStorage) LoadByKey(_ context.Context, key string) (*models.CreatedTeamAPIKey, bool) {
+	s.calls = append(s.calls, key)
+	user, ok := s.byKey[key]
+	return user, ok
+}
+
+func (s *lookupKeyStorage) LoadByID(_ context.Context, id string) (*models.CreatedTeamAPIKey, bool) {
+	for _, user := range s.byKey {
+		if user.ID.String() == id {
+			return user, true
+		}
+	}
+	return nil, false
+}
+
+func (s *lookupKeyStorage) CreateKey(context.Context, *models.CreatedTeamAPIKey, keys.CreateKeyOptions) (*models.CreatedTeamAPIKey, error) {
+	return nil, nil
+}
+
+func (s *lookupKeyStorage) DeleteKey(context.Context, *models.CreatedTeamAPIKey) error {
+	return nil
+}
+
+func (s *lookupKeyStorage) ListByOwnerTeam(context.Context, *models.CreatedTeamAPIKey) ([]*models.TeamAPIKey, error) {
+	return nil, nil
+}
+
+func (s *lookupKeyStorage) ListTeams(context.Context, *models.CreatedTeamAPIKey) ([]*models.ListedTeam, error) {
+	return nil, nil
+}
+
+func (s *lookupKeyStorage) FindTeamByName(context.Context, string) (*models.Team, bool, error) {
+	return nil, false, nil
+}
+
 // TestCheckApiKey_BasicTests tests basic CheckApiKey middleware functionality
 // Note: The "keys nil (auth disabled)" scenario is tested separately
 // to avoid peer initialization timeout issues. See TestCheckApiKey_AnonymousUserWithAdminKeyID
@@ -80,18 +124,25 @@ func TestCheckApiKey_WithRealSetup(t *testing.T) {
 			expectedUser:  regularUser,
 		},
 		{
+			name:          "valid E2B SDK compatible regular user API key",
+			apiKeyHeader:  keys.EncodeForE2BSDK(regularUser.Key),
+			expectError:   false,
+			expectCtxUser: true,
+			expectedUser:  regularUser,
+		},
+		{
 			name:         "invalid API key",
 			apiKeyHeader: "invalid-key",
 			expectError:  true,
 			expectedCode: http.StatusUnauthorized,
-			expectedMsg:  "Invalid API Key: invalid-key",
+			expectedMsg:  "Invalid API Key",
 		},
 		{
 			name:         "empty X-API-KEY header",
 			apiKeyHeader: "",
 			expectError:  true,
 			expectedCode: http.StatusUnauthorized,
-			expectedMsg:  "Invalid API Key: ",
+			expectedMsg:  "Invalid API Key",
 		},
 	}
 
@@ -101,7 +152,7 @@ func TestCheckApiKey_WithRealSetup(t *testing.T) {
 			require.NoError(t, err)
 
 			if tt.apiKeyHeader != "" {
-				req.Header.Set("X-API-KEY", tt.apiKeyHeader)
+				req.Header.Set(models.HeaderApiKey, tt.apiKeyHeader)
 			}
 
 			ctx := logs.NewContext()
@@ -112,6 +163,12 @@ func TestCheckApiKey_WithRealSetup(t *testing.T) {
 				if apiErr != nil {
 					assert.Equal(t, tt.expectedCode, apiErr.Code)
 					assert.Equal(t, tt.expectedMsg, apiErr.Message)
+					if tt.apiKeyHeader != "" {
+						assert.NotContains(t, apiErr.Message, tt.apiKeyHeader)
+						if decoded, ok := keys.DecodeFromE2BSDKCompatible(tt.apiKeyHeader); ok {
+							assert.NotContains(t, apiErr.Message, decoded)
+						}
+					}
 				}
 			} else {
 				assert.Nil(t, apiErr)
@@ -123,6 +180,81 @@ func TestCheckApiKey_WithRealSetup(t *testing.T) {
 					}
 				}
 			}
+		})
+	}
+}
+
+func TestCheckApiKey_CanonicalizesE2BSDKCompatibleKeys(t *testing.T) {
+	rawKey := "legacy-raw-key"
+	rawUser := &models.CreatedTeamAPIKey{
+		ID:   uuid.New(),
+		Key:  rawKey,
+		Name: "legacy-user",
+		Team: &models.Team{Name: "team-a"},
+	}
+	encodedRawKey := keys.EncodeForE2BSDK(rawKey)
+
+	e2bLikeRawKey := "e2b_000000000000000"
+	e2bLikeUser := &models.CreatedTeamAPIKey{
+		ID:   uuid.New(),
+		Key:  e2bLikeRawKey,
+		Name: "e2b-like-user",
+		Team: &models.Team{Name: "team-a"},
+	}
+	encodedE2bLikeKey := keys.EncodeForE2BSDK(e2bLikeRawKey)
+
+	tests := []struct {
+		name      string
+		stored    map[string]*models.CreatedTeamAPIKey
+		header    string
+		wantUser  *models.CreatedTeamAPIKey
+		wantCalls []string
+	}{
+		{
+			name:      "raw key authenticates directly",
+			stored:    map[string]*models.CreatedTeamAPIKey{rawKey: rawUser},
+			header:    rawKey,
+			wantUser:  rawUser,
+			wantCalls: []string{rawKey},
+		},
+		{
+			name:      "compatible key authenticates as decoded raw key",
+			stored:    map[string]*models.CreatedTeamAPIKey{rawKey: rawUser},
+			header:    encodedRawKey,
+			wantUser:  rawUser,
+			wantCalls: []string{rawKey},
+		},
+		{
+			name:      "E2B-like raw key authenticates directly",
+			stored:    map[string]*models.CreatedTeamAPIKey{e2bLikeRawKey: e2bLikeUser},
+			header:    e2bLikeRawKey,
+			wantUser:  e2bLikeUser,
+			wantCalls: []string{e2bLikeRawKey},
+		},
+		{
+			name:      "E2B-like key authenticates as decoded raw key",
+			stored:    map[string]*models.CreatedTeamAPIKey{e2bLikeRawKey: e2bLikeUser},
+			header:    encodedE2bLikeKey,
+			wantUser:  e2bLikeUser,
+			wantCalls: []string{e2bLikeRawKey},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage := &lookupKeyStorage{byKey: tt.stored}
+			controller := &Controller{keys: storage}
+			req, err := http.NewRequest(http.MethodGet, "http://localhost/test", nil)
+			require.NoError(t, err)
+			req.Header.Set(models.HeaderApiKey, tt.header)
+
+			newCtx, apiErr := controller.CheckApiKey(logs.NewContext(), req)
+
+			require.Nil(t, apiErr)
+			user := GetUserFromContext(newCtx)
+			require.NotNil(t, user)
+			assert.Equal(t, tt.wantUser.ID, user.ID)
+			assert.Equal(t, tt.wantCalls, storage.calls)
 		})
 	}
 }
@@ -241,7 +373,7 @@ func TestCheckApiKey_SandboxOwnership(t *testing.T) {
 			require.NoError(t, err)
 
 			if tt.apiKeyHeader != "" {
-				req.Header.Set("X-API-KEY", tt.apiKeyHeader)
+				req.Header.Set(models.HeaderApiKey, tt.apiKeyHeader)
 			}
 
 			if tt.sandboxID != "" {

--- a/sdk/customized_e2b/demo.py
+++ b/sdk/customized_e2b/demo.py
@@ -1,6 +1,6 @@
 import os
 os.environ["E2B_DOMAIN"] = "localhost"
-os.environ["E2B_API_KEY"] = "some-api-key"
+os.environ["E2B_API_KEY"] = "e2b_00000000"
 # Import and patch the E2B SDK
 import time
 from e2b_code_interpreter import Sandbox

--- a/sdk/customized_e2b/kruise_agents/keys.py
+++ b/sdk/customized_e2b/kruise_agents/keys.py
@@ -1,0 +1,32 @@
+import hashlib
+
+# Constants must stay in sync with pkg/servers/e2b/keys/compat.go.
+_E2B_SDK_PREFIX = "e2b_"
+_E2B_SDK_COMPAT_MAGIC = "6f6b6167"
+_E2B_SDK_COMPAT_VERSION = "01"
+_E2B_SDK_COMPAT_CHECKSUM_SALT = "openkruise-agents/e2b-key-compat/v1"
+
+
+def _e2b_sdk_compat_checksum(raw_bytes: bytes) -> str:
+    payload = _E2B_SDK_COMPAT_CHECKSUM_SALT.encode("utf-8") + raw_bytes
+    digest = hashlib.sha256(payload).digest()
+    return digest[:8].hex()
+
+
+def encode_for_e2b_sdk(raw: str) -> str:
+    """Wrap a raw OpenKruise Agents API key in an E2B SDK-compatible form.
+
+    This is the Python counterpart to ``EncodeForE2BSDK`` in
+    ``pkg/servers/e2b/keys/compat.go``. Callers must pass a regular API key
+    (UUID or admin key, well under 4 GB); inputs larger than 4 GB would
+    overflow the 8-hex-character length field and are not supported.
+    """
+    raw_bytes = raw.encode("utf-8")
+    return "{prefix}{magic}{version}{length:08x}{body}{checksum}".format(
+        prefix=_E2B_SDK_PREFIX,
+        magic=_E2B_SDK_COMPAT_MAGIC,
+        version=_E2B_SDK_COMPAT_VERSION,
+        length=len(raw_bytes),
+        body=raw_bytes.hex(),
+        checksum=_e2b_sdk_compat_checksum(raw_bytes),
+    )

--- a/sdk/customized_e2b/kruise_agents/patch_e2b.py
+++ b/sdk/customized_e2b/kruise_agents/patch_e2b.py
@@ -25,10 +25,24 @@ def __connection_config_get_sandbox_url_http(self, sandbox_id: str, sandbox_doma
 def __jupyter_url_http(self) -> str:
     return f"http://{__sandbox_get_host(self, JUPYTER_PORT)}"
 
-def patch_e2b(https: bool = True):
+def patch_e2b(https: bool = True, validate_key: bool = True):
+    """
+    patch e2b sdk to use kruise private protocol
+    :param https: Use https to connect to sandbox-manager
+    :param validate_key: Set to false to disable api key validation. Only works for e2b>=2.25.0, other versions may cause an error
+    :return: None
+    """
     os.environ["E2B_API_URL"] = __get_api_url(https)
     SandboxBase.get_host = __sandbox_get_host
     ConnectionConfig.get_host = __connection_config_get_host
     if not https:
         ConnectionConfig.get_sandbox_url = __connection_config_get_sandbox_url_http
         setattr(SandboxSync, '_jupyter_url', property(__jupyter_url_http))
+    if not validate_key:
+        try:
+            import e2b.api as e2b_api
+        except ImportError as exc:
+            raise RuntimeError(
+                "validate_key=False requires an e2b version exposing e2b.api.validate_api_key"
+            ) from exc
+        e2b_api.validate_api_key = lambda _api_key: None

--- a/test/e2b/test_apikey.py
+++ b/test/e2b/test_apikey.py
@@ -14,7 +14,7 @@ def get_api_url():
 
 def get_headers():
     # E2B_API_KEY is used for authentication
-    api_key = os.environ.get("E2B_API_KEY", "some-api-key")
+    api_key = os.environ.get("E2B_API_KEY", "e2b_00000000")
     return {
         "X-API-KEY": api_key,
         "Content-Type": "application/json"


### PR DESCRIPTION
## Summary

- E2B SDK `>=2.25.0` rejects API keys not matching `e2b_[0-9a-f]+`, breaking legacy UUID / `admin-*` keys before they ever reach the server. This PR adds a reversible compatibility encoding so server-issued and server-accepted keys satisfy the SDK validator without changing Secret/MySQL storage semantics.
- `POST /api-keys` now returns the SDK-compatible form via `PresentCreatedAPIKey`; storage still holds the raw key, MySQL still HMACs the raw key.
- `CheckApiKey` canonicalizes the presented key (raw or encoded) before lookup, so existing raw keys keep working unchanged.
- New `GET /api-keys/compatible` returns the SDK-compatible form of the currently authenticated credential (for clients that authenticated with a raw key and need to upgrade).
- Authentication failure messages and key-create logs no longer reflect raw or encoded keys.

Design details: `docs/specs/2026-05-28-e2b-api-key-compat-design.md`.

## Test plan

- [ ] `go test ./pkg/servers/e2b/... ./pkg/servers/e2b/keys/...`
- [ ] Verify legacy raw `X-API-KEY` still authenticates against `/sandboxes` and `/api-keys`.
- [ ] Verify an SDK-encoded `X-API-KEY` (returned from `POST /api-keys` or `GET /api-keys/compatible`) authenticates and routes to the same identity as its decoded raw form.
- [ ] Verify `GET /api-keys/compatible` returns the same encoded value when authenticated with either the raw or encoded form.
- [ ] Verify unauthorized responses do not echo back the presented key.