### PR TITLE
feat(controller): add SecurityTokenRefreshReconciler for proactive token rotation

### DIFF
--- a/pkg/controller/controllers.go
+++ b/pkg/controller/controllers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openkruise/agents/pkg/controller/sandboxclaim"
 	"github.com/openkruise/agents/pkg/controller/sandboxset"
 	"github.com/openkruise/agents/pkg/controller/sandboxupdateops"
+	"github.com/openkruise/agents/pkg/controller/securitytokenrefresh"
 )
 
 var controllerAddFuncs []func(manager.Manager) error
@@ -32,6 +33,7 @@ func init() {
 	controllerAddFuncs = append(controllerAddFuncs, sandboxset.Add)
 	controllerAddFuncs = append(controllerAddFuncs, sandboxclaim.Add)
 	controllerAddFuncs = append(controllerAddFuncs, sandboxupdateops.Add)
+	controllerAddFuncs = append(controllerAddFuncs, securitytokenrefresh.Add)
 }
 
 func SetupWithManager(m manager.Manager) error {

--- a/pkg/controller/securitytokenrefresh/AGENTS.md
+++ b/pkg/controller/securitytokenrefresh/AGENTS.md
@@ -1,0 +1,101 @@
+# Security Token Refresh Controller
+
+## Role
+
+This package hosts a controller-runtime reconciler that proactively refreshes the
+security token of claimed sandboxes shortly before the token recorded in the
+sandbox annotation `security.agents.kruise.io/token-status`
+(`utils.AgentKeyTokenRefreshStatus`) expires.
+
+It runs inside the **agent-sandbox-controller** binary and is registered via
+`pkg/controller/controllers.go`. It is gated by the
+`SecurityIdentityProvider` feature gate and by Sandbox CRD discovery, so
+clusters without an identity provider behave exactly like before.
+
+## Responsibilities
+
+- Watch `Sandbox` resources, filtered by `needsRefreshPredicate()`:
+  - `LabelSandboxIsClaimed == "true"`,
+  - non-empty `token-status` annotation,
+  - not currently being deleted.
+  - On `Update`: only re-enqueue when the `token-status` annotation actually changes
+    (timing-based refreshes are driven by `RequeueAfter`, not status churn).
+  - `Delete` events are dropped.
+- Decode the annotation, compute `refreshAt = expireAt - refreshLeadTime ± jitter`,
+  and either `RequeueAfter` until that moment or trigger a refresh.
+- Delegate the actual side-effects to `core.Refresher`, which performs:
+  1. `identity.IssueSandboxToken`
+  2. `identity.PropagateSandboxToken`
+  3. patch the sandbox `token-status` annotation (only if 1 and 2 succeeded)
+- Emit Kubernetes events (`TokenRefreshed`, `TokenRefreshFailed`,
+  `TokenStatusDecodeFailed`, `TokenExpirationInvalid`) so operators can debug
+  the pipeline without reading controller logs.
+
+## Extension surface
+
+`Add(mgr)` exposes a `SetupHook` registration point so downstream
+distributions (e.g. enterprise builds) can attach extra peer Runnables
+alongside the reconciler **without forking this package**:
+
+```go
+type SetupHook func(mgr manager.Manager) error
+func RegisterSetupHook(h SetupHook)
+```
+
+Hooks are called from `init()` in the downstream package, run in
+registration order at the tail of `Add()` after the reconciler is wired,
+and may freely use `mgr.Add(...)`, `mgr.GetClient()`, etc. The first hook
+returning a non-nil error aborts controller setup; the error is wrapped
+with a `securitytokenrefresh setup hook #N failed:` prefix so the failure
+surface is unambiguous. `nil` hooks are silently dropped.
+
+This is the canonical mechanism to bolt on capabilities such as a CA
+bundle sync runnable, additional metrics emitters, or audit reporters
+that share the controller's lifecycle but are not part of the open-source
+baseline.
+
+## Out of scope
+
+- Issuing the **first** security token. That still happens during
+  `TryClaimSandbox` in `pkg/sandbox-manager/infra/sandboxcr/claim.go`. The two
+  call sites share `pkg/identity/sandbox_token_helper.go` so semantics stay in
+  sync.
+- Cleanup on sandbox deletion / release. The sandbox controller owns lifecycle.
+
+## Layout
+
+```
+pkg/controller/securitytokenrefresh/
+├── token_refresh_controller.go   # Reconciler, Add(mgr), SetupHook registration
+├── predicate.go                  # needsRefreshPredicate / isRefreshTarget
+├── token_refresh_controller_test.go
+├── predicate_test.go
+└── core/
+    ├── refresher.go              # Refresher interface + defaultRefresher
+    └── refresher_test.go
+```
+
+## Flags
+
+| Flag | Default | Notes |
+| ---- | ------- | ----- |
+| `--security-token-refresh-workers` | `10` | `MaxConcurrentReconciles` |
+| `--security-token-refresh-lead-time` | `30m` | How long BEFORE expiration the refresh starts |
+| `--security-token-refresh-jitter-ratio` | `0.1` | `±10%` jitter on the window |
+| `--security-token-refresh-retry-after` | `1m` | Requeue interval after a failed refresh; with the default 30m lead window this allows ~30 retries before expiry |
+
+## Conventions
+
+- New `.go` files **must** start with the Apache 2.0 license header
+  (`hack/boilerplate.go.txt`).
+- All comments in English.
+- Logging: `logf.FromContext(ctx)` (controller-runtime) or `klog` for static
+  messages such as the Add() startup log.
+- Tests are table-driven, use `expectError string` for error assertions, and
+  inject fakes (`fakeRefresher`, `stubIdentityProvider`) instead of touching
+  real network / global identity provider state at runtime.
+- Tests that exercise `RegisterSetupHook` must snapshot and restore the
+  package-level `setupHooks` slice (see `withSetupHooks(t)`) so they do not
+  leak registrations into sibling tests.
+- Do **not** reach into `pkg/sandbox-manager` from this package; shared logic
+  belongs in `pkg/identity`.

--- a/pkg/controller/securitytokenrefresh/CLAUDE.md
+++ b/pkg/controller/securitytokenrefresh/CLAUDE.md
@@ -1,0 +1,1 @@
+@./AGENTS.md

--- a/pkg/controller/securitytokenrefresh/core/refresher.go
+++ b/pkg/controller/securitytokenrefresh/core/refresher.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package core implements the side-effecting steps of the security-token
+// refresh controller (issue, propagate, patch). It is split out from the
+// reconciler so reconciliation logic stays focused on policy decisions
+// (timing, requeue) and the core can be replaced with a stub in unit tests.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/identity"
+	"github.com/openkruise/agents/pkg/utils"
+)
+
+// Refresher performs the actual security-token refresh on a single sandbox.
+//
+// Implementations must guarantee the following ordering invariants:
+//  1. Issue a new token via identity.IssueSandboxToken.
+//  2. Propagate the new token to the runtime via identity.PropagateSandboxToken.
+//  3. Only after a successful propagation, patch the sandbox annotation
+//     utils.AgentKeyTokenRefreshStatus with the new expiration.
+//
+// If any earlier step fails, the annotation MUST NOT be updated, so the next
+// reconcile keeps trying with the same expiration window.
+type Refresher interface {
+	// Refresh issues, propagates and persists a new security token for the given sandbox.
+	// On success it returns the new TokenResponse so the caller can decide the next
+	// requeue interval based on the freshly issued AccessTokenExpiration.
+	Refresh(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (*identity.TokenResponse, error)
+}
+
+// defaultRefresher implements Refresher against a real controller-runtime client.
+// It is the production implementation used by the security-token-refresh controller.
+type defaultRefresher struct {
+	client client.Client
+}
+
+// NewDefaultRefresher constructs the production Refresher backed by the given
+// controller-runtime client. The client is used to patch the sandbox annotation
+// once the new token has been propagated successfully.
+func NewDefaultRefresher(c client.Client) Refresher {
+	return &defaultRefresher{client: c}
+}
+
+// Refresh executes the issue → propagate → patch sequence described on Refresher.
+// Errors are returned to the caller so controller-runtime can apply its rate-limited
+// retry policy on the workqueue; partial side-effects (e.g. propagation succeeded
+// but patch failed) are surfaced explicitly so the next reconcile can converge.
+func (r *defaultRefresher) Refresh(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (*identity.TokenResponse, error) {
+	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
+
+	tokenResp, _, err := identity.IssueSandboxToken(ctx, sbx)
+	if err != nil {
+		return nil, fmt.Errorf("issue token: %w", err)
+	}
+
+	if err := identity.PropagateSandboxToken(ctx, sbx, tokenResp); err != nil {
+		return nil, fmt.Errorf("propagate token: %w", err)
+	}
+
+	if err := r.patchAnnotation(ctx, sbx, tokenResp); err != nil {
+		return nil, fmt.Errorf("patch token-status annotation: %w", err)
+	}
+
+	log.Info("security token refreshed", "expiration", tokenResp.AccessTokenExpiration)
+	return tokenResp, nil
+}
+
+// patchAnnotation persists the freshly issued token's expiration into the sandbox
+// annotation utils.AgentKeyTokenRefreshStatus using a MergeFrom patch so concurrent
+// updates on unrelated fields are not stomped.
+func (r *defaultRefresher) patchAnnotation(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
+	raw, err := identity.EncodeTokenRefreshStatus(identity.BuildTokenRefreshStatus(tokenResp))
+	if err != nil {
+		return err
+	}
+	// MergeFrom only reads the base to compute the diff, so the base does not
+	// need its own DeepCopy; cloning `updated` alone is enough to keep the
+	// caller's object untouched.
+	updated := sbx.DeepCopy()
+	if updated.Annotations == nil {
+		updated.Annotations = make(map[string]string, 1)
+	}
+	updated.Annotations[utils.AgentKeyTokenRefreshStatus] = raw
+	return r.client.Patch(ctx, updated, client.MergeFrom(sbx))
+}

--- a/pkg/controller/securitytokenrefresh/core/refresher_test.go
+++ b/pkg/controller/securitytokenrefresh/core/refresher_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/identity"
+	"github.com/openkruise/agents/pkg/utils"
+)
+
+// stubIdentityProvider is a hand-rolled IdentityProvider that returns the configured
+// TokenResponse / errors. It is installed via identity.RegisterProvider() for the
+// duration of a single sub-test.
+type stubIdentityProvider struct {
+	resp           *identity.TokenResponse
+	issueErr       error
+	propagateErr   error
+	propagateCalls int
+	issueCalls     int
+}
+
+func (s *stubIdentityProvider) IssueToken(_ context.Context, _ identity.TokenRequest) (*identity.TokenResponse, error) {
+	s.issueCalls++
+	if s.issueErr != nil {
+		return nil, s.issueErr
+	}
+	return s.resp, nil
+}
+
+func (s *stubIdentityProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *identity.TokenResponse) error {
+	s.propagateCalls++
+	return s.propagateErr
+}
+
+// withProvider installs stub as the global identity provider for the test.
+// It is intentionally not parallelisable: the registry is a process-wide singleton.
+func withProvider(t *testing.T, stub *stubIdentityProvider) {
+	t.Helper()
+	identity.RegisterProvider(stub)
+}
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, agentsv1alpha1.AddToScheme(s))
+	require.NoError(t, corev1.AddToScheme(s))
+	return s
+}
+
+func newSandbox(name string) *agentsv1alpha1.Sandbox {
+	return &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.True,
+			},
+			Annotations: map[string]string{
+				utils.AgentKeyTokenRefreshStatus: `{"accessTokenExpiration":"2025-01-01T00:00:00Z"}`,
+			},
+		},
+	}
+}
+
+func TestDefaultRefresher_Refresh(t *testing.T) {
+	const newExpire = "2099-12-31T23:59:59Z"
+
+	tests := []struct {
+		name string
+		// stub configures the global identity provider for the duration of the case.
+		stub *stubIdentityProvider
+		// expectErr is the substring expected in the returned error (empty == no error).
+		expectErr string
+		// expectAnnotation is the value the sandbox annotation should have AFTER Refresh.
+		// Empty means "annotation must remain unchanged".
+		expectAnnotation string
+	}{
+		{
+			name: "happy path: issue, propagate, patch annotation",
+			stub: &stubIdentityProvider{
+				resp: &identity.TokenResponse{
+					AccessToken:           "fresh",
+					AccessTokenExpiration: newExpire,
+				},
+			},
+			expectAnnotation: `{"accessTokenExpiration":"` + newExpire + `"}`,
+		},
+		{
+			name: "issue fails -> returns error directly, annotation NOT touched",
+			stub: &stubIdentityProvider{
+				issueErr: errors.New("issue down"),
+			},
+			expectErr: "issue token",
+		},
+		{
+			name: "propagate fails -> annotation NOT touched",
+			stub: &stubIdentityProvider{
+				resp: &identity.TokenResponse{
+					AccessToken:           "fresh",
+					AccessTokenExpiration: newExpire,
+				},
+				propagateErr: errors.New("propagate down"),
+			},
+			expectErr: "propagate token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withProvider(t, tt.stub)
+
+			sbx := newSandbox("sbx-1")
+			c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(sbx).Build()
+			r := NewDefaultRefresher(c)
+
+			_, err := r.Refresh(context.Background(), sbx.DeepCopy())
+			if tt.expectErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+			}
+
+			got := &agentsv1alpha1.Sandbox{}
+			require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "sbx-1", Namespace: "default"}, got))
+
+			if tt.expectErr != "" {
+				assert.Equal(t, sbx.Annotations[utils.AgentKeyTokenRefreshStatus],
+					got.Annotations[utils.AgentKeyTokenRefreshStatus],
+					"annotation must NOT change when an upstream step fails")
+				return
+			}
+			if tt.expectAnnotation != "" {
+				assert.Equal(t, tt.expectAnnotation, got.Annotations[utils.AgentKeyTokenRefreshStatus])
+			}
+		})
+	}
+}
+
+// TestDefaultRefresher_PatchAnnotation_NilAnnotations exercises the branch where the
+// sandbox starts with a nil Annotations map: patchAnnotation must allocate it before
+// inserting the token-status entry.
+func TestDefaultRefresher_PatchAnnotation_NilAnnotations(t *testing.T) {
+	withProvider(t, &stubIdentityProvider{
+		resp: &identity.TokenResponse{
+			AccessToken:           "fresh",
+			AccessTokenExpiration: "2099-12-31T23:59:59Z",
+		},
+	})
+
+	sbx := newSandbox("sbx-2")
+	sbx.Annotations = nil
+
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(sbx).Build()
+	r := NewDefaultRefresher(c)
+
+	_, err := r.Refresh(context.Background(), sbx.DeepCopy())
+	require.NoError(t, err)
+
+	got := &agentsv1alpha1.Sandbox{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "sbx-2", Namespace: "default"}, got))
+	assert.Equal(t, `{"accessTokenExpiration":"2099-12-31T23:59:59Z"}`, got.Annotations[utils.AgentKeyTokenRefreshStatus])
+}

