### PR TITLE
feat: support memory resize for sandbox claims

### DIFF
--- a/api/v1alpha1/sandboxclaim_types.go
+++ b/api/v1alpha1/sandboxclaim_types.go
@@ -126,18 +126,17 @@ type SandboxClaimInplaceUpdateOptions struct {
 	Resources *SandboxClaimInplaceUpdateResourcesOptions `json:"resources,omitempty"`
 }
 
-// SandboxClaimInplaceUpdateResourcesOptions
-// TODO: now we only support cpu inplace resize, consider support mem resize in the future.
+// SandboxClaimInplaceUpdateResourcesOptions specifies resources for in-place resize.
 type SandboxClaimInplaceUpdateResourcesOptions struct {
 	// Requests specifies the target resource requests for each container.
-	// Only CPU is supported for now. The container's original request must already be set;
+	// CPU and memory are supported. The container's original request must already be set;
 	// otherwise the value is ignored.
 	// The new value must not change the Pod's QoS class; otherwise the claim will be rejected.
 	// +optional
 	Requests corev1.ResourceList `json:"requests,omitempty"`
 
 	// Limits specifies the target resource limits for each container.
-	// Only CPU is supported for now. The container's original limit must already be set;
+	// CPU and memory are supported. The container's original limit must already be set;
 	// otherwise the value is ignored.
 	// The new value must not change the Pod's QoS class; otherwise the claim will be rejected.
 	// +optional

--- a/api/v1alpha1/sandboxclaim_types.go
+++ b/api/v1alpha1/sandboxclaim_types.go
@@ -131,6 +131,9 @@ type SandboxClaimInplaceUpdateResourcesOptions struct {
 	// Requests specifies the target resource requests for each container.
 	// CPU and memory are supported. The container's original request must already be set;
 	// otherwise the value is ignored.
+	// Memory may only be increased: a target lower than the container's current memory is rejected.
+	// Memory resize may restart the container when the pod template declares
+	// resizePolicy: {resourceName: memory, restartPolicy: RestartContainer}.
 	// The new value must not change the Pod's QoS class; otherwise the claim will be rejected.
 	// +optional
 	Requests corev1.ResourceList `json:"requests,omitempty"`
@@ -138,6 +141,9 @@ type SandboxClaimInplaceUpdateResourcesOptions struct {
 	// Limits specifies the target resource limits for each container.
 	// CPU and memory are supported. The container's original limit must already be set;
 	// otherwise the value is ignored.
+	// Memory may only be increased: a target lower than the container's current memory is rejected.
+	// Memory resize may restart the container when the pod template declares
+	// resizePolicy: {resourceName: memory, restartPolicy: RestartContainer}.
 	// The new value must not change the Pod's QoS class; otherwise the claim will be rejected.
 	// +optional
 	Limits corev1.ResourceList `json:"limits,omitempty"`

--- a/api/v1alpha1/sandboxclaim_types.go
+++ b/api/v1alpha1/sandboxclaim_types.go
@@ -129,8 +129,9 @@ type SandboxClaimInplaceUpdateOptions struct {
 // SandboxClaimInplaceUpdateResourcesOptions specifies resources for in-place resize.
 type SandboxClaimInplaceUpdateResourcesOptions struct {
 	// Requests specifies the target resource requests for each container.
-	// CPU and memory are supported. The container's original request must already be set;
-	// otherwise the value is ignored.
+	// Only CPU and memory are supported; other resource names are rejected.
+	// The container's original request must already be set; otherwise the value is ignored.
+	// A request must not exceed the target limit of the same resource.
 	// Memory may only be increased: a target lower than the container's current memory is rejected.
 	// Memory resize may restart the container when the pod template declares
 	// resizePolicy: {resourceName: memory, restartPolicy: RestartContainer}.
@@ -139,8 +140,9 @@ type SandboxClaimInplaceUpdateResourcesOptions struct {
 	Requests corev1.ResourceList `json:"requests,omitempty"`
 
 	// Limits specifies the target resource limits for each container.
-	// CPU and memory are supported. The container's original limit must already be set;
-	// otherwise the value is ignored.
+	// Only CPU and memory are supported; other resource names are rejected.
+	// The container's original limit must already be set; otherwise the value is ignored.
+	// A limit must not be lower than the target request of the same resource.
 	// Memory may only be increased: a target lower than the container's current memory is rejected.
 	// Memory resize may restart the container when the pod template declares
 	// resizePolicy: {resourceName: memory, restartPolicy: RestartContainer}.

--- a/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
@@ -131,7 +131,7 @@ spec:
                           x-kubernetes-int-or-string: true
                         description: |-
                           Limits specifies the target resource limits for each container.
-                          Only CPU is supported for now. The container's original limit must already be set;
+                          CPU and memory are supported. The container's original limit must already be set;
                           otherwise the value is ignored.
                           The new value must not change the Pod's QoS class; otherwise the claim will be rejected.
                         type: object
@@ -144,7 +144,7 @@ spec:
                           x-kubernetes-int-or-string: true
                         description: |-
                           Requests specifies the target resource requests for each container.
-                          Only CPU is supported for now. The container's original request must already be set;
+                          CPU and memory are supported. The container's original request must already be set;
                           otherwise the value is ignored.
                           The new value must not change the Pod's QoS class; otherwise the claim will be rejected.
                         type: object

--- a/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
@@ -135,7 +135,7 @@ spec:
                           x-kubernetes-int-or-string: true
                         description: |-
                           Limits specifies the target resource limits for each container.
-                          Only CPU is supported for now. The container's original limit must already be set;
+                          CPU and memory are supported. The container's original limit must already be set;
                           otherwise the value is ignored.
                           The new value must not change the Pod's QoS class; otherwise the claim will be rejected.
                         type: object
@@ -148,7 +148,7 @@ spec:
                           x-kubernetes-int-or-string: true
                         description: |-
                           Requests specifies the target resource requests for each container.
-                          Only CPU is supported for now. The container's original request must already be set;
+                          CPU and memory are supported. The container's original request must already be set;
                           otherwise the value is ignored.
                           The new value must not change the Pod's QoS class; otherwise the claim will be rejected.
                         type: object

--- a/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
@@ -137,6 +137,9 @@ spec:
                           Limits specifies the target resource limits for each container.
                           CPU and memory are supported. The container's original limit must already be set;
                           otherwise the value is ignored.
+                          Memory may only be increased: a target lower than the container's current memory is rejected.
+                          Memory resize may restart the container when the pod template declares
+                          resizePolicy: {resourceName: memory, restartPolicy: RestartContainer}.
                           The new value must not change the Pod's QoS class; otherwise the claim will be rejected.
                         type: object
                       requests:
@@ -150,6 +153,9 @@ spec:
                           Requests specifies the target resource requests for each container.
                           CPU and memory are supported. The container's original request must already be set;
                           otherwise the value is ignored.
+                          Memory may only be increased: a target lower than the container's current memory is rejected.
+                          Memory resize may restart the container when the pod template declares
+                          resizePolicy: {resourceName: memory, restartPolicy: RestartContainer}.
                           The new value must not change the Pod's QoS class; otherwise the claim will be rejected.
                         type: object
                     type: object

--- a/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
@@ -135,8 +135,9 @@ spec:
                           x-kubernetes-int-or-string: true
                         description: |-
                           Limits specifies the target resource limits for each container.
-                          CPU and memory are supported. The container's original limit must already be set;
-                          otherwise the value is ignored.
+                          Only CPU and memory are supported; other resource names are rejected.
+                          The container's original limit must already be set; otherwise the value is ignored.
+                          A limit must not be lower than the target request of the same resource.
                           Memory may only be increased: a target lower than the container's current memory is rejected.
                           Memory resize may restart the container when the pod template declares
                           resizePolicy: {resourceName: memory, restartPolicy: RestartContainer}.
@@ -151,8 +152,9 @@ spec:
                           x-kubernetes-int-or-string: true
                         description: |-
                           Requests specifies the target resource requests for each container.
-                          CPU and memory are supported. The container's original request must already be set;
-                          otherwise the value is ignored.
+                          Only CPU and memory are supported; other resource names are rejected.
+                          The container's original request must already be set; otherwise the value is ignored.
+                          A request must not exceed the target limit of the same resource.
                           Memory may only be increased: a target lower than the container's current memory is rejected.
                           Memory resize may restart the container when the pod template declares
                           resizePolicy: {resourceName: memory, restartPolicy: RestartContainer}.

--- a/pkg/controller/sandbox/core/common_inplace_update_handler.go
+++ b/pkg/controller/sandbox/core/common_inplace_update_handler.go
@@ -142,21 +142,14 @@ func handleInPlaceUpdateCommon(
 		return true, nil
 	}
 
-	// Reject memory downscale up front. The resize path treats "actual >= desired"
-	// as satisfied, so a lower memory target would otherwise be silently ignored
-	// and leave the sandbox template permanently diverged from the live pod.
+	// Memory downscale is rejected at the claim write path (SetResources) and
+	// at claim admission; here we only surface an advisory event. A hard
+	// failure would misclassify pods whose memory was raised by the
+	// environment (LimitRange minimums, admission webhooks, VPA actuation) as
+	// downscales and permanently block unrelated image/metadata rollouts.
 	if downscaleErr := inplaceupdate.CheckMemoryDownscale(box, pod); downscaleErr != nil {
-		msg := downscaleErr.Error()
-		klog.FromContext(ctx).Info(msg, "sandbox", klog.KObj(box))
-		handler.GetRecorder().Eventf(box, corev1.EventTypeWarning, "InplaceUpdateFailed", msg)
-		utils.SetSandboxCondition(newStatus, metav1.Condition{
-			Type:               string(agentsv1alpha1.SandboxConditionInplaceUpdate),
-			Status:             metav1.ConditionFalse,
-			Reason:             agentsv1alpha1.SandboxInplaceUpdateReasonFailed,
-			Message:            msg,
-			LastTransitionTime: metav1.Now(),
-		})
-		return true, nil
+		klog.FromContext(ctx).Info("skipping memory downscale", "sandbox", klog.KObj(box), "reason", downscaleErr.Error())
+		handler.GetRecorder().Eventf(box, corev1.EventTypeWarning, "MemoryDownscaleSkipped", downscaleErr.Error())
 	}
 
 	// If only metadata (labels/annotations) changed, directly patch the pod metadata

--- a/pkg/controller/sandbox/core/common_inplace_update_handler.go
+++ b/pkg/controller/sandbox/core/common_inplace_update_handler.go
@@ -142,6 +142,23 @@ func handleInPlaceUpdateCommon(
 		return true, nil
 	}
 
+	// Reject memory downscale up front. The resize path treats "actual >= desired"
+	// as satisfied, so a lower memory target would otherwise be silently ignored
+	// and leave the sandbox template permanently diverged from the live pod.
+	if downscaleErr := inplaceupdate.CheckMemoryDownscale(box, pod); downscaleErr != nil {
+		msg := downscaleErr.Error()
+		klog.FromContext(ctx).Info(msg, "sandbox", klog.KObj(box))
+		handler.GetRecorder().Eventf(box, corev1.EventTypeWarning, "InplaceUpdateFailed", msg)
+		utils.SetSandboxCondition(newStatus, metav1.Condition{
+			Type:               string(agentsv1alpha1.SandboxConditionInplaceUpdate),
+			Status:             metav1.ConditionFalse,
+			Reason:             agentsv1alpha1.SandboxInplaceUpdateReasonFailed,
+			Message:            msg,
+			LastTransitionTime: metav1.Now(),
+		})
+		return true, nil
+	}
+
 	// If only metadata (labels/annotations) changed, directly patch the pod metadata
 	// without going through the in-place update flow. This avoids unnecessarily
 	// setting the InplaceUpdate condition and Ready=False, which would block

--- a/pkg/controller/sandbox/core/common_inplace_update_handler_test.go
+++ b/pkg/controller/sandbox/core/common_inplace_update_handler_test.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -470,6 +471,118 @@ func TestHandleInPlaceUpdateCommon_QoSChangeRejected(t *testing.T) {
 			}
 			if cond.Message == "" {
 				t.Error("Expected non-empty message about QoS change")
+			}
+		}
+	}
+	if !found {
+		t.Error("InplaceUpdate condition not found in status")
+	}
+}
+
+func TestHandleInPlaceUpdateCommon_MemoryDownscaleRejected(t *testing.T) {
+	ctx := context.Background()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				agentsv1alpha1.PodLabelTemplateHash: "old-revision",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "main",
+				Image: "nginx:latest",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("250m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			}},
+		},
+	}
+
+	_, hashWithoutImageAndResource := HashSandbox(&agentsv1alpha1.Sandbox{
+		Spec: agentsv1alpha1.SandboxSpec{
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: pod.Spec,
+				},
+			},
+		},
+	})
+
+	// Sandbox template lowers memory 256Mi -> 128Mi; this is a downscale-only
+	// change that must be rejected instead of silently ignored.
+	box := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+			Annotations: map[string]string{
+				agentsv1alpha1.SandboxHashImmutablePart: hashWithoutImageAndResource,
+			},
+		},
+		Spec: agentsv1alpha1.SandboxSpec{
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "main",
+							Image: "nginx:latest",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("250m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	newStatus := &agentsv1alpha1.SandboxStatus{
+		UpdateRevision: "new-revision",
+	}
+
+	recorder := createTestRecorder()
+	handler := &MockInPlaceUpdateHandler{
+		control:  inplaceupdate.NewInPlaceUpdateControl(nil, inplaceupdate.DefaultGeneratePatchBodyFunc),
+		recorder: recorder,
+		logger:   logr.Discard(),
+	}
+
+	result, err := handleInPlaceUpdateCommon(ctx, handler, pod, box, newStatus)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !result {
+		t.Error("Expected result true (done, no requeue), got false")
+	}
+
+	var found bool
+	for _, cond := range newStatus.Conditions {
+		if cond.Type == string(agentsv1alpha1.SandboxConditionInplaceUpdate) {
+			found = true
+			if cond.Reason != agentsv1alpha1.SandboxInplaceUpdateReasonFailed {
+				t.Errorf("Expected reason %s, got %s", agentsv1alpha1.SandboxInplaceUpdateReasonFailed, cond.Reason)
+			}
+			if cond.Status != metav1.ConditionFalse {
+				t.Errorf("Expected status ConditionFalse, got %s", cond.Status)
+			}
+			if !strings.Contains(cond.Message, "downscale") {
+				t.Errorf("Expected message about memory downscale, got %q", cond.Message)
 			}
 		}
 	}

--- a/pkg/controller/sandbox/core/common_inplace_update_handler_test.go
+++ b/pkg/controller/sandbox/core/common_inplace_update_handler_test.go
@@ -479,8 +479,39 @@ func TestHandleInPlaceUpdateCommon_QoSChangeRejected(t *testing.T) {
 	}
 }
 
-func TestHandleInPlaceUpdateCommon_MemoryDownscaleRejected(t *testing.T) {
+func TestHandleInPlaceUpdateCommon_MemoryDownscaleSkippedAdvisory(t *testing.T) {
+	// The pod's live memory (256Mi) was raised above the template (128Mi) by
+	// the environment. A memory downscale must NOT hard-fail the rollout:
+	// the image update proceeds and only an advisory event is emitted.
 	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	oldPodSpec := corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:  "main",
+			Image: "nginx:old",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+			},
+		}},
+	}
+
+	newPodSpec := corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:  "main",
+			Image: "nginx:new",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("128Mi")},
+				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("128Mi")},
+			},
+		}},
+	}
+
+	box := buildMatchingHashBox("test-sandbox", "default", newPodSpec)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -490,67 +521,10 @@ func TestHandleInPlaceUpdateCommon_MemoryDownscaleRejected(t *testing.T) {
 				agentsv1alpha1.PodLabelTemplateHash: "old-revision",
 			},
 		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:  "main",
-				Image: "nginx:latest",
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("250m"),
-						corev1.ResourceMemory: resource.MustParse("256Mi"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("500m"),
-						corev1.ResourceMemory: resource.MustParse("256Mi"),
-					},
-				},
-			}},
-		},
+		Spec: oldPodSpec,
 	}
 
-	_, hashWithoutImageAndResource := HashSandbox(&agentsv1alpha1.Sandbox{
-		Spec: agentsv1alpha1.SandboxSpec{
-			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
-				Template: &corev1.PodTemplateSpec{
-					Spec: pod.Spec,
-				},
-			},
-		},
-	})
-
-	// Sandbox template lowers memory 256Mi -> 128Mi; this is a downscale-only
-	// change that must be rejected instead of silently ignored.
-	box := &agentsv1alpha1.Sandbox{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-sandbox",
-			Namespace: "default",
-			Annotations: map[string]string{
-				agentsv1alpha1.SandboxHashImmutablePart: hashWithoutImageAndResource,
-			},
-		},
-		Spec: agentsv1alpha1.SandboxSpec{
-			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
-				Template: &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{{
-							Name:  "main",
-							Image: "nginx:latest",
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("250m"),
-									corev1.ResourceMemory: resource.MustParse("128Mi"),
-								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("500m"),
-									corev1.ResourceMemory: resource.MustParse("128Mi"),
-								},
-							},
-						}},
-					},
-				},
-			},
-		},
-	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
 		UpdateRevision: "new-revision",
@@ -558,7 +532,7 @@ func TestHandleInPlaceUpdateCommon_MemoryDownscaleRejected(t *testing.T) {
 
 	recorder := createTestRecorder()
 	handler := &MockInPlaceUpdateHandler{
-		control:  inplaceupdate.NewInPlaceUpdateControl(nil, inplaceupdate.DefaultGeneratePatchBodyFunc),
+		control:  inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		recorder: recorder,
 		logger:   logr.Discard(),
 	}
@@ -567,27 +541,30 @@ func TestHandleInPlaceUpdateCommon_MemoryDownscaleRejected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if !result {
-		t.Error("Expected result true (done, no requeue), got false")
+	if result {
+		t.Error("Expected result false (update in progress), got true")
 	}
 
-	var found bool
+	// The image rollout must proceed: condition is InplaceUpdating, not Failed.
 	for _, cond := range newStatus.Conditions {
-		if cond.Type == string(agentsv1alpha1.SandboxConditionInplaceUpdate) {
+		if cond.Type != string(agentsv1alpha1.SandboxConditionInplaceUpdate) {
+			continue
+		}
+		if cond.Reason == agentsv1alpha1.SandboxInplaceUpdateReasonFailed {
+			t.Errorf("Expected no InplaceUpdate failure, got reason %s message %q", cond.Reason, cond.Message)
+		}
+	}
+
+	// An advisory event about the skipped downscale must be recorded.
+	fakeRecorder := recorder.(*record.FakeRecorder)
+	found := false
+	for len(fakeRecorder.Events) > 0 {
+		if ev := <-fakeRecorder.Events; strings.Contains(ev, "MemoryDownscaleSkipped") {
 			found = true
-			if cond.Reason != agentsv1alpha1.SandboxInplaceUpdateReasonFailed {
-				t.Errorf("Expected reason %s, got %s", agentsv1alpha1.SandboxInplaceUpdateReasonFailed, cond.Reason)
-			}
-			if cond.Status != metav1.ConditionFalse {
-				t.Errorf("Expected status ConditionFalse, got %s", cond.Status)
-			}
-			if !strings.Contains(cond.Message, "downscale") {
-				t.Errorf("Expected message about memory downscale, got %q", cond.Message)
-			}
 		}
 	}
 	if !found {
-		t.Error("InplaceUpdate condition not found in status")
+		t.Error("Expected MemoryDownscaleSkipped event, none recorded")
 	}
 }
 

--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -44,6 +44,7 @@ import (
 	annotationutils "github.com/openkruise/agents/pkg/utils/annotations"
 	"github.com/openkruise/agents/pkg/utils/csiutils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
+	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
 	runtimeclient "github.com/openkruise/agents/pkg/utils/runtime"
 	"github.com/openkruise/agents/pkg/utils/timeout"
 )
@@ -140,6 +141,32 @@ func (c *commonControl) EnsureClaimClaiming(ctx context.Context, args ClaimArgs)
 				c.recorder.Event(claim, "Warning", "FeatureGateDisabled", msg)
 				TransitionToCompleted(args.NewStatus, "FeatureGateDisabled", msg)
 				return NoRequeue(), nil
+			}
+		}
+	}
+
+	// Step 7.1: Validate the inplace update request up front so invalid input
+	// fails fast with an accurate reason instead of spinning until
+	// ClaimTimeout with a misleading NoAvailableSandboxes event.
+	if claim.Spec.InplaceUpdate != nil && claim.Spec.InplaceUpdate.Resources != nil {
+		res := claim.Spec.InplaceUpdate.Resources
+		if err := sandboxcr.ValidateResizeResources(res.Requests, res.Limits); err != nil {
+			msg := err.Error()
+			log.Info(msg)
+			c.recorder.Event(claim, "Warning", "InvalidInplaceUpdateResources", msg)
+			TransitionToCompleted(args.NewStatus, "InvalidInplaceUpdateResources", msg)
+			return NoRequeue(), nil
+		}
+		if sandboxSet.Spec.Template != nil {
+			for i := range sandboxSet.Spec.Template.Spec.Containers {
+				templateContainer := &sandboxSet.Spec.Template.Spec.Containers[i]
+				if err := inplaceupdate.CheckContainerMemoryDownscale(templateContainer, res.Requests, res.Limits); err != nil {
+					msg := fmt.Sprintf("container %q: %v", templateContainer.Name, err)
+					log.Info(msg)
+					c.recorder.Event(claim, "Warning", "MemoryDownscaleNotSupported", msg)
+					TransitionToCompleted(args.NewStatus, "MemoryDownscaleNotSupported", msg)
+					return NoRequeue(), nil
+				}
 			}
 		}
 	}

--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -44,7 +44,6 @@ import (
 	annotationutils "github.com/openkruise/agents/pkg/utils/annotations"
 	"github.com/openkruise/agents/pkg/utils/csiutils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
-	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
 	runtimeclient "github.com/openkruise/agents/pkg/utils/runtime"
 	"github.com/openkruise/agents/pkg/utils/timeout"
 )
@@ -147,7 +146,10 @@ func (c *commonControl) EnsureClaimClaiming(ctx context.Context, args ClaimArgs)
 
 	// Step 7.1: Validate the inplace update request up front so invalid input
 	// fails fast with an accurate reason instead of spinning until
-	// ClaimTimeout with a misleading NoAvailableSandboxes event.
+	// ClaimTimeout with a misleading NoAvailableSandboxes event. Only
+	// sandbox-independent rules are checked here; revision-dependent checks
+	// (memory downscale, QoS class change) run per candidate in
+	// sandboxcr.preCheckCandidate.
 	if claim.Spec.InplaceUpdate != nil && claim.Spec.InplaceUpdate.Resources != nil {
 		res := claim.Spec.InplaceUpdate.Resources
 		if err := sandboxcr.ValidateResizeResources(res.Requests, res.Limits); err != nil {
@@ -156,18 +158,6 @@ func (c *commonControl) EnsureClaimClaiming(ctx context.Context, args ClaimArgs)
 			c.recorder.Event(claim, "Warning", "InvalidInplaceUpdateResources", msg)
 			TransitionToCompleted(args.NewStatus, "InvalidInplaceUpdateResources", msg)
 			return NoRequeue(), nil
-		}
-		if sandboxSet.Spec.Template != nil {
-			for i := range sandboxSet.Spec.Template.Spec.Containers {
-				templateContainer := &sandboxSet.Spec.Template.Spec.Containers[i]
-				if err := inplaceupdate.CheckContainerMemoryDownscale(templateContainer, res.Requests, res.Limits); err != nil {
-					msg := fmt.Sprintf("container %q: %v", templateContainer.Name, err)
-					log.Info(msg)
-					c.recorder.Event(claim, "Warning", "MemoryDownscaleNotSupported", msg)
-					TransitionToCompleted(args.NewStatus, "MemoryDownscaleNotSupported", msg)
-					return NoRequeue(), nil
-				}
-			}
 		}
 	}
 

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -541,7 +541,7 @@ func TestCommonControl_EnsureClaimClaiming_ClaimedGreaterThanZero(t *testing.T) 
 	assert.Equal(t, int32(1), newStatus.ClaimedReplicas, "ClaimedReplicas should be 1")
 }
 
-func TestCommonControl_EnsureClaimClaiming_CPUResizeFeatureGatePrecondition(t *testing.T) {
+func TestCommonControl_EnsureClaimClaiming_ResourceResizeFeatureGatePrecondition(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = agentsv1alpha1.AddToScheme(scheme)
 
@@ -557,7 +557,7 @@ func TestCommonControl_EnsureClaimClaiming_CPUResizeFeatureGatePrecondition(t *t
 				Replicas:     int32Ptr(1),
 				InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
 					Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
-						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
 					},
 				},
 			},
@@ -1031,16 +1031,22 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 			name: "claim with inplaceUpdate resources",
 			claim: &agentsv1alpha1.SandboxClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-claim-cpu-resize",
+					Name:      "test-claim-resource-resize",
 					Namespace: "default",
-					UID:       "test-uid-cpu-resize",
+					UID:       "test-uid-resource-resize",
 				},
 				Spec: agentsv1alpha1.SandboxClaimSpec{
 					TemplateName: "test-template",
 					InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
 						Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
-							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
-							Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
 						},
 					},
 				},
@@ -1059,6 +1065,10 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 				reqCPU := opts.InplaceUpdate.Resources.Requests[corev1.ResourceCPU]
 				if reqCPU.String() != "500m" {
 					t.Errorf("InplaceUpdate.Resources.Requests[cpu] = %v, want 500m", reqCPU.String())
+				}
+				reqMemory := opts.InplaceUpdate.Resources.Requests[corev1.ResourceMemory]
+				if reqMemory.String() != "512Mi" {
+					t.Errorf("InplaceUpdate.Resources.Requests[memory] = %v, want 512Mi", reqMemory.String())
 				}
 			},
 		},

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -567,7 +567,7 @@ func TestCommonControl_EnsureClaimClaiming_ClaimedGreaterThanZero(t *testing.T) 
 	assert.Equal(t, int32(1), newStatus.ClaimedReplicas, "ClaimedReplicas should be 1")
 }
 
-func TestCommonControl_EnsureClaimClaiming_CPUResizeFeatureGatePrecondition(t *testing.T) {
+func TestCommonControl_EnsureClaimClaiming_ResourceResizeFeatureGatePrecondition(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = agentsv1alpha1.AddToScheme(scheme)
 
@@ -583,7 +583,7 @@ func TestCommonControl_EnsureClaimClaiming_CPUResizeFeatureGatePrecondition(t *t
 				Replicas:     int32Ptr(1),
 				InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
 					Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
-						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
 					},
 				},
 			},
@@ -1061,16 +1061,22 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 			name: "claim with inplaceUpdate resources",
 			claim: &agentsv1alpha1.SandboxClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-claim-cpu-resize",
+					Name:      "test-claim-resource-resize",
 					Namespace: "default",
-					UID:       "test-uid-cpu-resize",
+					UID:       "test-uid-resource-resize",
 				},
 				Spec: agentsv1alpha1.SandboxClaimSpec{
 					TemplateName: "test-template",
 					InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
 						Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
-							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
-							Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
 						},
 					},
 				},
@@ -1089,6 +1095,10 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 				reqCPU := opts.InplaceUpdate.Resources.Requests[corev1.ResourceCPU]
 				if reqCPU.String() != "500m" {
 					t.Errorf("InplaceUpdate.Resources.Requests[cpu] = %v, want 500m", reqCPU.String())
+				}
+				reqMemory := opts.InplaceUpdate.Resources.Requests[corev1.ResourceMemory]
+				if reqMemory.String() != "512Mi" {
+					t.Errorf("InplaceUpdate.Resources.Requests[memory] = %v, want 512Mi", reqMemory.String())
 				}
 			},
 		},

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -35,6 +35,7 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/agent-runtime/storages"
+	"github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/cache/cachetest"
 	"github.com/openkruise/agents/pkg/features"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
@@ -662,6 +663,151 @@ func TestCommonControl_EnsureClaimClaiming_ResourceResizeFeatureGatePrecondition
 		assert.Equal(t, agentsv1alpha1.SandboxClaimPhaseClaiming, newStatus.Phase)
 		assert.Equal(t, int32(0), newStatus.ClaimedReplicas)
 	})
