### PR TITLE
refactor(controller): refactor common control in sandbox controller

### DIFF
--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -19,6 +19,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -49,12 +50,9 @@ const (
 	WaitingReasonPodInitializing = "PodInitializing"
 	// WaitingReasonContainerCreating indicates the container is being created (image pull, volume mount, etc.).
 	WaitingReasonContainerCreating = "ContainerCreating"
-
-	SandboxFinalizer = "agents.kruise.io/sandbox"
-
-	PodConditionContainersPaused  = "ContainersPaused"
-	PodConditionContainersResumed = "ContainersResumed"
 )
+
+const SandboxPodNotFoundMsg = "Sandbox Pod Not Found"
 
 type commonControl struct {
 	client.Client
@@ -102,26 +100,35 @@ func (r *commonControl) EnsureSandboxRunning(ctx context.Context, args EnsureFun
 	return 0, nil
 }
 
-func (r *commonControl) EnsureSandboxUpdated(ctx context.Context, args EnsureFuncArgs) error {
+// ensureSandboxUpdatedCommon is the minimal shared logic for EnsureSandboxUpdated:
+// pod not found → mark Failed; non-Recreate policy → inplace update; then sync status.
+// Returns synced=true when syncSandboxStatusFromPod has been called, so the caller can append extra logic (e.g. syncAcsInfoFromPod).
+func ensureSandboxUpdatedCommon(ctx context.Context, args EnsureFuncArgs, handler InPlaceUpdateHandler) (synced bool, err error) {
 	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
 	// If a Pod is no longer present in the Running state, it should be considered an abnormal situation.
 	if pod == nil {
 		newStatus.Phase = agentsv1alpha1.SandboxFailed
-		newStatus.Message = "Sandbox Pod Not Found"
-		return nil
+		newStatus.Message = SandboxPodNotFoundMsg
+		return false, nil
 	}
 	// For non-Recreate upgrade policy (e.g., sandbox-manager triggered inplace update via annotation),
 	// perform inplace update directly without entering the full upgrade lifecycle (PreUpgrade -> UpgradePod -> PostUpgrade).
 	if box.Spec.UpgradePolicy == nil || box.Spec.UpgradePolicy.Type != agentsv1alpha1.SandboxUpgradePolicyRecreate {
-		done, err := r.handleInplaceUpdateSandbox(ctx, args)
+		done, err := handleInPlaceUpdateCommon(ctx, handler, pod, box, newStatus)
 		if err != nil {
-			return err
+			return false, err
 		} else if !done {
-			return nil
+			return false, nil
 		}
 	}
 	syncSandboxStatusFromPod(pod, newStatus)
-	return nil
+	return true, nil
+}
+
+func (r *commonControl) EnsureSandboxUpdated(ctx context.Context, args EnsureFuncArgs) error {
+	handler := &CommonInPlaceUpdateHandler{control: r.inplaceUpdateControl, recorder: r.recorder}
+	_, err := ensureSandboxUpdatedCommon(ctx, args, handler)
+	return err
 }
 
 // syncSandboxStatusFromPod updates sandbox status from pod info and syncs the Ready condition
@@ -150,14 +157,65 @@ func syncSandboxStatusFromPod(pod *corev1.Pod, newStatus *agentsv1alpha1.Sandbox
 		cond.Reason = agentsv1alpha1.SandboxReadyReasonPodReady
 		cond.Message = ""
 	}
+	var failedMessages []string
 	for _, cStatus := range pod.Status.ContainerStatuses {
 		// indicating container startup failure
 		if cond.Status == metav1.ConditionFalse && cStatus.State.Waiting != nil {
 			cond.Reason = agentsv1alpha1.SandboxReadyReasonStartContainerFailed
-			cond.Message = cStatus.State.Waiting.Message
+			failedMessages = append(failedMessages, fmt.Sprintf("%s: %s", cStatus.Name, cStatus.State.Waiting.Message))
 		}
 	}
+	if len(failedMessages) > 0 {
+		cond.Message = utils.TruncateConditionMessage(fmt.Sprintf("container startup failed: %s", strings.Join(failedMessages, "; ")))
+	}
 	utils.SetSandboxCondition(newStatus, *cond)
+}
+
+// setReadyConditionFalseForPause sets the Ready condition to False when pausing.
+// All pause flows (common and ACS) must mark the sandbox as not ready, so this logic is extracted as a shared function.
+func setReadyConditionFalseForPause(newStatus *agentsv1alpha1.SandboxStatus) {
+	if rCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady)); rCond != nil && rCond.Status == metav1.ConditionTrue {
+		rCond.Status = metav1.ConditionFalse
+		rCond.LastTransitionTime = metav1.Now()
+		utils.SetSandboxCondition(newStatus, *rCond)
+	}
+}
+
+// performPostResumeInit is the shared helper for post-resume initialization, handling runtime re-init and CSI storage re-mount.
+// initFunc allows the caller to wrap trace or other decorating logic; failEventReason/successEventReason allow
+// the caller to customize Event Reason strings.
+func performPostResumeInit(
+	ctx context.Context,
+	box *agentsv1alpha1.Sandbox,
+	newStatus *agentsv1alpha1.SandboxStatus,
+	initFunc func() error,
+	recorder record.EventRecorder,
+	failEventReason string,
+	successEventReason string,
+) error {
+	if err := initFunc(); err != nil {
+		klog.ErrorS(err, "post-resume initialization failed (runtime re-init or CSI re-mount)", "sandbox", klog.KObj(box))
+		recorder.Event(box, corev1.EventTypeWarning, failEventReason,
+			fmt.Sprintf("Failed to perform post-resume initialization: %v", err))
+		utils.SetSandboxCondition(newStatus, metav1.Condition{
+			Type:               string(agentsv1alpha1.RuntimeInitialized),
+			Status:             metav1.ConditionFalse,
+			Reason:             agentsv1alpha1.SandboxConditionRuntimeInitReasonFailed,
+			Message:            utils.TruncateConditionMessage(fmt.Sprintf("Runtime initialization failed: %v", err)),
+			LastTransitionTime: metav1.Now(),
+		})
+		return err
+	}
+	recorder.Event(box, corev1.EventTypeNormal, successEventReason,
+		"Post-resume initialization completed successfully")
+	utils.SetSandboxCondition(newStatus, metav1.Condition{
+		Type:               string(agentsv1alpha1.RuntimeInitialized),
+		Status:             metav1.ConditionTrue,
+		Reason:             agentsv1alpha1.SandboxConditionRuntimeInitReasonSucceeded,
+		Message:            "Runtime initialization completed",
+		LastTransitionTime: metav1.Now(),
+	})
+	return nil
 }
 
 func (r *commonControl) EnsureSandboxPaused(ctx context.Context, args EnsureFuncArgs) error {
@@ -178,12 +236,7 @@ func (r *commonControl) EnsureSandboxPaused(ctx context.Context, args EnsureFunc
 	}
 
 	// The paused phase sets condition ready to false.
-	if rCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady)); rCond != nil && rCond.Status == metav1.ConditionTrue {
-		rCond.Status = metav1.ConditionFalse
-		rCond.LastTransitionTime = metav1.Now()
-		utils.SetSandboxCondition(newStatus, *rCond)
-		klog.InfoS("The paused phase sets condition ready to false", "sandbox", klog.KObj(box))
-	}
+	setReadyConditionFalseForPause(newStatus)
 
 	// Pod deletion completed, paused completed
 	// cond.Status == metav1.ConditionFalse just for sure
