### PR TITLE
refactor(sidecarutils): pass *Sandbox into doSidecarInjection

### DIFF
--- a/pkg/utils/sidecarutils/utils.go
+++ b/pkg/utils/sidecarutils/utils.go
@@ -43,22 +43,15 @@ func InjectSandboxRuntimes(ctx context.Context, sandbox *agentsv1alpha1.Sandbox,
 		return err
 	}
 
-	return doSidecarInjection(ctx, extractRuntimes(sandbox), pod, config)
+	return doSidecarInjection(ctx, sandbox, pod, config)
 }
 
-func extractRuntimes(sandbox *agentsv1alpha1.Sandbox) []string {
-	runtimes := []string{}
-	for _, runtime := range sandbox.Spec.Runtimes {
-		runtimes = append(runtimes, runtime.Name)
-	}
-	return runtimes
-}
-
-func doSidecarInjection(ctx context.Context, runtimes []string, pod *corev1.Pod, injectConfigMap map[string]string) error {
+func doSidecarInjection(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod, injectConfigMap map[string]string) error {
 	logger := logf.FromContext(ctx)
 
 	injectedRuntimes := sets.NewString()
-	for _, runtime := range runtimes {
+	for _, r := range sandbox.Spec.Runtimes {
+		runtime := r.Name
 		if injectedRuntimes.Has(runtime) {
 			logger.V(5).Info("skipping duplicate runtime, already processed", "runtime", runtime)
 			continue

--- a/pkg/utils/sidecarutils/utils_test.go
+++ b/pkg/utils/sidecarutils/utils_test.go
@@ -1113,7 +1113,7 @@ func TestDoSidecarInjection(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			// Call the function
-			err := doSidecarInjection(ctx, extractRuntimes(tt.sandbox), tt.pod, tt.injectConfigMap)
+			err := doSidecarInjection(ctx, tt.sandbox, tt.pod, tt.injectConfigMap)
 			// Verify no error
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -1410,7 +1410,7 @@ func TestDoSidecarInjectionConflicts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			err := doSidecarInjection(ctx, extractRuntimes(tt.sandbox), tt.pod, tt.injectConfigMap)
+			err := doSidecarInjection(ctx, tt.sandbox, tt.pod, tt.injectConfigMap)
 			if tt.expectError {
 				if err == nil {
 					t.Fatalf("expected error but got nil")
@@ -1602,7 +1602,7 @@ func TestDoSidecarInjectionDuplicateRuntimes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			err := doSidecarInjection(ctx, extractRuntimes(tt.sandbox), tt.pod, tt.injectConfigMap)
+			err := doSidecarInjection(ctx, tt.sandbox, tt.pod, tt.injectConfigMap)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}


### PR DESCRIPTION
Replace the second parameter of doSidecarInjection from a pre-extracted []string of runtime names to *agentsv1alpha1.Sandbox, and inline the former extractRuntimes helper at the top of doSidecarInjection. The function still treats Spec.Runtimes as read-only, dedups by name, and applies the trailing health-probe rewrite, so behavior is unchanged.

This prepares for follow-up work where downstream callers (e.g. the enterprise overlay that conditionally appends
RuntimeConfigForInjectTrafficProxy based on
trafficproxy.ShouldInjectTrafficProxy, and upcoming CA bundle injection) need access to the full Sandbox object rather than just runtime names.

DeepCopy is intentionally not performed in the community baseline since doSidecarInjection does not mutate the sandbox; any caller that needs to mutate Spec.Runtimes is responsible for its own DeepCopy.

- Drop the standalone extractRuntimes helper (now inlined).
- Update three doSidecarInjection call sites in utils_test.go to pass tt.sandbox directly.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

