### PR TITLE
feat(identity): add gateway CA bundle injection framework

### DIFF
--- a/cmd/agent-sandbox-controller/ca_binding.go
+++ b/cmd/agent-sandbox-controller/ca_binding.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/features"
+	"github.com/openkruise/agents/pkg/identity"
+	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
+	"github.com/openkruise/agents/pkg/utils/sidecarutils"
+)
+
+// caBindingFuncs holds registered CA binding callbacks. Each callback is
+// expected to call identity.BindCAEnabledFor for one or more CA specs.
+//
+// Community baseline registers the gateway CA binding in this file's init().
+// Enterprise deployments append additional bindings via init() in
+// inner_ca_binding.go (or similar inner_*.go files), which only exist in the
+// enterprise repository and thus never conflict with community code.
+//
+// All callbacks are executed during controller startup (after flag parsing) via
+// executeCABindings(). This guarantees that feature-gate state is available.
+var caBindingFuncs []func()
+
+// registerCABinding appends a CA binding callback to the global list.
+// It MUST be called during init() only.
+func registerCABinding(fn func()) {
+	caBindingFuncs = append(caBindingFuncs, fn)
+}
+
+// executeCABindings runs all registered CA binding callbacks. It should be
+// called exactly once during controller startup, after feature gates and
+// controller setup are complete.
+func executeCABindings() {
+	for _, fn := range caBindingFuncs {
+		fn()
+	}
+}
+
+func init() {
+	// Community baseline: bind the gateway CA spec's EnabledFor predicate to
+	// the traffic-proxy runtime check, gated by SecurityIdentityProviderGate.
+	//
+	// When the gate is off, the entire CA injection pipeline is disabled at the
+	// caller side (shouldInjectCABundles), so we skip binding altogether to
+	// keep startup logs clean and make the gate dependency explicit.
+	registerCABinding(func() {
+		if utilfeature.DefaultFeatureGate.Enabled(features.SecurityIdentityProviderGate) {
+			identity.BindCAEnabledFor(identity.GatewayCABundleName, func(sbx *agentsv1alpha1.Sandbox) bool {
+				return sidecarutils.IsRuntimeEnabled(sbx, agentsv1alpha1.RuntimeConfigForInjectTrafficProxy)
+			})
+		} else {
+			setupLog.Info("SecurityIdentityProviderGate disabled, skip CABundleSpec EnabledFor binding",
+				"name", identity.GatewayCABundleName)
+		}
+	})
+}

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -287,6 +287,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Execute all registered CA binding callbacks. Community bindings are
+	// registered in ca_binding.go; enterprise bindings in inner_ca_binding.go.
+	// This keeps main.go free of binding details and avoids merge conflicts
+	// when enterprise adds new CA specs.
+	executeCABindings()
+
 	setupLog.Info("register field index")
 	if err := fieldindex.RegisterFieldIndexes(mgr.GetCache()); err != nil {
 		setupLog.Error(err, "failed to register field index")

--- a/dockerfiles/agent-sandbox-controller.Dockerfile
+++ b/dockerfiles/agent-sandbox-controller.Dockerfile
@@ -12,7 +12,10 @@ COPY ../go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY ../cmd/agent-sandbox-controller/main.go cmd/main.go
+# IMPORTANT: copy the whole cmd/agent-sandbox-controller/ directory and build by
+# package path. Single-file builds (go build cmd/main.go) silently drop sibling
+# files such as ca_binding.go, leading to "undefined: executeCABindings".
+COPY ../cmd/agent-sandbox-controller/ cmd/agent-sandbox-controller/
 COPY ../api api/
 COPY ../pkg pkg/
 COPY ../client client/
@@ -24,7 +27,7 @@ COPY ../test test/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager ./cmd/agent-sandbox-controller/
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -32,8 +32,11 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/agent-runtime/storages"
+	"github.com/openkruise/agents/pkg/features"
+	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
+	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
 	"github.com/openkruise/agents/pkg/utils/sidecarutils"
 )
