### PR TITLE
feat(identity): gate security token issuance on agent-name label

### DIFF
--- a/pkg/identity/sandbox_token_helper.go
+++ b/pkg/identity/sandbox_token_helper.go
@@ -27,6 +27,27 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 )
 
+// IsIdentityProviderRequested reports whether the sandbox opts into the
+// identity provider issuance path.
+//
+// The opt-in signal is the presence of a non-empty
+// "security.agents.kruise.io/agent-name" label on the sandbox: setting this
+// label expresses the user's intent to bind the sandbox to a logical agent
+// identity, which is the precondition for the identity provider to mint a
+// security token. A nil sandbox, a sandbox without Labels, or one whose value
+// for that key is empty all collapse to "not requested", letting callers
+// short-circuit the issuance path without paying any provider cost.
+//
+// The check is intentionally label-only and value-presence-only: it does NOT
+// validate the label value against any naming convention, since the identity
+// provider is the authoritative source of truth for agent-name semantics.
+func IsIdentityProviderRequested(sbx *agentsv1alpha1.Sandbox) bool {
+	if sbx == nil {
+		return false
+	}
+	return sbx.GetLabels()[LabelAgentName] != ""
+}
+
 // IssueSandboxToken issues a security token for the given sandbox using the
 // registered identity provider.
 //

--- a/pkg/identity/sandbox_token_helper_test.go
+++ b/pkg/identity/sandbox_token_helper_test.go
@@ -315,3 +315,124 @@ func TestPropagateSandboxToken(t *testing.T) {
 		})
 	}
 }
+
+// TestIsIdentityProviderRequested verifies the opt-in predicate that gates the
+// identity provider issuance path. The contract is: a sandbox opts in iff its
+// Labels carry a non-empty value under LabelAgentName; every other shape
+// (nil sandbox, missing Labels map, absent key, empty value, near-miss key)
+// must collapse to false so callers can safely short-circuit.
+func TestIsIdentityProviderRequested(t *testing.T) {
+	tests := []struct {
+		name   string
+		sbx    *agentsv1alpha1.Sandbox
+		want   bool
+		reason string
+	}{
+		{
+			name:   "nil sandbox returns false",
+			sbx:    nil,
+			want:   false,
+			reason: "a nil sandbox must never trigger the provider path",
+		},
+		{
+			name: "sandbox without Labels map returns false",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "sbx", Namespace: "ns"},
+			},
+			want:   false,
+			reason: "GetLabels() on a sandbox without ObjectMeta.Labels yields a nil map; lookup must be false",
+		},
+		{
+			name: "empty Labels map returns false",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sbx",
+					Namespace: "ns",
+					Labels:    map[string]string{},
+				},
+			},
+			want:   false,
+			reason: "an explicitly empty map carries no opt-in signal",
+		},
+		{
+			name: "agent-name label absent returns false",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sbx",
+					Namespace: "ns",
+					Labels: map[string]string{
+						"app":                             "demo",
+						SecurityMetadataPrefix + "tenant": "t1",
+					},
+				},
+			},
+			want:   false,
+			reason: "other security-prefixed labels must not opt the sandbox into the provider path",
+		},
+		{
+			name: "agent-name label present but empty returns false",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sbx",
+					Namespace: "ns",
+					Labels: map[string]string{
+						LabelAgentName: "",
+					},
+				},
+			},
+			want:   false,
+			reason: "empty value carries no agent identity; opt-in must require a non-empty value",
+		},
+		{
+			name: "near-miss key with same prefix returns false",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sbx",
+					Namespace: "ns",
+					Labels: map[string]string{
+						SecurityMetadataPrefix + "agent-name-suffix": "foo",
+						"agent-name": "bar",
+					},
+				},
+			},
+			want:   false,
+			reason: "the predicate matches the FQ key exactly; near-miss keys must not trigger the path",
+		},
+		{
+			name: "agent-name label present with value returns true",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sbx",
+					Namespace: "ns",
+					Labels: map[string]string{
+						LabelAgentName: "my-agent",
+					},
+				},
+			},
+			want:   true,
+			reason: "the canonical opt-in: a non-empty agent-name value",
+		},
+		{
+			name: "agent-name label coexisting with unrelated labels returns true",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sbx",
+					Namespace: "ns",
+					Labels: map[string]string{
+						LabelAgentName:                     "agent-x",
+						SecurityMetadataPrefix + "tenant": "t1",
+						"app":                             "demo",
+					},
+				},
+			},
+			want:   true,
+			reason: "presence of other labels must not interfere with the opt-in decision",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsIdentityProviderRequested(tt.sbx), tt.reason)
+		})
+	}
+}