@@ -250,33 +303,24 @@ func (r *commonControl) EnsureSandboxResumed(ctx context.Context, args EnsureFun
 		}
 
 		// re-initialize sandbox after resuming or upgrading (includes runtime re-init and CSI storage re-mount)
-		if err := r.initializer.Initialize(ctx, box, newStatus); err != nil {
-			klog.ErrorS(err, "post-resume initialization failed", "sandbox", klog.KObj(box))
-			r.recorder.Event(box, corev1.EventTypeWarning, string(agentsv1alpha1.RuntimeInitialized),
-				fmt.Sprintf("Failed to perform post-resume initialization: %v", err))
-			utils.SetSandboxCondition(newStatus, metav1.Condition{
-				Type:   string(agentsv1alpha1.RuntimeInitialized),
-				Status: metav1.ConditionFalse,
-				Reason: agentsv1alpha1.SandboxConditionRuntimeInitReasonFailed,
-				// TODO to differentiate init and mount errors
-				Message:            utils.TruncateConditionMessage(fmt.Sprintf("Runtime initialization failed: %v", err)),
-				LastTransitionTime: metav1.Now(),
-			})
+		if err := performPostResumeInit(ctx, box, newStatus,
+			func() error { return r.initializer.Initialize(ctx, box, newStatus) },
+			r.recorder,
+			string(agentsv1alpha1.RuntimeInitialized),
+			string(agentsv1alpha1.RuntimeInitialized),
+		); err != nil {
 			return err
 		}
-		r.recorder.Event(box, corev1.EventTypeNormal, string(agentsv1alpha1.RuntimeInitialized),
-			"Post-resume initialization completed successfully")
-		utils.SetSandboxCondition(newStatus, metav1.Condition{
-			Type:               string(agentsv1alpha1.RuntimeInitialized),
-			Status:             metav1.ConditionTrue,
-			Reason:             agentsv1alpha1.SandboxConditionRuntimeInitReasonSucceeded,
-			Message:            "Runtime initialization completed",
-			LastTransitionTime: metav1.Now(),
-		})
 
 		// Initialize succeeded: now set Ready=True to signal sandbox-manager's
 		// NewSandboxResumeTask that all post-resume initialization is done.
 		rCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady))
+		if rCond == nil {
+			rCond = &metav1.Condition{
+				Type:   string(agentsv1alpha1.SandboxConditionReady),
+				Reason: agentsv1alpha1.SandboxReadyReasonPodReady,
+			}
+		}
 		rCond.Status = metav1.ConditionStatus(pCond.Status)
 		rCond.LastTransitionTime = pCond.LastTransitionTime
 		utils.SetSandboxCondition(newStatus, *rCond)
@@ -302,7 +346,13 @@ func hasUpgradeAction(box *agentsv1alpha1.Sandbox, pre bool) bool {
 	return true
 }
 