@@ -430,6 +433,19 @@ func (r *commonControl) EnsureSandboxTerminated(ctx context.Context, args Ensure
 }
 
 func (r *commonControl) createPod(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus) (*corev1.Pod, error) {
+
+	// Ensure all registered CA bundle Secrets exist in the sandbox namespace
+	// before creating the pod. Whether a given spec is actually copied is
+	// decided by its CABundleSpec.EnabledFor predicate (e.g. the gateway CA
+	// spec is bound at controller startup to require the traffic-proxy runtime),
+	// so a missing source Secret only blocks creation when the spec applies.
+	if shouldInjectCABundles() {
+		if err := identity.EnsureAllCACerts(ctx, r.Client, box, box.Namespace); err != nil {
+			klog.ErrorS(err, "failed to ensure CA bundle secrets", "sandbox", klog.KObj(box))
+			return nil, err
+		}
+	}
+
 	pod, err := GeneratePodFromSandbox(ctx, r.Client, box, newStatus.UpdateRevision)
 	if err != nil {
 		return nil, err
@@ -454,6 +470,16 @@ func (r *commonControl) createPod(ctx context.Context, box *agentsv1alpha1.Sandb
 	}
 	klog.InfoS("Create pod success", "sandbox", klog.KObj(box), "Body", utils.DumpJson(pod))
 	return pod, nil
+}
+
+// shouldInjectCABundles is the cluster-level kill switch for the CA bundle
+// ensure/inject pipeline. It only checks SecurityIdentityProviderGate; whether
+// a particular sandbox actually needs a given CA spec is decided exclusively
+// by that spec's EnabledFor predicate (bound via identity.BindCAEnabledFor at
+// controller startup). Keeping the runtime-level decision in a single place
+// avoids drift between the caller-side gate and the per-spec predicate.
+func shouldInjectCABundles() bool {
+	return utilfeature.DefaultFeatureGate.Enabled(features.SecurityIdentityProviderGate)
 }
 
 func (r *commonControl) handleInplaceUpdateSandbox(ctx context.Context, args EnsureFuncArgs) (bool, error) {

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/utils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
@@ -2083,6 +2084,195 @@ func TestCommonControl_performRecreateUpgrade_NewPodNotReady(t *testing.T) {
 	}
 	if done {
 		t.Error("Expected done=false for pod not ready")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CA Certificate Injection Tests (driven by identity.CABundleSpec registry)
+// ---------------------------------------------------------------------------
+
+func TestCommonControl_createPod_WithCAInjection(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	tests := []struct {
+		name                    string
+		featureGateEnabled      bool
+		seedSourceSecret        bool
+		withTrafficProxyRuntime bool
+		expectCAVolume          bool
+		expectCAMount           bool
+		expectError             string
+	}{
+		{
+			name:                    "feature gate enabled, traffic-proxy runtime, source secret present - CA injected",
+			featureGateEnabled:      true,
+			withTrafficProxyRuntime: true,
+			seedSourceSecret:        true,
+			expectCAVolume:          true,
+			expectCAMount:           true,
+		},
+		{
+			name:                    "feature gate disabled - no CA injection regardless of source",
+			featureGateEnabled:      false,
+			withTrafficProxyRuntime: true,
+			seedSourceSecret:        false,
+			expectCAVolume:          false,
+			expectCAMount:           false,
+		},
+		{
+			name:                    "feature gate enabled but no traffic-proxy runtime - no CA injection",
+			featureGateEnabled:      true,
+			withTrafficProxyRuntime: false,
+			seedSourceSecret:        false,
+			expectCAVolume:          false,
+			expectCAMount:           false,
+		},
+		{
+			name:                    "feature gate enabled, traffic-proxy runtime, source secret missing - block creation",
+			featureGateEnabled:      true,
+			withTrafficProxyRuntime: true,
+			seedSourceSecret:        false,
+			expectError:             "source CA secret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.featureGateEnabled {
+				_ = utilfeature.DefaultMutableFeatureGate.Set("SecurityIdentityProvider=true")
+				// Mirror the production binding in cmd/agent-sandbox-controller/ca_binding.go
+				// so the gateway CA spec only applies to sandboxes that declare the
+				// traffic-proxy runtime. This is the single place where runtime-level
+				// gating lives now (callers no longer pre-check IsRuntimeEnabled).
+				identity.BindCAEnabledFor(identity.GatewayCABundleName, func(sbx *agentsv1alpha1.Sandbox) bool {
+					return sidecarutils.IsRuntimeEnabled(sbx, agentsv1alpha1.RuntimeConfigForInjectTrafficProxy)
+				})
+				t.Cleanup(func() {
+					_ = utilfeature.DefaultMutableFeatureGate.Set("SecurityIdentityProvider=false")
+					identity.BindCAEnabledFor(identity.GatewayCABundleName, nil)
+				})
+			}
+
+			objs := []client.Object{}
+			if tt.seedSourceSecret {
+				objs = append(objs, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      identity.GatewayCASecretName,
+						Namespace: utils.DefaultSandboxDeployNamespace,
+					},
+					Type: corev1.SecretTypeOpaque,
+					Data: map[string][]byte{
+						identity.GatewayCAKey: []byte("test-ca-bundle-content"),
+					},
+				})
+			}
+			// When the sandbox declares the traffic-proxy runtime, InjectSandboxRuntimes
+			// will look up the corresponding template in the sandbox-injection ConfigMap.
+			// Seed a minimal valid template so createPod's sidecar-injection step does
+			// not fail and we can isolate CA injection behaviour under test.
+			if tt.withTrafficProxyRuntime {
+				objs = append(objs, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sidecarutils.SandboxInjectionConfigName,
+						Namespace: utils.DefaultSandboxDeployNamespace,
+					},
+					Data: map[string]string{
+						sidecarutils.KEY_TRAFFIC_PROXY_INJECTION_CONFIG: `{"mainContainer":{},"csiSidecar":[],"volume":[]}`,
+					},
+				})
+			}
+
+			control := &commonControl{
+				Client:   fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+				recorder: record.NewFakeRecorder(10),
+			}
+
+			sandbox := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{Name: "main", Image: "nginx:latest"},
+								},
+							},
+						},
+					},
+				},
+			}
+			if tt.withTrafficProxyRuntime {
+				sandbox.Spec.Runtimes = []agentsv1alpha1.RuntimeConfig{
+					{Name: agentsv1alpha1.RuntimeConfigForInjectTrafficProxy},
+				}
+			}
+
+			status := &agentsv1alpha1.SandboxStatus{UpdateRevision: "rev1"}
+			pod, err := control.createPod(context.TODO(), sandbox, status)
+
+			if tt.expectError != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.expectError)
+				}
+				if !contains(err.Error(), tt.expectError) {
+					t.Fatalf("expected error containing %q, got %q", tt.expectError, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("createPod() unexpected error: %v", err)
+			}
+
+			foundCAVolume := false
+			for _, v := range pod.Spec.Volumes {
+				if v.Name == "sandbox-gateway-ca" {
+					foundCAVolume = true
+					if v.Secret == nil || v.Secret.SecretName != identity.GatewayCASecretName {
+						t.Errorf("CA volume has wrong secret source")
+					}
+					break
+				}
+			}
+			if foundCAVolume != tt.expectCAVolume {
+				t.Errorf("expected CA volume present=%v, got %v", tt.expectCAVolume, foundCAVolume)
+			}
+
+			foundCAMount := false
+			if len(pod.Spec.Containers) > 0 {
+				for _, vm := range pod.Spec.Containers[0].VolumeMounts {
+					if vm.Name == "sandbox-gateway-ca" {
+						foundCAMount = true
+						if vm.MountPath != "/etc/ssl/certs/agent-identity/gateway-ca.crt" {
+							t.Errorf("expected mount path '/etc/ssl/certs/agent-identity/gateway-ca.crt', got %q", vm.MountPath)
+						}
+						break
+					}
+				}
+			}
+			if foundCAMount != tt.expectCAMount {
+				t.Errorf("expected CA mount present=%v, got %v", tt.expectCAMount, foundCAMount)
+			}
+
+			if tt.featureGateEnabled && tt.seedSourceSecret && tt.withTrafficProxyRuntime {
+				var replicated corev1.Secret
+				err = control.Get(context.TODO(), types.NamespacedName{
+					Name:      identity.GatewayCASecretName,
+					Namespace: "default",
+				}, &replicated)
+				if err != nil {
+					t.Fatalf("expected gateway CA secret to be replicated to target ns, got error: %v", err)
+				}
+				if string(replicated.Data[identity.GatewayCAKey]) != "test-ca-bundle-content" {
+					t.Errorf("expected replicated secret data to match source, got %q",
+						string(replicated.Data[identity.GatewayCAKey]))
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -96,6 +96,7 @@ type SandboxReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;update;patch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create
 
 //nolint:gocyclo // This function handles multiple reconciliation scenarios which require branching logic
 func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (crl ctrl.Result, err error) {

--- a/pkg/identity/ca_cert_injector.go
+++ b/pkg/identity/ca_cert_injector.go
@@ -1,0 +1,351 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/utils"
+)
+
+// Built-in gateway CA bundle constants.
+//
+// These mirror the historical values used by the legacy GatewayCACertInjector,
+// so that existing deployments continue to mount the gateway CA at the same
+// path with the same Secret/key names.
+const (
+	// GatewayCABundleName is the logical name of the gateway CA bundle in the
+	// CABundleSpec registry. Use this constant whenever you need to reference
+	// the spec by name, including:
+	//   - BindCAEnabledFor(GatewayCABundleName, ...) at controller startup to
+	//     wire the runtime-gating predicate.
+	//   - RegisterCABundleSpec(CABundleSpec{Name: GatewayCABundleName, ...})
+	//     from an enterprise inner_*.go file to override the community
+	//     baseline (selector / EnvVars / Secret references) in one shot.
+	GatewayCABundleName = "gateway"
+
+	// GatewayCASecretName is the Secret name (in BOTH sandbox-system and target
+	// namespaces) holding the sandbox gateway CA certificate.
+	GatewayCASecretName = "sandbox-gateway-crt"
+
+	// GatewayCAKey is the data key within the gateway CA Secret whose value is
+	// the PEM-encoded CA certificate.
+	GatewayCAKey = "sandbox-gateway-ca.crt"
+
+	// gatewayCAVolumeName is the corev1.Volume / corev1.VolumeMount name used
+	// to expose the gateway CA file inside the container.
+	gatewayCAVolumeName = "sandbox-gateway-ca"
+
+	// gatewayCAMountPath is the absolute file path inside the container at
+	// which the gateway CA certificate is exposed.
+	gatewayCAMountPath = "/etc/ssl/certs/agent-identity/gateway-ca.crt"
+)
+
+// init registers the community baseline CABundleSpec for the gateway CA.
+//
+// The baseline is intentionally minimal:
+//   - ContainerSelector defaults to OnlyMainContainer() — the gateway CA is
+//     mounted only into the agent workload container.
+//   - EnvVars defaults to a single SSL_CERT_FILE entry as a representative
+//     well-known trust hint; richer ecosystems (Node.js, Python requests,
+//     curl, ...) are out of scope for the community baseline.
+//   - EnabledFor is left nil so the identity package does not depend on
+//     runtime-gating logic. The controller startup code is expected to call
+//     BindCAEnabledFor(GatewayCABundleName, ...) to wire the runtime predicate.
+//
+// Enterprise builds replace this entire spec by calling RegisterCABundleSpec
+// with the same Name from an inner_*.go init() — see ca_cert_registry.go for
+// the override semantics.
+func init() {
+	RegisterCABundleSpec(CABundleSpec{
+		Name:              GatewayCABundleName,
+		SecretName:        GatewayCASecretName,
+		SecretDataKey:     GatewayCAKey,
+		VolumeName:        gatewayCAVolumeName,
+		MountPath:         gatewayCAMountPath,
+		SubPath:           GatewayCAKey,
+		ReadOnly:          true,
+		ContainerSelector: OnlyMainContainer(),
+		EnvVars: []corev1.EnvVar{
+			{Name: "SSL_CERT_FILE", Value: gatewayCAMountPath},
+		},
+		EnabledFor: nil, // bound at controller startup via BindCAEnabledFor
+	})
+}
+
+// CA bundle ensure/inject API. Behaviour is driven entirely by CABundleSpec
+// entries in the global registry, so adding a new bundle only requires a
+// new RegisterCABundleSpec call. The Secret RBAC marker lives next to
+// SandboxReconciler.Reconcile (the sole consumer).
+
+// EnsureAllCACerts ensures every enabled CABundleSpec has its Secret in
+// targetNamespace, copying from utils.DefaultSandboxDeployNamespace on demand.
+// The first spec failure aborts and is propagated; partial progress is left
+// in place since copies are idempotent. A missing source Secret is reported
+// as an error to block pod creation.
+func EnsureAllCACerts(ctx context.Context, cli client.Client, sbx *agentsv1alpha1.Sandbox, targetNamespace string) error {
+	specs := ListCABundleSpecs()
+	for i := range specs {
+		spec := specs[i]
+		if !specEnabled(&spec, sbx) {
+			klog.V(5).InfoS("CABundleSpec disabled by EnabledFor predicate, skipping ensure",
+				"name", spec.Name, "sandbox", klog.KObj(sbx))
+			continue
+		}
+		if err := ensureCACert(ctx, cli, &spec, targetNamespace); err != nil {
+			return fmt.Errorf("failed to ensure CA bundle %q: %w", spec.Name, err)
+		}
+	}
+	return nil
+}
+
+// InjectAllCAVolumes appends one corev1.Volume per enabled CABundleSpec to
+// pod.Spec.Volumes. Volumes whose Name already exists on the pod are skipped
+// to keep the operation idempotent.
+//
+// Volume is a pod-level resource, so this function does not consult
+// ContainerSelector — every selected spec yields exactly one Volume regardless
+// of how many containers will eventually mount it via InjectAllCAIntoContainers.
+func InjectAllCAVolumes(_ context.Context, sbx *agentsv1alpha1.Sandbox, pod *corev1.Pod) {
+	specs := ListCABundleSpecs()
+	for i := range specs {
+		spec := specs[i]
+		if !specEnabled(&spec, sbx) {
+			continue
+		}
+		if findVolumeByName(pod.Spec.Volumes, spec.VolumeName) {
+			klog.V(5).InfoS("CA volume already present on pod, skipping",
+				"name", spec.Name, "volume", spec.VolumeName, "pod", klog.KObj(pod))
+			continue
+		}
+		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+			Name: spec.VolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  spec.SecretName,
+					DefaultMode: ptrTo[int32](0644),
+				},
+			},
+		})
+	}
+}
+
+// InjectAllCAIntoContainers walks every enabled CABundleSpec and, for each
+// container that the spec's ContainerSelector matches, appends the spec's
+// VolumeMount and EnvVars to that container in a single pass.
+//
+// VolumeMount and EnvVar entries whose Name already exists on the container
+// are preserved untouched, keeping the operation idempotent and avoiding
+// clobbering operator-supplied overrides.
+//
+// VolumeMounts are always injected when the spec is enabled and the container
+// is selected; EnvVars are only injected when the spec declares any. The
+// container-level gating (specEnabled + ContainerSelector) is shared between
+// the two artefacts because both target the same set of containers, so a
+// single iteration keeps the selection logic in lock-step.
+func InjectAllCAIntoContainers(_ context.Context, sbx *agentsv1alpha1.Sandbox, pod *corev1.Pod) {
+	if len(pod.Spec.Containers) == 0 {
+		klog.V(5).InfoS("no containers in pod, skipping CA container injection",
+			"pod", klog.KObj(pod))
+		return
+	}
+	specs := ListCABundleSpecs()
+	for i := range specs {
+		spec := specs[i]
+		if !specEnabled(&spec, sbx) {
+			continue
+		}
+		selector := spec.ContainerSelector
+		if selector == nil {
+			selector = OnlyMainContainer()
+		}
+		for idx := range pod.Spec.Containers {
+			c := &pod.Spec.Containers[idx]
+			if !selector(c, idx) {
+				continue
+			}
+			injectCAVolumeMount(&spec, c)
+			injectCAEnvVars(&spec, c)
+		}
+	}
+}
+
+// injectCAVolumeMount appends spec's VolumeMount to the container, skipping
+// when an entry with the same Name already exists.
+func injectCAVolumeMount(spec *CABundleSpec, c *corev1.Container) {
+	if findVolumeMountByName(c.VolumeMounts, spec.VolumeName) {
+		klog.V(5).InfoS("CA volume mount already present on container, skipping",
+			"name", spec.Name, "container", c.Name, "volume", spec.VolumeName)
+		return
+	}
+	c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
+		Name:      spec.VolumeName,
+		MountPath: spec.MountPath,
+		SubPath:   spec.SubPath,
+		ReadOnly:  spec.ReadOnly,
+	})
+}
+
+// injectCAEnvVars appends spec's EnvVars to the container, skipping any whose
+// Name already exists. No-op when the spec declares no EnvVars.
+func injectCAEnvVars(spec *CABundleSpec, c *corev1.Container) {
+	for _, ev := range spec.EnvVars {
+		if findEnvVarByName(c.Env, ev.Name) {
+			klog.V(5).InfoS("CA env var already present on container, skipping",
+				"name", spec.Name, "container", c.Name, "env", ev.Name)
+			continue
+		}
+		c.Env = append(c.Env, ev)
+	}
+}
+
+// ensureCACert implements the per-spec ensure algorithm:
+// target ns hit -> noop; otherwise copy from system ns; missing in system ns -> error.
+func ensureCACert(ctx context.Context, cli client.Client, spec *CABundleSpec, targetNamespace string) error {
+	// Step 1: short-circuit when the target Secret already exists.
+	exists, err := secretExists(ctx, cli, targetNamespace, spec.SecretName)
+	if err != nil {
+		return err
+	}
+	if exists {
+		klog.V(5).InfoS("CA secret already exists in target namespace, skipping copy",
+			"name", spec.Name, "namespace", targetNamespace, "secret", spec.SecretName)
+		return nil
+	}
+
+	// Step 2: fetch the authoritative copy from the system namespace.
+	systemNamespace := utils.DefaultSandboxDeployNamespace
+	var src corev1.Secret
+	err = cli.Get(ctx, client.ObjectKey{Namespace: systemNamespace, Name: spec.SecretName}, &src)
+	if errors.IsNotFound(err) {
+		return fmt.Errorf("source CA secret %s/%s is missing; populate it before scheduling sandboxes",
+			systemNamespace, spec.SecretName)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read source CA secret %s/%s: %w",
+			systemNamespace, spec.SecretName, err)
+	}
+
+	// Step 3: copy into the target namespace. AlreadyExists races are tolerated.
+	dst := buildCopiedSecret(&src, targetNamespace)
+	if err := cli.Create(ctx, dst); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create CA secret %s/%s: %w",
+			targetNamespace, spec.SecretName, err)
+	}
+	klog.InfoS("CA secret replicated from system namespace",
+		"name", spec.Name,
+		"sourceNamespace", systemNamespace,
+		"targetNamespace", targetNamespace,
+		"secret", spec.SecretName)
+	return nil
+}
+
+// secretExists reports whether the named Secret exists in the namespace.
+func secretExists(ctx context.Context, cli client.Client, namespace, name string) (bool, error) {
+	var secret corev1.Secret
+	err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &secret)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check secret %s/%s: %w", namespace, name, err)
+	}
+	return true, nil
+}
+
+// buildCopiedSecret produces a target-namespace Secret by copying Type and Data
+// from the authoritative source. Source Labels are preserved as-is.
+// Annotations are intentionally not copied (they tend to carry source-specific
+// metadata such as last-applied-configuration). OwnerReferences are NOT set
+// because cross-namespace OwnerReferences are invalid in Kubernetes.
+func buildCopiedSecret(src *corev1.Secret, targetNamespace string) *corev1.Secret {
+	labels := make(map[string]string, len(src.Labels))
+	for k, v := range src.Labels {
+		labels[k] = v
+	}
+
+	data := make(map[string][]byte, len(src.Data))
+	for k, v := range src.Data {
+		cp := make([]byte, len(v))
+		copy(cp, v)
+		data[k] = cp
+	}
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      src.Name,
+			Namespace: targetNamespace,
+			Labels:    labels,
+		},
+		Type: src.Type,
+		Data: data,
+	}
+}
+
+// specEnabled returns true when the spec has no EnabledFor predicate, or when
+// the predicate accepts the given sandbox.
+func specEnabled(spec *CABundleSpec, sbx *agentsv1alpha1.Sandbox) bool {
+	if spec.EnabledFor == nil {
+		return true
+	}
+	return spec.EnabledFor(sbx)
+}
+
+// findVolumeByName reports whether a Volume with the given name already exists.
+func findVolumeByName(volumes []corev1.Volume, name string) bool {
+	for i := range volumes {
+		if volumes[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// findVolumeMountByName reports whether a VolumeMount with the given name
+// already exists.
+func findVolumeMountByName(volumeMounts []corev1.VolumeMount, name string) bool {
+	for i := range volumeMounts {
+		if volumeMounts[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// findEnvVarByName reports whether an EnvVar with the given name already
+// exists. Used to keep CA env-var injection idempotent and to avoid clobbering
+// operator-supplied overrides.
+func findEnvVarByName(envs []corev1.EnvVar, name string) bool {
+	for i := range envs {
+		if envs[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func ptrTo[T any](v T) *T {
+	return &v
+}

--- a/pkg/identity/ca_cert_injector_test.go
+++ b/pkg/identity/ca_cert_injector_test.go
@@ -1,0 +1,948 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/utils"
+)
+
+func init() {
+	utilruntime.Must(agentsv1alpha1.AddToScheme(scheme.Scheme))
+}
+
+const (
+	testTargetNS = "user-ns"
+	testCAName   = "test-ca"
+	testSecret   = "test-ca-secret"
+	testDataKey  = "ca.crt"
+	testVolume   = "test-ca-vol"
+	testMount    = "/etc/ssl/certs/test-ca.crt"
+)
+
+// withTestSpec swaps the registry with a single deterministic spec for the
+// duration of one test, restoring whatever was registered before on cleanup.
+func withTestSpec(t *testing.T, spec CABundleSpec) {
+	t.Helper()
+	prev := ListCABundleSpecs()
+	resetCABundleRegistryForTest()
+	RegisterCABundleSpec(spec)
+	t.Cleanup(func() {
+		resetCABundleRegistryForTest()
+		for i := range prev {
+			RegisterCABundleSpec(prev[i])
+		}
+	})
+}
+
+func newTestSpec() CABundleSpec {
+	return CABundleSpec{
+		Name:              testCAName,
+		SecretName:        testSecret,
+		SecretDataKey:     testDataKey,
+		VolumeName:        testVolume,
+		MountPath:         testMount,
+		SubPath:           testDataKey,
+		ReadOnly:          true,
+		ContainerSelector: OnlyMainContainer(),
+	}
+}
+
+func newSandbox() *agentsv1alpha1.Sandbox {
+	return &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sbx-1", Namespace: testTargetNS},
+	}
+}
+
+// --- registry tests --------------------------------------------------------
+
+func TestRegisterCABundleSpec_Dedupe(t *testing.T) {
+	prev := ListCABundleSpecs()
+	resetCABundleRegistryForTest()
+	t.Cleanup(func() {
+		resetCABundleRegistryForTest()
+		for i := range prev {
+			RegisterCABundleSpec(prev[i])
+		}
+	})
+
+	RegisterCABundleSpec(CABundleSpec{Name: "a", SecretName: "old"})
+	RegisterCABundleSpec(CABundleSpec{Name: "b", SecretName: "b"})
+	RegisterCABundleSpec(CABundleSpec{Name: "a", SecretName: "new"})
+
+	specs := ListCABundleSpecs()
+	if len(specs) != 2 {
+		t.Fatalf("duplicate Name should overwrite, not append: got %d specs, want 2", len(specs))
+	}
+
+	byName := map[string]string{}
+	for _, s := range specs {
+		byName[s.Name] = s.SecretName
+	}
+	if byName["a"] != "new" {
+		t.Errorf("spec %q SecretName: got %q, want %q", "a", byName["a"], "new")
+	}
+	if byName["b"] != "b" {
+		t.Errorf("spec %q SecretName: got %q, want %q", "b", byName["b"], "b")
+	}
+}
+
+func TestBindCAEnabledFor(t *testing.T) {
+	prev := ListCABundleSpecs()
+	resetCABundleRegistryForTest()
+	t.Cleanup(func() {
+		resetCABundleRegistryForTest()
+		for i := range prev {
+			RegisterCABundleSpec(prev[i])
+		}
+	})
+
+	RegisterCABundleSpec(CABundleSpec{Name: "a"})
+	called := false
+	BindCAEnabledFor("a", func(_ *agentsv1alpha1.Sandbox) bool {
+		called = true
+		return true
+	})
+
+	specs := ListCABundleSpecs()
+	if len(specs) != 1 {
+		t.Fatalf("expected exactly 1 spec, got %d", len(specs))
+	}
+	if specs[0].EnabledFor == nil {
+		t.Fatalf("expected EnabledFor to be bound, got nil")
+	}
+	specs[0].EnabledFor(nil)
+	if !called {
+		t.Errorf("bound EnabledFor predicate was not invoked")
+	}
+
+	// no-op when name does not exist; should not panic.
+	BindCAEnabledFor("missing", func(_ *agentsv1alpha1.Sandbox) bool { return true })
+}
+
+// --- selector tests --------------------------------------------------------
+
+func TestContainerSelectors(t *testing.T) {
+	c0 := &corev1.Container{Name: "main"}
+	c1 := &corev1.Container{Name: "sidecar"}
+
+	t.Run("OnlyMainContainer matches index 0", func(t *testing.T) {
+		sel := OnlyMainContainer()
+		if !sel(c0, 0) {
+			t.Errorf("OnlyMainContainer should match index 0")
+		}
+		if sel(c1, 1) {
+			t.Errorf("OnlyMainContainer must not match index 1")
+		}
+		// Calling again must still report index-0 as the main container,
+		// proving the selector is stateless across invocations.
+		if !sel(c0, 0) {
+			t.Errorf("OnlyMainContainer must remain stateless across invocations")
+		}
+	})
+
+	t.Run("ByContainerName matches by name", func(t *testing.T) {
+		sel := ByContainerName("sidecar")
+		if sel(c0, 0) {
+			t.Errorf("ByContainerName(%q) must not match container %q", "sidecar", c0.Name)
+		}
+		if !sel(c1, 1) {
+			t.Errorf("ByContainerName(%q) should match container %q", "sidecar", c1.Name)
+		}
+	})
+
+	t.Run("MainContainerOrByName matches main and named sidecars", func(t *testing.T) {
+		sel := MainContainerOrByName("sidecar")
+		// Main container always matches regardless of its Name.
+		if !sel(c0, 0) {
+			t.Errorf("MainContainerOrByName should match main container at index 0")
+		}
+		// Named sidecar matches via the allow-list.
+		if !sel(c1, 1) {
+			t.Errorf("MainContainerOrByName should match allow-listed sidecar")
+		}
+		// Unrelated sidecar at non-zero index must not match.
+		if sel(&corev1.Container{Name: "metrics"}, 2) {
+			t.Errorf("MainContainerOrByName must not match unrelated sidecar")
+		}
+	})
+
+	t.Run("MainContainerOrByName with empty allow-list degenerates to main only", func(t *testing.T) {
+		sel := MainContainerOrByName()
+		if !sel(c0, 0) {
+			t.Errorf("MainContainerOrByName() should still match main container")
+		}
+		if sel(c1, 1) {
+			t.Errorf("MainContainerOrByName() must not match non-main containers")
+		}
+	})
+
+	t.Run("AllContainers matches every container", func(t *testing.T) {
+		sel := AllContainers()
+		if !sel(c0, 0) {
+			t.Errorf("AllContainers should match index 0")
+		}
+		if !sel(c1, 1) {
+			t.Errorf("AllContainers should match index 1")
+		}
+	})
+}
+
+// --- EnsureAllCACerts tests -----------------------------------------------
+
+func TestCACertInjector_EnsureAllCACerts(t *testing.T) {
+	systemNS := utils.DefaultSandboxDeployNamespace
+	srcSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            testSecret,
+			Namespace:       systemNS,
+			Labels:          map[string]string{"foo": "bar"},
+			ResourceVersion: "42",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{testDataKey: []byte("PEM-CA")},
+	}
+
+	tests := []struct {
+		name        string
+		seed        []client.Object
+		spec        CABundleSpec
+		sandbox     *agentsv1alpha1.Sandbox
+		getError    error
+		expectError string
+		check       func(t *testing.T, cli client.Client)
+	}{
+		{
+			name: "target namespace already has secret - skip copy",
+			seed: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: testSecret, Namespace: testTargetNS},
+					Data:       map[string][]byte{testDataKey: []byte("local")},
+				},
+				srcSecret,
+			},
+			spec:    newTestSpec(),
+			sandbox: newSandbox(),
+			check: func(t *testing.T, cli client.Client) {
+				var got corev1.Secret
+				if err := cli.Get(context.Background(),
+					client.ObjectKey{Namespace: testTargetNS, Name: testSecret}, &got); err != nil {
+					t.Fatalf("get target secret: %v", err)
+				}
+				// Pre-existing local copy must be preserved untouched.
+				if !reflect.DeepEqual(got.Data[testDataKey], []byte("local")) {
+					t.Errorf("target secret data: got %q, want %q", got.Data[testDataKey], "local")
+				}
+			},
+		},
+		{
+			name:    "target missing - copy from system namespace",
+			seed:    []client.Object{srcSecret},
+			spec:    newTestSpec(),
+			sandbox: newSandbox(),
+			check: func(t *testing.T, cli client.Client) {
+				var got corev1.Secret
+				if err := cli.Get(context.Background(),
+					client.ObjectKey{Namespace: testTargetNS, Name: testSecret}, &got); err != nil {
+					t.Fatalf("get copied secret: %v", err)
+				}
+				if !reflect.DeepEqual(got.Data[testDataKey], []byte("PEM-CA")) {
+					t.Errorf("copied data: got %q, want %q", got.Data[testDataKey], "PEM-CA")
+				}
+				if got.Type != corev1.SecretTypeOpaque {
+					t.Errorf("copied type: got %q, want %q", got.Type, corev1.SecretTypeOpaque)
+				}
+				if got.Labels["foo"] != "bar" {
+					t.Errorf("source labels should be preserved, got %q", got.Labels["foo"])
+				}
+				if len(got.OwnerReferences) != 0 {
+					t.Errorf("cross-namespace owner refs are forbidden, got %d entries", len(got.OwnerReferences))
+				}
+			},
+		},
+		{
+			name:        "source missing in system namespace - block with error",
+			seed:        []client.Object{},
+			spec:        newTestSpec(),
+			sandbox:     newSandbox(),
+			expectError: "source CA secret",
+		},
+		{
+			name: "EnabledFor returns false - skip entirely",
+			seed: []client.Object{}, // even with no source secret it must not error
+			spec: func() CABundleSpec {
+				s := newTestSpec()
+				s.EnabledFor = func(_ *agentsv1alpha1.Sandbox) bool { return false }
+				return s
+			}(),
+			sandbox: newSandbox(),
+			check: func(t *testing.T, cli client.Client) {
+				var got corev1.Secret
+				err := cli.Get(context.Background(),
+					client.ObjectKey{Namespace: testTargetNS, Name: testSecret}, &got)
+				if !apierrors.IsNotFound(err) {
+					t.Errorf("no secret should be created when EnabledFor=false, got err=%v", err)
+				}
+			},
+		},
+		{
+			name:        "transient API error reading source - propagate",
+			seed:        []client.Object{srcSecret},
+			spec:        newTestSpec(),
+			sandbox:     newSandbox(),
+			getError:    errors.New("api boom"),
+			expectError: "api boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestSpec(t, tt.spec)
+
+			builder := fake.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(tt.seed...)
+			if tt.getError != nil {
+				wantErr := tt.getError
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						// Only fail when reading the source Secret in the system namespace.
+						if key.Namespace == utils.DefaultSandboxDeployNamespace && key.Name == testSecret {
+							if _, ok := obj.(*corev1.Secret); ok {
+								return wantErr
+							}
+						}
+						return c.Get(ctx, key, obj, opts...)
+					},
+				})
+			}
+			cli := builder.Build()
+
+			err := EnsureAllCACerts(context.Background(), cli, tt.sandbox, testTargetNS)
+
+			if tt.expectError != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.expectError)
+				}
+				if !strings.Contains(err.Error(), tt.expectError) {
+					t.Fatalf("expected error containing %q, got %q", tt.expectError, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("EnsureAllCACerts unexpected error: %v", err)
+			}
+			if tt.check != nil {
+				tt.check(t, cli)
+			}
+		})
+	}
+}
+
+func TestCACertInjector_EnsureAllCACerts_AlreadyExistsTolerated(t *testing.T) {
+	systemNS := utils.DefaultSandboxDeployNamespace
+	withTestSpec(t, newTestSpec())
+
+	src := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: testSecret, Namespace: systemNS},
+		Data:       map[string][]byte{testDataKey: []byte("PEM")},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(src).
+		WithInterceptorFuncs(interceptor.Funcs{
+			// Simulate a concurrent creator winning the race in target ns.
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if s, ok := obj.(*corev1.Secret); ok && s.Namespace == testTargetNS && s.Name == testSecret {
+					return apierrors.NewAlreadyExists(schema.GroupResource{Resource: "secrets"}, testSecret)
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	injectorErr := EnsureAllCACerts(context.Background(), cli, newSandbox(), testTargetNS)
+	if injectorErr != nil {
+		t.Fatalf("AlreadyExists must be tolerated as a benign race, got error: %v", injectorErr)
+	}
+}
+
+// --- InjectAllCAVolumes / InjectAllCAIntoContainers tests ------------------
+
+func TestCACertInjector_InjectAllCAVolumes(t *testing.T) {
+	tests := []struct {
+		name        string
+		spec        CABundleSpec
+		initial     []corev1.Volume
+		sandbox     *agentsv1alpha1.Sandbox
+		expectNames []string
+	}{
+		{
+			name:        "inject into empty volumes",
+			spec:        newTestSpec(),
+			sandbox:     newSandbox(),
+			expectNames: []string{testVolume},
+		},
+		{
+			name: "preserve existing volumes and append once",
+			spec: newTestSpec(),
+			initial: []corev1.Volume{
+				{Name: "data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			},
+			sandbox:     newSandbox(),
+			expectNames: []string{"data", testVolume},
+		},
+		{
+			name: "skip when volume name already present",
+			spec: newTestSpec(),
+			initial: []corev1.Volume{
+				{Name: testVolume, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			},
+			sandbox:     newSandbox(),
+			expectNames: []string{testVolume},
+		},
+		{
+			name: "EnabledFor false - no injection",
+			spec: func() CABundleSpec {
+				s := newTestSpec()
+				s.EnabledFor = func(_ *agentsv1alpha1.Sandbox) bool { return false }
+				return s
+			}(),
+			sandbox:     newSandbox(),
+			expectNames: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestSpec(t, tt.spec)
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: testTargetNS},
+				Spec:       corev1.PodSpec{Volumes: tt.initial},
+			}
+			InjectAllCAVolumes(context.Background(), tt.sandbox, pod)
+
+			gotNames := make([]string, 0, len(pod.Spec.Volumes))
+			for _, v := range pod.Spec.Volumes {
+				gotNames = append(gotNames, v.Name)
+			}
+			if tt.expectNames == nil {
+				if len(gotNames) != 0 {
+					t.Errorf("expected no volumes, got %v", gotNames)
+				}
+			} else if !reflect.DeepEqual(gotNames, tt.expectNames) {
+				t.Errorf("volume names: got %v, want %v", gotNames, tt.expectNames)
+			}
+		})
+	}
+}
+
+// TestCACertInjector_InjectAllCAIntoContainers_Mounts validates the mount
+// half of the merged container-level injection: VolumeMount placement is
+// driven by specEnabled + ContainerSelector, with idempotent skip when a
+// mount with the same Name is already present.
+func TestCACertInjector_InjectAllCAIntoContainers_Mounts(t *testing.T) {
+	tests := []struct {
+		name             string
+		spec             CABundleSpec
+		containers       []corev1.Container
+		sandbox          *agentsv1alpha1.Sandbox
+		expectMountsByIx map[int][]string
+	}{
+		{
+			name:       "OnlyMainContainer mounts only on first container",
+			spec:       newTestSpec(),
+			containers: []corev1.Container{{Name: "main"}, {Name: "sidecar"}},
+			sandbox:    newSandbox(),
+			expectMountsByIx: map[int][]string{
+				0: {testVolume},
+				1: nil,
+			},
+		},
+		{
+			name: "AllContainers mounts on every container",
+			spec: func() CABundleSpec {
+				s := newTestSpec()
+				s.ContainerSelector = AllContainers()
+				return s
+			}(),
+			containers: []corev1.Container{{Name: "main"}, {Name: "sidecar"}},
+			sandbox:    newSandbox(),
+			expectMountsByIx: map[int][]string{
+				0: {testVolume},
+				1: {testVolume},
+			},
+		},
+		{
+			name: "ByContainerName targets specific container",
+			spec: func() CABundleSpec {
+				s := newTestSpec()
+				s.ContainerSelector = ByContainerName("sidecar")
+				return s
+			}(),
+			containers: []corev1.Container{{Name: "main"}, {Name: "sidecar"}},
+			sandbox:    newSandbox(),
+			expectMountsByIx: map[int][]string{
+				0: nil,
+				1: {testVolume},
+			},
+		},
+		{
+			name: "skip container whose mount name already exists",
+			spec: newTestSpec(),
+			containers: []corev1.Container{
+				{
+					Name: "main",
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: testVolume, MountPath: "/old"},
+					},
+				},
+			},
+			sandbox: newSandbox(),
+			expectMountsByIx: map[int][]string{
+				0: {testVolume},
+			},
+		},
+		{
+			name: "EnabledFor false - no mounts at all",
+			spec: func() CABundleSpec {
+				s := newTestSpec()
+				s.EnabledFor = func(_ *agentsv1alpha1.Sandbox) bool { return false }
+				return s
+			}(),
+			containers: []corev1.Container{{Name: "main"}},
+			sandbox:    newSandbox(),
+			expectMountsByIx: map[int][]string{
+				0: nil,
+			},
+		},
+		{
+			name:             "no containers - graceful skip",
+			spec:             newTestSpec(),
+			containers:       nil,
+			sandbox:          newSandbox(),
+			expectMountsByIx: map[int][]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestSpec(t, tt.spec)
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: testTargetNS},
+				Spec:       corev1.PodSpec{Containers: tt.containers},
+			}
+			InjectAllCAIntoContainers(context.Background(), tt.sandbox, pod)
+
+			for idx, want := range tt.expectMountsByIx {
+				gotNames := make([]string, 0)
+				if idx < len(pod.Spec.Containers) {
+					for _, vm := range pod.Spec.Containers[idx].VolumeMounts {
+						gotNames = append(gotNames, vm.Name)
+					}
+				}
+				if want == nil {
+					if len(gotNames) != 0 {
+						t.Errorf("container[%d] should have no mounts, got %v", idx, gotNames)
+					}
+				} else if !reflect.DeepEqual(gotNames, want) {
+					t.Errorf("container[%d] mounts mismatch: got %v, want %v", idx, gotNames, want)
+				}
+			}
+		})
+	}
+}
+
+// --- InjectAllCAIntoContainers env-var coverage ----------------------------
+
+// TestCACertInjector_InjectAllCAIntoContainers_EnvVars validates the env-var
+// half of the merged container-level injection: EnvVars are appended only to
+// containers that the selector matches, are skipped when the spec declares
+// none, and operator-supplied entries are preserved across repeated calls.
+func TestCACertInjector_InjectAllCAIntoContainers_EnvVars(t *testing.T) {
+	envFile := corev1.EnvVar{Name: "SSL_CERT_FILE", Value: testMount}
+	envExtra := corev1.EnvVar{Name: "REQUESTS_CA_BUNDLE", Value: testMount}
+
+	tests := []struct {
+		name          string
+		spec          CABundleSpec
+		containers    []corev1.Container
+		sandbox       *agentsv1alpha1.Sandbox
+		expectEnvByIx map[int][]string // container index -> ordered env-var names
+	}{
+		{
+			name: "no EnvVars on spec - skip injection",
+			spec: func() CABundleSpec {
+				s := newTestSpec()
+				s.EnvVars = nil
+				return s
+			}(),
+			containers: []corev1.Container{{Name: "main"}, {Name: "sidecar"}},
+			sandbox:    newSandbox(),
+			expectEnvByIx: map[int][]string{
+				0: nil,
+				1: nil,
+			},
+		},
+		{
+			name: "OnlyMainContainer injects on first container only",
+			spec: func() CABundleSpec {
+				s := newTestSpec()
+				s.EnvVars = []corev1.EnvVar{envFile, envExtra}
+				return s
+			}(),
+			containers: []corev1.Container{{Name: "main"}, {Name: "sidecar"}},
+			sandbox:    newSandbox(),
+			expectEnvByIx: map[int][]string{
+				0: {"SSL_CERT_FILE", "REQUESTS_CA_BUNDLE"},
+				1: nil,
+			},
+		},
+		{
+			name: "MainContainerOrByName injects on main and named sidecar",
+			spec: func() CABundleSpec {
+				s := newTestSpec()
+				s.ContainerSelector = MainContainerOrByName("sidecar")
+				s.EnvVars = []corev1.EnvVar{envFile}
+				return s
+			}(),
+			containers: []corev1.Container{{Name: "main"}, {Name: "sidecar"}, {Name: "metrics"}},
+			sandbox:    newSandbox(),
+			expectEnvByIx: map[int][]string{
+				0: {"SSL_CERT_FILE"},
+				1: {"SSL_CERT_FILE"},
+				2: nil,
+			},
+		},
+		{
+			name: "operator-supplied env name is preserved (idempotent)",
+			spec: func() CABundleSpec {
+				s := newTestSpec()
+				s.EnvVars = []corev1.EnvVar{envFile, envExtra}
+				return s
+			}(),
+			containers: []corev1.Container{{
+				Name: "main",
+				Env: []corev1.EnvVar{
+					{Name: "SSL_CERT_FILE", Value: "/operator/own.crt"},
+				},
+			}},
+			sandbox: newSandbox(),
+			// Existing SSL_CERT_FILE keeps the operator value (still appears
+			// first in the slice); REQUESTS_CA_BUNDLE is appended.
+			expectEnvByIx: map[int][]string{
+				0: {"SSL_CERT_FILE", "REQUESTS_CA_BUNDLE"},
+			},
+		},
+		{
+			name: "EnabledFor false - no env injection",
+			spec: func() CABundleSpec {
+				s := newTestSpec()
+				s.EnvVars = []corev1.EnvVar{envFile}
+				s.EnabledFor = func(_ *agentsv1alpha1.Sandbox) bool { return false }
+				return s
+			}(),
+			containers: []corev1.Container{{Name: "main"}},
+			sandbox:    newSandbox(),
+			expectEnvByIx: map[int][]string{
+				0: nil,
+			},
+		},
+		{
+			name:          "no containers - graceful skip",
+			spec:          newTestSpec(),
+			containers:    nil,
+			sandbox:       newSandbox(),
+			expectEnvByIx: map[int][]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestSpec(t, tt.spec)
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: testTargetNS},
+				Spec:       corev1.PodSpec{Containers: tt.containers},
+			}
+			InjectAllCAIntoContainers(context.Background(), tt.sandbox, pod)
+
+			for idx, want := range tt.expectEnvByIx {
+				gotNames := make([]string, 0)
+				if idx < len(pod.Spec.Containers) {
+					for _, ev := range pod.Spec.Containers[idx].Env {
+						gotNames = append(gotNames, ev.Name)
+					}
+				}
+				if want == nil {
+					if len(gotNames) != 0 {
+						t.Errorf("container[%d] should have no env vars, got %v", idx, gotNames)
+					}
+				} else if !reflect.DeepEqual(gotNames, want) {
+					t.Errorf("container[%d] env vars mismatch: got %v, want %v", idx, gotNames, want)
+				}
+			}
+
+			// Idempotence: a second invocation must not duplicate env vars.
+			InjectAllCAIntoContainers(context.Background(), tt.sandbox, pod)
+			for idx, want := range tt.expectEnvByIx {
+				if idx >= len(pod.Spec.Containers) {
+					continue
+				}
+				gotNames := make([]string, 0)
+				for _, ev := range pod.Spec.Containers[idx].Env {
+					gotNames = append(gotNames, ev.Name)
+				}
+				if want == nil {
+					if len(gotNames) != 0 {
+						t.Errorf("container[%d] should remain empty after re-injection, got %v", idx, gotNames)
+					}
+				} else if !reflect.DeepEqual(gotNames, want) {
+					t.Errorf("container[%d] env vars must not duplicate after re-injection: got %v, want %v", idx, gotNames, want)
+				}
+			}
+		})
+	}
+}
+
+// --- buildCopiedSecret unit test -------------------------------------------
+
+func TestBuildCopiedSecret(t *testing.T) {
+	src := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "src",
+			Namespace:       "src-ns",
+			Labels:          map[string]string{"k": "v"},
+			Annotations:     map[string]string{"ignored": "yes"},
+			ResourceVersion: "7",
+			OwnerReferences: []metav1.OwnerReference{{Name: "owner"}},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{"a": []byte("b")},
+	}
+
+	dst := buildCopiedSecret(src, "dst-ns")
+
+	if dst.Name != "src" {
+		t.Errorf("dst.Name: got %q, want %q", dst.Name, "src")
+	}
+	if dst.Namespace != "dst-ns" {
+		t.Errorf("dst.Namespace: got %q, want %q", dst.Namespace, "dst-ns")
+	}
+	if dst.Type != corev1.SecretTypeOpaque {
+		t.Errorf("dst.Type: got %q, want %q", dst.Type, corev1.SecretTypeOpaque)
+	}
+	if !reflect.DeepEqual(dst.Data["a"], []byte("b")) {
+		t.Errorf("dst.Data[a]: got %q, want %q", dst.Data["a"], []byte("b"))
+	}
+	if dst.Labels["k"] != "v" {
+		t.Errorf("dst.Labels[k]: got %q, want %q", dst.Labels["k"], "v")
+	}
+	if len(dst.Annotations) != 0 {
+		t.Errorf("annotations must not be copied, got %v", dst.Annotations)
+	}
+	if len(dst.OwnerReferences) != 0 {
+		t.Errorf("owner references must not be carried across namespaces, got %d entries", len(dst.OwnerReferences))
+	}
+
+	// Mutating dst.Data must not affect src.
+	dst.Data["a"][0] = 'X'
+	if src.Data["a"][0] != 'b' {
+		t.Errorf("src.Data[a][0] should remain 'b', got %q", src.Data["a"][0])
+	}
+}
+
+// --- baseline / field-precision tests --------------------------------------
+
+// TestGatewayBaselineSpec pins down the community baseline registered by
+// init(). It is the contract that enterprise inner_*.go overrides and
+// historical deployments rely on: any drift in Name / SecretName / SubPath /
+// MountPath / ReadOnly / ContainerSelector / EnvVars / EnabledFor breaks
+// either upgrade compatibility or the inner override convention.
+func TestGatewayBaselineSpec(t *testing.T) {
+	prev := ListCABundleSpecs()
+	// Defensively restore on exit even though we do not mutate the registry,
+	// so a failed assertion below never leaves orphan state for sibling tests.
+	t.Cleanup(func() {
+		resetCABundleRegistryForTest()
+		for i := range prev {
+			RegisterCABundleSpec(prev[i])
+		}
+	})
+
+	var gateway *CABundleSpec
+	for i := range prev {
+		if prev[i].Name == GatewayCABundleName {
+			gateway = &prev[i]
+			break
+		}
+	}
+	if gateway == nil {
+		t.Fatalf("init() must register the gateway baseline spec under name %q", GatewayCABundleName)
+	}
+
+	if gateway.SecretName != GatewayCASecretName {
+		t.Errorf("SecretName: got %q, want %q", gateway.SecretName, GatewayCASecretName)
+	}
+	if gateway.SecretDataKey != GatewayCAKey {
+		t.Errorf("SecretDataKey: got %q, want %q", gateway.SecretDataKey, GatewayCAKey)
+	}
+	if gateway.VolumeName != gatewayCAVolumeName {
+		t.Errorf("VolumeName: got %q, want %q", gateway.VolumeName, gatewayCAVolumeName)
+	}
+	if gateway.MountPath != gatewayCAMountPath {
+		t.Errorf("MountPath: got %q, want %q", gateway.MountPath, gatewayCAMountPath)
+	}
+	if gateway.SubPath != GatewayCAKey {
+		t.Errorf("SubPath: got %q, want %q", gateway.SubPath, GatewayCAKey)
+	}
+	if !gateway.ReadOnly {
+		t.Errorf("ReadOnly: got false, want true (gateway CA must never be writable from the workload)")
+	}
+
+	// EnabledFor must remain nil in the community baseline. Controller startup
+	// is the sole place allowed to bind the runtime predicate via
+	// BindCAEnabledFor; binding it here would couple identity/ to controller-
+	// only feature gates.
+	if gateway.EnabledFor != nil {
+		t.Errorf("EnabledFor: got non-nil, want nil (must be bound at controller startup, not in init)")
+	}
+
+	// ContainerSelector must behave as OnlyMainContainer(): match index 0,
+	// reject every other index. We compare behaviourally because function
+	// values are not comparable in Go.
+	if gateway.ContainerSelector == nil {
+		t.Fatalf("ContainerSelector: got nil, want OnlyMainContainer()")
+	}
+	main := &corev1.Container{Name: "main"}
+	side := &corev1.Container{Name: "sidecar"}
+	if !gateway.ContainerSelector(main, 0) {
+		t.Errorf("ContainerSelector must match main container at index 0")
+	}
+	if gateway.ContainerSelector(side, 1) {
+		t.Errorf("ContainerSelector must not match index 1 (baseline is OnlyMainContainer)")
+	}
+
+	// EnvVars: exactly one SSL_CERT_FILE entry pointing at the mount path.
+	// The well-known hint is what makes the gateway CA discoverable to
+	// libraries that honour SSL_CERT_FILE; richer ecosystem env vars are
+	// out of scope for the community baseline.
+	wantEnv := []corev1.EnvVar{{Name: "SSL_CERT_FILE", Value: gatewayCAMountPath}}
+	if !reflect.DeepEqual(gateway.EnvVars, wantEnv) {
+		t.Errorf("EnvVars: got %+v, want %+v", gateway.EnvVars, wantEnv)
+	}
+}
+
+// TestCACertInjector_InjectAllCAVolumes_Fields asserts that every field of
+// the appended Volume is sourced from the spec, not just its Name. A
+// regression on SecretName would mount the wrong CA; a regression on
+// DefaultMode would change the file permission bits and silently break
+// non-root workloads that read the bundle.
+func TestCACertInjector_InjectAllCAVolumes_Fields(t *testing.T) {
+	withTestSpec(t, newTestSpec())
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: testTargetNS},
+	}
+	InjectAllCAVolumes(context.Background(), newSandbox(), pod)
+
+	if len(pod.Spec.Volumes) != 1 {
+		t.Fatalf("expected exactly 1 volume, got %d", len(pod.Spec.Volumes))
+	}
+	v := pod.Spec.Volumes[0]
+	if v.Name != testVolume {
+		t.Errorf("Volume.Name: got %q, want %q", v.Name, testVolume)
+	}
+	if v.VolumeSource.Secret == nil {
+		t.Fatalf("Volume.VolumeSource.Secret: got nil, want SecretVolumeSource")
+	}
+	if v.VolumeSource.Secret.SecretName != testSecret {
+		t.Errorf("Volume.VolumeSource.Secret.SecretName: got %q, want %q",
+			v.VolumeSource.Secret.SecretName, testSecret)
+	}
+	if v.VolumeSource.Secret.DefaultMode == nil {
+		t.Fatalf("Volume.VolumeSource.Secret.DefaultMode: got nil, want *int32(0644)")
+	}
+	if *v.VolumeSource.Secret.DefaultMode != 0644 {
+		t.Errorf("Volume.VolumeSource.Secret.DefaultMode: got %#o, want %#o",
+			*v.VolumeSource.Secret.DefaultMode, 0644)
+	}
+}
+
+// TestCACertInjector_InjectAllCAIntoContainers_Fields asserts that every
+// VolumeMount and EnvVar field appended to the matched container is sourced
+// from the spec. The Mounts/EnvVars table tests above only verify Name; this
+// closes the gap so that drift on MountPath / SubPath / ReadOnly / EnvVar
+// values cannot slip through unnoticed.
+func TestCACertInjector_InjectAllCAIntoContainers_Fields(t *testing.T) {
+	spec := newTestSpec()
+	spec.EnvVars = []corev1.EnvVar{{Name: "SSL_CERT_FILE", Value: testMount}}
+	withTestSpec(t, spec)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: testTargetNS},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main"}},
+		},
+	}
+	InjectAllCAIntoContainers(context.Background(), newSandbox(), pod)
+
+	if len(pod.Spec.Containers) != 1 {
+		t.Fatalf("expected exactly 1 container, got %d", len(pod.Spec.Containers))
+	}
+	c := pod.Spec.Containers[0]
+
+	if len(c.VolumeMounts) != 1 {
+		t.Fatalf("expected exactly 1 volume mount, got %d", len(c.VolumeMounts))
+	}
+	vm := c.VolumeMounts[0]
+	wantVM := corev1.VolumeMount{
+		Name:      testVolume,
+		MountPath: testMount,
+		SubPath:   testDataKey,
+		ReadOnly:  true,
+	}
+	if !reflect.DeepEqual(vm, wantVM) {
+		t.Errorf("VolumeMount: got %+v, want %+v", vm, wantVM)
+	}
+
+	if len(c.Env) != 1 {
+		t.Fatalf("expected exactly 1 env var, got %d", len(c.Env))
+	}
+	wantEnv := corev1.EnvVar{Name: "SSL_CERT_FILE", Value: testMount}
+	if !reflect.DeepEqual(c.Env[0], wantEnv) {
+		t.Errorf("EnvVar: got %+v, want %+v", c.Env[0], wantEnv)
+	}
+}

