### PR TITLE
feat(e2b): remove secure handling from E2B sandbox create

### DIFF
--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -95,7 +95,7 @@ func (sc *Controller) CreateSandbox(r *http.Request) (web.ApiResponse[*models.Sa
 func (sc *Controller) createSandboxWithClaim(ctx context.Context, request models.NewSandboxRequest, user *models.CreatedTeamAPIKey) (web.ApiResponse[*models.Sandbox], *web.ApiError) {
 	log := klog.FromContext(ctx)
 	claimStart := time.Now()
-	accessToken := config.NewDefaultAccessToken()
+	var accessToken string
 	opts := infra.ClaimSandboxOptions{
 		Namespace:    sc.getNamespaceOfUser(user),
 		Template:     request.TemplateID,
@@ -111,6 +111,7 @@ func (sc *Controller) createSandboxWithClaim(ctx context.Context, request models
 	}
 
 	if !request.Extensions.SkipInitRuntime {
+		accessToken = config.NewDefaultAccessToken()
 		opts.InitRuntime = &config.InitRuntimeOptions{
 			EnvVars:     request.EnvVars,
 			AccessToken: accessToken,

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -95,10 +95,7 @@ func (sc *Controller) CreateSandbox(r *http.Request) (web.ApiResponse[*models.Sa
 func (sc *Controller) createSandboxWithClaim(ctx context.Context, request models.NewSandboxRequest, user *models.CreatedTeamAPIKey) (web.ApiResponse[*models.Sandbox], *web.ApiError) {
 	log := klog.FromContext(ctx)
 	claimStart := time.Now()
-	var accessToken string
-	if request.Secure {
-		accessToken = config.NewDefaultAccessToken()
-	}
+	accessToken := config.NewDefaultAccessToken()
 	opts := infra.ClaimSandboxOptions{
 		Namespace:    sc.getNamespaceOfUser(user),
 		Template:     request.TemplateID,

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -53,7 +53,6 @@ type NewSandboxRequest struct {
 	TemplateID string            `json:"templateID"`
 	Timeout    int               `json:"timeout,omitempty"`
 	AutoPause  bool              `json:"autoPause,omitempty"`
-	Secure     bool              `json:"secure,omitempty"`
 	Metadata   map[string]string `json:"metadata,omitempty"`
 	EnvVars    EnvVars           `json:"envVars,omitempty"`
 

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -608,6 +608,55 @@ func TestCreateSandboxAlwaysCreatesAccessToken(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxSkipsAccessTokenWhenInitRuntimeIsSkipped(t *testing.T) {
+	controller, fc, teardown := Setup(t)
+	defer teardown()
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "test-user",
+	}
+
+	tests := []struct {
+		name string
+		body map[string]any
+	}{
+		{
+			name: "skip init runtime extension",
+			body: map[string]any{
+				"metadata": map[string]string{
+					models.ExtensionKeyClaimTimeout:    "1",
+					models.ExtensionKeySkipInitRuntime: v1alpha1.True,
+				},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			templateName := fmt.Sprintf("skip-init-access-token-template-%d", i)
+			cleanup := CreateSandboxPool(t, controller, templateName, 1)
+			defer cleanup()
+
+			body := map[string]any{
+				"templateID": templateName,
+			}
+			for k, v := range tt.body {
+				body[k] = v
+			}
+
+			resp, apiError := controller.CreateSandbox(NewRequest(t, nil, body, nil, user))
+			require.Nil(t, apiError)
+			require.NotNil(t, resp.Body)
+			assert.Empty(t, resp.Body.EnvdAccessToken)
+
+			sbx := GetSandbox(t, resp.Body.SandboxID, fc)
+			assert.NotContains(t, sbx.Annotations, v1alpha1.AnnotationRuntimeAccessToken)
+		})
+	}
+}
+
 // CreateCheckpointAndTemplate creates a Checkpoint with associated SandboxTemplate for clone tests
 func CreateCheckpointAndTemplate(t *testing.T, controller *Controller, checkpointID string) func() {
 	tmpl := v1alpha1.EmbeddedSandboxTemplate{

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -538,6 +538,76 @@ func TestCreateSandbox(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxAlwaysCreatesAccessToken(t *testing.T) {
+	controller, fc, teardown := Setup(t)
+	defer teardown()
+
+	server := testutils.NewTestRuntimeServer(testutils.TestRuntimeServerOptions{
+		RunCommandResult: runtime.RunCommandResult{
+			PID:    1,
+			Exited: true,
+		},
+		RunCommandImmediately: true,
+	})
+	defer server.Close()
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "test-user",
+	}
+
+	tests := []struct {
+		name string
+		body map[string]any
+	}{
+		{
+			name: "secure omitted",
+			body: map[string]any{},
+		},
+		{
+			name: "secure false ignored",
+			body: map[string]any{
+				"secure": false,
+			},
+		},
+		{
+			name: "secure true ignored",
+			body: map[string]any{
+				"secure": true,
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			templateName := fmt.Sprintf("access-token-template-%d", i)
+			cleanup := CreateSandboxPool(t, controller, templateName, 1, CreateSandboxPoolOptions{
+				RuntimeURL: server.URL,
+			})
+			defer cleanup()
+
+			body := map[string]any{
+				"templateID": templateName,
+				"metadata": map[string]string{
+					models.ExtensionKeyClaimTimeout: "1",
+				},
+			}
+			for k, v := range tt.body {
+				body[k] = v
+			}
+
+			resp, apiError := controller.CreateSandbox(NewRequest(t, nil, body, nil, user))
+			require.Nil(t, apiError)
+			require.NotNil(t, resp.Body)
+			assert.NotEmpty(t, resp.Body.EnvdAccessToken)
+
+			sbx := GetSandbox(t, resp.Body.SandboxID, fc)
+			assert.Equal(t, resp.Body.EnvdAccessToken, sbx.Annotations[v1alpha1.AnnotationRuntimeAccessToken])
+		})
+	}
+}
+
 // CreateCheckpointAndTemplate creates a Checkpoint with associated SandboxTemplate for clone tests
 func CreateCheckpointAndTemplate(t *testing.T, controller *Controller, checkpointID string) func() {
 	tmpl := v1alpha1.EmbeddedSandboxTemplate{
@@ -796,18 +866,6 @@ func TestCloneSandbox(t *testing.T) {
 			expectError: &web.ApiError{
 				Code:    400,
 				Message: "Template or Checkpoint not found",
-			},
-		},
-		{
-			name: "clone success with secure mode",
-			request: models.NewSandboxRequest{
-				TemplateID: checkpointID,
-				Timeout:    300,
-				Secure:     true,
-			},
-			postCheck: func(t *testing.T, resp *models.Sandbox, controller *Controller) {
-				// In secure mode, access token should be generated
-				assert.NotEmpty(t, resp.SandboxID)
 			},
 		},
 		{

--- a/test/utils/runtime.go
+++ b/test/utils/runtime.go
@@ -18,8 +18,12 @@ package utils
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"time"
 
 	"connectrpc.com/connect"
@@ -99,6 +103,7 @@ func NewTestRuntimeServer(opts TestRuntimeServerOptions) *httptest.Server {
 	service := &TestProcessService{
 		responses:   testResponses,
 		immediately: opts.RunCommandImmediately,
+		accessToken: runtime.AccessToken,
 	}
 	mux := http.NewServeMux()
 	grpcPath, handler := processconnect.NewProcessHandler(service)
@@ -108,6 +113,18 @@ func NewTestRuntimeServer(opts TestRuntimeServerOptions) *httptest.Server {
 			return web.ApiResponse[struct{}]{}, &web.ApiError{
 				Code: opts.InitErrCode,
 			}
+		}
+		var initRequest struct {
+			AccessToken string `json:"accessToken"`
+		}
+		if decodeErr := json.NewDecoder(r.Body).Decode(&initRequest); decodeErr != nil && !errors.Is(decodeErr, io.EOF) {
+			return web.ApiResponse[struct{}]{}, &web.ApiError{
+				Code:    http.StatusBadRequest,
+				Message: decodeErr.Error(),
+			}
+		}
+		if initRequest.AccessToken != "" {
+			service.SetAccessToken(initRequest.AccessToken)
 		}
 		return web.ApiResponse[struct{}]{
 			Code: http.StatusNoContent,
@@ -120,6 +137,20 @@ func NewTestRuntimeServer(opts TestRuntimeServerOptions) *httptest.Server {
 type TestProcessService struct {
 	responses   []process.StartResponse
 	immediately bool
+	mu          sync.RWMutex
+	accessToken string
+}
+
+func (s *TestProcessService) SetAccessToken(accessToken string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.accessToken = accessToken
+}
+
+func (s *TestProcessService) GetAccessToken() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.accessToken
 }
 
 func (s *TestProcessService) List(context.Context, *connect.Request[process.ListRequest]) (*connect.Response[process.ListResponse], error) {
@@ -131,7 +162,7 @@ func (s *TestProcessService) Connect(context.Context, *connect.Request[process.C
 }
 
 func (s *TestProcessService) Start(_ context.Context, req *connect.Request[process.StartRequest], stream *connect.ServerStream[process.StartResponse]) error {
-	if req.Header().Get("X-Access-Token") != runtime.AccessToken {
+	if req.Header().Get("X-Access-Token") != s.GetAccessToken() {
 		return connect.NewError(connect.CodeUnauthenticated, nil)
 	}
 	start := time.Now()


### PR DESCRIPTION
## Summary
- Remove the E2B create request secure field and ignore legacy JSON secure values.
- Always issue a runtime access token for normal create requests, regardless of secure=true/false/omitted.
- Preserve skip-init-runtime semantics by not generating or returning a token when runtime init is skipped.

## Root Cause
CreateSandbox previously gated token issuance on request.secure. Removing that gate must still avoid returning a token when InitRuntime is skipped, because skip-init does not persist the runtime token annotation or call /init.

## Test Plan
- go test ./pkg/servers/e2b/... -count=1
