### PR TITLE
feat(runtime): support per-call file mode in WriteFileWithRuntime and harden AccessToken

### DIFF
--- a/pkg/utils/runtime/runtime.go
+++ b/pkg/utils/runtime/runtime.go
@@ -23,6 +23,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -55,7 +56,11 @@ import (
 	"github.com/openkruise/agents/proto/envd/process/processconnect"
 )
 
-var AccessToken = "access-token"
+// AccessToken is the well-known header key name used by tests that interact with the
+// runtime files/process APIs. It is a constant — not a variable — so that no package
+// can accidentally mutate it at runtime, which would redirect the real access-token
+// header to an attacker-controlled name.
+const AccessToken = "access-token"
 
 type RunCommandResult struct {
 	PID      uint32
@@ -158,6 +163,11 @@ type WriteFileArgs struct {
 	// Timeout bounds the duration of a single HTTP write request. Defaults to
 	// defaultRuntimeWriteTimeout when zero or negative.
 	Timeout time.Duration
+	// Permissions is the UNIX file mode applied to the written file by the runtime after
+	// creation (e.g. 0600 for credential files, 0644 for non-sensitive files). When zero,
+	// the runtime applies its default permissions (typically 0644 derived from umask).
+	// Transmitted to the agent-runtime via the X-File-Mode HTTP header as an octal string.
+	Permissions os.FileMode
 }
 
 // WriteFileResult carries metadata about a write call. The HTTP response body is drained
@@ -172,6 +182,12 @@ const (
 	defaultRuntimeWriteTimeout  = 10 * time.Second
 	defaultRuntimeFilesUsername = "root"
 	runtimeFilesFieldName       = "file"
+
+	// HeaderFileMode is the HTTP header used to transmit the desired UNIX file permissions
+	// (as an octal string, e.g. "0600") from WriteFileWithRuntime to the agent-runtime
+	// files API handler. The runtime is expected to apply os.Chmod(path, mode) after
+	// writing the file. When absent, the runtime uses its default umask-derived permissions.
+	HeaderFileMode = "X-File-Mode"
 )
 
 // runtimeFilesHTTPClient is the package-level HTTP client used by WriteFileWithRuntime.
@@ -246,6 +262,9 @@ func WriteFileWithRuntime(ctx context.Context, args WriteFileArgs) (WriteFileRes
 	// Basic auth header mirrors the agent-runtime expectation (root user, empty password)
 	// and matches the value used by RunCommandWithRuntime above.
 	req.Header.Set("Authorization", "Basic cm9vdDo=") // Basic root:
+	if args.Permissions != 0 {
+		req.Header.Set(HeaderFileMode, fmt.Sprintf("%04o", args.Permissions))
+	}
 
 	start := time.Now()
 	log.Info("writing file to runtime via files API",

--- a/pkg/utils/runtime/runtime_test.go
+++ b/pkg/utils/runtime/runtime_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -579,6 +580,7 @@ type capturedFilesRequest struct {
 	accessToken     string
 	authorization   string
 	contentType     string
+	fileMode        string            // X-File-Mode header value
 	multipartFields map[string][]byte // form field name -> raw file content
 }
 
@@ -593,6 +595,7 @@ func newRuntimeFilesServer(t *testing.T, statusCode int, respBody string, captur
 		captured.accessToken = r.Header.Get("X-Access-Token")
 		captured.authorization = r.Header.Get("Authorization")
 		captured.contentType = r.Header.Get("Content-Type")
+		captured.fileMode = r.Header.Get(HeaderFileMode)
 
 		if strings.HasPrefix(captured.contentType, "multipart/") {
 			mediaParams := captured.contentType
@@ -846,6 +849,52 @@ func TestWriteFileWithRuntime_HonorsLargeArgsTimeout(t *testing.T) {
 	// The request itself is fast; we only assert it returned in well under the timeout
 	// to make sure no hidden cap aborted it. Generous bound to keep CI stable.
 	assert.Less(t, time.Since(start), 5*time.Second)
+}
+
+// TestWriteFileWithRuntime_PermissionsHeader verifies that the Permissions field on
+// WriteFileArgs is transmitted to the runtime via the X-File-Mode header as an octal
+// string, and that a zero value (default) omits the header entirely.
+func TestWriteFileWithRuntime_PermissionsHeader(t *testing.T) {
+	tests := []struct {
+		name           string
+		permissions    os.FileMode
+		expectFileMode string // expected X-File-Mode header value; empty means header absent
+	}{
+		{
+			name:           "0600 sends X-File-Mode: 0600",
+			permissions:    0600,
+			expectFileMode: "0600",
+		},
+		{
+			name:           "0644 sends X-File-Mode: 0644",
+			permissions:    0644,
+			expectFileMode: "0644",
+		},
+		{
+			name:           "zero value omits X-File-Mode header",
+			permissions:    0,
+			expectFileMode: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			captured := &capturedFilesRequest{}
+			server := newRuntimeFilesServer(t, http.StatusOK, "", captured)
+			defer server.Close()
+			sbx := newWriteFileSandbox(server.URL, "runtime-token")
+			args := WriteFileArgs{
+				Sbx:         sbx,
+				FilePath:    "/var/opt/sandbox/agent-token/test.token",
+				Content:     []byte(`{"accessToken":"tok"}`),
+				Permissions: tt.permissions,
+			}
+			res, err := WriteFileWithRuntime(context.Background(), args)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, res.StatusCode)
+			assert.Equal(t, tt.expectFileMode, captured.fileMode,
+				"X-File-Mode header should match the Permissions field (empty when zero)")
+		})
+	}
 }
 
 func TestBuildRuntimeFilesEndpoint(t *testing.T) {


### PR DESCRIPTION
… harden AccessToken

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Extend WriteFileWithRuntime so callers can declare the UNIX file permission
that agent-runtime should apply after writing the file. This is the underlying
capability that lets the security token propagator land credential files at
0600 instead of relying on the runtime's umask-derived default (0644), which
would otherwise leave the agent token world-readable inside the sandbox pod.

Changes
-------
* api: add `Permissions os.FileMode` to WriteFileArgs. Zero value preserves
  the current behavior (runtime default), so all existing call sites are
  unaffected.
* wire protocol: introduce `HeaderFileMode = "X-File-Mode"`. When
  Permissions is non-zero, the value is serialized as a 4-digit octal
  string (e.g. "0600") and sent on the multipart upload request. The
  agent-runtime is expected to chmod the file after it has been written.
* security hardening: convert `AccessToken` from `var` to `const` so no
  package can mutate the well-known header key at runtime and redirect
  the access-token to an attacker-controlled name.

Tests
-----
* extend the captured-request helper with a `fileMode` field so the
  httptest server records the X-File-Mode header.
* add TestWriteFileWithRuntime_PermissionsHeader, a table-driven contract
  test that pins:
    - 0600 -> "0600"
    - 0644 -> "0644"
    - zero -> header omitted (default umask path preserved)

Backward compatibility
----------------------
Default behavior is unchanged when callers do not set Permissions; the
header is simply not sent. No agent-runtime upgrade is required for the
zero-value path.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