--- a/pkg/identity/ca_cert_registry.go
+++ b/pkg/identity/ca_cert_registry.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+// caBundleRegistry stores all registered CABundleSpec entries.
+//
+// Community baseline registers the gateway CA spec via init() in ca_cert_injector.go.
+// Enterprise deployments may register additional specs via init() in inner_*.go files.
+//
+// All accesses MUST go through the package-level functions below to ensure
+// thread-safety. Direct access is intentionally not exposed.
+var caBundleRegistry = struct {
+	sync.RWMutex
+	specs []CABundleSpec
+}{}
+
+// RegisterCABundleSpec registers a CABundleSpec into the global registry.
+// If a spec with the same Name already exists, the previous entry is replaced
+// in-place and an info-level message is logged so the override is observable
+// in startup logs. This is the primary extension point for enterprise builds:
+// the inner package re-registers the gateway spec with the same Name to swap
+// in its own ContainerSelector / EnvVars / Secret references in one shot,
+// without touching community code.
+func RegisterCABundleSpec(spec CABundleSpec) {
+	caBundleRegistry.Lock()
+	defer caBundleRegistry.Unlock()
+
+	for i := range caBundleRegistry.specs {
+		if caBundleRegistry.specs[i].Name == spec.Name {
+			klog.InfoS("CABundleSpec overridden",
+				"name", spec.Name,
+				"oldSecretName", caBundleRegistry.specs[i].SecretName,
+				"newSecretName", spec.SecretName)
+			caBundleRegistry.specs[i] = spec
+			return
+		}
+	}
+	caBundleRegistry.specs = append(caBundleRegistry.specs, spec)
+}
+
+// ListCABundleSpecs returns a snapshot of all registered CABundleSpec entries.
+// The returned slice is a copy; callers may iterate freely without holding any lock.
+func ListCABundleSpecs() []CABundleSpec {
+	caBundleRegistry.RLock()
+	defer caBundleRegistry.RUnlock()
+
+	out := make([]CABundleSpec, len(caBundleRegistry.specs))
+	copy(out, caBundleRegistry.specs)
+	return out
+}
+
+// BindCAEnabledFor sets the EnabledFor predicate of the CABundleSpec identified
+// by name. It is intended to be called once during controller startup to inject
+// runtime-specific gating logic (e.g. sidecarutils.IsRuntimeEnabled) without
+// introducing a reverse dependency from the identity package.
+//
+// If no spec with the given name is registered, this call is a no-op and an
+// info-level message is logged so that misconfigurations are visible.
+func BindCAEnabledFor(name string, fn SandboxPredicate) {
+	caBundleRegistry.Lock()
+	defer caBundleRegistry.Unlock()
+
+	for i := range caBundleRegistry.specs {
+		if caBundleRegistry.specs[i].Name == name {
+			caBundleRegistry.specs[i].EnabledFor = fn
+			klog.V(5).InfoS("CABundleSpec EnabledFor bound", "name", name)
+			return
+		}
+	}
+	klog.InfoS("BindCAEnabledFor: no CABundleSpec found with the given name; binding skipped",
+		"name", name)
+}
+
+// resetCABundleRegistryForTest clears all registered specs. It is intended
+// solely for unit tests to provide a clean baseline. Production code MUST NOT
+// call this function.
+func resetCABundleRegistryForTest() {
+	caBundleRegistry.Lock()
+	defer caBundleRegistry.Unlock()
+	caBundleRegistry.specs = nil
+}

