### PR TITLE
feat(e2b): raise create timeout floor to 300s with skip override

### DIFF
--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -262,10 +262,15 @@ func (sc *Controller) parseCreateSandboxRequest(r *http.Request) (models.NewSand
 		request.Timeout = models.DefaultTimeoutSeconds
 	}
 
-	if request.Timeout < models.DefaultMinTimeoutSeconds || request.Timeout > sc.maxTimeout {
+	minTimeout := models.DefaultMinCreateTimeoutSeconds
+	if request.Extensions.SkipCreateTimeoutMin {
+		minTimeout = 0
+	}
+
+	if request.Timeout < minTimeout || request.Timeout > sc.maxTimeout {
 		return request, &web.ApiError{
 			Code:    http.StatusBadRequest,
-			Message: fmt.Sprintf("timeout should between %d and %d", models.DefaultMinTimeoutSeconds, sc.maxTimeout),
+			Message: fmt.Sprintf("timeout should between %d and %d", minTimeout, sc.maxTimeout),
 		}
 	}
 

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -503,4 +503,69 @@ func TestParseCreateSandboxRequest(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, apiErr.Code)
 		assert.Contains(t, apiErr.Message, "timeout should between")
 	})
+
+	t.Run("timeout minimum floor", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			timeout       int
+			metadata      map[string]string
+			expectError   string
+			expectTimeout int
+		}{
+			{
+				name:        "rejects timeout below create minimum without override",
+				timeout:     60,
+				expectError: "timeout should between 300 and",
+			},
+			{
+				name:    "allows positive timeout below create minimum with override",
+				timeout: 1,
+				metadata: map[string]string{
+					models.ExtensionKeySkipCreateTimeoutMin: agentsv1alpha1.True,
+				},
+				expectTimeout: 1,
+			},
+			{
+				name:    "rejects timeout above maximum even with override",
+				timeout: ctrl.maxTimeout + 1,
+				metadata: map[string]string{
+					models.ExtensionKeySkipCreateTimeoutMin: agentsv1alpha1.True,
+				},
+				expectError: "timeout should between 0 and",
+			},
+			{
+				name:    "rejects non-positive timeout with override",
+				timeout: -1,
+				metadata: map[string]string{
+					models.ExtensionKeySkipCreateTimeoutMin: agentsv1alpha1.True,
+				},
+				expectError: "timeout should between 0 and",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				raw, err := json.Marshal(models.NewSandboxRequest{
+					TemplateID: "t1",
+					Timeout:    tt.timeout,
+					Metadata:   tt.metadata,
+				})
+				require.NoError(t, err)
+				req := httptest.NewRequest(http.MethodPost, "/sandboxes", bytes.NewReader(raw))
+
+				got, apiErr := ctrl.parseCreateSandboxRequest(req)
+				if tt.expectError != "" {
+					require.NotNil(t, apiErr)
+					assert.Equal(t, http.StatusBadRequest, apiErr.Code)
+					assert.Contains(t, apiErr.Message, tt.expectError)
+					return
+				}
+
+				require.Nil(t, apiErr)
+				assert.Equal(t, tt.expectTimeout, got.Timeout)
+				_, exists := got.Metadata[models.ExtensionKeySkipCreateTimeoutMin]
+				assert.False(t, exists)
+			})
+		}
+	})
 }

