### PR TITLE
fix(sandbox-manager): normalize rate limiter deadline error in clone

### DIFF
--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -18,6 +18,7 @@ package sandboxcr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -213,6 +214,21 @@ func waitCloneCreateLimiter(ctx context.Context, opts infra.CloneSandboxOptions,
 	metrics.Wait += cost
 	metrics.Total += cost
 	if waitErr != nil {
+		// rate.Limiter.Wait can return its own "rate: Wait(n=1) would exceed
+		// context deadline" sentinel when, at the moment Wait inspected the
+		// context, the wall-clock had already passed ctx.Deadline() but
+		// ctx.Done() was not yet observable. That is the same outcome as a
+		// plain deadline expiry, just surfaced through a different branch in
+		// the limiter. Normalize it so callers (and wait.Interrupted in the
+		// outer retry loop) always see the canonical context error and tests
+		// do not depend on which branch the runtime happens to pick.
+		if !errors.Is(waitErr, context.Canceled) && !errors.Is(waitErr, context.DeadlineExceeded) {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				waitErr = ctxErr
+			} else if deadline, ok := ctx.Deadline(); ok && !time.Now().Before(deadline) {
+				waitErr = context.DeadlineExceeded
+			}
+		}
 		log.Error(waitErr, "failed to wait create sandbox limiter")
 		return metrics, waitErr
 	}


### PR DESCRIPTION
## What this PR does / why we need it

Normalize the error returned by the create rate limiter inside `waitCloneCreateLimiter` so that callers and the outer `retry.OnError` loop always observe the canonical context error on deadline expiry.

### Background

`Infra.CloneSandbox` wraps the work in a per-call context with `CloneTimeout` and drives retries through `retry.OnError`. Each attempt blocks on `opts.CreateLimiter.Wait(ctx)` (`golang.org/x/time/rate`). When the context deadline has already passed in wall-clock time at the moment `Wait` inspects it but the runtime timer has not yet closed `ctx.Done()`, the limiter takes the second branch in `(*Limiter).wait` and returns its own sentinel:

```
rate: Wait(n=1) would exceed context deadline
```

instead of `context.DeadlineExceeded`. Both branches mean exactly the same thing — the deadline has elapsed — but the sentinel:

- is not recognized by `wait.Interrupted`, so [preserveInterruptedError](pkg/sandbox-manager/infra/sandboxcr/errors.go) cannot tell the outer retry loop to bail out cleanly;
- leaks an implementation detail of the limiter through to upper layers (and to test assertions);
- makes `TestInfra_CloneSandboxRetriesCreateFailure/always-failing_create_exhausts_retry_budget` flaky in CI, because which branch wins depends on a benign timer-vs-`time.Now()` race that only shows up under load.

### Change

In `waitCloneCreateLimiter`, after `Limiter.Wait` returns a non-context error, check whether the context has actually expired (`ctx.Err()` non-nil, or `time.Now() >= ctx.Deadline()`). If so, replace the error with the canonical `ctx.Err()` / `context.DeadlineExceeded`. All other limiter / context errors are passed through unchanged.

This is a one-file, surgical fix that:

- preserves existing retry semantics for any genuinely non-deadline limiter error (none today, but defensive);
- aligns the clone path's deadline reporting with what callers see for any other ctx-aware step in the same function;
- makes `wait.Interrupted` recognize the timeout and lets `retry.OnError` exit instead of treating it as a non-retriable surprise.

## Which issue(s) this PR fixes

Fixes a CI flake in `TestInfra_CloneSandboxRetriesCreateFailure/always-failing_create_exhausts_retry_budget`:

```
Error: "rate: Wait(n=1) would exceed context deadline" does not contain "context deadline exceeded"
```

## Special notes for your reviewer

- Behavior change is limited to error normalization — no change to retry counts, metrics, or the limiter itself.
- No new tests added: the existing `TestInfra_CloneSandboxRetriesCreateFailure` table already covers the failure path; with this change its `assert.Contains(err.Error(), "context deadline exceeded")` is now deterministic. Verified locally via `go test ./pkg/sandbox-manager/infra/sandboxcr/ -run TestInfra_CloneSandboxRetriesCreateFailure -count=20` (passes 20/20) and the broader `TestInfra_Clone*` suite.
- Suggested review focus: the early-return condition in `waitCloneCreateLimiter`, in particular the order `errors.Is(..., context.Canceled/DeadlineExceeded) → ctx.Err() → wall-clock vs deadline`.

## Does this PR introduce a user-facing change?

```release-note
NONE
```
