### PR TITLE
fix(checkpoint): correct pause condition reasons for checkpoint-disabled and pod-deleted paths

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -333,6 +333,7 @@ const (
 	SandboxPausedReasonCheckpointSucceeded = "CheckpointSucceeded"
 	SandboxPausedReasonCheckpointFailed    = "CheckpointFailed"
 	SandboxPausedReasonSetPause            = "SetPause"
+	SandboxPausedReasonPausedSucceed       = "PauseSucceed"
 	SandboxPausedReasonDeletePod           = "DeletePod"
 
 	// SandboxConditionResume Reason

--- a/pkg/controller/sandbox/core/checkpoint.go
+++ b/pkg/controller/sandbox/core/checkpoint.go
@@ -52,6 +52,7 @@ func NewCheckpointControl(cli client.Client, recorder record.EventRecorder) *Che
 // Returns true if the pause flow should wait (checkpoint in progress or image rejected).
 func (c *CheckpointControl) AssumePodCheckpointed(ctx context.Context, pod *corev1.Pod, box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus, cond *metav1.Condition) bool {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.SandboxPauseCheckpointGate) {
+		cond.Reason = agentsv1alpha1.SandboxPausedReasonCheckpointSucceeded
 		return false
 	}
 	// Allow-list of paused reasons that should drive the checkpoint flow.

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -192,7 +192,7 @@ func (r *commonControl) EnsureSandboxPaused(ctx context.Context, args EnsureFunc
 	// cond.Status == metav1.ConditionFalse just for sure
 	if pod == nil && cond.Status == metav1.ConditionFalse {
 		cond.Status = metav1.ConditionTrue
-		cond.Reason = agentsv1alpha1.SandboxPausedReasonSetPause
+		cond.Reason = agentsv1alpha1.SandboxPausedReasonDeletePod
 		cond.LastTransitionTime = metav1.Now()
 		utils.SetSandboxCondition(newStatus, *cond)
 		klog.InfoS("Pod deletion completed, pause phase completed", "sandbox", klog.KObj(box))


### PR DESCRIPTION
## Summary
- When the checkpoint feature gate is disabled, set `cond.Reason` to `CheckpointSucceeded` before returning so downstream callers see a valid reason instead of an uninitialized value.
- When pod is already deleted during pause, use `DeletePod` reason instead of `SetPause` to accurately reflect the pause cause.
- Add `PauseSucceed` reason constant for future use.

## Test plan
- [ ] Verify pause flow with checkpoint feature gate disabled sets correct condition reason
- [ ] Verify pod-deleted pause path uses `DeletePod` reason
- [ ] Run unit tests for `pkg/controller/sandbox/core/`