### PR TITLE
fix(cache): fallback to api reader for checkpoint wait

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -339,19 +338,6 @@ func (c *Cache) ListSandboxesInPool(ctx context.Context, opts ListSandboxesInPoo
 		return nil, err
 	}
 	return resultVal.([]*agentsv1alpha1.Sandbox), nil
-}
-
-// refreshCheckpoint retrieves the latest Checkpoint from cache.
-func (c *Cache) refreshCheckpoint(ctx context.Context, cp *agentsv1alpha1.Checkpoint) (*agentsv1alpha1.Checkpoint, error) {
-	fresh := &agentsv1alpha1.Checkpoint{}
-	err := c.client.Get(ctx, types.NamespacedName{Namespace: cp.Namespace, Name: cp.Name}, fresh)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, fmt.Errorf("checkpoint %s not found in cache", cp.Name)
-		}
-		return nil, fmt.Errorf("failed to get checkpoint %s from cache: %w", cp.Name, err)
-	}
-	return fresh, nil
 }
 
 // GetSandboxController returns the sandbox custom reconciler for external handler registration.

--- a/pkg/cache/tasks.go
+++ b/pkg/cache/tasks.go
@@ -43,7 +43,12 @@ func (c *Cache) SandboxUpdateFunc(ctx context.Context) cacheutils.UpdateFunc[*ag
 
 func (c *Cache) CheckpointUpdateFunc(ctx context.Context) cacheutils.UpdateFunc[*agentsv1alpha1.Checkpoint] {
 	return func(cp *agentsv1alpha1.Checkpoint) (*agentsv1alpha1.Checkpoint, error) {
-		return c.refreshCheckpoint(ctx, cp)
+		key := types.NamespacedName{Namespace: cp.Namespace, Name: cp.Name}
+		got := &agentsv1alpha1.Checkpoint{}
+		if err := utils.GetFromInformerOrApiServer(ctx, got, key, c.client, c.reader); err != nil {
+			return nil, err
+		}
+		return got, nil
 	}
 }
 

--- a/pkg/cache/tasks_internal_test.go
+++ b/pkg/cache/tasks_internal_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+type checkpointUpdateFuncTestCase struct {
+	name               string
+	cacheObjects       []ctrlclient.Object
+	apiObjects         []ctrlclient.Object
+	expectCheckpointID string
+	expectError        string
+}
+
+func TestCheckpointUpdateFunc_FallsBackToAPIReader(t *testing.T) {
+	tests := []checkpointUpdateFuncTestCase{
+		{
+			name: "cache hit returns cached checkpoint",
+			cacheObjects: []ctrlclient.Object{
+				newCheckpointUpdateFuncTestCheckpoint("cp-cache-hit", "cache-id"),
+			},
+			apiObjects: []ctrlclient.Object{
+				newCheckpointUpdateFuncTestCheckpoint("cp-cache-hit", "api-id"),
+			},
+			expectCheckpointID: "cache-id",
+		},
+		{
+			name: "cache miss falls back to api reader",
+			apiObjects: []ctrlclient.Object{
+				newCheckpointUpdateFuncTestCheckpoint("cp-api-hit", "api-id"),
+			},
+			expectCheckpointID: "api-id",
+		},
+		{
+			name:        "cache and api reader miss returns not found",
+			expectError: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cacheClient := newCheckpointUpdateFuncTestClient(t, tt.cacheObjects...)
+			apiReader := newCheckpointUpdateFuncTestClient(t, tt.apiObjects...)
+			c := &Cache{client: cacheClient, reader: apiReader}
+
+			cp := &agentsv1alpha1.Checkpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: checkpointUpdateFuncTestCheckpointName(tt), Namespace: "default"},
+			}
+			got, err := c.CheckpointUpdateFunc(context.Background())(cp)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectCheckpointID, got.Status.CheckpointId)
+		})
+	}
+}
+
+func checkpointUpdateFuncTestCheckpointName(tt checkpointUpdateFuncTestCase) string {
+	if len(tt.cacheObjects) > 0 {
+		return tt.cacheObjects[0].GetName()
+	}
+	if len(tt.apiObjects) > 0 {
+		return tt.apiObjects[0].GetName()
+	}
+	return "cp-missing"
+}
+
+func newCheckpointUpdateFuncTestCheckpoint(name, checkpointID string) *agentsv1alpha1.Checkpoint {
+	return &agentsv1alpha1.Checkpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Status:     agentsv1alpha1.CheckpointStatus{CheckpointId: checkpointID},
+	}
+}
+
+func newCheckpointUpdateFuncTestClient(t *testing.T, objects ...ctrlclient.Object) ctrlclient.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, agentsv1alpha1.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}


### PR DESCRIPTION
## Summary
- Make CheckpointUpdateFunc fall back to the APIReader when the informer cache misses a checkpoint by namespace/name.
- Remove the checkpoint wait path's cache-only refresh helper.
- Add regression coverage for cache hit, cache miss fallback, and double miss cases.

## Test Plan
- [x] go test ./pkg/cache -run TestCheckpointUpdateFunc_FallsBackToAPIReader
- [x] go test ./pkg/cache
- [x] go test ./pkg/cache ./pkg/sandbox-manager/infra/sandboxcr ./pkg/servers/e2b
- [x] go test ./pkg/...