### PR TITLE
feat(cache): add CountActiveSandboxes to optimize claim hot path

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -296,6 +296,21 @@ func (c *Cache) ListSandboxes(ctx context.Context, opts ListSandboxesOptions) ([
 	return result, nil
 }
 
+func (c *Cache) CountActiveSandboxes(ctx context.Context, opts ListSandboxesOptions) (int32, error) {
+	list := &agentsv1alpha1.SandboxList{}
+	if err := listObjectWithUserAndNamespace(ctx, c.client, list, opts.User, opts.Namespace); err != nil {
+		return 0, err
+	}
+	var cnt int32
+	for i := range list.Items {
+		state, _ := utils.GetSandboxState(&list.Items[i])
+		if state != agentsv1alpha1.SandboxStateDead {
+			cnt++
+		}
+	}
+	return cnt, nil
+}
+
 func (c *Cache) ListCheckpoints(ctx context.Context, opts ListCheckpointsOptions) ([]*agentsv1alpha1.Checkpoint, error) {
 	list := &agentsv1alpha1.CheckpointList{}
 	if err := listObjectWithUserAndNamespace(ctx, c.client, list, opts.User, opts.Namespace); err != nil {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -421,6 +421,109 @@ func TestCache_ListSandboxesWithOptions_WithoutUserReturnsNamespaceScopedResults
 	require.Len(t, list, 2)
 }
 
+func TestCache_CountActiveSandboxes(t *testing.T) {
+	sbx1 := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sbx-1", Namespace: "default",
+			Annotations: map[string]string{agentsv1alpha1.AnnotationOwner: "user-1"},
+			Labels:      map[string]string{agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.True},
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxRunning,
+			Conditions: []metav1.Condition{
+				{Type: string(agentsv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue},
+			},
+			PodInfo: agentsv1alpha1.PodInfo{PodIP: "10.0.0.1"},
+		},
+	}
+	sbx2 := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sbx-2", Namespace: "default",
+			Annotations: map[string]string{agentsv1alpha1.AnnotationOwner: "user-1"},
+			Labels:      map[string]string{agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.True},
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxRunning,
+			Conditions: []metav1.Condition{
+				{Type: string(agentsv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue},
+			},
+			PodInfo: agentsv1alpha1.PodInfo{PodIP: "10.0.0.2"},
+		},
+	}
+	// Dead sandbox: should be excluded from count
+	sbx3 := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sbx-3", Namespace: "default",
+			Annotations:     map[string]string{agentsv1alpha1.AnnotationOwner: "user-1"},
+			Labels:          map[string]string{agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.True},
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
+			Finalizers:      []string{"agents.kruise.io/sandbox"},
+		},
+	}
+	// Different user
+	sbx4 := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sbx-4", Namespace: "default",
+			Annotations: map[string]string{agentsv1alpha1.AnnotationOwner: "user-2"},
+			Labels:      map[string]string{agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.True},
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxRunning,
+			Conditions: []metav1.Condition{
+				{Type: string(agentsv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue},
+			},
+			PodInfo: agentsv1alpha1.PodInfo{PodIP: "10.0.0.4"},
+		},
+	}
+
+	c, _, err := cachetest.NewTestCache(t, sbx1, sbx2, sbx3, sbx4)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		opts        cache.ListSandboxesOptions
+		expectCount int32
+	}{
+		{
+			name:        "user-1 counts 2 non-dead sandboxes",
+			opts:        cache.ListSandboxesOptions{User: "user-1"},
+			expectCount: 2,
+		},
+		{
+			name:        "user-2 counts 1 sandbox",
+			opts:        cache.ListSandboxesOptions{User: "user-2"},
+			expectCount: 1,
+		},
+		{
+			name:        "unknown user counts 0",
+			opts:        cache.ListSandboxesOptions{User: "user-nobody"},
+			expectCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cnt, err := c.CountActiveSandboxes(t.Context(), tt.opts)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectCount, cnt)
+		})
+	}
+
+	// Verify CountActiveSandboxes matches ListSandboxes result length (minus dead) for user-1
+	list, err := c.ListSandboxes(t.Context(), cache.ListSandboxesOptions{User: "user-1"})
+	require.NoError(t, err)
+	var listNonDead int32
+	for _, sbx := range list {
+		state, _ := utils.GetSandboxState(sbx)
+		if state != agentsv1alpha1.SandboxStateDead {
+			listNonDead++
+		}
+	}
+	cnt, err := c.CountActiveSandboxes(t.Context(), cache.ListSandboxesOptions{User: "user-1"})
+	require.NoError(t, err)
+	assert.Equal(t, listNonDead, cnt, "CountActiveSandboxes should match ListSandboxes non-dead count")
+}
+
 func TestCache_ListCheckpointsWithOptions_UserScoped(t *testing.T) {
 	cp1 := &agentsv1alpha1.Checkpoint{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cache/interface.go
+++ b/pkg/cache/interface.go
@@ -47,6 +47,10 @@ type Provider interface {
 	// Ownership is determined by the AnnotationOwner annotation on the Sandbox resource when User is set.
 	ListSandboxes(ctx context.Context, opts ListSandboxesOptions) ([]*agentsv1alpha1.Sandbox, error)
 
+	// CountActiveSandboxes counts active (non-dead) sandboxes filtered by namespace
+	// and optional owner. Faster than ListSandboxes when only the count is needed.
+	CountActiveSandboxes(ctx context.Context, opts ListSandboxesOptions) (int32, error)
+
 	// ListCheckpoints returns Checkpoint CRD objects filtered by namespace and optional owner.
 	// Ownership is determined by the AnnotationOwner annotation on the Checkpoint resource when User is set.
 	ListCheckpoints(ctx context.Context, opts ListCheckpointsOptions) ([]*agentsv1alpha1.Checkpoint, error)

--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -404,24 +404,10 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 	return sandboxcr.ValidateAndInitClaimOptions(opts)
 }
 
-// countClaimedSandboxes counts sandboxes that are claimed by this claim
+// countClaimedSandboxes counts active sandboxes claimed by this claim.
 func (c *commonControl) countClaimedSandboxes(ctx context.Context, claim *agentsv1alpha1.SandboxClaim) (int32, error) {
-	log := logf.FromContext(ctx)
-	sandboxes, err := c.cache.ListSandboxes(ctx, cache.ListSandboxesOptions{
+	return c.cache.CountActiveSandboxes(ctx, cache.ListSandboxesOptions{
 		User:      string(claim.UID),
 		Namespace: claim.Namespace,
 	})
-	if err != nil {
-		return 0, err
-	}
-	var cnt int32
-	for _, sbx := range sandboxes {
-		state, reason := utils.GetSandboxState(sbx)
-		if state == agentsv1alpha1.SandboxStateDead {
-			log.Info("skip counting dead sandbox", "reason", reason)
-			continue
-		}
-		cnt++
-	}
-	return cnt, nil
 }


### PR DESCRIPTION
## Summary

Add `CountActiveSandboxes` method to the cache interface, optimizing the SandboxClaim reconcile hot path.

## What Changed

- **`cache.Provider` interface**: Add `CountActiveSandboxes(ctx, opts) (int32, error)`
- **`cache.Cache` implementation**: Iterate `list.Items` in-place and count active (non-dead) sandboxes, returning only an `int32`
- **`common_control.countClaimedSandboxes`**: Replace `ListSandboxes` + manual counting with `CountActiveSandboxes`
- **Unit tests**: Add `TestCache_CountActiveSandboxes` covering multi-user, dead sandbox exclusion, and consistency with `ListSandboxes`

## Why

Before: `countClaimedSandboxes` called `ListSandboxes` → allocated `[]*Sandbox` slice → copied pointers → caller iterated again to count.

After: `CountActiveSandboxes` iterates in-place and returns a count, skipping the slice allocation and pointer copies. On the claim reconcile hot path (called every cycle), this reduces GC pressure at scale.

## Test

```
go test ./pkg/cache/... -run TestCache_CountActiveSandboxes -v
--- PASS: TestCache_CountActiveSandboxes
    --- PASS: TestCache_CountActiveSandboxes/user-1_counts_2_non-dead_sandboxes
    --- PASS: TestCache_CountActiveSandboxes/user-2_counts_1_sandbox
    --- PASS: TestCache_CountActiveSandboxes/unknown_user_counts_0
```