--- a/pkg/controller/securitytokenrefresh/predicate.go
+++ b/pkg/controller/securitytokenrefresh/predicate.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package securitytokenrefresh
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/utils"
+)
+
+// needsRefreshPredicate filters Sandbox events down to the subset that this controller
+// is interested in:
+//
+//   - The sandbox has been claimed (label LabelSandboxIsClaimed == "true").
+//   - The sandbox carries a security-token refresh status annotation produced by the
+//     claim flow. Sandboxes without this annotation are not under the
+//     SecurityIdentityProvider regime and must be ignored.
+//   - The sandbox is not being deleted.
+//
+// On Update events, the predicate additionally short-circuits unrelated noise:
+// only mutations of the token-status annotation itself are treated as relevant,
+// because expiration-driven requeues are handled via RequeueAfter rather than
+// arbitrary status churn from the sandbox controller.
+func needsRefreshPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return isRefreshTarget(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if !isRefreshTarget(e.ObjectNew) {
+				return false
+			}
+			oldRaw := tokenStatusAnnotation(e.ObjectOld)
+			newRaw := tokenStatusAnnotation(e.ObjectNew)
+			return oldRaw != newRaw
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			// Deletion is handled by the sandbox controller / GC; nothing to refresh.
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return isRefreshTarget(e.Object)
+		},
+	}
+}
+
+// isRefreshTarget reports whether the given object is a claimed, alive sandbox
+// that carries a meaningful token-status annotation. The annotation must not
+// only be present, but also decode into a status that actually has an access
+// token expiration to refresh; otherwise the workqueue would be woken up for
+// sandboxes that have nothing to do (e.g. a stale `{}` payload).
+//
+// Malformed annotation payloads are intentionally treated as a refresh target:
+// the reconciler will surface a TokenStatusDecodeFailed event so the bad
+// payload becomes observable instead of being silently dropped here.
+func isRefreshTarget(obj client.Object) bool {
+	if obj == nil || !obj.GetDeletionTimestamp().IsZero() {
+		return false
+	}
+	if obj.GetLabels()[agentsv1alpha1.LabelSandboxIsClaimed] != agentsv1alpha1.True {
+		return false
+	}
+	raw := tokenStatusAnnotation(obj)
+	if raw == "" {
+		return false
+	}
+	status, err := decodeTokenRefreshStatus(raw)
+	if err != nil {
+		// Let the reconciler surface the decode failure as an event.
+		return true
+	}
+	return status != nil && status.AccessTokenExpiration != ""
+}
+
+// tokenStatusAnnotation returns the raw value of the token-status annotation,
+// or an empty string when missing. It centralises annotation access so callers
+// stay decoupled from the constant key.
+func tokenStatusAnnotation(obj client.Object) string {
+	if obj == nil {
+		return ""
+	}
+	return obj.GetAnnotations()[utils.AgentKeyTokenRefreshStatus]
+}

