### PR TITLE
test(ci): expand sandbox-manager e2e coverage

### DIFF
--- a/.github/workflows/e2e-e2b-2.24.0.yaml
+++ b/.github/workflows/e2e-e2b-2.24.0.yaml
@@ -34,8 +34,6 @@ jobs:
         include:
           - name: without sandbox-gateway
             with_gateway: false
-          - name: with sandbox-gateway
-            with_gateway: true
     name: sandbox (${{ matrix.name }})
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/e2e-e2b-2.8.1.yaml
+++ b/.github/workflows/e2e-e2b-2.8.1.yaml
@@ -34,8 +34,6 @@ jobs:
         include:
           - name: without sandbox-gateway
             with_gateway: false
-          - name: with sandbox-gateway
-            with_gateway: true
     name: sandbox (${{ matrix.name }})
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/e2e-e2b-latest.yaml
+++ b/.github/workflows/e2e-e2b-latest.yaml
@@ -131,6 +131,7 @@ jobs:
             {
               echo ""
               echo "# Disable E2B auth (appended by e2e-e2b-latest auth-disabled matrix)"
+              echo "# Positional path targets --e2b-enable-auth in config/sandbox-manager/deployment.yaml."
               echo "- op: replace"
               echo "  path: /spec/template/spec/containers/0/args/8"
               echo "  value: --e2b-enable-auth=false"

--- a/.github/workflows/e2e-e2b-latest.yaml
+++ b/.github/workflows/e2e-e2b-latest.yaml
@@ -34,8 +34,13 @@ jobs:
         include:
           - name: without sandbox-gateway
             with_gateway: false
+            e2b_enable_auth: true
           - name: with sandbox-gateway
             with_gateway: true
+            e2b_enable_auth: true
+          - name: with sandbox-gateway, auth disabled
+            with_gateway: true
+            e2b_enable_auth: false
     name: sandbox (${{ matrix.name }})
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -122,6 +127,17 @@ jobs:
 
       - name: Install Kruise Agents
         run: |
+          if [ "${{ matrix.e2b_enable_auth }}" = "false" ]; then
+            {
+              echo ""
+              echo "# Disable E2B auth (appended by e2e-e2b-latest auth-disabled matrix)"
+              echo "- op: replace"
+              echo "  path: /spec/template/spec/containers/0/args/8"
+              echo "  value: --e2b-enable-auth=false"
+            } >> config/sandbox-manager/configuration_patch.yaml
+            echo "deployment patch:"
+            cat config/sandbox-manager/configuration_patch.yaml
+          fi
           make deploy-agent-sandbox-controller
           make deploy-sandbox-manager
           bash hack/wait-agent-sandbox-controller.sh
@@ -134,9 +150,16 @@ jobs:
         run: |
           export KUBECONFIG=/home/runner/.kube/config
           export E2B_DOMAIN=localhost
-          export E2B_API_KEY=some-api-key
-          if [ "${{ matrix.with_gateway }}" = "true" ]; then
-            bash hack/run-e2b-e2e-test.sh --with-gateway
+          if [ "${{ matrix.e2b_enable_auth }}" = "false" ]; then
+            export E2B_API_KEY=e2b_abc123
           else
-            bash hack/run-e2b-e2e-test.sh
+            export E2B_API_KEY=some-api-key
           fi
+          args=()
+          if [ "${{ matrix.with_gateway }}" = "true" ]; then
+            args+=(--with-gateway)
+          fi
+          if [ "${{ matrix.e2b_enable_auth }}" = "false" ]; then
+            args+=(--auth-disabled)
+          fi
+          bash hack/run-e2b-e2e-test.sh "${args[@]}"

--- a/.github/workflows/e2e-e2b-mysql-latest.yaml
+++ b/.github/workflows/e2e-e2b-mysql-latest.yaml
@@ -128,6 +128,33 @@ jobs:
           {
             echo ""
             echo "# E2B MySQL key storage (appended by e2e-e2b-mysql-latest before deploy)"
+            echo "- op: replace"
+            echo "  path: /spec/replicas"
+            echo "  value: 3"
+            echo "- op: replace"
+            echo "  path: /spec/template/spec/containers/0/resources/limits/cpu"
+            echo '  value: "500m"'
+            echo "- op: replace"
+            echo "  path: /spec/template/spec/containers/0/resources/limits/memory"
+            echo '  value: "1Gi"'
+            echo "- op: replace"
+            echo "  path: /spec/template/spec/containers/0/resources/requests/cpu"
+            echo '  value: "500m"'
+            echo "- op: replace"
+            echo "  path: /spec/template/spec/containers/0/resources/requests/memory"
+            echo '  value: "1Gi"'
+            echo "- op: replace"
+            echo "  path: /spec/template/spec/containers/1/resources/limits/cpu"
+            echo '  value: "500m"'
+            echo "- op: replace"
+            echo "  path: /spec/template/spec/containers/1/resources/limits/memory"
+            echo '  value: "1Gi"'
+            echo "- op: replace"
+            echo "  path: /spec/template/spec/containers/1/resources/requests/cpu"
+            echo '  value: "500m"'
+            echo "- op: replace"
+            echo "  path: /spec/template/spec/containers/1/resources/requests/memory"
+            echo '  value: "1Gi"'
             echo "- op: add"
             echo "  path: /spec/template/spec/containers/0/args/-"
             echo "  value: --e2b-key-storage=mysql"

--- a/.github/workflows/e2e-e2b-mysql-latest.yaml
+++ b/.github/workflows/e2e-e2b-mysql-latest.yaml
@@ -126,9 +126,9 @@ jobs:
           MYSQL_ROOT_PASSWORD: ${{ env.MYSQL_ROOT_PASSWORD }}
         run: |
           kubectl exec -i deployment/mysql -n "${MYSQL_NAMESPACE}" -- \
-            env MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -uroot "${MYSQL_DATABASE}" < hack/mysql-schema.sql
+            env MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql --protocol=TCP -h 127.0.0.1 -uroot "${MYSQL_DATABASE}" < hack/mysql-schema.sql
           kubectl exec deployment/mysql -n "${MYSQL_NAMESPACE}" -- \
-            env MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -uroot "${MYSQL_DATABASE}" \
+            env MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql --protocol=TCP -h 127.0.0.1 -uroot "${MYSQL_DATABASE}" \
               -e "SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name IN ('teams', 'team_api_keys') ORDER BY table_name;"
 
       - name: Install Kruise Agents

--- a/.github/workflows/e2e-e2b-mysql-latest.yaml
+++ b/.github/workflows/e2e-e2b-mysql-latest.yaml
@@ -89,7 +89,7 @@ jobs:
             echo "Cached inplace-update image"
           fi
 
-      # Flow: build/load images → MySQL → deploy agents with MySQL key storage (no post-deploy patch) → E2E
+      # Flow: build/load images → MySQL → schema → deploy agents with MySQL key storage (no post-deploy patch) → E2E
       - name: Build and load container images
         run: |
            make docker-build-manager
@@ -118,6 +118,18 @@ jobs:
           MYSQL_DATABASE: ${{ env.MYSQL_DATABASE }}
           MYSQL_ROOT_PASSWORD: ${{ env.MYSQL_ROOT_PASSWORD }}
         run: bash hack/deploy-mysql-kind-ci.sh
+
+      - name: Initialize MySQL key storage schema
+        env:
+          MYSQL_DATABASE: ${{ env.MYSQL_DATABASE }}
+          MYSQL_NAMESPACE: sandbox-system
+          MYSQL_ROOT_PASSWORD: ${{ env.MYSQL_ROOT_PASSWORD }}
+        run: |
+          kubectl exec -i deployment/mysql -n "${MYSQL_NAMESPACE}" -- \
+            env MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -uroot "${MYSQL_DATABASE}" < hack/mysql-schema.sql
+          kubectl exec deployment/mysql -n "${MYSQL_NAMESPACE}" -- \
+            env MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -uroot "${MYSQL_DATABASE}" \
+              -e "SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name IN ('teams', 'team_api_keys') ORDER BY table_name;"
 
       - name: Install Kruise Agents
         env:
@@ -158,6 +170,9 @@ jobs:
             echo "- op: add"
             echo "  path: /spec/template/spec/containers/0/args/-"
             echo "  value: --e2b-key-storage=mysql"
+            echo "- op: add"
+            echo "  path: /spec/template/spec/containers/0/args/-"
+            echo "  value: --e2b-key-storage-disable-schema-auto-update"
             echo "- op: add"
             echo "  path: /spec/template/spec/containers/0/env/-"
             printf '  value: {"name":"E2B_KEY_STORAGE_DSN","value":"%s"}\n' "${MYSQL_DSN}"

--- a/.github/workflows/e2e-e2b-mysql-latest.yaml
+++ b/.github/workflows/e2e-e2b-mysql-latest.yaml
@@ -143,30 +143,6 @@ jobs:
             echo "- op: replace"
             echo "  path: /spec/replicas"
             echo "  value: 3"
-            echo "- op: replace"
-            echo "  path: /spec/template/spec/containers/0/resources/limits/cpu"
-            echo '  value: "500m"'
-            echo "- op: replace"
-            echo "  path: /spec/template/spec/containers/0/resources/limits/memory"
-            echo '  value: "1Gi"'
-            echo "- op: replace"
-            echo "  path: /spec/template/spec/containers/0/resources/requests/cpu"
-            echo '  value: "500m"'
-            echo "- op: replace"
-            echo "  path: /spec/template/spec/containers/0/resources/requests/memory"
-            echo '  value: "1Gi"'
-            echo "- op: replace"
-            echo "  path: /spec/template/spec/containers/1/resources/limits/cpu"
-            echo '  value: "500m"'
-            echo "- op: replace"
-            echo "  path: /spec/template/spec/containers/1/resources/limits/memory"
-            echo '  value: "1Gi"'
-            echo "- op: replace"
-            echo "  path: /spec/template/spec/containers/1/resources/requests/cpu"
-            echo '  value: "500m"'
-            echo "- op: replace"
-            echo "  path: /spec/template/spec/containers/1/resources/requests/memory"
-            echo '  value: "1Gi"'
             echo "- op: add"
             echo "  path: /spec/template/spec/containers/0/args/-"
             echo "  value: --e2b-key-storage=mysql"

--- a/config/sandbox-manager/deployment.yaml
+++ b/config/sandbox-manager/deployment.yaml
@@ -77,8 +77,8 @@ spec:
               cpu: "1"
               memory: "2Gi"
             requests:
-              cpu: "1"
-              memory: "2Gi"
+              cpu: "500m"
+              memory: "1Gi"
         - name: envoy-proxy
           image: envoyproxy/envoy:v1.33-latest
           imagePullPolicy: IfNotPresent
@@ -116,8 +116,8 @@ spec:
               cpu: "1"
               memory: "2Gi"
             requests:
-              cpu: "1"
-              memory: "2Gi"
+              cpu: "500m"
+              memory: "1Gi"
       volumes:
         - name: envoy-config
           configMap:

--- a/hack/run-e2b-e2e-test.sh
+++ b/hack/run-e2b-e2e-test.sh
@@ -18,6 +18,7 @@ set -e
 # Default values
 TIMEOUT="60m"
 WITH_GATEWAY="false"
+AUTH_DISABLED="false"
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -143,9 +144,13 @@ while [[ $# -gt 0 ]]; do
             WITH_GATEWAY="true"
             shift # past argument
             ;;
+        --auth-disabled)
+            AUTH_DISABLED="true"
+            shift # past argument
+            ;;
         *)
             echo "Unknown parameter passed: $1"
-            echo "Usage: $0 [--e2b-version VERSION] [--sdk-version VERSION] [--timeout TIMEOUT] [--with-gateway]"
+            echo "Usage: $0 [--e2b-version VERSION] [--sdk-version VERSION] [--timeout TIMEOUT] [--with-gateway] [--auth-disabled]"
             exit 1
             ;;
     esac
@@ -215,7 +220,12 @@ if [ -z "$installed_e2b_version" ]; then
     echo "Error: failed to determine installed e2b version"
     exit 1
 fi
-convert_e2b_api_key_for_sdk_if_needed "$installed_e2b_version"
+if [ "$AUTH_DISABLED" = "true" ]; then
+    echo "E2B auth is disabled; skipping API key compatibility conversion"
+    export E2B_API_KEY="${E2B_AUTH_DISABLED_API_KEY:-e2b_abc123}"
+else
+    convert_e2b_api_key_for_sdk_if_needed "$installed_e2b_version"
+fi
 
 # Step 3: Run pytest tests serially (print the key for debug, it's safe to print it in a ci pipeline)
 echo "Using E2B_API_KEY: ${E2B_API_KEY:-}"
@@ -246,11 +256,15 @@ fi
 
 # Run pytest with serial execution (no parallel flag)
 cd "$PROJECT_ROOT"
-if [ "$WITH_GATEWAY" = "true" ]; then
-    pytest -v -s -x --tb=short "$TEST_DIR"
-else
-    pytest -v -s -x --tb=short --ignore="$TEST_DIR/test_gateway.py" --ignore="$TEST_DIR/test_gateway_auth.py" "$TEST_DIR"
+pytest_args=(-v -s -x --tb=short)
+if [ "$WITH_GATEWAY" != "true" ]; then
+    pytest_args+=(--ignore="$TEST_DIR/test_gateway.py")
+    pytest_args+=(--ignore="$TEST_DIR/test_gateway_auth.py")
 fi
+if [ "$AUTH_DISABLED" = "true" ]; then
+    pytest_args+=(--ignore="$TEST_DIR/test_apikey.py")
+fi
+pytest "${pytest_args[@]}" "$TEST_DIR"
 retVal=$?
 
 set +x

--- a/hack/run-e2b-e2e-test.sh
+++ b/hack/run-e2b-e2e-test.sh
@@ -18,6 +18,7 @@ set -e
 # Default values
 TIMEOUT="60m"
 WITH_GATEWAY="false"
+AUTH_DISABLED="false"
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -143,9 +144,13 @@ while [[ $# -gt 0 ]]; do
             WITH_GATEWAY="true"
             shift # past argument
             ;;
+        --auth-disabled)
+            AUTH_DISABLED="true"
+            shift # past argument
+            ;;
         *)
             echo "Unknown parameter passed: $1"
-            echo "Usage: $0 [--e2b-version VERSION] [--sdk-version VERSION] [--timeout TIMEOUT] [--with-gateway]"
+            echo "Usage: $0 [--e2b-version VERSION] [--sdk-version VERSION] [--timeout TIMEOUT] [--with-gateway] [--auth-disabled]"
             exit 1
             ;;
     esac
@@ -215,7 +220,12 @@ if [ -z "$installed_e2b_version" ]; then
     echo "Error: failed to determine installed e2b version"
     exit 1
 fi
-convert_e2b_api_key_for_sdk_if_needed "$installed_e2b_version"
+if [ "$AUTH_DISABLED" = "true" ]; then
+    echo "E2B auth is disabled; skipping API key compatibility conversion"
+    export E2B_API_KEY="${E2B_AUTH_DISABLED_API_KEY:-e2b_abc123}"
+else
+    convert_e2b_api_key_for_sdk_if_needed "$installed_e2b_version"
+fi
 
 # Step 3: Run pytest tests serially (print the key for debug, it's safe to print it in a ci pipeline)
 echo "Using E2B_API_KEY: ${E2B_API_KEY:-}"
@@ -246,11 +256,14 @@ fi
 
 # Run pytest with serial execution (no parallel flag)
 cd "$PROJECT_ROOT"
-if [ "$WITH_GATEWAY" = "true" ]; then
-    pytest -v -s -x --tb=short "$TEST_DIR"
-else
-    pytest -v -s -x --tb=short --ignore="$TEST_DIR/test_gateway.py" "$TEST_DIR"
+pytest_args=(-v -s -x --tb=short)
+if [ "$WITH_GATEWAY" != "true" ]; then
+    pytest_args+=(--ignore="$TEST_DIR/test_gateway.py")
 fi
+if [ "$AUTH_DISABLED" = "true" ]; then
+    pytest_args+=(--ignore="$TEST_DIR/test_apikey.py")
+fi
+pytest "${pytest_args[@]}" "$TEST_DIR"
 retVal=$?
 
 set +x

--- a/pkg/servers/e2b/keys/mysql.go
+++ b/pkg/servers/e2b/keys/mysql.go
@@ -212,7 +212,19 @@ func (k *mysqlKeyStorage) repairAdminKeyAfterDuplicate(ctx context.Context, key 
 		return fmt.Errorf("lookup admin key after duplicate insert: %w", err)
 	}
 
+	if adminKeyEqual(existing, key) {
+		return nil
+	}
+
 	return k.updateAdminKey(ctx, key)
+}
+
+func adminKeyEqual(existing, expected TeamAPIKeyEntity) bool {
+	return existing.UID == expected.UID &&
+		existing.Name == expected.Name &&
+		existing.KeyHash == expected.KeyHash &&
+		existing.TeamID == expected.TeamID &&
+		!existing.DeletedAt.Valid
 }
 
 func (k *mysqlKeyStorage) updateAdminKey(ctx context.Context, key TeamAPIKeyEntity) error {

--- a/pkg/servers/e2b/keys/mysql.go
+++ b/pkg/servers/e2b/keys/mysql.go
@@ -191,17 +191,39 @@ func (k *mysqlKeyStorage) ensureAdminKey(ctx context.Context, adminTeamID uint) 
 			return fmt.Errorf("lookup admin key by uid: %w", err)
 		}
 		if err := k.db.WithContext(ctx).Session(&gorm.Session{SkipDefaultTransaction: true}).Create(&key).Error; err != nil {
+			if errors.Is(err, gorm.ErrDuplicatedKey) {
+				return k.repairAdminKeyAfterDuplicate(ctx, key)
+			}
 			return fmt.Errorf("create admin key: %w", err)
 		}
 		return nil
 	}
 
