### PR TITLE
feat: skip SandboxHashImmutablePart check when annotation is missing

### DIFF
--- a/pkg/controller/sandbox/core/common_inplace_update_handler.go
+++ b/pkg/controller/sandbox/core/common_inplace_update_handler.go
@@ -59,7 +59,8 @@ func handleInPlaceUpdateCommon(
 	if pod.Labels[agentsv1alpha1.PodLabelTemplateHash] == "" {
 		return true, nil
 		// todo, update inplaceupdate condition
-	} else if box.Annotations[agentsv1alpha1.SandboxHashImmutablePart] != hashImmutablePart {
+	} else if box.Annotations[agentsv1alpha1.SandboxHashImmutablePart] != "" &&
+		box.Annotations[agentsv1alpha1.SandboxHashImmutablePart] != hashImmutablePart {
 		klog.InfoS("sandbox hash-immutable-part changed, and does not permit in-place upgrades", "sandbox", klog.KObj(box),
 			"old hash", box.Annotations[agentsv1alpha1.SandboxHashImmutablePart],
 			"new hash", hashImmutablePart)

--- a/pkg/controller/sandbox/core/common_inplace_update_handler_test.go
+++ b/pkg/controller/sandbox/core/common_inplace_update_handler_test.go
@@ -159,6 +159,69 @@ func TestHandleInPlaceUpdateCommon(t *testing.T) {
 			description:    "When hash mismatch occurs, should return true",
 		},
 		{
+			name: "missing SandboxHashImmutablePart annotation should skip hash check",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Labels: map[string]string{
+						agentsv1alpha1.PodLabelTemplateHash: "some-hash",
+					},
+					Annotations: map[string]string{
+						// Previous inplace update completed (no updateImages/updateResources flags)
+						inplaceupdate.PodAnnotationInPlaceUpdateStateKey: `{"revision":"prev-revision","updateTimestamp":"2024-01-01T00:00:00Z"}`,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test-container",
+							Image: "nginx:latest",
+						},
+					},
+				},
+			},
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-sandbox",
+					Namespace:   "default",
+					Annotations: map[string]string{}, // No SandboxHashImmutablePart annotation
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "test-container",
+										Image: "nginx:latest",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newStatus: &agentsv1alpha1.SandboxStatus{
+				UpdateRevision: "test-revision",
+			},
+			setupHandler: func() InPlaceUpdateHandler {
+				scheme := runtime.NewScheme()
+				_ = clientgoscheme.AddToScheme(scheme)
+				_ = agentsv1alpha1.AddToScheme(scheme)
+
+				recorder := createTestRecorder()
+				return &MockInPlaceUpdateHandler{
+					control:  inplaceupdate.NewInPlaceUpdateControl(nil, inplaceupdate.DefaultGeneratePatchBodyFunc),
+					recorder: recorder,
+					logger:   logr.Discard(),
+				}
+			},
+			expectedResult: true,
+			expectError:    false,
+			description:    "When SandboxHashImmutablePart annotation is missing, hash check should be skipped and continue processing",
+		},
+		{
 			name: "revision consistent and update completed should return true",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds a pre-check to only compare `SandboxHashImmutablePart` annotation when it exists, preventing false negatives for older Sandboxes that don't have this annotation set yet.

**Changes:**
- Modified `handleInPlaceUpdateCommon` in `pkg/controller/sandbox/core/common_inplace_update_handler.go` to check if `SandboxHashImmutablePart` annotation exists before comparing hashes
- Added unit test case in `pkg/controller/sandbox/core/common_inplace_update_handler_test.go` to verify hash check is skipped when annotation is absent
- Ensures backward compatibility with legacy Sandbox resources

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run unit tests: `go test ./pkg/controller/sandbox/core/...`
2. Verify that Sandboxes without `SandboxHashImmutablePart` annotation can still proceed with inplace update checks
3. Verify that Sandboxes with mismatched annotations are still correctly rejected

### Ⅳ. Special notes for reviews

The change ensures that:
1. If the `SandboxHashImmutablePart` annotation is empty (doesn't exist), the hash comparison is skipped
2. Only when the annotation exists AND differs from the computed hash, the in-place update is forbidden
3. This prevents false negatives for older Sandboxes that don't have this annotation set yet