### PR TITLE
fix(sandboxset): add legacy revision hash compat to prevent sandbox recreation on upgrade

### DIFF
--- a/pkg/controller/sandboxset/revision.go
+++ b/pkg/controller/sandboxset/revision.go
@@ -21,7 +21,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"strconv"
 
+	apps "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -74,4 +79,105 @@ func computeRevisionHash(spec *agentsv1alpha1.SandboxTemplateSpec) (string, erro
 	hf := fnv.New32()
 	hf.Write(data)
 	return rand.SafeEncodeString(fmt.Sprint(hf.Sum32())), nil
+}
+
+// computeLegacyRevisionHash replicates the release-v0.3 hash algorithm so that
+// existing sandboxes carrying the old-format hash are not incorrectly flagged
+// as outdated after an in-place controller upgrade.
+//
+// Legacy algorithm:
+//  1. JSON-marshal the PodTemplateSpec (inline or from referenced SandboxTemplate)
+//  2. Unmarshal to map[string]interface{} and inject "$patch": "replace"
+//  3. Wrap as {"spec": {"template": <map>}}
+//  4. JSON-marshal the wrapper and FNV-32 hash the bytes
+//
+// The legacy hash only considers spec.template; it does NOT include
+// VolumeClaimTemplates, PersistentContents, or Runtimes.
+func (r *Reconciler) computeLegacyRevisionHash(_ context.Context, sbs *agentsv1alpha1.SandboxSet) (string, error) {
+	// Legacy SandboxSets only use inline templates; templateRef was introduced
+	// after the hash algorithm change, so no backward compat is needed for it.
+	if sbs.Spec.TemplateRef != nil || sbs.Spec.Template == nil {
+		return "", nil
+	}
+	specCopy := make(map[string]interface{})
+	str, err := runtime.Encode(r.Codec, sbs)
+	if err != nil {
+		return "", err
+	}
+	var raw map[string]interface{}
+	if err = json.Unmarshal(str, &raw); err != nil {
+		return "", err
+	}
+	if spec, ok := raw["spec"].(map[string]interface{}); ok {
+		if template, ok := spec["template"].(map[string]interface{}); ok {
+			template["$patch"] = "replace"
+			specCopy["template"] = template
+		}
+	}
+	patch, err := json.Marshal(map[string]interface{}{"spec": specCopy})
+	if err != nil {
+		return "", err
+	}
+	// When the SandboxSet uses spec.templateRef, spec.template is nil. The
+	// revision labels on ControllerRevision are only informational here
+	// (the hash label is what the controller actually reads), so fall back
+	// to an empty label set to avoid a nil dereference.
+	var templateLabels map[string]string
+	if sbs.Spec.Template != nil {
+		templateLabels = sbs.Spec.Template.Labels
+	}
+	cr, err := NewControllerRevision(sbs,
+		agentsv1alpha1.SandboxSetControllerKind,
+		templateLabels,
+		runtime.RawExtension{Raw: patch},
+		0,
+		nil)
+	if err != nil {
+		return "", err
+	}
+	return cr.Labels[ControllerRevisionHashLabel], nil
+}
+
+// NewControllerRevision returns a ControllerRevision with a ControllerRef pointing to parent and indicating that
+// parent is of parentKind. The ControllerRevision has labels matching template labels, contains Data equal to data, and
+// has a Revision equal to revision. The collisionCount is used when creating the name of the ControllerRevision
+// so the name is likely unique. If the returned error is nil, the returned ControllerRevision is valid. If the
+// returned error is not nil, the returned ControllerRevision is invalid for use.
+func NewControllerRevision(parent metav1.Object,
+	parentKind schema.GroupVersionKind,
+	templateLabels map[string]string,
+	data runtime.RawExtension,
+	revision int64,
+	collisionCount *int32) (*apps.ControllerRevision, error) {
+	labelMap := make(map[string]string)
+	for k, v := range templateLabels {
+		labelMap[k] = v
+	}
+	cr := &apps.ControllerRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:          labelMap,
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(parent, parentKind)},
+		},
+		Data:     data,
+		Revision: revision,
+	}
+	hash := HashControllerRevision(cr, collisionCount)
+	cr.Labels[ControllerRevisionHashLabel] = hash
+	return cr, nil
+}
+
+// ControllerRevisionHashLabel is the label used to indicate the hash value of a ControllerRevision's Data.
+const ControllerRevisionHashLabel = "controller.kubernetes.io/hash"
+
+// HashControllerRevision hashes the contents of revision's Data using FNV hashing. If probe is not nil, the byte value
+// of probe is added written to the hash as well. The returned hash will be a safe encoded string to avoid bad words.
+func HashControllerRevision(revision *apps.ControllerRevision, probe *int32) string {
+	hf := fnv.New32()
+	if len(revision.Data.Raw) > 0 {
+		hf.Write(revision.Data.Raw)
+	}
+	if probe != nil {
+		hf.Write([]byte(strconv.FormatInt(int64(*probe), 10)))
+	}
+	return rand.SafeEncodeString(fmt.Sprint(hf.Sum32()))
 }