+	return k.updateAdminKey(ctx, key)
+}
+
+func (k *mysqlKeyStorage) repairAdminKeyAfterDuplicate(ctx context.Context, key TeamAPIKeyEntity) error {
+	var existing TeamAPIKeyEntity
+	if err := k.db.WithContext(ctx).Unscoped().Where(&TeamAPIKeyEntity{UID: key.UID}).
+		First(&existing).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("create admin key: duplicate conflict but admin uid %s not present", key.UID)
+		}
+		return fmt.Errorf("lookup admin key after duplicate insert: %w", err)
+	}
+
+	return k.updateAdminKey(ctx, key)
+}
+
+func (k *mysqlKeyStorage) updateAdminKey(ctx context.Context, key TeamAPIKeyEntity) error {
 	if err := k.db.WithContext(ctx).Session(&gorm.Session{SkipDefaultTransaction: true}).Model(&TeamAPIKeyEntity{}).
+		Unscoped().
 		Where("uid = ?", key.UID).
 		Updates(map[string]any{
-			"name":     key.Name,
-			"key_hash": key.KeyHash,
-			"team_id":  key.TeamID,
+			"name":       key.Name,
+			"key_hash":   key.KeyHash,
+			"team_id":    key.TeamID,
+			"deleted_at": nil,
 		}).Error; err != nil {
 		return fmt.Errorf("update admin key: %w", err)
 	}

--- a/pkg/servers/e2b/keys/mysql_test.go
+++ b/pkg/servers/e2b/keys/mysql_test.go
@@ -50,6 +50,8 @@ const listByOwnerRegex = "SELECT `created_at`,`uid`,`name`,`created_by_uid` FROM
 // listTeamsRegex matches the EXISTS subquery used by ListTeams for admin users.
 const listTeamsRegex = "SELECT `uid`,`name` FROM `teams` WHERE \\(EXISTS \\(SELECT 1 FROM team_api_keys WHERE team_api_keys\\.team_id = teams\\.id AND team_api_keys\\.deleted_at IS NULL\\)\\) AND `teams`\\.`deleted_at` IS NULL"
 
+const updateAdminKeyRegex = "UPDATE `team_api_keys` SET .*`deleted_at`=.*"
+
 func newMockStorage(t *testing.T) (*mysqlKeyStorage, sqlmock.Sqlmock, func()) {
 	t.Helper()
 	sqlDB, mock, err := sqlmock.New()
@@ -142,7 +144,7 @@ func TestMySQL_InitBranches(t *testing.T) {
 		h := st.hashKey("admin")
 		mock.ExpectQuery("SELECT .*FROM `teams`.*").WillReturnRows(sqlmock.NewRows([]string{"id", "uid", "name"}).AddRow(1, AdminTeamUID.String(), "admin"))
 		mock.ExpectQuery("SELECT .*FROM `team_api_keys`.*").WillReturnRows(sqlmock.NewRows([]string{"id", "uid", "key_hash", "name", "team_id", "deleted_at"}).AddRow(1, AdminKeyID.String(), h, "admin", 1, nil))
-		mock.ExpectExec("UPDATE `team_api_keys` SET .*").WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec(updateAdminKeyRegex).WillReturnResult(sqlmock.NewResult(0, 1))
 		require.NoError(t, st.Init(context.Background()))
 	})
 
@@ -163,7 +165,7 @@ func TestMySQL_InitBranches(t *testing.T) {
 		h := st.hashKey("admin")
 		mock.ExpectQuery("SELECT .*FROM `teams`.*").WillReturnRows(sqlmock.NewRows([]string{"id", "uid", "name"}).AddRow(1, AdminTeamUID.String(), "admin"))
 		mock.ExpectQuery("SELECT .*FROM `team_api_keys`.*").WillReturnRows(sqlmock.NewRows([]string{"id", "uid", "key_hash", "name", "team_id", "deleted_at"}).AddRow(1, AdminKeyID.String(), h, "admin", 1, nil))
-		mock.ExpectExec("UPDATE `team_api_keys` SET .*").WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec(updateAdminKeyRegex).WillReturnResult(sqlmock.NewResult(0, 1))
 
 		require.NoError(t, st.Init(context.Background()))
 		require.Zero(t, autoMigrateCalls)
@@ -195,7 +197,7 @@ func TestMySQL_EnsureAdminTeamAndKey(t *testing.T) {
 		mock.ExpectQuery("SELECT .*FROM `team_api_keys`.*").WillReturnRows(
 			sqlmock.NewRows([]string{"id", "uid", "key_hash", "name", "team_id", "deleted_at"}).AddRow(1, AdminKeyID.String(), h, "admin", 1, nil),
 		)
-		mock.ExpectExec("UPDATE `team_api_keys` SET .*").WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec(updateAdminKeyRegex).WillReturnResult(sqlmock.NewResult(0, 1))
 		require.NoError(t, st.ensureAdminKey(context.Background(), 1))
 	})
 
@@ -221,6 +223,52 @@ func TestMySQL_EnsureAdminTeamAndKey(t *testing.T) {
 		mock.ExpectExec("INSERT INTO `team_api_keys`.*").WillReturnError(errors.New("insert fail"))
 		require.Error(t, st.ensureAdminKey(context.Background(), 1))
 	})