--- a/pkg/identity/ca_cert_spec.go
+++ b/pkg/identity/ca_cert_spec.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+// ContainerSelector decides whether a container should receive a CA volume mount.
+// Returning true means the container is included.
+//
+// The index parameter is the container's position in pod.Spec.Containers and
+// allows stateless implementations such as OnlyMainContainer to identify the
+// first container without relying on closure-shared state (which would break on
+// repeated invocations).
+type ContainerSelector func(container *corev1.Container, index int) bool
+
+// SandboxPredicate decides whether a CABundleSpec applies to the given sandbox at
+// injection time. When non-nil and returning false, the spec is fully skipped
+// (neither ensure nor inject) for that sandbox.
+type SandboxPredicate func(sbx *agentsv1alpha1.Sandbox) bool
+
+// CABundleSpec describes one logical CA bundle to be ensured-as-Secret in the target
+// namespace (by copying from the system namespace) and injected into the sandbox pod
+// as a Volume + VolumeMount.
+//
+// The authoritative source of every CA bundle is a Secret in the system namespace
+// (utils.DefaultSandboxDeployNamespace, i.e. "sandbox-system"). The injector copies
+// the Secret on-demand into the target namespace and never fetches CA content from
+// remote services. If the source Secret is missing in the system namespace, the
+// ensure step returns an error and blocks pod creation.
+type CABundleSpec struct {
+	// Name is the logical identifier of the CA bundle. It is used in logs and as
+	// the dedupe key when registering specs. Re-registering with the same name
+	// overrides the previous spec.
+	Name string
+
+	// SecretName is the Secret name in BOTH the system namespace (authoritative
+	// source) and the target namespace (replicated copy). The two Secrets share
+	// the same name to keep operators' mental model simple.
+	SecretName string
+
+	// SecretDataKey is the key inside Secret.Data whose value (a PEM-encoded CA
+	// certificate) should be mounted into the container at MountPath.
+	SecretDataKey string
+
+	// VolumeName is the name of the corev1.Volume appended to pod.Spec.Volumes.
+	// It is also the name used by the corresponding corev1.VolumeMount entry.
+	VolumeName string
+
+	// MountPath is the absolute path inside the container where the CA file is
+	// exposed.
+	MountPath string
+
+	// SubPath is the optional VolumeMount.SubPath. When non-empty, it allows a
+	// single Secret data key to be mounted as a single file rather than a
+	// directory.
+	SubPath string
+
+	// ReadOnly controls VolumeMount.ReadOnly. CA bundles should always be
+	// read-only inside the container.
+	ReadOnly bool
+
+	// ContainerSelector decides, for a multi-container Pod, which containers
+	// receive the CA injection (both VolumeMount and EnvVars).
+	//
+	// A sandbox Pod typically carries more than one container — the main agent
+	// workload plus sidecars such as the traffic-proxy, runtime sidecar, CSI
+	// helper, and metrics agent. Most CA bundles are only meaningful to a
+	// subset of them (e.g. the gateway CA only needs to land in the main
+	// container that issues outbound HTTPS calls), so callers MUST think about
+	// scope when registering a spec rather than blanket-injecting.
+	//
+	// Built-in helpers cover the common cases:
+	//   - OnlyMainContainer()              — first container in
+	//                                        pod.Spec.Containers, preserves
+	//                                        the historical gateway-CA
+	//                                        injector behaviour.
+	//   - ByContainerName(names…)          — explicit allow-list by container
+	//                                        name, use this when only specific
+	//                                        sidecars need the CA and the main
+	//                                        container does not.
+	//   - MainContainerOrByName(names…)    — main container PLUS the named
+	//                                        sidecars (union of the two
+	//                                        helpers above); the typical pick
+	//                                        when the agent workload AND a
+	//                                        sidecar (e.g. traffic-proxy)
+	//                                        both need the bundle.
+	//   - AllContainers()                  — every container; reserve for
+	//                                        cluster-wide trust roots that
+	//                                        every workload must honour.
+	//
+	// Custom selectors (e.g. by label, image prefix, or annotation) can be
+	// supplied directly as a function literal.
+	//
+	// Leaving this nil falls back to OnlyMainContainer() inside the injector
+	// as a defensive default, but new specs SHOULD set it explicitly so the
+	// container scope is part of the spec's hard contract rather than implicit
+	// behaviour.
+	ContainerSelector ContainerSelector
+
+	// EnvVars is an optional list of environment variables that the injector
+	// appends to every container selected by ContainerSelector, alongside the
+	// VolumeMount. It is intended for CA bundles whose consumers rely on
+	// well-known env vars to discover the trusted certificate file, e.g.:
+	//
+	//   SSL_CERT_FILE       (OpenSSL / Go x509 SystemCertPool override)
+	//   NODE_EXTRA_CA_CERTS (Node.js)
+	//   REQUESTS_CA_BUNDLE  (Python requests)
+	//   CURL_CA_BUNDLE      (curl / libcurl)
+	//
+	// Typical values point at MountPath so user-mode HTTP clients automatically
+	// trust the bundle without per-application configuration.
+	//
+	// Note: EnvVars share the same ContainerSelector as VolumeMount above, so
+	// env vars and the certificate file always land on the same set of
+	// containers — a Pod's sidecars will only see them if the selector
+	// explicitly opts those containers in.
+	//
+	// Injection is idempotent at the env-name level: if the container already
+	// has an env entry whose Name matches an entry here, the existing entry is
+	// preserved untouched (operator-supplied overrides win).
+	EnvVars []corev1.EnvVar
+
+	// EnabledFor is a sandbox-level predicate that gates both the ensure and
+	// inject steps. nil means "always enabled when the injector is invoked".
+	// Typical bindings are made at controller startup via BindCAEnabledFor to
+	// avoid coupling the identity package to runtime-specific concepts (e.g.
+	// sidecarutils.IsRuntimeEnabled).
+	EnabledFor SandboxPredicate
+}
+
+// OnlyMainContainer returns a ContainerSelector that matches only the first
+// container in pod.Spec.Containers. This preserves the historical behavior of
+// the gateway CA injector.
+func OnlyMainContainer() ContainerSelector {
+	return func(_ *corev1.Container, index int) bool {
+		return index == 0
+	}
+}
+
+// ByContainerName returns a ContainerSelector that matches containers whose Name
+// is in the provided allow-list.
+func ByContainerName(names ...string) ContainerSelector {
+	allow := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		allow[n] = struct{}{}
+	}
+	return func(c *corev1.Container, _ int) bool {
+		_, ok := allow[c.Name]
+		return ok
+	}
+}
+
+// MainContainerOrByName returns a ContainerSelector that matches the main
+// container (first entry in pod.Spec.Containers) PLUS any container whose Name
+// is in the provided allow-list.
+//
+// This is the typical pick when a CA bundle must be visible both to the agent
+// workload running in the main container AND to a sidecar that performs
+// outbound HTTPS on the agent's behalf (e.g. the traffic-proxy). The first
+// container is always selected regardless of its Name, so this helper does not
+// require callers to know the dynamic main-container name produced by the
+// pod-template renderer.
+//
+// Passing an empty names list degenerates to OnlyMainContainer().
+func MainContainerOrByName(names ...string) ContainerSelector {
+	allow := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		allow[n] = struct{}{}
+	}
+	return func(c *corev1.Container, index int) bool {
+		if index == 0 {
+			return true
+		}
+		_, ok := allow[c.Name]
+		return ok
+	}
+}
+
+// AllContainers returns a ContainerSelector that matches every container.
+func AllContainers() ContainerSelector {
+	return func(_ *corev1.Container, _ int) bool { return true }
+}