+}
+
+func TestCommonControl_EnsureClaimClaiming_ResizeIncompatibleSandboxRetries(t *testing.T) {
+	claim := &agentsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim-resize-downscale",
+			Namespace: "default",
+			UID:       types.UID("test-uid-resize-downscale"),
+		},
+		Spec: agentsv1alpha1.SandboxClaimSpec{
+			TemplateName: "test-template",
+			Replicas:     int32Ptr(1),
+			InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
+				Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
+					Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("128Mi")},
+				},
+			},
+		},
+	}
+	sandboxSet := &agentsv1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+	}
+	provider, fakeClient, err := cachetest.NewTestCache(t)
+	require.NoError(t, err)
+
+	// The only warm sandbox runs 256Mi, so a 128Mi claim is a downscale: every
+	// candidate is incompatible and the claim must keep retrying.
+	warm := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "warm-sbx",
+			Namespace:         "default",
+			Labels:            map[string]string{agentsv1alpha1.LabelSandboxTemplate: "test-template"},
+			Annotations:       map[string]string{},
+			CreationTimestamp: metav1.Now(),
+			OwnerReferences:   []metav1.OwnerReference{*metav1.NewControllerRef(sandboxSet, agentsv1alpha1.SandboxSetControllerKind)},
+		},
+		Spec: agentsv1alpha1.SandboxSpec{
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+							},
+						}},
+					},
+				},
+			},
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase:      agentsv1alpha1.SandboxRunning,
+			Conditions: []metav1.Condition{{Type: string(agentsv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue}},
+			PodInfo:    agentsv1alpha1.PodInfo{PodIP: "1.2.3.4"},
+		},
+	}
+	require.NoError(t, fakeClient.Create(t.Context(), warm))
+	require.NoError(t, fakeClient.Status().Update(t.Context(), warm))
+	require.Eventually(t, func() bool {
+		objs, err := provider.ListSandboxesInPool(t.Context(), cache.ListSandboxesInPoolOptions{Pool: "test-template"})
+		return err == nil && len(objs) == 1
+	}, 200*time.Millisecond, 5*time.Millisecond)
+
+	newStatus := &agentsv1alpha1.SandboxClaimStatus{Phase: agentsv1alpha1.SandboxClaimPhaseClaiming}
+	control := NewCommonControl(fakeClient, record.NewFakeRecorder(10), provider, nil)
+
+	strategy, err := control.EnsureClaimClaiming(t.Context(), ClaimArgs{
+		Claim:      claim,
+		SandboxSet: sandboxSet,
+		NewStatus:  newStatus,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, RequeueAfter(ClaimRetryInterval), strategy)
+	assert.Equal(t, agentsv1alpha1.SandboxClaimPhaseClaiming, newStatus.Phase)
+	assert.Equal(t, int32(0), newStatus.ClaimedReplicas)
+	// The sandbox must stay in the pool, untouched by the failed attempt.
+	got := &agentsv1alpha1.Sandbox{}
+	require.NoError(t, fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "warm-sbx"}, got))
+	assert.Empty(t, got.Annotations[agentsv1alpha1.AnnotationOwner])
+}
+
+func TestCommonControl_EnsureClaimClaiming_InvalidInplaceUpdateResourcesFailsFast(t *testing.T) {
+	sandboxSet := &agentsv1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+	}
+
+	tests := []struct {
+		name      string
+		requests  corev1.ResourceList
+		limits    corev1.ResourceList
+		expectMsg string
+	}{
+		{
+			name:      "cpu request exceeding limit",
+			requests:  corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+			limits:    corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			expectMsg: "must not exceed limit",
+		},
+		{
+			name:      "unsupported resource",
+			requests:  corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")},
+			expectMsg: "not supported for in-place resize",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache, fakeClient, err := cachetest.NewTestCache(t)
+			require.NoError(t, err)
+
+			claim := &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim-invalid-resize",
+					Namespace: "default",
+					UID:       types.UID("test-uid-invalid-resize"),
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "test-template",
+					Replicas:     int32Ptr(1),
+					InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
+						Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
+							Requests: tt.requests,
+							Limits:   tt.limits,
+						},
+					},
+				},
+			}
+			newStatus := &agentsv1alpha1.SandboxClaimStatus{Phase: agentsv1alpha1.SandboxClaimPhaseClaiming}
+			control := NewCommonControl(fakeClient, record.NewFakeRecorder(10), cache, nil)
+
+			strategy, err := control.EnsureClaimClaiming(t.Context(), ClaimArgs{
+				Claim:      claim,
+				SandboxSet: sandboxSet,
+				NewStatus:  newStatus,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, NoRequeue(), strategy)
+			assert.Equal(t, agentsv1alpha1.SandboxClaimPhaseCompleted, newStatus.Phase)
+			assert.Equal(t, int32(0), newStatus.ClaimedReplicas)
+			assert.Contains(t, newStatus.Message, tt.expectMsg)
+			cond := GetClaimCondition(newStatus, string(agentsv1alpha1.SandboxClaimConditionCompleted))
+			require.NotNil(t, cond)
+			assert.Equal(t, "InvalidInplaceUpdateResources", cond.Reason)
+		})
+	}
 }
 
 func TestCommonControl_EnsureClaimCompleted(t *testing.T) {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -77,9 +77,12 @@ func ValidateAndInitClaimOptions(opts infra.ClaimSandboxOptions) (infra.ClaimSan
 			return infra.ClaimSandboxOptions{}, fmt.Errorf("resources must specify at least one of requests or limits")
 		}
 		for _, rl := range []corev1.ResourceList{res.Requests, res.Limits} {
-			if cpu, ok := rl[corev1.ResourceCPU]; ok {
-				if cpu.IsZero() || cpu.Cmp(resource.Quantity{}) < 0 {
-					return infra.ClaimSandboxOptions{}, fmt.Errorf("target cpu must be a positive value")
+			for resourceName, quantity := range rl {
+				if !supportedResizeResources[resourceName] {
+					continue
+				}
+				if quantity.IsZero() || quantity.Cmp(resource.Quantity{}) < 0 {
+					return infra.ClaimSandboxOptions{}, fmt.Errorf("target %s must be a positive value", resourceName)
 				}
 			}
 		}
@@ -679,7 +682,8 @@ func buildResourceResizedPod(pod *corev1.Pod, requests, limits corev1.ResourceLi
 
 // supportedResizeResources defines which resources are allowed for in-place resize.
 var supportedResizeResources = map[corev1.ResourceName]bool{
-	corev1.ResourceCPU: true,
+	corev1.ResourceCPU:    true,
+	corev1.ResourceMemory: true,
 }
 
 // setContainerResources updates the container's requests and limits for resources

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -88,9 +88,12 @@ func ValidateAndInitClaimOptions(opts infra.ClaimSandboxOptions) (infra.ClaimSan
 			return infra.ClaimSandboxOptions{}, fmt.Errorf("resources must specify at least one of requests or limits")
 		}
 		for _, rl := range []corev1.ResourceList{res.Requests, res.Limits} {
-			if cpu, ok := rl[corev1.ResourceCPU]; ok {
-				if cpu.IsZero() || cpu.Cmp(resource.Quantity{}) < 0 {
-					return infra.ClaimSandboxOptions{}, fmt.Errorf("target cpu must be a positive value")
+			for resourceName, quantity := range rl {
+				if !supportedResizeResources[resourceName] {
+					continue
+				}
+				if quantity.IsZero() || quantity.Cmp(resource.Quantity{}) < 0 {
+					return infra.ClaimSandboxOptions{}, fmt.Errorf("target %s must be a positive value", resourceName)
 				}
 			}
 		}
@@ -833,7 +836,8 @@ func buildResourceResizedPod(pod *corev1.Pod, requests, limits corev1.ResourceLi
 
 // supportedResizeResources defines which resources are allowed for in-place resize.
 var supportedResizeResources = map[corev1.ResourceName]bool{
-	corev1.ResourceCPU: true,
+	corev1.ResourceCPU:    true,
+	corev1.ResourceMemory: true,
 }
 
 // setContainerResources updates the container's requests and limits for resources

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -44,12 +45,14 @@ import (
 	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/logs"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/tracing"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
+	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
 	"github.com/openkruise/agents/pkg/utils/runtime"
 	timeoututils "github.com/openkruise/agents/pkg/utils/timeout"
 
@@ -104,46 +107,70 @@ func ValidateAndInitClaimOptions(opts infra.ClaimSandboxOptions) (infra.ClaimSan
 	return opts, nil
 }
 
-// validateInplaceUpdateResources validates in-place update resource targets.
-// Unsupported resource names are rejected, values must be positive, and
-// requests must not exceed limits. Validation runs in a fixed order so error
-// messages are deterministic regardless of map iteration order.
+// validateInplaceUpdateResources validates in-place update resource targets
+// through the shared ValidateResizeResources.
 func validateInplaceUpdateResources(inplace *config.InplaceUpdateOptions) error {
 	if inplace == nil || inplace.Resources == nil {
 		return nil
 	}
-	res := inplace.Resources
-	if len(res.Requests) == 0 && len(res.Limits) == 0 {
-		return fmt.Errorf("resources must specify at least one of requests or limits")
+	return ValidateResizeResources(inplace.Resources.Requests, inplace.Resources.Limits)
+}
+
+// ValidateResizeResources validates in-place resize targets shared by the E2B
+// create path and the SandboxClaim controller. Unsupported resource names are
+// rejected, values must be positive, and requests must not exceed limits.
+// Validation runs in a fixed order so error messages are deterministic
+// regardless of map iteration order. All returned errors are classified as
+// ErrorBadRequest so callers map them to HTTP 400.
+func ValidateResizeResources(requests, limits corev1.ResourceList) error {
+	if len(requests) == 0 && len(limits) == 0 {
+		return managererrors.NewError(managererrors.ErrorBadRequest, "resources must specify at least one of requests or limits")
 	}
-	for name := range res.Requests {
-		if !supportedResizeResources[name] {
-			return fmt.Errorf("resource %s is not supported for in-place resize", name)
-		}
-	}
-	for name := range res.Limits {
-		if !supportedResizeResources[name] {
-			return fmt.Errorf("resource %s is not supported for in-place resize", name)
-		}
+	unknown := unsupportedResourceNames(requests, limits)
+	if len(unknown) > 0 {
+		return managererrors.NewError(managererrors.ErrorBadRequest, "resource %s is not supported for in-place resize", unknown[0])
 	}
 	for _, name := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
-		if quantity, ok := res.Requests[name]; ok {
+		if quantity, ok := requests[name]; ok {
 			if quantity.IsZero() || quantity.Cmp(resource.Quantity{}) < 0 {
-				return fmt.Errorf("target %s must be a positive value", name)
+				return managererrors.NewError(managererrors.ErrorBadRequest, "target %s must be a positive value", name)
 			}
 		}
-		if quantity, ok := res.Limits[name]; ok {
+		if quantity, ok := limits[name]; ok {
 			if quantity.IsZero() || quantity.Cmp(resource.Quantity{}) < 0 {
-				return fmt.Errorf("target %s must be a positive value", name)
+				return managererrors.NewError(managererrors.ErrorBadRequest, "target %s must be a positive value", name)
 			}
 		}
-		req, hasReq := res.Requests[name]
-		lim, hasLim := res.Limits[name]
+		req, hasReq := requests[name]
+		lim, hasLim := limits[name]
 		if hasReq && hasLim && req.Cmp(lim) > 0 {
-			return fmt.Errorf("target %s request %s must not exceed limit %s", name, req.String(), lim.String())
+			return managererrors.NewError(managererrors.ErrorBadRequest, "target %s request %s must not exceed limit %s", name, req.String(), lim.String())
 		}
 	}
 	return nil
+}
+
+// unsupportedResourceNames returns the sorted resource names present in the
+// given lists that are not allowed for in-place resize, so the reported name
+// is deterministic even with several invalid keys.
+func unsupportedResourceNames(requests, limits corev1.ResourceList) []corev1.ResourceName {
+	seen := make(map[corev1.ResourceName]struct{}, len(requests)+len(limits))
+	for name := range requests {
+		if !supportedResizeResources[name] {
+			seen[name] = struct{}{}
+		}
+	}
+	for name := range limits {
+		if !supportedResizeResources[name] {
+			seen[name] = struct{}{}
+		}
+	}
+	names := make([]corev1.ResourceName, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool { return names[i] < names[j] })
+	return names
 }
 
 // chooseLockString returns the lock string to use for the current attempt.
@@ -745,7 +772,7 @@ func modifyPickedSandbox(sbx *Sandbox, lockType infra.LockType, opts infra.Claim
 		}
 		if opts.InplaceUpdate.Resources != nil {
 			if err := sbx.SetResources(opts.InplaceUpdate.Resources.Requests, opts.InplaceUpdate.Resources.Limits); err != nil {
-				return terminalMutationError{stage: "inplace update", err: err}
+				return terminalValidationError{err: err}
 			}
 		}
 	}
@@ -882,12 +909,16 @@ var supportedResizeResources = map[corev1.ResourceName]bool{
 }
 
 // setContainerResources updates the container's requests and limits for resources
-// listed in supportedResizeResources. Unsupported resource types are silently ignored.
+// listed in supportedResizeResources. Unsupported resource types are skipped at
+// this layer; callers must validate targets with ValidateResizeResources first.
 // A resource is also skipped if it was not originally set on the container.
 // Memory may only be increased: a target memory request or limit lower than the
-// container's current value returns an error because in-place memory downscale
-// is not supported.
+// container's current value returns a BadRequest error because in-place memory
+// downscale is not supported.
 func setContainerResources(container *corev1.Container, requests, limits corev1.ResourceList) (bool, error) {
+	if err := inplaceupdate.CheckContainerMemoryDownscale(container, requests, limits); err != nil {
+		return false, managererrors.WrapError(managererrors.ErrorBadRequest, err, "%s", err.Error())
+	}
 	changed := false
 	for resName, target := range requests {
 		if !supportedResizeResources[resName] {
@@ -896,9 +927,6 @@ func setContainerResources(container *corev1.Container, requests, limits corev1.
 		cur, ok := container.Resources.Requests[resName]
 		if !ok || cur.IsZero() {
 			continue
-		}
-		if resName == corev1.ResourceMemory && target.Cmp(cur) < 0 {
-			return false, fmt.Errorf("target memory request %s must not be lower than the current value %s: in-place memory downscale is not supported", target.String(), cur.String())
 		}
 		if container.Resources.Requests == nil {
 			container.Resources.Requests = corev1.ResourceList{}
@@ -913,9 +941,6 @@ func setContainerResources(container *corev1.Container, requests, limits corev1.
 		cur, ok := container.Resources.Limits[resName]
 		if !ok || cur.IsZero() {
 			continue
-		}
-		if resName == corev1.ResourceMemory && target.Cmp(cur) < 0 {
-			return false, fmt.Errorf("target memory limit %s must not be lower than the current value %s: in-place memory downscale is not supported", target.String(), cur.String())
 		}
 		if container.Resources.Limits == nil {
 			container.Resources.Limits = corev1.ResourceList{}

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -42,6 +42,7 @@ import (
 	cacheutils "github.com/openkruise/agents/pkg/cache/utils"
 	"github.com/openkruise/agents/pkg/controller/sandboxset"
 	"github.com/openkruise/agents/pkg/identity"
+	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/logs"
@@ -82,21 +83,8 @@ func ValidateAndInitClaimOptions(opts infra.ClaimSandboxOptions) (infra.ClaimSan
 	if opts.InplaceUpdate != nil && opts.InplaceUpdate.Image == "" && opts.InplaceUpdate.Resources == nil {
 		return infra.ClaimSandboxOptions{}, fmt.Errorf("inplace update requires at least one of image or resources to be set")
 	}
-	if opts.InplaceUpdate != nil && opts.InplaceUpdate.Resources != nil {
-		res := opts.InplaceUpdate.Resources
-		if len(res.Requests) == 0 && len(res.Limits) == 0 {
-			return infra.ClaimSandboxOptions{}, fmt.Errorf("resources must specify at least one of requests or limits")
-		}
-		for _, rl := range []corev1.ResourceList{res.Requests, res.Limits} {
-			for resourceName, quantity := range rl {
-				if !supportedResizeResources[resourceName] {
-					continue
-				}
-				if quantity.IsZero() || quantity.Cmp(resource.Quantity{}) < 0 {
-					return infra.ClaimSandboxOptions{}, fmt.Errorf("target %s must be a positive value", resourceName)
-				}
-			}
-		}
+	if err := validateInplaceUpdateResources(opts.InplaceUpdate); err != nil {
+		return infra.ClaimSandboxOptions{}, err
 	}
 	if opts.CandidateCounts <= 0 {
 		opts.CandidateCounts = consts.DefaultPoolingCandidateCounts
@@ -114,6 +102,48 @@ func ValidateAndInitClaimOptions(opts infra.ClaimSandboxOptions) (infra.ClaimSan
 		opts.ReserveFailedSandboxFor = ptr.To(DefaultReserveFailedSandboxFor)
 	}
 	return opts, nil
+}
+
+// validateInplaceUpdateResources validates in-place update resource targets.
+// Unsupported resource names are rejected, values must be positive, and
+// requests must not exceed limits. Validation runs in a fixed order so error
+// messages are deterministic regardless of map iteration order.
+func validateInplaceUpdateResources(inplace *config.InplaceUpdateOptions) error {
+	if inplace == nil || inplace.Resources == nil {
+		return nil
+	}
+	res := inplace.Resources
+	if len(res.Requests) == 0 && len(res.Limits) == 0 {
+		return fmt.Errorf("resources must specify at least one of requests or limits")
+	}
+	for name := range res.Requests {
+		if !supportedResizeResources[name] {
+			return fmt.Errorf("resource %s is not supported for in-place resize", name)
+		}
+	}
+	for name := range res.Limits {
+		if !supportedResizeResources[name] {
+			return fmt.Errorf("resource %s is not supported for in-place resize", name)
+		}
+	}
+	for _, name := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		if quantity, ok := res.Requests[name]; ok {
+			if quantity.IsZero() || quantity.Cmp(resource.Quantity{}) < 0 {
+				return fmt.Errorf("target %s must be a positive value", name)
+			}
+		}
+		if quantity, ok := res.Limits[name]; ok {
+			if quantity.IsZero() || quantity.Cmp(resource.Quantity{}) < 0 {
+				return fmt.Errorf("target %s must be a positive value", name)
+			}
+		}
+		req, hasReq := res.Requests[name]
+		lim, hasLim := res.Limits[name]
+		if hasReq && hasLim && req.Cmp(lim) > 0 {
+			return fmt.Errorf("target %s request %s must not exceed limit %s", name, req.String(), lim.String())
+		}
+	}
+	return nil
 }
 
 // chooseLockString returns the lock string to use for the current attempt.
@@ -714,7 +744,9 @@ func modifyPickedSandbox(sbx *Sandbox, lockType infra.LockType, opts infra.Claim
 			sbx.SetImage(opts.InplaceUpdate.Image)
 		}
 		if opts.InplaceUpdate.Resources != nil {
-			sbx.SetResources(opts.InplaceUpdate.Resources.Requests, opts.InplaceUpdate.Resources.Limits)
+			if err := sbx.SetResources(opts.InplaceUpdate.Resources.Requests, opts.InplaceUpdate.Resources.Limits); err != nil {
+				return terminalMutationError{stage: "inplace update", err: err}
+			}
 		}
 	}
 	// claim sandbox
@@ -762,15 +794,21 @@ func modifyPickedSandbox(sbx *Sandbox, lockType infra.LockType, opts infra.Claim
 }
 
 // SetResources applies in-place resource resize to the first container.
-func (s *Sandbox) SetResources(requests, limits corev1.ResourceList) {
+// It returns an error when the requested memory would lower the container's
+// current memory, since in-place memory downscale is not supported.
+func (s *Sandbox) SetResources(requests, limits corev1.ResourceList) error {
 	if s.Spec.Template == nil {
-		return
+		return nil
 	}
 	pod := &corev1.Pod{
 		Spec: s.Spec.Template.Spec,
 	}
-	resizedPod, _ := buildResourceResizedPod(pod, requests, limits)
+	resizedPod, _, err := buildResourceResizedPod(pod, requests, limits)
+	if err != nil {
+		return err
+	}
 	s.Spec.Template.Spec = resizedPod.Spec
+	return nil
 }
 
 var DefaultCreateSandbox = createSandbox
@@ -825,13 +863,16 @@ func performLockSandbox(ctx context.Context, sbx *Sandbox, lockType infra.LockTy
 	return err
 }
 
-func buildResourceResizedPod(pod *corev1.Pod, requests, limits corev1.ResourceList) (*corev1.Pod, bool) {
+func buildResourceResizedPod(pod *corev1.Pod, requests, limits corev1.ResourceList) (*corev1.Pod, bool, error) {
 	if len(pod.Spec.Containers) == 0 {
-		return pod.DeepCopy(), false
+		return pod.DeepCopy(), false, nil
 	}
 	clone := pod.DeepCopy()
-	changed := setContainerResources(&clone.Spec.Containers[0], requests, limits)
-	return clone, changed
+	changed, err := setContainerResources(&clone.Spec.Containers[0], requests, limits)
+	if err != nil {
+		return nil, false, err
+	}
+	return clone, changed, nil
 }
 
 // supportedResizeResources defines which resources are allowed for in-place resize.
@@ -843,14 +884,21 @@ var supportedResizeResources = map[corev1.ResourceName]bool{
 // setContainerResources updates the container's requests and limits for resources
 // listed in supportedResizeResources. Unsupported resource types are silently ignored.
 // A resource is also skipped if it was not originally set on the container.
-func setContainerResources(container *corev1.Container, requests, limits corev1.ResourceList) bool {
+// Memory may only be increased: a target memory request or limit lower than the
+// container's current value returns an error because in-place memory downscale
+// is not supported.
+func setContainerResources(container *corev1.Container, requests, limits corev1.ResourceList) (bool, error) {
 	changed := false
 	for resName, target := range requests {
 		if !supportedResizeResources[resName] {
 			continue
 		}
-		if cur, ok := container.Resources.Requests[resName]; !ok || cur.IsZero() {
+		cur, ok := container.Resources.Requests[resName]
+		if !ok || cur.IsZero() {
 			continue
+		}
+		if resName == corev1.ResourceMemory && target.Cmp(cur) < 0 {
+			return false, fmt.Errorf("target memory request %s must not be lower than the current value %s: in-place memory downscale is not supported", target.String(), cur.String())
 		}
 		if container.Resources.Requests == nil {
 			container.Resources.Requests = corev1.ResourceList{}
@@ -862,8 +910,12 @@ func setContainerResources(container *corev1.Container, requests, limits corev1.
 		if !supportedResizeResources[resName] {
 			continue
 		}
-		if cur, ok := container.Resources.Limits[resName]; !ok || cur.IsZero() {
+		cur, ok := container.Resources.Limits[resName]
+		if !ok || cur.IsZero() {
 			continue
+		}
+		if resName == corev1.ResourceMemory && target.Cmp(cur) < 0 {
+			return false, fmt.Errorf("target memory limit %s must not be lower than the current value %s: in-place memory downscale is not supported", target.String(), cur.String())
 		}
 		if container.Resources.Limits == nil {
 			container.Resources.Limits = corev1.ResourceList{}
@@ -871,7 +923,7 @@ func setContainerResources(container *corev1.Container, requests, limits corev1.
 		container.Resources.Limits[resName] = target.DeepCopy()
 		changed = true
 	}
-	return changed
+	return changed, nil
 }
 
 func waitForSandboxReady(ctx context.Context, sbx *Sandbox, opts infra.ClaimSandboxOptions, cache infracache.Provider) (cost time.Duration, err error) {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -128,7 +128,12 @@ func ValidateResizeResources(requests, limits corev1.ResourceList) error {
 	}
 	unknown := unsupportedResourceNames(requests, limits)
 	if len(unknown) > 0 {
-		return managererrors.NewError(managererrors.ErrorBadRequest, "resource %s is not supported for in-place resize", unknown[0])
+		names := make([]string, 0, len(unknown))
+		for _, name := range unknown {
+			names = append(names, string(name))
+		}
+		return managererrors.NewError(managererrors.ErrorBadRequest,
+			"resources %s are not supported for in-place resize", strings.Join(names, ", "))
 	}
 	for _, name := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
 		if quantity, ok := requests[name]; ok {
@@ -151,8 +156,8 @@ func ValidateResizeResources(requests, limits corev1.ResourceList) error {
 }
 
 // unsupportedResourceNames returns the sorted resource names present in the
-// given lists that are not allowed for in-place resize, so the reported name
-// is deterministic even with several invalid keys.
+// given lists that are not allowed for in-place resize, so all invalid keys
+// can be reported deterministically.
 func unsupportedResourceNames(requests, limits corev1.ResourceList) []corev1.ResourceName {
 	seen := make(map[corev1.ResourceName]struct{}, len(requests)+len(limits))
 	for name := range requests {
@@ -589,9 +594,12 @@ func pickAnAvailableSandbox(ctx context.Context, opts infra.ClaimSandboxOptions,
 		updateRevision = sbs.Status.UpdateRevision
 	}
 
-	// Select available candidates and speculated creating sandboxes
+	// Select available and speculated candidates. Track the resize-incompatible
+	// skip reason so it can be surfaced when nothing else is available; resize
+	// skips never terminate the claim because the pool changes over time.
 	availableCandidates := make([]*v1alpha1.Sandbox, 0, cnt)
 	speculatingCandidates := make([]*v1alpha1.Sandbox, 0, cnt)
+	var resizeSkipReason error
 	for _, obj := range objects {
 		if len(availableCandidates) >= cnt {
 			if opts.SpeculateCreatingDuration == 0 || len(speculatingCandidates) >= cnt {
@@ -602,8 +610,12 @@ func pickAnAvailableSandbox(ctx context.Context, opts infra.ClaimSandboxOptions,
 			log.Info("skip out-dated sandbox cache", "sandbox", klog.KObj(obj))
 			continue
 		}
-		if checkErr := preCheckCandidate(obj); checkErr != nil {
+		if checkErr := preCheckCandidate(obj, opts.InplaceUpdate); checkErr != nil {
 			log.Error(checkErr, "skip invalid sandbox", "sandbox", klog.KObj(obj), "resourceVersion", obj.GetResourceVersion())
+			var resizeIncompatible *candidateResizeIncompatibleError
+			if errors.As(checkErr, &resizeIncompatible) {
+				resizeSkipReason = checkErr
+			}
 			continue
 		}
 		state, _ := utils.GetSandboxState(obj)
@@ -675,6 +687,11 @@ func pickAnAvailableSandbox(ctx context.Context, opts infra.ClaimSandboxOptions,
 		log.Info("will create a new sandbox")
 		return newSandboxFromSandboxSet(ctx, opts, cache)
 	}
+	if resizeSkipReason != nil && len(availableCandidates) == 0 && len(speculatingCandidates) == 0 {
+		// Keep the error retriable: the pool changes over time (rollout, scale-up).
+		log.Info("no candidate compatible with inplace resize", "reason", resizeSkipReason)
+		return nil, "", NoAvailableError(template, fmt.Sprintf("no candidate compatible with inplace resize: %v", resizeSkipReason))
+	}
 	return nil, "", NoAvailableError(template, pickErr.Error())
 }
 
@@ -745,13 +762,54 @@ func newSandboxFromSandboxSet(ctx context.Context, opts infra.ClaimSandboxOption
 	return AsSandbox(sbx, cache), infra.LockTypeCreate, nil
 }
 
-func preCheckCandidate(sbx *v1alpha1.Sandbox) error {
+// preCheckCandidate rejects locked sandboxes, objects without a creation
+// timestamp, and — for resize claims — candidates whose own resources cannot
+// serve the resize (memory downscale or QoS class change). Comparing against
+// the candidate's own template keeps old-revision sandboxes claimable during
+// a SandboxSet rollout.
+func preCheckCandidate(sbx *v1alpha1.Sandbox, inplace *config.InplaceUpdateOptions) error {
 	lock := sbx.Annotations[v1alpha1.AnnotationLock]
 	if lock != "" {
 		return fmt.Errorf("sandbox is locked by %s", lock)
 	}
 	if sbx.CreationTimestamp.IsZero() {
 		return errors.New("creation timestamp is zero")
+	}
+	if inplace != nil && inplace.Resources != nil {
+		if err := checkCandidateResize(sbx, inplace.Resources.Requests, inplace.Resources.Limits); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkCandidateResize verifies that the candidate can serve the requested
+// resize, mirroring what SetResources later applies to the first container.
+// Rejected conditions: no pod template, memory downscale, merged request above
+// limit, or a QoS class change.
+//
+// QoS is evaluated against the candidate's template, not the live pod, so
+// injected sidecar/admission resources may make this check skip a candidate
+// conservatively; a false skip only costs a retry.
+func checkCandidateResize(sbx *v1alpha1.Sandbox, requests, limits corev1.ResourceList) error {
+	if sbx.Spec.Template == nil || len(sbx.Spec.Template.Spec.Containers) == 0 {
+		return &candidateResizeIncompatibleError{err: managererrors.NewError(
+			managererrors.ErrorBadRequest,
+			"cannot apply in-place resize: sandbox has no pod template")}
+	}
+	// DeepCopy to avoid mutating informer-cached objects.
+	current := (&corev1.Pod{Spec: sbx.Spec.Template.Spec}).DeepCopy()
+	resized := current.DeepCopy()
+	if _, err := setContainerResources(&resized.Spec.Containers[0], requests, limits); err != nil {
+		return &candidateResizeIncompatibleError{err: err}
+	}
+	resizedBox := &v1alpha1.Sandbox{}
+	resizedBox.Spec.Template = &corev1.PodTemplateSpec{Spec: resized.Spec}
+	orig, updated, changed := inplaceupdate.CheckResizeQoSChange(resizedBox, current)
+	if changed {
+		return &candidateResizeIncompatibleError{err: managererrors.NewError(
+			managererrors.ErrorBadRequest,
+			"in-place resize would change pod QoS class from %s to %s", orig, updated)}
 	}
 	return nil
 }
@@ -820,12 +878,12 @@ func modifyPickedSandbox(sbx *Sandbox, lockType infra.LockType, opts infra.Claim
 	return nil
 }
 
-// SetResources applies in-place resource resize to the first container.
-// It returns an error when the requested memory would lower the container's
-// current memory, since in-place memory downscale is not supported.
+// SetResources applies in-place resource resize to the first container. It
+// errors on memory downscale or when the sandbox has no pod template.
 func (s *Sandbox) SetResources(requests, limits corev1.ResourceList) error {
 	if s.Spec.Template == nil {
-		return nil
+		return managererrors.NewError(managererrors.ErrorBadRequest,
+			"cannot apply in-place resize: sandbox has no pod template")
 	}
 	pod := &corev1.Pod{
 		Spec: s.Spec.Template.Spec,
@@ -947,6 +1005,17 @@ func setContainerResources(container *corev1.Container, requests, limits corev1.
 		}
 		container.Resources.Limits[resName] = target.DeepCopy()
 		changed = true
+	}
+	// Reject merged request > limit; the apiserver would reject the pod update
+	// anyway, but only after the sandbox is already locked.
+	for _, resName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		req, hasReq := container.Resources.Requests[resName]
+		lim, hasLim := container.Resources.Limits[resName]
+		if hasReq && hasLim && !req.IsZero() && !lim.IsZero() && req.Cmp(lim) > 0 {
+			return false, managererrors.NewError(managererrors.ErrorBadRequest,
+				"in-place resize would set %s request %s above the container limit %s",
+				resName, req.String(), lim.String())
+		}
 	}
 	return changed, nil
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -300,7 +300,7 @@ func TestInfra_ClaimSandbox(t *testing.T) {
 			},
 		},
 		{
-			name:      "claim with cpu resize",
+			name:      "claim with resource resize",
 			available: 1,
 			options: infra.ClaimSandboxOptions{
 				User:     user,
@@ -308,10 +308,12 @@ func TestInfra_ClaimSandbox(t *testing.T) {
 				InplaceUpdate: &config.InplaceUpdateOptions{
 					Resources: &config.InplaceUpdateResourcesOptions{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU: resource.MustParse("1"),
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("768Mi"),
 						},
 						Limits: corev1.ResourceList{
-							corev1.ResourceCPU: resource.MustParse("1"),
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
 						},
 					},
 				},
@@ -333,6 +335,11 @@ func TestInfra_ClaimSandbox(t *testing.T) {
 			postCheck: func(t *testing.T, sbx infra.Sandbox) {
 				metrics := GetMetricsFromSandbox(t, sbx)
 				assert.Greater(t, metrics.WaitReady, time.Duration(0))
+				container := sbx.(*Sandbox).Spec.Template.Spec.Containers[0]
+				assert.Equal(t, resource.MustParse("1"), container.Resources.Requests[corev1.ResourceCPU])
+				assert.Equal(t, resource.MustParse("768Mi"), container.Resources.Requests[corev1.ResourceMemory])
+				assert.Equal(t, resource.MustParse("1"), container.Resources.Limits[corev1.ResourceCPU])
+				assert.Equal(t, resource.MustParse("1Gi"), container.Resources.Limits[corev1.ResourceMemory])
 			},
 		},
 		{
@@ -1066,7 +1073,7 @@ func TestSandboxReadyFailureMessage(t *testing.T) {
 	}
 }
 
-func TestModifyPickedSandboxCPUResize(t *testing.T) {
+func TestModifyPickedSandboxResourceResize(t *testing.T) {
 	base := &Sandbox{
 		Sandbox: &v1alpha1.Sandbox{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1110,14 +1117,22 @@ func TestModifyPickedSandboxCPUResize(t *testing.T) {
 		Template: "test-template",
 		InplaceUpdate: &config.InplaceUpdateOptions{
 			Resources: &config.InplaceUpdateResourcesOptions{
-				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
-				Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
 			},
 		},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, int64(500), base.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue())
 	assert.Equal(t, int64(500), base.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().MilliValue())
+	assert.Equal(t, resource.MustParse("512Mi"), *base.Spec.Template.Spec.Containers[0].Resources.Requests.Memory())
+	assert.Equal(t, resource.MustParse("1Gi"), *base.Spec.Template.Spec.Containers[0].Resources.Limits.Memory())
 }
 
 func TestModifyPickedSandboxCPUResizeCases(t *testing.T) {
@@ -1304,6 +1319,106 @@ func TestModifyPickedSandboxCPUResizeCases(t *testing.T) {
 			}
 			if tt.wantSidecarCPU > 0 {
 				assert.Equal(t, tt.wantSidecarCPU, sbx.Spec.Template.Spec.Containers[1].Resources.Limits.Cpu().MilliValue())
+			}
+		})
+	}
+}
+
+func TestModifyPickedSandboxMemoryResizeCases(t *testing.T) {
+	tests := []struct {
+		name          string
+		templateSpec  corev1.PodSpec
+		inplaceReq    corev1.ResourceList
+		inplaceLim    corev1.ResourceList
+		wantReqMemory string
+		wantLimMemory string
+	}{
+		{
+			name: "memory requests and limits are resized",
+			templateSpec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "main",
+						Image: "img",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+						},
+					},
+				},
+			},
+			inplaceReq:    corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("384Mi")},
+			inplaceLim:    corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("768Mi")},
+			wantReqMemory: "384Mi",
+			wantLimMemory: "768Mi",
+		},
+		{
+			name: "memory target is ignored when original memory is unset",
+			templateSpec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "main",
+						Image: "img",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("100m"),
+							},
+						},
+					},
+				},
+			},
+			inplaceReq: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("384Mi")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := &Sandbox{
+				Sandbox: &v1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "sbx-1",
+						Namespace:   "default",
+						Labels:      map[string]string{},
+						Annotations: map[string]string{},
+					},
+					Spec: v1alpha1.SandboxSpec{
+						EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+							Template: &corev1.PodTemplateSpec{
+								Spec: tt.templateSpec,
+							},
+						},
+					},
+				},
+			}
+
+			err := modifyPickedSandbox(sbx, infra.LockTypeUpdate, infra.ClaimSandboxOptions{
+				User:     "u1",
+				Template: "test-template",
+				InplaceUpdate: &config.InplaceUpdateOptions{
+					Resources: &config.InplaceUpdateResourcesOptions{
+						Requests: tt.inplaceReq,
+						Limits:   tt.inplaceLim,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			container := sbx.Spec.Template.Spec.Containers[0]
+			if tt.wantReqMemory == "" {
+				_, ok := container.Resources.Requests[corev1.ResourceMemory]
+				assert.False(t, ok)
+			} else {
+				assert.Equal(t, resource.MustParse(tt.wantReqMemory), container.Resources.Requests[corev1.ResourceMemory])
+			}
+			if tt.wantLimMemory == "" {
+				_, ok := container.Resources.Limits[corev1.ResourceMemory]
+				assert.False(t, ok)
+			} else {
+				assert.Equal(t, resource.MustParse(tt.wantLimMemory), container.Resources.Limits[corev1.ResourceMemory])
 			}
 		})
 	}
@@ -1552,34 +1667,78 @@ func TestBuildResourceResizedPod(t *testing.T) {
 	}
 
 	targetCPU := resource.MustParse("500m")
-	requests := corev1.ResourceList{corev1.ResourceCPU: targetCPU}
-	limits := corev1.ResourceList{corev1.ResourceCPU: targetCPU}
+	targetMemory := resource.MustParse("512Mi")
+	requests := corev1.ResourceList{
+		corev1.ResourceCPU:    targetCPU,
+		corev1.ResourceMemory: targetMemory,
+	}
+	limits := corev1.ResourceList{
+		corev1.ResourceCPU:    targetCPU,
+		corev1.ResourceMemory: targetMemory,
+	}
 	got, changed := buildResourceResizedPod(pod, requests, limits)
 	require.True(t, changed)
 	assert.Equal(t, int64(500), got.Spec.Containers[0].Resources.Requests.Cpu().MilliValue())
 	assert.Equal(t, int64(500), got.Spec.Containers[0].Resources.Limits.Cpu().MilliValue())
+	assert.Equal(t, targetMemory, got.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory])
+	assert.Equal(t, targetMemory, got.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory])
 }
 
-func TestValidateAndInitClaimOptions_CPUResize(t *testing.T) {
-	_, err := ValidateAndInitClaimOptions(infra.ClaimSandboxOptions{
-		User:     "u",
-		Template: "t",
-		InplaceUpdate: &config.InplaceUpdateOptions{
-			Resources: &config.InplaceUpdateResourcesOptions{
+func TestValidateAndInitClaimOptions_ResourceResize(t *testing.T) {
+	tests := []struct {
+		name        string
+		resources   *config.InplaceUpdateResourcesOptions
+		expectError string
+	}{
+		{
+			name: "zero cpu request rejected",
+			resources: &config.InplaceUpdateResourcesOptions{
 				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("0")},
 			},
+			expectError: "target cpu must be a positive value",
 		},
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "target cpu must be a positive value")
+		{
+			name: "zero memory limit rejected",
+			resources: &config.InplaceUpdateResourcesOptions{
+				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("0")},
+			},
+			expectError: "target memory must be a positive value",
+		},
+		{
+			name: "positive cpu and memory accepted",
+			resources: &config.InplaceUpdateResourcesOptions{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ValidateAndInitClaimOptions(infra.ClaimSandboxOptions{
+				User:     "u",
+				Template: "t",
+				InplaceUpdate: &config.InplaceUpdateOptions{
+					Resources: tt.resources,
+				},
+			})
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestValidateAndInitClaimOptions_InplaceUpdateValidation(t *testing.T) {
 	tests := []struct {
 		name        string
 		opts        infra.ClaimSandboxOptions
-		expectErr   bool
-		errContains string
+		expectError string
 	}{
 		{
 			name: "inplace update requires image or resources",
@@ -1588,8 +1747,7 @@ func TestValidateAndInitClaimOptions_InplaceUpdateValidation(t *testing.T) {
 				Template:      "t",
 				InplaceUpdate: &config.InplaceUpdateOptions{},
 			},
-			expectErr:   true,
-			errContains: "requires either image or resources",
+			expectError: "requires either image or resources",
 		},
 		{
 			name: "resources require requests or limits",
@@ -1600,8 +1758,7 @@ func TestValidateAndInitClaimOptions_InplaceUpdateValidation(t *testing.T) {
 					Resources: &config.InplaceUpdateResourcesOptions{},
 				},
 			},
-			expectErr:   true,
-			errContains: "resources must specify at least one of requests or limits",
+			expectError: "resources must specify at least one of requests or limits",
 		},
 		{
 			name: "negative cpu request rejected",
@@ -1614,8 +1771,20 @@ func TestValidateAndInitClaimOptions_InplaceUpdateValidation(t *testing.T) {
 					},
 				},
 			},
-			expectErr:   true,
-			errContains: "target cpu must be a positive value",
+			expectError: "target cpu must be a positive value",
+		},
+		{
+			name: "negative memory request rejected",
+			opts: infra.ClaimSandboxOptions{
+				User:     "u",
+				Template: "t",
+				InplaceUpdate: &config.InplaceUpdateOptions{
+					Resources: &config.InplaceUpdateResourcesOptions{
+						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("-1")},
+					},
+				},
+			},
+			expectError: "target memory must be a positive value",
 		},
 		{
 			name: "cpu limit only is allowed",
@@ -1628,7 +1797,18 @@ func TestValidateAndInitClaimOptions_InplaceUpdateValidation(t *testing.T) {
 					},
 				},
 			},
-			expectErr: false,
+		},
+		{
+			name: "memory limit only is allowed",
+			opts: infra.ClaimSandboxOptions{
+				User:     "u",
+				Template: "t",
+				InplaceUpdate: &config.InplaceUpdateOptions{
+					Resources: &config.InplaceUpdateResourcesOptions{
+						Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+					},
+				},
+			},
 		},
 		{
 			name: "image only is allowed",
@@ -1639,16 +1819,15 @@ func TestValidateAndInitClaimOptions_InplaceUpdateValidation(t *testing.T) {
 					Image: "nginx:stable",
 				},
 			},
-			expectErr: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := ValidateAndInitClaimOptions(tt.opts)
-			if tt.expectErr {
+			if tt.expectError != "" {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errContains)
+				assert.Contains(t, err.Error(), tt.expectError)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -1922,12 +1922,78 @@ func TestBuildResourceResizedPod(t *testing.T) {
 		corev1.ResourceCPU:    targetCPU,
 		corev1.ResourceMemory: targetMemory,
 	}
-	got, changed := buildResourceResizedPod(pod, requests, limits)
+	got, changed, err := buildResourceResizedPod(pod, requests, limits)
+	require.NoError(t, err)
 	require.True(t, changed)
 	assert.Equal(t, int64(500), got.Spec.Containers[0].Resources.Requests.Cpu().MilliValue())
 	assert.Equal(t, int64(500), got.Spec.Containers[0].Resources.Limits.Cpu().MilliValue())
 	assert.Equal(t, targetMemory, got.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory])
 	assert.Equal(t, targetMemory, got.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory])
+}
+
+func TestBuildResourceResizedPod_MemoryDownscaleRejected(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "main",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
+			}},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		requests    corev1.ResourceList
+		limits      corev1.ResourceList
+		expectError string
+	}{
+		{
+			name:        "lower memory request rejected",
+			requests:    corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("128Mi")},
+			expectError: "in-place memory downscale is not supported",
+		},
+		{
+			name:        "lower memory limit rejected",
+			limits:      corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+			expectError: "in-place memory downscale is not supported",
+		},
+		{
+			name:     "equal memory accepted",
+			requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+			limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+		},
+		{
+			name:     "memory upscale accepted",
+			requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+			limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+		},
+		{
+			name:     "cpu downscale still allowed",
+			requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
+			limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := buildResourceResizedPod(pod, tt.requests, tt.limits)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestValidateAndInitClaimOptions_ResourceResize(t *testing.T) {
@@ -1958,6 +2024,36 @@ func TestValidateAndInitClaimOptions_ResourceResize(t *testing.T) {
 					corev1.ResourceMemory: resource.MustParse("512Mi"),
 				},
 			},
+		},
+		{
+			name: "cpu request exceeding limit rejected",
+			resources: &config.InplaceUpdateResourcesOptions{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+				Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			},
+			expectError: "target cpu request 2 must not exceed limit 1",
+		},
+		{
+			name: "memory request exceeding limit rejected",
+			resources: &config.InplaceUpdateResourcesOptions{
+				Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+			},
+			expectError: "target memory request 1Gi must not exceed limit 512Mi",
+		},
+		{
+			name: "unknown request resource rejected",
+			resources: &config.InplaceUpdateResourcesOptions{
+				Requests: corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")},
+			},
+			expectError: "resource nvidia.com/gpu is not supported for in-place resize",
+		},
+		{
+			name: "unknown limit resource rejected",
+			resources: &config.InplaceUpdateResourcesOptions{
+				Limits: corev1.ResourceList{corev1.ResourceEphemeralStorage: resource.MustParse("1Gi")},
+			},
+			expectError: "resource ephemeral-storage is not supported for in-place resize",
 		},
 	}
 

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -450,7 +450,7 @@ func TestInfra_ClaimSandbox(t *testing.T) {
 						},
 						Limits: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("1"),
-							corev1.ResourceMemory: resource.MustParse("1Gi"),
+							corev1.ResourceMemory: resource.MustParse("768Mi"),
 						},
 					},
 				},
@@ -476,8 +476,39 @@ func TestInfra_ClaimSandbox(t *testing.T) {
 				assert.Equal(t, resource.MustParse("1"), container.Resources.Requests[corev1.ResourceCPU])
 				assert.Equal(t, resource.MustParse("768Mi"), container.Resources.Requests[corev1.ResourceMemory])
 				assert.Equal(t, resource.MustParse("1"), container.Resources.Limits[corev1.ResourceCPU])
-				assert.Equal(t, resource.MustParse("1Gi"), container.Resources.Limits[corev1.ResourceMemory])
+				assert.Equal(t, resource.MustParse("768Mi"), container.Resources.Limits[corev1.ResourceMemory])
 			},
+		},
+		{
+			name:      "claim with qos breaking resource resize rejected",
+			available: 1,
+			options: infra.ClaimSandboxOptions{
+				User:     user,
+				Template: existTemplate,
+				InplaceUpdate: &config.InplaceUpdateOptions{
+					Resources: &config.InplaceUpdateResourcesOptions{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+			preModifier: func(sbx *v1alpha1.Sandbox, infra *Infra) {
+				reqCPU := resource.MustParse("500m")
+				reqMem := resource.MustParse("512Mi")
+				sbx.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    reqCPU,
+						corev1.ResourceMemory: reqMem,
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    reqCPU,
+						corev1.ResourceMemory: reqMem,
+					},
+				}
+			},
+			expectError: "QoS class",
 		},
 		{
 			name:      "claim with csi mount",
@@ -1670,7 +1701,7 @@ func TestModifyPickedSandboxMemoryResizeCases(t *testing.T) {
 	}
 }
 
-func TestModifyPickedSandboxCPUNilTemplate(t *testing.T) {
+func TestModifyPickedSandboxResizeNilTemplateRejected(t *testing.T) {
 	sbx := &Sandbox{
 		Sandbox: &v1alpha1.Sandbox{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1687,6 +1718,8 @@ func TestModifyPickedSandboxCPUNilTemplate(t *testing.T) {
 		},
 	}
 
+	// Resizing a sandbox without a pod template must fail instead of claiming
+	// it unchanged.
 	err := modifyPickedSandbox(sbx, infra.LockTypeUpdate, infra.ClaimSandboxOptions{
 		User:     "u1",
 		Template: "test-template",
@@ -1697,7 +1730,8 @@ func TestModifyPickedSandboxCPUNilTemplate(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no pod template")
 	assert.Nil(t, sbx.Spec.Template)
 }
 
@@ -2049,14 +2083,24 @@ func TestValidateAndInitClaimOptions_ResourceResize(t *testing.T) {
 			resources: &config.InplaceUpdateResourcesOptions{
 				Requests: corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")},
 			},
-			expectError: "resource nvidia.com/gpu is not supported for in-place resize",
+			expectError: "resources nvidia.com/gpu are not supported for in-place resize",
 		},
 		{
 			name: "unknown limit resource rejected",
 			resources: &config.InplaceUpdateResourcesOptions{
 				Limits: corev1.ResourceList{corev1.ResourceEphemeralStorage: resource.MustParse("1Gi")},
 			},
-			expectError: "resource ephemeral-storage is not supported for in-place resize",
+			expectError: "resources ephemeral-storage are not supported for in-place resize",
+		},
+		{
+			name: "multiple unknown resources all listed",
+			resources: &config.InplaceUpdateResourcesOptions{
+				Requests: corev1.ResourceList{
+					"nvidia.com/gpu": resource.MustParse("1"),
+					"hugepages-2Mi":  resource.MustParse("1Gi"),
+				},
+			},
+			expectError: "resources hugepages-2Mi, nvidia.com/gpu are not supported for in-place resize",
 		},
 	}
 
@@ -4184,6 +4228,310 @@ func TestPickAnAvailableSandbox_PrefersMatchingRevision(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPreCheckCandidateResizeCompatibility(t *testing.T) {
+	utestutils.InitLogOutput()
+
+	memContainer := func(req, lim string) corev1.Container {
+		c := corev1.Container{Name: "main", Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{},
+			Limits:   corev1.ResourceList{},
+		}}
+		if req != "" {
+			c.Resources.Requests[corev1.ResourceMemory] = resource.MustParse(req)
+		}
+		if lim != "" {
+			c.Resources.Limits[corev1.ResourceMemory] = resource.MustParse(lim)
+		}
+		return c
+	}
+	qosContainer := func(reqCPU, reqMem, limCPU, limMem string) corev1.Container {
+		return corev1.Container{
+			Name: "main",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse(reqCPU),
+					corev1.ResourceMemory: resource.MustParse(reqMem),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse(limCPU),
+					corev1.ResourceMemory: resource.MustParse(limMem),
+				},
+			},
+		}
+	}
+	sbxWithContainer := func(container *corev1.Container) *v1alpha1.Sandbox {
+		sbx := &v1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-sbx",
+				Namespace:         "default",
+				Annotations:       map[string]string{},
+				CreationTimestamp: metav1.Now(),
+			},
+		}
+		if container != nil {
+			sbx.Spec.Template = &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{*container}},
+			}
+		}
+		return sbx
+	}
+	resourcesInplace := func(requests, limits map[corev1.ResourceName]string) *config.InplaceUpdateOptions {
+		parse := func(m map[corev1.ResourceName]string) corev1.ResourceList {
+			if len(m) == 0 {
+				return nil
+			}
+			rl := corev1.ResourceList{}
+			for name, q := range m {
+				rl[name] = resource.MustParse(q)
+			}
+			return rl
+		}
+		return &config.InplaceUpdateOptions{
+			Resources: &config.InplaceUpdateResourcesOptions{
+				Requests: parse(requests),
+				Limits:   parse(limits),
+			},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		sbx             *v1alpha1.Sandbox
+		inplace         *config.InplaceUpdateOptions
+		expectErr       string
+		expectResizeErr bool
+	}{
+		{
+			name:    "no inplace update accepted",
+			sbx:     sbxWithContainer(ptr.To(memContainer("256Mi", ""))),
+			inplace: nil,
+		},
+		{
+			name:    "inplace update without resources accepted",
+			sbx:     sbxWithContainer(ptr.To(memContainer("256Mi", ""))),
+			inplace: &config.InplaceUpdateOptions{},
+		},
+		{
+			name:            "nil template with resize rejected",
+			sbx:             sbxWithContainer(nil),
+			inplace:         resourcesInplace(map[corev1.ResourceName]string{corev1.ResourceMemory: "128Mi"}, nil),
+			expectErr:       "no pod template",
+			expectResizeErr: true,
+		},
+		{
+			name:    "memory upscale accepted",
+			sbx:     sbxWithContainer(ptr.To(memContainer("256Mi", "512Mi"))),
+			inplace: resourcesInplace(map[corev1.ResourceName]string{corev1.ResourceMemory: "512Mi"}, map[corev1.ResourceName]string{corev1.ResourceMemory: "1Gi"}),
+		},
+		{
+			name:    "equal memory accepted",
+			sbx:     sbxWithContainer(ptr.To(memContainer("256Mi", ""))),
+			inplace: resourcesInplace(map[corev1.ResourceName]string{corev1.ResourceMemory: "256Mi"}, nil),
+		},
+		{
+			name:            "memory request downscale rejected",
+			sbx:             sbxWithContainer(ptr.To(memContainer("256Mi", ""))),
+			inplace:         resourcesInplace(map[corev1.ResourceName]string{corev1.ResourceMemory: "128Mi"}, nil),
+			expectErr:       "downscale",
+			expectResizeErr: true,
+		},
+		{
+			name:            "memory limit downscale rejected",
+			sbx:             sbxWithContainer(ptr.To(memContainer("", "512Mi"))),
+			inplace:         resourcesInplace(nil, map[corev1.ResourceName]string{corev1.ResourceMemory: "256Mi"}),
+			expectErr:       "downscale",
+			expectResizeErr: true,
+		},
+		{
+			name:            "request raised above existing limit rejected",
+			sbx:             sbxWithContainer(ptr.To(qosContainer("100m", "256Mi", "500m", "512Mi"))),
+			inplace:         resourcesInplace(map[corev1.ResourceName]string{corev1.ResourceCPU: "1"}, nil),
+			expectErr:       "above the container limit",
+			expectResizeErr: true,
+		},
+		{
+			name:            "qos class change rejected",
+			sbx:             sbxWithContainer(ptr.To(qosContainer("100m", "256Mi", "200m", "512Mi"))),
+			inplace:         resourcesInplace(map[corev1.ResourceName]string{corev1.ResourceCPU: "200m", corev1.ResourceMemory: "512Mi"}, nil),
+			expectErr:       "QoS class",
+			expectResizeErr: true,
+		},
+		{
+			name:    "qos class preserved accepted",
+			sbx:     sbxWithContainer(ptr.To(qosContainer("100m", "256Mi", "200m", "512Mi"))),
+			inplace: resourcesInplace(map[corev1.ResourceName]string{corev1.ResourceCPU: "200m"}, nil),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := preCheckCandidate(tt.sbx, tt.inplace)
+			if tt.expectErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectErr)
+			if tt.expectResizeErr {
+				var resizeErr *candidateResizeIncompatibleError
+				require.ErrorAs(t, err, &resizeErr)
+			}
+		})
+	}
+}
+
+func TestPickAnAvailableSandbox_ResizeCompatibilityUsesCandidateResources(t *testing.T) {
+	utestutils.InitLogOutput()
+
+	template := "test-resize-compat-template"
+	oldRevision := "rev-old"
+	newRevision := "rev-new"
+
+	newCandidate := func(name, templateHash, reqMem string) *v1alpha1.Sandbox {
+		return &v1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels: map[string]string{
+					v1alpha1.LabelSandboxTemplate:  template,
+					v1alpha1.LabelSandboxIsClaimed: "false",
+					v1alpha1.LabelTemplateHash:     templateHash,
+				},
+				Annotations:       map[string]string{},
+				CreationTimestamp: metav1.Now(),
+				OwnerReferences:   GetSbsOwnerReference(),
+			},
+			Spec: v1alpha1.SandboxSpec{
+				EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "main",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(reqMem)},
+								},
+							}},
+						},
+					},
+				},
+			},
+			Status: v1alpha1.SandboxStatus{
+				Phase:      v1alpha1.SandboxRunning,
+				Conditions: []metav1.Condition{{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue}},
+				PodInfo:    v1alpha1.PodInfo{PodIP: "1.2.3.4"},
+			},
+		}
+	}
+
+	setup := func(t *testing.T) (*Infra, client.Client) {
+		testInfra, c := NewTestInfra(t)
+		// Rollout in progress: template memory raised to 1Gi, old sandboxes still lower.
+		sbs := &v1alpha1.SandboxSet{
+			ObjectMeta: metav1.ObjectMeta{Name: template, Namespace: "default"},
+			Spec: v1alpha1.SandboxSetSpec{
+				Replicas: 1,
+				EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "main",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+								},
+							}},
+						},
+					},
+				},
+			},
+			Status: v1alpha1.SandboxSetStatus{UpdateRevision: newRevision},
+		}
+		require.NoError(t, c.Create(t.Context(), sbs))
+		require.NoError(t, c.Status().Update(t.Context(), sbs))
+		return testInfra, c
+	}
+
+	waitPool := func(t *testing.T, testInfra *Infra, count int) {
+		require.Eventually(t, func() bool {
+			objs, err := testInfra.Cache.ListSandboxesInPool(t.Context(), infracache.ListSandboxesInPoolOptions{Pool: template})
+			return err == nil && len(objs) == count
+		}, 200*time.Millisecond, 5*time.Millisecond)
+	}
+
+	t.Run("old revision candidate below new template memory stays claimable", func(t *testing.T) {
+		testInfra, c := setup(t)
+		CreateSandboxWithStatus(t, c, newCandidate("old-512mi", oldRevision, "512Mi"))
+		waitPool(t, testInfra, 1)
+
+		opts, err := ValidateAndInitClaimOptions(infra.ClaimSandboxOptions{
+			Namespace: "default",
+			User:      "test-user",
+			Template:  template,
+			InplaceUpdate: &config.InplaceUpdateOptions{
+				Resources: &config.InplaceUpdateResourcesOptions{
+					Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("768Mi")},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		sbx, lockType, err := pickAnAvailableSandbox(t.Context(), opts, &testInfra.pickCache, testInfra.Cache)
+		require.NoError(t, err)
+		require.Equal(t, infra.LockTypeUpdate, lockType)
+		assert.Equal(t, "old-512mi", sbx.GetName())
+	})
+
+	t.Run("all candidates resize incompatible returns retriable no-available error", func(t *testing.T) {
+		testInfra, c := setup(t)
+		CreateSandboxWithStatus(t, c, newCandidate("old-1gi", oldRevision, "1Gi"))
+		waitPool(t, testInfra, 1)
+
+		opts, err := ValidateAndInitClaimOptions(infra.ClaimSandboxOptions{
+			Namespace: "default",
+			User:      "test-user",
+			Template:  template,
+			InplaceUpdate: &config.InplaceUpdateOptions{
+				Resources: &config.InplaceUpdateResourcesOptions{
+					Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		_, _, err = pickAnAvailableSandbox(t.Context(), opts, &testInfra.pickCache, testInfra.Cache)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "downscale")
+		assert.Contains(t, err.Error(), "inplace resize")
+		var retriable retriableError
+		assert.True(t, errors.As(err, &retriable), "resize-incompatible pool must stay retriable")
+	})
+
+	t.Run("locked candidates keep the generic no-available path", func(t *testing.T) {
+		testInfra, c := setup(t)
+		locked := newCandidate("locked-1gi", oldRevision, "1Gi")
+		locked.Annotations[v1alpha1.AnnotationLock] = "someone-else"
+		CreateSandboxWithStatus(t, c, locked)
+		waitPool(t, testInfra, 1)
+
+		opts, err := ValidateAndInitClaimOptions(infra.ClaimSandboxOptions{
+			Namespace: "default",
+			User:      "test-user",
+			Template:  template,
+			InplaceUpdate: &config.InplaceUpdateOptions{
+				Resources: &config.InplaceUpdateResourcesOptions{
+					Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		_, _, err = pickAnAvailableSandbox(t.Context(), opts, &testInfra.pickCache, testInfra.Cache)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "inplace resize")
+		var retriable retriableError
+		assert.True(t, errors.As(err, &retriable))
+	})
 }
 
 func TestModifyPickedSandbox_InitRuntime(t *testing.T) {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -437,7 +437,7 @@ func TestInfra_ClaimSandbox(t *testing.T) {
 			},
 		},
 		{
-			name:      "claim with cpu resize",
+			name:      "claim with resource resize",
 			available: 1,
 			options: infra.ClaimSandboxOptions{
 				User:     user,
@@ -445,10 +445,12 @@ func TestInfra_ClaimSandbox(t *testing.T) {
 				InplaceUpdate: &config.InplaceUpdateOptions{
 					Resources: &config.InplaceUpdateResourcesOptions{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU: resource.MustParse("1"),
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("768Mi"),
 						},
 						Limits: corev1.ResourceList{
-							corev1.ResourceCPU: resource.MustParse("1"),
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
 						},
 					},
 				},
@@ -470,6 +472,11 @@ func TestInfra_ClaimSandbox(t *testing.T) {
 			postCheck: func(t *testing.T, sbx infra.Sandbox) {
 				metrics := GetMetricsFromSandbox(t, sbx)
 				assert.Greater(t, metrics.WaitReady, time.Duration(0))
+				container := sbx.(*Sandbox).Spec.Template.Spec.Containers[0]
+				assert.Equal(t, resource.MustParse("1"), container.Resources.Requests[corev1.ResourceCPU])
+				assert.Equal(t, resource.MustParse("768Mi"), container.Resources.Requests[corev1.ResourceMemory])
+				assert.Equal(t, resource.MustParse("1"), container.Resources.Limits[corev1.ResourceCPU])
+				assert.Equal(t, resource.MustParse("1Gi"), container.Resources.Limits[corev1.ResourceMemory])
 			},
 		},
 		{
@@ -1312,7 +1319,7 @@ func TestSandboxReadyFailureMessage(t *testing.T) {
 	}
 }
 
-func TestModifyPickedSandboxCPUResize(t *testing.T) {
+func TestModifyPickedSandboxResourceResize(t *testing.T) {
 	base := &Sandbox{
 		Sandbox: &v1alpha1.Sandbox{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1356,14 +1363,22 @@ func TestModifyPickedSandboxCPUResize(t *testing.T) {
 		Template: "test-template",
 		InplaceUpdate: &config.InplaceUpdateOptions{
 			Resources: &config.InplaceUpdateResourcesOptions{
-				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
-				Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
 			},
 		},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, int64(500), base.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue())
 	assert.Equal(t, int64(500), base.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().MilliValue())
+	assert.Equal(t, resource.MustParse("512Mi"), *base.Spec.Template.Spec.Containers[0].Resources.Requests.Memory())
+	assert.Equal(t, resource.MustParse("1Gi"), *base.Spec.Template.Spec.Containers[0].Resources.Limits.Memory())
 }
 
 func TestModifyPickedSandboxCPUResizeCases(t *testing.T) {
@@ -1550,6 +1565,106 @@ func TestModifyPickedSandboxCPUResizeCases(t *testing.T) {
 			}
 			if tt.wantSidecarCPU > 0 {
 				assert.Equal(t, tt.wantSidecarCPU, sbx.Spec.Template.Spec.Containers[1].Resources.Limits.Cpu().MilliValue())
+			}
+		})
+	}
+}
+
+func TestModifyPickedSandboxMemoryResizeCases(t *testing.T) {
+	tests := []struct {
+		name          string
+		templateSpec  corev1.PodSpec
+		inplaceReq    corev1.ResourceList
+		inplaceLim    corev1.ResourceList
+		wantReqMemory string
+		wantLimMemory string
+	}{
+		{
+			name: "memory requests and limits are resized",
+			templateSpec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "main",
+						Image: "img",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+							},
+						},
+					},
+				},
+			},
+			inplaceReq:    corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("384Mi")},
+			inplaceLim:    corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("768Mi")},
+			wantReqMemory: "384Mi",
+			wantLimMemory: "768Mi",
+		},
+		{
+			name: "memory target is ignored when original memory is unset",
+			templateSpec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "main",
+						Image: "img",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("100m"),
+							},
+						},
+					},
+				},
+			},
+			inplaceReq: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("384Mi")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := &Sandbox{
+				Sandbox: &v1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "sbx-1",
+						Namespace:   "default",
+						Labels:      map[string]string{},
+						Annotations: map[string]string{},
+					},
+					Spec: v1alpha1.SandboxSpec{
+						EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+							Template: &corev1.PodTemplateSpec{
+								Spec: tt.templateSpec,
+							},
+						},
+					},
+				},
+			}
+
+			err := modifyPickedSandbox(sbx, infra.LockTypeUpdate, infra.ClaimSandboxOptions{
+				User:     "u1",
+				Template: "test-template",
+				InplaceUpdate: &config.InplaceUpdateOptions{
+					Resources: &config.InplaceUpdateResourcesOptions{
+						Requests: tt.inplaceReq,
+						Limits:   tt.inplaceLim,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			container := sbx.Spec.Template.Spec.Containers[0]
+			if tt.wantReqMemory == "" {
+				_, ok := container.Resources.Requests[corev1.ResourceMemory]
+				assert.False(t, ok)
+			} else {
+				assert.Equal(t, resource.MustParse(tt.wantReqMemory), container.Resources.Requests[corev1.ResourceMemory])
+			}
+			if tt.wantLimMemory == "" {
+				_, ok := container.Resources.Limits[corev1.ResourceMemory]
+				assert.False(t, ok)
+			} else {
+				assert.Equal(t, resource.MustParse(tt.wantLimMemory), container.Resources.Limits[corev1.ResourceMemory])
 			}
 		})
 	}
@@ -1798,26 +1913,71 @@ func TestBuildResourceResizedPod(t *testing.T) {
 	}
 
 	targetCPU := resource.MustParse("500m")
-	requests := corev1.ResourceList{corev1.ResourceCPU: targetCPU}
-	limits := corev1.ResourceList{corev1.ResourceCPU: targetCPU}
+	targetMemory := resource.MustParse("512Mi")
+	requests := corev1.ResourceList{
+		corev1.ResourceCPU:    targetCPU,
+		corev1.ResourceMemory: targetMemory,
+	}
+	limits := corev1.ResourceList{
+		corev1.ResourceCPU:    targetCPU,
+		corev1.ResourceMemory: targetMemory,
+	}
 	got, changed := buildResourceResizedPod(pod, requests, limits)
 	require.True(t, changed)
 	assert.Equal(t, int64(500), got.Spec.Containers[0].Resources.Requests.Cpu().MilliValue())
 	assert.Equal(t, int64(500), got.Spec.Containers[0].Resources.Limits.Cpu().MilliValue())
+	assert.Equal(t, targetMemory, got.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory])
+	assert.Equal(t, targetMemory, got.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory])
 }
 
