### PR TITLE
feat(e2b): add sandbox refresh endpoint

### DIFF
--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -96,11 +96,14 @@ type SetTimeoutRequest struct {
 	TimeoutSeconds int `json:"timeout"`
 }
 
+type RefreshSandboxRequest struct {
+	Duration int `json:"duration"`
+}
+
 type NewSnapshotRequest struct {
 	Name       string                      `json:"name"` // name is not used by the E2B SDK yet, just reserved for future use
 	Extensions NewSnapshotRequestExtension `json:"-"`
 }
-
 type NewSnapshotRequestExtension struct {
 	KeepRunning        *bool
 	TTL                *string

--- a/pkg/servers/e2b/refresh.go
+++ b/pkg/servers/e2b/refresh.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2b
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/openkruise/agents/pkg/servers/web"
+	timeoututils "github.com/openkruise/agents/pkg/utils/timeout"
+)
+
+func (sc *Controller) RefreshSandbox(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
+	ctx := r.Context()
+
+	var req models.RefreshSandboxRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return web.ApiResponse[struct{}]{}, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: err.Error(),
+		}
+	}
+
+	if req.Duration < 0 || req.Duration > 3600 {
+		return web.ApiResponse[struct{}]{}, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: "duration should be between 0 and 3600",
+		}
+	}
+
+	id := r.PathValue("sandboxID")
+
+	sbx, apiErr := sc.getSandboxOfUser(ctx, id)
+	if apiErr != nil {
+		return web.ApiResponse[struct{}]{}, apiErr
+	}
+
+	autoPause, timeoutAt := ParseTimeout(sbx)
+
+	// Preserve never-timeout behavior.
+	if timeoutAt.IsZero() {
+		return web.ApiResponse[struct{}]{
+			Code: http.StatusNoContent,
+		}, nil
+	}
+
+	opts := sc.buildSetTimeoutOptions(
+		autoPause,
+		time.Now(),
+		req.Duration,
+	)
+
+	if _, err := sbx.SaveTimeoutWithPolicy(
+		ctx,
+		opts,
+		timeoututils.UpdatePolicyExtendOnly,
+	); err != nil {
+		return web.ApiResponse[struct{}]{}, &web.ApiError{
+			Message: fmt.Sprintf("failed to refresh sandbox: %v", err),
+		}
+	}
+
+	return web.ApiResponse[struct{}]{
+		Code: http.StatusNoContent,
+	}, nil
+}

