### PR TITLE
fix(test): update sandbox connection method in resume function

### DIFF
--- a/test/e2b/test_sandbox.py
+++ b/test/e2b/test_sandbox.py
@@ -669,7 +669,7 @@ def test_concurrent_pause_resume_on_running_sandbox(sandbox_context):
 
     def do_resume():
         try:
-            connect_sandbox(sbx)
+            sbx.connect()
         except Exception as e:
             if "409" in str(e) or "conflict" in str(e).lower():
                 print(f"Concurrent resume got expected conflict: {e}")


### PR DESCRIPTION
The `connect_sandbox` function includes a retry mechanism for the **Pausing** state. During the retry interval when `pause` and `connect` are executed concurrently, the sandbox may be resumed after the pause operation completes, which does not match the expectation of this test. Therefore, we chose to use `connect` directly.