--- a/pkg/controller/securitytokenrefresh/predicate_test.go
+++ b/pkg/controller/securitytokenrefresh/predicate_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package securitytokenrefresh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/utils"
+)
+
+// newSandbox builds a *Sandbox with the given knobs. It mirrors the shape of the
+// test helpers used in pkg/controller/bypass-sandbox so the two suites stay
+// stylistically aligned.
+func newSandbox(name string, claimed bool, tokenStatus string, deleted bool) *agentsv1alpha1.Sandbox {
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "default",
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+		},
+	}
+	if claimed {
+		sbx.Labels[agentsv1alpha1.LabelSandboxIsClaimed] = agentsv1alpha1.True
+	}
+	if tokenStatus != "" {
+		sbx.Annotations[utils.AgentKeyTokenRefreshStatus] = tokenStatus
+	}
+	if deleted {
+		now := metav1.Now()
+		sbx.DeletionTimestamp = &now
+		sbx.Finalizers = []string{"keep"}
+	}
+	return sbx
+}
+
+func TestIsRefreshTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *agentsv1alpha1.Sandbox
+		want bool
+	}{
+		{
+			name: "claimed with token status -> true",
+			obj:  newSandbox("a", true, `{"accessTokenExpiration":"2099-01-01T00:00:00Z"}`, false),
+			want: true,
+		},
+		{
+			name: "claimed without token status -> false",
+			obj:  newSandbox("b", true, "", false),
+			want: false,
+		},
+		{
+			name: "unclaimed with token status -> false",
+			obj:  newSandbox("c", false, `{"accessTokenExpiration":"2099-01-01T00:00:00Z"}`, false),
+			want: false,
+		},
+		{
+			name: "claimed but deleting -> false",
+			obj:  newSandbox("d", true, `{"accessTokenExpiration":"2099-01-01T00:00:00Z"}`, true),
+			want: false,
+		},
+		{
+			name: "nil object -> false",
+			obj:  nil,
+			want: false,
+		},
+		{
+			name: "non-true claimed label -> false",
+			obj: func() *agentsv1alpha1.Sandbox {
+				s := newSandbox("e", false, `{"accessTokenExpiration":"2099-01-01T00:00:00Z"}`, false)
+				s.Labels[agentsv1alpha1.LabelSandboxIsClaimed] = "yes" // not exactly "true"
+				return s
+			}(),
+			want: false,
+		},
+		{
+			name: "claimed with empty status object -> false",
+			obj:  newSandbox("f", true, `{}`, false),
+			want: false,
+		},
+		{
+			name: "claimed with status missing expiration -> false",
+			obj:  newSandbox("g", true, `{"otherField":"x"}`, false),
+			want: false,
+		},
+		{
+			name: "claimed with malformed status -> true (let reconciler surface event)",
+			obj:  newSandbox("h", true, `not-json`, false),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got bool
+			if tt.obj == nil {
+				got = isRefreshTarget(nil)
+			} else {
+				got = isRefreshTarget(tt.obj)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNeedsRefreshPredicate(t *testing.T) {
+	const sampleStatus = `{"accessTokenExpiration":"2099-01-01T00:00:00Z"}`
+	const otherStatus = `{"accessTokenExpiration":"2098-01-01T00:00:00Z"}`
+
+	target := newSandbox("a", true, sampleStatus, false)
+	nonTarget := newSandbox("b", false, sampleStatus, false)
+	deleting := newSandbox("c", true, sampleStatus, true)
+	updatedAnnotation := newSandbox("a", true, otherStatus, false)
+	unrelatedUpdate := newSandbox("a", true, sampleStatus, false)
+	unrelatedUpdate.Spec.Paused = true // a non-annotation mutation
+
+	p := needsRefreshPredicate()
+
+	t.Run("create on refresh target", func(t *testing.T) {
+		assert.True(t, p.Create(event.CreateEvent{Object: target}))
+	})
+	t.Run("create on non-target", func(t *testing.T) {
+		assert.False(t, p.Create(event.CreateEvent{Object: nonTarget}))
+	})
+	t.Run("delete is always dropped", func(t *testing.T) {
+		assert.False(t, p.Delete(event.DeleteEvent{Object: target}))
+	})
+	t.Run("generic on refresh target", func(t *testing.T) {
+		assert.True(t, p.Generic(event.GenericEvent{Object: target}))
+	})
+	t.Run("update with annotation change", func(t *testing.T) {
+		assert.True(t, p.Update(event.UpdateEvent{ObjectOld: target, ObjectNew: updatedAnnotation}))
+	})
+	t.Run("update without annotation change", func(t *testing.T) {
+		assert.False(t, p.Update(event.UpdateEvent{ObjectOld: target, ObjectNew: unrelatedUpdate}))
+	})
+	t.Run("update onto deleting sandbox", func(t *testing.T) {
+		assert.False(t, p.Update(event.UpdateEvent{ObjectOld: target, ObjectNew: deleting}))
+	})
+}
+
+func TestTokenStatusAnnotation(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *corev1.Pod
+		want string
+	}{
+		{name: "nil object", obj: nil, want: ""},
+		{
+			name: "missing annotation",
+			obj:  &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}},
+			want: "",
+		},
+		{
+			name: "annotation present",
+			obj: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Name:        "p",
+				Annotations: map[string]string{utils.AgentKeyTokenRefreshStatus: "raw"},
+			}},
+			want: "raw",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.obj == nil {
+				assert.Equal(t, tt.want, tokenStatusAnnotation(nil))
+				return
+			}
+			assert.Equal(t, tt.want, tokenStatusAnnotation(tt.obj))
+		})
+	}
+}