--- a/pkg/servers/e2b/refresh_test.go
+++ b/pkg/servers/e2b/refresh_test.go
@@ -1,0 +1,190 @@
+package e2b
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/servers/e2b/keys"
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+)
+
+func TestRefreshSandboxInvalidDuration(t *testing.T) {
+	controller, _, teardown := Setup(t)
+	defer teardown()
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+	}
+
+	_, apiError := controller.RefreshSandbox(NewRequest(
+		t,
+		nil,
+		models.RefreshSandboxRequest{
+			Duration: 3601,
+		},
+		map[string]string{
+			"sandboxID": "dummy",
+		},
+		user,
+	))
+
+	assert.NotNil(t, apiError)
+	if apiError != nil {
+		assert.Equal(t, 400, apiError.Code)
+	}
+}
+
+func TestRefreshSandboxNotFound(t *testing.T) {
+	controller, _, teardown := Setup(t)
+	defer teardown()
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+	}
+
+	_, apiError := controller.RefreshSandbox(NewRequest(
+		t,
+		nil,
+		models.RefreshSandboxRequest{
+			Duration: 300,
+		},
+		map[string]string{
+			"sandboxID": "does-not-exist",
+		},
+		user,
+	))
+
+	assert.NotNil(t, apiError)
+}
+
+func TestRefreshSandboxUpdatesTimeout(t *testing.T) {
+	controller, client, teardown := Setup(t)
+	defer teardown()
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+	}
+
+	templateName := "test-refresh-timeout"
+
+	cleanup := CreateSandboxPool(t, controller, templateName, 1)
+	defer cleanup()
+
+	createResp, err := controller.CreateSandbox(NewRequest(
+		t,
+		nil,
+		models.NewSandboxRequest{
+			TemplateID: templateName,
+			Timeout:    600,
+			Metadata: map[string]string{
+				models.ExtensionKeySkipInitRuntime: v1alpha1.True,
+			},
+		},
+		nil,
+		user,
+	))
+	require.Nil(t, err)
+
+	beforeRefresh := time.Now()
+
+	_, apiError := controller.RefreshSandbox(NewRequest(
+		t,
+		nil,
+		models.RefreshSandboxRequest{
+			Duration: 900,
+		},
+		map[string]string{
+			"sandboxID": createResp.Body.SandboxID,
+		},
+		user,
+	))
+	require.Nil(t, apiError)
+
+	describeResp, err := controller.DescribeSandbox(NewRequest(
+		t,
+		nil,
+		nil,
+		map[string]string{
+			"sandboxID": createResp.Body.SandboxID,
+		},
+		user,
+	))
+	require.Nil(t, err)
+
+	AssertEndAt(
+		t,
+		beforeRefresh.Add(900*time.Second),
+		describeResp.Body.EndAt,
+	)
+
+	sbx := GetSandbox(t, createResp.Body.SandboxID, client)
+
+	require.NotNil(t, sbx.Spec.ShutdownTime)
+
+	assert.WithinDuration(
+		t,
+		beforeRefresh.Add(900*time.Second),
+		sbx.Spec.ShutdownTime.Time,
+		5*time.Second,
+	)
+}
+
+func TestRefreshSandboxNeverTimeout(t *testing.T) {
+	controller, client, teardown := Setup(t)
+	defer teardown()
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+	}
+
+	templateName := "test-refresh-never-timeout"
+
+	cleanup := CreateSandboxPool(t, controller, templateName, 1)
+	defer cleanup()
+
+	createResp, err := controller.CreateSandbox(NewRequest(
+		t,
+		nil,
+		models.NewSandboxRequest{
+			TemplateID: templateName,
+			Timeout:    300,
+			Metadata: map[string]string{
+				models.ExtensionKeySkipInitRuntime: v1alpha1.True,
+				models.ExtensionKeyNeverTimeout:    v1alpha1.True,
+			},
+		},
+		nil,
+		user,
+	))
+	require.Nil(t, err)
+
+	_, apiError := controller.RefreshSandbox(NewRequest(
+		t,
+		nil,
+		models.RefreshSandboxRequest{
+			Duration: 600,
+		},
+		map[string]string{
+			"sandboxID": createResp.Body.SandboxID,
+		},
+		user,
+	))
+	require.Nil(t, apiError)
+
+	sbx := GetSandbox(t, createResp.Body.SandboxID, client)
+
+	assert.Nil(t, sbx.Spec.ShutdownTime)
+	assert.Nil(t, sbx.Spec.PauseTime)
+}

--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -57,6 +57,7 @@ func (sc *Controller) registerRoutes() {
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/resume", sc.ResumeSandbox, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/connect", sc.ConnectSandbox, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/timeout", sc.SetSandboxTimeout, sc.CheckApiKey)
+	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/refreshes", sc.RefreshSandbox, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/snapshots", sc.CreateSnapshot, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodGet, "/snapshots", sc.ListSnapshots, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodGet, "/templates", sc.ListTemplates, sc.CheckApiKey)


### PR DESCRIPTION
Fixes #506

## Summary

This change adds support for the E2B-compatible sandbox refresh endpoint:

POST /sandboxes/{sandboxID}/refreshes

The endpoint allows clients to refresh a sandbox's TTL without modifying other lifecycle operations.

## What Changed

- Added `RefreshSandboxRequest` model with `duration` field.
- Added `RefreshSandbox` handler.
- Registered the new `/sandboxes/{sandboxID}/refreshes` route.
- Reused existing timeout utilities to keep refresh behavior consistent with the rest of the E2B lifecycle implementation.
- Preserved existing never-timeout sandbox behavior.
- Applied `ExtendOnly` timeout updates to avoid shortening an existing longer deadline.

## Tests

Added coverage for:

- Invalid duration requests.
- Refreshing a non-existent sandbox.
- Refreshing a running sandbox updates its timeout.
- Never-timeout sandboxes remain unchanged after refresh.

## Validation

```bash
CGO_ENABLED=0 go test ./pkg/servers/e2b/...