-func TestValidateAndInitClaimOptions_CPUResize(t *testing.T) {
-	_, err := ValidateAndInitClaimOptions(infra.ClaimSandboxOptions{
-		User:     "u",
-		Template: "t",
-		InplaceUpdate: &config.InplaceUpdateOptions{
-			Resources: &config.InplaceUpdateResourcesOptions{
+func TestValidateAndInitClaimOptions_ResourceResize(t *testing.T) {
+	tests := []struct {
+		name        string
+		resources   *config.InplaceUpdateResourcesOptions
+		expectError string
+	}{
+		{
+			name: "zero cpu request rejected",
+			resources: &config.InplaceUpdateResourcesOptions{
 				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("0")},
 			},
+			expectError: "target cpu must be a positive value",
 		},
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "target cpu must be a positive value")
+		{
+			name: "zero memory limit rejected",
+			resources: &config.InplaceUpdateResourcesOptions{
+				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("0")},
+			},
+			expectError: "target memory must be a positive value",
+		},
+		{
+			name: "positive cpu and memory accepted",
+			resources: &config.InplaceUpdateResourcesOptions{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ValidateAndInitClaimOptions(infra.ClaimSandboxOptions{
+				User:     "u",
+				Template: "t",
+				InplaceUpdate: &config.InplaceUpdateOptions{
+					Resources: tt.resources,
+				},
+			})
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestValidateAndInitClaimOptions_InplaceUpdateValidation(t *testing.T) {
@@ -1860,6 +2020,19 @@ func TestValidateAndInitClaimOptions_InplaceUpdateValidation(t *testing.T) {
 			expectError: "target cpu must be a positive value",
 		},
 		{
+			name: "negative memory request rejected",
+			opts: infra.ClaimSandboxOptions{
+				User:     "u",
+				Template: "t",
+				InplaceUpdate: &config.InplaceUpdateOptions{
+					Resources: &config.InplaceUpdateResourcesOptions{
+						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("-1")},
+					},
+				},
+			},
+			expectError: "target memory must be a positive value",
+		},
+		{
 			name: "cpu limit only is allowed",
 			opts: infra.ClaimSandboxOptions{
 				User:     "u",
@@ -1867,6 +2040,18 @@ func TestValidateAndInitClaimOptions_InplaceUpdateValidation(t *testing.T) {
 				InplaceUpdate: &config.InplaceUpdateOptions{
 					Resources: &config.InplaceUpdateResourcesOptions{
 						Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+					},
+				},
+			},
+		},
+		{
+			name: "memory limit only is allowed",
+			opts: infra.ClaimSandboxOptions{
+				User:     "u",
+				Template: "t",
+				InplaceUpdate: &config.InplaceUpdateOptions{
+					Resources: &config.InplaceUpdateResourcesOptions{
+						Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
 					},
 				},
 			},

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -1989,6 +1989,9 @@ func TestBuildResourceResizedPod_MemoryDownscaleRejected(t *testing.T) {
 			if tt.expectError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectError)
+				// Downscale rejection is a client input error and must carry
+				// ErrorBadRequest so the E2B API maps it to HTTP 400.
+				assert.Equal(t, managererrors.ErrorBadRequest, managererrors.GetErrCode(err))
 				return
 			}
 			require.NoError(t, err)
@@ -2069,6 +2072,9 @@ func TestValidateAndInitClaimOptions_ResourceResize(t *testing.T) {
 			if tt.expectError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectError)
+				// Validation failures are client input errors and must carry
+				// ErrorBadRequest so the E2B API maps them to HTTP 400.
+				assert.Equal(t, managererrors.ErrorBadRequest, managererrors.GetErrCode(err))
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
@@ -692,10 +692,9 @@ func TestCloneSandbox_AdmissionReceivesPreparedResource(t *testing.T) {
 		{
 			name: "clone admission sees modifier-updated cpu limit",
 			modifier: func(sbx infra.Sandbox) error {
-				sbx.(*Sandbox).SetResources(nil, corev1.ResourceList{
+				return sbx.(*Sandbox).SetResources(nil, corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("2"),
 				})
-				return nil
 			},
 			wantReqCPU: 500,
 			wantLimCPU: 2000,

--- a/pkg/sandbox-manager/infra/sandboxcr/errors.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/errors.go
@@ -79,6 +79,21 @@ func (e terminalValidationError) Unwrap() error {
 	return e.err
 }
 
+// candidateResizeIncompatibleError marks a candidate that cannot serve the
+// requested resize. pickAnAvailableSandbox records the skip reason so it can
+// be surfaced in the no-available error; skips never terminate the claim.
+type candidateResizeIncompatibleError struct {
+	err error
+}
+
+func (e *candidateResizeIncompatibleError) Error() string {
+	return e.err.Error()
+}
+
+func (e *candidateResizeIncompatibleError) Unwrap() error {
+	return e.err
+}
+
 // classifyCreateError classifies a Kubernetes API error from a Create
 // operation into one of three categories:
 // - ambiguous: transient server errors, conflicts, network errors -> managererrors.Error{ErrorInternal}

--- a/pkg/sandbox-manager/infra/sandboxcr/errors.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/errors.go
@@ -63,6 +63,22 @@ func (e terminalMutationError) Unwrap() error {
 	return e.err
 }
 
+// terminalValidationError marks an input-validation failure during sandbox
+// mutation (e.g. memory downscale) as terminal at the outer claim/clone retry
+// boundary. Unwrap keeps the underlying classified manager error (such as
+// ErrorBadRequest) available to errors.As so it maps to HTTP 400.
+type terminalValidationError struct {
+	err error
+}
+
+func (e terminalValidationError) Error() string {
+	return fmt.Sprintf("sandbox claim validation failed: %v", e.err)
+}
+
+func (e terminalValidationError) Unwrap() error {
+	return e.err
+}
+
 // classifyCreateError classifies a Kubernetes API error from a Create
 // operation into one of three categories:
 // - ambiguous: transient server errors, conflicts, network errors -> managererrors.Error{ErrorInternal}

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -181,7 +181,7 @@ func (i *Infra) ClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions
 		}
 		metrics.RetryCost += tryMetrics.Total
 		lastErr = claimErr
-		if errors.As(claimErr, &terminalMutationError{}) {
+		if errors.As(claimErr, &terminalMutationError{}) || errors.As(claimErr, &terminalValidationError{}) {
 			return false, claimErr
 		}
 		if errors.As(claimErr, &retriableError{}) {
@@ -256,7 +256,7 @@ func (i *Infra) CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions
 		}
 		metrics.LastError = cloneErr
 		lastErr = cloneErr
-		if errors.As(cloneErr, &terminalMutationError{}) {
+		if errors.As(cloneErr, &terminalMutationError{}) || errors.As(cloneErr, &terminalValidationError{}) {
 			return false, cloneErr
 		}
 		if errors.As(cloneErr, &retriableError{}) {

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -172,7 +172,7 @@ func (sc *Controller) createSandboxWithClone(ctx context.Context, request models
 	log := klog.FromContext(ctx)
 	start := time.Now()
 
-	if request.Extensions.InplaceUpdate.Image != "" {
+	if request.Extensions.InplaceUpdate.Image != "" || request.Extensions.InplaceUpdate.Resources != nil {
 		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
 			Code:    http.StatusBadRequest,
 			Message: "InplaceUpdate is not supported for clone",

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -239,7 +239,7 @@ func (sc *Controller) createSandboxWithClone(ctx context.Context, request models
 	log := klog.FromContext(ctx)
 	start := time.Now()
 
-	if request.Extensions.InplaceUpdate.Image != "" {
+	if request.Extensions.InplaceUpdate.Image != "" || request.Extensions.InplaceUpdate.Resources != nil {
 		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
 			Code:    http.StatusBadRequest,
 			Message: "InplaceUpdate is not supported for clone",

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 
@@ -69,20 +68,6 @@ func mapInfraErrorToApiError(err error) *web.ApiError {
 	}
 }
 
-func validateCreateResourceOverride(request models.NewSandboxRequest) *web.ApiError {
-	res := request.Extensions.InplaceUpdate.Resources
-	if res == nil {
-		return nil
-	}
-	if _, ok := res.Requests[corev1.ResourceMemory]; ok {
-		return &web.ApiError{Code: http.StatusBadRequest, Message: "memory inplace update is not supported"}
-	}
-	if _, ok := res.Limits[corev1.ResourceMemory]; ok {
-		return &web.ApiError{Code: http.StatusBadRequest, Message: "memory inplace update is not supported"}
-	}
-	return nil
-}
-
 // resolveServerTimeout maps an extension-provided seconds value to a server-side
 // timeout. A positive value yields a finite timeout; an absent (zero) or
 // non-positive value yields noServerTimeout.
@@ -107,9 +92,6 @@ func (sc *Controller) CreateSandbox(r *http.Request) (web.ApiResponse[*models.Sa
 	request, parseErr := sc.parseCreateSandboxRequest(r)
 	if parseErr != nil {
 		return web.ApiResponse[*models.Sandbox]{}, parseErr
-	}
-	if validateErr := validateCreateResourceOverride(request); validateErr != nil {
-		return web.ApiResponse[*models.Sandbox]{}, validateErr
 	}
 	domain, apiErr := sc.resolveSandboxDomain(r)
 	if apiErr != nil {

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openkruise/agents/api/v1alpha1"
@@ -409,21 +411,48 @@ func TestCreateSandboxWithClone_CSIMount(t *testing.T) {
 }
 
 func TestCreateSandboxWithClone_InplaceUpdateRejected(t *testing.T) {
-	ctrl := &Controller{}
-	request := models.NewSandboxRequest{
-		TemplateID: "test-checkpoint",
-		Extensions: models.NewSandboxRequestExtension{
-			InplaceUpdate: models.InplaceUpdateExtension{
+	tests := []struct {
+		name        string
+		inplace     models.InplaceUpdateExtension
+		expectError string
+	}{
+		{
+			name: "image update rejected",
+			inplace: models.InplaceUpdateExtension{
 				Image: "nginx:latest",
 			},
+			expectError: "InplaceUpdate is not supported for clone",
+		},
+		{
+			name: "memory resize rejected",
+			inplace: models.InplaceUpdateExtension{
+				Resources: &models.InplaceUpdateResourcesExtension{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
+			},
+			expectError: "InplaceUpdate is not supported for clone",
 		},
 	}
-	user := &models.CreatedTeamAPIKey{ID: uuid.New(), Name: "test-user"}
 
-	_, apiErr := ctrl.createSandboxWithClone(context.Background(), request, user)
-	require.NotNil(t, apiErr)
-	assert.Equal(t, http.StatusBadRequest, apiErr.Code)
-	assert.Contains(t, apiErr.Message, "InplaceUpdate is not supported for clone")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := &Controller{}
+			request := models.NewSandboxRequest{
+				TemplateID: "test-checkpoint",
+				Extensions: models.NewSandboxRequestExtension{
+					InplaceUpdate: tt.inplace,
+				},
+			}
+			user := &models.CreatedTeamAPIKey{ID: uuid.New(), Name: "test-user"}
+
+			_, apiErr := ctrl.createSandboxWithClone(context.Background(), request, user)
+			require.NotNil(t, apiErr)
+			assert.Equal(t, http.StatusBadRequest, apiErr.Code)
+			assert.Contains(t, apiErr.Message, tt.expectError)
+		})
+	}
 }
 
 func TestParseCreateSandboxRequest(t *testing.T) {

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -1033,6 +1033,38 @@ func TestCreateSandbox_MemoryOverridePropagatedToClaimedSandbox(t *testing.T) {
 	assert.Equal(t, resource.MustParse("100m"), resources.Requests[corev1.ResourceCPU])
 }
 
+func TestCreateSandbox_InvalidResourceOverrideReturns400(t *testing.T) {
+	fakeQuota := &fakeQuotaManager{}
+	controller, _, teardown := SetupWithQuota(t, fakeQuota)
+	defer teardown()
+
+	cleanup := CreateSandboxPool(t, controller, "invalid-override-tmpl", 1, CreateSandboxPoolOptions{
+		CPURequest: "100m",
+		Memory:     "256Mi",
+	})
+	defer cleanup()
+
+	user := quotaLimitedUser([]quotaspec.QuotaLimit{{
+		Dimension: quotaspec.DimSandboxCount,
+		Scope:     quotaspec.ScopeRunning,
+		Limit:     10,
+	}})
+	// A memory downscale is client input error and must map to HTTP 400,
+	// not 500, and must not lock or consume the pooled sandbox.
+	resp, apiErr := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+		TemplateID: "invalid-override-tmpl",
+		Metadata: map[string]string{
+			models.ExtensionKeySkipInitRuntime:        v1alpha1.True,
+			models.ExtensionKeyClaimWithMemoryRequest: "128Mi",
+		},
+	}, nil, user))
+
+	require.NotNil(t, apiErr)
+	assert.Equal(t, http.StatusBadRequest, apiErr.Code)
+	assert.Contains(t, apiErr.Message, "downscale")
+	assert.Zero(t, resp.Code)
+}
+
 func quotaLimitedUser(limits []quotaspec.QuotaLimit) *models.CreatedTeamAPIKey {
 	return &models.CreatedTeamAPIKey{
 		ID:   uuid.New(),

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -573,21 +573,48 @@ func TestCreateSandboxWithClaim_NamingExtensionRejected(t *testing.T) {
 }
 
 func TestCreateSandboxWithClone_InplaceUpdateRejected(t *testing.T) {
-	ctrl := &Controller{}
-	request := models.NewSandboxRequest{
-		TemplateID: "test-checkpoint",
-		Extensions: models.NewSandboxRequestExtension{
-			InplaceUpdate: models.InplaceUpdateExtension{
+	tests := []struct {
+		name        string
+		inplace     models.InplaceUpdateExtension
+		expectError string
+	}{
+		{
+			name: "image update rejected",
+			inplace: models.InplaceUpdateExtension{
 				Image: "nginx:latest",
 			},
+			expectError: "InplaceUpdate is not supported for clone",
+		},
+		{
+			name: "memory resize rejected",
+			inplace: models.InplaceUpdateExtension{
+				Resources: &models.InplaceUpdateResourcesExtension{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
+			},
+			expectError: "InplaceUpdate is not supported for clone",
 		},
 	}
-	user := &models.CreatedTeamAPIKey{ID: uuid.New(), Name: "test-user"}
 
-	_, apiErr := ctrl.createSandboxWithClone(context.Background(), request, user, "")
-	require.NotNil(t, apiErr)
-	assert.Equal(t, http.StatusBadRequest, apiErr.Code)
-	assert.Contains(t, apiErr.Message, "InplaceUpdate is not supported for clone")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := &Controller{}
+			request := models.NewSandboxRequest{
+				TemplateID: "test-checkpoint",
+				Extensions: models.NewSandboxRequestExtension{
+					InplaceUpdate: tt.inplace,
+				},
+			}
+			user := &models.CreatedTeamAPIKey{ID: uuid.New(), Name: "test-user"}
+
+			_, apiErr := ctrl.createSandboxWithClone(context.Background(), request, user, "")
+			require.NotNil(t, apiErr)
+			assert.Equal(t, http.StatusBadRequest, apiErr.Code)
+			assert.Contains(t, apiErr.Message, tt.expectError)
+		})
+	}
 }
 
 // TestCreateSandboxWithClone_Naming asserts that Extensions.Name and

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -1008,12 +1008,14 @@ func TestCreateSandbox_MemoryOverridePropagatedToClaimedSandbox(t *testing.T) {
 		Scope:     quotaspec.ScopeRunning,
 		Limit:     10,
 	}})
+	// Keep requests == limits so the resize preserves the pool's Guaranteed QoS
+	// class; a request/limit split would change QoS and be rejected.
 	resp, apiErr := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
 		TemplateID: "memory-override-tmpl",
 		Metadata: map[string]string{
 			models.ExtensionKeySkipInitRuntime:        v1alpha1.True,
 			models.ExtensionKeyClaimWithMemoryRequest: "512Mi",
-			models.ExtensionKeyClaimWithMemoryLimit:   "1Gi",
+			models.ExtensionKeyClaimWithMemoryLimit:   "512Mi",
 		},
 	}, nil, user))
 
@@ -1028,7 +1030,7 @@ func TestCreateSandbox_MemoryOverridePropagatedToClaimedSandbox(t *testing.T) {
 	claimed := GetSandbox(t, resp.Body.SandboxID, client)
 	resources := claimed.Spec.Template.Spec.Containers[0].Resources
 	assert.Equal(t, resource.MustParse("512Mi"), resources.Requests[corev1.ResourceMemory])
-	assert.Equal(t, resource.MustParse("1Gi"), resources.Limits[corev1.ResourceMemory])
+	assert.Equal(t, resource.MustParse("512Mi"), resources.Limits[corev1.ResourceMemory])
 	// Unrelated resources must be preserved by the memory override.
 	assert.Equal(t, resource.MustParse("100m"), resources.Requests[corev1.ResourceCPU])
 }

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -992,29 +992,45 @@ func TestCreateSandbox_TopLevelMissingTemplateOrCheckpointReturns400(t *testing.
 	assert.Equal(t, int64(0), fakeQuota.acquireCalls.Load())
 }
 
-func TestCreateSandbox_MemoryOverrideRejectedBeforeQuotaAcquire(t *testing.T) {
+func TestCreateSandbox_MemoryOverridePropagatedToClaimedSandbox(t *testing.T) {
 	fakeQuota := &fakeQuotaManager{}
+	controller, client, teardown := SetupWithQuota(t, fakeQuota)
+	defer teardown()
 
-	apiErr := validateCreateResourceOverride(models.NewSandboxRequest{
-		TemplateID: "claim-template",
-		Extensions: models.NewSandboxRequestExtension{
-			InplaceUpdate: models.InplaceUpdateExtension{
-				Resources: &models.InplaceUpdateResourcesExtension{
-					Limits: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("1024Mi"),
-					},
-				},
-			},
-		},
-		Metadata: map[string]string{
-			models.ExtensionKeySkipInitRuntime: v1alpha1.True,
-		},
+	cleanup := CreateSandboxPool(t, controller, "memory-override-tmpl", 1, CreateSandboxPoolOptions{
+		CPURequest: "100m",
+		Memory:     "128Mi",
 	})
+	defer cleanup()
 
-	require.NotNil(t, apiErr)
-	assert.Equal(t, http.StatusBadRequest, apiErr.Code)
-	assert.Contains(t, apiErr.Message, "memory")
-	assert.Equal(t, int64(0), fakeQuota.acquireCalls.Load())
+	user := quotaLimitedUser([]quotaspec.QuotaLimit{{
+		Dimension: quotaspec.DimSandboxCount,
+		Scope:     quotaspec.ScopeRunning,
+		Limit:     10,
+	}})
+	resp, apiErr := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+		TemplateID: "memory-override-tmpl",
+		Metadata: map[string]string{
+			models.ExtensionKeySkipInitRuntime:        v1alpha1.True,
+			models.ExtensionKeyClaimWithMemoryRequest: "512Mi",
+			models.ExtensionKeyClaimWithMemoryLimit:   "1Gi",
+		},
+	}, nil, user))
+
+	require.Nil(t, apiErr)
+	require.Equal(t, http.StatusCreated, resp.Code)
+	require.NotNil(t, resp.Body)
+	// The request must proceed past request parsing into the claim flow, so
+	// quota acquisition happens exactly once (the old behavior rejected
+	// memory overrides before quota was ever acquired).
+	assert.Equal(t, int64(1), fakeQuota.acquireCalls.Load())
+
+	claimed := GetSandbox(t, resp.Body.SandboxID, client)
+	resources := claimed.Spec.Template.Spec.Containers[0].Resources
+	assert.Equal(t, resource.MustParse("512Mi"), resources.Requests[corev1.ResourceMemory])
+	assert.Equal(t, resource.MustParse("1Gi"), resources.Limits[corev1.ResourceMemory])
+	// Unrelated resources must be preserved by the memory override.
+	assert.Equal(t, resource.MustParse("100m"), resources.Requests[corev1.ResourceCPU])
 }
 
 func quotaLimitedUser(limits []quotaspec.QuotaLimit) *models.CreatedTeamAPIKey {

--- a/pkg/servers/e2b/models/extensions.go
+++ b/pkg/servers/e2b/models/extensions.go
@@ -47,6 +47,8 @@ const (
 	ExtensionKeyWaitReadyTimeout              = v1alpha1.E2BPrefix + "wait-ready-timeout-seconds"
 	ExtensionKeyClaimWithCPURequest           = v1alpha1.E2BPrefix + "cpu-request"
 	ExtensionKeyClaimWithCPULimit             = v1alpha1.E2BPrefix + "cpu-limit"
+	ExtensionKeyClaimWithMemoryRequest        = v1alpha1.E2BPrefix + "memory-request"
+	ExtensionKeyClaimWithMemoryLimit          = v1alpha1.E2BPrefix + "memory-limit"
 	ExtensionKeyClaimWithImage                = v1alpha1.E2BPrefix + "image"
 	ExtensionKeyClaimWithCSIMount             = v1alpha1.E2BPrefix + "csi"
 	ExtensionKeyClaimWithCSIMount_VolumeName  = ExtensionKeyClaimWithCSIMount + "-volume-name"
@@ -163,31 +165,38 @@ func (r *NewSandboxRequest) parseExtensionImage() error {
 }
 
 func (r *NewSandboxRequest) parseExtensionResources() error {
-	cpuReq, hasCPUReq, err := r.parseAndRemoveQuantity(ExtensionKeyClaimWithCPURequest)
-	if err != nil {
-		return err
+	resourceExtensions := []struct {
+		key          string
+		resourceName corev1.ResourceName
+		isRequest    bool
+	}{
+		{key: ExtensionKeyClaimWithCPURequest, resourceName: corev1.ResourceCPU, isRequest: true},
+		{key: ExtensionKeyClaimWithCPULimit, resourceName: corev1.ResourceCPU},
+		{key: ExtensionKeyClaimWithMemoryRequest, resourceName: corev1.ResourceMemory, isRequest: true},
+		{key: ExtensionKeyClaimWithMemoryLimit, resourceName: corev1.ResourceMemory},
 	}
-	cpuLim, hasCPULim, err := r.parseAndRemoveQuantity(ExtensionKeyClaimWithCPULimit)
-	if err != nil {
-		return err
-	}
-	if !hasCPUReq && !hasCPULim {
-		return nil
-	}
-	if r.Extensions.InplaceUpdate.Resources == nil {
-		r.Extensions.InplaceUpdate.Resources = &InplaceUpdateResourcesExtension{}
-	}
-	if hasCPUReq {
-		if r.Extensions.InplaceUpdate.Resources.Requests == nil {
-			r.Extensions.InplaceUpdate.Resources.Requests = corev1.ResourceList{}
+	for _, extension := range resourceExtensions {
+		quantity, ok, err := r.parseAndRemoveQuantity(extension.key)
+		if err != nil {
+			return err
 		}
-		r.Extensions.InplaceUpdate.Resources.Requests[corev1.ResourceCPU] = cpuReq
-	}
-	if hasCPULim {
+		if !ok {
+			continue
+		}
+		if r.Extensions.InplaceUpdate.Resources == nil {
+			r.Extensions.InplaceUpdate.Resources = &InplaceUpdateResourcesExtension{}
+		}
+		if extension.isRequest {
+			if r.Extensions.InplaceUpdate.Resources.Requests == nil {
+				r.Extensions.InplaceUpdate.Resources.Requests = corev1.ResourceList{}
+			}
+			r.Extensions.InplaceUpdate.Resources.Requests[extension.resourceName] = quantity
+			continue
+		}
 		if r.Extensions.InplaceUpdate.Resources.Limits == nil {
 			r.Extensions.InplaceUpdate.Resources.Limits = corev1.ResourceList{}
 		}
-		r.Extensions.InplaceUpdate.Resources.Limits[corev1.ResourceCPU] = cpuLim
+		r.Extensions.InplaceUpdate.Resources.Limits[extension.resourceName] = quantity
 	}
 	return nil
 }

--- a/pkg/servers/e2b/models/extensions.go
+++ b/pkg/servers/e2b/models/extensions.go
@@ -51,6 +51,8 @@ const (
 	ExtensionKeyWaitReadyTimeout              = v1alpha1.E2BPrefix + "wait-ready-timeout-seconds"
 	ExtensionKeyClaimWithCPURequest           = v1alpha1.E2BPrefix + "cpu-request"
 	ExtensionKeyClaimWithCPULimit             = v1alpha1.E2BPrefix + "cpu-limit"
+	ExtensionKeyClaimWithMemoryRequest        = v1alpha1.E2BPrefix + "memory-request"
+	ExtensionKeyClaimWithMemoryLimit          = v1alpha1.E2BPrefix + "memory-limit"
 	ExtensionKeyClaimWithImage                = v1alpha1.E2BPrefix + "image"
 	ExtensionKeyClaimWithCSIMount             = v1alpha1.E2BPrefix + "csi"
 	ExtensionKeyClaimWithCSIMount_VolumeName  = ExtensionKeyClaimWithCSIMount + "-volume-name"
@@ -243,31 +245,38 @@ func (r *NewSandboxRequest) parseExtensionImage() error {
 }
 
 func (r *NewSandboxRequest) parseExtensionResources() error {
-	cpuReq, hasCPUReq, err := r.parseAndRemoveQuantity(ExtensionKeyClaimWithCPURequest)
-	if err != nil {
-		return err
+	resourceExtensions := []struct {
+		key          string
+		resourceName corev1.ResourceName
+		isRequest    bool
+	}{
+		{key: ExtensionKeyClaimWithCPURequest, resourceName: corev1.ResourceCPU, isRequest: true},
+		{key: ExtensionKeyClaimWithCPULimit, resourceName: corev1.ResourceCPU},
+		{key: ExtensionKeyClaimWithMemoryRequest, resourceName: corev1.ResourceMemory, isRequest: true},
+		{key: ExtensionKeyClaimWithMemoryLimit, resourceName: corev1.ResourceMemory},
 	}
-	cpuLim, hasCPULim, err := r.parseAndRemoveQuantity(ExtensionKeyClaimWithCPULimit)
-	if err != nil {
-		return err
-	}
-	if !hasCPUReq && !hasCPULim {
-		return nil
-	}
-	if r.Extensions.InplaceUpdate.Resources == nil {
-		r.Extensions.InplaceUpdate.Resources = &InplaceUpdateResourcesExtension{}
-	}
-	if hasCPUReq {
-		if r.Extensions.InplaceUpdate.Resources.Requests == nil {
-			r.Extensions.InplaceUpdate.Resources.Requests = corev1.ResourceList{}
+	for _, extension := range resourceExtensions {
+		quantity, ok, err := r.parseAndRemoveQuantity(extension.key)
+		if err != nil {
+			return err
 		}
-		r.Extensions.InplaceUpdate.Resources.Requests[corev1.ResourceCPU] = cpuReq
-	}
-	if hasCPULim {
+		if !ok {
+			continue
+		}
+		if r.Extensions.InplaceUpdate.Resources == nil {
+			r.Extensions.InplaceUpdate.Resources = &InplaceUpdateResourcesExtension{}
+		}
+		if extension.isRequest {
+			if r.Extensions.InplaceUpdate.Resources.Requests == nil {
+				r.Extensions.InplaceUpdate.Resources.Requests = corev1.ResourceList{}
+			}
+			r.Extensions.InplaceUpdate.Resources.Requests[extension.resourceName] = quantity
+			continue
+		}
 		if r.Extensions.InplaceUpdate.Resources.Limits == nil {
 			r.Extensions.InplaceUpdate.Resources.Limits = corev1.ResourceList{}
 		}
-		r.Extensions.InplaceUpdate.Resources.Limits[corev1.ResourceCPU] = cpuLim
+		r.Extensions.InplaceUpdate.Resources.Limits[extension.resourceName] = quantity
 	}
 	return nil
 }

--- a/pkg/servers/e2b/models/extensions.go
+++ b/pkg/servers/e2b/models/extensions.go
@@ -245,15 +245,20 @@ func (r *NewSandboxRequest) parseExtensionImage() error {
 }
 
 func (r *NewSandboxRequest) parseExtensionResources() error {
+	type resourceTarget int
+	const (
+		targetRequests resourceTarget = iota
+		targetLimits
+	)
 	resourceExtensions := []struct {
 		key          string
 		resourceName corev1.ResourceName
-		isRequest    bool
+		target       resourceTarget
 	}{
-		{key: ExtensionKeyClaimWithCPURequest, resourceName: corev1.ResourceCPU, isRequest: true},
-		{key: ExtensionKeyClaimWithCPULimit, resourceName: corev1.ResourceCPU},
-		{key: ExtensionKeyClaimWithMemoryRequest, resourceName: corev1.ResourceMemory, isRequest: true},
-		{key: ExtensionKeyClaimWithMemoryLimit, resourceName: corev1.ResourceMemory},
+		{key: ExtensionKeyClaimWithCPURequest, resourceName: corev1.ResourceCPU, target: targetRequests},
+		{key: ExtensionKeyClaimWithCPULimit, resourceName: corev1.ResourceCPU, target: targetLimits},
+		{key: ExtensionKeyClaimWithMemoryRequest, resourceName: corev1.ResourceMemory, target: targetRequests},
+		{key: ExtensionKeyClaimWithMemoryLimit, resourceName: corev1.ResourceMemory, target: targetLimits},
 	}
 	for _, extension := range resourceExtensions {
 		quantity, ok, err := r.parseAndRemoveQuantity(extension.key)
@@ -266,7 +271,7 @@ func (r *NewSandboxRequest) parseExtensionResources() error {
 		if r.Extensions.InplaceUpdate.Resources == nil {
 			r.Extensions.InplaceUpdate.Resources = &InplaceUpdateResourcesExtension{}
 		}
-		if extension.isRequest {
+		if extension.target == targetRequests {
 			if r.Extensions.InplaceUpdate.Resources.Requests == nil {
 				r.Extensions.InplaceUpdate.Resources.Requests = corev1.ResourceList{}
 			}

--- a/pkg/servers/e2b/models/extensions_test.go
+++ b/pkg/servers/e2b/models/extensions_test.go
@@ -215,18 +215,26 @@ func TestParseExtensions(t *testing.T) {
 			},
 		},
 		{
-			name: "valid cpu target",
+			name: "valid cpu and memory target",
 			metadata: map[string]string{
-				ExtensionKeyClaimWithCPURequest: "500m",
-				ExtensionKeyClaimWithCPULimit:   "500m",
+				ExtensionKeyClaimWithCPURequest:    "500m",
+				ExtensionKeyClaimWithCPULimit:      "500m",
+				ExtensionKeyClaimWithMemoryRequest: "512Mi",
+				ExtensionKeyClaimWithMemoryLimit:   "1Gi",
 			},
 			wantErr: false,
 			expectExtension: NewSandboxRequestExtension{
 				CreateOnNoStock: true,
 				InplaceUpdate: InplaceUpdateExtension{
 					Resources: &InplaceUpdateResourcesExtension{
-						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
-						Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
 					},
 				},
 			},
@@ -252,6 +260,13 @@ func TestParseExtensions(t *testing.T) {
 			name: "invalid cpu target - zero",
 			metadata: map[string]string{
 				ExtensionKeyClaimWithCPURequest: "0",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid memory target - zero",
+			metadata: map[string]string{
+				ExtensionKeyClaimWithMemoryLimit: "0",
 			},
 			wantErr: true,
 		},
@@ -454,6 +469,13 @@ func TestParseAndRemoveQuantity(t *testing.T) {
 			expectOK:  true,
 			expectQty: resource.MustParse("1500m"),
 		},
+		{
+			name:      "valid memory quantity",
+			metadata:  map[string]string{ExtensionKeyClaimWithMemoryRequest: "512Mi"},
+			key:       ExtensionKeyClaimWithMemoryRequest,
+			expectOK:  true,
+			expectQty: resource.MustParse("512Mi"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -501,6 +523,18 @@ func TestParseExtensions_InvalidCPULimitError(t *testing.T) {
 	err := req.ParseExtensions()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid quantity for "+ExtensionKeyClaimWithCPULimit)
+}
+
+func TestParseExtensions_InvalidMemoryLimitError(t *testing.T) {
+	req := &NewSandboxRequest{
+		Metadata: map[string]string{
+			ExtensionKeyClaimWithMemoryLimit: "bad-limit",
+		},
+	}
+
+	err := req.ParseExtensions()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid quantity for "+ExtensionKeyClaimWithMemoryLimit)
 }
 
 func TestParseExtensions_InvalidMultiCSIMountJSON(t *testing.T) {

--- a/pkg/servers/e2b/models/extensions_test.go
+++ b/pkg/servers/e2b/models/extensions_test.go
@@ -268,10 +268,12 @@ func TestParseExtensions(t *testing.T) {
 			},
 		},
 		{
-			name: "valid cpu target",
+			name: "valid cpu and memory target",
 			metadata: map[string]string{
-				ExtensionKeyClaimWithCPURequest: "500m",
-				ExtensionKeyClaimWithCPULimit:   "500m",
+				ExtensionKeyClaimWithCPURequest:    "500m",
+				ExtensionKeyClaimWithCPULimit:      "500m",
+				ExtensionKeyClaimWithMemoryRequest: "512Mi",
+				ExtensionKeyClaimWithMemoryLimit:   "1Gi",
 			},
 			wantErr: false,
 			expectExtension: NewSandboxRequestExtension{
@@ -279,8 +281,14 @@ func TestParseExtensions(t *testing.T) {
 				ReservePausedSandboxDuration: timeout.ReservePausedSandboxDurationForeverValue,
 				InplaceUpdate: InplaceUpdateExtension{
 					Resources: &InplaceUpdateResourcesExtension{
-						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
-						Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
 					},
 				},
 			},
@@ -307,6 +315,13 @@ func TestParseExtensions(t *testing.T) {
 			name: "invalid cpu target - zero",
 			metadata: map[string]string{
 				ExtensionKeyClaimWithCPURequest: "0",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid memory target - zero",
+			metadata: map[string]string{
+				ExtensionKeyClaimWithMemoryLimit: "0",
 			},
 			wantErr: true,
 		},
@@ -513,6 +528,13 @@ func TestParseAndRemoveQuantity(t *testing.T) {
 			expectOK:  true,
 			expectQty: resource.MustParse("1500m"),
 		},
+		{
+			name:      "valid memory quantity",
+			metadata:  map[string]string{ExtensionKeyClaimWithMemoryRequest: "512Mi"},
+			key:       ExtensionKeyClaimWithMemoryRequest,
+			expectOK:  true,
+			expectQty: resource.MustParse("512Mi"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -558,6 +580,13 @@ func TestParseExtensions_ErrorPropagation(t *testing.T) {
 				ExtensionKeyClaimWithCPULimit: "bad-limit",
 			},
 			expectError: "invalid quantity for " + ExtensionKeyClaimWithCPULimit,
+		},
+		{
+			name: "invalid memory limit error propagates",
+			metadata: map[string]string{
+				ExtensionKeyClaimWithMemoryLimit: "bad-limit",
+			},
+			expectError: "invalid quantity for " + ExtensionKeyClaimWithMemoryLimit,
 		},
 		{
 			name: "invalid multi CSI mount JSON error propagates",

--- a/pkg/utils/inplaceupdate/inplace_update.go
+++ b/pkg/utils/inplaceupdate/inplace_update.go
@@ -432,7 +432,7 @@ func (c *InPlaceUpdateControl) Update(ctx context.Context, opts InPlaceUpdateOpt
 
 	current := pod.DeepCopy()
 	// In-place update involves two sub-operations:
-	//   1. Resource resize  — adjust CPU via the pods/resize subresource.
+	//   1. Resource resize  — adjust compute resources via the pods/resize subresource.
 	//   2. Metadata/image patch — update container images and the pod-template-hash annotation.
 	//
 	// The pod-template-hash annotation is the authoritative signal that the upgrade has completed.
@@ -496,19 +496,20 @@ func (c *InPlaceUpdateControl) Update(ctx context.Context, opts InPlaceUpdateOpt
 	return true, nil
 }
 
-// resizePod applies a resource resize to the pod. It uses the pods/resize subresource
+// resizePod applies a resource resize to the pod. It patches the pods/resize subresource
 // on K8s >= 1.33 (see https://kubernetes.io/blog/2025/05/16/kubernetes-v1-33-in-place-pod-resize-beta/),
 // and falls back to a direct strategic merge patch on older versions (K8s 1.27-1.32).
 // The detection result is cached so the subresource is only probed once per controller lifetime.
 func (c *InPlaceUpdateControl) resizePod(ctx context.Context, logger klog.Logger, pod *corev1.Pod, resizeBody *corev1.Pod) error {
 	if !c.useDirectResourcePatch.Load() {
-		err := c.SubResource("resize").Update(ctx, pod, client.WithSubResourceBody(resizeBody))
+		resourcePatch := buildResourcePatch(resizeBody)
+		err := c.SubResource("resize").Patch(ctx, pod, client.RawPatch(types.StrategicMergePatchType, []byte(resourcePatch)))
 		if err == nil {
-			logger.Info("inplace update pod resize succeeded via resize subresource (K8s >= 1.33)")
+			logger.Info("inplace update pod resize succeeded via resize subresource patch (K8s >= 1.33)")
 			return nil
 		}
 		if !apierrors.IsNotFound(err) {
-			logger.Error(err, "inplace update pod resize failed via resize subresource")
+			logger.Error(err, "inplace update pod resize failed via resize subresource patch")
 			return err
 		}
 		// The pods/resize subresource was introduced in K8s 1.33. On K8s 1.27-1.32,

--- a/pkg/utils/inplaceupdate/inplace_update.go
+++ b/pkg/utils/inplaceupdate/inplace_update.go
@@ -133,8 +133,8 @@ func (c *InPlaceUpdateControl) generatePatchBody(opts InPlaceUpdateOptions) stri
 	return c.generatePatchBodyFunc(opts)
 }
 
-func (c *InPlaceUpdateControl) generateResizeSubresourceBody(opts InPlaceUpdateOptions) *corev1.Pod {
-	return DefaultGenerateResizeSubresourceBody(opts)
+func (c *InPlaceUpdateControl) generateResizePatch(opts InPlaceUpdateOptions) string {
+	return DefaultGenerateResizePatch(opts)
 }
 
 func DefaultGeneratePatchBodyFunc(opts InPlaceUpdateOptions) string {
@@ -234,15 +234,21 @@ func buildContainerResourcesMap(containers []corev1.Container) map[string]corev1
 	return result
 }
 
-// DefaultGenerateResizeSubresourceBody generates the Pod body for resize subResource update.
-// It compares the current pod's container resources with the sandbox's container resources,
-// and returns a minimal Pod object containing only the fields required by the resize API:
-//   - metadata.name, metadata.namespace, metadata.resourceVersion
-//   - spec.containers[].resources
+// DefaultGenerateResizePatch generates the strategic merge patch for in-place resize.
+// It compares the current pod's container resources with the sandbox's container resources
+// and returns a patch containing only spec.containers[].resources for changed regular containers.
 //
-// Only the main containers are processed; init containers are not resized.
-// Returns nil if no resource changes are detected.
-func DefaultGenerateResizeSubresourceBody(opts InPlaceUpdateOptions) *corev1.Pod {
+// Only regular containers are processed; init containers are not resized.
+// Returns an empty string if no resource changes are detected.
+func DefaultGenerateResizePatch(opts InPlaceUpdateOptions) string {
+	resizeContainers := buildResizeContainers(opts)
+	if len(resizeContainers) == 0 {
+		return ""
+	}
+	return buildResourcePatch(resizeContainers)
+}
+
+func buildResizeContainers(opts InPlaceUpdateOptions) []corev1.Container {
 	box, pod := opts.Box, opts.Pod
 	if box.Spec.Template == nil {
 		return nil
@@ -250,33 +256,9 @@ func DefaultGenerateResizeSubresourceBody(opts InPlaceUpdateOptions) *corev1.Pod
 
 	originContainers := buildContainerResourcesMap(box.Spec.Template.Spec.Containers)
 
-	resizeBody := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            pod.Name,
-			Namespace:       pod.Namespace,
-			ResourceVersion: pod.ResourceVersion,
-		},
-		Spec: corev1.PodSpec{
-			Containers:     make([]corev1.Container, len(pod.Spec.Containers)),
-			InitContainers: make([]corev1.Container, len(pod.Spec.InitContainers)),
-		},
-	}
+	resizeContainers := make([]corev1.Container, 0, len(pod.Spec.Containers))
 	for i := range pod.Spec.Containers {
-		resizeBody.Spec.Containers[i] = corev1.Container{
-			Name:      pod.Spec.Containers[i].Name,
-			Resources: pod.Spec.Containers[i].Resources,
-		}
-	}
-	for i := range pod.Spec.InitContainers {
-		resizeBody.Spec.InitContainers[i] = corev1.Container{
-			Name:      pod.Spec.InitContainers[i].Name,
-			Resources: pod.Spec.InitContainers[i].Resources,
-		}
-	}
-
-	changed := false
-	for i := range resizeBody.Spec.Containers {
-		container := &resizeBody.Spec.Containers[i]
+		container := &pod.Spec.Containers[i]
 		origin, ok := originContainers[container.Name]
 		if !ok {
 			continue
@@ -286,27 +268,32 @@ func DefaultGenerateResizeSubresourceBody(opts InPlaceUpdateOptions) *corev1.Pod
 		}
 		// Merge origin resources into container, preserving system-injected fields
 		// (e.g., ephemeral-storage) that are not specified in the sandbox spec.
-		mergeResourceList(container.Resources.Limits, origin.Resources.Limits)
-		mergeResourceList(container.Resources.Requests, origin.Resources.Requests)
-		changed = true
+		resources := *container.Resources.DeepCopy()
+		if resources.Limits == nil && len(origin.Resources.Limits) > 0 {
+			resources.Limits = corev1.ResourceList{}
+		}
+		if resources.Requests == nil && len(origin.Resources.Requests) > 0 {
+			resources.Requests = corev1.ResourceList{}
+		}
+		mergeResourceList(resources.Limits, origin.Resources.Limits)
+		mergeResourceList(resources.Requests, origin.Resources.Requests)
+		resizeContainers = append(resizeContainers, corev1.Container{
+			Name:      container.Name,
+			Resources: resources,
+		})
 	}
-	if !changed {
-		return nil
-	}
-	return resizeBody
+	return resizeContainers
 }
 
-// buildResourcePatch converts a resize body (as produced by generateResizeSubresourceBody)
-// into a strategic merge patch that can be applied directly to the pod object. This is
-// the fallback path for K8s 1.27-1.32, where InPlacePodVerticalScaling is supported but
-// the pods/resize subresource does not yet exist.
-func buildResourcePatch(resizeBody *corev1.Pod) string {
+// buildResourcePatch converts resize containers into a strategic merge patch that can be
+// applied to either the pods/resize subresource or directly to the pod object.
+func buildResourcePatch(resizeContainers []corev1.Container) string {
 	type containerPatch struct {
 		Name      string                      `json:"name"`
 		Resources corev1.ResourceRequirements `json:"resources"`
 	}
-	var containers []containerPatch
-	for _, c := range resizeBody.Spec.Containers {
+	containers := make([]containerPatch, 0, len(resizeContainers))
+	for _, c := range resizeContainers {
 		containers = append(containers, containerPatch{
 			Name:      c.Name,
 			Resources: c.Resources,
@@ -443,18 +430,16 @@ func (c *InPlaceUpdateControl) Update(ctx context.Context, opts InPlaceUpdateOpt
 	// do we apply the metadata/image patch to finalize the upgrade.
 
 	// Step 1: perform resize (resource adjustment)
-	resizeBody := c.generateResizeSubresourceBody(InPlaceUpdateOptions{
+	resizePatch := c.generateResizePatch(InPlaceUpdateOptions{
 		Box:      box,
 		Revision: revision,
-		// Use `current` (the post-patch pod) instead of the original `pod` so that
-		// generateResizeSubresourceBody picks up the latest ResourceVersion set by
-		// the patch response, avoiding "the object has been modified" conflicts on
-		// the subsequent resize sub-resource call.
+		// Use `current` instead of the original `pod` so the patch is generated
+		// from the latest resource state during conflict retries.
 		Pod: current,
 	})
-	if resizeBody != nil {
+	if resizePatch != "" {
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			err := c.resizePod(ctx, logger, current, resizeBody)
+			err := c.resizePod(ctx, logger, current, resizePatch)
 			if !apierrors.IsConflict(err) {
 				return err
 			}
@@ -464,12 +449,12 @@ func (c *InPlaceUpdateControl) Update(ctx context.Context, opts InPlaceUpdateOpt
 				return getErr
 			}
 			current = latestPod
-			resizeBody = c.generateResizeSubresourceBody(InPlaceUpdateOptions{
+			resizePatch = c.generateResizePatch(InPlaceUpdateOptions{
 				Box:      box,
 				Revision: revision,
 				Pod:      current,
 			})
-			if resizeBody == nil {
+			if resizePatch == "" {
 				return nil
 			}
 
@@ -489,10 +474,10 @@ func (c *InPlaceUpdateControl) Update(ctx context.Context, opts InPlaceUpdateOpt
 		}
 	}
 
-	if patchBody == "" && resizeBody == nil {
+	if patchBody == "" && resizePatch == "" {
 		return false, nil
 	}
-	logger.Info("inplace update pod success", "revision", revision, "patchBody", patchBody, "hasResizeBody", resizeBody != nil)
+	logger.Info("inplace update pod success", "revision", revision, "patchBody", patchBody, "hasResizePatch", resizePatch != "")
 	return true, nil
 }
 
@@ -500,9 +485,8 @@ func (c *InPlaceUpdateControl) Update(ctx context.Context, opts InPlaceUpdateOpt
 // on K8s >= 1.33 (see https://kubernetes.io/blog/2025/05/16/kubernetes-v1-33-in-place-pod-resize-beta/),
 // and falls back to a direct strategic merge patch on older versions (K8s 1.27-1.32).
 // The detection result is cached so the subresource is only probed once per controller lifetime.
-func (c *InPlaceUpdateControl) resizePod(ctx context.Context, logger klog.Logger, pod *corev1.Pod, resizeBody *corev1.Pod) error {
+func (c *InPlaceUpdateControl) resizePod(ctx context.Context, logger klog.Logger, pod *corev1.Pod, resourcePatch string) error {
 	if !c.useDirectResourcePatch.Load() {
-		resourcePatch := buildResourcePatch(resizeBody)
 		err := c.SubResource("resize").Patch(ctx, pod, client.RawPatch(types.StrategicMergePatchType, []byte(resourcePatch)))
 		if err == nil {
 			logger.Info("inplace update pod resize succeeded via resize subresource patch (K8s >= 1.33)")
@@ -517,12 +501,11 @@ func (c *InPlaceUpdateControl) resizePod(ctx context.Context, logger klog.Logger
 		logger.Info("resize subresource not found, switching to direct resource patch (K8s < 1.33)")
 		c.useDirectResourcePatch.Store(true)
 	}
-	return c.patchPodResources(ctx, logger, pod, resizeBody)
+	return c.patchPodResources(ctx, logger, pod, resourcePatch)
 }
 
 // patchPodResources applies a strategic merge patch to update pod resources directly.
-func (c *InPlaceUpdateControl) patchPodResources(ctx context.Context, logger klog.Logger, pod *corev1.Pod, resizeBody *corev1.Pod) error {
-	resourcePatch := buildResourcePatch(resizeBody)
+func (c *InPlaceUpdateControl) patchPodResources(ctx context.Context, logger klog.Logger, pod *corev1.Pod, resourcePatch string) error {
 	if err := c.Patch(ctx, pod, client.RawPatch(types.StrategicMergePatchType, []byte(resourcePatch))); err != nil {
 		if apierrors.IsConflict(err) {
 			logger.Error(err, "direct resource patch conflicted")

--- a/pkg/utils/inplaceupdate/inplace_update.go
+++ b/pkg/utils/inplaceupdate/inplace_update.go
@@ -317,11 +317,32 @@ func CheckResizeQoSChange(box *agentsv1alpha1.Sandbox, pod *corev1.Pod) (orig, u
 	return orig, updated, orig != updated
 }
 
+// CheckContainerMemoryDownscale returns an error when any target memory
+// request or limit in the given resource lists is lower than the container's
+// current memory. In-place memory downscale is not supported: a lower target
+// would otherwise be silently treated as satisfied by the relaxed resource
+// comparison used in the resize path.
+func CheckContainerMemoryDownscale(container *corev1.Container, requests, limits corev1.ResourceList) error {
+	if cur, ok := container.Resources.Requests[corev1.ResourceMemory]; ok && !cur.IsZero() {
+		if target, has := requests[corev1.ResourceMemory]; has && !target.IsZero() && target.Cmp(cur) < 0 {
+			return memoryDownscaleError("request", target, cur)
+		}
+	}
+	if cur, ok := container.Resources.Limits[corev1.ResourceMemory]; ok && !cur.IsZero() {
+		if target, has := limits[corev1.ResourceMemory]; has && !target.IsZero() && target.Cmp(cur) < 0 {
+			return memoryDownscaleError("limit", target, cur)
+		}
+	}
+	return nil
+}
+
+func memoryDownscaleError(kind string, target, cur resource.Quantity) error {
+	return fmt.Errorf("target memory %s %s must not be lower than the current value %s: in-place memory downscale is not supported", kind, target.String(), cur.String())
+}
+
 // CheckMemoryDownscale returns an error if applying the sandbox template
 // resources to the pod would lower any container's memory request or limit
-// below its current value. In-place memory downscale is not supported: a lower
-// target would otherwise be silently treated as satisfied by the relaxed
-// resource comparison used in the resize path.
+// below its current value.
 func CheckMemoryDownscale(box *agentsv1alpha1.Sandbox, pod *corev1.Pod) error {
 	if box.Spec.Template == nil {
 		return nil
@@ -333,15 +354,8 @@ func CheckMemoryDownscale(box *agentsv1alpha1.Sandbox, pod *corev1.Pod) error {
 		if !ok {
 			continue
 		}
-		if cur, ok := container.Resources.Requests[corev1.ResourceMemory]; ok && !cur.IsZero() {
-			if target, has := desired.Resources.Requests[corev1.ResourceMemory]; has && !target.IsZero() && target.Cmp(cur) < 0 {
-				return fmt.Errorf("in-place memory downscale is not supported: container %q memory request %s is lower than the current value %s", container.Name, target.String(), cur.String())
-			}
-		}
-		if cur, ok := container.Resources.Limits[corev1.ResourceMemory]; ok && !cur.IsZero() {
-			if target, has := desired.Resources.Limits[corev1.ResourceMemory]; has && !target.IsZero() && target.Cmp(cur) < 0 {
-				return fmt.Errorf("in-place memory downscale is not supported: container %q memory limit %s is lower than the current value %s", container.Name, target.String(), cur.String())
-			}
+		if err := CheckContainerMemoryDownscale(container, desired.Resources.Requests, desired.Resources.Limits); err != nil {
+			return fmt.Errorf("container %q: %w", container.Name, err)
 		}
 	}
 	return nil

--- a/pkg/utils/inplaceupdate/inplace_update.go
+++ b/pkg/utils/inplaceupdate/inplace_update.go
@@ -409,7 +409,7 @@ func (c *InPlaceUpdateControl) Update(ctx context.Context, opts InPlaceUpdateOpt
 
 	current := pod.DeepCopy()
 	// In-place update involves two sub-operations:
-	//   1. Resource resize  — adjust CPU via the pods/resize subresource.
+	//   1. Resource resize  — adjust compute resources via the pods/resize subresource.
 	//   2. Metadata/image patch — update container images and the pod-template-hash annotation.
 	//
 	// The pod-template-hash annotation is the authoritative signal that the upgrade has completed.
@@ -479,11 +479,11 @@ func (c *InPlaceUpdateControl) resizeContainers(ctx context.Context, logger klog
 	if !c.useDirectResourcePatch.Load() {
 		err := c.SubResource("resize").Patch(ctx, pod, client.RawPatch(types.StrategicMergePatchType, []byte(resourcePatch)))
 		if err == nil {
-			logger.Info("inplace update pod resize succeeded via resize subresource (K8s >= 1.33)")
+			logger.Info("inplace update pod resize succeeded via resize subresource patch (K8s >= 1.33)")
 			return nil
 		}
 		if !apierrors.IsNotFound(err) {
-			logger.Error(err, "inplace update pod resize failed via resize subresource")
+			logger.Error(err, "inplace update pod resize failed via resize subresource patch")
 			return err
 		}
 		// The pods/resize subresource was introduced in K8s 1.33. On K8s 1.27-1.32,

--- a/pkg/utils/inplaceupdate/inplace_update.go
+++ b/pkg/utils/inplaceupdate/inplace_update.go
@@ -317,6 +317,36 @@ func CheckResizeQoSChange(box *agentsv1alpha1.Sandbox, pod *corev1.Pod) (orig, u
 	return orig, updated, orig != updated
 }
 
+// CheckMemoryDownscale returns an error if applying the sandbox template
+// resources to the pod would lower any container's memory request or limit
+// below its current value. In-place memory downscale is not supported: a lower
+// target would otherwise be silently treated as satisfied by the relaxed
+// resource comparison used in the resize path.
+func CheckMemoryDownscale(box *agentsv1alpha1.Sandbox, pod *corev1.Pod) error {
+	if box.Spec.Template == nil {
+		return nil
+	}
+	templateContainers := buildContainerResourcesMap(box.Spec.Template.Spec.Containers)
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		desired, ok := templateContainers[container.Name]
+		if !ok {
+			continue
+		}
+		if cur, ok := container.Resources.Requests[corev1.ResourceMemory]; ok && !cur.IsZero() {
+			if target, has := desired.Resources.Requests[corev1.ResourceMemory]; has && !target.IsZero() && target.Cmp(cur) < 0 {
+				return fmt.Errorf("in-place memory downscale is not supported: container %q memory request %s is lower than the current value %s", container.Name, target.String(), cur.String())
+			}
+		}
+		if cur, ok := container.Resources.Limits[corev1.ResourceMemory]; ok && !cur.IsZero() {
+			if target, has := desired.Resources.Limits[corev1.ResourceMemory]; has && !target.IsZero() && target.Cmp(cur) < 0 {
+				return fmt.Errorf("in-place memory downscale is not supported: container %q memory limit %s is lower than the current value %s", container.Name, target.String(), cur.String())
+			}
+		}
+	}
+	return nil
+}
+
 var zeroQuantity = resource.MustParse("0")
 
 func isSupportedQoSComputeResource(name corev1.ResourceName) bool {

--- a/pkg/utils/inplaceupdate/inplace_update_test.go
+++ b/pkg/utils/inplaceupdate/inplace_update_test.go
@@ -833,8 +833,8 @@ func TestInPlaceUpdateControl_Update_ResizeConflictRetryNoLongerNeeded(t *testin
 			}
 			resizeAttempts++
 			// Simulate that another actor has already applied the resize, so
-			// recomputing resizeBody from the latest pod returns nil and the
-			// retry loop should exit successfully without a re-attempt.
+			// recomputing the resize patch from the latest pod returns empty
+			// and the retry loop should exit successfully without a re-attempt.
 			latest := &corev1.Pod{}
 			if err := c.Get(ctx, client.ObjectKeyFromObject(obj), latest); err != nil {
 				return err
@@ -965,18 +965,13 @@ func TestInPlaceUpdateControl_PatchPodResources_Conflict(t *testing.T) {
 	})
 	ctrl := NewInPlaceUpdateControl(wrapped, nil)
 
-	resizeBody := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name: "c",
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
-				},
-			}},
+	resourcePatch := buildResourcePatch([]corev1.Container{{
+		Name: "c",
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
 		},
-	}
-	err := ctrl.patchPodResources(context.Background(), klog.NewKlogr(), pod, resizeBody)
+	}})
+	err := ctrl.patchPodResources(context.Background(), klog.NewKlogr(), pod, resourcePatch)
 	if err == nil {
 		t.Fatalf("expected error from conflicted patch")
 	}
@@ -1166,8 +1161,8 @@ func TestResizeNotSupportedError(t *testing.T) {
 	}
 }
 
-func TestBuildResourcePatch(t *testing.T) {
-	body := &corev1.Pod{
+func TestDefaultGenerateResizePatch(t *testing.T) {
+	pod := &corev1.Pod{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
@@ -1181,11 +1176,61 @@ func TestBuildResourcePatch(t *testing.T) {
 						},
 					},
 				},
-				{Name: "c2"},
+				{
+					Name: "c2",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("10m"),
+						},
+					},
+				},
+			},
+			InitContainers: []corev1.Container{
+				{
+					Name: "init",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("50m"),
+						},
+					},
+				},
 			},
 		},
 	}
-	patch := buildResourcePatch(body)
+	patch := DefaultGenerateResizePatch(InPlaceUpdateOptions{
+		Box: &agentsv1alpha1.Sandbox{
+			Spec: agentsv1alpha1.SandboxSpec{
+				EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "c1",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU: resource.MustParse("500m"),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceMemory: resource.MustParse("256Mi"),
+										},
+									},
+								},
+								{
+									Name: "c2",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU: resource.MustParse("20m"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Pod: pod,
+	})
 	if patch == "" {
 		t.Fatalf("expected non-empty patch")
 	}
@@ -1207,20 +1252,27 @@ func TestBuildResourcePatch(t *testing.T) {
 	if _, exists := parsed["metadata"]; exists {
 		t.Fatalf("resource patch should not include metadata")
 	}
+	if _, exists := spec["initContainers"]; exists {
+		t.Fatalf("resource patch should not include initContainers")
+	}
+	cpuReq := pod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	if cpuReq.Cmp(resource.MustParse("250m")) != 0 {
+		t.Fatalf("generating patch mutated pod resources: got %s", cpuReq.String())
+	}
 }
 
-func TestDefaultGenerateResizeSubresourceBody_NilTemplateAndNoChange(t *testing.T) {
-	if got := DefaultGenerateResizeSubresourceBody(InPlaceUpdateOptions{
+func TestDefaultGenerateResizePatch_NilTemplateAndNoChange(t *testing.T) {
+	if got := DefaultGenerateResizePatch(InPlaceUpdateOptions{
 		Box: &agentsv1alpha1.Sandbox{},
 		Pod: &corev1.Pod{},
-	}); got != nil {
-		t.Fatalf("expected nil body when template is nil, got %+v", got)
+	}); got != "" {
+		t.Fatalf("expected empty patch when template is nil, got %s", got)
 	}
 
 	identical := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
 	}
-	body := DefaultGenerateResizeSubresourceBody(InPlaceUpdateOptions{
+	patch := DefaultGenerateResizePatch(InPlaceUpdateOptions{
 		Box: &agentsv1alpha1.Sandbox{
 			Spec: agentsv1alpha1.SandboxSpec{
 				EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
@@ -1244,8 +1296,8 @@ func TestDefaultGenerateResizeSubresourceBody_NilTemplateAndNoChange(t *testing.
 			},
 		},
 	})
-	if body != nil {
-		t.Fatalf("expected nil body when no resource changes, got %+v", body)
+	if patch != "" {
+		t.Fatalf("expected empty patch when no resource changes, got %s", patch)
 	}
 }
 
@@ -1652,13 +1704,12 @@ func TestResourceOnlyUpdatePayloads(t *testing.T) {
 		t.Fatalf("resource-only patch should not contain spec, got: %s", patchBody)
 	}
 
-	resizeBody := DefaultGenerateResizeSubresourceBody(opts)
-	if resizeBody == nil {
-		t.Fatalf("expected resize subresource body")
+	resizePatch := DefaultGenerateResizePatch(opts)
+	if resizePatch == "" {
+		t.Fatalf("expected resize patch")
 	}
-	got := resizeBody.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
-	if got.MilliValue() != 1000 {
-		t.Fatalf("expected cpu request=1000m, got=%dm", got.MilliValue())
+	if !strings.Contains(resizePatch, `"spec"`) {
+		t.Fatalf("resize patch should contain spec, got: %s", resizePatch)
 	}
 }
 
@@ -2264,19 +2315,16 @@ func TestComputeQoSClass(t *testing.T) {
 	}
 }
 
-func TestDefaultGenerateResizeSubresourceBody_MinimalFields(t *testing.T) {
+func TestBuildResizeContainers_MinimalFields(t *testing.T) {
 	tests := []struct {
 		name                   string
 		box                    *agentsv1alpha1.Sandbox
 		pod                    *corev1.Pod
-		expectNil              bool
 		expectContainerCount   int
-		expectInitCount        int
 		verifyContainerMinimal bool
-		verifyInitMinimal      bool
 	}{
 		{
-			name: "main containers have no Image field in resizeBody",
+			name: "main containers have no Image field",
 			box: &agentsv1alpha1.Sandbox{
 				Spec: agentsv1alpha1.SandboxSpec{
 					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
@@ -2314,13 +2362,11 @@ func TestDefaultGenerateResizeSubresourceBody_MinimalFields(t *testing.T) {
 					},
 				},
 			},
-			expectNil:              false,
 			expectContainerCount:   1,
-			expectInitCount:        0,
 			verifyContainerMinimal: true,
 		},
 		{
-			name: "initContainers only contain Name and Resources",
+			name: "initContainers are omitted",
 			box: &agentsv1alpha1.Sandbox{
 				Spec: agentsv1alpha1.SandboxSpec{
 					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
@@ -2382,10 +2428,7 @@ func TestDefaultGenerateResizeSubresourceBody_MinimalFields(t *testing.T) {
 					},
 				},
 			},
-			expectNil:            false,
 			expectContainerCount: 1,
-			expectInitCount:      2,
-			verifyInitMinimal:    true,
 		},
 		{
 			name: "multiple containers all minimal",
@@ -2438,37 +2481,23 @@ func TestDefaultGenerateResizeSubresourceBody_MinimalFields(t *testing.T) {
 					},
 				},
 			},
-			expectNil:              false,
 			expectContainerCount:   2,
-			expectInitCount:        0,
 			verifyContainerMinimal: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			body := DefaultGenerateResizeSubresourceBody(InPlaceUpdateOptions{
+			containers := buildResizeContainers(InPlaceUpdateOptions{
 				Box: tt.box,
 				Pod: tt.pod,
 			})
-			if tt.expectNil {
-				if body != nil {
-					t.Fatalf("expected nil body, got %+v", body)
-				}
-				return
-			}
-			if body == nil {
-				t.Fatalf("expected non-nil body")
-			}
-			if len(body.Spec.Containers) != tt.expectContainerCount {
-				t.Fatalf("expected %d containers, got %d", tt.expectContainerCount, len(body.Spec.Containers))
-			}
-			if len(body.Spec.InitContainers) != tt.expectInitCount {
-				t.Fatalf("expected %d initContainers, got %d", tt.expectInitCount, len(body.Spec.InitContainers))
+			if len(containers) != tt.expectContainerCount {
+				t.Fatalf("expected %d containers, got %d", tt.expectContainerCount, len(containers))
 			}
 
 			if tt.verifyContainerMinimal {
-				for i, c := range body.Spec.Containers {
+				for i, c := range containers {
 					if c.Image != "" {
 						t.Errorf("container[%d] %q should have empty Image, got %q", i, c.Name, c.Image)
 					}
@@ -2484,27 +2513,6 @@ func TestDefaultGenerateResizeSubresourceBody_MinimalFields(t *testing.T) {
 				}
 			}
 
-			if tt.verifyInitMinimal {
-				for i, c := range body.Spec.InitContainers {
-					if c.Image != "" {
-						t.Errorf("initContainer[%d] %q should have empty Image, got %q", i, c.Name, c.Image)
-					}
-					if c.Name == "" {
-						t.Errorf("initContainer[%d] should have a Name", i)
-					}
-					if len(c.VolumeMounts) > 0 {
-						t.Errorf("initContainer[%d] %q should have no VolumeMounts", i, c.Name)
-					}
-					if len(c.Command) > 0 {
-						t.Errorf("initContainer[%d] %q should have no Command", i, c.Name)
-					}
-					// Verify that Resources are preserved
-					podInit := tt.pod.Spec.InitContainers[i]
-					if c.Resources.Requests == nil && podInit.Resources.Requests != nil {
-						t.Errorf("initContainer[%d] %q lost its Resources.Requests", i, c.Name)
-					}
-				}
-			}
 		})
 	}
 }
@@ -2876,7 +2884,7 @@ func TestResourcesEqual(t *testing.T) {
 	}
 }
 
-func TestDefaultGenerateResizeSubresourceBody_NoResizeWhenExtraOrUnitDiff(t *testing.T) {
+func TestDefaultGenerateResizePatch_NoResizeWhenExtraOrUnitDiff(t *testing.T) {
 	tests := []struct {
 		name string
 		box  *agentsv1alpha1.Sandbox
@@ -2982,12 +2990,12 @@ func TestDefaultGenerateResizeSubresourceBody_NoResizeWhenExtraOrUnitDiff(t *tes
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := DefaultGenerateResizeSubresourceBody(InPlaceUpdateOptions{
+			result := DefaultGenerateResizePatch(InPlaceUpdateOptions{
 				Box: tt.box,
 				Pod: tt.pod,
 			})
-			if result != nil {
-				t.Errorf("expected nil (no resize needed), but got a resize body")
+			if result != "" {
+				t.Errorf("expected empty patch (no resize needed), got %s", result)
 			}
 		})
 	}
@@ -3059,7 +3067,7 @@ func TestMergeResourceList(t *testing.T) {
 	}
 }
 
-func TestDefaultGenerateResizeSubresourceBody_PreservesSystemInjectedFields(t *testing.T) {
+func TestBuildResizeContainers_PreservesSystemInjectedFields(t *testing.T) {
 	tests := []struct {
 		name string
 		box  *agentsv1alpha1.Sandbox
@@ -3121,17 +3129,14 @@ func TestDefaultGenerateResizeSubresourceBody_PreservesSystemInjectedFields(t *t
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := DefaultGenerateResizeSubresourceBody(InPlaceUpdateOptions{
+			result := buildResizeContainers(InPlaceUpdateOptions{
 				Box: tt.box,
 				Pod: tt.pod,
 			})
-			if result == nil {
-				t.Fatalf("expected non-nil resize body, but got nil")
+			if len(result) == 0 {
+				t.Fatalf("expected at least one container")
 			}
-			if len(result.Spec.Containers) == 0 {
-				t.Fatalf("expected at least one container in resize body")
-			}
-			c := result.Spec.Containers[0]
+			c := result[0]
 
 			gotEphemeral, ok := c.Resources.Requests[corev1.ResourceEphemeralStorage]
 			if !ok {

--- a/pkg/utils/inplaceupdate/inplace_update_test.go
+++ b/pkg/utils/inplaceupdate/inplace_update_test.go
@@ -51,6 +51,34 @@ func buildTestScheme(t *testing.T) *runtime.Scheme {
 	return scheme
 }
 
+func applyResizeSubresourcePatch(ctx context.Context, c client.Client, obj client.Object, patch client.Patch) error {
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+	resizePatch := struct {
+		Spec struct {
+			Containers []corev1.Container `json:"containers"`
+		} `json:"spec"`
+	}{}
+	if err := json.Unmarshal(data, &resizePatch); err != nil {
+		return err
+	}
+
+	existing := &corev1.Pod{}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), existing); err != nil {
+		return err
+	}
+	for i, container := range existing.Spec.Containers {
+		for _, patchContainer := range resizePatch.Spec.Containers {
+			if patchContainer.Name == container.Name {
+				existing.Spec.Containers[i].Resources = patchContainer.Resources
+			}
+		}
+	}
+	return c.Update(ctx, existing)
+}
+
 func TestGetPodInPlaceUpdateState(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -354,6 +382,12 @@ func TestInPlaceUpdateControl_Update_ResizeViaSubresource(t *testing.T) {
 			Containers: []corev1.Container{{
 				Name:  "c",
 				Image: "img:1",
+				ResizePolicy: []corev1.ContainerResizePolicy{
+					{
+						ResourceName:  corev1.ResourceMemory,
+						RestartPolicy: corev1.RestartContainer,
+					},
+				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
 				},
@@ -381,34 +415,20 @@ func TestInPlaceUpdateControl_Update_ResizeViaSubresource(t *testing.T) {
 	resizeCalls := 0
 	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
 	wrapped := interceptor.NewClient(base, interceptor.Funcs{
-		SubResourceUpdate: func(ctx context.Context, c client.Client, sub string, obj client.Object,
-			opts ...client.SubResourceUpdateOption) error {
+		SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object,
+			patch client.Patch, opts ...client.SubResourcePatchOption) error {
 			if sub != "resize" {
-				return c.SubResource(sub).Update(ctx, obj, opts...)
+				return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
 			}
 			resizeCalls++
-			body := obj
-			updateOpts := &client.SubResourceUpdateOptions{}
-			updateOpts.ApplyOptions(opts)
-			if updateOpts.SubResourceBody != nil {
-				body = updateOpts.SubResourceBody
-			}
-			resizePod, ok := body.(*corev1.Pod)
-			if !ok {
-				return fmt.Errorf("expected *corev1.Pod, got %T", body)
-			}
-			existing := &corev1.Pod{}
-			if err := c.Get(ctx, client.ObjectKeyFromObject(obj), existing); err != nil {
+			data, err := patch.Data(obj)
+			if err != nil {
 				return err
 			}
-			for i, container := range existing.Spec.Containers {
-				for _, rc := range resizePod.Spec.Containers {
-					if rc.Name == container.Name {
-						existing.Spec.Containers[i].Resources = rc.Resources
-					}
-				}
+			if strings.Contains(string(data), "resizePolicy") {
+				return fmt.Errorf("resize subresource patch must not include resizePolicy: %s", string(data))
 			}
-			return c.Update(ctx, existing)
+			return applyResizeSubresourcePatch(ctx, c, obj, patch)
 		},
 	})
 
@@ -478,13 +498,13 @@ func TestInPlaceUpdateControl_Update_ResizeFallbackToDirectPatch(t *testing.T) {
 	patchCalls := 0
 	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
 	wrapped := interceptor.NewClient(base, interceptor.Funcs{
-		SubResourceUpdate: func(ctx context.Context, c client.Client, sub string, obj client.Object,
-			opts ...client.SubResourceUpdateOption) error {
+		SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object,
+			patch client.Patch, opts ...client.SubResourcePatchOption) error {
 			if sub == "resize" {
 				subCalls++
 				return apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, obj.GetName())
 			}
-			return c.SubResource(sub).Update(ctx, obj, opts...)
+			return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
 		},
 		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch,
 			opts ...client.PatchOption) error {
@@ -571,12 +591,12 @@ func TestInPlaceUpdateControl_Update_ResizeNotSupported(t *testing.T) {
 
 	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
 	wrapped := interceptor.NewClient(base, interceptor.Funcs{
-		SubResourceUpdate: func(ctx context.Context, c client.Client, sub string, obj client.Object,
-			opts ...client.SubResourceUpdateOption) error {
+		SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object,
+			patch client.Patch, opts ...client.SubResourcePatchOption) error {
 			if sub == "resize" {
 				return apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, obj.GetName())
 			}
-			return c.SubResource(sub).Update(ctx, obj, opts...)
+			return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
 		},
 		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch,
 			opts ...client.PatchOption) error {
@@ -646,12 +666,12 @@ func TestInPlaceUpdateControl_Update_ResizeSubresourceServerError(t *testing.T) 
 
 	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
 	wrapped := interceptor.NewClient(base, interceptor.Funcs{
-		SubResourceUpdate: func(ctx context.Context, c client.Client, sub string, obj client.Object,
-			opts ...client.SubResourceUpdateOption) error {
+		SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object,
+			patch client.Patch, opts ...client.SubResourcePatchOption) error {
 			if sub == "resize" {
 				return apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
 			}
-			return c.SubResource(sub).Update(ctx, obj, opts...)
+			return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
 		},
 	})
 	ctrl := NewInPlaceUpdateControl(wrapped, nil)
@@ -716,10 +736,10 @@ func TestInPlaceUpdateControl_Update_ResizeConflictRetrySucceeds(t *testing.T) {
 	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
 	resizeAttempts := 0
 	wrapped := interceptor.NewClient(base, interceptor.Funcs{
-		SubResourceUpdate: func(ctx context.Context, c client.Client, sub string, obj client.Object,
-			opts ...client.SubResourceUpdateOption) error {
+		SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object,
+			patch client.Patch, opts ...client.SubResourcePatchOption) error {
 			if sub != "resize" {
-				return c.SubResource(sub).Update(ctx, obj, opts...)
+				return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
 			}
 			resizeAttempts++
 			if resizeAttempts == 1 {
@@ -740,25 +760,7 @@ func TestInPlaceUpdateControl_Update_ResizeConflictRetrySucceeds(t *testing.T) {
 				)
 			}
 			// Subsequent attempts succeed and apply the resize.
-			body := obj
-			updateOpts := &client.SubResourceUpdateOptions{}
-			updateOpts.ApplyOptions(opts)
-			if updateOpts.SubResourceBody != nil {
-				body = updateOpts.SubResourceBody
-			}
-			rp := body.(*corev1.Pod)
-			existing := &corev1.Pod{}
-			if err := c.Get(ctx, client.ObjectKeyFromObject(obj), existing); err != nil {
-				return err
-			}
-			for i, container := range existing.Spec.Containers {
-				for _, rc := range rp.Spec.Containers {
-					if rc.Name == container.Name {
-						existing.Spec.Containers[i].Resources = rc.Resources
-					}
-				}
-			}
-			return c.Update(ctx, existing)
+			return applyResizeSubresourcePatch(ctx, c, obj, patch)
 		},
 	})
 	ctrl := NewInPlaceUpdateControl(wrapped, nil)
@@ -824,10 +826,10 @@ func TestInPlaceUpdateControl_Update_ResizeConflictRetryNoLongerNeeded(t *testin
 	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
 	resizeAttempts := 0
 	wrapped := interceptor.NewClient(base, interceptor.Funcs{
-		SubResourceUpdate: func(ctx context.Context, c client.Client, sub string, obj client.Object,
-			opts ...client.SubResourceUpdateOption) error {
+		SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object,
+			patch client.Patch, opts ...client.SubResourcePatchOption) error {
 			if sub != "resize" {
-				return c.SubResource(sub).Update(ctx, obj, opts...)
+				return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
 			}
 			resizeAttempts++
 			// Simulate that another actor has already applied the resize, so
@@ -903,10 +905,10 @@ func TestInPlaceUpdateControl_Update_ResizeConflictGetFails(t *testing.T) {
 	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
 	getFailErr := fmt.Errorf("simulated get failure after conflict")
 	wrapped := interceptor.NewClient(base, interceptor.Funcs{
-		SubResourceUpdate: func(ctx context.Context, c client.Client, sub string, obj client.Object,
-			opts ...client.SubResourceUpdateOption) error {
+		SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object,
+			patch client.Patch, opts ...client.SubResourcePatchOption) error {
 			if sub != "resize" {
-				return c.SubResource(sub).Update(ctx, obj, opts...)
+				return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
 			}
 			// Always return conflict to trigger the retry path
 			return apierrors.NewConflict(
@@ -2548,32 +2550,14 @@ func TestInPlaceUpdateControl_Update_ResizeBeforePatch(t *testing.T) {
 	var callOrder []string
 	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
 	wrapped := interceptor.NewClient(base, interceptor.Funcs{
-		SubResourceUpdate: func(ctx context.Context, c client.Client, sub string, obj client.Object,
-			opts ...client.SubResourceUpdateOption) error {
+		SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object,
+			patch client.Patch, opts ...client.SubResourcePatchOption) error {
 			if sub == "resize" {
 				callOrder = append(callOrder, "resize")
 				// Simulate a successful resize by applying resources
-				body := obj
-				updateOpts := &client.SubResourceUpdateOptions{}
-				updateOpts.ApplyOptions(opts)
-				if updateOpts.SubResourceBody != nil {
-					body = updateOpts.SubResourceBody
-				}
-				rp := body.(*corev1.Pod)
-				existing := &corev1.Pod{}
-				if err := c.Get(ctx, client.ObjectKeyFromObject(obj), existing); err != nil {
-					return err
-				}
-				for i, container := range existing.Spec.Containers {
-					for _, rc := range rp.Spec.Containers {
-						if rc.Name == container.Name {
-							existing.Spec.Containers[i].Resources = rc.Resources
-						}
-					}
-				}
-				return c.Update(ctx, existing)
+				return applyResizeSubresourcePatch(ctx, c, obj, patch)
 			}
-			return c.SubResource(sub).Update(ctx, obj, opts...)
+			return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
 		},
 		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch,
 			opts ...client.PatchOption) error {

--- a/pkg/utils/inplaceupdate/inplace_update_test.go
+++ b/pkg/utils/inplaceupdate/inplace_update_test.go
@@ -2689,6 +2689,106 @@ func TestCheckResizeQoSChange(t *testing.T) {
 	}
 }
 
+func TestCheckMemoryDownscale(t *testing.T) {
+	boxWithMemory := func(req, lim string) *agentsv1alpha1.Sandbox {
+		return &agentsv1alpha1.Sandbox{
+			Spec: agentsv1alpha1.SandboxSpec{
+				EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "main",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(req)},
+									Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(lim)},
+								},
+							}},
+						},
+					},
+				},
+			},
+		}
+	}
+	podWithMemory := func(req, lim string) *corev1.Pod {
+		return &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(req)},
+						Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(lim)},
+					},
+				}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		box         *agentsv1alpha1.Sandbox
+		pod         *corev1.Pod
+		expectError string
+	}{
+		{
+			name:        "lower memory request rejected",
+			box:         boxWithMemory("128Mi", "512Mi"),
+			pod:         podWithMemory("256Mi", "512Mi"),
+			expectError: "memory request 128Mi is lower than the current value 256Mi",
+		},
+		{
+			name:        "lower memory limit rejected",
+			box:         boxWithMemory("256Mi", "256Mi"),
+			pod:         podWithMemory("256Mi", "512Mi"),
+			expectError: "memory limit 256Mi is lower than the current value 512Mi",
+		},
+		{
+			name: "upscale accepted",
+			box:  boxWithMemory("512Mi", "1Gi"),
+			pod:  podWithMemory("256Mi", "512Mi"),
+		},
+		{
+			name: "equal accepted",
+			box:  boxWithMemory("256Mi", "512Mi"),
+			pod:  podWithMemory("256Mi", "512Mi"),
+		},
+		{
+			name: "container not in template ignored",
+			box:  boxWithMemory("128Mi", "512Mi"),
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "other",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+					},
+				}},
+			}},
+		},
+		{
+			name: "nil template accepted",
+			box:  &agentsv1alpha1.Sandbox{},
+			pod:  podWithMemory("256Mi", "512Mi"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckMemoryDownscale(tt.box, tt.pod)
+			if tt.expectError != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.expectError)
+				}
+				if !strings.Contains(err.Error(), tt.expectError) {
+					t.Fatalf("expected error containing %q, got %v", tt.expectError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestComputeQoSClass(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/utils/inplaceupdate/inplace_update_test.go
+++ b/pkg/utils/inplaceupdate/inplace_update_test.go
@@ -64,6 +64,51 @@ func mustGetInPlaceUpdateStateFromPod(t *testing.T, pod *corev1.Pod) *InPlaceUpd
 	return state
 }
 
+func applyResizeSubresourcePatch(ctx context.Context, c client.Client, obj client.Object, patch client.Patch) error {
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+	resizePatch := struct {
+		Spec struct {
+			Containers []corev1.Container `json:"containers"`
+		} `json:"spec"`
+	}{}
+	if err := json.Unmarshal(data, &resizePatch); err != nil {
+		return err
+	}
+
+	existing := &corev1.Pod{}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), existing); err != nil {
+		return err
+	}
+	for i := range existing.Spec.Containers {
+		for _, patchContainer := range resizePatch.Spec.Containers {
+			if patchContainer.Name != existing.Spec.Containers[i].Name {
+				continue
+			}
+			// The pods/resize subresource applies a strategic merge patch:
+			// resources.requests and resources.limits are merged key-wise,
+			// preserving unrelated entries such as ephemeral-storage or
+			// system-injected resources on the live pod.
+			resources := &existing.Spec.Containers[i].Resources
+			for name, quantity := range patchContainer.Resources.Requests {
+				if resources.Requests == nil {
+					resources.Requests = corev1.ResourceList{}
+				}
+				resources.Requests[name] = quantity
+			}
+			for name, quantity := range patchContainer.Resources.Limits {
+				if resources.Limits == nil {
+					resources.Limits = corev1.ResourceList{}
+				}
+				resources.Limits[name] = quantity
+			}
+		}
+	}
+	return c.Update(ctx, existing)
+}
+
 func TestGetPodInPlaceUpdateState(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -368,6 +413,12 @@ func TestInPlaceUpdateControl_Update_ResizeViaSubresource(t *testing.T) {
 			Containers: []corev1.Container{{
 				Name:  "c",
 				Image: "img:1",
+				ResizePolicy: []corev1.ContainerResizePolicy{
+					{
+						ResourceName:  corev1.ResourceMemory,
+						RestartPolicy: corev1.RestartContainer,
+					},
+				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("100m"),
@@ -408,7 +459,14 @@ func TestInPlaceUpdateControl_Update_ResizeViaSubresource(t *testing.T) {
 				return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
 			}
 			resizeCalls++
-			return c.Patch(ctx, obj, patch)
+			data, err := patch.Data(obj)
+			if err != nil {
+				return err
+			}
+			if strings.Contains(string(data), "resizePolicy") {
+				return fmt.Errorf("resize subresource patch must not include resizePolicy: %s", string(data))
+			}
+			return applyResizeSubresourcePatch(ctx, c, obj, patch)
 		},
 	})
 
@@ -753,7 +811,7 @@ func TestInPlaceUpdateControl_Update_ResizeConflictRetrySucceeds(t *testing.T) {
 				)
 			}
 			// Subsequent attempts succeed and apply the resize.
-			return c.Patch(ctx, obj, patch)
+			return applyResizeSubresourcePatch(ctx, c, obj, patch)
 		},
 	})
 	ctrl := NewInPlaceUpdateControl(wrapped, nil)
@@ -1221,6 +1279,9 @@ func TestBuildResourcePatch(t *testing.T) {
 	}
 	if _, exists := parsed["metadata"]; exists {
 		t.Fatalf("resource patch should not include metadata")
+	}
+	if _, exists := spec["initContainers"]; exists {
+		t.Fatalf("resource patch should not include initContainers")
 	}
 }
 
@@ -2987,7 +3048,8 @@ func TestInPlaceUpdateControl_Update_ResizeBeforePatch(t *testing.T) {
 			patch client.Patch, opts ...client.SubResourcePatchOption) error {
 			if sub == "resize" {
 				callOrder = append(callOrder, "resize")
-				return c.Patch(ctx, obj, patch)
+				// Simulate a successful resize by applying resources
+				return applyResizeSubresourcePatch(ctx, c, obj, patch)
 			}
 			return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
 		},

--- a/pkg/utils/inplaceupdate/inplace_update_test.go
+++ b/pkg/utils/inplaceupdate/inplace_update_test.go
@@ -2733,13 +2733,13 @@ func TestCheckMemoryDownscale(t *testing.T) {
 			name:        "lower memory request rejected",
 			box:         boxWithMemory("128Mi", "512Mi"),
 			pod:         podWithMemory("256Mi", "512Mi"),
-			expectError: "memory request 128Mi is lower than the current value 256Mi",
+			expectError: "target memory request 128Mi must not be lower than the current value 256Mi",
 		},
 		{
 			name:        "lower memory limit rejected",
 			box:         boxWithMemory("256Mi", "256Mi"),
 			pod:         podWithMemory("256Mi", "512Mi"),
-			expectError: "memory limit 256Mi is lower than the current value 512Mi",
+			expectError: "target memory limit 256Mi must not be lower than the current value 512Mi",
 		},
 		{
 			name: "upscale accepted",

--- a/test/e2e/sandboxclaim_test.go
+++ b/test/e2e/sandboxclaim_test.go
@@ -1071,6 +1071,165 @@ var _ = Describe("SandboxClaim", func() {
 			Expect(sidecar.Resources.Limits[corev1.ResourceCPU]).To(Equal(resource.MustParse("200m")))
 		})
 
+		It("should resize the main container without mutating init containers", func() {
+			By("Creating a SandboxSet with an init container")
+			initContainerSet := &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-pool-init-resize-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								InitContainers: []corev1.Container{
+									{
+										Name:    "init-setup",
+										Image:   "busybox:1.36",
+										Command: []string{"sh", "-c", "echo init-ready"},
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("50m"),
+												corev1.ResourceMemory: resource.MustParse("32Mi"),
+											},
+											Limits: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("100m"),
+												corev1.ResourceMemory: resource.MustParse("64Mi"),
+											},
+										},
+									},
+								},
+								Containers: []corev1.Container{
+									{
+										Name:  "main",
+										Image: "nginx:stable-alpine3.23",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("250m"),
+												corev1.ResourceMemory: resource.MustParse("128Mi"),
+											},
+											Limits: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("500m"),
+												corev1.ResourceMemory: resource.MustParse("256Mi"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, initContainerSet)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, initContainerSet) }()
+
+			By("Waiting for pool to be ready")
+			Eventually(func() int32 {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      initContainerSet.Name,
+					Namespace: initContainerSet.Namespace,
+				}, initContainerSet)
+				return initContainerSet.Status.AvailableReplicas
+			}, time.Minute*2, time.Second).Should(Equal(int32(1)))
+
+			var initWarmName string
+			findInitContainer := func(pod *corev1.Pod) *corev1.Container {
+				for i := range pod.Spec.InitContainers {
+					if pod.Spec.InitContainers[i].Name == "init-setup" {
+						return &pod.Spec.InitContainers[i]
+					}
+				}
+				return nil
+			}
+
+			By("Verifying the warm pod has the expected init container resources")
+			Eventually(func() bool {
+				sandboxList := &agentsv1alpha1.SandboxList{}
+				if err := k8sClient.List(ctx, sandboxList, client.InNamespace(namespace), client.MatchingLabels{
+					agentsv1alpha1.LabelSandboxPool: initContainerSet.Name,
+				}); err != nil || len(sandboxList.Items) != 1 {
+					return false
+				}
+				initWarmName = sandboxList.Items[0].Name
+
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      initWarmName,
+					Namespace: namespace,
+				}, pod); err != nil {
+					return false
+				}
+				initContainer := findInitContainer(pod)
+				if initContainer == nil || initContainer.Image != "busybox:1.36" {
+					return false
+				}
+				cpuReq, ok := initContainer.Resources.Requests[corev1.ResourceCPU]
+				if !ok || cpuReq.Cmp(resource.MustParse("50m")) != 0 {
+					return false
+				}
+				cpuLim, ok := initContainer.Resources.Limits[corev1.ResourceCPU]
+				return ok && cpuLim.Cmp(resource.MustParse("100m")) == 0
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Creating a SandboxClaim that resizes only the main container")
+			initContainerClaim := &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-claim-init-resize-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    initContainerSet.Name,
+					Replicas:        ptr.To(int32(1)),
+					SkipInitRuntime: true,
+					WaitReadyTimeout: &metav1.Duration{
+						Duration: 2 * time.Minute,
+					},
+					InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
+						Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("300m")},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, initContainerClaim)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, initContainerClaim) }()
+
+			By("Verifying claim completes")
+			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      initContainerClaim.Name,
+					Namespace: initContainerClaim.Namespace,
+				}, initContainerClaim)
+				return initContainerClaim.Status.Phase
+			}, time.Minute*3, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
+
+			By("Verifying main container CPU is resized and init container resources are unchanged")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      initWarmName,
+					Namespace: namespace,
+				}, pod); err != nil || len(pod.Spec.Containers) == 0 {
+					return false
+				}
+				mainReq, ok := pod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+				if !ok || mainReq.Cmp(resource.MustParse("300m")) != 0 {
+					return false
+				}
+				initContainer := findInitContainer(pod)
+				if initContainer == nil || initContainer.Image != "busybox:1.36" {
+					return false
+				}
+				initReq, ok := initContainer.Resources.Requests[corev1.ResourceCPU]
+				if !ok || initReq.Cmp(resource.MustParse("50m")) != 0 {
+					return false
+				}
+				initLim, ok := initContainer.Resources.Limits[corev1.ResourceCPU]
+				return ok && initLim.Cmp(resource.MustParse("100m")) == 0
+			}, time.Minute*2, time.Second).Should(BeTrue())
+		})
+
 		It("should apply CPU and memory resize when QoS class is preserved", func() {
 			By("Creating a SandboxClaim with both CPU and memory in requests/limits")
 			resourceResizeClaim := &agentsv1alpha1.SandboxClaim{

--- a/test/e2e/sandboxclaim_test.go
+++ b/test/e2e/sandboxclaim_test.go
@@ -287,7 +287,7 @@ var _ = Describe("SandboxClaim", func() {
 		})
 	})
 
-	Context("CPU resize on claim", func() {
+	Context("Resource resize on claim", func() {
 		var (
 			sandboxSet      *agentsv1alpha1.SandboxSet
 			sandboxClaim    *agentsv1alpha1.SandboxClaim
@@ -297,7 +297,7 @@ var _ = Describe("SandboxClaim", func() {
 		BeforeEach(func() {
 			sandboxSet = &agentsv1alpha1.SandboxSet{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("test-pool-cpu-resize-%d", time.Now().UnixNano()),
+					Name:      fmt.Sprintf("test-pool-resource-resize-%d", time.Now().UnixNano()),
 					Namespace: namespace,
 				},
 				Spec: agentsv1alpha1.SandboxSetSpec{
@@ -1071,11 +1071,11 @@ var _ = Describe("SandboxClaim", func() {
 			Expect(sidecar.Resources.Limits[corev1.ResourceCPU]).To(Equal(resource.MustParse("200m")))
 		})
 
-		It("should ignore memory in resize and only apply CPU", func() {
+		It("should apply CPU and memory resize when QoS class is preserved", func() {
 			By("Creating a SandboxClaim with both CPU and memory in requests/limits")
-			memIgnoreClaim := &agentsv1alpha1.SandboxClaim{
+			resourceResizeClaim := &agentsv1alpha1.SandboxClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("test-claim-mem-ignore-%d", time.Now().UnixNano()),
+					Name:      fmt.Sprintf("test-claim-resource-resize-%d", time.Now().UnixNano()),
 					Namespace: namespace,
 				},
 				Spec: agentsv1alpha1.SandboxClaimSpec{
@@ -1089,30 +1089,30 @@ var _ = Describe("SandboxClaim", func() {
 						Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("400m"),
-								corev1.ResourceMemory: resource.MustParse("999Mi"),
+								corev1.ResourceMemory: resource.MustParse("192Mi"),
 							},
 							Limits: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("400m"),
-								corev1.ResourceMemory: resource.MustParse("999Mi"),
+								corev1.ResourceMemory: resource.MustParse("384Mi"),
 							},
 						},
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, memIgnoreClaim)).To(Succeed())
-			defer func() { _ = k8sClient.Delete(ctx, memIgnoreClaim) }()
+			Expect(k8sClient.Create(ctx, resourceResizeClaim)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, resourceResizeClaim) }()
 
 			By("Verifying claim completes successfully")
 			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
 				_ = k8sClient.Get(ctx, types.NamespacedName{
-					Name:      memIgnoreClaim.Name,
-					Namespace: memIgnoreClaim.Namespace,
-				}, memIgnoreClaim)
-				return memIgnoreClaim.Status.Phase
+					Name:      resourceResizeClaim.Name,
+					Namespace: resourceResizeClaim.Namespace,
+				}, resourceResizeClaim)
+				return resourceResizeClaim.Status.Phase
 			}, time.Minute*3, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
 
-			By("Verifying CPU was resized to 400m")
-			claimedSandboxes, err := listClaimedSandboxes(ctx, memIgnoreClaim)
+			By("Verifying CPU and memory were resized")
+			claimedSandboxes, err := listClaimedSandboxes(ctx, resourceResizeClaim)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(claimedSandboxes).To(HaveLen(1))
 
@@ -1127,19 +1127,587 @@ var _ = Describe("SandboxClaim", func() {
 			cpuLim := pod.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU]
 			Expect(cpuLim.MilliValue()).To(Equal(int64(400)))
 
-			By("Verifying memory remains unchanged (original values, not 999Mi)")
 			memReq := pod.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]
-			Expect(memReq.String()).To(Equal("128Mi"))
+			Expect(memReq.String()).To(Equal("192Mi"))
 			memLim := pod.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory]
-			Expect(memLim.String()).To(Equal("256Mi"))
+			Expect(memLim.String()).To(Equal("384Mi"))
 
-			By("Verifying status resources reflect the actual CPU resize (if populated by kubelet)")
+			By("Verifying status resources reflect the actual resize (if populated by kubelet)")
 			if len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].Resources != nil {
 				cpuReq, ok := pod.Status.ContainerStatuses[0].Resources.Requests[corev1.ResourceCPU]
 				if ok {
 					Expect(cpuReq.MilliValue()).To(Equal(int64(400)))
 				}
+				memReq, ok := pod.Status.ContainerStatuses[0].Resources.Requests[corev1.ResourceMemory]
+				if ok {
+					Expect(memReq.String()).To(Equal("192Mi"))
+				}
 			}
+		})
+
+		It("should resize memory and restart the container when the warm pod already has memory RestartContainer resizePolicy", func() {
+			By("Creating a SandboxSet whose container declares resizePolicy")
+			resizePolicySet := &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-pool-resize-policy-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "main",
+										Image: "nginx:stable-alpine3.23",
+										ResizePolicy: []corev1.ContainerResizePolicy{
+											{
+												ResourceName:  corev1.ResourceCPU,
+												RestartPolicy: corev1.NotRequired,
+											},
+											{
+												ResourceName:  corev1.ResourceMemory,
+												RestartPolicy: corev1.RestartContainer,
+											},
+										},
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("100m"),
+												corev1.ResourceMemory: resource.MustParse("128Mi"),
+											},
+											Limits: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("200m"),
+												corev1.ResourceMemory: resource.MustParse("256Mi"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resizePolicySet)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, resizePolicySet) }()
+
+			By("Waiting for the resizePolicy warm pool to be ready")
+			Eventually(func() int32 {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resizePolicySet.Name,
+					Namespace: resizePolicySet.Namespace,
+				}, resizePolicySet)
+				return resizePolicySet.Status.AvailableReplicas
+			}, time.Minute*2, time.Second).Should(Equal(int32(1)))
+
+			var warmName string
+			var initialRestartCount int32
+			var initialContainerID string
+			By("Verifying the warm pod starts with resizePolicy")
+			Eventually(func() bool {
+				sandboxList := &agentsv1alpha1.SandboxList{}
+				if err := k8sClient.List(ctx, sandboxList, client.InNamespace(namespace), client.MatchingLabels{
+					agentsv1alpha1.LabelSandboxPool: resizePolicySet.Name,
+				}); err != nil || len(sandboxList.Items) != 1 {
+					return false
+				}
+				warmName = sandboxList.Items[0].Name
+
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil || len(pod.Spec.Containers) == 0 {
+					return false
+				}
+
+				for _, policy := range pod.Spec.Containers[0].ResizePolicy {
+					if policy.ResourceName == corev1.ResourceMemory && policy.RestartPolicy == corev1.RestartContainer {
+						return true
+					}
+				}
+				return false
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Recording the warm container restart count before memory resize")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil {
+					return false
+				}
+				for _, status := range pod.Status.ContainerStatuses {
+					if status.Name == "main" && status.ContainerID != "" {
+						initialRestartCount = status.RestartCount
+						initialContainerID = status.ContainerID
+						return true
+					}
+				}
+				return false
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Creating a SandboxClaim that resizes memory only")
+			resizePolicyClaim := &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-claim-resize-policy-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    resizePolicySet.Name,
+					Replicas:        ptr.To(int32(1)),
+					SkipInitRuntime: true,
+					ClaimTimeout:    &metav1.Duration{Duration: 3 * time.Minute},
+					WaitReadyTimeout: &metav1.Duration{
+						Duration: 3 * time.Minute,
+					},
+					InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
+						Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("200Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("300Mi"),
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resizePolicyClaim)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, resizePolicyClaim) }()
+
+			By("Verifying claim completes without resizePolicy mutation errors")
+			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resizePolicyClaim.Name,
+					Namespace: resizePolicyClaim.Namespace,
+				}, resizePolicyClaim)
+				return resizePolicyClaim.Status.Phase
+			}, time.Minute*4, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
+
+			By("Verifying memory resources were resized and resizePolicy was preserved")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil || len(pod.Spec.Containers) == 0 {
+					return false
+				}
+
+				container := pod.Spec.Containers[0]
+				req, ok := container.Resources.Requests[corev1.ResourceMemory]
+				if !ok || req.Cmp(resource.MustParse("200Mi")) != 0 {
+					return false
+				}
+				lim, ok := container.Resources.Limits[corev1.ResourceMemory]
+				if !ok || lim.Cmp(resource.MustParse("300Mi")) != 0 {
+					return false
+				}
+				for _, policy := range container.ResizePolicy {
+					if policy.ResourceName == corev1.ResourceMemory && policy.RestartPolicy == corev1.RestartContainer {
+						return true
+					}
+				}
+				return false
+			}, time.Minute*2, time.Second).Should(BeTrue())
+
+			By("Verifying memory resize restarted the main container")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil {
+					return false
+				}
+				for _, status := range pod.Status.ContainerStatuses {
+					if status.Name != "main" {
+						continue
+					}
+					return status.RestartCount > initialRestartCount &&
+						status.ContainerID != "" &&
+						status.ContainerID != initialContainerID
+				}
+				return false
+			}, time.Minute*2, time.Second).Should(BeTrue())
+		})
+
+		It("should resize CPU without restarting the container when resizePolicy is NotRequired", func() {
+			By("Creating a SandboxSet whose CPU resizePolicy is NotRequired")
+			noRestartSet := &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-pool-cpu-no-restart-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "main",
+										Image: "nginx:stable-alpine3.23",
+										ResizePolicy: []corev1.ContainerResizePolicy{
+											{
+												ResourceName:  corev1.ResourceCPU,
+												RestartPolicy: corev1.NotRequired,
+											},
+											{
+												ResourceName:  corev1.ResourceMemory,
+												RestartPolicy: corev1.NotRequired,
+											},
+										},
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("100m"),
+												corev1.ResourceMemory: resource.MustParse("128Mi"),
+											},
+											Limits: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("200m"),
+												corev1.ResourceMemory: resource.MustParse("256Mi"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, noRestartSet)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, noRestartSet) }()
+
+			By("Waiting for the no-restart warm pool to be ready")
+			Eventually(func() int32 {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      noRestartSet.Name,
+					Namespace: noRestartSet.Namespace,
+				}, noRestartSet)
+				return noRestartSet.Status.AvailableReplicas
+			}, time.Minute*2, time.Second).Should(Equal(int32(1)))
+
+			var warmName string
+			var initialRestartCount int32
+			var initialContainerID string
+			By("Verifying the warm pod starts with CPU NotRequired resizePolicy")
+			Eventually(func() bool {
+				sandboxList := &agentsv1alpha1.SandboxList{}
+				if err := k8sClient.List(ctx, sandboxList, client.InNamespace(namespace), client.MatchingLabels{
+					agentsv1alpha1.LabelSandboxPool: noRestartSet.Name,
+				}); err != nil || len(sandboxList.Items) != 1 {
+					return false
+				}
+				warmName = sandboxList.Items[0].Name
+
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil || len(pod.Spec.Containers) == 0 {
+					return false
+				}
+
+				for _, policy := range pod.Spec.Containers[0].ResizePolicy {
+					if policy.ResourceName == corev1.ResourceCPU && policy.RestartPolicy == corev1.NotRequired {
+						return true
+					}
+				}
+				return false
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Recording the warm container identity before CPU resize")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil {
+					return false
+				}
+				for _, status := range pod.Status.ContainerStatuses {
+					if status.Name == "main" && status.ContainerID != "" {
+						initialRestartCount = status.RestartCount
+						initialContainerID = status.ContainerID
+						return true
+					}
+				}
+				return false
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Creating a SandboxClaim that resizes CPU only")
+			noRestartClaim := &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-claim-cpu-no-restart-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    noRestartSet.Name,
+					Replicas:        ptr.To(int32(1)),
+					SkipInitRuntime: true,
+					ClaimTimeout:    &metav1.Duration{Duration: 3 * time.Minute},
+					WaitReadyTimeout: &metav1.Duration{
+						Duration: 3 * time.Minute,
+					},
+					InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
+						Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("150m"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("300m"),
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, noRestartClaim)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, noRestartClaim) }()
+
+			By("Verifying claim completes")
+			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      noRestartClaim.Name,
+					Namespace: noRestartClaim.Namespace,
+				}, noRestartClaim)
+				return noRestartClaim.Status.Phase
+			}, time.Minute*4, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
+
+			By("Verifying CPU resources were resized and resizePolicy was preserved")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil || len(pod.Spec.Containers) == 0 {
+					return false
+				}
+
+				container := pod.Spec.Containers[0]
+				req, ok := container.Resources.Requests[corev1.ResourceCPU]
+				if !ok || req.Cmp(resource.MustParse("150m")) != 0 {
+					return false
+				}
+				lim, ok := container.Resources.Limits[corev1.ResourceCPU]
+				if !ok || lim.Cmp(resource.MustParse("300m")) != 0 {
+					return false
+				}
+				for _, policy := range container.ResizePolicy {
+					if policy.ResourceName == corev1.ResourceCPU && policy.RestartPolicy == corev1.NotRequired {
+						return true
+					}
+				}
+				return false
+			}, time.Minute*2, time.Second).Should(BeTrue())
+
+			By("Verifying CPU resize does not restart the main container")
+			Consistently(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil {
+					return false
+				}
+				for _, status := range pod.Status.ContainerStatuses {
+					if status.Name != "main" {
+						continue
+					}
+					return status.RestartCount == initialRestartCount &&
+						status.ContainerID == initialContainerID
+				}
+				return false
+			}, 15*time.Second, time.Second).Should(BeTrue())
+		})
+
+		It("should resize memory without restarting the container when memory resizePolicy is NotRequired", func() {
+			By("Creating a SandboxSet whose memory resizePolicy is NotRequired")
+			memoryNoRestartSet := &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-pool-memory-no-restart-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "main",
+										Image: "nginx:stable-alpine3.23",
+										ResizePolicy: []corev1.ContainerResizePolicy{
+											{
+												ResourceName:  corev1.ResourceCPU,
+												RestartPolicy: corev1.NotRequired,
+											},
+											{
+												ResourceName:  corev1.ResourceMemory,
+												RestartPolicy: corev1.NotRequired,
+											},
+										},
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("100m"),
+												corev1.ResourceMemory: resource.MustParse("128Mi"),
+											},
+											Limits: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("200m"),
+												corev1.ResourceMemory: resource.MustParse("256Mi"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, memoryNoRestartSet)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, memoryNoRestartSet) }()
+
+			By("Waiting for the memory no-restart warm pool to be ready")
+			Eventually(func() int32 {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      memoryNoRestartSet.Name,
+					Namespace: memoryNoRestartSet.Namespace,
+				}, memoryNoRestartSet)
+				return memoryNoRestartSet.Status.AvailableReplicas
+			}, time.Minute*2, time.Second).Should(Equal(int32(1)))
+
+			var warmName string
+			var initialRestartCount int32
+			var initialContainerID string
+			By("Verifying the warm pod starts with memory NotRequired resizePolicy")
+			Eventually(func() bool {
+				sandboxList := &agentsv1alpha1.SandboxList{}
+				if err := k8sClient.List(ctx, sandboxList, client.InNamespace(namespace), client.MatchingLabels{
+					agentsv1alpha1.LabelSandboxPool: memoryNoRestartSet.Name,
+				}); err != nil || len(sandboxList.Items) != 1 {
+					return false
+				}
+				warmName = sandboxList.Items[0].Name
+
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil || len(pod.Spec.Containers) == 0 {
+					return false
+				}
+
+				for _, policy := range pod.Spec.Containers[0].ResizePolicy {
+					if policy.ResourceName == corev1.ResourceMemory && policy.RestartPolicy == corev1.NotRequired {
+						return true
+					}
+				}
+				return false
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Recording the warm container identity before memory resize")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil {
+					return false
+				}
+				for _, status := range pod.Status.ContainerStatuses {
+					if status.Name == "main" && status.ContainerID != "" {
+						initialRestartCount = status.RestartCount
+						initialContainerID = status.ContainerID
+						return true
+					}
+				}
+				return false
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Creating a SandboxClaim that resizes memory with NotRequired policy")
+			memoryNoRestartClaim := &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-claim-memory-no-restart-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    memoryNoRestartSet.Name,
+					Replicas:        ptr.To(int32(1)),
+					SkipInitRuntime: true,
+					ClaimTimeout:    &metav1.Duration{Duration: 3 * time.Minute},
+					WaitReadyTimeout: &metav1.Duration{
+						Duration: 3 * time.Minute,
+					},
+					InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
+						Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("192Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("384Mi"),
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, memoryNoRestartClaim)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, memoryNoRestartClaim) }()
+
+			By("Verifying claim completes")
+			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      memoryNoRestartClaim.Name,
+					Namespace: memoryNoRestartClaim.Namespace,
+				}, memoryNoRestartClaim)
+				return memoryNoRestartClaim.Status.Phase
+			}, time.Minute*4, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
+
+			By("Verifying memory resources were resized and resizePolicy was preserved")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil || len(pod.Spec.Containers) == 0 {
+					return false
+				}
+
+				container := pod.Spec.Containers[0]
+				req, ok := container.Resources.Requests[corev1.ResourceMemory]
+				if !ok || req.Cmp(resource.MustParse("192Mi")) != 0 {
+					return false
+				}
+				lim, ok := container.Resources.Limits[corev1.ResourceMemory]
+				if !ok || lim.Cmp(resource.MustParse("384Mi")) != 0 {
+					return false
+				}
+				for _, policy := range container.ResizePolicy {
+					if policy.ResourceName == corev1.ResourceMemory && policy.RestartPolicy == corev1.NotRequired {
+						return true
+					}
+				}
+				return false
+			}, time.Minute*2, time.Second).Should(BeTrue())
+
+			By("Verifying memory resize with NotRequired does not restart the main container")
+			Consistently(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil {
+					return false
+				}
+				for _, status := range pod.Status.ContainerStatuses {
+					if status.Name != "main" {
+						continue
+					}
+					return status.RestartCount == initialRestartCount &&
+						status.ContainerID == initialContainerID
+				}
+				return false
+			}, 15*time.Second, time.Second).Should(BeTrue())
 		})
 
 	})

--- a/test/e2e/sandboxclaim_test.go
+++ b/test/e2e/sandboxclaim_test.go
@@ -287,7 +287,7 @@ var _ = Describe("SandboxClaim", func() {
 		})
 	})
 
-	Context("CPU resize on claim", func() {
+	Context("Resource resize on claim", func() {
 		var (
 			sandboxSet      *agentsv1alpha1.SandboxSet
 			sandboxClaim    *agentsv1alpha1.SandboxClaim
@@ -297,7 +297,7 @@ var _ = Describe("SandboxClaim", func() {
 		BeforeEach(func() {
 			sandboxSet = &agentsv1alpha1.SandboxSet{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("test-pool-cpu-resize-%d", time.Now().UnixNano()),
+					Name:      fmt.Sprintf("test-pool-resource-resize-%d", time.Now().UnixNano()),
 					Namespace: namespace,
 				},
 				Spec: agentsv1alpha1.SandboxSetSpec{
@@ -1071,11 +1071,170 @@ var _ = Describe("SandboxClaim", func() {
 			Expect(sidecar.Resources.Limits[corev1.ResourceCPU]).To(Equal(resource.MustParse("200m")))
 		})
 
-		It("should ignore memory in resize and only apply CPU", func() {
-			By("Creating a SandboxClaim with both CPU and memory in requests/limits")
-			memIgnoreClaim := &agentsv1alpha1.SandboxClaim{
+		It("should resize the main container without mutating init containers", func() {
+			By("Creating a SandboxSet with an init container")
+			initContainerSet := &agentsv1alpha1.SandboxSet{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("test-claim-mem-ignore-%d", time.Now().UnixNano()),
+					Name:      fmt.Sprintf("test-pool-init-resize-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								InitContainers: []corev1.Container{
+									{
+										Name:    "init-setup",
+										Image:   "busybox:1.36",
+										Command: []string{"sh", "-c", "echo init-ready"},
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("50m"),
+												corev1.ResourceMemory: resource.MustParse("32Mi"),
+											},
+											Limits: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("100m"),
+												corev1.ResourceMemory: resource.MustParse("64Mi"),
+											},
+										},
+									},
+								},
+								Containers: []corev1.Container{
+									{
+										Name:  "main",
+										Image: "nginx:stable-alpine3.23",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("250m"),
+												corev1.ResourceMemory: resource.MustParse("128Mi"),
+											},
+											Limits: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("500m"),
+												corev1.ResourceMemory: resource.MustParse("256Mi"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, initContainerSet)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, initContainerSet) }()
+
+			By("Waiting for pool to be ready")
+			Eventually(func() int32 {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      initContainerSet.Name,
+					Namespace: initContainerSet.Namespace,
+				}, initContainerSet)
+				return initContainerSet.Status.AvailableReplicas
+			}, time.Minute*2, time.Second).Should(Equal(int32(1)))
+
+			var initWarmName string
+			findInitContainer := func(pod *corev1.Pod) *corev1.Container {
+				for i := range pod.Spec.InitContainers {
+					if pod.Spec.InitContainers[i].Name == "init-setup" {
+						return &pod.Spec.InitContainers[i]
+					}
+				}
+				return nil
+			}
+
+			By("Verifying the warm pod has the expected init container resources")
+			Eventually(func() bool {
+				sandboxList := &agentsv1alpha1.SandboxList{}
+				if err := k8sClient.List(ctx, sandboxList, client.InNamespace(namespace), client.MatchingLabels{
+					agentsv1alpha1.LabelSandboxPool: initContainerSet.Name,
+				}); err != nil || len(sandboxList.Items) != 1 {
+					return false
+				}
+				initWarmName = sandboxList.Items[0].Name
+
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      initWarmName,
+					Namespace: namespace,
+				}, pod); err != nil {
+					return false
+				}
+				initContainer := findInitContainer(pod)
+				if initContainer == nil || initContainer.Image != "busybox:1.36" {
+					return false
+				}
+				cpuReq, ok := initContainer.Resources.Requests[corev1.ResourceCPU]
+				if !ok || cpuReq.Cmp(resource.MustParse("50m")) != 0 {
+					return false
+				}
+				cpuLim, ok := initContainer.Resources.Limits[corev1.ResourceCPU]
+				return ok && cpuLim.Cmp(resource.MustParse("100m")) == 0
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Creating a SandboxClaim that resizes only the main container")
+			initContainerClaim := &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-claim-init-resize-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    initContainerSet.Name,
+					Replicas:        ptr.To(int32(1)),
+					SkipInitRuntime: true,
+					WaitReadyTimeout: &metav1.Duration{
+						Duration: 2 * time.Minute,
+					},
+					InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
+						Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("300m")},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, initContainerClaim)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, initContainerClaim) }()
+
+			By("Verifying claim completes")
+			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      initContainerClaim.Name,
+					Namespace: initContainerClaim.Namespace,
+				}, initContainerClaim)
+				return initContainerClaim.Status.Phase
+			}, time.Minute*3, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
+
+			By("Verifying main container CPU is resized and init container resources are unchanged")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      initWarmName,
+					Namespace: namespace,
+				}, pod); err != nil || len(pod.Spec.Containers) == 0 {
+					return false
+				}
+				mainReq, ok := pod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+				if !ok || mainReq.Cmp(resource.MustParse("300m")) != 0 {
+					return false
+				}
+				initContainer := findInitContainer(pod)
+				if initContainer == nil || initContainer.Image != "busybox:1.36" {
+					return false
+				}
+				initReq, ok := initContainer.Resources.Requests[corev1.ResourceCPU]
+				if !ok || initReq.Cmp(resource.MustParse("50m")) != 0 {
+					return false
+				}
+				initLim, ok := initContainer.Resources.Limits[corev1.ResourceCPU]
+				return ok && initLim.Cmp(resource.MustParse("100m")) == 0
+			}, time.Minute*2, time.Second).Should(BeTrue())
+		})
+
+		It("should apply CPU and memory resize when QoS class is preserved", func() {
+			By("Creating a SandboxClaim with both CPU and memory in requests/limits")
+			resourceResizeClaim := &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-claim-resource-resize-%d", time.Now().UnixNano()),
 					Namespace: namespace,
 				},
 				Spec: agentsv1alpha1.SandboxClaimSpec{
@@ -1089,30 +1248,30 @@ var _ = Describe("SandboxClaim", func() {
 						Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("400m"),
-								corev1.ResourceMemory: resource.MustParse("999Mi"),
+								corev1.ResourceMemory: resource.MustParse("192Mi"),
 							},
 							Limits: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("400m"),
-								corev1.ResourceMemory: resource.MustParse("999Mi"),
+								corev1.ResourceMemory: resource.MustParse("384Mi"),
 							},
 						},
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, memIgnoreClaim)).To(Succeed())
-			defer func() { _ = k8sClient.Delete(ctx, memIgnoreClaim) }()
+			Expect(k8sClient.Create(ctx, resourceResizeClaim)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, resourceResizeClaim) }()
 
 			By("Verifying claim completes successfully")
 			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
 				_ = k8sClient.Get(ctx, types.NamespacedName{
-					Name:      memIgnoreClaim.Name,
-					Namespace: memIgnoreClaim.Namespace,
-				}, memIgnoreClaim)
-				return memIgnoreClaim.Status.Phase
+					Name:      resourceResizeClaim.Name,
+					Namespace: resourceResizeClaim.Namespace,
+				}, resourceResizeClaim)
+				return resourceResizeClaim.Status.Phase
 			}, time.Minute*3, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
 
-			By("Verifying CPU was resized to 400m")
-			claimedSandboxes, err := listClaimedSandboxes(ctx, memIgnoreClaim)
+			By("Verifying CPU and memory were resized")
+			claimedSandboxes, err := listClaimedSandboxes(ctx, resourceResizeClaim)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(claimedSandboxes).To(HaveLen(1))
 
@@ -1127,19 +1286,587 @@ var _ = Describe("SandboxClaim", func() {
 			cpuLim := pod.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU]
 			Expect(cpuLim.MilliValue()).To(Equal(int64(400)))
 
-			By("Verifying memory remains unchanged (original values, not 999Mi)")
 			memReq := pod.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]
-			Expect(memReq.String()).To(Equal("128Mi"))
+			Expect(memReq.String()).To(Equal("192Mi"))
 			memLim := pod.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory]
-			Expect(memLim.String()).To(Equal("256Mi"))
+			Expect(memLim.String()).To(Equal("384Mi"))
 
-			By("Verifying status resources reflect the actual CPU resize (if populated by kubelet)")
+			By("Verifying status resources reflect the actual resize (if populated by kubelet)")
 			if len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].Resources != nil {
 				cpuReq, ok := pod.Status.ContainerStatuses[0].Resources.Requests[corev1.ResourceCPU]
 				if ok {
 					Expect(cpuReq.MilliValue()).To(Equal(int64(400)))
 				}
+				memReq, ok := pod.Status.ContainerStatuses[0].Resources.Requests[corev1.ResourceMemory]
+				if ok {
+					Expect(memReq.String()).To(Equal("192Mi"))
+				}
 			}
+		})
+
+		It("should resize memory and restart the container when the warm pod already has memory RestartContainer resizePolicy", func() {
+			By("Creating a SandboxSet whose container declares resizePolicy")
+			resizePolicySet := &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-pool-resize-policy-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "main",
+										Image: "nginx:stable-alpine3.23",
+										ResizePolicy: []corev1.ContainerResizePolicy{
+											{
+												ResourceName:  corev1.ResourceCPU,
+												RestartPolicy: corev1.NotRequired,
+											},
+											{
+												ResourceName:  corev1.ResourceMemory,
+												RestartPolicy: corev1.RestartContainer,
+											},
+										},
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("100m"),
+												corev1.ResourceMemory: resource.MustParse("128Mi"),
+											},
+											Limits: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("200m"),
+												corev1.ResourceMemory: resource.MustParse("256Mi"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resizePolicySet)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, resizePolicySet) }()
+
+			By("Waiting for the resizePolicy warm pool to be ready")
+			Eventually(func() int32 {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resizePolicySet.Name,
+					Namespace: resizePolicySet.Namespace,
+				}, resizePolicySet)
+				return resizePolicySet.Status.AvailableReplicas
+			}, time.Minute*2, time.Second).Should(Equal(int32(1)))
+
+			var warmName string
+			var initialRestartCount int32
+			var initialContainerID string
+			By("Verifying the warm pod starts with resizePolicy")
+			Eventually(func() bool {
+				sandboxList := &agentsv1alpha1.SandboxList{}
+				if err := k8sClient.List(ctx, sandboxList, client.InNamespace(namespace), client.MatchingLabels{
+					agentsv1alpha1.LabelSandboxPool: resizePolicySet.Name,
+				}); err != nil || len(sandboxList.Items) != 1 {
+					return false
+				}
+				warmName = sandboxList.Items[0].Name
+
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil || len(pod.Spec.Containers) == 0 {
+					return false
+				}
+
+				for _, policy := range pod.Spec.Containers[0].ResizePolicy {
+					if policy.ResourceName == corev1.ResourceMemory && policy.RestartPolicy == corev1.RestartContainer {
+						return true
+					}
+				}
+				return false
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Recording the warm container restart count before memory resize")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil {
+					return false
+				}
+				for _, status := range pod.Status.ContainerStatuses {
+					if status.Name == "main" && status.ContainerID != "" {
+						initialRestartCount = status.RestartCount
+						initialContainerID = status.ContainerID
+						return true
+					}
+				}
+				return false
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Creating a SandboxClaim that resizes memory only")
+			resizePolicyClaim := &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-claim-resize-policy-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    resizePolicySet.Name,
+					Replicas:        ptr.To(int32(1)),
+					SkipInitRuntime: true,
+					ClaimTimeout:    &metav1.Duration{Duration: 3 * time.Minute},
+					WaitReadyTimeout: &metav1.Duration{
+						Duration: 3 * time.Minute,
+					},
+					InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
+						Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("200Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("300Mi"),
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resizePolicyClaim)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, resizePolicyClaim) }()
+
+			By("Verifying claim completes without resizePolicy mutation errors")
+			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resizePolicyClaim.Name,
+					Namespace: resizePolicyClaim.Namespace,
+				}, resizePolicyClaim)
+				return resizePolicyClaim.Status.Phase
+			}, time.Minute*4, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
+
+			By("Verifying memory resources were resized and resizePolicy was preserved")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil || len(pod.Spec.Containers) == 0 {
+					return false
+				}
+
+				container := pod.Spec.Containers[0]
+				req, ok := container.Resources.Requests[corev1.ResourceMemory]
+				if !ok || req.Cmp(resource.MustParse("200Mi")) != 0 {
+					return false
+				}
+				lim, ok := container.Resources.Limits[corev1.ResourceMemory]
+				if !ok || lim.Cmp(resource.MustParse("300Mi")) != 0 {
+					return false
+				}
+				for _, policy := range container.ResizePolicy {
+					if policy.ResourceName == corev1.ResourceMemory && policy.RestartPolicy == corev1.RestartContainer {
+						return true
+					}
+				}
+				return false
+			}, time.Minute*2, time.Second).Should(BeTrue())
+
+			By("Verifying memory resize restarted the main container")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil {
+					return false
+				}
+				for _, status := range pod.Status.ContainerStatuses {
+					if status.Name != "main" {
+						continue
+					}
+					return status.RestartCount > initialRestartCount &&
+						status.ContainerID != "" &&
+						status.ContainerID != initialContainerID
+				}
+				return false
+			}, time.Minute*2, time.Second).Should(BeTrue())
+		})
+
+		It("should resize CPU without restarting the container when resizePolicy is NotRequired", func() {
+			By("Creating a SandboxSet whose CPU resizePolicy is NotRequired")
+			noRestartSet := &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-pool-cpu-no-restart-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "main",
+										Image: "nginx:stable-alpine3.23",
+										ResizePolicy: []corev1.ContainerResizePolicy{
+											{
+												ResourceName:  corev1.ResourceCPU,
+												RestartPolicy: corev1.NotRequired,
+											},
+											{
+												ResourceName:  corev1.ResourceMemory,
+												RestartPolicy: corev1.NotRequired,
+											},
+										},
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("100m"),
+												corev1.ResourceMemory: resource.MustParse("128Mi"),
+											},
+											Limits: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("200m"),
+												corev1.ResourceMemory: resource.MustParse("256Mi"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, noRestartSet)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, noRestartSet) }()
+
+			By("Waiting for the no-restart warm pool to be ready")
+			Eventually(func() int32 {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      noRestartSet.Name,
+					Namespace: noRestartSet.Namespace,
+				}, noRestartSet)
+				return noRestartSet.Status.AvailableReplicas
+			}, time.Minute*2, time.Second).Should(Equal(int32(1)))
+
+			var warmName string
+			var initialRestartCount int32
+			var initialContainerID string
+			By("Verifying the warm pod starts with CPU NotRequired resizePolicy")
+			Eventually(func() bool {
+				sandboxList := &agentsv1alpha1.SandboxList{}
+				if err := k8sClient.List(ctx, sandboxList, client.InNamespace(namespace), client.MatchingLabels{
+					agentsv1alpha1.LabelSandboxPool: noRestartSet.Name,
+				}); err != nil || len(sandboxList.Items) != 1 {
+					return false
+				}
+				warmName = sandboxList.Items[0].Name
+
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil || len(pod.Spec.Containers) == 0 {
+					return false
+				}
+
+				for _, policy := range pod.Spec.Containers[0].ResizePolicy {
+					if policy.ResourceName == corev1.ResourceCPU && policy.RestartPolicy == corev1.NotRequired {
+						return true
+					}
+				}
+				return false
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Recording the warm container identity before CPU resize")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil {
+					return false
+				}
+				for _, status := range pod.Status.ContainerStatuses {
+					if status.Name == "main" && status.ContainerID != "" {
+						initialRestartCount = status.RestartCount
+						initialContainerID = status.ContainerID
+						return true
+					}
+				}
+				return false
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Creating a SandboxClaim that resizes CPU only")
+			noRestartClaim := &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-claim-cpu-no-restart-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    noRestartSet.Name,
+					Replicas:        ptr.To(int32(1)),
+					SkipInitRuntime: true,
+					ClaimTimeout:    &metav1.Duration{Duration: 3 * time.Minute},
+					WaitReadyTimeout: &metav1.Duration{
+						Duration: 3 * time.Minute,
+					},
+					InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
+						Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("150m"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("300m"),
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, noRestartClaim)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, noRestartClaim) }()
+
+			By("Verifying claim completes")
+			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      noRestartClaim.Name,
+					Namespace: noRestartClaim.Namespace,
+				}, noRestartClaim)
+				return noRestartClaim.Status.Phase
+			}, time.Minute*4, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
+
+			By("Verifying CPU resources were resized and resizePolicy was preserved")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil || len(pod.Spec.Containers) == 0 {
+					return false
+				}
+
+				container := pod.Spec.Containers[0]
+				req, ok := container.Resources.Requests[corev1.ResourceCPU]
+				if !ok || req.Cmp(resource.MustParse("150m")) != 0 {
+					return false
+				}
+				lim, ok := container.Resources.Limits[corev1.ResourceCPU]
+				if !ok || lim.Cmp(resource.MustParse("300m")) != 0 {
+					return false
+				}
+				for _, policy := range container.ResizePolicy {
+					if policy.ResourceName == corev1.ResourceCPU && policy.RestartPolicy == corev1.NotRequired {
+						return true
+					}
+				}
+				return false
+			}, time.Minute*2, time.Second).Should(BeTrue())
+
+			By("Verifying CPU resize does not restart the main container")
+			Consistently(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil {
+					return false
+				}
+				for _, status := range pod.Status.ContainerStatuses {
+					if status.Name != "main" {
+						continue
+					}
+					return status.RestartCount == initialRestartCount &&
+						status.ContainerID == initialContainerID
+				}
+				return false
+			}, 15*time.Second, time.Second).Should(BeTrue())
+		})
+
+		It("should resize memory without restarting the container when memory resizePolicy is NotRequired", func() {
+			By("Creating a SandboxSet whose memory resizePolicy is NotRequired")
+			memoryNoRestartSet := &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-pool-memory-no-restart-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "main",
+										Image: "nginx:stable-alpine3.23",
+										ResizePolicy: []corev1.ContainerResizePolicy{
+											{
+												ResourceName:  corev1.ResourceCPU,
+												RestartPolicy: corev1.NotRequired,
+											},
+											{
+												ResourceName:  corev1.ResourceMemory,
+												RestartPolicy: corev1.NotRequired,
+											},
+										},
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("100m"),
+												corev1.ResourceMemory: resource.MustParse("128Mi"),
+											},
+											Limits: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("200m"),
+												corev1.ResourceMemory: resource.MustParse("256Mi"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, memoryNoRestartSet)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, memoryNoRestartSet) }()
+
+			By("Waiting for the memory no-restart warm pool to be ready")
+			Eventually(func() int32 {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      memoryNoRestartSet.Name,
+					Namespace: memoryNoRestartSet.Namespace,
+				}, memoryNoRestartSet)
+				return memoryNoRestartSet.Status.AvailableReplicas
+			}, time.Minute*2, time.Second).Should(Equal(int32(1)))
+
+			var warmName string
+			var initialRestartCount int32
+			var initialContainerID string
+			By("Verifying the warm pod starts with memory NotRequired resizePolicy")
+			Eventually(func() bool {
+				sandboxList := &agentsv1alpha1.SandboxList{}
+				if err := k8sClient.List(ctx, sandboxList, client.InNamespace(namespace), client.MatchingLabels{
+					agentsv1alpha1.LabelSandboxPool: memoryNoRestartSet.Name,
+				}); err != nil || len(sandboxList.Items) != 1 {
+					return false
+				}
+				warmName = sandboxList.Items[0].Name
+
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil || len(pod.Spec.Containers) == 0 {
+					return false
+				}
+
+				for _, policy := range pod.Spec.Containers[0].ResizePolicy {
+					if policy.ResourceName == corev1.ResourceMemory && policy.RestartPolicy == corev1.NotRequired {
+						return true
+					}
+				}
+				return false
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Recording the warm container identity before memory resize")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil {
+					return false
+				}
+				for _, status := range pod.Status.ContainerStatuses {
+					if status.Name == "main" && status.ContainerID != "" {
+						initialRestartCount = status.RestartCount
+						initialContainerID = status.ContainerID
+						return true
+					}
+				}
+				return false
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Creating a SandboxClaim that resizes memory with NotRequired policy")
+			memoryNoRestartClaim := &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-claim-memory-no-restart-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    memoryNoRestartSet.Name,
+					Replicas:        ptr.To(int32(1)),
+					SkipInitRuntime: true,
+					ClaimTimeout:    &metav1.Duration{Duration: 3 * time.Minute},
+					WaitReadyTimeout: &metav1.Duration{
+						Duration: 3 * time.Minute,
+					},
+					InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
+						Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("192Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("384Mi"),
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, memoryNoRestartClaim)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, memoryNoRestartClaim) }()
+
+			By("Verifying claim completes")
+			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      memoryNoRestartClaim.Name,
+					Namespace: memoryNoRestartClaim.Namespace,
+				}, memoryNoRestartClaim)
+				return memoryNoRestartClaim.Status.Phase
+			}, time.Minute*4, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
+
+			By("Verifying memory resources were resized and resizePolicy was preserved")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil || len(pod.Spec.Containers) == 0 {
+					return false
+				}
+
+				container := pod.Spec.Containers[0]
+				req, ok := container.Resources.Requests[corev1.ResourceMemory]
+				if !ok || req.Cmp(resource.MustParse("192Mi")) != 0 {
+					return false
+				}
+				lim, ok := container.Resources.Limits[corev1.ResourceMemory]
+				if !ok || lim.Cmp(resource.MustParse("384Mi")) != 0 {
+					return false
+				}
+				for _, policy := range container.ResizePolicy {
+					if policy.ResourceName == corev1.ResourceMemory && policy.RestartPolicy == corev1.NotRequired {
+						return true
+					}
+				}
+				return false
+			}, time.Minute*2, time.Second).Should(BeTrue())
+
+			By("Verifying memory resize with NotRequired does not restart the main container")
+			Consistently(func() bool {
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil {
+					return false
+				}
+				for _, status := range pod.Status.ContainerStatuses {
+					if status.Name != "main" {
+						continue
+					}
+					return status.RestartCount == initialRestartCount &&
+						status.ContainerID == initialContainerID
+				}
+				return false
+			}, 15*time.Second, time.Second).Should(BeTrue())
 		})
 
 	})