--- a/pkg/controller/securitytokenrefresh/token_refresh_controller.go
+++ b/pkg/controller/securitytokenrefresh/token_refresh_controller.go
@@ -1,0 +1,392 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package securitytokenrefresh implements a controller-runtime reconciler that
+// refreshes the security token of claimed sandboxes shortly before the token
+// stored in the sandbox annotation utils.AgentKeyTokenRefreshStatus expires.
+//
+// The controller is meant to run inside the agent-sandbox-controller binary,
+// alongside the existing Sandbox / SandboxClaim / Checkpoint controllers. It is
+// gated by the SecurityIdentityProvider feature gate so that clusters without
+// an identity provider behave exactly like before.
+package securitytokenrefresh
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/rand/v2"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/controller/securitytokenrefresh/core"
+	"github.com/openkruise/agents/pkg/discovery"
+	"github.com/openkruise/agents/pkg/features"
+	"github.com/openkruise/agents/pkg/identity"
+	"github.com/openkruise/agents/pkg/utils"
+	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
+)
+
+const (
+	controllerName = "security-token-refresh"
+
+	// defaultRefreshLeadTime is how long BEFORE AccessTokenExpiration the
+	// controller proactively rotates the token. With the default of 30m, a
+	// token that expires at T will normally be refreshed somewhere in
+	// [T-30m ± jitter], so the runtime never observes an expired credential
+	// even under transient identity-provider slowdowns.
+	//
+	// Operators that want refreshes to happen even earlier (e.g. for tokens
+	// with very short TTLs) can shorten this via the
+	// --security-token-refresh-lead-time flag.
+	defaultRefreshLeadTime = 30 * time.Minute
+	// defaultJitterRatio randomises the lead time by ±ratio so a fleet of
+	// sandboxes does not stampede the identity provider at the same instant.
+	defaultJitterRatio = 0.1
+	// defaultRefreshRetryAfter is the requeue interval used after a refresh
+	// attempt fails. It is intentionally aligned with the lead window: the
+	// reconciler only ever calls refresher.Refresh once we are inside
+	// [refreshAt, expireAt] (or past expireAt), so a 1-minute requeue means
+	// that, with the default 30m lead time, the controller gets up to ~30
+	// retry chances before the credential actually expires. controller-runtime
+	// additionally applies its own rate-limited workqueue back-off on top of
+	// this value when the reconciler returns an error.
+	defaultRefreshRetryAfter = 1 * time.Minute
+	// minRequeueAfter clamps the requeue duration so we never schedule a
+	// zero-duration requeue (which would behave like an immediate retry).
+	minRequeueAfter = time.Second
+)
+
+func init() {
+	flag.IntVar(&concurrentReconciles, "security-token-refresh-workers", concurrentReconciles,
+		"Max concurrent reconciles for SecurityTokenRefresh controller.")
+	flag.DurationVar(&refreshLeadTime, "security-token-refresh-lead-time", defaultRefreshLeadTime,
+		"How long BEFORE AccessTokenExpiration the controller starts a refresh (default 30m).")
+	flag.Float64Var(&jitterRatio, "security-token-refresh-jitter-ratio", defaultJitterRatio,
+		"Jitter ratio (0~1) applied to the refresh lead time to spread refresh load.")
+	flag.DurationVar(&refreshRetryAfter, "security-token-refresh-retry-after", defaultRefreshRetryAfter,
+		"Requeue interval applied after a refresh attempt fails; with the default 30m lead window this gives ~30 retry chances before the token actually expires.")
+}
+
+var (
+	concurrentReconciles = 10
+	refreshLeadTime      = defaultRefreshLeadTime
+	jitterRatio          = defaultJitterRatio
+	refreshRetryAfter    = defaultRefreshRetryAfter
+
+	securityTokenRefreshControllerKind = agentsv1alpha1.GroupVersion.WithKind("Sandbox")
+
+	// setupHooks holds extension hooks registered via RegisterSetupHook. They
+	// run at the tail of Add, after the reconciler is wired with the manager,
+	// so downstream distributions can attach extra peer workers (e.g. a CA
+	// bundle sync runnable, additional metrics emitters, ...) without forking
+	// this package. The slice is mutated only at init() time and during tests.
+	setupHooks []SetupHook
+)
+
+// SetupHook is the canonical extension point invoked from Add after the
+// SecurityTokenRefresh reconciler has been registered with the manager.
+//
+// The manager passed in is fully constructed but not yet started, so a hook
+// may freely call mgr.Add(...) to attach additional Runnables, or use
+// mgr.GetClient() / mgr.GetEventRecorderFor(...) when wiring its own state.
+// A hook that returns a non-nil error aborts controller setup, which mirrors
+// the behaviour of the reconciler's own SetupWithManager failure.
+type SetupHook func(mgr manager.Manager) error
+
+// RegisterSetupHook appends h to the list of hooks executed at the end of
+// Add. It is meant to be called from a package-level init() in a downstream
+// (e.g. enterprise) build that wants to extend the token-refresh controller
+// without modifying this file.
+//
+// Registration order is preserved and hooks run sequentially; the first hook
+// that returns an error stops further execution. The function is safe to call
+// before Add but is NOT safe for concurrent use, mirroring the standard
+// controller-runtime registration pattern.
+func RegisterSetupHook(h SetupHook) {
+	if h == nil {
+		return
+	}
+	setupHooks = append(setupHooks, h)
+}
+
+// runSetupHooks executes every registered SetupHook in registration order. It
+// is split out from Add purely for testability: tests can drive it directly
+// without needing a fully-fledged manager. The error returned by the first
+// failing hook is wrapped so the caller can tell it came from the extension
+// surface rather than from the reconciler itself.
+func runSetupHooks(mgr manager.Manager) error {
+	for i, h := range setupHooks {
+		if err := h(mgr); err != nil {
+			return fmt.Errorf("securitytokenrefresh setup hook #%d failed: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func Add(mgr manager.Manager) error {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.SecurityIdentityProviderGate) ||
+		!discovery.DiscoverGVK(securityTokenRefreshControllerKind) {
+		return nil
+	}
+
+	err := (&SecurityTokenRefreshReconciler{
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorderFor(controllerName),
+		refresher: core.NewDefaultRefresher(mgr.GetClient()),
+		now:       time.Now,
+		// rand.Float64 returns [0,1); centred to [-1,1) below for symmetric jitter.
+		randFloat: rand.Float64,
+	}).SetupWithManager(mgr)
+	if err != nil {
+		return err
+	}
+	// Run downstream-registered extension hooks. They execute AFTER the
+	// reconciler is wired so they can rely on the same manager / client /
+	// recorder, and BEFORE Add returns so a hook failure aborts startup.
+	if err := runSetupHooks(mgr); err != nil {
+		return err
+	}
+	klog.Infof("Started SecurityTokenRefreshReconciler successfully, refreshLeadTime=%s jitterRatio=%v refreshRetryAfter=%s setupHooks=%d",
+		refreshLeadTime, jitterRatio, refreshRetryAfter, len(setupHooks))
+	return nil
+}
+
+// SecurityTokenRefreshReconciler refreshes sandbox security tokens before they expire.
+type SecurityTokenRefreshReconciler struct {
+	client.Client
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+
+	refresher core.Refresher
+
+	// now and randFloat are injected to keep the reconciler deterministic in tests.
+	now       func() time.Time
+	randFloat func() float64
+}
+
+// +kubebuilder:rbac:groups=agents.kruise.io,resources=sandboxes,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch;update
+
+// Reconcile decides, for the sandbox referenced by req, whether its security
+// token has to be refreshed right now and, if not, when to come back.
+//
+// The flow is intentionally side-effect-light: every decision (refresh vs.
+// requeue) is derived from the AccessTokenExpiration recorded in the
+// utils.AgentKeyTokenRefreshStatus annotation. The actual issue/propagate/patch
+// chain lives in core.Refresher to keep this method focused on policy.
+func (r *SecurityTokenRefreshReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// Fetch the sandbox instance
+	box := &agentsv1alpha1.Sandbox{}
+	err := r.Get(ctx, req.NamespacedName, box)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		klog.ErrorS(err, "get sandbox failed", "sandbox", req.NamespacedName)
+		return reconcile.Result{}, err
+	}
+
+	// Re-check eligibility on the freshly-read object. The predicate only
+	// guarantees an event was relevant *at enqueue time*; by the time the
+	// reconciler picks it up the sandbox might have been released or deleted.
+	if !isRefreshTarget(box) {
+		klog.V(5).InfoS("sandbox is not a refresh target, skip", "sandbox", klog.KObj(box))
+		return reconcile.Result{}, nil
+	}
+
+	klog.V(5).InfoS("Began to process Sandbox for security token refresh", "sandbox", klog.KObj(box))
+
+	raw := box.Annotations[utils.AgentKeyTokenRefreshStatus]
+	status, err := decodeTokenRefreshStatus(raw)
+	if err != nil {
+		// A malformed annotation should not put us into a hot retry loop.
+		// Surface it as an event and back off; an operator must clean it up.
+		klog.ErrorS(err, "decode token-status annotation failed", "sandbox", klog.KObj(box), "raw", raw)
+		r.Recorder.Eventf(box, corev1.EventTypeWarning, "TokenStatusDecodeFailed",
+			"failed to decode %s annotation: %v", utils.AgentKeyTokenRefreshStatus, err)
+		return ctrl.Result{RequeueAfter: refreshRetryAfter}, nil
+	}
+	// Annotation absent or decoded into an empty / partial object: there is
+	// nothing to refresh yet. The empty-string AccessTokenExpiration case is
+	// reachable when legacy annotation data (from before the upgrade that
+	// removed UUID fallback) persists, or when a misconfigured provider does
+	// not populate an expiration. We defend in depth here so a missing
+	// expiration never spirals into a hot retry loop emitting
+	// TokenExpirationInvalid events forever.
+	if status == nil || status.AccessTokenExpiration == "" {
+		klog.V(5).InfoS("token refresh status is empty, skip", "sandbox", klog.KObj(box), "raw", raw)
+		return reconcile.Result{}, nil
+	}
+
+	expireAt, err := parseExpiration(status.AccessTokenExpiration)
+	if err != nil {
+		klog.ErrorS(err, "parse access token expiration failed", "sandbox", klog.KObj(box), "expiration", status.AccessTokenExpiration)
+		r.Recorder.Eventf(box, corev1.EventTypeWarning, "TokenExpirationInvalid",
+			"failed to parse accessTokenExpiration %q: %v", status.AccessTokenExpiration, err)
+		return ctrl.Result{RequeueAfter: refreshRetryAfter}, nil
+	}
+
+	// Schedule semantics: rotate the token at refreshAt = expireAt - leadTime,
+	// where leadTime is `refreshLeadTime ± jitter` (default 30m ±10%). Until
+	// that moment, requeue with the remaining duration so the workqueue stays
+	// idle for the bulk of the token's lifetime. Once we are inside the lead
+	// window (refreshAt is not after now) we hand over to the refresher
+	// unconditionally; the runtime should always see a fresh credential well
+	// before T-0.
+	now := r.now()
+	leadTime := r.jitteredRefreshLeadTime()
+	refreshAt := expireAt.Add(-leadTime)
+	if refreshAt.After(now) {
+		d := refreshAt.Sub(now)
+		klog.V(5).InfoS("token not yet due for refresh", "sandbox", klog.KObj(box),
+			"expireAt", expireAt, "refreshAt", refreshAt, "leadTime", leadTime, "requeueIn", d)
+		return ctrl.Result{RequeueAfter: clampRequeue(d)}, nil
+	}
+
+	klog.InfoS("refreshing security token", "sandbox", klog.KObj(box),
+		"expireAt", expireAt, "leadTime", leadTime, "overdueBy", now.Sub(refreshAt))
+	tokenResp, err := r.refresher.Refresh(ctx, box)
+	if err != nil {
+		// We are already inside the lead window (or past expireAt). A failure
+		// here must be retried promptly so that the runtime is not left with a
+		// stale credential. We therefore requeue every refreshRetryAfter
+		// (default 1m) instead of waiting for the next normal refreshAt; with
+		// the default 30m lead window this gives the refresher ~30 attempts
+		// before the token actually expires.
+		//
+		// NOTE: we deliberately return a nil error alongside RequeueAfter.
+		// controller-runtime prioritises a non-nil reconcile error and applies
+		// its own rate-limited exponential backoff, which would override the
+		// fixed retryAfter we want here. Logging + the TokenRefreshFailed
+		// event below already preserve full observability of the failure.
+		klog.ErrorS(err, "refresh security token failed, will retry within lead window",
+			"sandbox", klog.KObj(box), "retryAfter", refreshRetryAfter,
+			"expireAt", expireAt, "timeToExpire", expireAt.Sub(now))
+		r.Recorder.Eventf(box, corev1.EventTypeWarning, "TokenRefreshFailed",
+			"failed to refresh security token (will retry in %s): %v", refreshRetryAfter, err)
+		return ctrl.Result{RequeueAfter: refreshRetryAfter}, nil
+	}
+
+	r.Recorder.Eventf(box, corev1.EventTypeNormal, "TokenRefreshed",
+		"security token refreshed, new expiration %s", tokenResp.AccessTokenExpiration)
+
+	nextExpire, err := parseExpiration(tokenResp.AccessTokenExpiration)
+	if err != nil {
+		// A successful refresh that produced an unparsable expiration is
+		// suspicious but not fatal; rely on the watch on the patched
+		// annotation to re-enqueue the sandbox once its store reflects it.
+		klog.ErrorS(err, "parse new access token expiration failed", "sandbox", klog.KObj(box),
+			"expiration", tokenResp.AccessTokenExpiration)
+		return reconcile.Result{}, nil
+	}
+	// Schedule the next refresh at (newExpiration - leadTime); this keeps the
+	// invariant that every reconcile leaves the workqueue armed for the next
+	// rotation, even if no further annotation update arrives.
+	remaining := nextExpire.Sub(r.now())
+	leadTime = r.jitteredRefreshLeadTime()
+	next := remaining - leadTime
+	if remaining > 0 && next <= 0 {
+		// Token TTL shorter than configured lead time (e.g. a 10-minute
+		// token while leadTime is 30 minutes). Refresh at the midpoint of
+		// the token's lifetime so we rotate before expiry without spinning
+		// the controller in a tight requeue loop.
+		next = remaining / 2
+	}
+	next = clampRequeue(next)
+	klog.InfoS("security token refresh succeeded", "sandbox", klog.KObj(box),
+		"nextRefreshIn", next, "remaining", remaining, "leadTime", leadTime)
+	return ctrl.Result{RequeueAfter: next}, nil
+}
+
+// jitteredRefreshLeadTime returns refreshLeadTime ± (refreshLeadTime * jitterRatio).
+// A jitterRatio outside [0, 1) is clamped, and a zero ratio short-circuits to
+// the raw lead time so unit tests can assert deterministic behaviour by
+// setting it to 0.
+func (r *SecurityTokenRefreshReconciler) jitteredRefreshLeadTime() time.Duration {
+	if jitterRatio <= 0 {
+		return refreshLeadTime
+	}
+	ratio := jitterRatio
+	if ratio >= 1 {
+		ratio = 0.99
+	}
+	// rand.Float64 ∈ [0,1) → centred to [-1,1) for symmetric jitter.
+	delta := (r.randFloat()*2 - 1) * ratio
+	jittered := time.Duration(float64(refreshLeadTime) * (1 + delta))
+	if jittered <= 0 {
+		return refreshLeadTime
+	}
+	return jittered
+}
+
+// parseExpiration parses an RFC3339 timestamp. An empty value is reported as
+// an error so the caller surfaces a Kubernetes event instead of silently
+// treating the token as already expired (which would cause an immediate
+// refresh storm).
+func parseExpiration(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, fmt.Errorf("accessTokenExpiration is empty")
+	}
+	return time.Parse(time.RFC3339, s)
+}
+
+// clampRequeue ensures the RequeueAfter passed to controller-runtime is at
+// least minRequeueAfter, so a near-zero or negative computed delay never
+// degenerates into an immediate-retry loop.
+func clampRequeue(d time.Duration) time.Duration {
+	if d < minRequeueAfter {
+		return minRequeueAfter
+	}
+	return d
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *SecurityTokenRefreshReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: concurrentReconciles}).
+		For(&agentsv1alpha1.Sandbox{}, builder.WithPredicates(needsRefreshPredicate())).
+		Named(controllerName).
+		Complete(r)
+}
+
+// DecodeTokenRefreshStatus parses a JSON string previously produced by EncodeTokenRefreshStatus.
+// An empty input is treated as a non-error nil result so callers can short-circuit
+// reconciliation with a simple nil-check when the annotation is not yet populated.
+func decodeTokenRefreshStatus(raw string) (*identity.TokenRefreshStatus, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var status identity.TokenRefreshStatus
+	if err := json.Unmarshal([]byte(raw), &status); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal token refresh status: %w", err)
+	}
+	return &status, nil
+}

