### PR TITLE
fix(sidecarutils): stabilize init container injection order for backward compatibility

### DIFF
--- a/pkg/utils/sidecarutils/utils.go
+++ b/pkg/utils/sidecarutils/utils.go
@@ -49,23 +49,40 @@ func InjectSandboxRuntimes(ctx context.Context, sandbox *agentsv1alpha1.Sandbox,
 	return doSidecarInjection(ctx, sandbox, pod, config)
 }
 
+// fixedOrderRuntimes defines the injection order for built-in runtimes.
+// Preserve historical injection order: agent-runtime first, then csi-mount,
+// to keep init container ordering stable for pre-existing pods regardless of
+// the declaration order in sandbox.Spec.Runtimes.
+var fixedOrderRuntimes = []string{
+	agentsv1alpha1.RuntimeConfigForInjectAgentRuntime,
+	agentsv1alpha1.RuntimeConfigForInjectCsiMount,
+}
+
 func doSidecarInjection(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod, injectConfigMap map[string]string) error {
 	logger := logf.FromContext(ctx)
 
-	injectedRuntimes := sets.NewString()
+	// Build a quick-lookup set of declared runtimes for the fixed-order phase.
+	declared := sets.NewString()
 	for _, r := range sandbox.Spec.Runtimes {
-		runtime := r.Name
-		if injectedRuntimes.Has(runtime) {
-			logger.V(5).Info("skipping duplicate runtime, already processed", "runtime", runtime)
+		declared.Insert(r.Name)
+	}
+
+	injectedRuntimes := sets.NewString()
+
+	// Phase 1: inject built-in runtimes in a deterministic fixed order so that
+	// the resulting InitContainers sequence is stable across spec permutations.
+	for _, runtime := range fixedOrderRuntimes {
+		if !declared.Has(runtime) {
 			continue
 		}
-		injectedRuntimes.Insert(runtime)
 
 		runtimeInjectConfig, err := parseInjectConfig(ctx, runtime, injectConfigMap)
 		if err != nil {
 			logger.Error(err, "failed to parse runtime injection configuration")
 			return err
 		}
+		logger.V(5).Info("injecting runtime", "name", runtime)
+		injectedRuntimes.Insert(runtime)
 		switch runtime {
 		case agentsv1alpha1.RuntimeConfigForInjectAgentRuntime:
 			if !isContainersExists(pod.Spec.InitContainers, runtimeInjectConfig.Sidecars) && !isContainersExists(pod.Spec.Containers, runtimeInjectConfig.Sidecars) {
@@ -75,14 +92,28 @@ func doSidecarInjection(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, po
 			if !isContainersExists(pod.Spec.InitContainers, runtimeInjectConfig.Sidecars) && !isContainersExists(pod.Spec.Containers, runtimeInjectConfig.Sidecars) {
 				setCSIMountContainer(ctx, &pod.Spec, runtimeInjectConfig)
 			}
-		default:
-			logger.V(5).Info("injecting runtime", "name", runtime)
-			// not mute the conflicts
-			if conflictErr := checkInjectionConflicts(pod, runtimeInjectConfig); conflictErr != nil {
-				return fmt.Errorf("failed to inject runtime %s: %v", runtime, conflictErr)
-			}
-			applyInjectionTemplate(pod, runtimeInjectConfig)
 		}
+	}
+
+	// Phase 2: inject remaining runtimes in their declaration order. New runtime
+	// types (e.g. traffic-proxy) fall through to the generic handler.
+	for _, r := range sandbox.Spec.Runtimes {
+		runtime := r.Name
+		if injectedRuntimes.Has(runtime) {
+			continue
+		}
+
+		runtimeInjectConfig, err := parseInjectConfig(ctx, runtime, injectConfigMap)
+		if err != nil {
+			logger.Error(err, "failed to parse runtime injection configuration")
+			return err
+		}
+		logger.V(5).Info("injecting runtime", "name", runtime)
+		if conflictErr := checkInjectionConflicts(pod, runtimeInjectConfig); conflictErr != nil {
+			return fmt.Errorf("failed to inject runtime %s: %v", runtime, conflictErr)
+		}
+		injectedRuntimes.Insert(runtime)
+		applyInjectionTemplate(pod, runtimeInjectConfig)
 	}
 
 	// Enable health probes rewrite if needed.

--- a/pkg/utils/sidecarutils/utils_test.go
+++ b/pkg/utils/sidecarutils/utils_test.go
@@ -1659,6 +1659,136 @@ func TestDoSidecarInjectionDuplicateRuntimes(t *testing.T) {
 	}
 }
 
+// TestDoSidecarInjection_FixedOrder verifies that regardless of the declaration
+// order of agent-runtime and csi-mount in sandbox.Spec.Runtimes, the resulting
+// InitContainers always appear in the historical fixed order:
+// [runtime-sidecar, csi-sidecar]. This guarantees backward compatibility with
+// pods injected by the older non-loop logic.
+func TestDoSidecarInjection_FixedOrder(t *testing.T) {
+	runtimeConfig := `{
+		"mainContainer": {"env": [{"name": "RUNTIME", "value": "on"}], "volumeMounts": []},
+		"csiSidecar": [{"name": "runtime-sidecar", "image": "runtime:v1"}],
+		"volume": []
+	}`
+	csiConfig := `{
+		"mainContainer": {"volumeMounts": [{"name": "csi-vol", "mountPath": "/csi"}]},
+		"csiSidecar": [{"name": "csi-sidecar", "image": "csi:v1"}],
+		"volume": [{"name": "csi-vol", "emptyDir": {}}]
+	}`
+
+	tests := []struct {
+		name     string
+		runtimes []agentsv1alpha1.RuntimeConfig
+		// expectSidecars is the ordered subsequence of known sidecar
+		// container names ("runtime-sidecar" / "csi-sidecar") that MUST
+		// appear in pod.Spec.InitContainers after injection. Other
+		// containers (e.g. the user "main" container) are ignored.
+		expectSidecars []string
+	}{
+		{
+			name: "normal order: agent-runtime then csi-mount",
+			runtimes: []agentsv1alpha1.RuntimeConfig{
+				{Name: agentsv1alpha1.RuntimeConfigForInjectAgentRuntime},
+				{Name: agentsv1alpha1.RuntimeConfigForInjectCsiMount},
+			},
+			expectSidecars: []string{"runtime-sidecar", "csi-sidecar"},
+		},
+		{
+			name: "reversed order: csi-mount then agent-runtime",
+			runtimes: []agentsv1alpha1.RuntimeConfig{
+				{Name: agentsv1alpha1.RuntimeConfigForInjectCsiMount},
+				{Name: agentsv1alpha1.RuntimeConfigForInjectAgentRuntime},
+			},
+			expectSidecars: []string{"runtime-sidecar", "csi-sidecar"},
+		},
+		{
+			name: "reversed order with traffic-proxy interleaved",
+			runtimes: []agentsv1alpha1.RuntimeConfig{
+				{Name: agentsv1alpha1.RuntimeConfigForInjectCsiMount},
+				{Name: agentsv1alpha1.RuntimeConfigForInjectTrafficProxy},
+				{Name: agentsv1alpha1.RuntimeConfigForInjectAgentRuntime},
+			},
+			expectSidecars: []string{"runtime-sidecar", "csi-sidecar"},
+		},
+		{
+			// Phase 1 must skip the absent csi-mount runtime and only
+			// inject runtime-sidecar; InitContainers list must remain
+			// well-formed (no panic, no stray csi-sidecar entry).
+			// Note: the symmetric "only csi-mount" combination is
+			// intentionally NOT covered here because csi-mount alone
+			// cannot work in production -- the CSI dynamic mount flow
+			// is driven by the agent-runtime sidecar (envd), so a pod
+			// declaring csi-mount without agent-runtime is an invalid
+			// business state and must not be modeled as a happy-path
+			// test case.
+			name: "only agent-runtime declared (csi-mount absent)",
+			runtimes: []agentsv1alpha1.RuntimeConfig{
+				{Name: agentsv1alpha1.RuntimeConfigForInjectAgentRuntime},
+			},
+			expectSidecars: []string{"runtime-sidecar"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sandbox := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Runtimes: tt.runtimes,
+				},
+			}
+			pod := &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "nginx"}},
+				},
+			}
+			injectConfigMap := map[string]string{
+				KEY_RUNTIME_INJECTION_CONFIG:       runtimeConfig,
+				KEY_CSI_INJECTION_CONFIG:           csiConfig,
+				KEY_TRAFFIC_PROXY_INJECTION_CONFIG: `{"mainContainer":{},"csiSidecar":[],"volume":[]}`,
+			}
+
+			err := doSidecarInjection(context.Background(), sandbox, pod, injectConfigMap)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Extract only the known sidecar names from InitContainers
+			// while preserving their relative order, then compare with
+			// the expected subsequence. This keeps the assertion robust
+			// even when only one of the two built-in runtimes is present.
+			knownSidecars := map[string]struct{}{
+				"runtime-sidecar": {},
+				"csi-sidecar":     {},
+			}
+			var got []string
+			for _, c := range pod.Spec.InitContainers {
+				if _, ok := knownSidecars[c.Name]; ok {
+					got = append(got, c.Name)
+				}
+			}
+			if len(got) != len(tt.expectSidecars) {
+				t.Fatalf("expected sidecars %v, got %v (full InitContainers=%v)", tt.expectSidecars, got, initContainerNames(pod))
+			}
+			for i := range tt.expectSidecars {
+				if got[i] != tt.expectSidecars[i] {
+					t.Errorf("InitContainers sidecar at position %d: expected %q, got %q (full sequence=%v)", i, tt.expectSidecars[i], got[i], got)
+				}
+			}
+		})
+	}
+}
+
+// initContainerNames is a tiny test helper that extracts ordered
+// InitContainer names for richer error messages.
+func initContainerNames(pod *corev1.Pod) []string {
+	names := make([]string, 0, len(pod.Spec.InitContainers))
+	for _, c := range pod.Spec.InitContainers {
+		names = append(names, c.Name)
+	}
+	return names
+}
+
 // TestDoSidecarInjection_CAInjection covers the CA bundle Volume / VolumeMount
 // / EnvVar block embedded at the tail of doSidecarInjection. It exercises the
 // two-tier gating contract:


### PR DESCRIPTION
…ard compatibility

The previous loop-based injection iterated sandbox.Spec.Runtimes in declaration order, which could produce different InitContainers ordering when the spec listed csi-mount before agent-runtime. This breaks compatibility with pre-existing pods that were injected by the older two-phase logic (agent-runtime first, then csi-mount).

Refactor doSidecarInjection into two phases:
- Phase 1: inject agent-runtime and csi-mount in a deterministic fixed order (matching historical behavior), regardless of spec declaration.
- Phase 2: inject remaining runtimes (e.g. traffic-proxy) in their declaration order via the generic conflict-check + apply path.

Also add TestDoSidecarInjection_FixedOrder with table-driven cases covering normal order, reversed order, and interleaved traffic-proxy to verify InitContainers stability.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