--- a/test/e2e/sandboxclaim_test.go
+++ b/test/e2e/sandboxclaim_test.go
@@ -484,25 +484,31 @@ var _ = Describe("SandboxClaim", func() {
 			Expect(k8sClient.Create(ctx, qosBreakClaim)).To(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, qosBreakClaim) }()
 
-			By("Verifying sandbox InplaceUpdate condition reports QoS change failure")
-			Eventually(func() string {
-				sbx := &agentsv1alpha1.Sandbox{}
-				if err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      warmName,
-					Namespace: namespace,
-				}, sbx); err != nil {
-					return ""
+			By("Verifying the claim completes by timeout with zero claimed replicas")
+			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      qosBreakClaim.Name,
+					Namespace: qosBreakClaim.Namespace,
+				}, qosBreakClaim)
+				return qosBreakClaim.Status.Phase
+			}, time.Minute*2, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
+			Expect(qosBreakClaim.Status.ClaimedReplicas).To(Equal(int32(0)))
+			timedOutCondFound := false
+			for _, cond := range qosBreakClaim.Status.Conditions {
+				if cond.Type == string(agentsv1alpha1.SandboxClaimConditionTimedOut) && cond.Status == metav1.ConditionTrue {
+					timedOutCondFound = true
+					break
 				}
-				for _, cond := range sbx.Status.Conditions {
-					if cond.Type == string(agentsv1alpha1.SandboxConditionInplaceUpdate) &&
-						cond.Reason == agentsv1alpha1.SandboxInplaceUpdateReasonFailed {
-						return cond.Message
-					}
-				}
-				return ""
-			}, time.Minute*2, time.Second).Should(ContainSubstring("QoS"))
+			}
+			Expect(timedOutCondFound).To(BeTrue())
 