--- a/pkg/controller/securitytokenrefresh/token_refresh_controller_test.go
+++ b/pkg/controller/securitytokenrefresh/token_refresh_controller_test.go
@@ -1,0 +1,837 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package securitytokenrefresh
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/identity"
+	"github.com/openkruise/agents/pkg/utils"
+)
+
+func newControllerScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, agentsv1alpha1.AddToScheme(s))
+	require.NoError(t, corev1.AddToScheme(s))
+	return s
+}
+
+// fakeRefresher records every Refresh call and either returns the configured
+// response or the configured error. It lets the reconciler tests exercise the
+// timing branches without exercising the real identity provider.
+type fakeRefresher struct {
+	resp     *identity.TokenResponse
+	err      error
+	calls    int
+	lastSbx  *agentsv1alpha1.Sandbox
+	lastTime time.Time
+	now      func() time.Time
+}
+
+func (f *fakeRefresher) Refresh(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (*identity.TokenResponse, error) {
+	f.calls++
+	f.lastSbx = sbx.DeepCopy()
+	if f.now != nil {
+		f.lastTime = f.now()
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.resp, nil
+}
+
+// withFlags temporarily overrides the package-level flag values and returns a
+// cleanup that restores them. Tests use this to lock down jitter and the
+// refresh lead time so timing assertions stay deterministic.
+func withFlags(leadTime time.Duration, ratio float64, retry time.Duration) func() {
+	prevW, prevR, prevE := refreshLeadTime, jitterRatio, refreshRetryAfter
+	refreshLeadTime, jitterRatio, refreshRetryAfter = leadTime, ratio, retry
+	return func() {
+		refreshLeadTime, jitterRatio, refreshRetryAfter = prevW, prevR, prevE
+	}
+}
+
+func newReconciler(t *testing.T, refresher *fakeRefresher, now time.Time, sbx *agentsv1alpha1.Sandbox) (*SecurityTokenRefreshReconciler, *record.FakeRecorder, client.Client) {
+	t.Helper()
+	scheme := newControllerScheme(t)
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	if sbx != nil {
+		builder = builder.WithObjects(sbx)
+	}
+	c := builder.Build()
+	rec := record.NewFakeRecorder(16)
+	r := &SecurityTokenRefreshReconciler{
+		Client:    c,
+		Scheme:    scheme,
+		Recorder:  rec,
+		refresher: refresher,
+		now:       func() time.Time { return now },
+		// deterministic: 0.5 → centred jitter delta is exactly 0.
+		randFloat: func() float64 { return 0.5 },
+	}
+	if refresher != nil {
+		refresher.now = r.now
+	}
+	return r, rec, c
+}
+
+// drainEvents non-blockingly drains the FakeRecorder so individual sub-cases
+// can assert on the final emitted event without ordering dependencies.
+func drainEvents(rec *record.FakeRecorder) []string {
+	var got []string
+	for {
+		select {
+		case e := <-rec.Events:
+			got = append(got, e)
+		default:
+			return got
+		}
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	const sandboxName = "sbx-1"
+	const sandboxNs = "default"
+
+	type tc struct {
+		name string
+		// status sets the JSON written into utils.AgentKeyTokenRefreshStatus.
+		status string
+		// claimed toggles the LabelSandboxIsClaimed=true label.
+		claimed       bool
+		objectMissing bool
+		refresher     *fakeRefresher
+		// expected outcomes
+		expectErr        string
+		expectRequeueMin time.Duration
+		expectRequeueMax time.Duration
+		expectCalls      int
+		expectEvent      string
+		// expectAnnotation is checked when the fake refresher succeeds and we
+		// want to make sure the reconciler did NOT touch the annotation itself
+		// (defaultRefresher / fakeRefresher own that side-effect).
+		expectAnnotationUnchanged bool
+	}
+
+	expireFar := now.Add(1 * time.Hour).Format(time.RFC3339)
+	expireNow := now.Add(-time.Minute).Format(time.RFC3339)
+	expireSoon := now.Add(refreshLeadTimeFor(t) - time.Second).Format(time.RFC3339) // already inside the refresh lead window
+
+	cases := []tc{
+		{
+			name:                      "not yet due, requeue near refreshAt",
+			status:                    `{"accessTokenExpiration":"` + expireFar + `"}`,
+			claimed:                   true,
+			refresher:                 &fakeRefresher{},
+			expectErr:                 "",
+			// expire=now+1h, leadTime=30m → refreshAt=now+30m, requeue ≈ 30m.
+			expectRequeueMin:          29 * time.Minute,
+			expectRequeueMax:          31 * time.Minute,
+			expectCalls:               0,
+			expectAnnotationUnchanged: true,
+		},
+		{
+			name:    "due now, refresher succeeds, requeue based on new expiration",
+			status:  `{"accessTokenExpiration":"` + expireNow + `"}`,
+			claimed: true,
+			refresher: &fakeRefresher{
+				resp: &identity.TokenResponse{
+					AccessToken:           "new-token",
+					AccessTokenExpiration: now.Add(2 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			expectErr:        "",
+			expectRequeueMin: time.Hour,
+			expectRequeueMax: 2*time.Hour + time.Second,
+			expectCalls:      1,
+			expectEvent:      "TokenRefreshed",
+		},
+		{
+			name:    "inside safety window, triggers refresh",
+			status:  `{"accessTokenExpiration":"` + expireSoon + `"}`,
+			claimed: true,
+			refresher: &fakeRefresher{
+				resp: &identity.TokenResponse{
+					AccessToken:           "new",
+					AccessTokenExpiration: now.Add(1 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			expectCalls: 1,
+			expectEvent: "TokenRefreshed",
+		},
+		{
+			name:    "refresher fails, requeue with refreshRetryAfter and swallow error",
+			status:  `{"accessTokenExpiration":"` + expireNow + `"}`,
+			claimed: true,
+			refresher: &fakeRefresher{
+				err: errors.New("boom"),
+			},
+			// Returning a nil error keeps controller-runtime from kicking in its
+			// own exponential workqueue backoff, which would otherwise override
+			// the fixed refreshRetryAfter we configure here. The failure is
+			// already surfaced via the TokenRefreshFailed event.
+			expectErr:        "",
+			expectRequeueMin: defaultRefreshRetryAfter,
+			expectRequeueMax: defaultRefreshRetryAfter,
+			expectCalls:      1,
+			expectEvent:      "TokenRefreshFailed",
+		},
+		{
+			name:        "malformed annotation does not retry hot",
+			status:      `{not json`,
+			claimed:     true,
+			refresher:   &fakeRefresher{},
+			expectErr:   "",
+			expectCalls: 0,
+			expectEvent: "TokenStatusDecodeFailed",
+		},
+		{
+			name:        "empty status object is treated as no-op",
+			status:      `{}`,
+			claimed:     true,
+			refresher:   &fakeRefresher{},
+			expectErr:   "",
+			expectCalls: 0,
+		},
+		{
+			name:        "empty expiration string is treated as no-op (defends against degraded provider fallback)",
+			status:      `{"accessTokenExpiration":""}`,
+			claimed:     true,
+			refresher:   &fakeRefresher{},
+			expectErr:   "",
+			expectCalls: 0,
+		},
+		{
+			name:        "missing annotation is treated as no-op",
+			status:      ``,
+			claimed:     true,
+			refresher:   &fakeRefresher{},
+			expectErr:   "",
+			expectCalls: 0,
+		},
+		{
+			name:        "sandbox not claimed -> skip",
+			status:      `{"accessTokenExpiration":"` + expireFar + `"}`,
+			claimed:     false,
+			refresher:   &fakeRefresher{},
+			expectErr:   "",
+			expectCalls: 0,
+		},
+		{
+			name:          "sandbox missing -> no error",
+			objectMissing: true,
+			refresher:     &fakeRefresher{},
+			expectErr:     "",
+			expectCalls:   0,
+		},
+		{
+			// Defends against a malformed annotation expiration: the
+			// annotation decodes successfully but the timestamp itself is not
+			// RFC3339. The reconciler must surface a TokenExpirationInvalid
+			// event and back off using refreshRetryAfter, never call the
+			// refresher, and never propagate an error (which would otherwise
+			// trigger controller-runtime's exponential workqueue backoff and
+			// override the fixed retry interval).
+			name:             "annotation expiration unparsable -> TokenExpirationInvalid event with retry backoff",
+			status:           `{"accessTokenExpiration":"not-a-date"}`,
+			claimed:          true,
+			refresher:        &fakeRefresher{},
+			expectErr:        "",
+			expectRequeueMin: defaultRefreshRetryAfter,
+			expectRequeueMax: defaultRefreshRetryAfter,
+			expectCalls:      0,
+			expectEvent:      "TokenExpirationInvalid",
+		},
+		{
+			// Defends against a refresher that returns a TokenResponse whose
+			// AccessTokenExpiration is unparsable. The current refresh has
+			// already succeeded (TokenRefreshed event must still be emitted),
+			// but we cannot compute the next refreshAt; the reconciler then
+			// returns Result{}, nil so that the next reconcile relies on the
+			// annotation watch rather than a self-scheduled requeue.
+			name:    "refresh succeeds but new expiration unparsable -> no requeue, still emits TokenRefreshed",
+			status:  `{"accessTokenExpiration":"` + expireNow + `"}`,
+			claimed: true,
+			refresher: &fakeRefresher{
+				resp: &identity.TokenResponse{
+					AccessToken:           "new-token",
+					AccessTokenExpiration: "not-a-date",
+				},
+			},
+			expectErr:   "",
+			expectCalls: 1,
+			expectEvent: "TokenRefreshed",
+		},
+		{
+			// Provider issued a token whose TTL (10m) is shorter than the
+			// configured lead time (30m). Without the short-TTL guard the
+			// next requeue would be `10m - 30m = -20m` clamped to 1s,
+			// spinning the controller. With the guard the next requeue is
+			// `remaining/2 = 5m`, leaving the queue idle for half the
+			// token's lifetime instead.
+			name:    "short TTL token avoids tight requeue loop",
+			status:  `{"accessTokenExpiration":"` + expireNow + `"}`,
+			claimed: true,
+			refresher: &fakeRefresher{
+				resp: &identity.TokenResponse{
+					AccessToken:           "short-ttl",
+					AccessTokenExpiration: now.Add(10 * time.Minute).Format(time.RFC3339),
+				},
+			},
+			expectErr:        "",
+			expectRequeueMin: 5 * time.Minute,
+			expectRequeueMax: 5*time.Minute + time.Second,
+			expectCalls:      1,
+			expectEvent:      "TokenRefreshed",
+		},
+	}
+
+	cleanup := withFlags(defaultRefreshLeadTime, 0, defaultRefreshRetryAfter)
+	defer cleanup()
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var sbx *agentsv1alpha1.Sandbox
+			if !tt.objectMissing {
+				sbx = newSandbox(sandboxName, tt.claimed, tt.status, false)
+				sbx.Namespace = sandboxNs
+			}
+			r, rec, c := newReconciler(t, tt.refresher, now, sbx)
+
+			res, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: sandboxNs},
+			})
+
+			if tt.expectErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+			}
+
+			assert.Equal(t, tt.expectCalls, tt.refresher.calls, "refresher call count")
+
+			if tt.expectRequeueMin > 0 || tt.expectRequeueMax > 0 {
+				assert.GreaterOrEqual(t, res.RequeueAfter, tt.expectRequeueMin, "requeue lower bound")
+				assert.LessOrEqual(t, res.RequeueAfter, tt.expectRequeueMax, "requeue upper bound")
+			}
+
+			events := drainEvents(rec)
+			if tt.expectEvent != "" {
+				found := false
+				for _, e := range events {
+					if assert.NotEmpty(t, e) && strings.Contains(e, tt.expectEvent) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "event %q not found in %v", tt.expectEvent, events)
+			} else {
+				assert.Empty(t, events)
+			}
+
+			if tt.expectAnnotationUnchanged && sbx != nil {
+				got := &agentsv1alpha1.Sandbox{}
+				require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: sandboxName, Namespace: sandboxNs}, got))
+				assert.Equal(t, sbx.Annotations[utils.AgentKeyTokenRefreshStatus], got.Annotations[utils.AgentKeyTokenRefreshStatus])
+			}
+		})
+	}
+}
+
+// refreshLeadTimeFor returns the package-level refreshLeadTime at the moment
+// of the call, isolating the test from import-time flag mutations done by
+// other tests.
+func refreshLeadTimeFor(t *testing.T) time.Duration {
+	t.Helper()
+	return refreshLeadTime
+}
+
+func TestParseExpiration(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          string
+		expectErr   string
+		expectEqual time.Time
+	}{
+		{name: "empty", in: "", expectErr: "empty"},
+		{name: "garbage", in: "not-a-date", expectErr: "cannot parse"},
+		{
+			name:        "valid rfc3339",
+			in:          "2026-01-01T12:00:00Z",
+			expectEqual: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseExpiration(tt.in)
+			if tt.expectErr == "" {
+				require.NoError(t, err)
+				assert.True(t, got.Equal(tt.expectEqual))
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+			}
+		})
+	}
+}
+
+func TestClampRequeue(t *testing.T) {
+	tests := []struct {
+		name string
+		in   time.Duration
+		want time.Duration
+	}{
+		{name: "negative", in: -time.Minute, want: minRequeueAfter},
+		{name: "zero", in: 0, want: minRequeueAfter},
+		{name: "below floor", in: 500 * time.Millisecond, want: minRequeueAfter},
+		{name: "at floor", in: minRequeueAfter, want: minRequeueAfter},
+		{name: "above floor", in: 5 * time.Minute, want: 5 * time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, clampRequeue(tt.in))
+		})
+	}
+}
+
+func TestJitteredRefreshLeadTime(t *testing.T) {
+	cleanup := withFlags(10*time.Minute, 0.1, defaultRefreshRetryAfter)
+	defer cleanup()
+
+	r := &SecurityTokenRefreshReconciler{}
+
+	tests := []struct {
+		name    string
+		ratio   float64
+		rand    func() float64
+		want    time.Duration
+		wantMin time.Duration
+		wantMax time.Duration
+	}{
+		{
+			name: "ratio == 0 returns raw lead time",
+			rand: func() float64 { return 0.5 },
+			ratio: 0,
+			want: 10 * time.Minute,
+		},
+		{
+			name:  "rand == 0.5 cancels delta",
+			rand:  func() float64 { return 0.5 },
+			ratio: 0.1,
+			want:  10 * time.Minute,
+		},
+		{
+			name:    "rand == 0 produces lower bound",
+			rand:    func() float64 { return 0 },
+			ratio:   0.1,
+			wantMin: 9 * time.Minute,
+			wantMax: 9*time.Minute + time.Second,
+		},
+		{
+			name:    "ratio clamped to 0.99 with rand near 1",
+			rand:    func() float64 { return 0.999999 },
+			ratio:   5,
+			wantMin: 19 * time.Minute,
+			wantMax: 20 * time.Minute,
+		},
+		{
+			// Defensive branch: when the lead time is so small that the
+			// jittered duration truncates to <= 0 (e.g. 1ns * 0.01 = 0ns
+			// after time.Duration float-to-int truncation), the function
+			// must fall back to the raw refreshLeadTime instead of returning
+			// a zero/negative value that would cause an immediate requeue.
+			name:    "jittered truncates to 0 falls back to raw lead time",
+			rand:    func() float64 { return 0 },
+			ratio:   5, // clamped to 0.99 → delta = -0.99
+			want:    1 * time.Nanosecond,
+			wantMin: 0,
+			wantMax: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jitterRatio = tt.ratio
+			r.randFloat = tt.rand
+			// The "jittered truncates to 0" case requires a tiny lead time so
+			// the float-to-Duration truncation hits the defensive branch.
+			// Other cases keep the 10m lead time established by withFlags.
+			if tt.name == "jittered truncates to 0 falls back to raw lead time" {
+				prev := refreshLeadTime
+				refreshLeadTime = 1 * time.Nanosecond
+				defer func() { refreshLeadTime = prev }()
+			}
+			got := r.jitteredRefreshLeadTime()
+			if tt.want > 0 {
+				assert.Equal(t, tt.want, got)
+			} else {
+				assert.GreaterOrEqual(t, got, tt.wantMin)
+				assert.LessOrEqual(t, got, tt.wantMax)
+			}
+		})
+	}
+}
+
+// TestDecodeTokenRefreshStatus locks down the contract that the reconciler
+// relies on at Reconcile():
+//   - empty input ALWAYS returns (nil, nil) so callers can short-circuit with
+//     a single nil-check when the annotation is not yet populated; this branch
+//     must NEVER surface as an error otherwise newly claimed sandboxes would
+//     emit a TokenStatusDecodeFailed event on every reconcile;
+//   - malformed JSON returns a wrapped error whose message starts with
+//     "failed to unmarshal token refresh status" so the reconciler can keep
+//     using a stable substring in its event reason / log message;
+//   - well-formed JSON populates AccessTokenExpiration verbatim, including
+//     timezone offsets, with unknown fields silently ignored to keep the
+//     decoder forward-compatible with future status additions.
+func TestDecodeTokenRefreshStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         string
+		expect      *identity.TokenRefreshStatus
+		expectError string
+	}{
+		{
+			name:   "empty input yields nil status without error",
+			raw:    "",
+			expect: nil,
+		},
+		{
+			name:   "empty json object yields zero-value status",
+			raw:    "{}",
+			expect: &identity.TokenRefreshStatus{},
+		},
+		{
+			name:   "valid json with expiration is decoded verbatim",
+			raw:    `{"accessTokenExpiration":"2099-01-01T00:00:00Z"}`,
+			expect: &identity.TokenRefreshStatus{AccessTokenExpiration: "2099-01-01T00:00:00Z"},
+		},
+		{
+			name:   "timezone offset preserved verbatim",
+			raw:    `{"accessTokenExpiration":"2026-05-25T16:24:50+08:00"}`,
+			expect: &identity.TokenRefreshStatus{AccessTokenExpiration: "2026-05-25T16:24:50+08:00"},
+		},
+		{
+			name:   "unknown fields are ignored to keep the decoder forward-compatible",
+			raw:    `{"accessTokenExpiration":"2099-01-01T00:00:00Z","futureField":"ignored"}`,
+			expect: &identity.TokenRefreshStatus{AccessTokenExpiration: "2099-01-01T00:00:00Z"},
+		},
+		{
+			name:        "malformed json returns wrapped error",
+			raw:         "not-json",
+			expectError: "failed to unmarshal token refresh status",
+		},
+		{
+			name:        "type mismatch on expiration returns wrapped error",
+			raw:         `{"accessTokenExpiration":12345}`,
+			expectError: "failed to unmarshal token refresh status",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decodeTokenRefreshStatus(tt.raw)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				assert.Nil(t, got, "decoder must not return a partial status when JSON is malformed")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expect, got)
+		})
+	}
+}
+
+// withSetupHooks snapshots the package-level setupHooks slice, clears it for
+// the duration of the test, and returns a cleanup that restores the original
+// value. Tests use this so they can drive RegisterSetupHook / runSetupHooks
+// against a deterministic empty starting state without leaking registrations
+// into sibling tests.
+func withSetupHooks(t *testing.T) {
+	t.Helper()
+	prev := setupHooks
+	setupHooks = nil
+	t.Cleanup(func() { setupHooks = prev })
+}
+
+func TestRegisterSetupHook(t *testing.T) {
+	type tc struct {
+		name         string
+		register     []SetupHook
+		expectStored int
+	}
+
+	noop := func(manager.Manager) error { return nil }
+	tests := []tc{
+		{
+			name:         "nil hook is dropped silently",
+			register:     []SetupHook{nil},
+			expectStored: 0,
+		},
+		{
+			name:         "single hook is appended",
+			register:     []SetupHook{noop},
+			expectStored: 1,
+		},
+		{
+			name:         "multiple hooks preserve registration order",
+			register:     []SetupHook{noop, noop, noop},
+			expectStored: 3,
+		},
+		{
+			name:         "nil entries interleaved with real hooks are filtered",
+			register:     []SetupHook{nil, noop, nil, noop},
+			expectStored: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withSetupHooks(t)
+
+			for _, h := range tt.register {
+				RegisterSetupHook(h)
+			}
+			assert.Len(t, setupHooks, tt.expectStored)
+		})
+	}
+}
+
+func TestRunSetupHooks(t *testing.T) {
+	type tc struct {
+		name        string
+		hooks       []SetupHook
+		expectErr   string
+		expectCalls []int // expected indices that ran, in order
+	}
+
+	tests := []tc{
+		{
+			name:        "no hooks registered returns nil",
+			hooks:       nil,
+			expectErr:   "",
+			expectCalls: nil,
+		},
+		{
+			name: "all hooks succeed and run in registration order",
+			hooks: []SetupHook{
+				func(manager.Manager) error { return nil },
+				func(manager.Manager) error { return nil },
+				func(manager.Manager) error { return nil },
+			},
+			expectErr:   "",
+			expectCalls: []int{0, 1, 2},
+		},
+		{
+			name: "first failing hook short-circuits and wraps the error",
+			hooks: []SetupHook{
+				func(manager.Manager) error { return nil },
+				func(manager.Manager) error { return errors.New("boom") },
+				func(manager.Manager) error { t.Fatal("must not run after a failure"); return nil },
+			},
+			expectErr:   "securitytokenrefresh setup hook #1 failed: boom",
+			expectCalls: []int{0, 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withSetupHooks(t)
+
+			// Re-instrument the hooks so we can record call order without
+			// relying on captured state from the table literal.
+			var calls []int
+			for i, h := range tt.hooks {
+				idx, original := i, h
+				RegisterSetupHook(func(mgr manager.Manager) error {
+					calls = append(calls, idx)
+					return original(mgr)
+				})
+			}
+
+			err := runSetupHooks(nil)
+
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectCalls, calls)
+		})
+	}
+}
+
+// TestReconcile_GetError covers the Get-error transparent path of Reconcile:
+// any non-NotFound API failure returned by client.Get must be propagated
+// verbatim so controller-runtime applies its rate-limited workqueue backoff,
+// and the reconciler must not attempt a refresh nor emit any event in that
+// case. NotFound is exercised via the existing "sandbox missing" sub-case in
+// TestReconcile and asserted there to return a clean Result{}, nil.
+func TestReconcile_GetError(t *testing.T) {
+	const sandboxName = "sbx-1"
+	const sandboxNs = "default"
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		injectErr   error
+		expectErr   string
+		expectCalls int
+	}{
+		{
+			name:        "transient API server error is propagated",
+			injectErr:   errors.New("etcd unavailable"),
+			expectErr:   "etcd unavailable",
+			expectCalls: 0,
+		},
+		{
+			name: "non-NotFound status error is propagated",
+			injectErr: apierrors.NewServiceUnavailable(
+				"the server is currently unable to handle the request"),
+			expectErr:   "unable to handle the request",
+			expectCalls: 0,
+		},
+		{
+			// NotFound must be swallowed, NOT propagated. The fake client's
+			// natural NotFound is already exercised in TestReconcile via the
+			// "sandbox missing" sub-case, but here we additionally confirm
+			// that an interceptor-injected NotFound takes the same fast path
+			// and never reaches the refresher.
+			name: "NotFound from interceptor is swallowed",
+			injectErr: apierrors.NewNotFound(
+				schema.GroupResource{Group: agentsv1alpha1.GroupVersion.Group, Resource: "sandboxes"},
+				sandboxName),
+			expectErr:   "",
+			expectCalls: 0,
+		},
+	}
+
+	cleanup := withFlags(defaultRefreshLeadTime, 0, defaultRefreshRetryAfter)
+	defer cleanup()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newControllerScheme(t)
+			injectedErr := tt.injectErr
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey,
+						obj client.Object, opts ...client.GetOption) error {
+						return injectedErr
+					},
+				}).
+				Build()
+
+			refresher := &fakeRefresher{}
+			rec := record.NewFakeRecorder(8)
+			r := &SecurityTokenRefreshReconciler{
+				Client:    c,
+				Scheme:    scheme,
+				Recorder:  rec,
+				refresher: refresher,
+				now:       func() time.Time { return now },
+				randFloat: func() float64 { return 0.5 },
+			}
+
+			res, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: sandboxNs},
+			})
+
+			if tt.expectErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+			}
+			// On any Get failure path the reconciler must not requeue itself
+			// (controller-runtime's workqueue backoff drives the next attempt
+			// when err != nil; on swallowed NotFound there is nothing to do).
+			assert.Equal(t, time.Duration(0), res.RequeueAfter)
+			assert.False(t, res.Requeue)
+			assert.Equal(t, tt.expectCalls, refresher.calls)
+			assert.Empty(t, drainEvents(rec), "no event should be emitted before the sandbox is loaded")
+		})
+	}
+}
+
+// fakeManager is a minimal manager.Manager stub used by TestAdd to feed Add
+// when the feature gate is OFF. Add must short-circuit at the gate check
+// without touching the manager, so all methods return zero values and a t.Fatal
+// in the unlikely path that they are invoked.
+type fakeManager struct {
+	manager.Manager
+	t *testing.T
+}
+
+func (f *fakeManager) GetClient() client.Client {
+	f.t.Fatalf("Add must not call GetClient when the feature gate is disabled")
+	return nil
+}
+func (f *fakeManager) GetScheme() *runtime.Scheme {
+	f.t.Fatalf("Add must not call GetScheme when the feature gate is disabled")
+	return nil
+}
+
+// TestAdd_FeatureGateDisabled covers the early-return path of Add when the
+// SecurityIdentityProvider feature gate is OFF (the default), which is the
+// hot path on clusters that do not deploy an identity provider. Under that
+// branch Add must return nil immediately without ever wiring the reconciler
+// or running setup hooks; otherwise a misconfigured cluster would emit
+// spurious controller logs and book a worker slot it does not need.
+func TestAdd_FeatureGateDisabled(t *testing.T) {
+	// The default feature gate state already has SecurityIdentityProvider=off.
+	// We still snapshot setupHooks so that an accidental hook execution would
+	// be observable as a failure rather than silently leaking state into
+	// sibling tests.
+	withSetupHooks(t)
+	called := false
+	RegisterSetupHook(func(manager.Manager) error {
+		called = true
+		return nil
+	})
+
+	mgr := &fakeManager{t: t}
+	err := Add(mgr)
+	assert.NoError(t, err, "Add must return nil when the feature gate is disabled")
+	assert.False(t, called, "setup hooks must not run when the feature gate is disabled")
+}
+

