### PR TITLE
feat(sandboxupdateops): relax sandbox filter to allow non-SandboxSet-controlled sandboxes

### DIFF
--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
@@ -40,6 +40,7 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/discovery"
 	"github.com/openkruise/agents/pkg/utils/expectations"
+	"github.com/openkruise/agents/pkg/utils/sandboxutils"
 )
 
 const finalizerName = "agents.kruise.io/sandboxupdateops-protection"
@@ -144,12 +145,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	// 4. List matching sandboxes in the same namespace (only claimed ones)
+	// 4. List matching sandboxes in the same namespace (exclude sandboxes controlled by SandboxSet)
 	sandboxList := &agentsv1alpha1.SandboxList{}
 	if err := r.List(ctx, sandboxList,
 		client.InNamespace(ops.Namespace),
 		client.MatchingLabelsSelector{Selector: selector},
-		client.MatchingLabels{agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.True},
 		client.UnsafeDisableDeepCopy); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -227,6 +227,11 @@ func (r *Reconciler) classifySandboxes(sandboxList *agentsv1alpha1.SandboxList, 
 		sbx := &sandboxList.Items[i]
 		if !sbx.DeletionTimestamp.IsZero() || (sbx.Status.Phase != agentsv1alpha1.SandboxRunning &&
 			sbx.Status.Phase != agentsv1alpha1.SandboxUpgrading) {
+			continue
+		}
+
+		// Skip sandboxes controlled by SandboxSet (pool sandboxes, not intended for update)
+		if sandboxutils.IsControlledBySandboxSet(sbx) {
 			continue
 		}
 

--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
@@ -587,6 +587,92 @@ func mustMarshalPatch(tmpl corev1.PodTemplateSpec) runtime.RawExtension {
 	return runtime.RawExtension{Raw: data}
 }
 
+func TestReconcile_SkipsSandboxSetControlledSandboxes(t *testing.T) {
+	ops := newSandboxUpdateOps("test-ops", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil)
+	ops.Spec.Patch = mustMarshalPatch(corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "main", Image: "busybox:2.0"},
+			},
+		},
+	})
+
+	sbs := &agentsv1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sbs",
+			Namespace: "default",
+			UID:       types.UID("sbs-uid"),
+		},
+	}
+
+	// sbx-pool: controlled by SandboxSet, should be skipped
+	sbxPool := newSandbox("sbx-pool", "default", "", agentsv1alpha1.SandboxRunning, nil)
+	sbxPool.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(sbs, agentsv1alpha1.SandboxSetControllerKind),
+	}
+
+	// sbx-standalone: not controlled by SandboxSet, should be processed
+	sbxStandalone := newSandbox("sbx-standalone", "default", "", agentsv1alpha1.SandboxRunning, nil)
+	// Remove the claimed label to verify it's no longer required
+	delete(sbxStandalone.Labels, agentsv1alpha1.LabelSandboxIsClaimed)
+
+	r := newTestReconciler(ops, sbxPool, sbxStandalone)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-ops", Namespace: "default"},
+	})
+	assert.NoError(t, err)
+
+	// sbx-pool should NOT have been patched (still no ops label)
+	updatedPool := &agentsv1alpha1.Sandbox{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "sbx-pool", Namespace: "default"}, updatedPool)
+	assert.NoError(t, err)
+	assert.Empty(t, updatedPool.Labels[agentsv1alpha1.LabelSandboxUpdateOps],
+		"pool sandbox should not be patched")
+
+	// sbx-standalone should have been patched
+	updatedStandalone := &agentsv1alpha1.Sandbox{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "sbx-standalone", Namespace: "default"}, updatedStandalone)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-ops", updatedStandalone.Labels[agentsv1alpha1.LabelSandboxUpdateOps],
+		"standalone sandbox should be patched")
+
+	// Verify status: only sbx-standalone counted (total=1)
+	updatedOps := &agentsv1alpha1.SandboxUpdateOps{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "test-ops", Namespace: "default"}, updatedOps)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(1), updatedOps.Status.Replicas, "only non-SandboxSet-controlled sandboxes should be counted")
+}
+
+func TestReconcile_ProcessesSandboxWithoutClaimedLabel(t *testing.T) {
+	// Verify that sandboxes without the claimed label are still processed
+	// as long as they are not controlled by a SandboxSet
+	ops := newSandboxUpdateOps("test-ops", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil)
+	ops.Spec.Patch = mustMarshalPatch(corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "main", Image: "busybox:2.0"},
+			},
+		},
+	})
+
+	sbx := newSandbox("sbx-no-claim", "default", "", agentsv1alpha1.SandboxRunning, nil)
+	delete(sbx.Labels, agentsv1alpha1.LabelSandboxIsClaimed)
+
+	r := newTestReconciler(ops, sbx)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-ops", Namespace: "default"},
+	})
+	assert.NoError(t, err)
+
+	updatedSbx := &agentsv1alpha1.Sandbox{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "sbx-no-claim", Namespace: "default"}, updatedSbx)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-ops", updatedSbx.Labels[agentsv1alpha1.LabelSandboxUpdateOps],
+		"sandbox without claimed label should still be patched")
+}
+
 func TestReconcile_StatusUnchangedSkipsUpdate(t *testing.T) {
 	// When status doesn't change, updateStatus should be a no-op
 	ops := newSandboxUpdateOps("test-ops", "default", agentsv1alpha1.SandboxUpdateOpsCompleted, false, nil)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

SandboxUpdateOps currently only processes sandboxes with the
`agents.kruise.io/sandbox-claimed=true` label. This change relaxes
the restriction: any sandbox whose ownerReference is NOT a SandboxSet
is now eligible for updates.

- Remove `LabelSandboxIsClaimed` label filter from the sandbox List
  call in Reconcile
- Add `IsControlledBySandboxSet` check in `classifySandboxes` to skip
  pool sandboxes owned by a SandboxSet
- Add tests for the new filtering behavior

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run unit tests: `go test ./pkg/controller/sandboxupdateops/...`
2. Verify that sandboxes controlled by a SandboxSet are skipped
   (not counted, not patched)
3. Verify that sandboxes without the `sandbox-claimed` label but not
   controlled by a SandboxSet are still processed

### Ⅳ. Special notes for reviews

- The `IsControlledBySandboxSet` utility already exists in
  `pkg/utils/sandboxutils` and is used in other parts of the codebase
- The `handleDeletion` path is unchanged — it only cleans up the ops
  label from sandboxes that were already processed