--- a/pkg/controller/sandboxset/revision_test.go
+++ b/pkg/controller/sandboxset/revision_test.go
@@ -25,6 +25,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -38,6 +41,7 @@ func newRevisionTestReconciler(objs ...client.Object) *Reconciler {
 	return &Reconciler{
 		Client: c,
 		Scheme: testScheme,
+		Codec:  serializer.NewCodecFactory(testScheme).LegacyCodec(v1alpha1.SchemeGroupVersion),
 	}
 }
 
@@ -326,4 +330,464 @@ func TestComputeRevisionHash_InlineAndTemplateRefConsistency(t *testing.T) {
 
 	assert.Equal(t, hashInline, hashRef,
 		"inline and templateRef describing the same content must produce identical hash")
+}
+
+// TestComputeLegacyRevisionHash verifies the backward-compatible legacy hash
+// computation that replicates the release-v0.3 algorithm.
+func TestComputeLegacyRevisionHash(t *testing.T) {
+	tests := []struct {
+		name        string
+		sbs         *v1alpha1.SandboxSet
+		expectEmpty bool
+	}{
+		{
+			name: "inline template produces non-empty hash",
+			sbs: &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: v1alpha1.SandboxSetSpec{
+					Replicas: 2,
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: samplePodTemplate("img:v1", nil),
+					},
+				},
+			},
+		},
+		{
+			name: "nil template returns empty hash",
+			sbs: &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "nil", Namespace: "default"},
+				Spec:       v1alpha1.SandboxSetSpec{Replicas: 1},
+			},
+			expectEmpty: true,
+		},
+		{
+			name: "templateRef returns empty (no legacy compat needed)",
+			sbs: &v1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "ref", Namespace: "default"},
+				Spec: v1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						TemplateRef: &v1alpha1.SandboxTemplateRef{Name: "tpl-legacy"},
+					},
+				},
+			},
+			expectEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newRevisionTestReconciler()
+			hash, err := r.computeLegacyRevisionHash(context.Background(), tt.sbs)
+			require.NoError(t, err)
+			if tt.expectEmpty {
+				assert.Empty(t, hash)
+			} else {
+				assert.NotEmpty(t, hash)
+			}
+		})
+	}
+}
+
+// TestLegacyHashDiffersFromNewHash verifies that the legacy hash and the new
+// hash produce different values for the same spec (confirming the need for
+// backward compat logic).
+func TestLegacyHashDiffersFromNewHash(t *testing.T) {
+	sbs := &v1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: v1alpha1.SandboxSetSpec{
+			Replicas: 2,
+			EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+				Template: samplePodTemplate("img:v1", map[string]string{"app": "test"}),
+				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{
+					ObjectMeta: metav1.ObjectMeta{Name: "data"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+						},
+					},
+				}},
+			},
+			PersistentContents: []string{"filesystem"},
+			Runtimes:           []v1alpha1.RuntimeConfig{{Name: "agent-runtime"}},
+		},
+	}
+
+	r := newRevisionTestReconciler()
+
+	// Legacy hash
+	legacyHash, err := r.computeLegacyRevisionHash(context.Background(), sbs)
+	require.NoError(t, err)
+	require.NotEmpty(t, legacyHash)
+
+	// New hash
+	spec, err := r.buildSandboxTemplateSpec(context.Background(), sbs)
+	require.NoError(t, err)
+	newHash, err := computeRevisionHash(spec)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, legacyHash, newHash,
+		"legacy and new hash algorithms must differ for the same spec")
+}
+
+// TestLegacyHashChangesWhenTemplateModified verifies that when the SandboxSet
+// template is actually modified, the legacy hash changes too. This means old
+// sandboxes (carrying the previous legacy hash) won't be falsely compat'd and
+// will correctly trigger a rolling update.
+func TestLegacyHashChangesWhenTemplateModified(t *testing.T) {
+	// Original SandboxSet
+	sbsOriginal := &v1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "sbs", Namespace: "default"},
+		Spec: v1alpha1.SandboxSetSpec{
+			Replicas: 3,
+			EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+				Template: samplePodTemplate("img:v1", map[string]string{"app": "web"}),
+			},
+		},
+	}
+
+	// Modified SandboxSet (user changed image from v1 to v2)
+	sbsModified := &v1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "sbs", Namespace: "default"},
+		Spec: v1alpha1.SandboxSetSpec{
+			Replicas: 3,
+			EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+				Template: samplePodTemplate("img:v2", map[string]string{"app": "web"}),
+			},
+		},
+	}
+
+	r := newRevisionTestReconciler()
+
+	// Compute legacy hash for original
+	legacyHashOriginal, err := r.computeLegacyRevisionHash(context.Background(), sbsOriginal)
+	require.NoError(t, err)
+	require.NotEmpty(t, legacyHashOriginal)
+
+	// Compute legacy hash for modified
+	legacyHashModified, err := r.computeLegacyRevisionHash(context.Background(), sbsModified)
+	require.NoError(t, err)
+	require.NotEmpty(t, legacyHashModified)
+
+	// Both new-algorithm hashes
+	specOrig, err := r.buildSandboxTemplateSpec(context.Background(), sbsOriginal)
+	require.NoError(t, err)
+	newHashOriginal, err := computeRevisionHash(specOrig)
+	require.NoError(t, err)
+
+	specMod, err := r.buildSandboxTemplateSpec(context.Background(), sbsModified)
+	require.NoError(t, err)
+	newHashModified, err := computeRevisionHash(specMod)
+	require.NoError(t, err)
+
+	// Legacy hash must change when template is modified
+	assert.NotEqual(t, legacyHashOriginal, legacyHashModified,
+		"legacy hash must change when template is modified")
+
+	// New hash must also change
+	assert.NotEqual(t, newHashOriginal, newHashModified,
+		"new hash must change when template is modified")
+
+	// Critical: old sandboxes (carrying legacyHashOriginal) should NOT match
+	// either the new updateRevision (newHashModified) or the new legacy hash
+	// (legacyHashModified). This ensures rolling update is triggered.
+	assert.False(t, isRevisionUpdated(legacyHashOriginal, newHashModified, legacyHashModified),
+		"old sandboxes must NOT be compat'd after template modification")
+
+	// New sandboxes will carry newHashModified (from updateRevision) which
+	// matches the new updateRevision.
+	assert.True(t, isRevisionUpdated(newHashModified, newHashModified, legacyHashModified),
+		"new sandboxes (carrying new hash) must match updateRevision")
+}
+
+// TestLegacyHashStableAcrossCalls verifies idempotency.
+func TestLegacyHashStableAcrossCalls(t *testing.T) {
+	sbs := &v1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "stable", Namespace: "default"},
+		Spec: v1alpha1.SandboxSetSpec{
+			Replicas: 1,
+			EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+				Template: samplePodTemplate("img:v1", map[string]string{"app": "stable"}),
+			},
+		},
+	}
+
+	r := newRevisionTestReconciler()
+	h1, err := r.computeLegacyRevisionHash(context.Background(), sbs)
+	require.NoError(t, err)
+	h2, err := r.computeLegacyRevisionHash(context.Background(), sbs)
+	require.NoError(t, err)
+	assert.Equal(t, h1, h2, "legacy hash must be deterministic")
+}
+
+// TestIsRevisionUpdated verifies the helper used in buildUpdateGroups.
+func TestIsRevisionUpdated(t *testing.T) {
+	tests := []struct {
+		name           string
+		revision       string
+		updateRevision string
+		legacyRevision string
+		expect         bool
+	}{
+		{
+			name:           "matches updateRevision",
+			revision:       "abc123",
+			updateRevision: "abc123",
+			legacyRevision: "xyz789",
+			expect:         true,
+		},
+		{
+			name:           "matches legacyRevision",
+			revision:       "xyz789",
+			updateRevision: "abc123",
+			legacyRevision: "xyz789",
+			expect:         true,
+		},
+		{
+			name:           "matches neither",
+			revision:       "old-old",
+			updateRevision: "abc123",
+			legacyRevision: "xyz789",
+			expect:         false,
+		},
+		{
+			name:           "empty legacyRevision only checks updateRevision",
+			revision:       "abc123",
+			updateRevision: "abc123",
+			legacyRevision: "",
+			expect:         true,
+		},
+		{
+			name:           "empty legacyRevision does not match arbitrary revision",
+			revision:       "something",
+			updateRevision: "abc123",
+			legacyRevision: "",
+			expect:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRevisionUpdated(tt.revision, tt.updateRevision, tt.legacyRevision)
+			assert.Equal(t, tt.expect, got)
+		})
+	}
+}
+
+// TestBuildUpdateGroupsWithLegacyRevision tests that sandboxes carrying the
+// legacy hash are correctly classified as Updated rather than Old.
+func TestBuildUpdateGroupsWithLegacyRevision(t *testing.T) {
+	now := metav1.Now().Time
+	newRev := "new-hash"
+	legacyRev := "66df5848ff"
+	oldRev := "completely-stale"
+
+	tests := []struct {
+		name                  string
+		groups                GroupedSandboxes
+		expectUpdatedCreating int
+		expectUpdatedAvail    int
+		expectOldCreating     int
+		expectOldAvail        int
+	}{
+		{
+			name: "legacy hash sandboxes treated as updated",
+			groups: GroupedSandboxes{
+				Available: []*v1alpha1.Sandbox{
+					newSandbox("a1", legacyRev, v1alpha1.SandboxStateAvailable, false, now),
+					newSandbox("a2", legacyRev, v1alpha1.SandboxStateAvailable, false, now),
+				},
+			},
+			expectUpdatedAvail: 2,
+		},
+		{
+			name: "new hash sandboxes still treated as updated",
+			groups: GroupedSandboxes{
+				Creating: []*v1alpha1.Sandbox{
+					newSandbox("c1", newRev, v1alpha1.SandboxStateCreating, false, now),
+				},
+			},
+			expectUpdatedCreating: 1,
+		},
+		{
+			name: "truly old sandboxes still flagged as old",
+			groups: GroupedSandboxes{
+				Available: []*v1alpha1.Sandbox{
+					newSandbox("a1", oldRev, v1alpha1.SandboxStateAvailable, false, now),
+				},
+			},
+			expectOldAvail: 1,
+		},
+		{
+			name: "mixed legacy and new hashes all treated as updated",
+			groups: GroupedSandboxes{
+				Available: []*v1alpha1.Sandbox{
+					newSandbox("a1", legacyRev, v1alpha1.SandboxStateAvailable, false, now),
+					newSandbox("a2", newRev, v1alpha1.SandboxStateAvailable, false, now),
+					newSandbox("a3", oldRev, v1alpha1.SandboxStateAvailable, false, now),
+				},
+			},
+			expectUpdatedAvail: 2,
+			expectOldAvail:     1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ug := buildUpdateGroups(tt.groups, newRev, legacyRev)
+			require.NotNil(t, ug)
+			assert.Equal(t, tt.expectUpdatedCreating, len(ug.UpdatedCreating))
+			assert.Equal(t, tt.expectUpdatedAvail, len(ug.UpdatedAvailable))
+			assert.Equal(t, tt.expectOldCreating, len(ug.OldCreating))
+			assert.Equal(t, tt.expectOldAvail, len(ug.OldAvailable))
+		})
+	}
+}
+
+// TestTemplateModificationTriggersRollingUpdateEndToEnd simulates an end-to-end
+// scenario: SandboxSet template is modified, old sandboxes (with the OLD legacy
+// hash) should be flagged as Old, and new sandboxes get the new updateRevision.
+func TestTemplateModificationTriggersRollingUpdateEndToEnd(t *testing.T) {
+	now := metav1.Now().Time
+
+	// Simulate: original SandboxSet with img:v1
+	sbsOriginal := &v1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "sbs", Namespace: "default"},
+		Spec: v1alpha1.SandboxSetSpec{
+			Replicas: 3,
+			EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+				Template: samplePodTemplate("img:v1", map[string]string{"app": "web"}),
+			},
+		},
+	}
+
+	// User modifies template: img:v1 → img:v2
+	sbsModified := &v1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "sbs", Namespace: "default"},
+		Spec: v1alpha1.SandboxSetSpec{
+			Replicas: 3,
+			EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+				Template: samplePodTemplate("img:v2", map[string]string{"app": "web"}),
+			},
+		},
+	}
+
+	r := newRevisionTestReconciler()
+
+	// Step 1: Compute the old legacy hash (what existing sandboxes carry)
+	oldLegacyHash, err := r.computeLegacyRevisionHash(context.Background(), sbsOriginal)
+	require.NoError(t, err)
+	require.NotEmpty(t, oldLegacyHash)
+
+	// Step 2: After modification, compute new updateRevision and new legacy hash
+	newSpec, err := r.buildSandboxTemplateSpec(context.Background(), sbsModified)
+	require.NoError(t, err)
+	newUpdateRevision, err := computeRevisionHash(newSpec)
+	require.NoError(t, err)
+
+	newLegacyHash, err := r.computeLegacyRevisionHash(context.Background(), sbsModified)
+	require.NoError(t, err)
+
+	// Step 3: Old sandboxes carry oldLegacyHash. After modification,
+	// buildUpdateGroups should classify them as Old.
+	groups := GroupedSandboxes{
+		Available: []*v1alpha1.Sandbox{
+			newSandbox("old-1", oldLegacyHash, v1alpha1.SandboxStateAvailable, false, now),
+			newSandbox("old-2", oldLegacyHash, v1alpha1.SandboxStateAvailable, false, now),
+			newSandbox("old-3", oldLegacyHash, v1alpha1.SandboxStateAvailable, false, now),
+		},
+	}
+
+	ug := buildUpdateGroups(groups, newUpdateRevision, newLegacyHash)
+	require.NotNil(t, ug)
+
+	// All old sandboxes should be in OldAvailable (rolling update needed)
+	assert.Equal(t, 3, len(ug.OldAvailable),
+		"old sandboxes must be flagged for rolling update after template modification")
+	assert.Equal(t, 0, len(ug.UpdatedAvailable),
+		"no sandbox should be treated as updated")
+
+	// Step 4: After rolling update, new sandboxes carry newUpdateRevision.
+	// Verify they're correctly classified as Updated.
+	newGroups := GroupedSandboxes{
+		Available: []*v1alpha1.Sandbox{
+			newSandbox("new-1", newUpdateRevision, v1alpha1.SandboxStateAvailable, false, now),
+			newSandbox("new-2", newUpdateRevision, v1alpha1.SandboxStateAvailable, false, now),
+			newSandbox("new-3", newUpdateRevision, v1alpha1.SandboxStateAvailable, false, now),
+		},
+	}
+
+	ugNew := buildUpdateGroups(newGroups, newUpdateRevision, newLegacyHash)
+	require.NotNil(t, ugNew)
+	assert.Equal(t, 3, len(ugNew.UpdatedAvailable),
+		"new sandboxes carrying updateRevision must be classified as Updated")
+	assert.Equal(t, 0, len(ugNew.OldAvailable))
+}
+
+func TestComputeUpdateRevision(t *testing.T) {
+	sbs := &v1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "code-interpreter",
+			Namespace: "default",
+			UID:       types.UID("test-uid-123"),
+		},
+		Spec: v1alpha1.SandboxSetSpec{
+			Replicas:           3,
+			PersistentContents: []string{"filesystem"},
+			Runtimes: []v1alpha1.RuntimeConfig{
+				{Name: "agent-runtime"},
+				{Name: "csi"},
+			},
+			EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "code-interpreter",
+							"env": "production",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "sandbox",
+								Image: "registry.example.com/sandbox/code-interpreter:v1.3",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: resource.MustParse("1Gi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("2"),
+										corev1.ResourceMemory: resource.MustParse("2Gi"),
+									},
+								},
+								Ports: []corev1.ContainerPort{
+									{Name: "interpreter", ContainerPort: 49999},
+									{Name: "envd", ContainerPort: 49983},
+								},
+							},
+						},
+						TerminationGracePeriodSeconds: ptr.To(int64(1)),
+					},
+				},
+			},
+		},
+	}
+
+	// testUpdateRevision is the golden value produced by the legacy hash algorithm
+	// (release-v0.3) for the above SandboxSet spec. It was captured from a real
+	// production cluster and MUST NEVER be changed.
+	//
+	// If this test fails, it almost certainly means the computeLegacyRevisionHash
+	// implementation has regressed — fix the code, NOT this constant. Changing
+	// this value would break backward compatibility with all existing sandboxes
+	// created before the hash algorithm migration.
+	const testUpdateRevision = "5bf5fbb5d6"
+
+	r := newRevisionTestReconciler()
+	legacyHash, err := r.computeLegacyRevisionHash(context.Background(), sbs)
+	require.NoError(t, err)
+	assert.Equal(t, testUpdateRevision, legacyHash,
+		"computeLegacyRevisionHash must produce the same hash as the legacy algorithm")
 }