--- a/pkg/identity/sandbox_token_helper.go
+++ b/pkg/identity/sandbox_token_helper.go
@@ -71,3 +71,28 @@ func IssueSandboxToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (*Token
 	log.Info("sandbox security token issued", "cost", cost)
 	return tokenResp, cost, nil
 }
+
+// PropagateSandboxToken propagates the freshly issued security token to the
+// runtime side via the registered SecurityTokenPropagators. It is the symmetric
+// twin of IssueSandboxToken: callers obtain a TokenResponse first (issue) and
+// then push it into the runtime (propagate).
+//
+// The function intentionally has no side-effect on the sandbox object — it
+// only delegates to PropagateSecurityToken while emitting uniform structured
+// logs (propagator count, cost) so every call site (claim flow, refresh
+// controller, future SDK helpers) shares the same observability surface.
+//
+// The error returned by the underlying provider is surfaced verbatim so
+// callers can decide their own retry / event semantics; this function never
+// wraps or rewrites it.
+func PropagateSandboxToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tokenResp *TokenResponse) error {
+	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx), "action", "PropagateSandboxToken")
+	start := time.Now()
+	log.Info("propagating sandbox security token", "propagatorCount", SecurityTokenPropagatorCount())
+	if err := PropagateSecurityToken(ctx, sbx, tokenResp); err != nil {
+		log.Error(err, "failed to propagate sandbox security token", "cost", time.Since(start))
+		return err
+	}
+	log.Info("sandbox security token propagated", "cost", time.Since(start))
+	return nil
+}