-			By("Verifying pod QoS class remains Burstable (resize was not applied)")
+			By("Verifying the sandbox stays unclaimed and pod QoS class remains Burstable")
+			sbx := &agentsv1alpha1.Sandbox{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      warmName,
+				Namespace: namespace,
+			}, sbx)).To(Succeed())
+			Expect(sbx.Annotations[agentsv1alpha1.AnnotationOwner]).To(BeEmpty())
 			pod := &corev1.Pod{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
 				Name:      warmName,
@@ -1959,25 +1965,31 @@ var _ = Describe("SandboxClaim", func() {
 			Expect(k8sClient.Create(ctx, qosBreakClaim)).To(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, qosBreakClaim) }()
 
-			By("Verifying sandbox InplaceUpdate condition reports QoS change failure")
-			Eventually(func() string {
-				sbx := &agentsv1alpha1.Sandbox{}
-				if err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      warmName,
-					Namespace: namespace,
-				}, sbx); err != nil {
-					return ""
+			By("Verifying the claim completes by timeout with zero claimed replicas")
+			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      qosBreakClaim.Name,
+					Namespace: qosBreakClaim.Namespace,
+				}, qosBreakClaim)
+				return qosBreakClaim.Status.Phase
+			}, time.Minute*2, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
+			Expect(qosBreakClaim.Status.ClaimedReplicas).To(Equal(int32(0)))
+			timedOutCondFound := false
+			for _, cond := range qosBreakClaim.Status.Conditions {
+				if cond.Type == string(agentsv1alpha1.SandboxClaimConditionTimedOut) && cond.Status == metav1.ConditionTrue {
+					timedOutCondFound = true
+					break
 				}
-				for _, cond := range sbx.Status.Conditions {
-					if cond.Type == string(agentsv1alpha1.SandboxConditionInplaceUpdate) &&
-						cond.Reason == agentsv1alpha1.SandboxInplaceUpdateReasonFailed {
-						return cond.Message
-					}
-				}
-				return ""
-			}, time.Minute*2, time.Second).Should(ContainSubstring("QoS"))
+			}
+			Expect(timedOutCondFound).To(BeTrue())
 