--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -35,6 +35,10 @@ const (
 	// AgentKeyTokenRefreshStatus is the Sandbox Annotation Key,
 	// used to store the JSON serialized result of TokenRefreshStatus.
 	AgentKeyTokenRefreshStatus = SecurityMetadataPrefix + "token-status"
+	// LabelAgentName is the sandbox Label Key whose presence opts the sandbox
+	// into the identity provider issuance path. Its value carries the logical
+	// agent name that the identity provider uses to mint the security token.
+	LabelAgentName = SecurityMetadataPrefix + "agent-name"
 )
 
 // TokenRequest represents a request to issue an identity-aware access token.

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -233,7 +233,7 @@ func TryClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions, pickCa
 	// Any failure in issuance, status recording, or propagation returns a retriable error so callers can retry.
 	// We deliberately do NOT degrade to a UUID token on issuance failure: a UUID carries no identity and would
 	// be propagated to the runtime as a meaningless credential, masking real provider outages.
-	if utilfeature.DefaultFeatureGate.Enabled(features.SecurityIdentityProviderGate) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.SecurityIdentityProviderGate) && identity.IsIdentityProviderRequested(sbx.Sandbox) {
 		opts.SecurityToken = &infra.SecurityTokenOptions{}
 		log.Info("starting to issue security token via identity provider")
 		metrics.SecurityToken, err = issueSecurityToken(ctx, sbx, opts.SecurityToken)

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -3618,6 +3618,44 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				assert.Greater(t, metrics.SecurityToken, time.Duration(0))
 			},
 		},
+		{
+			// Verifies the second clause of the gate at claim.go:236 — when the
+			// sandbox does NOT carry the security.agents.kruise.io/agent-name
+			// label, the entire identity provider branch must be skipped: neither
+			// IssueToken nor PropagateSecurityToken may run, no TokenRefreshStatus
+			// annotation may be persisted, and metrics.SecurityToken must remain
+			// zero. This is the dedicated opt-in regression test for the
+			// IsIdentityProviderRequested predicate.
+			name: "skips security token issuance when agent-name label is absent",
+			options: infra.ClaimSandboxOptions{
+				User:     user,
+				Template: existTemplate,
+				InitRuntime: &config.InitRuntimeOptions{
+					AccessToken: "original-uuid-token",
+				},
+			},
+			preModifier: func(sbx *v1alpha1.Sandbox) {
+				// Strip the opt-in label so IsIdentityProviderRequested returns false.
+				delete(sbx.Labels, identity.LabelAgentName)
+			},
+			mockProvider: &mockIdentityProvider{
+				issueTokenFunc: func(ctx context.Context, req identity.TokenRequest) (*identity.TokenResponse, error) {
+					t.Fatalf("IssueToken must not be called when agent-name label is absent")
+					return nil, nil
+				},
+				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
+					t.Fatalf("PropagateSecurityToken must not be called when agent-name label is absent")
+					return nil
+				},
+			},
+			postCheck: func(t *testing.T, sbx infra.Sandbox, metrics infra.ClaimMetrics) {
+				annotations := sbx.GetAnnotations()
+				assert.Empty(t, annotations[identity.AgentKeyTokenRefreshStatus],
+					"TokenRefreshStatus annotation must NOT be written when the provider branch is skipped")
+				assert.Equal(t, time.Duration(0), metrics.SecurityToken,
+					"SecurityToken metric must remain zero when the provider branch is skipped")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -3644,6 +3682,9 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 					Labels: map[string]string{
 						v1alpha1.LabelSandboxTemplate:        existTemplate,
 						agentsv1alpha1.LabelSandboxIsClaimed: "false",
+						// Opt the sandbox into the identity provider issuance path;
+						// the dedicated "absent" sub-test strips this label via preModifier.
+						identity.LabelAgentName: "test-agent",
 					},
 					CreationTimestamp: metav1.Now(),
 					Annotations: map[string]string{

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/google/uuid"
+
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 
 	"github.com/openkruise/agents/pkg/features"


### PR DESCRIPTION
Add an explicit opt-in predicate for the identity-provider issuance path on the claim flow:

* Introduce identity.LabelAgentName (security.agents.kruise.io/agent-name) and identity.IsIdentityProviderRequested(sbx), which returns true only when the sandbox carries a non-empty agent-name label.

* Tighten the gate at sandboxcr/claim.go so the issue/record/propagate sub-steps now require both the SecurityIdentityProvider feature gate AND the opt-in label; sandboxes without the label short-circuit the provider entirely (no IssueToken, no PropagateSecurityToken, no TokenRefreshStatus annotation, no SecurityToken metric).

* Cover the predicate with table-driven unit tests in pkg/identity (8 sub-cases: nil, missing/empty Labels, absent/empty value, near-miss prefix, present, coexistence).

* Update TestTryClaimSandbox_SecurityToken to add the opt-in label to the default sandbox so existing sub-tests continue to exercise the issuance path, and add a dedicated regression case verifying that stripping the label skips the entire provider branch without errors.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

