### PR TITLE
feat(api): add CommitConditionTypeNotFound condition type

### DIFF
--- a/api/v1alpha1/commit_types.go
+++ b/api/v1alpha1/commit_types.go
@@ -43,6 +43,8 @@ const (
 	CommitConditionTypePullBaseImage CommitConditionType = "PullBaseImage"
 	// CommitConditionTypePushCommittedImage indicates whether the committed image push step succeeded.
 	CommitConditionTypePushCommittedImage CommitConditionType = "PushCommittedImage"
+	// CommitConditionTypeNotFound indicates that the target Pod or container was not found.
+	CommitConditionTypeNotFound CommitConditionType = "CommitNotFound"
 )
 
 type CommitSpec struct {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Add `CommitConditionTypeNotFound` condition type to the Commit CRD. This condition indicates that the target Pod or container was not found during commit processing.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Check `api/v1alpha1/commit_types.go` — new constant `CommitConditionTypeNotFound` is added alongside existing condition types.
2. Run `make manifests generate` to verify generated artifacts are consistent.

### Ⅳ. Special notes for reviews

- Follow-up to #502 (Commit CRD type definition). The `CommitNotFound` condition was originally defined but dropped during review iterations.
- No CRD schema change — this is a Go constant only, not a CRD field.