--- a/pkg/identity/sandbox_token_helper_test.go
+++ b/pkg/identity/sandbox_token_helper_test.go
@@ -217,3 +217,102 @@ func TestIssueSandboxToken_DefaultProviderIntegration(t *testing.T) {
 // Compile-time guard: fakeIdentityProvider must satisfy IdentityProvider so it
 // is accepted by RegisterProvider.
 var _ IdentityProvider = (*fakeIdentityProvider)(nil)
+
+// propagatingFakeProvider is a stand-alone IdentityProvider whose IssueToken is
+// intentionally inert (it must NEVER be invoked by PropagateSandboxToken) and
+// whose PropagateSecurityToken is fully programmable — including a call counter
+// so tests can pin down "exactly one delegation per call".
+type propagatingFakeProvider struct {
+	gotSandbox *agentsv1alpha1.Sandbox
+	gotResp    *TokenResponse
+	calls      int
+	issueCalls int
+
+	err error
+}
+
+func (p *propagatingFakeProvider) IssueToken(_ context.Context, _ TokenRequest) (*TokenResponse, error) {
+	p.issueCalls++
+	return nil, nil
+}
+
+func (p *propagatingFakeProvider) PropagateSecurityToken(_ context.Context, sbx *agentsv1alpha1.Sandbox, resp *TokenResponse) error {
+	p.calls++
+	p.gotSandbox = sbx
+	p.gotResp = resp
+	return p.err
+}
+
+var _ IdentityProvider = (*propagatingFakeProvider)(nil)
+
+// TestPropagateSandboxToken locks down the contract that callers (claim flow
+// and the security-token refresh controller) rely on:
+//   - the helper delegates to the registered IdentityProvider exactly once;
+//   - on success it returns nil and never touches the issuance path;
+//   - on provider failure it surfaces the underlying error VERBATIM (no
+//     wrapping with fmt.Errorf), so callers can keep matching against stable
+//     error strings or unwrap with errors.Is.
+func TestPropagateSandboxToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		fake        *propagatingFakeProvider
+		tokenResp   *TokenResponse
+		expectError string
+	}{
+		{
+			name: "success delegates to provider and returns nil",
+			fake: &propagatingFakeProvider{},
+			tokenResp: &TokenResponse{
+				AccessToken:           "tok",
+				AccessTokenExpiration: "2099-12-31T23:59:59Z",
+			},
+		},
+		{
+			name: "provider error is returned verbatim without wrapping",
+			fake: &propagatingFakeProvider{
+				err: errors.New("write to runtime failed"),
+			},
+			tokenResp:   &TokenResponse{AccessToken: "tok"},
+			expectError: "write to runtime failed",
+		},
+		{
+			name:      "nil tokenResp still reaches the provider for it to decide",
+			fake:      &propagatingFakeProvider{},
+			tokenResp: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			saved := provider
+			RegisterProvider(tt.fake)
+			t.Cleanup(func() { RegisterProvider(saved) })
+
+			sbx := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sbx-propagate",
+					Namespace: "default",
+					UID:       types.UID("uid-propagate"),
+				},
+			}
+
+			err := PropagateSandboxToken(context.Background(), sbx, tt.tokenResp)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.EqualError(t, err, tt.expectError,
+					"helper must surface the provider error VERBATIM (no wrapping)")
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, 1, tt.fake.calls,
+				"helper must invoke provider.PropagateSecurityToken exactly once regardless of outcome")
+			assert.Equal(t, 0, tt.fake.issueCalls,
+				"helper must not touch the issuance path")
+			assert.Same(t, sbx, tt.fake.gotSandbox,
+				"helper must forward the original sandbox pointer without copying")
+			assert.Same(t, tt.tokenResp, tt.fake.gotResp,
+				"helper must forward the original TokenResponse pointer without copying")
+		})
+	}
+}

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -257,15 +257,11 @@ func TryClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions, pickCa
 			return
 		}
 