--- a/pkg/servers/e2b/models/consts.go
+++ b/pkg/servers/e2b/models/consts.go
@@ -17,9 +17,9 @@ limitations under the License.
 package models
 
 const (
-	DefaultMaxTimeout        = 2592000 // 30 days
-	DefaultMinTimeoutSeconds = 30
-	DefaultTimeoutSeconds    = 300
+	DefaultMaxTimeout              = 2592000 // 30 days
+	DefaultMinCreateTimeoutSeconds = 300
+	DefaultTimeoutSeconds          = 300
 	// DefaultMinResumeTimeoutSeconds floors Connect/Resume requests that
 	// trigger Resume on a Paused sandbox, so the placeholder cannot expire
 	// mid-Resume. Tune via --e2b-min-resume-timeout.

--- a/pkg/servers/e2b/models/extensions.go
+++ b/pkg/servers/e2b/models/extensions.go
@@ -58,6 +58,7 @@ const (
 	ExtensionKeyReserveFailedSandboxFor       = v1alpha1.E2BPrefix + "reserve-failed-sandbox-for"
 	ExtensionKeyCreateOnNoStock               = v1alpha1.E2BPrefix + "create-on-no-stock"
 	ExtensionKeyNeverTimeout                  = v1alpha1.E2BPrefix + "never-timeout"
+	ExtensionKeySkipCreateTimeoutMin          = v1alpha1.E2BPrefix + "skip-create-timeout-min"
 	ExtensionKeyReturnPodIP                   = v1alpha1.E2BPrefix + "return-sandbox-ip"
 	MetadataKeyPodIP                          = v1alpha1.E2BPrefix + "sandbox-ip"
 )
@@ -104,11 +105,13 @@ func (r *NewSandboxRequest) parseCommonExtensions() error {
 	}
 	r.Extensions.CreateOnNoStock = r.Metadata[ExtensionKeyCreateOnNoStock] != v1alpha1.False
 	r.Extensions.NeverTimeout = r.Metadata[ExtensionKeyNeverTimeout] == v1alpha1.True
+	r.Extensions.SkipCreateTimeoutMin = r.Metadata[ExtensionKeySkipCreateTimeoutMin] == v1alpha1.True
 	r.Extensions.ReturnPodIP = r.Metadata[ExtensionKeyReturnPodIP] == v1alpha1.True
 	delete(r.Metadata, ExtensionKeySkipInitRuntime)
 	delete(r.Metadata, ExtensionKeyReserveFailedSandbox)
 	delete(r.Metadata, ExtensionKeyCreateOnNoStock)
 	delete(r.Metadata, ExtensionKeyNeverTimeout)
+	delete(r.Metadata, ExtensionKeySkipCreateTimeoutMin)
 	delete(r.Metadata, ExtensionKeyReturnPodIP)
 	if r.Extensions.TimeoutSeconds, err = r.parseAndRemoveIntExtension(ExtensionKeyClaimTimeout); err != nil {
 		return err

--- a/pkg/servers/e2b/models/extensions_test.go
+++ b/pkg/servers/e2b/models/extensions_test.go
@@ -190,6 +190,17 @@ func TestParseExtensions(t *testing.T) {
 			},
 		},
 		{
+			name: "skip create timeout min == true",
+			metadata: map[string]string{
+				ExtensionKeySkipCreateTimeoutMin: v1alpha1.True,
+			},
+			wantErr: false,
+			expectExtension: NewSandboxRequestExtension{
+				CreateOnNoStock:      true,
+				SkipCreateTimeoutMin: true,
+			},
+		},
+		{
 			name: "invalid image extension",
 			metadata: map[string]string{
 				ExtensionKeyClaimWithImage: "invalid:image:name",

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -68,6 +68,7 @@ type NewSandboxRequestExtension struct {
 	WaitReadySeconds        int
 	TimeoutSeconds          int
 	NeverTimeout            bool
+	SkipCreateTimeoutMin    bool
 	ReturnPodIP             bool
 	Labels                  map[string]string
 }

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -117,7 +117,7 @@ func TestCreateSandbox(t *testing.T) {
 			userName:  "test-user",
 			request: models.NewSandboxRequest{
 				TemplateID: templateName,
-				Timeout:    30,
+				Timeout:    models.DefaultMinCreateTimeoutSeconds,
 			},
 		},
 		{
@@ -139,7 +139,7 @@ func TestCreateSandbox(t *testing.T) {
 			},
 			expectError: &web.ApiError{
 				Code:    400,
-				Message: "timeout should between 30 and 2592000",
+				Message: "timeout should between 300 and 2592000",
 			},
 		},
 		{
@@ -152,7 +152,7 @@ func TestCreateSandbox(t *testing.T) {
 			},
 			expectError: &web.ApiError{
 				Code:    400,
-				Message: "timeout should between 30 and 2592000",
+				Message: "timeout should between 300 and 2592000",
 			},
 		},
 		{
@@ -903,7 +903,7 @@ func TestCloneSandbox(t *testing.T) {
 			},
 			expectError: &web.ApiError{
 				Code:    400,
-				Message: "timeout should between 30 and 2592000",
+				Message: "timeout should between 300 and 2592000",
 			},
 		},
 		{

--- a/pkg/servers/e2b/timeout_test.go
+++ b/pkg/servers/e2b/timeout_test.go
@@ -211,7 +211,8 @@ func TestSetTimeout(t *testing.T) {
 				AutoPause:  tt.autoPause,
 				Timeout:    initTimeoutSeconds,
 				Metadata: map[string]string{
-					models.ExtensionKeySkipInitRuntime: v1alpha1.True,
+					models.ExtensionKeySkipInitRuntime:      v1alpha1.True,
+					models.ExtensionKeySkipCreateTimeoutMin: v1alpha1.True,
 				},
 			}, nil, user))
 			assert.Nil(t, err)

--- a/test/e2b/test_code_interpreter.py
+++ b/test/e2b/test_code_interpreter.py
@@ -18,7 +18,7 @@ def execute_python_code(s: Sandbox, code: str, expect_stdout: list[str]):
 def test_run_code(sandbox_context):
     sbx: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        timeout=30,
+        timeout=300,
         metadata={"test_case": "test_run_code"},
         headers={
             "x-request-id": sandbox_context.request_id
@@ -58,7 +58,7 @@ def test_static_charts(sandbox_context):
 
     sandbox: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        timeout=30,
+        timeout=300,
         metadata={"test_case": "test_static_charts"},
         headers={
             "x-request-id": sandbox_context.request_id
@@ -105,7 +105,7 @@ def test_code_stream(sandbox_context):
     code_result = None
     sandbox: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        timeout=30,
+        timeout=300,
         metadata={"test_case": "test_code_stream"},
         headers={
             "x-request-id": sandbox_context.request_id

--- a/test/e2b/test_commands_run.py
+++ b/test/e2b/test_commands_run.py
@@ -36,7 +36,7 @@ def test_commands_run(sandbox_context):
     """Test basic shell command execution"""
     sbx: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        timeout=30,
+        timeout=300,
         metadata={"test_case": "test_commands_run"},
         headers={
             "x-request-id": sandbox_context.request_id
@@ -67,7 +67,7 @@ def test_commands_run_error_handling(sandbox_context):
     """Test error handling for invalid commands"""
     sbx: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        timeout=30,
+        timeout=300,
         metadata={"test_case": "test_commands_run_error_handling"},
         headers={
             "x-request-id": sandbox_context.request_id
@@ -95,7 +95,7 @@ def test_commands_background_execution(sandbox_context):
     """Test background command execution and killing"""
     sbx: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        timeout=30,
+        timeout=300,
         metadata={"test_case": "test_commands_background_execution"},
         headers={
             "x-request-id": sandbox_context.request_id
@@ -126,7 +126,7 @@ def test_commands_realtime_callbacks(sandbox_context):
     """Test real-time output callbacks"""
     sbx: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        timeout=30,
+        timeout=300,
         metadata={"test_case": "test_commands_realtime_callbacks"},
         headers={
             "x-request-id": sandbox_context.request_id

--- a/test/e2b/test_filesystem.py
+++ b/test/e2b/test_filesystem.py
@@ -8,7 +8,7 @@ from e2b_code_interpreter import Sandbox
 def test_read_write_file(sandbox_context):
     sbx: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        timeout=30,
+        timeout=300,
         metadata={"test_case": "test_read_write_file"},
         headers={
             "x-request-id": sandbox_context.request_id
@@ -25,7 +25,7 @@ def test_read_write_file(sandbox_context):
 def test_read_write_multifile(sandbox_context):
     sbx: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        timeout=30,
+        timeout=300,
         metadata={"test_case": "test_read_write_multifile"},
         headers={
             "x-request-id": sandbox_context.request_id

--- a/test/e2b/test_gateway.py
+++ b/test/e2b/test_gateway.py
@@ -12,7 +12,7 @@ def test_gateway_header_based_routing(sandbox_context):
     """Test routing via e2b-sandbox-id and e2b-sandbox-port headers."""
     sandbox: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        timeout=120,
+        timeout=300,
         headers={
             "x-request-id": sandbox_context.request_id
         }
@@ -37,7 +37,7 @@ def test_gateway_host_based_routing(sandbox_context):
     """Test routing via native E2B host header format: {port}-{sandboxID}.{domain}."""
     sandbox: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        timeout=120,
+        timeout=300,
         headers={
             "x-request-id": sandbox_context.request_id
         }

--- a/test/e2b/test_sandbox.py
+++ b/test/e2b/test_sandbox.py
@@ -11,7 +11,12 @@ from dateutil.tz import tzutc
 from e2b.exceptions import NotFoundException
 from e2b_code_interpreter import Sandbox, SandboxQuery, SandboxState
 
-from utils import list_sandbox, connect_sandbox, run_code_sandbox
+from utils import (
+    SKIP_CREATE_TIMEOUT_MIN_METADATA_KEY,
+    list_sandbox,
+    connect_sandbox,
+    run_code_sandbox,
+)
 
 # e2b-code-interpreter 2.4.x predates the `lifecycle={"on_timeout": "pause"}`
 # parameter, so auto-pause cannot be requested through that SDK.
@@ -57,7 +62,7 @@ def assert_pod_ip_metadata(info, expected_pod_ip: str | None = None) -> str:
 def test_lifecycle(sandbox_context):
     sandbox: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        timeout=30,
+        timeout=300,
         metadata={
             'userId': '123',
         },
@@ -120,7 +125,7 @@ def test_sandbox_with_pod_ip(sandbox_context):
 def test_no_stock(sandbox_context):
     sandbox: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter-0",
-        timeout=30,
+        timeout=300,
         metadata={
             'userId': '123',
         },
@@ -141,7 +146,7 @@ def test_list_by_metadata(sandbox_context):
 
     sandbox: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        timeout=30,
+        timeout=300,
         metadata={
             'userId': random_user_id,
         },
@@ -167,7 +172,7 @@ def test_list_by_metadata(sandbox_context):
 def test_list_by_state(sandbox_context):
     sbx: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        timeout=30,
+        timeout=300,
         metadata={"test_case": "test_list_by_state"},
         headers={
             "x-request-id": sandbox_context.request_id
@@ -198,7 +203,10 @@ def test_list_by_state(sandbox_context):
 def test_timeout(sandbox_context):
     sandbox: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        metadata={"case": "timeout"},
+        metadata={
+            "case": "timeout",
+            SKIP_CREATE_TIMEOUT_MIN_METADATA_KEY: "true",
+        },
         timeout=30,
         headers={
             "x-request-id": sandbox_context.request_id
@@ -263,7 +271,10 @@ def test_auto_pause_resume_no_immediate_repause(sandbox_context):
         template="code-interpreter",
         timeout=auto_pause_timeout_seconds,
         lifecycle={"on_timeout": "pause"},
-        metadata={"test_case": "test_auto_pause_resume_no_immediate_repause"},
+        metadata={
+            "test_case": "test_auto_pause_resume_no_immediate_repause",
+            SKIP_CREATE_TIMEOUT_MIN_METADATA_KEY: "true",
+        },
         headers={
             "x-request-id": sandbox_context.request_id
         }
@@ -442,7 +453,7 @@ def test_inplace_update(sandbox_context):
     pytest.skip("inplace update is not supported yet")
     sbx: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
-        timeout=30,
+        timeout=300,
         metadata={
             "case": "inplace-update",
             "e2b.agents.kruise.io/image": "registry-ap-southeast-1.ack.aliyuncs.com/acs/code-interpreter:v1.6-new"
@@ -466,6 +477,7 @@ def test_never_timeout(sandbox_context):
             "x-request-id": sandbox_context.request_id
         },
         metadata={
+            SKIP_CREATE_TIMEOUT_MIN_METADATA_KEY: "true",
             "e2b.agents.kruise.io/never-timeout": "true"
         }
     ))

--- a/test/e2b/utils.py
+++ b/test/e2b/utils.py
@@ -9,6 +9,9 @@ from e2b.sandbox.sandbox_api import SandboxInfo, SandboxQuery
 from e2b_code_interpreter import Sandbox
 
 
+SKIP_CREATE_TIMEOUT_MIN_METADATA_KEY = "e2b.agents.kruise.io/skip-create-timeout-min"
+
+
 def connect_sandbox(sbx: Sandbox, timeout: Optional[int] = None) -> Sandbox | None:
     """Connect to a sandbox with retry logic for pausing state.
     


### PR DESCRIPTION
## Summary
- Raise the minimum create-sandbox timeout from 30s to 300s (`DefaultMinTimeoutSeconds` → `DefaultMinCreateTimeoutSeconds`).
- Add the `e2b.agents.kruise.io/skip-create-timeout-min` extension so callers can opt out of the min floor; the max cap still applies.
- Update Go unit tests and the E2B Python tests to the new floor.

## Test Plan
- [x] `go test ./pkg/servers/e2b/...` passes
- [ ] E2B Python integration tests run against a live cluster