--- a/pkg/controller/sandboxset/rolling_update.go
+++ b/pkg/controller/sandboxset/rolling_update.go
@@ -64,8 +64,10 @@ type UpdateInfo struct {
 // buildUpdateGroups builds update-specific groupings from existing GroupedSandboxes.
 // It categorizes unclaimed Creating and Available sandboxes by whether their template hash
 // matches the update revision. Claimed sandboxes are excluded from update consideration.
+// legacyRevision is the hash computed using the release-v0.3 algorithm; sandboxes whose
+// label matches either updateRevision or legacyRevision are considered up-to-date.
 // Returns nil if scale expectations are not satisfied, indicating the caller should wait.
-func buildUpdateGroups(groups GroupedSandboxes, updateRevision string) *UpdateGroupedSandboxes {
+func buildUpdateGroups(groups GroupedSandboxes, updateRevision, legacyRevision string) *UpdateGroupedSandboxes {
 	updateGroups := &UpdateGroupedSandboxes{}
 
 	// Categorize Creating sandboxes by revision (skip claimed)
@@ -74,7 +76,7 @@ func buildUpdateGroups(groups GroupedSandboxes, updateRevision string) *UpdateGr
 			continue
 		}
 		revision := sbx.Labels[agentsv1alpha1.LabelTemplateHash]
-		if revision == updateRevision {
+		if isRevisionUpdated(revision, updateRevision, legacyRevision) {
 			updateGroups.UpdatedCreating = append(updateGroups.UpdatedCreating, sbx)
 		} else {
 			updateGroups.OldCreating = append(updateGroups.OldCreating, sbx)
@@ -87,7 +89,7 @@ func buildUpdateGroups(groups GroupedSandboxes, updateRevision string) *UpdateGr
 			continue
 		}
 		revision := sbx.Labels[agentsv1alpha1.LabelTemplateHash]
-		if revision == updateRevision {
+		if isRevisionUpdated(revision, updateRevision, legacyRevision) {
 			updateGroups.UpdatedAvailable = append(updateGroups.UpdatedAvailable, sbx)
 		} else {
 			updateGroups.OldAvailable = append(updateGroups.OldAvailable, sbx)
@@ -95,6 +97,15 @@ func buildUpdateGroups(groups GroupedSandboxes, updateRevision string) *UpdateGr
 	}
 
 	return updateGroups
+}
+
+// isRevisionUpdated returns true if the sandbox's revision label matches
+// either the current updateRevision or the legacy (v0.3-compatible) revision.
+func isRevisionUpdated(revision, updateRevision, legacyRevision string) bool {
+	if revision == updateRevision {
+		return true
+	}
+	return legacyRevision != "" && revision == legacyRevision
 }
 
 // isSandboxClaimed checks if a sandbox has been claimed.

--- a/pkg/controller/sandboxset/rolling_update_test.go
+++ b/pkg/controller/sandboxset/rolling_update_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -179,7 +180,7 @@ func TestBuildUpdateGroups(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ug := buildUpdateGroups(tt.groups, tt.updateRevision)
+			ug := buildUpdateGroups(tt.groups, tt.updateRevision, "")
 			if tt.expectNil {
 				assert.Nil(t, ug)
 			} else {
@@ -443,6 +444,7 @@ func TestReconcile_RollingUpdate(t *testing.T) {
 				Client:   k8sClient,
 				Scheme:   testScheme,
 				Recorder: eventRecorder,
+				Codec:    serializer.NewCodecFactory(testScheme).LegacyCodec(v1alpha1.SchemeGroupVersion),
 			}
 			sbs := getSandboxSet(tt.replicas)
 			assert.NoError(t, k8sClient.Create(ctx, sbs))
@@ -451,9 +453,9 @@ func TestReconcile_RollingUpdate(t *testing.T) {
 
 			// Use an old hash to create sandboxes (simulate old revision)
 			if tt.oldHash != "" {
-				newStatus.UpdateRevision = tt.oldHash
+				newStatus.status.UpdateRevision = tt.oldHash
 			}
-			sbs.Status = *newStatus
+			sbs.Status = *newStatus.status
 			CreateSandboxes(t, tt.request, sbs, k8sClient)
 
 			// Now update the SandboxSet template to trigger update
@@ -502,6 +504,7 @@ func TestReconcile_RollingUpdate_SurgeGate(t *testing.T) {
 		Client:   k8sClient,
 		Scheme:   testScheme,
 		Recorder: eventRecorder,
+		Codec:    serializer.NewCodecFactory(testScheme).LegacyCodec(v1alpha1.SchemeGroupVersion),
 	}
 
 	// replicas=4, default maxSurge=20% (ceil→1), maxUnavailable=20% (floor→0)
@@ -509,11 +512,11 @@ func TestReconcile_RollingUpdate_SurgeGate(t *testing.T) {
 	assert.NoError(t, k8sClient.Create(ctx, sbs))
 	newStatus, err := reconciler.initNewStatus(ctx, sbs)
 	assert.NoError(t, err)
-	newHash := newStatus.UpdateRevision
+	newHash := newStatus.status.UpdateRevision
 
 	// Create 4 old-revision available sandboxes (simulating pre-edit state)
-	newStatus.UpdateRevision = oldHash
-	sbs.Status = *newStatus
+	newStatus.status.UpdateRevision = oldHash
+	sbs.Status = *newStatus.status
 	CreateSandboxes(t, createSandboxRequest{createAvailableSandboxes: 4}, sbs, k8sClient)
 
 	// Simulate scaleUpExpectation being unsatisfied: a previous rolling update create

--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -30,6 +30,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -81,6 +82,7 @@ type Reconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+	Codec    runtime.Codec
 }
 
 const (
@@ -115,11 +117,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	recordSandboxSetMetrics(sbs)
 
 	// Preparation
-	newStatus, err := r.initNewStatus(ctx, sbs)
+	result, err := r.initNewStatus(ctx, sbs)
 	if err != nil {
 		log.Error(err, "failed to init new status")
 		return ctrl.Result{}, err
 	}
+	newStatus := result.status
+	legacyRevision := result.legacyRevision
 
 	controllerKey := GetControllerKey(sbs)
 	groups, err := r.groupAllSandboxes(ctx, sbs)
@@ -160,7 +164,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if !scaleUpSatisfied || !scaleDownSatisfied {
 			log.Info("skip scale down for scaleUpExpectation or scaleDownExpectation is not satisfied")
 		} else {
-			err = r.scaleDown(ctx, -delta, sbs, groups, newStatus.UpdateRevision)
+			err = r.scaleDown(ctx, -delta, sbs, groups, newStatus.UpdateRevision, legacyRevision)
 		}
 	}
 	if err != nil {
@@ -182,7 +186,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Step 3: perform rolling update if needed
 	// update groups because status may change after scale
 	if delta == 0 && scaleUpSatisfied && scaleDownSatisfied {
-		updateGroups := buildUpdateGroups(groups, newStatus.UpdateRevision)
+		updateGroups := buildUpdateGroups(groups, newStatus.UpdateRevision, legacyRevision)
 		if updateGroups == nil {
 			log.Info("skip rolling update: scale expectations not satisfied, waiting for pending operations")
 		} else if needsUpdate(updateGroups) {
@@ -237,7 +241,7 @@ func (r *Reconciler) scaleUp(ctx context.Context, count int, sbs *agentsv1alpha1
 
 // scaleDown is allowed when both scaleUpExpectation and scaleDownExpectation are satisfied.
 // It prioritizes deleting old revision sandboxes first, then updated ones.
-func (r *Reconciler) scaleDown(ctx context.Context, count int, sbs *agentsv1alpha1.SandboxSet, groups GroupedSandboxes, updateRevision string) error {
+func (r *Reconciler) scaleDown(ctx context.Context, count int, sbs *agentsv1alpha1.SandboxSet, groups GroupedSandboxes, updateRevision, legacyRevision string) error {
 	log := logf.FromContext(ctx)
 	controllerKey := GetControllerKey(sbs)
 	lock := uuid.New().String()
@@ -252,10 +256,10 @@ func (r *Reconciler) scaleDown(ctx context.Context, count int, sbs *agentsv1alph
 	candidates = append(candidates, groups.Available...)
 	var oldCandidates, updatedCandidates []*agentsv1alpha1.Sandbox
 	for _, sbx := range candidates {
-		if sbx.Labels[agentsv1alpha1.LabelTemplateHash] != updateRevision {
-			oldCandidates = append(oldCandidates, sbx)
-		} else {
+		if isRevisionUpdated(sbx.Labels[agentsv1alpha1.LabelTemplateHash], updateRevision, legacyRevision) {
 			updatedCandidates = append(updatedCandidates, sbx)
+		} else {
+			oldCandidates = append(oldCandidates, sbx)
 		}
 	}
 
@@ -469,6 +473,7 @@ func (r *Reconciler) groupAllSandboxes(ctx context.Context, sbs *agentsv1alpha1.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controllerName := "sandboxset-controller"
 	r.Recorder = mgr.GetEventRecorderFor(controllerName)
+	r.Codec = serializer.NewCodecFactory(mgr.GetScheme()).LegacyCodec(agentsv1alpha1.SchemeGroupVersion)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(controllerName).
 		WithOptions(controller.Options{MaxConcurrentReconciles: concurrentReconciles}).

--- a/pkg/controller/sandboxset/sandboxset_controller_test.go
+++ b/pkg/controller/sandboxset/sandboxset_controller_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
@@ -308,17 +309,18 @@ func TestReconcile_DeleteDead(t *testing.T) {
 				Client:   k8sClient,
 				Scheme:   testScheme,
 				Recorder: eventRecorder,
+				Codec:    serializer.NewCodecFactory(testScheme).LegacyCodec(v1alpha1.SchemeGroupVersion),
 			}
 			assert.NoError(t, k8sClient.Create(ctx, sbs))
 			newStatus, err := reconciler.initNewStatus(ctx, sbs)
-
+		
 			assert.NoError(t, err)
-			sbs.Status = *newStatus
+			sbs.Status = *newStatus.status
 			CreateSandboxes(t, tt.request, sbs, k8sClient)
-
+		
 			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(sbs)})
 			assert.NoError(t, err)
-
+		
 			if tt.checkFunc != nil {
 				tt.checkFunc(t, k8sClient, sbs)
 			}
@@ -570,11 +572,12 @@ func TestReconcile_BasicScale(t *testing.T) {
 				Client:   k8sClient,
 				Scheme:   testScheme,
 				Recorder: eventRecorder,
+				Codec:    serializer.NewCodecFactory(testScheme).LegacyCodec(v1alpha1.SchemeGroupVersion),
 			}
 			newStatus, err := reconciler.initNewStatus(ctx, sbs)
 
 			assert.NoError(t, err)
-			sbs.Status = *newStatus
+			sbs.Status = *newStatus.status
 			_ = CreateSandboxes(t, tt.request, sbs, k8sClient)
 			scaleUpExpectation.DeleteExpectations(GetControllerKey(sbs))
 			scaleDownExpectation.DeleteExpectations(GetControllerKey(sbs))
@@ -698,6 +701,7 @@ func TestReconcile_ScaleDown(t *testing.T) {
 				Client:   k8sClient,
 				Scheme:   testScheme,
 				Recorder: eventRecorder,
+				Codec:    serializer.NewCodecFactory(testScheme).LegacyCodec(v1alpha1.SchemeGroupVersion),
 			}
 			sbs := getSandboxSet(tt.replicas)
 			// Run preSetup if provided (e.g., to set UpdateRevision before creating sandboxes)
@@ -777,12 +781,13 @@ func TestSandboxSetReconcile_WithVolumeClaimTemplates(t *testing.T) {
 				Client:   k8sClient,
 				Scheme:   testScheme,
 				Recorder: eventRecorder,
+				Codec:    serializer.NewCodecFactory(testScheme).LegacyCodec(v1alpha1.SchemeGroupVersion),
 			}
 
 			assert.NoError(t, k8sClient.Create(ctx, sbs))
 			newStatus, err := reconciler.initNewStatus(ctx, sbs)
 			assert.NoError(t, err)
-			sbs.Status = *newStatus
+			sbs.Status = *newStatus.status
 
 			// First reconcile to create sandboxes
 			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(sbs)})
@@ -1130,6 +1135,7 @@ func TestReconciler_createSandbox(t *testing.T) {
 				Client:   k8sClient,
 				Scheme:   testScheme,
 				Recorder: eventRecorder,
+				Codec:    serializer.NewCodecFactory(testScheme).LegacyCodec(v1alpha1.SchemeGroupVersion),
 			}
 
 			sbx, err := reconciler.createSandbox(ctx, tt.sbs, "rev-1")

--- a/pkg/controller/sandboxset/utils.go
+++ b/pkg/controller/sandboxset/utils.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
@@ -49,7 +50,13 @@ type GroupedSandboxes struct {
 	Dead      []*agentsv1alpha1.Sandbox // Sandboxes should be deleted
 }
 
-func (r *Reconciler) initNewStatus(ctx context.Context, ss *agentsv1alpha1.SandboxSet) (*agentsv1alpha1.SandboxSetStatus, error) {
+// initStatusResult bundles the output of initNewStatus to avoid excessive return values.
+type initStatusResult struct {
+	status         *agentsv1alpha1.SandboxSetStatus
+	legacyRevision string
+}
+
+func (r *Reconciler) initNewStatus(ctx context.Context, ss *agentsv1alpha1.SandboxSet) (*initStatusResult, error) {
 	newStatus := ss.Status.DeepCopy()
 	hash, name, err := r.ensureTemplateRevision(ctx, ss)
 	if err != nil {
@@ -58,7 +65,19 @@ func (r *Reconciler) initNewStatus(ctx context.Context, ss *agentsv1alpha1.Sandb
 	newStatus.UpdateRevision = hash
 	newStatus.ObservedGeneration = ss.Generation
 	newStatus.CurrentRevision = name
-	return newStatus, nil
+
+	// Compute legacy hash for backward compatibility with sandboxes created
+	// before the hash algorithm was changed. Errors are non-fatal: if legacy
+	// hash cannot be computed, we simply skip the fallback comparison.
+	legacyHash, err := r.computeLegacyRevisionHash(ctx, ss)
+	if err != nil {
+		klog.ErrorS(err, "Failed to compute legacy revision hash")
+	}
+
+	return &initStatusResult{
+		status:         newStatus,
+		legacyRevision: legacyHash,
+	}, nil
 }
 
 func calculateSandboxSetStatusFromGroup(ctx context.Context, newStatus *agentsv1alpha1.SandboxSetStatus, groups GroupedSandboxes, dirtyScaleUp map[expectations.ScaleAction][]string) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

After the revision hash algorithm was changed from release-v0.3 (ControllerRevision-based FNV-32 over `spec.template` with `$patch:replace` wrapper) to the current approach (`json.Marshal` of `SandboxTemplateSpec` including VolumeClaimTemplates, PersistentContents, Runtimes), existing sandboxes would be incorrectly flagged as outdated and mass-recreated during a controller upgrade.

This PR adds backward-compatible legacy hash computation so that existing sandboxes are preserved:

- `computeLegacyRevisionHash` replicates the v0.3 algorithm for inline templates
- `isRevisionUpdated` helper checks both new and legacy hashes during update-group classification
- `buildUpdateGroups` and `scaleDown` accept `legacyRevision` for dual comparison
- `templateRef` path skips legacy compat (templateRef was introduced after the algorithm change, no legacy sandboxes exist)

**Key invariant:** When the SandboxSet template is actually modified, the legacy hash also changes — so rolling updates are still correctly triggered for real config changes.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run unit tests:
   ```bash
   go test ./pkg/controller/sandboxset/ -count=1 -timeout 60s
   ```
2. Key test cases to review:
   - `TestLegacyHashChangesWhenTemplateModified` — verifies real config changes still trigger rolling update
   - `TestTemplateModificationTriggersRollingUpdateEndToEnd` — end-to-end scenario with `buildUpdateGroups`
   - `TestBuildUpdateGroupsWithLegacyRevision` — verifies old-hash sandboxes are compat'd as Updated

### Ⅳ. Special notes for reviews

- The legacy hash function only handles inline templates. SandboxSets using `templateRef` skip the legacy path entirely (return empty string), since `templateRef` was introduced after the hash algorithm change.
- `computeLegacyRevisionHash` errors are intentionally non-fatal — if it fails, we simply skip the fallback comparison and only use the new hash.
- The `initResult` struct bundles `status` + `legacyRevision` to avoid adding extra return values to `initNewStatus`.