-		log.Info("propagating security token to runtime", "propagatorCount", identity.SecurityTokenPropagatorCount())
-		startTime := time.Now()
 		// 4.2: to propagate security token to runtime
-		if err = identity.PropagateSecurityToken(ctx, sbx.Sandbox, &opts.SecurityToken.TokenResponse); err != nil {
-			log.Error(err, "security token propagation failed")
+		if err = identity.PropagateSandboxToken(ctx, sbx.Sandbox, &opts.SecurityToken.TokenResponse); err != nil {
 			err = retriableError{Message: fmt.Sprintf("security token propagation failed: %s", err)}
 			return
 		}
-		log.Info("security token propagated", "cost", time.Since(startTime))
 	}
 
 	if opts.CSIMount != nil {


### PR DESCRIPTION
…ken rotation

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does



Introduce a controller-runtime reconciler that proactively rotates the
security token of claimed sandboxes shortly before AccessTokenExpiration,
so the runtime never observes an expired credential.

The controller is gated by SecurityIdentityProvider feature gate and
auto-skips when the Sandbox CRD is not present, keeping clusters without
an identity provider behave exactly like before.

Core design
-----------
* Predicate-driven enqueue (predicate.go): only sandboxes carrying the
  claimed label AND a non-empty TokenRefreshStatus annotation flow into
  the workqueue, avoiding hot-loops on freshly created or already
  released sandboxes.
* Reconcile is policy-only: it parses AccessTokenExpiration, schedules
  refreshAt = expireAt - (refreshLeadTime ± jitter) and either requeues
  or hands over to the Refresher. Default lead time is 30m with ±10%
  jitter; failure inside the lead window requeues every 1m, giving
  ~30 retry chances before T-0.
* core.Refresher encapsulates issue / propagate / annotation-patch as a
  single side-effect surface, so the reconciler stays focused on timing.
  A defaultRefresher composes identity.IssueSandboxToken,
  identity.PropagateSandboxToken and a controller-runtime client patch.

Extension surface
-----------------
* SetupHook + RegisterSetupHook expose a downstream extension point at
  the tail of Add(). Hooks run after the reconciler is wired with the
  manager and may attach extra peer Runnables (e.g. CA-bundle sync,
  metrics emitters) without forking this package. Errors are wrapped
  with a hook-index prefix and short-circuit further hooks.

Identity helper symmetry
------------------------
* Add identity.PropagateSandboxToken as the symmetric twin of
  identity.IssueSandboxToken. Both helpers carry the uniform
  klog skeleton (action, propagatorCount, cost) so claim flow and
  refresh controller share the same observability surface.
* Migrate sandbox-manager/infra/sandboxcr claim flow to the new helper,
  collapsing the inline propagator block into a single call.

Configurability
---------------
Three flags allow operators to tune behaviour without rebuilding:
  --security-token-refresh-workers       (default 10)
  --security-token-refresh-lead-time     (default 30m)
  --security-token-refresh-jitter-ratio  (default 0.1)
  --security-token-refresh-retry-after   (default 1m)

Tests
-----
* Reconcile timing matrix: not-yet-due / due-now / inside-window /
  refresher-failure / malformed-annotation / empty-status / not-claimed.
* Predicate matrix: claim flips, annotation diff vs equal, deletion.
* Refresher table tests: issue error, propagate error verbatim, patch
  failure, happy path with annotation persistence assertion.
* SetupHook table tests: nil filter, registration order, first-error
  short-circuit with wrapped error.
* PropagateSandboxToken: success / provider error verbatim / nil resp.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