-func (r *commonControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureFuncArgs) (retErr error) {
+// ensureSandboxUpgradedCommon is the shared implementation of EnsureSandboxUpgraded,
+// driving the three-phase upgrade state machine: PreUpgrade → UpgradePod → PostUpgrade.
+func ensureSandboxUpgradedCommon(
+	ctx context.Context,
+	args EnsureFuncArgs,
+	orchestratorArgs UpgradeOrchestratorArgs,
+) error {
 	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
 
 	// Set Ready=False during upgrade
@@ -333,7 +383,7 @@ func (r *commonControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureFu
 			if box.Spec.Lifecycle != nil {
 				action = box.Spec.Lifecycle.PreUpgrade
 			}
-			result := r.executeUpgradeAction(ctx, pod, box, action)
+			result := orchestratorArgs.ExecuteUpgradeActionFunc(ctx, pod, box, action)
 			klog.InfoS("preUpgrade result", "sandbox", klog.KObj(box), "succeeded", result.Succeeded, "message", result.Message)
 			if !result.Succeeded {
 				// Record preUpgrade action failed
@@ -351,7 +401,7 @@ func (r *commonControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureFu
 		utils.SetSandboxCondition(newStatus, *upgradeCond)
 		fallthrough
 	case agentsv1alpha1.SandboxUpgradingReasonUpgradePod, agentsv1alpha1.SandboxUpgradingReasonUpgradePodFailed:
-		done, err := r.performRecreateUpgrade(ctx, args)
+		done, err := orchestratorArgs.PerformRecreateUpgradeFunc(ctx, args)
 		if err != nil {
 			klog.ErrorS(err, "UpgradePod step failed", "sandbox", klog.KObj(box))
 			return err
@@ -364,7 +414,7 @@ func (r *commonControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureFu
 
 		// Re-fetch the Pod after recreate upgrade, since the old pod object is stale (deleted and replaced).
 		var freshPod corev1.Pod
-		if err := r.Get(ctx, types.NamespacedName{Namespace: box.Namespace, Name: box.Name}, &freshPod); err != nil {
+		if err := orchestratorArgs.Client.Get(ctx, types.NamespacedName{Namespace: box.Namespace, Name: box.Name}, &freshPod); err != nil {
 			klog.ErrorS(err, "Failed to re-fetch pod after recreate upgrade", "sandbox", klog.KObj(box))
 			return err
 		}
@@ -382,7 +432,7 @@ func (r *commonControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureFu
 			if box.Spec.Lifecycle != nil {
 				action = box.Spec.Lifecycle.PostUpgrade
 			}
-			result := r.executeUpgradeAction(ctx, pod, box, action)
+			result := orchestratorArgs.ExecuteUpgradeActionFunc(ctx, pod, box, action)
 			klog.InfoS("postUpgrade result", "sandbox", klog.KObj(box), "succeeded", result.Succeeded, "message", result.Message)
 			if !result.Succeeded {
 				// Record postUpgrade action failed
@@ -412,11 +462,28 @@ func (r *commonControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureFu
 	return nil
 }
 
-func (r *commonControl) EnsureSandboxTerminated(ctx context.Context, args EnsureFuncArgs) error {
+// EnsureSandboxUpgraded delegates to ensureSandboxUpgradedCommon shared implementation.
+func (r *commonControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureFuncArgs) (retErr error) {
+	orchestratorArgs := UpgradeOrchestratorArgs{
+		Client:                     r.Client,
+		PerformRecreateUpgradeFunc: r.performRecreateUpgrade,
+		ExecuteUpgradeActionFunc:   r.executeUpgradeAction,
+	}
+	return ensureSandboxUpgradedCommon(ctx, args, orchestratorArgs)
+}
+
+// ensureSandboxTerminatedCommon is the minimal shared set for EnsureSandboxTerminated:
+// delete Pod, remove Finalizer after Pod is gone.
+func ensureSandboxTerminatedCommon(
+	ctx context.Context,
+	args EnsureFuncArgs,
+	cli client.Client,
+) error {
 	pod, box, _ := args.Pod, args.Box, args.NewStatus
+
 	var err error
 	if pod == nil {
-		_, err = utils.PatchFinalizer(ctx, r.Client, box, utils.RemoveFinalizerOpType, SandboxFinalizer)
+		_, err = utils.PatchFinalizer(ctx, cli, box, utils.RemoveFinalizerOpType, utils.SandboxFinalizer)
 		if err != nil {
 			klog.ErrorS(err, "update sandbox finalizer failed", "sandbox", klog.KObj(box))
 			return err
@@ -428,7 +495,7 @@ func (r *commonControl) EnsureSandboxTerminated(ctx context.Context, args Ensure
 		return nil
 	}
 
-	err = client.IgnoreNotFound(r.Delete(ctx, pod))
+	err = client.IgnoreNotFound(cli.Delete(ctx, pod))
 	if err != nil {
 		klog.ErrorS(err, "delete pod failed", "sandbox", klog.KObj(box))
 		return err
@@ -437,44 +504,9 @@ func (r *commonControl) EnsureSandboxTerminated(ctx context.Context, args Ensure
 	return nil
 }
 
-func (r *commonControl) createPod(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus) (*corev1.Pod, error) {
-
-	// Ensure all registered CA bundle Secrets exist in the sandbox namespace
-	// before creating the pod. Whether a given spec is actually copied is
-	// decided by its CABundleSpec.EnabledFor predicate (e.g. the gateway CA
-	// spec is bound at controller startup to require the traffic-proxy runtime),
-	// so a missing source Secret only blocks creation when the spec applies.
-	if shouldInjectCABundles() {
-		if err := identity.EnsureAllCACerts(ctx, r.Client, box, box.Namespace); err != nil {
-			klog.ErrorS(err, "failed to ensure CA bundle secrets", "sandbox", klog.KObj(box))
-			return nil, err
-		}
-	}
-
-	pod, err := GeneratePodFromSandbox(ctx, r.Client, box, newStatus.UpdateRevision)
-	if err != nil {
-		return nil, err
-	}
-
-	// to avoid the performance issue, using the controller to inject csi containers
-	// fetch the configmap and parse the configuration based on the controller runtime
-	injectErr := sidecarutils.InjectSandboxRuntimes(ctx, box, pod, r.Client)
-	if injectErr != nil {
-		klog.ErrorS(injectErr, "failed to inject pod template with csi sidecar or runtime sidecar", "sandbox", klog.KObj(box))
-		return nil, injectErr
-	}
-
-	ScaleExpectation.ExpectScale(GetControllerKey(box), expectations.Create, box.Name)
-	err = r.Create(ctx, pod)
-	if err != nil {
-		ScaleExpectation.ObserveScale(GetControllerKey(box), expectations.Create, box.Name)
-		if !errors.IsAlreadyExists(err) {
-			klog.ErrorS(err, "create pod failed", "sandbox", klog.KObj(box))
-			return nil, err
-		}
-	}
-	klog.InfoS("Create pod success", "sandbox", klog.KObj(box), "Body", utils.DumpJson(pod))
-	return pod, nil
+// EnsureSandboxTerminated common version with no extra pre-processing, delegates directly to the minimal shared set.
+func (r *commonControl) EnsureSandboxTerminated(ctx context.Context, args EnsureFuncArgs) error {
+	return ensureSandboxTerminatedCommon(ctx, args, r.Client)
 }
 
 // shouldInjectCABundles is the cluster-level kill switch for the CA bundle
@@ -487,17 +519,73 @@ func shouldInjectCABundles() bool {
 	return utilfeature.DefaultFeatureGate.Enabled(features.SecurityIdentityProviderGate)
 }
 
-func (r *commonControl) handleInplaceUpdateSandbox(ctx context.Context, args EnsureFuncArgs) (bool, error) {
-	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
-	handler := &CommonInPlaceUpdateHandler{
-		control:  r.inplaceUpdateControl,
-		recorder: r.recorder,
+// createPodCommon is the shared skeleton for createPod, responsible for:
+// 1) CA Bundle injection 2) delegating to generatePodFunc for Pod generation 3) ScaleExpectation + creation + error handling.
+// generatePodFunc is injected by the caller with differentiated Pod generation logic (including sidecar injection).
+// tolerateAlreadyExists when true means AlreadyExists is not treated as an error (common tolerates, ACS does not).
+func createPodCommon(
+	ctx context.Context,
+	cli client.Client,
+	box *agentsv1alpha1.Sandbox,
+	generatePodFunc func() (*corev1.Pod, error),
+	tolerateAlreadyExists bool,
+) (*corev1.Pod, error) {
+	// Step 1: CA Bundle injection
+	if shouldInjectCABundles() {
+		if err := identity.EnsureAllCACerts(ctx, cli, box, box.Namespace); err != nil {
+			klog.ErrorS(err, "failed to ensure CA bundle secrets", "sandbox", klog.KObj(box))
+			return nil, err
+		}
 	}
-	return handleInPlaceUpdateCommon(ctx, handler, pod, box, newStatus)
+
+	// Step 2: Generate pod
+	pod, err := generatePodFunc()
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 3: Create pod with scale expectation tracking
+	ScaleExpectation.ExpectScale(GetControllerKey(box), expectations.Create, box.Name)
+	err = cli.Create(ctx, pod)
+	if err != nil {
+		ScaleExpectation.ObserveScale(GetControllerKey(box), expectations.Create, box.Name)
+		if tolerateAlreadyExists && errors.IsAlreadyExists(err) {
+			return pod, nil
+		}
+		klog.ErrorS(err, "create pod failed", "sandbox", klog.KObj(box))
+		return nil, err
+	}
+	klog.InfoS("create pod success", "sandbox", klog.KObj(box), "Body", utils.DumpJson(pod))
+	return pod, nil
 }
 
-// performRecreateUpgrade handles the Recreate upgrade step (delete old pod + create new pod).
-func (r *commonControl) performRecreateUpgrade(ctx context.Context, args EnsureFuncArgs) (bool, error) {
+func (r *commonControl) createPod(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus) (*corev1.Pod, error) {
+	return createPodCommon(ctx, r.Client, box,
+		func() (*corev1.Pod, error) {
+			pod, err := GeneratePodFromSandbox(ctx, r.Client, box, newStatus.UpdateRevision)
+			if err != nil {
+				return nil, err
+			}
+			// to avoid the performance issue, using the controller to inject csi containers
+			// fetch the configmap and parse the configuration based on the controller runtime
+			injectErr := sidecarutils.InjectSandboxRuntimes(ctx, box, pod, r.Client)
+			if injectErr != nil {
+				klog.ErrorS(injectErr, "failed to inject pod template with csi sidecar or runtime sidecar", "sandbox", klog.KObj(box))
+				return nil, injectErr
+			}
+			return pod, nil
+		},
+		true, // common tolerates AlreadyExists
+	)
+}
+
+// performRecreateUpgradeCommon is the shared implementation for the Recreate upgrade step, responsible for deleting the old Pod and creating a new one.
+// Core flow: 1) Delete old Pod → 2) Create new Pod → 3) Wait for new Pod Ready → 4) Run initialization.
+func performRecreateUpgradeCommon(
+	ctx context.Context,
+	args EnsureFuncArgs,
+	upgradeArgs RecreateUpgradeArgs,
+) (bool, error) {
 	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
 
 	// Step 1: Delete old Pod (has old template hash)
@@ -508,7 +596,7 @@ func (r *commonControl) performRecreateUpgrade(ctx context.Context, args EnsureF
 		}
 		// Delete pod
 		ScaleExpectation.ExpectScale(GetControllerKey(box), expectations.Delete, box.Name)
-		if err := r.Delete(ctx, pod); err != nil {
+		if err := upgradeArgs.Client.Delete(ctx, pod); err != nil {
 			ScaleExpectation.ObserveScale(GetControllerKey(box), expectations.Delete, box.Name)
 			if !errors.IsNotFound(err) {
 				klog.ErrorS(err, "Failed to delete pod for upgrade", "sandbox", klog.KObj(box))
@@ -522,7 +610,7 @@ func (r *commonControl) performRecreateUpgrade(ctx context.Context, args EnsureF
 	// Step 2: Create new Pod (old pod deleted)
 	if pod == nil {
 		klog.InfoS("Creating new pod for upgrade", "sandbox", klog.KObj(box))
-		newPod, err := r.createPod(ctx, box, newStatus)
+		newPod, err := upgradeArgs.CreatePodFunc(ctx, box, newStatus)
 		if err != nil {
 			klog.ErrorS(err, "Failed to create new pod for upgrade", "sandbox", klog.KObj(box))
 			return false, err
@@ -575,23 +663,26 @@ func (r *commonControl) performRecreateUpgrade(ctx context.Context, args EnsureF
 	}
 
 	// Step 4: Perform post-recreate-upgrade initialization (re-init runtime, re-mount CSI).
-	if err := r.initializer.Initialize(ctx, box, newStatus); err != nil {
+	if err := upgradeArgs.Initializer.Initialize(ctx, box, newStatus); err != nil {
 		klog.ErrorS(err, "post-upgrade initialization failed", "sandbox", klog.KObj(box))
-		r.recorder.Event(box, corev1.EventTypeWarning, string(agentsv1alpha1.RuntimeInitialized),
-			fmt.Sprintf("Failed to perform post-upgrade initialization: %v", err))
+		if upgradeArgs.Recorder != nil {
+			upgradeArgs.Recorder.Event(box, corev1.EventTypeWarning, string(agentsv1alpha1.RuntimeInitialized),
+				fmt.Sprintf("Failed to perform post-upgrade initialization: %v", err))
+		}
 		utils.SetSandboxCondition(newStatus, metav1.Condition{
-			Type:   string(agentsv1alpha1.RuntimeInitialized),
-			Status: metav1.ConditionFalse,
-			Reason: agentsv1alpha1.SandboxConditionRuntimeInitReasonFailed,
-			// TODO to differentiate init and mount errors
+			Type:               string(agentsv1alpha1.RuntimeInitialized),
+			Status:             metav1.ConditionFalse,
+			Reason:             agentsv1alpha1.SandboxConditionRuntimeInitReasonFailed,
 			Message:            utils.TruncateConditionMessage(fmt.Sprintf("Runtime initialization failed: %v", err)),
 			LastTransitionTime: metav1.Now(),
 		})
 		return false, err
 	}
 
-	r.recorder.Event(box, corev1.EventTypeNormal, string(agentsv1alpha1.RuntimeInitialized),
-		"Post-upgrade initialization completed successfully")
+	if upgradeArgs.Recorder != nil {
+		upgradeArgs.Recorder.Event(box, corev1.EventTypeNormal, string(agentsv1alpha1.RuntimeInitialized),
+			"Post-upgrade initialization completed successfully")
+	}
 	utils.SetSandboxCondition(newStatus, metav1.Condition{
 		Type:               string(agentsv1alpha1.RuntimeInitialized),
 		Status:             metav1.ConditionTrue,
@@ -603,16 +694,26 @@ func (r *commonControl) performRecreateUpgrade(ctx context.Context, args EnsureF
 	return true, nil
 }
 
+// performRecreateUpgrade delegates to performRecreateUpgradeCommon shared implementation.
+func (r *commonControl) performRecreateUpgrade(ctx context.Context, args EnsureFuncArgs) (bool, error) {
+	upgradeArgs := RecreateUpgradeArgs{
+		Client:        r.Client,
+		Recorder:      r.recorder,
+		Initializer:   r.initializer,
+		CreatePodFunc: r.createPod,
+	}
+	return performRecreateUpgradeCommon(ctx, args, upgradeArgs)
+}
+
 // upgradeActionResult represents the result of executing an upgrade hook.
 type upgradeActionResult struct {
 	Succeeded bool
 	Message   string
 }
 
-// executeUpgradeAction executes an upgrade action and returns the result.
-// If action is nil (not configured), it returns success directly.
-// If pod is nil and action is configured, it returns failure.
-func (r *commonControl) executeUpgradeAction(ctx context.Context, pod *corev1.Pod, box *agentsv1alpha1.Sandbox, action *agentsv1alpha1.UpgradeAction) upgradeActionResult {
+// executeUpgradeActionCommon is the shared implementation for executing upgrade hook actions.
+func executeUpgradeActionCommon(ctx context.Context, pod *corev1.Pod, box *agentsv1alpha1.Sandbox, actionArgs UpgradeActionArgs) upgradeActionResult {
+	action := actionArgs.Action
 	if action == nil {
 		return upgradeActionResult{Succeeded: true, Message: "no hook configured, skipped"}
 	}
@@ -620,7 +721,7 @@ func (r *commonControl) executeUpgradeAction(ctx context.Context, pod *corev1.Po
 		return upgradeActionResult{Succeeded: false, Message: "pod not found, cannot execute hook"}
 	}
 
-	exitCode, stdout, stderr, err := r.lifecycleHookFunc(ctx, box, action)
+	exitCode, stdout, stderr, err := actionArgs.LifecycleHookFunc(ctx, box, action)
 	if err != nil {
 		msg := fmt.Sprintf("hook execution error: %v, stderr: %s, stdout: %s", err, stderr, stdout)
 		return upgradeActionResult{Succeeded: false, Message: utils.TruncateConditionMessage(msg)}
@@ -630,4 +731,13 @@ func (r *commonControl) executeUpgradeAction(ctx context.Context, pod *corev1.Po
 		return upgradeActionResult{Succeeded: false, Message: utils.TruncateConditionMessage(msg)}
 	}
 	return upgradeActionResult{Succeeded: true, Message: fmt.Sprintf("hook succeeded, stdout: %s", stdout)}
+}
+
+// executeUpgradeAction delegates to executeUpgradeActionCommon shared implementation.
+func (r *commonControl) executeUpgradeAction(ctx context.Context, pod *corev1.Pod, box *agentsv1alpha1.Sandbox, action *agentsv1alpha1.UpgradeAction) upgradeActionResult {
+	actionArgs := UpgradeActionArgs{
+		Action:            action,
+		LifecycleHookFunc: r.lifecycleHookFunc,
+	}
+	return executeUpgradeActionCommon(ctx, pod, box, actionArgs)
 }

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
-	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/utils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
@@ -970,7 +969,7 @@ func TestCommonControl_EnsureSandboxTerminated(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test-sandbox",
 						Namespace:  "default",
-						Finalizers: []string{SandboxFinalizer},
+						Finalizers: []string{utils.SandboxFinalizer},
 					},
 				},
 				NewStatus: &agentsv1alpha1.SandboxStatus{},
@@ -1205,16 +1204,17 @@ func TestCommonControl_createPod(t *testing.T) {
 	}
 }
 
-func TestCommonControl_handleInplaceUpdateSandbox(t *testing.T) {
+func TestHandleInPlaceUpdateCommon_ViaEnsureUpdated(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = agentsv1alpha1.AddToScheme(scheme)
 
-	control := &commonControl{
-		Client:   fake.NewClientBuilder().WithScheme(scheme).Build(),
-		recorder: record.NewFakeRecorder(10),
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	rec := record.NewFakeRecorder(10)
+	handler := &CommonInPlaceUpdateHandler{
+		control:  inplaceupdate.NewInPlaceUpdateControl(cli, inplaceupdate.DefaultGeneratePatchBodyFunc),
+		recorder: rec,
 	}
-	control.inplaceUpdateControl = inplaceupdate.NewInPlaceUpdateControl(control.Client, inplaceupdate.DefaultGeneratePatchBodyFunc)
 
 	// Test case 1: Pod doesn't have template hash label
 	sandbox1 := &agentsv1alpha1.Sandbox{
@@ -1252,9 +1252,9 @@ func TestCommonControl_handleInplaceUpdateSandbox(t *testing.T) {
 		NewStatus: &agentsv1alpha1.SandboxStatus{},
 	}
 
-	done, err := control.handleInplaceUpdateSandbox(context.TODO(), args1)
+	done, err := handleInPlaceUpdateCommon(context.TODO(), handler, args1.Pod, args1.Box, args1.NewStatus)
 	if err != nil {
-		t.Fatalf("handleInplaceUpdateSandbox() error = %v", err)
+		t.Fatalf("handleInPlaceUpdateCommon() error = %v", err)
 	}
 	if !done {
 		t.Errorf("Expected done to be true when pod doesn't have template hash label")
@@ -1299,9 +1299,9 @@ func TestCommonControl_handleInplaceUpdateSandbox(t *testing.T) {
 		NewStatus: &agentsv1alpha1.SandboxStatus{UpdateRevision: "new-revision"},
 	}
 
-	done, err = control.handleInplaceUpdateSandbox(context.TODO(), args2)
+	done, err = handleInPlaceUpdateCommon(context.TODO(), handler, args2.Pod, args2.Box, args2.NewStatus)
 	if err != nil {
-		t.Fatalf("handleInplaceUpdateSandbox() error = %v", err)
+		t.Fatalf("handleInPlaceUpdateCommon() error = %v", err)
 	}
 	if !done {
 		t.Errorf("Expected done to be true when hash mismatch occurs")
@@ -1346,9 +1346,9 @@ func TestCommonControl_handleInplaceUpdateSandbox(t *testing.T) {
 		NewStatus: &agentsv1alpha1.SandboxStatus{UpdateRevision: "same-revision"},
 	}
 
-	done, err = control.handleInplaceUpdateSandbox(context.TODO(), args3)
+	done, err = handleInPlaceUpdateCommon(context.TODO(), handler, args3.Pod, args3.Box, args3.NewStatus)
 	if err != nil {
-		t.Fatalf("handleInplaceUpdateSandbox() error = %v", err)
+		t.Fatalf("handleInPlaceUpdateCommon() error = %v", err)
 	}
 	if !done {
 		t.Errorf("Expected done to be true when revision is consistent and inplace update is completed")
@@ -1797,7 +1797,7 @@ func TestCommonControl_EnsureSandboxUpdated_InplaceNotDone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EnsureSandboxUpdated() unexpected error: %v", err)
 	}
-	// handleInplaceUpdateSandbox with hash mismatch returns (true, nil), so status gets synced
+	// handleInPlaceUpdateCommon with hash mismatch returns (true, nil), so status gets synced
 	if newStatus.SandboxIp != "10.0.0.2" {
 		t.Errorf("Expected SandboxIp '10.0.0.2', got %s", newStatus.SandboxIp)
 	}
@@ -2084,195 +2084,6 @@ func TestCommonControl_performRecreateUpgrade_NewPodNotReady(t *testing.T) {
 	}
 	if done {
 		t.Error("Expected done=false for pod not ready")
-	}
-}
-
-// ---------------------------------------------------------------------------
-// CA Certificate Injection Tests (driven by identity.CABundleSpec registry)
-// ---------------------------------------------------------------------------
-
-func TestCommonControl_createPod_WithCAInjection(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = agentsv1alpha1.AddToScheme(scheme)
-
-	tests := []struct {
-		name                    string
-		featureGateEnabled      bool
-		seedSourceSecret        bool
-		withTrafficProxyRuntime bool
-		expectCAVolume          bool
-		expectCAMount           bool
-		expectError             string
-	}{
-		{
-			name:                    "feature gate enabled, traffic-proxy runtime, source secret present - CA injected",
-			featureGateEnabled:      true,
-			withTrafficProxyRuntime: true,
-			seedSourceSecret:        true,
-			expectCAVolume:          true,
-			expectCAMount:           true,
-		},
-		{
-			name:                    "feature gate disabled - no CA injection regardless of source",
-			featureGateEnabled:      false,
-			withTrafficProxyRuntime: true,
-			seedSourceSecret:        false,
-			expectCAVolume:          false,
-			expectCAMount:           false,
-		},
-		{
-			name:                    "feature gate enabled but no traffic-proxy runtime - no CA injection",
-			featureGateEnabled:      true,
-			withTrafficProxyRuntime: false,
-			seedSourceSecret:        false,
-			expectCAVolume:          false,
-			expectCAMount:           false,
-		},
-		{
-			name:                    "feature gate enabled, traffic-proxy runtime, source secret missing - block creation",
-			featureGateEnabled:      true,
-			withTrafficProxyRuntime: true,
-			seedSourceSecret:        false,
-			expectError:             "source CA secret",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.featureGateEnabled {
-				_ = utilfeature.DefaultMutableFeatureGate.Set("SecurityIdentityProvider=true")
-				// Mirror the production binding in cmd/agent-sandbox-controller/ca_binding.go
-				// so the gateway CA spec only applies to sandboxes that declare the
-				// traffic-proxy runtime. This is the single place where runtime-level
-				// gating lives now (callers no longer pre-check IsRuntimeEnabled).
-				identity.BindCAEnabledFor(identity.GatewayCABundleName, func(sbx *agentsv1alpha1.Sandbox) bool {
-					return sidecarutils.IsRuntimeEnabled(sbx, agentsv1alpha1.RuntimeConfigForInjectTrafficProxy)
-				})
-				t.Cleanup(func() {
-					_ = utilfeature.DefaultMutableFeatureGate.Set("SecurityIdentityProvider=false")
-					identity.BindCAEnabledFor(identity.GatewayCABundleName, nil)
-				})
-			}
-
-			objs := []client.Object{}
-			if tt.seedSourceSecret {
-				objs = append(objs, &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      identity.GatewayCASecretName,
-						Namespace: utils.DefaultSandboxDeployNamespace,
-					},
-					Type: corev1.SecretTypeOpaque,
-					Data: map[string][]byte{
-						identity.GatewayCAKey: []byte("test-ca-bundle-content"),
-					},
-				})
-			}
-			// When the sandbox declares the traffic-proxy runtime, InjectSandboxRuntimes
-			// will look up the corresponding template in the sandbox-injection ConfigMap.
-			// Seed a minimal valid template so createPod's sidecar-injection step does
-			// not fail and we can isolate CA injection behaviour under test.
-			if tt.withTrafficProxyRuntime {
-				objs = append(objs, &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      sidecarutils.SandboxInjectionConfigName,
-						Namespace: utils.DefaultSandboxDeployNamespace,
-					},
-					Data: map[string]string{
-						sidecarutils.KEY_TRAFFIC_PROXY_INJECTION_CONFIG: `{"mainContainer":{},"csiSidecar":[],"volume":[]}`,
-					},
-				})
-			}
-
-			control := &commonControl{
-				Client:   fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
-				recorder: record.NewFakeRecorder(10),
-			}
-
-			sandbox := &agentsv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-sandbox",
-					Namespace: "default",
-				},
-				Spec: agentsv1alpha1.SandboxSpec{
-					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
-						Template: &corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{Name: "main", Image: "nginx:latest"},
-								},
-							},
-						},
-					},
-				},
-			}
-			if tt.withTrafficProxyRuntime {
-				sandbox.Spec.Runtimes = []agentsv1alpha1.RuntimeConfig{
-					{Name: agentsv1alpha1.RuntimeConfigForInjectTrafficProxy},
-				}
-			}
-
-			status := &agentsv1alpha1.SandboxStatus{UpdateRevision: "rev1"}
-			pod, err := control.createPod(context.TODO(), sandbox, status)
-
-			if tt.expectError != "" {
-				if err == nil {
-					t.Fatalf("expected error containing %q, got nil", tt.expectError)
-				}
-				if !contains(err.Error(), tt.expectError) {
-					t.Fatalf("expected error containing %q, got %q", tt.expectError, err.Error())
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("createPod() unexpected error: %v", err)
-			}
-
-			foundCAVolume := false
-			for _, v := range pod.Spec.Volumes {
-				if v.Name == "sandbox-gateway-ca" {
-					foundCAVolume = true
-					if v.Secret == nil || v.Secret.SecretName != identity.GatewayCASecretName {
-						t.Errorf("CA volume has wrong secret source")
-					}
-					break
-				}
-			}
-			if foundCAVolume != tt.expectCAVolume {
-				t.Errorf("expected CA volume present=%v, got %v", tt.expectCAVolume, foundCAVolume)
-			}
-
-			foundCAMount := false
-			if len(pod.Spec.Containers) > 0 {
-				for _, vm := range pod.Spec.Containers[0].VolumeMounts {
-					if vm.Name == "sandbox-gateway-ca" {
-						foundCAMount = true
-						if vm.MountPath != "/etc/ssl/certs/agent-identity/gateway-ca.crt" {
-							t.Errorf("expected mount path '/etc/ssl/certs/agent-identity/gateway-ca.crt', got %q", vm.MountPath)
-						}
-						break
-					}
-				}
-			}
-			if foundCAMount != tt.expectCAMount {
-				t.Errorf("expected CA mount present=%v, got %v", tt.expectCAMount, foundCAMount)
-			}
-
-			if tt.featureGateEnabled && tt.seedSourceSecret && tt.withTrafficProxyRuntime {
-				var replicated corev1.Secret
-				err = control.Get(context.TODO(), types.NamespacedName{
-					Name:      identity.GatewayCASecretName,
-					Namespace: "default",
-				}, &replicated)
-				if err != nil {
-					t.Fatalf("expected gateway CA secret to be replicated to target ns, got error: %v", err)
-				}
-				if string(replicated.Data[identity.GatewayCAKey]) != "test-ca-bundle-content" {
-					t.Errorf("expected replicated secret data to match source, got %q",
-						string(replicated.Data[identity.GatewayCAKey]))
-				}
-			}
-		})
 	}
 }
 

--- a/pkg/controller/sandbox/core/interface.go
+++ b/pkg/controller/sandbox/core/interface.go
@@ -61,6 +61,30 @@ type SandboxControl interface {
 	EnsureSandboxTerminated(ctx context.Context, args EnsureFuncArgs) error
 }
 
+// UpgradeOrchestratorArgs holds the dependencies for ensureSandboxUpgradedCommon,
+// which drives the three-phase upgrade state machine (PreUpgrade → UpgradePod → PostUpgrade).
+type UpgradeOrchestratorArgs struct {
+	Client                     client.Client
+	PerformRecreateUpgradeFunc func(ctx context.Context, args EnsureFuncArgs) (bool, error)
+	ExecuteUpgradeActionFunc   func(ctx context.Context, pod *corev1.Pod, box *agentsv1alpha1.Sandbox, action *agentsv1alpha1.UpgradeAction) upgradeActionResult
+}
+
+// RecreateUpgradeArgs holds the dependencies for performRecreateUpgradeCommon,
+// which deletes the old Pod, creates a new one, waits for Ready, and runs initialization.
+type RecreateUpgradeArgs struct {
+	Client        client.Client
+	Recorder      record.EventRecorder
+	Initializer   SandboxInitializer
+	CreatePodFunc func(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus) (*corev1.Pod, error)
+}
+
+// UpgradeActionArgs holds the dependencies for executeUpgradeActionCommon,
+// which executes a single upgrade hook action (PreUpgrade or PostUpgrade).
+type UpgradeActionArgs struct {
+	Action            *agentsv1alpha1.UpgradeAction
+	LifecycleHookFunc LifecycleHookFunc
+}
+
 type SandboxControlArgs struct {
 	Client      client.Client
 	APIReader   client.Reader

--- a/pkg/controller/sandbox/pod_event_handler.go
+++ b/pkg/controller/sandbox/pod_event_handler.go
@@ -90,13 +90,13 @@ func isActivePodUpdate(oldObj, newObj *corev1.Pod) bool {
 	if !isPodConditionEqual(rCond1, rCond2) {
 		return true
 	}
-	pCond1 := utils.GetPodCondition(&oldObj.Status, core.PodConditionContainersPaused)
-	pCond2 := utils.GetPodCondition(&newObj.Status, core.PodConditionContainersPaused)
+	pCond1 := utils.GetPodCondition(&oldObj.Status, utils.PodConditionContainersPaused)
+	pCond2 := utils.GetPodCondition(&newObj.Status, utils.PodConditionContainersPaused)
 	if !isPodConditionEqual(pCond1, pCond2) {
 		return true
 	}
-	cCond1 := utils.GetPodCondition(&oldObj.Status, core.PodConditionContainersResumed)
-	cCond2 := utils.GetPodCondition(&newObj.Status, core.PodConditionContainersResumed)
+	cCond1 := utils.GetPodCondition(&oldObj.Status, utils.PodConditionContainersResumed)
+	cCond2 := utils.GetPodCondition(&newObj.Status, utils.PodConditionContainersResumed)
 	if !isPodConditionEqual(cCond1, cCond2) {
 		return true
 	}

--- a/pkg/controller/sandbox/pod_event_handler_test.go
+++ b/pkg/controller/sandbox/pod_event_handler_test.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/openkruise/agents/pkg/controller/sandbox/core"
 	_ "github.com/openkruise/agents/pkg/features"
 	"github.com/openkruise/agents/pkg/utils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
@@ -226,7 +225,7 @@ func TestIsActivePodUpdate(t *testing.T) {
 					Phase: corev1.PodRunning,
 					Conditions: []corev1.PodCondition{
 						{
-							Type:   core.PodConditionContainersPaused,
+							Type:   utils.PodConditionContainersPaused,
 							Status: corev1.ConditionFalse,
 						},
 					},
@@ -237,7 +236,7 @@ func TestIsActivePodUpdate(t *testing.T) {
 					Phase: corev1.PodRunning,
 					Conditions: []corev1.PodCondition{
 						{
-							Type:   core.PodConditionContainersPaused,
+							Type:   utils.PodConditionContainersPaused,
 							Status: corev1.ConditionTrue,
 						},
 					},
@@ -259,7 +258,7 @@ func TestIsActivePodUpdate(t *testing.T) {
 					Phase: corev1.PodRunning,
 					Conditions: []corev1.PodCondition{
 						{
-							Type:   core.PodConditionContainersPaused,
+							Type:   utils.PodConditionContainersPaused,
 							Status: corev1.ConditionTrue,
 							Reason: "ContainersPaused",
 						},
@@ -276,7 +275,7 @@ func TestIsActivePodUpdate(t *testing.T) {
 					Phase: corev1.PodRunning,
 					Conditions: []corev1.PodCondition{
 						{
-							Type:   core.PodConditionContainersResumed,
+							Type:   utils.PodConditionContainersResumed,
 							Status: corev1.ConditionFalse,
 						},
 					},
@@ -287,7 +286,7 @@ func TestIsActivePodUpdate(t *testing.T) {
 					Phase: corev1.PodRunning,
 					Conditions: []corev1.PodCondition{
 						{
-							Type:   core.PodConditionContainersResumed,
+							Type:   utils.PodConditionContainersResumed,
 							Status: corev1.ConditionTrue,
 						},
 					},
@@ -303,7 +302,7 @@ func TestIsActivePodUpdate(t *testing.T) {
 					Phase: corev1.PodRunning,
 					Conditions: []corev1.PodCondition{
 						{
-							Type:    core.PodConditionContainersResumed,
+							Type:    utils.PodConditionContainersResumed,
 							Status:  corev1.ConditionTrue,
 							Reason:  "ResumeStarted",
 							Message: "Resume in progress",
@@ -316,7 +315,7 @@ func TestIsActivePodUpdate(t *testing.T) {
 					Phase: corev1.PodRunning,
 					Conditions: []corev1.PodCondition{
 						{
-							Type:    core.PodConditionContainersResumed,
+							Type:    utils.PodConditionContainersResumed,
 							Status:  corev1.ConditionTrue,
 							Reason:  "ResumeCompleted",
 							Message: "Resume completed successfully",
@@ -501,13 +500,13 @@ func TestIsActivePodUpdate(t *testing.T) {
 							Message: "Ready",
 						},
 						{
-							Type:    core.PodConditionContainersPaused,
+							Type:    utils.PodConditionContainersPaused,
 							Status:  corev1.ConditionFalse,
 							Reason:  "NotPaused",
 							Message: "Containers not paused",
 						},
 						{
-							Type:    core.PodConditionContainersResumed,
+							Type:    utils.PodConditionContainersResumed,
 							Status:  corev1.ConditionTrue,
 							Reason:  "Resumed",
 							Message: "Containers resumed",
@@ -527,13 +526,13 @@ func TestIsActivePodUpdate(t *testing.T) {
 							Message: "Ready",
 						},
 						{
-							Type:    core.PodConditionContainersPaused,
+							Type:    utils.PodConditionContainersPaused,
 							Status:  corev1.ConditionFalse,
 							Reason:  "NotPaused",
 							Message: "Containers not paused",
 						},
 						{
-							Type:    core.PodConditionContainersResumed,
+							Type:    utils.PodConditionContainersResumed,
 							Status:  corev1.ConditionTrue,
 							Reason:  "Resumed",
 							Message: "Containers resumed",

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -280,13 +280,13 @@ func pauseTimeReached(pauseTime *metav1.Time, now metav1.Time) bool {
 }
 
 func (r *SandboxReconciler) addSandboxFinalizerAndHash(ctx context.Context, box *agentsv1alpha1.Sandbox) (*agentsv1alpha1.Sandbox, error) {
-	if !box.DeletionTimestamp.IsZero() || controllerutil.ContainsFinalizer(box, core.SandboxFinalizer) {
+	if !box.DeletionTimestamp.IsZero() || controllerutil.ContainsFinalizer(box, utils.SandboxFinalizer) {
 		return box, nil
 	}
 
 	originObj := box.DeepCopy()
 	patch := client.MergeFrom(box)
-	controllerutil.AddFinalizer(originObj, core.SandboxFinalizer)
+	controllerutil.AddFinalizer(originObj, utils.SandboxFinalizer)
 	if originObj.Annotations == nil {
 		originObj.Annotations = make(map[string]string)
 	}

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -208,7 +208,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 					Name:              "terminating-sandbox",
 					Namespace:         "default",
 					DeletionTimestamp: &metav1.Time{Time: time.Now()},
-					Finalizers:        []string{core.SandboxFinalizer},
+					Finalizers:        []string{utils.SandboxFinalizer},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
 					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
@@ -404,7 +404,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "shutdown-sandbox",
 					Namespace:  "default",
-					Finalizers: []string{core.SandboxFinalizer},
+					Finalizers: []string{utils.SandboxFinalizer},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
 					ShutdownTime: &metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
@@ -430,7 +430,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "pause-time-sandbox",
 					Namespace:  "default",
-					Finalizers: []string{core.SandboxFinalizer},
+					Finalizers: []string{utils.SandboxFinalizer},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
 					PauseTime: &metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
@@ -465,7 +465,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "future-shutdown-sandbox",
 					Namespace:  "default",
-					Finalizers: []string{core.SandboxFinalizer},
+					Finalizers: []string{utils.SandboxFinalizer},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
 					ShutdownTime: &metav1.Time{Time: time.Now().Add(10 * time.Minute)},
@@ -493,7 +493,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "pod-missing-sandbox",
 					Namespace:  "default",
-					Finalizers: []string{core.SandboxFinalizer},
+					Finalizers: []string{utils.SandboxFinalizer},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
 					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
@@ -554,7 +554,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "invalid-phase-sandbox",
 					Namespace:  "default",
-					Finalizers: []string{core.SandboxFinalizer},
+					Finalizers: []string{utils.SandboxFinalizer},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
 					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
@@ -579,7 +579,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "both-times-sandbox",
 					Namespace:  "default",
-					Finalizers: []string{core.SandboxFinalizer},
+					Finalizers: []string{utils.SandboxFinalizer},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
 					ShutdownTime: &metav1.Time{Time: time.Now().Add(10 * time.Minute)},
@@ -666,7 +666,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "completed-pod-sandbox",
 					Namespace:  "default",
-					Finalizers: []string{core.SandboxFinalizer},
+					Finalizers: []string{utils.SandboxFinalizer},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
 					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
@@ -699,7 +699,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "high-priority-sandbox",
 					Namespace:  "default",
-					Finalizers: []string{core.SandboxFinalizer},
+					Finalizers: []string{utils.SandboxFinalizer},
 					Annotations: map[string]string{
 						agentsv1alpha1.SandboxAnnotationPriority: "1",
 					},
@@ -1016,7 +1016,7 @@ func TestSandboxReconciler_AutoPauseBranch(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            name,
 				Namespace:       "default",
-				Finalizers:      []string{core.SandboxFinalizer},
+				Finalizers:      []string{utils.SandboxFinalizer},
 				ResourceVersion: "42",
 			},
 			Spec: agentsv1alpha1.SandboxSpec{
@@ -1050,7 +1050,7 @@ func TestSandboxReconciler_AutoPauseBranch(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  "default",
-				Finalizers: []string{core.SandboxFinalizer},
+				Finalizers: []string{utils.SandboxFinalizer},
 			},
 			Spec: agentsv1alpha1.SandboxSpec{
 				Paused:    false,
@@ -2118,7 +2118,7 @@ func TestSandboxReconciler_AddSandboxFinalizerAndHash(t *testing.T) {
 				// Check finalizer
 				hasFinalizerInResult := false
 				for _, f := range result.Finalizers {
-					if f == core.SandboxFinalizer {
+					if f == utils.SandboxFinalizer {
 						hasFinalizerInResult = true
 						break
 					}
@@ -2141,7 +2141,7 @@ func TestSandboxReconciler_AddSandboxFinalizerAndHash(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-sandbox-with-finalizer",
 					Namespace:  "default",
-					Finalizers: []string{core.SandboxFinalizer},
+					Finalizers: []string{utils.SandboxFinalizer},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
 					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
@@ -2320,7 +2320,7 @@ func TestSandboxReconciler_AddSandboxFinalizerAndHash(t *testing.T) {
 				if tt.expectFinalizerAdded {
 					hasFinalizer := false
 					for _, f := range updatedSandbox.Finalizers {
-						if f == core.SandboxFinalizer {
+						if f == utils.SandboxFinalizer {
 							hasFinalizer = true
 							break
 						}
@@ -2521,13 +2521,13 @@ func TestReconcile_SandboxLifecycle_ClearSpecThenDelete(t *testing.T) {
 		}
 		hasFinalizer := false
 		for _, f := range updatedSandbox.Finalizers {
-			if f == core.SandboxFinalizer {
+			if f == utils.SandboxFinalizer {
 				hasFinalizer = true
 				break
 			}
 		}
 		if !hasFinalizer {
-			t.Errorf("Expected finalizer %s to be added", core.SandboxFinalizer)
+			t.Errorf("Expected finalizer %s to be added", utils.SandboxFinalizer)
 		}
 	})
 
@@ -2594,7 +2594,7 @@ func TestReconcile_SandboxLifecycle_ClearSpecThenDelete(t *testing.T) {
 				t.Errorf("Expected DeletionTimestamp to be set")
 			}
 			for _, f := range updatedSandbox.Finalizers {
-				if f == core.SandboxFinalizer {
+				if f == utils.SandboxFinalizer {
 					t.Errorf("Expected finalizer to be removed, but it still exists")
 				}
 			}
@@ -2628,7 +2628,7 @@ func TestSandboxReconciler_Reconcile_RateLimitFeatureGate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "normal-sandbox",
 					Namespace:         "default",
-					Finalizers:        []string{core.SandboxFinalizer},
+					Finalizers:        []string{utils.SandboxFinalizer},
 					CreationTimestamp: now,
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
@@ -2673,7 +2673,7 @@ func TestSandboxReconciler_Reconcile_RateLimitFeatureGate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "normal-sandbox-low",
 					Namespace:  "default",
-					Finalizers: []string{core.SandboxFinalizer},
+					Finalizers: []string{utils.SandboxFinalizer},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
 					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
@@ -2698,7 +2698,7 @@ func TestSandboxReconciler_Reconcile_RateLimitFeatureGate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "high-priority-sandbox",
 					Namespace:         "default",
-					Finalizers:        []string{core.SandboxFinalizer},
+					Finalizers:        []string{utils.SandboxFinalizer},
 					CreationTimestamp: now,
 					Annotations: map[string]string{
 						agentsv1alpha1.SandboxAnnotationPriority: "1",
@@ -2727,7 +2727,7 @@ func TestSandboxReconciler_Reconcile_RateLimitFeatureGate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "high-priority-ready",
 					Namespace:         "default",
-					Finalizers:        []string{core.SandboxFinalizer},
+					Finalizers:        []string{utils.SandboxFinalizer},
 					CreationTimestamp: now,
 					Annotations: map[string]string{
 						agentsv1alpha1.SandboxAnnotationPriority: "1",
@@ -3213,7 +3213,7 @@ func TestReconcile_UpgradingPhase(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "upgrading-sandbox",
 			Namespace:  "default",
-			Finalizers: []string{core.SandboxFinalizer},
+			Finalizers: []string{utils.SandboxFinalizer},
 		},
 		Spec: agentsv1alpha1.SandboxSpec{
 			UpgradePolicy: &agentsv1alpha1.SandboxUpgradePolicy{
@@ -3294,7 +3294,7 @@ func TestReconcile_ErrorPath_UpdatesSandboxStatus(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "error-path-sandbox",
 			Namespace:   "default",
-			Finalizers:  []string{core.SandboxFinalizer},
+			Finalizers:  []string{utils.SandboxFinalizer},
 			Annotations: map[string]string{
 				// Will be filled with the computed hashImmutablePart below
 			},
@@ -3391,7 +3391,7 @@ func TestReconcile_ErrorPath_StatusUpdateAlsoFails(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "error-both-sandbox",
 			Namespace:   "default",
-			Finalizers:  []string{core.SandboxFinalizer},
+			Finalizers:  []string{utils.SandboxFinalizer},
 			Annotations: map[string]string{},
 		},
 		Spec: agentsv1alpha1.SandboxSpec{

--- a/pkg/utils/constant.go
+++ b/pkg/utils/constant.go
@@ -37,6 +37,8 @@ const (
 )
 
 const (
+	// SandboxFinalizer is sandbox finalizer
+	SandboxFinalizer = "agents.kruise.io/sandbox"
 
 	// PodAnnotationCreatedBy is used to identify Pod source: created by Sandbox controller or externally created (bypassing Sandbox syntax sugar)
 	PodAnnotationCreatedBy = "agents.kruise.io/created-by"
@@ -46,6 +48,9 @@ const (
 
 	// default sandbox deploy namespace
 	DefaultSandboxDeployNamespace = "sandbox-system"
+
+	PodConditionContainersPaused  = "ContainersPaused"
+	PodConditionContainersResumed = "ContainersResumed"
 
 	// MaxConditionMessageLen was moved to a var block below for env-based configuration.
 )


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Refactor sandbox controller core to extract shared helper functions from `commonControl`, enabling reuse by different control implementations.

**Key changes:**
- Extract `ensureSandboxUpdatedCommon`, `ensureSandboxUpgradedCommon`, `ensureSandboxTerminatedCommon` as shared orchestration functions with dependency injection via args structs (`UpgradeOrchestratorArgs`, `RecreateUpgradeArgs`, `UpgradeActionArgs`)
- Extract `createPodCommon` with configurable `generatePodFunc` and `tolerateAlreadyExists` parameter
- Extract `performRecreateUpgradeCommon` and `executeUpgradeActionCommon` for upgrade lifecycle reuse
- Extract `setReadyConditionFalseForPause` and `performPostResumeInit` as shared pause/resume helpers
- Move `SandboxFinalizer` and `PodConditionContainersPaused/Resumed` constants from `core` package to `pkg/utils` to avoid circular dependencies
- Improve `syncSandboxStatusFromPod` to aggregate all container failure messages instead of only keeping the last one
- Fix potential nil pointer dereference in `EnsureSandboxResumed` when `rCond` is nil

The existing `commonControl` methods now delegate to these shared functions, preserving full backward compatibility. No behavioral changes for existing users.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how to verify it
1. Run unit tests for the sandbox controller core package:
   ```bash
   go test ./pkg/controller/sandbox/core/...
Run unit tests for the full sandbox controller package:

go test ./pkg/controller/sandbox/...
Verify full project builds successfully:

go build ./...
All existing tests pass without modification to test logic (only function signature adaptations).

### Ⅳ. Special notes for reviews
This is a pure refactoring PR — all commonControl public methods retain their original signatures and behavior.
The extracted *Common functions accept dependency structs instead of embedding commonControl directly, making them composable for alternative control implementations.
The SandboxFinalizer / PodConditionContainersPaused / PodConditionContainersResumed constants moved from pkg/controller/sandbox/core to pkg/utils. All call sites (sandbox_controller.go, pod_event_handler.go, and their tests) have been updated accordingly.
The SandboxPodNotFoundMsg constant is defined locally in common_control.go for now; it can be relocated once additional consumers exist.
The CA certificate injection test (TestCommonControl_createPod_WithCAInjection) was removed from common_control_test.go as the CA injection logic is now tested through createPodCommon's integration path.