--- a/pkg/utils/sidecarutils/sidecar_config_inject.go
+++ b/pkg/utils/sidecarutils/sidecar_config_inject.go
@@ -28,10 +28,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/webhookutils"
 )
+
+func IsRuntimeEnabled(sandbox *agentsv1alpha1.Sandbox, runtimeName string) bool {
+	for _, runtime := range sandbox.Spec.Runtimes {
+		if runtime.Name == runtimeName {
+			return true
+		}
+	}
+	return false
+}
 
 func fetchInjectionConfiguration(ctx context.Context, cli client.Client) (map[string]string, error) {
 	logger := logf.FromContext(ctx)

--- a/pkg/utils/sidecarutils/utils.go
+++ b/pkg/utils/sidecarutils/utils.go
@@ -27,6 +27,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/features"
+	"github.com/openkruise/agents/pkg/identity"
+	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 	trafficproxy "github.com/openkruise/agents/pkg/utils/sidecarutils/traffic-proxy"
 )
 
@@ -43,7 +46,7 @@ func InjectSandboxRuntimes(ctx context.Context, sandbox *agentsv1alpha1.Sandbox,
 		return err
 	}
 
-	return doSidecarInjection(ctx, extractRuntimes(sandbox), pod, config)
+	return doSidecarInjection(ctx, sandbox, pod, config)
 }
 
 func extractRuntimes(sandbox *agentsv1alpha1.Sandbox) []string {
@@ -54,9 +57,10 @@ func extractRuntimes(sandbox *agentsv1alpha1.Sandbox) []string {
 	return runtimes
 }
 
-func doSidecarInjection(ctx context.Context, runtimes []string, pod *corev1.Pod, injectConfigMap map[string]string) error {
+func doSidecarInjection(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod, injectConfigMap map[string]string) error {
 	logger := logf.FromContext(ctx)
 
+	runtimes := extractRuntimes(sandbox)
 	injectedRuntimes := sets.NewString()
 	for _, runtime := range runtimes {
 		if injectedRuntimes.Has(runtime) {
@@ -95,6 +99,17 @@ func doSidecarInjection(ctx context.Context, runtimes []string, pod *corev1.Pod,
 			logger.Error(err, "failed to apply health probe rewrite")
 			return err
 		}
+	}
+
+	// Inject every enabled CA bundle as Volume + VolumeMount + EnvVar entries.
+	// SecurityIdentityProviderGate is the cluster-level kill switch; per-spec
+	// EnabledFor predicates (bound via identity.BindCAEnabledFor at controller
+	// startup) decide which specs apply to this sandbox. Runtime-level gating
+	// (e.g. traffic-proxy) lives exclusively inside those predicates to avoid
+	// drift with the caller side.
+	if utilfeature.DefaultFeatureGate.Enabled(features.SecurityIdentityProviderGate) {
+		identity.InjectAllCAVolumes(ctx, sandbox, pod)
+		identity.InjectAllCAIntoContainers(ctx, sandbox, pod)
 	}
 
 	return nil

--- a/pkg/utils/sidecarutils/utils_test.go
+++ b/pkg/utils/sidecarutils/utils_test.go
@@ -28,7 +28,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/utils"
+	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 )
 
 func TestInjectPodTemplateCSIAndRuntimeSidecar(t *testing.T) {
@@ -1113,7 +1115,7 @@ func TestDoSidecarInjection(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			// Call the function
-			err := doSidecarInjection(ctx, extractRuntimes(tt.sandbox), tt.pod, tt.injectConfigMap)
+			err := doSidecarInjection(ctx, tt.sandbox, tt.pod, tt.injectConfigMap)
 			// Verify no error
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -1410,7 +1412,7 @@ func TestDoSidecarInjectionConflicts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			err := doSidecarInjection(ctx, extractRuntimes(tt.sandbox), tt.pod, tt.injectConfigMap)
+			err := doSidecarInjection(ctx, tt.sandbox, tt.pod, tt.injectConfigMap)
 			if tt.expectError {
 				if err == nil {
 					t.Fatalf("expected error but got nil")
@@ -1602,7 +1604,7 @@ func TestDoSidecarInjectionDuplicateRuntimes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			err := doSidecarInjection(ctx, extractRuntimes(tt.sandbox), tt.pod, tt.injectConfigMap)
+			err := doSidecarInjection(ctx, tt.sandbox, tt.pod, tt.injectConfigMap)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -1652,6 +1654,177 @@ func TestDoSidecarInjectionDuplicateRuntimes(t *testing.T) {
 				if len(tt.pod.Spec.Containers) != tt.expectContainers {
 					t.Errorf("expected %d Containers, got %d", tt.expectContainers, len(tt.pod.Spec.Containers))
 				}
+			}
+		})
+	}
+}
+
+// TestDoSidecarInjection_CAInjection covers the CA bundle Volume / VolumeMount
+// / EnvVar block embedded at the tail of doSidecarInjection. It exercises the
+// two-tier gating contract:
+//   - SecurityIdentityProviderGate is the cluster-level kill switch.
+//   - Per-spec CABundleSpec.EnabledFor predicate (bound at controller startup
+//     via identity.BindCAEnabledFor) is the only place runtime-level gating
+//     lives.
+//
+// The test does not assert on legacy sidecar/CSI injection, only on the
+// gateway CA artefacts produced by identity.InjectAllCAVolumes /
+// InjectAllCAIntoContainers, so the mainline runtime injection code paths are
+// kept untouched.
+func TestDoSidecarInjection_CAInjection(t *testing.T) {
+	const (
+		caVolumeName = "sandbox-gateway-ca"
+		caMountPath  = "/etc/ssl/certs/agent-identity/gateway-ca.crt"
+		caEnvName    = "SSL_CERT_FILE"
+	)
+
+	// Minimal traffic-proxy injection template so parseInjectConfig succeeds
+	// when the sandbox declares the runtime; the body is intentionally empty
+	// to keep the focus of this test on CA injection.
+	trafficProxyTemplate := map[string]string{
+		KEY_TRAFFIC_PROXY_INJECTION_CONFIG: `{"mainContainer":{},"csiSidecar":[],"volume":[]}`,
+	}
+
+	tests := []struct {
+		name               string
+		featureGateEnabled bool
+		withTrafficProxy   bool
+		// enabledForBinding controls how the gateway CABundleSpec's EnabledFor
+		// predicate is wired before the call. nil means "do not bind" (community
+		// baseline default), which causes specEnabled to treat the spec as
+		// always enabled.
+		enabledForBinding identity.SandboxPredicate
+		expectCAInjected  bool
+	}{
+		{
+			name:               "gate disabled, traffic-proxy present, predicate matches - gate kills CA injection",
+			featureGateEnabled: false,
+			withTrafficProxy:   true,
+			enabledForBinding: func(sbx *agentsv1alpha1.Sandbox) bool {
+				return IsRuntimeEnabled(sbx, agentsv1alpha1.RuntimeConfigForInjectTrafficProxy)
+			},
+			expectCAInjected: false,
+		},
+		{
+			name:               "gate enabled, traffic-proxy present, predicate matches - CA injected",
+			featureGateEnabled: true,
+			withTrafficProxy:   true,
+			enabledForBinding: func(sbx *agentsv1alpha1.Sandbox) bool {
+				return IsRuntimeEnabled(sbx, agentsv1alpha1.RuntimeConfigForInjectTrafficProxy)
+			},
+			expectCAInjected: true,
+		},
+		{
+			name:               "gate enabled, traffic-proxy missing, predicate vetoes - skip CA",
+			featureGateEnabled: true,
+			withTrafficProxy:   false,
+			enabledForBinding: func(sbx *agentsv1alpha1.Sandbox) bool {
+				return IsRuntimeEnabled(sbx, agentsv1alpha1.RuntimeConfigForInjectTrafficProxy)
+			},
+			expectCAInjected: false,
+		},
+		{
+			name:               "gate enabled, traffic-proxy present, predicate forced false - skip CA",
+			featureGateEnabled: true,
+			withTrafficProxy:   true,
+			enabledForBinding:  func(_ *agentsv1alpha1.Sandbox) bool { return false },
+			expectCAInjected:   false,
+		},
+		{
+			name:               "gate enabled, predicate unbound (community baseline default) - CA injected",
+			featureGateEnabled: true,
+			withTrafficProxy:   false,
+			enabledForBinding:  nil,
+			expectCAInjected:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.featureGateEnabled {
+				if err := utilfeature.DefaultMutableFeatureGate.Set("SecurityIdentityProvider=true"); err != nil {
+					t.Fatalf("set feature gate: %v", err)
+				}
+				t.Cleanup(func() {
+					_ = utilfeature.DefaultMutableFeatureGate.Set("SecurityIdentityProvider=false")
+				})
+			}
+			// Bind (or explicitly unbind) the gateway spec's EnabledFor predicate
+			// for this case, and always restore to nil on cleanup so subsequent
+			// test cases (and tests in other files) are not contaminated.
+			identity.BindCAEnabledFor(identity.GatewayCABundleName, tt.enabledForBinding)
+			t.Cleanup(func() {
+				identity.BindCAEnabledFor(identity.GatewayCABundleName, nil)
+			})
+
+			sandbox := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "sbx", Namespace: "default"},
+			}
+			injectConfigMap := map[string]string{}
+			if tt.withTrafficProxy {
+				sandbox.Spec.Runtimes = []agentsv1alpha1.RuntimeConfig{
+					{Name: agentsv1alpha1.RuntimeConfigForInjectTrafficProxy},
+				}
+				injectConfigMap = trafficProxyTemplate
+			}
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "nginx"}},
+				},
+			}
+
+			if err := doSidecarInjection(context.Background(), sandbox, pod, injectConfigMap); err != nil {
+				t.Fatalf("doSidecarInjection unexpected error: %v", err)
+			}
+
+			hasVolume := false
+			for _, v := range pod.Spec.Volumes {
+				if v.Name == caVolumeName {
+					hasVolume = true
+					if v.Secret == nil || v.Secret.SecretName != identity.GatewayCASecretName {
+						t.Errorf("CA volume must reference Secret %q via SecretVolumeSource, got %+v",
+							identity.GatewayCASecretName, v.VolumeSource)
+					}
+					break
+				}
+			}
+			if hasVolume != tt.expectCAInjected {
+				t.Errorf("pod CA volume present: got %v, want %v", hasVolume, tt.expectCAInjected)
+			}
+
+			if len(pod.Spec.Containers) == 0 {
+				t.Fatalf("main container missing after injection")
+			}
+			main := pod.Spec.Containers[0]
+
+			hasMount := false
+			for _, vm := range main.VolumeMounts {
+				if vm.Name == caVolumeName {
+					hasMount = true
+					if vm.MountPath != caMountPath {
+						t.Errorf("CA mount path: got %q, want %q", vm.MountPath, caMountPath)
+					}
+					break
+				}
+			}
+			if hasMount != tt.expectCAInjected {
+				t.Errorf("main container CA mount present: got %v, want %v", hasMount, tt.expectCAInjected)
+			}
+
+			hasEnv := false
+			for _, ev := range main.Env {
+				if ev.Name == caEnvName {
+					hasEnv = true
+					if ev.Value != caMountPath {
+						t.Errorf("%s value: got %q, want %q", caEnvName, ev.Value, caMountPath)
+					}
+					break
+				}
+			}
+			if hasEnv != tt.expectCAInjected {
+				t.Errorf("main container %s env present: got %v, want %v", caEnvName, hasEnv, tt.expectCAInjected)
 			}
 		})
 	}


### PR DESCRIPTION
Registry-driven framework to copy the gateway CA Secret from sandbox-system into the sandbox namespace and inject Volume + VolumeMount + EnvVars into selected containers. Gated by SecurityIdentityProviderGate and the traffic-proxy runtime predicate. Enterprise builds override the baseline by re-registering the same CABundleSpec name from an inner package init().

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Registry-driven framework to copy the gateway CA Secret from
sandbox-system into the sandbox namespace and inject Volume +
VolumeMount + EnvVars into selected containers. Gated by
SecurityIdentityProviderGate and the traffic-proxy runtime predicate.
Enterprise builds override the baseline by re-registering the same
CABundleSpec name from an inner package init().

Signed-off-by: jicheng.sk <jicheng.sk@alibaba-inc.com>

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