+}
+
+func TestMySQL_EnsureAdminKeyDuplicateConflict(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(*mysqlKeyStorage, sqlmock.Sqlmock)
+		expectError string
+	}{
+		{
+			name: "recovers when concurrent replica creates admin key first",
+			setup: func(st *mysqlKeyStorage, mock sqlmock.Sqlmock) {
+				h := st.hashKey("admin")
+				mock.ExpectQuery("SELECT .*FROM `team_api_keys`.*").WillReturnError(gorm.ErrRecordNotFound)
+				mock.ExpectExec("INSERT INTO `team_api_keys`.*").WillReturnError(gorm.ErrDuplicatedKey)
+				mock.ExpectQuery("SELECT .*FROM `team_api_keys`.*").WillReturnRows(
+					sqlmock.NewRows([]string{"id", "uid", "key_hash", "name", "team_id", "deleted_at"}).AddRow(1, AdminKeyID.String(), h, "admin", 1, nil),
+				)
+				mock.ExpectExec(updateAdminKeyRegex).WillReturnResult(sqlmock.NewResult(0, 1))
+			},
+		},
+		{
+			name: "returns conflict when duplicate row is not admin key",
+			setup: func(_ *mysqlKeyStorage, mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT .*FROM `team_api_keys`.*").WillReturnError(gorm.ErrRecordNotFound)
+				mock.ExpectExec("INSERT INTO `team_api_keys`.*").WillReturnError(gorm.ErrDuplicatedKey)
+				mock.ExpectQuery("SELECT .*FROM `team_api_keys`.*").WillReturnError(gorm.ErrRecordNotFound)
+			},
+			expectError: "duplicate conflict but admin uid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st, mock, done := newMockStorage(t)
+			defer done()
+			tt.setup(st, mock)
+
+			err := st.ensureAdminKey(context.Background(), 1)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestMySQL_LoadByKeyAndID(t *testing.T) {

--- a/pkg/servers/e2b/keys/mysql_test.go
+++ b/pkg/servers/e2b/keys/mysql_test.go
@@ -232,13 +232,23 @@ func TestMySQL_EnsureAdminKeyDuplicateConflict(t *testing.T) {
 		expectError string
 	}{
 		{
-			name: "recovers when concurrent replica creates admin key first",
+			name: "succeeds when concurrent replica creates matching admin key first",
 			setup: func(st *mysqlKeyStorage, mock sqlmock.Sqlmock) {
 				h := st.hashKey("admin")
 				mock.ExpectQuery("SELECT .*FROM `team_api_keys`.*").WillReturnError(gorm.ErrRecordNotFound)
 				mock.ExpectExec("INSERT INTO `team_api_keys`.*").WillReturnError(gorm.ErrDuplicatedKey)
 				mock.ExpectQuery("SELECT .*FROM `team_api_keys`.*").WillReturnRows(
 					sqlmock.NewRows([]string{"id", "uid", "key_hash", "name", "team_id", "deleted_at"}).AddRow(1, AdminKeyID.String(), h, "admin", 1, nil),
+				)
+			},
+		},
+		{
+			name: "repairs when concurrent replica leaves stale admin key fields",
+			setup: func(_ *mysqlKeyStorage, mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT .*FROM `team_api_keys`.*").WillReturnError(gorm.ErrRecordNotFound)
+				mock.ExpectExec("INSERT INTO `team_api_keys`.*").WillReturnError(gorm.ErrDuplicatedKey)
+				mock.ExpectQuery("SELECT .*FROM `team_api_keys`.*").WillReturnRows(
+					sqlmock.NewRows([]string{"id", "uid", "key_hash", "name", "team_id", "deleted_at"}).AddRow(1, AdminKeyID.String(), "stale-hash", "admin", 1, nil),
 				)
 				mock.ExpectExec(updateAdminKeyRegex).WillReturnResult(sqlmock.NewResult(0, 1))
 			},


### PR DESCRIPTION
## Summary
- add a latest E2B gateway CI matrix entry with E2B auth disabled
- run MySQL key storage E2E only through the gateway and cover 3 sandbox-manager replicas
- add an auth-disabled test runner mode that skips API-key-only checks

## Test Plan
- [x] bash -n hack/run-e2b-e2e-test.sh
- [x] ruby YAML parse for updated workflow files
- [x] kustomize build config/sandbox-manager
- [x] simulated kustomize builds for auth-disabled and MySQL patches