-			By("Verifying pod QoS class remains Burstable (resize was not applied)")
+			By("Verifying the sandbox stays unclaimed and pod QoS class remains Burstable")
+			sbx := &agentsv1alpha1.Sandbox{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      warmName,
+				Namespace: namespace,
+			}, sbx)).To(Succeed())
+			Expect(sbx.Annotations[agentsv1alpha1.AnnotationOwner]).To(BeEmpty())
 			pod := &corev1.Pod{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
 				Name:      warmName,
@@ -1989,16 +2001,6 @@ var _ = Describe("SandboxClaim", func() {
 			specRes := pod.Spec.Containers[0].Resources
 			Expect(specRes.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("128Mi")))
 			Expect(specRes.Limits[corev1.ResourceMemory]).To(Equal(resource.MustParse("256Mi")))
-
-			By("Verifying the claim completes with the claimed sandbox")
-			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
-				_ = k8sClient.Get(ctx, types.NamespacedName{
-					Name:      qosBreakClaim.Name,
-					Namespace: qosBreakClaim.Namespace,
-				}, qosBreakClaim)
-				return qosBreakClaim.Status.Phase
-			}, time.Minute*2, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
-			Expect(qosBreakClaim.Status.ClaimedReplicas).To(Equal(int32(1)))
 		})
 
 		It("should reject memory downscale and leave the pooled sandbox claimable", func() {
@@ -2082,7 +2084,7 @@ var _ = Describe("SandboxClaim", func() {
 			Expect(k8sClient.Create(ctx, downscaleClaim)).To(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, downscaleClaim) }()
 
-			By("Verifying the claim fails fast with MemoryDownscaleNotSupported")
+			By("Verifying the claim completes by timeout with zero claimed replicas")
 			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
 				_ = k8sClient.Get(ctx, types.NamespacedName{
 					Name:      downscaleClaim.Name,
@@ -2091,16 +2093,14 @@ var _ = Describe("SandboxClaim", func() {
 				return downscaleClaim.Status.Phase
 			}, time.Minute*2, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
 			Expect(downscaleClaim.Status.ClaimedReplicas).To(Equal(int32(0)))
-			downscaleCondFound := false
+			timedOutCondFound := false
 			for _, cond := range downscaleClaim.Status.Conditions {
-				if cond.Type == string(agentsv1alpha1.SandboxClaimConditionCompleted) &&
-					cond.Status == metav1.ConditionTrue &&
-					cond.Reason == "MemoryDownscaleNotSupported" {
-					downscaleCondFound = true
+				if cond.Type == string(agentsv1alpha1.SandboxClaimConditionTimedOut) && cond.Status == metav1.ConditionTrue {
+					timedOutCondFound = true
 					break
 				}
 			}
-			Expect(downscaleCondFound).To(BeTrue())
+			Expect(timedOutCondFound).To(BeTrue())
 
 			By("Verifying the sandbox stays unclaimed and pod memory is unchanged")
 			sbx := &agentsv1alpha1.Sandbox{}

--- a/test/e2e/sandboxclaim_test.go
+++ b/test/e2e/sandboxclaim_test.go
@@ -1989,6 +1989,16 @@ var _ = Describe("SandboxClaim", func() {
 			specRes := pod.Spec.Containers[0].Resources
 			Expect(specRes.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("128Mi")))
 			Expect(specRes.Limits[corev1.ResourceMemory]).To(Equal(resource.MustParse("256Mi")))
+
+			By("Verifying the claim completes with the claimed sandbox")
+			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      qosBreakClaim.Name,
+					Namespace: qosBreakClaim.Namespace,
+				}, qosBreakClaim)
+				return qosBreakClaim.Status.Phase
+			}, time.Minute*2, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
+			Expect(qosBreakClaim.Status.ClaimedReplicas).To(Equal(int32(1)))
 		})
 
 		It("should reject memory downscale and leave the pooled sandbox claimable", func() {
@@ -2072,23 +2082,25 @@ var _ = Describe("SandboxClaim", func() {
 			Expect(k8sClient.Create(ctx, downscaleClaim)).To(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, downscaleClaim) }()
 
-			By("Verifying the claim times out with zero claimed replicas")
+			By("Verifying the claim fails fast with MemoryDownscaleNotSupported")
 			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
 				_ = k8sClient.Get(ctx, types.NamespacedName{
 					Name:      downscaleClaim.Name,
 					Namespace: downscaleClaim.Namespace,
 				}, downscaleClaim)
 				return downscaleClaim.Status.Phase
-			}, time.Minute*3, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
+			}, time.Minute*2, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
 			Expect(downscaleClaim.Status.ClaimedReplicas).To(Equal(int32(0)))
-			timedOutCondFound := false
+			downscaleCondFound := false
 			for _, cond := range downscaleClaim.Status.Conditions {
-				if cond.Type == string(agentsv1alpha1.SandboxClaimConditionTimedOut) && cond.Status == metav1.ConditionTrue {
-					timedOutCondFound = true
+				if cond.Type == string(agentsv1alpha1.SandboxClaimConditionCompleted) &&
+					cond.Status == metav1.ConditionTrue &&
+					cond.Reason == "MemoryDownscaleNotSupported" {
+					downscaleCondFound = true
 					break
 				}
 			}
-			Expect(timedOutCondFound).To(BeTrue())
+			Expect(downscaleCondFound).To(BeTrue())
 
 			By("Verifying the sandbox stays unclaimed and pod memory is unchanged")
 			sbx := &agentsv1alpha1.Sandbox{}
@@ -2097,6 +2109,7 @@ var _ = Describe("SandboxClaim", func() {
 				Namespace: namespace,
 			}, sbx)).To(Succeed())
 			Expect(sbx.Annotations[agentsv1alpha1.AnnotationOwner]).To(BeEmpty())
+			Expect(sbx.Labels[agentsv1alpha1.LabelSandboxIsClaimed]).NotTo(Equal(agentsv1alpha1.True))
 			pod := &corev1.Pod{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
 				Name:      warmName,

--- a/test/e2e/sandboxclaim_test.go
+++ b/test/e2e/sandboxclaim_test.go
@@ -1869,6 +1869,242 @@ var _ = Describe("SandboxClaim", func() {
 			}, 15*time.Second, time.Second).Should(BeTrue())
 		})
 
+		It("should reject memory resize that would change QoS class via sandbox condition", func() {
+			// Pool: CPU req=500m/lim=500m, Memory req=128Mi/lim=256Mi → Burstable
+			// (memory req != lim). Resizing memory to req=256Mi/lim=256Mi makes
+			// every request equal its limit → Guaranteed, so the resize is rejected.
+			qosBreakSet := &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-pool-memory-qos-break-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name:  "main",
+									Image: "nginx:stable-alpine3.23",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("128Mi"),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("256Mi"),
+										},
+									},
+								}},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, qosBreakSet)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, qosBreakSet) }()
+
+			By("Waiting for pool to be ready")
+			Eventually(func() int32 {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      qosBreakSet.Name,
+					Namespace: qosBreakSet.Namespace,
+				}, qosBreakSet)
+				return qosBreakSet.Status.AvailableReplicas
+			}, time.Minute*2, time.Second).Should(Equal(int32(1)))
+
+			By("Verifying warm sandbox is Burstable")
+			var warmName string
+			Eventually(func() corev1.PodQOSClass {
+				sandboxList := &agentsv1alpha1.SandboxList{}
+				if err := k8sClient.List(ctx, sandboxList, client.InNamespace(namespace), client.MatchingLabels{
+					agentsv1alpha1.LabelSandboxPool: qosBreakSet.Name,
+				}); err != nil || len(sandboxList.Items) == 0 {
+					return ""
+				}
+				warmName = sandboxList.Items[0].Name
+				pod := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, pod); err != nil {
+					return ""
+				}
+				return pod.Status.QOSClass
+			}, time.Minute, time.Second).Should(Equal(corev1.PodQOSBurstable))
+
+			By("Creating a claim with memory requests/limits=256Mi that would change QoS from Burstable to Guaranteed")
+			qosBreakClaim := &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-claim-memory-qos-break-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    qosBreakSet.Name,
+					Replicas:        ptr.To(int32(1)),
+					SkipInitRuntime: true,
+					ClaimTimeout:    &metav1.Duration{Duration: 60 * time.Second},
+					WaitReadyTimeout: &metav1.Duration{
+						Duration: 30 * time.Second,
+					},
+					InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
+						Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
+							Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+							Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, qosBreakClaim)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, qosBreakClaim) }()
+
+			By("Verifying sandbox InplaceUpdate condition reports QoS change failure")
+			Eventually(func() string {
+				sbx := &agentsv1alpha1.Sandbox{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      warmName,
+					Namespace: namespace,
+				}, sbx); err != nil {
+					return ""
+				}
+				for _, cond := range sbx.Status.Conditions {
+					if cond.Type == string(agentsv1alpha1.SandboxConditionInplaceUpdate) &&
+						cond.Reason == agentsv1alpha1.SandboxInplaceUpdateReasonFailed {
+						return cond.Message
+					}
+				}
+				return ""
+			}, time.Minute*2, time.Second).Should(ContainSubstring("QoS"))
+
+			By("Verifying pod QoS class remains Burstable (resize was not applied)")
+			pod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      warmName,
+				Namespace: namespace,
+			}, pod)).To(Succeed())
+			Expect(pod.Status.QOSClass).To(Equal(corev1.PodQOSBurstable))
+
+			By("Verifying spec resources remain at original values")
+			specRes := pod.Spec.Containers[0].Resources
+			Expect(specRes.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("128Mi")))
+			Expect(specRes.Limits[corev1.ResourceMemory]).To(Equal(resource.MustParse("256Mi")))
+		})
+
+		It("should reject memory downscale and leave the pooled sandbox claimable", func() {
+			// Pool memory is 256Mi; the claim targets 128Mi, which is a memory
+			// downscale and must be rejected before any sandbox is locked.
+			downscaleSet := &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-pool-memory-downscale-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Replicas: 1,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name:  "main",
+									Image: "nginx:stable-alpine3.23",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("100m"),
+											corev1.ResourceMemory: resource.MustParse("256Mi"),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("200m"),
+											corev1.ResourceMemory: resource.MustParse("256Mi"),
+										},
+									},
+								}},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, downscaleSet)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, downscaleSet) }()
+
+			By("Waiting for pool to be ready")
+			Eventually(func() int32 {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      downscaleSet.Name,
+					Namespace: downscaleSet.Namespace,
+				}, downscaleSet)
+				return downscaleSet.Status.AvailableReplicas
+			}, time.Minute*2, time.Second).Should(Equal(int32(1)))
+
+			By("Recording the warm sandbox name")
+			var warmName string
+			Eventually(func() bool {
+				sandboxList := &agentsv1alpha1.SandboxList{}
+				if err := k8sClient.List(ctx, sandboxList, client.InNamespace(namespace), client.MatchingLabels{
+					agentsv1alpha1.LabelSandboxPool: downscaleSet.Name,
+				}); err != nil || len(sandboxList.Items) != 1 {
+					return false
+				}
+				warmName = sandboxList.Items[0].Name
+				return true
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Creating a SandboxClaim that downscales memory")
+			downscaleClaim := &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-claim-memory-downscale-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    downscaleSet.Name,
+					Replicas:        ptr.To(int32(1)),
+					SkipInitRuntime: true,
+					ClaimTimeout:    &metav1.Duration{Duration: 45 * time.Second},
+					WaitReadyTimeout: &metav1.Duration{
+						Duration: 30 * time.Second,
+					},
+					InplaceUpdate: &agentsv1alpha1.SandboxClaimInplaceUpdateOptions{
+						Resources: &agentsv1alpha1.SandboxClaimInplaceUpdateResourcesOptions{
+							Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("128Mi")},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, downscaleClaim)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, downscaleClaim) }()
+
+			By("Verifying the claim times out with zero claimed replicas")
+			Eventually(func() agentsv1alpha1.SandboxClaimPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      downscaleClaim.Name,
+					Namespace: downscaleClaim.Namespace,
+				}, downscaleClaim)
+				return downscaleClaim.Status.Phase
+			}, time.Minute*3, time.Second).Should(Equal(agentsv1alpha1.SandboxClaimPhaseCompleted))
+			Expect(downscaleClaim.Status.ClaimedReplicas).To(Equal(int32(0)))
+			timedOutCondFound := false
+			for _, cond := range downscaleClaim.Status.Conditions {
+				if cond.Type == string(agentsv1alpha1.SandboxClaimConditionTimedOut) && cond.Status == metav1.ConditionTrue {
+					timedOutCondFound = true
+					break
+				}
+			}
+			Expect(timedOutCondFound).To(BeTrue())
+
+			By("Verifying the sandbox stays unclaimed and pod memory is unchanged")
+			sbx := &agentsv1alpha1.Sandbox{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      warmName,
+				Namespace: namespace,
+			}, sbx)).To(Succeed())
+			Expect(sbx.Annotations[agentsv1alpha1.AnnotationOwner]).To(BeEmpty())
+			pod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      warmName,
+				Namespace: namespace,
+			}, pod)).To(Succeed())
+			Expect(pod.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("256Mi")))
+		})
+
 	})
 
 	Context("Replicas immutability (webhook validation)", func() {


### PR DESCRIPTION


<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

SandboxClaim resource resize previously only supported CPU. Kubernetes in-place pod resize supports both CPU and memory, with behavior controlled by the pod container `resizePolicy`.

Memory resize should be supported through both the CRD API and the E2B-compatible API path, **while preserving the resize policy already defined on the underlying SandboxSet/Sandbox pod template.**


- Allow SandboxClaim inplaceUpdate.resources and E2B extensions to resize memory in addition to CPU.

- Add unit and e2e coverage for CPU and memory resize behavior, including RestartContainer and NotRequired resizePolicy cases.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

https://github.com/openkruise/agents/issues/515

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

