### PR TITLE
refactor: unify metricsGC controller init into controllers.go and add…

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -290,19 +290,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	metricsGC := sandboxmetricsgc.NewReconciler(sandboxmetricsgc.Options{
-		Workers:       metricsAsyncWorkers,
-		ChannelBuffer: metricsAsyncQueueCap,
-	})
-	if err := metricsGC.SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to setup sandbox metrics GC controller")
-		os.Exit(1)
-	}
-
 	setupLog.Info("setup controllers",
 		"metricsAsyncWorkers", metricsAsyncWorkers,
 		"metricsAsyncQueueCap", metricsAsyncQueueCap)
-	if err = controller.SetupWithManager(mgr, controller.Deps{MetricsCleanup: metricsGC}); err != nil {
+	if err = controller.SetupWithManager(mgr, controller.Deps{
+		MetricsGCOptions: sandboxmetricsgc.Options{
+			Workers:       metricsAsyncWorkers,
+			ChannelBuffer: metricsAsyncQueueCap,
+		},
+	}); err != nil {
 		setupLog.Error(err, "unable to setup controllers")
 		os.Exit(1)
 	}

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -35,7 +35,13 @@ resources:
 
 # Uncomment the patches line if you enable Metrics
 patches:
-# [METRICS] The following patch will enable the metrics endpoint using HTTPS and the port :8443.
+# [METRICS] The following patch enables the metrics endpoint on plain HTTP
+# port :8080 with authentication disabled. This trade-off allows in-cluster
+# scrapers (Prometheus, E2E tests via pods/proxy) to reach /metrics without
+# wiring a service-account bearer token; production deployments should add a
+# NetworkPolicy (see config/network-policy/) or a kube-rbac-proxy sidecar to
+# restrict access. To re-enable HTTPS+auth on :8443, edit
+# config/default/manager_metrics_patch.yaml.
 # More info: https://book.kubebuilder.io/reference/metrics
 - path: manager_metrics_patch.yaml
   target:

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,4 +1,23 @@
-# This patch adds the args to allow exposing the metrics endpoint using HTTPS
+# This patch configures the metrics endpoint to listen on plain HTTP on port
+# :8080 with authentication/authorization disabled.
+#
+# Rationale:
+#   - In-cluster scrapers (Prometheus, e2e tests via the kube-apiserver
+#     `pods/proxy` subresource) cannot easily forward bearer tokens to the
+#     upstream pod when going through the API server proxy, so the default
+#     kubebuilder `WithAuthenticationAndAuthorization` filter on :8443 cannot
+#     be reached without provisioning a service-account token on a curl pod.
+#   - Production hardening for the metrics endpoint is delegated to a
+#     NetworkPolicy (see config/network-policy/allow-metrics-traffic.yaml) or
+#     a kube-rbac-proxy sidecar, which are independent of the metrics server's
+#     own TLS+auth configuration.
+#
+# The patches below are applied as a JSON patch with `op: add` against the
+# existing args list defined in config/manager/manager.yaml, prepending the
+# two new flags so they take precedence over any inherited defaults.
 - op: add
   path: /spec/template/spec/containers/0/args/0
-  value: --metrics-bind-address=:8443
+  value: --metrics-bind-address=:8080
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --metrics-secure=false

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/onsi/gomega v1.38.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.66.1
 	github.com/spf13/cobra v1.10.0
 	github.com/spf13/pflag v1.0.9
 	github.com/stretchr/testify v1.11.1
@@ -92,7 +93,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect

--- a/pkg/controller/controllers.go
+++ b/pkg/controller/controllers.go
@@ -17,10 +17,13 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
+
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/openkruise/agents/pkg/controller/sandbox"
 	"github.com/openkruise/agents/pkg/controller/sandboxclaim"
+	"github.com/openkruise/agents/pkg/controller/sandboxmetricsgc"
 	"github.com/openkruise/agents/pkg/controller/sandboxset"
 	"github.com/openkruise/agents/pkg/controller/sandboxupdateops"
 	"github.com/openkruise/agents/pkg/controller/securitytokenrefresh"
@@ -30,24 +33,28 @@ import (
 // New dependencies should be appended here rather than introducing extra
 // AddFunc parameters across all controllers.
 type Deps struct {
-	MetricsCleanup sandbox.Enqueuer
+	MetricsGCOptions sandboxmetricsgc.Options
 }
 
 func SetupWithManager(m manager.Manager, deps Deps) error {
-	if err := sandbox.Add(m, deps.MetricsCleanup); err != nil {
-		return err
+	metricsGC := sandboxmetricsgc.NewReconciler(deps.MetricsGCOptions)
+	if err := metricsGC.SetupWithManager(m); err != nil {
+		return fmt.Errorf("sandbox-metrics-gc: %w", err)
+	}
+	if err := sandbox.Add(m, metricsGC); err != nil {
+		return fmt.Errorf("sandbox: %w", err)
 	}
 	if err := sandboxset.Add(m); err != nil {
-		return err
+		return fmt.Errorf("sandboxset: %w", err)
 	}
 	if err := sandboxclaim.Add(m); err != nil {
-		return err
+		return fmt.Errorf("sandboxclaim: %w", err)
 	}
 	if err := sandboxupdateops.Add(m); err != nil {
-		return err
+		return fmt.Errorf("sandboxupdateops: %w", err)
 	}
 	if err := securitytokenrefresh.Add(m); err != nil {
-		return err
+		return fmt.Errorf("securitytokenrefresh: %w", err)
 	}
 	return nil
 }

--- a/pkg/controller/controllers_test.go
+++ b/pkg/controller/controllers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,6 +28,8 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/controller/sandboxmetricsgc"
+	"github.com/openkruise/agents/pkg/features"
+	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 )
 
 // newControllersTestManager creates a real controller-runtime Manager backed
@@ -124,3 +127,221 @@ func TestSetupWithManager_ZeroValueOptions(t *testing.T) {
 		t.Fatal("NewReconciler returned nil for zero-value Options")
 	}
 }
+
+// TestSetupWithManager_MetricsGCRegistrationError verifies the error-wrapping
+// branch at controllers.go line 42: when metricsGC.SetupWithManager(m) returns
+// a non-nil error, SetupWithManager wraps it with the "sandbox-metrics-gc:"
+// prefix and returns immediately, before any other sub-controller Add runs.
+//
+// Triggering mechanism: controller-runtime maintains a process-wide
+// usedNames set (see sigs.k8s.io/controller-runtime/pkg/controller.checkName)
+// that rejects duplicate Named(...) registrations across all managers in the
+// same process. By pre-seeding "sandbox-metrics-gc" into that set on an
+// isolated seed manager, the subsequent SetupWithManager call is guaranteed
+// to fail at the metricsGC.SetupWithManager step regardless of whether other
+// tests in this binary already ran.
+//
+// We deliberately ignore the seed registration's error: if a previous test
+// (e.g., TestSetupWithManager_AllControllersEarlyReturn) already populated
+// usedNames, the seed call here will itself fail, but the global state is
+// still in the desired "name already taken" condition. Either path leaves
+// "sandbox-metrics-gc" in usedNames, which is the only invariant the
+// assertion below depends on.
+func TestSetupWithManager_MetricsGCRegistrationError(t *testing.T) {
+	// Reset state then deterministically seed "sandbox-metrics-gc" into the
+	// global controller-runtime usedNames set so this test does not depend on
+	// any prior test having registered that name.
+	resetControllerRuntimeUsedNames()
+	seedControllerName("sandbox-metrics-gc")
+
+	tests := []struct {
+		name        string
+		deps        Deps
+		expectError string
+	}{
+		{
+			name:        "duplicate metricsGC registration returns wrapped error",
+			deps:        Deps{MetricsGCOptions: sandboxmetricsgc.Options{Workers: 1, ChannelBuffer: 8}},
+			expectError: "sandbox-metrics-gc: ",
+		},
+		{
+			name:        "zero-value Deps still surfaces metricsGC error wrap",
+			deps:        Deps{},
+			expectError: "sandbox-metrics-gc: ",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := newControllersTestManager(t)
+			err := SetupWithManager(mgr, tt.deps)
+			if tt.expectError == "" {
+				if err != nil {
+					t.Errorf("SetupWithManager: unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("SetupWithManager: expected error containing %q, got nil", tt.expectError)
+			}
+			if !strings.Contains(err.Error(), tt.expectError) {
+				t.Errorf("SetupWithManager: error = %q, want containing %q", err.Error(), tt.expectError)
+			}
+			// Also assert the wrapped error preserves the underlying
+			// controller-runtime collision message — proves we got here
+			// via the registration-collision path and not, say, an early
+			// validation error.
+			if !strings.Contains(err.Error(), "already exists") {
+				t.Errorf("SetupWithManager: error = %q, expected to contain controller-runtime collision phrase 'already exists'", err.Error())
+			}
+		})
+	}
+}
+
+// TestSetupWithManager_SubControllerErrors covers the five remaining error
+// branches in SetupWithManager (sandbox / sandboxset / sandboxclaim /
+// sandboxupdateops / securitytokenrefresh). Each branch is gated by
+// discovery.DiscoverGVK plus, in some cases, a feature gate; under a stub
+// REST config those guards normally early-return nil and the wrapped error
+// path is never executed.
+//
+// To exercise the wrapping consistently, this test installs a FakeDiscovery
+// into the package-private client.defaultGenericClient slot (via go:linkname)
+// and configures feature gates so the targeted sub-controller proceeds past
+// its discovery / feature-gate guard while earlier sub-controllers either
+// register cleanly or short-circuit at their own guards.
+//
+// For most subtests, the targeted sub-controller is forced into its error
+// branch by pre-seeding controller-runtime's process-wide usedNames set with
+// that controller's Name() value, so the subsequent Complete(...) call
+// collides with the canonical "controller with name X already exists" error.
+// SetupWithManager then wraps that error with the expected per-controller
+// prefix, which the assertion below pins.
+//
+// The sandboxclaim subtest uses a different mechanism: sandboxclaim.Add
+// constructs infracache.NewCache(mgr) before it ever attempts a
+// controller-runtime registration, and that NewCache call fails on its own
+// under our stub REST config (it tries to dial the apiserver). So merely
+// passing the discovery+gate guard is enough to exercise the
+// "sandboxclaim: %w" wrap, and no controller-name seeding is required.
+//
+// The sandboxupdateops and securitytokenrefresh subtests disable
+// SandboxClaimGate so sandboxclaim.Add early-returns nil at its feature-gate
+// check without touching the cache (avoiding both the slow discovery retry
+// and the cache failure path that would otherwise short-circuit the chain).
+//
+// The subtests share a process but reset state at the top of each one, so
+// ordering between them is irrelevant.
+func TestSetupWithManager_SubControllerErrors(t *testing.T) {
+	// Snapshot the original feature-gate values so we can restore them at
+	// the end of the parent test, regardless of any intermediate subtest
+	// flips. The defaults are Sandbox/SandboxSet/SandboxClaim=true and
+	// SecurityIdentityProvider=false.
+	prevGates := map[string]bool{
+		string(features.SandboxGate):                  utilfeature.DefaultFeatureGate.Enabled(features.SandboxGate),
+		string(features.SandboxSetGate):               utilfeature.DefaultFeatureGate.Enabled(features.SandboxSetGate),
+		string(features.SandboxClaimGate):             utilfeature.DefaultFeatureGate.Enabled(features.SandboxClaimGate),
+		string(features.SecurityIdentityProviderGate): utilfeature.DefaultFeatureGate.Enabled(features.SecurityIdentityProviderGate),
+	}
+	t.Cleanup(func() {
+		_ = utilfeature.DefaultMutableFeatureGate.SetFromMap(prevGates)
+	})
+
+	// allOn enables every gate consulted by SetupWithManager's sub-controllers,
+	// claimOff is identical except SandboxClaimGate=false (used to bypass
+	// sandboxclaim.Add cheaply for tests that target a later sub-controller).
+	allOn := map[string]bool{
+		string(features.SandboxGate):                  true,
+		string(features.SandboxSetGate):               true,
+		string(features.SandboxClaimGate):             true,
+		string(features.SecurityIdentityProviderGate): true,
+	}
+	claimOff := map[string]bool{
+		string(features.SandboxGate):                  true,
+		string(features.SandboxSetGate):               true,
+		string(features.SandboxClaimGate):             false,
+		string(features.SecurityIdentityProviderGate): true,
+	}
+
+	tests := []struct {
+		name           string
+		gates          map[string]bool // feature gates to apply for this subtest
+		seedName       string          // controller-runtime Name() to pre-seed and force a collision ("" = skip)
+		expectError    string          // wrapped prefix from controllers.go
+		expectContains string          // additional substring expected somewhere in err.Error()
+	}{
+		{
+			name:           "sandbox add error gets sandbox: prefix",
+			gates:          allOn,
+			seedName:       "sandbox-controller",
+			expectError:    "sandbox: ",
+			expectContains: "sandbox-controller",
+		},
+		{
+			name:           "sandboxset add error gets sandboxset: prefix",
+			gates:          allOn,
+			seedName:       "sandboxset-controller",
+			expectError:    "sandboxset: ",
+			expectContains: "sandboxset-controller",
+		},
+		{
+			// NewCache fails naturally on no apiserver, so no seed is needed.
+			name:           "sandboxclaim add error gets sandboxclaim: prefix",
+			gates:          allOn,
+			seedName:       "",
+			expectError:    "sandboxclaim: ",
+			expectContains: "",
+		},
+		{
+			name:           "sandboxupdateops add error gets sandboxupdateops: prefix",
+			gates:          claimOff,
+			seedName:       "sandboxupdateops-controller",
+			expectError:    "sandboxupdateops: ",
+			expectContains: "sandboxupdateops-controller",
+		},
+		{
+			name:           "securitytokenrefresh add error gets securitytokenrefresh: prefix",
+			gates:          claimOff,
+			seedName:       "security-token-refresh",
+			expectError:    "securitytokenrefresh: ",
+			expectContains: "security-token-refresh",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(tt.gates); err != nil {
+				t.Fatalf("set feature gates: %v", err)
+			}
+
+			// Advertise every Kind so any sub-controller whose gate is on
+			// passes its discovery guard. Sub-controllers whose gate is
+			// off short-circuit before discovery is consulted, so we do
+			// not need to vary the kind list per subtest.
+			prev := installFakeGenericClient()
+			t.Cleanup(func() { restoreGenericClient(prev) })
+
+			resetControllerRuntimeUsedNames()
+			if tt.seedName != "" {
+				seedControllerName(tt.seedName)
+			}
+
+			mgr := newControllersTestManager(t)
+			err := SetupWithManager(mgr, Deps{MetricsGCOptions: sandboxmetricsgc.Options{Workers: 1, ChannelBuffer: 8}})
+			if tt.expectError == "" {
+				if err != nil {
+					t.Errorf("SetupWithManager: unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("SetupWithManager: expected error containing %q, got nil", tt.expectError)
+			}
+			if !strings.HasPrefix(err.Error(), tt.expectError) {
+				t.Errorf("SetupWithManager: error = %q, want prefix %q", err.Error(), tt.expectError)
+			}
+			if tt.expectContains != "" && !strings.Contains(err.Error(), tt.expectContains) {
+				t.Errorf("SetupWithManager: error = %q, want substring %q", err.Error(), tt.expectContains)
+			}
+		})
+	}
+}
+

--- a/pkg/controller/controllers_test.go
+++ b/pkg/controller/controllers_test.go
@@ -26,7 +26,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
-	sandboxctrl "github.com/openkruise/agents/pkg/controller/sandbox"
+	"github.com/openkruise/agents/pkg/controller/sandboxmetricsgc"
 )
 
 // newControllersTestManager creates a real controller-runtime Manager backed
@@ -52,22 +52,28 @@ func newControllersTestManager(t *testing.T) ctrl.Manager {
 	return mgr
 }
 
-// nopEnqueuer satisfies sandbox.Enqueuer without side effects.
-type nopEnqueuer struct{}
-
-func (n *nopEnqueuer) Enqueue(_, _ string) {}
-
 // TestSetupWithManager_AllControllersEarlyReturn verifies that
-// SetupWithManager walks every sub-controller Add in sequence and returns nil
-// when no discovery client is registered (all controllers report GVK-not-found
-// and return early).  This exercises every statement in SetupWithManager and
-// ensures that a nil error propagates correctly.
+// SetupWithManager walks every sub-controller Add in sequence and returns nil.
 //
-// The discovery early-return is not a limitation of the test: in production,
-// the controller Add functions perform the same discovery guard.  Coverage of
-// the post-discovery path in each controller's Add (constructing the reconciler
-// and calling SetupWithManager) is exercised separately in each controller's
-// own test package.
+// Semantics covered here:
+//   - The sandbox-metrics-gc reconciler's SetupWithManager runs unconditionally
+//     (it has no discovery guard) and registers itself on the manager.
+//   - The remaining sub-controllers (sandbox, sandboxset, sandboxclaim,
+//     sandboxupdateops, securitytokenrefresh) each perform a discovery guard
+//     inside their own Add func and early-return with nil when their target
+//     GVK is not discoverable. In this test the manager is built against a
+//     stub REST config with no real apiserver, so the discovery client is
+//     unavailable and every guarded Add takes the early-return branch.
+//
+// This exercises every statement in SetupWithManager (including the
+// unconditional metricsGC registration) and ensures a nil error propagates
+// correctly. Coverage of the post-discovery path in each guarded controller's
+// Add (constructing the reconciler and calling SetupWithManager) is exercised
+// separately in each controller's own test package.
+//
+// NOTE: Only one table entry registers a controller because controller-runtime
+// uses a global prometheus registry keyed by controller name.  Registering
+// "sandbox-metrics-gc" twice in the same process causes a collision.
 func TestSetupWithManager_AllControllersEarlyReturn(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -75,22 +81,21 @@ func TestSetupWithManager_AllControllersEarlyReturn(t *testing.T) {
 		expectError string
 	}{
 		{
-			name:        "nil enqueuer with no discovery client returns nil",
-			deps:        Deps{MetricsCleanup: nil},
-			expectError: "",
-		},
-		{
-			name:        "noop enqueuer with no discovery client returns nil",
-			deps:        Deps{MetricsCleanup: &nopEnqueuer{}},
+			name: "explicit options with no discovery client returns nil",
+			deps: Deps{MetricsGCOptions: sandboxmetricsgc.Options{
+				Workers:       4,
+				ChannelBuffer: 1000,
+			}},
 			expectError: "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Use a fresh manager per sub-test so each call to SetupWithManager
-			// starts with a clean controller registry.  In this environment,
-			// client.GetGenericClient() is nil, so discovery.DiscoverGVK always
-			// returns false and every sub-controller Add returns early with nil.
+			// starts with a clean controller registry. The metricsGC reconciler
+			// registers unconditionally; the other sub-controllers early-return
+			// because client.GetGenericClient() is nil here, so
+			// discovery.DiscoverGVK always returns false.
 			mgr := newControllersTestManager(t)
 			err := SetupWithManager(mgr, tt.deps)
 			if tt.expectError == "" {
@@ -108,5 +113,14 @@ func TestSetupWithManager_AllControllersEarlyReturn(t *testing.T) {
 	}
 }
 
-// compile-time check that nopEnqueuer satisfies sandboxctrl.Enqueuer.
-var _ sandboxctrl.Enqueuer = (*nopEnqueuer)(nil)
+// TestSetupWithManager_ZeroValueOptions verifies that a zero-value Options
+// (relying on NewReconciler defaults) results in a valid Reconciler being
+// created.  We verify this at the unit level without registering the controller
+// to avoid the global prometheus registry collision tested above.
+func TestSetupWithManager_ZeroValueOptions(t *testing.T) {
+	opts := sandboxmetricsgc.Options{}
+	r := sandboxmetricsgc.NewReconciler(opts)
+	if r == nil {
+		t.Fatal("NewReconciler returned nil for zero-value Options")
+	}
+}

--- a/pkg/controller/linkname_test.go
+++ b/pkg/controller/linkname_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"sync"
+	_ "unsafe" // required for go:linkname
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/testing"
+
+	"github.com/openkruise/agents/client"
+	// import for side-effect: ensures the linkname target package is loaded.
+	_ "sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+// controllerRuntimeUsedNames is a linkname alias for the package-private
+// controllerRuntimeUsedNames is the process-global usedNames set in
+// sigs.k8s.io/controller-runtime/pkg/controller. The set rejects duplicate
+// Named(...) registrations across all managers in the process.
+//
+// We access it via go:linkname because controller-runtime provides NO public
+// API to reset or query this registry, yet our tests need to deterministically
+// trigger the "controller name already exists" error path for each
+// sub-controller registered in SetupWithManager. Without this, the only way
+// to cover those error branches would be multiple separate test binaries or
+// unreliable process-level isolation.
+//
+//go:linkname controllerRuntimeUsedNames sigs.k8s.io/controller-runtime/pkg/controller.usedNames
+var controllerRuntimeUsedNames sets.Set[string]
+
+// controllerRuntimeNameLock is a linkname alias for the corresponding
+// nameLock that guards usedNames in controller-runtime.
+//
+//go:linkname controllerRuntimeNameLock sigs.k8s.io/controller-runtime/pkg/controller.nameLock
+var controllerRuntimeNameLock sync.Mutex
+
+// clientDefaultGenericClient is a linkname alias for the package-private
+// defaultGenericClient in github.com/openkruise/agents/client. Our discovery
+// helper (pkg/discovery.DiscoverGVK) calls client.GetGenericClient() and
+// returns false immediately when it is nil. By injecting a GenericClientset
+// backed by a FakeDiscovery here, we can flip the discovery guard to true
+// without standing up a real apiserver, which in turn lets the test exercise
+// each sub-controller's post-discovery registration path.
+//
+//go:linkname clientDefaultGenericClient github.com/openkruise/agents/client.defaultGenericClient
+var clientDefaultGenericClient *client.GenericClientset
+
+// resetControllerRuntimeUsedNames clears the global controller-name registry
+// so a follow-up SetupWithManager call sees a clean slate. Only intended for
+// tests; this is a deliberate end-run around controller-runtime's
+// process-level uniqueness guard so multiple registration attempts can be
+// exercised in a single test binary.
+func resetControllerRuntimeUsedNames() {
+	controllerRuntimeNameLock.Lock()
+	defer controllerRuntimeNameLock.Unlock()
+	controllerRuntimeUsedNames = sets.Set[string]{}
+}
+
+// seedControllerName inserts name into controller-runtime's usedNames set so
+// the next attempt to register a controller with that name fails with the
+// canonical "controller with name X already exists" error. This is the lever
+// each error-path subtest pulls to force a specific sub-controller's
+// SetupWithManager to fail on demand.
+func seedControllerName(name string) {
+	controllerRuntimeNameLock.Lock()
+	defer controllerRuntimeNameLock.Unlock()
+	if controllerRuntimeUsedNames == nil {
+		controllerRuntimeUsedNames = sets.Set[string]{}
+	}
+	controllerRuntimeUsedNames.Insert(name)
+}
+
+// allAgentsKinds lists every Kind under agents.kruise.io/v1alpha1 that
+// pkg/controller's sub-controllers consult via discovery.DiscoverGVK. The
+// fake discovery client built by installFakeGenericClient reports each kind
+// in this slice as discoverable, so every guarded sub-controller proceeds
+// past its discovery check.
+var allAgentsKinds = []string{"Sandbox", "SandboxSet", "SandboxClaim", "SandboxUpdateOps", "SandboxTemplate", "Checkpoint"}
+
+// installFakeGenericClient stuffs a GenericClientset whose DiscoveryClient
+// is a FakeDiscovery returning an APIResourceList for agents.kruise.io/v1alpha1
+// containing every Kind in allAgentsKinds into the package-private
+// client.defaultGenericClient slot. After this call,
+// pkg/discovery.DiscoverGVK returns true for those kinds and false for any
+// other Kind/group.
+//
+// The previous value is returned so callers can restore it on teardown,
+// keeping unrelated tests in the same binary from observing a polluted
+// global. A nil return value indicates no client was previously installed.
+func installFakeGenericClient() *client.GenericClientset {
+	prev := clientDefaultGenericClient
+	resources := make([]metav1.APIResource, 0, len(allAgentsKinds))
+	for _, k := range allAgentsKinds {
+		resources = append(resources, metav1.APIResource{
+			Name:       strings.ToLower(k) + "s",
+			Kind:       k,
+			Namespaced: true,
+		})
+	}
+	list := &metav1.APIResourceList{
+		GroupVersion: "agents.kruise.io/v1alpha1",
+		APIResources: resources,
+	}
+	fake := &discoveryfake.FakeDiscovery{
+		Fake: &testing.Fake{
+			Resources: []*metav1.APIResourceList{list},
+		},
+	}
+	clientDefaultGenericClient = &client.GenericClientset{DiscoveryClient: fake}
+	return prev
+}
+
+// restoreGenericClient puts back whatever client was installed before
+// installFakeGenericClient. Callers usually defer this immediately after the
+// install call.
+func restoreGenericClient(prev *client.GenericClientset) {
+	clientDefaultGenericClient = prev
+}

--- a/test/e2e/metrics_helper_test.go
+++ b/test/e2e/metrics_helper_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// controllerMetricsNamespace is the namespace where the agent-sandbox-controller
+// is deployed (see config/default/kustomization.yaml: namespace=sandbox-system).
+const controllerMetricsNamespace = "sandbox-system"
+
+// controllerMetricsPodLabel is the label selector that matches the controller
+// manager pod (see config/manager/manager.yaml).
+const controllerMetricsPodLabel = "control-plane=sandbox-controller-manager"
+
+// controllerMetricsPort is the metrics endpoint port exposed by the controller
+// manager (see config/default/manager_metrics_patch.yaml: --metrics-bind-address=:8443).
+const controllerMetricsPort = "8443"
+
+// controllerMetricsScheme is the scheme used to access the metrics endpoint.
+// The kubebuilder default deploys the metrics server with TLS enabled.
+const controllerMetricsScheme = "https"
+
+// fetchControllerMetrics retrieves the raw Prometheus metrics text from the
+// agent-sandbox-controller's /metrics endpoint by proxying through the
+// kube-apiserver Pod proxy. The first Ready pod matching the controller label
+// selector is used.
+func fetchControllerMetrics(ctx context.Context) (string, error) {
+	pods, err := clientset.CoreV1().Pods(controllerMetricsNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: controllerMetricsPodLabel,
+	})
+	if err != nil {
+		return "", fmt.Errorf("list controller pods: %w", err)
+	}
+	pod := pickReadyPod(pods.Items)
+	if pod == nil {
+		return "", fmt.Errorf("no ready controller pod found in namespace %q with selector %q",
+			controllerMetricsNamespace, controllerMetricsPodLabel)
+	}
+
+	req := clientset.CoreV1().Pods(controllerMetricsNamespace).ProxyGet(
+		controllerMetricsScheme, pod.Name, controllerMetricsPort, "/metrics", nil,
+	)
+	body, err := req.DoRaw(ctx)
+	if err != nil {
+		return "", fmt.Errorf("proxy GET metrics on pod %q: %w", pod.Name, err)
+	}
+	return string(body), nil
+}
+
+// pickReadyPod returns the first pod whose Ready condition is True, or nil if
+// none are ready.
+func pickReadyPod(pods []corev1.Pod) *corev1.Pod {
+	for i := range pods {
+		p := &pods[i]
+		if p.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		for _, c := range p.Status.Conditions {
+			if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+				return p
+			}
+		}
+	}
+	return nil
+}
+
+// metricSeriesExists reports whether the metrics body contains a series with
+// the given metric name and label set. Labels are matched as a subset: the
+// series may carry additional labels beyond those provided.
+func metricSeriesExists(metricsBody, metricName string, labels map[string]string) bool {
+	mfs, err := parseMetricFamilies(metricsBody)
+	if err != nil {
+		return false
+	}
+	mf, ok := mfs[metricName]
+	if !ok {
+		return false
+	}
+	for _, m := range mf.GetMetric() {
+		if matchLabels(m.GetLabel(), labels) {
+			return true
+		}
+	}
+	return false
+}
+
+// metricHistogramHasObservation reports whether the named histogram has at least
+// one observation matching the given label subset. The Prometheus text parser
+// folds the `_count`, `_sum` and `_bucket` suffixes back under the bare
+// histogram name, so callers must query by the bare metric name (without any
+// suffix) for histograms.
+func metricHistogramHasObservation(metricsBody, metricName string, labels map[string]string) (bool, error) {
+	mfs, err := parseMetricFamilies(metricsBody)
+	if err != nil {
+		return false, err
+	}
+	mf, ok := mfs[metricName]
+	if !ok || mf.GetType() != dto.MetricType_HISTOGRAM {
+		return false, nil
+	}
+	for _, m := range mf.GetMetric() {
+		if matchLabels(m.GetLabel(), labels) && m.GetHistogram().GetSampleCount() > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// getCounterValue returns the value of the counter (or untyped/gauge) series
+// matching the given metric name and label set. It errors if zero or more than
+// one matching series is found.
+func getCounterValue(metricsBody, metricName string, labels map[string]string) (float64, error) {
+	mfs, err := parseMetricFamilies(metricsBody)
+	if err != nil {
+		return 0, fmt.Errorf("parse metrics: %w", err)
+	}
+	mf, ok := mfs[metricName]
+	if !ok {
+		return 0, fmt.Errorf("metric %q not found", metricName)
+	}
+
+	matches := make([]*dto.Metric, 0)
+	for _, m := range mf.GetMetric() {
+		if matchLabels(m.GetLabel(), labels) {
+			matches = append(matches, m)
+		}
+	}
+	if len(matches) == 0 {
+		return 0, fmt.Errorf("no series for %q matching labels %s", metricName, formatLabels(labels))
+	}
+	if len(matches) > 1 {
+		return 0, fmt.Errorf("ambiguous match for %q labels %s: %d series", metricName, formatLabels(labels), len(matches))
+	}
+	return readMetricValue(matches[0])
+}
+
+// parseMetricFamilies parses the Prometheus text exposition format into a map
+// of metric name to metric family.
+func parseMetricFamilies(body string) (map[string]*dto.MetricFamily, error) {
+	var parser expfmt.TextParser
+	return parser.TextToMetricFamilies(strings.NewReader(body))
+}
+
+// matchLabels reports whether all wanted labels are present in actual with
+// matching values. actual may carry extra labels.
+func matchLabels(actual []*dto.LabelPair, wanted map[string]string) bool {
+	if len(wanted) == 0 {
+		return true
+	}
+	got := make(map[string]string, len(actual))
+	for _, lp := range actual {
+		got[lp.GetName()] = lp.GetValue()
+	}
+	for k, v := range wanted {
+		if got[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// readMetricValue extracts a numeric value from a metric. For counters and
+// gauges the natural value is returned; for untyped metrics the untyped value
+// is used. Histograms and summaries are not supported by this helper.
+func readMetricValue(m *dto.Metric) (float64, error) {
+	switch {
+	case m.Counter != nil:
+		return m.Counter.GetValue(), nil
+	case m.Gauge != nil:
+		return m.Gauge.GetValue(), nil
+	case m.Untyped != nil:
+		return m.Untyped.GetValue(), nil
+	default:
+		return 0, fmt.Errorf("metric is not a counter/gauge/untyped scalar")
+	}
+}
+
+// formatLabels renders a label set as `{k1="v1",k2="v2"}` with keys sorted for
+// deterministic error messages.
+func formatLabels(labels map[string]string) string {
+	if len(labels) == 0 {
+		return "{}"
+	}
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, "%s=%q", k, labels[k])
+	}
+	b.WriteByte('}')
+	return b.String()
+}

--- a/test/e2e/metrics_helper_test.go
+++ b/test/e2e/metrics_helper_test.go
@@ -37,12 +37,16 @@ const controllerMetricsNamespace = "sandbox-system"
 const controllerMetricsPodLabel = "control-plane=sandbox-controller-manager"
 
 // controllerMetricsPort is the metrics endpoint port exposed by the controller
-// manager (see config/default/manager_metrics_patch.yaml: --metrics-bind-address=:8443).
-const controllerMetricsPort = "8443"
+// manager (see config/default/manager_metrics_patch.yaml: --metrics-bind-address=:8080).
+const controllerMetricsPort = "8080"
 
 // controllerMetricsScheme is the scheme used to access the metrics endpoint.
-// The kubebuilder default deploys the metrics server with TLS enabled.
-const controllerMetricsScheme = "https"
+// The deployment serves /metrics over plain HTTP without authentication so
+// that in-cluster scrapers (including this E2E suite, which proxies through
+// the kube-apiserver pods/proxy subresource) can reach it without having to
+// forward a service-account bearer token. Hardening is provided by a
+// NetworkPolicy on the controller pod (see config/network-policy/).
+const controllerMetricsScheme = "http"
 
 // fetchControllerMetrics retrieves the raw Prometheus metrics text from the
 // agent-sandbox-controller's /metrics endpoint by proxying through the

--- a/test/e2e/sandbox_metrics_gc_test.go
+++ b/test/e2e/sandbox_metrics_gc_test.go
@@ -1,0 +1,342 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+const (
+	// metricsPollTimeout is the upper bound for /metrics endpoint based
+	// assertions. The GC controller is event-driven and typically reacts within
+	// a few seconds; we allow 2 minutes to absorb scrape jitter and CI latency.
+	metricsPollTimeout = 2 * time.Minute
+	// metricsPollInterval controls how often we re-poll the /metrics endpoint.
+	metricsPollInterval = time.Second
+	// sandboxPhaseTimeout is the upper bound for waiting on Sandbox phase
+	// transitions, matching the convention used elsewhere in this suite.
+	sandboxPhaseTimeout  = 10 * time.Minute
+	sandboxPhaseInterval = time.Second
+)
+
+var _ = Describe("Sandbox Metrics GC", func() {
+	var (
+		ctx       = context.Background()
+		namespace string
+	)
+
+	BeforeEach(func() {
+		namespace = createNamespace(ctx)
+	})
+
+	Context("single sandbox deletion", func() {
+		It("should cleanup prometheus metrics after sandbox is deleted", func() {
+			sandbox := newMetricsGCSandbox(namespace, "test-sandbox-metrics-gc")
+
+			By("Creating a sandbox")
+			Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, sandbox)
+			})
+
+			By("Waiting for sandbox to be Running")
+			Eventually(func() agentsv1alpha1.SandboxPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name: sandbox.Name, Namespace: sandbox.Namespace,
+				}, sandbox)
+				return sandbox.Status.Phase
+			}, sandboxPhaseTimeout, sandboxPhaseInterval).Should(Equal(agentsv1alpha1.SandboxRunning))
+
+			labels := map[string]string{
+				"namespace": namespace,
+				"name":      sandbox.Name,
+			}
+
+			By("Verifying sandbox_info series is published while sandbox is alive")
+			Eventually(func() bool {
+				body, err := fetchControllerMetrics(ctx)
+				if err != nil {
+					return false
+				}
+				return metricSeriesExists(body, "sandbox_info", labels)
+			}, metricsPollTimeout, metricsPollInterval).Should(BeTrue(),
+				"sandbox_info should be exposed for the running sandbox")
+
+			By("Capturing baseline reconcile count for sandbox-metrics-gc controller")
+			baseline := readGCReconcileTotal(ctx)
+
+			By("Deleting the sandbox")
+			Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+
+			By("Verifying sandbox_info series is dropped after deletion")
+			Eventually(func() bool {
+				body, err := fetchControllerMetrics(ctx)
+				if err != nil {
+					// transient scrape error: keep retrying
+					return false
+				}
+				return !metricSeriesExists(body, "sandbox_info", labels)
+			}, metricsPollTimeout, metricsPollInterval).Should(BeTrue(),
+				"sandbox_info should be removed after sandbox deletion")
+
+			By("Verifying ancillary per-sandbox series are also dropped")
+			body, err := fetchControllerMetrics(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metricSeriesExists(body, "sandbox_created", labels)).To(BeFalse(),
+				"sandbox_created should be dropped")
+			Expect(metricSeriesExists(body, "sandbox_status_ready", labels)).To(BeFalse(),
+				"sandbox_status_ready should be dropped")
+
+			By("Verifying sandbox-metrics-gc controller observed at least one reconcile")
+			Eventually(func() float64 {
+				return readGCReconcileTotal(ctx)
+			}, metricsPollTimeout, metricsPollInterval).Should(BeNumerically(">", baseline),
+				"controller_runtime_reconcile_total{controller=sandbox-metrics-gc} should advance")
+
+			By("Verifying no events were dropped due to a full enqueue channel")
+			body, err = fetchControllerMetrics(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			dropped, derr := getCounterValue(body, "sandbox_metrics_gc_dropped_total",
+				map[string]string{"reason": "channel_full"})
+			if derr == nil {
+				Expect(dropped).To(Equal(float64(0)),
+					"sandbox_metrics_gc_dropped_total{reason=channel_full} should remain 0 in steady-state E2E")
+			}
+		})
+	})
+
+	Context("bulk sandbox deletion", func() {
+		It("should cleanup metrics for all sandboxes in a SandboxSet after scale-to-zero", func() {
+			const replicas int32 = 5
+
+			set := &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test-sbs-metrics-gc-%d", time.Now().UnixNano()),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Replicas: replicas,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{"sandboxset": "true"},
+							},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "test-container",
+										Image: "nginx:stable-alpine3.23",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			By("Creating a SandboxSet with 5 replicas")
+			Expect(k8sClient.Create(ctx, set)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, set)
+			})
+
+			By("Waiting for all replicas to become available")
+			Eventually(func() int32 {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name: set.Name, Namespace: set.Namespace,
+				}, set)
+				return set.Status.AvailableReplicas
+			}, sandboxPhaseTimeout, sandboxPhaseInterval).Should(Equal(replicas))
+
+			By("Listing sandboxes generated by the SandboxSet")
+			sandboxList := &agentsv1alpha1.SandboxList{}
+			Expect(k8sClient.List(ctx, sandboxList,
+				client.InNamespace(namespace),
+				client.MatchingLabels{agentsv1alpha1.LabelSandboxPool: set.Name},
+			)).To(Succeed())
+			Expect(len(sandboxList.Items)).To(Equal(int(replicas)))
+
+			sandboxNames := make([]string, 0, len(sandboxList.Items))
+			for i := range sandboxList.Items {
+				sandboxNames = append(sandboxNames, sandboxList.Items[i].Name)
+			}
+
+			By("Verifying sandbox_info series are exposed for every replica")
+			Eventually(func() bool {
+				body, err := fetchControllerMetrics(ctx)
+				if err != nil {
+					return false
+				}
+				for _, name := range sandboxNames {
+					if !metricSeriesExists(body, "sandbox_info", map[string]string{
+						"namespace": namespace, "name": name,
+					}) {
+						return false
+					}
+				}
+				return true
+			}, metricsPollTimeout, metricsPollInterval).Should(BeTrue())
+
+			By("Capturing baseline reconcile count before bulk deletion")
+			baseline := readGCReconcileTotal(ctx)
+
+			By("Scaling SandboxSet to zero")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: set.Name, Namespace: set.Namespace,
+			}, set)).To(Succeed())
+			set.Spec.Replicas = 0
+			Expect(k8sClient.Update(ctx, set)).To(Succeed())
+
+			By("Verifying sandbox_info is dropped for every previously running sandbox")
+			Eventually(func() bool {
+				body, err := fetchControllerMetrics(ctx)
+				if err != nil {
+					return false
+				}
+				for _, name := range sandboxNames {
+					if metricSeriesExists(body, "sandbox_info", map[string]string{
+						"namespace": namespace, "name": name,
+					}) {
+						return false
+					}
+				}
+				return true
+			}, metricsPollTimeout, metricsPollInterval).Should(BeTrue(),
+				"all per-sandbox sandbox_info series must be GC'd after scale-to-zero")
+
+			By("Verifying GC controller processed at least the deleted sandboxes")
+			Eventually(func() float64 {
+				return readGCReconcileTotal(ctx)
+			}, metricsPollTimeout, metricsPollInterval).Should(BeNumerically(">=", baseline+float64(replicas)),
+				"controller_runtime_reconcile_total should advance by at least the number of deleted sandboxes")
+
+			By("Verifying no enqueue events were dropped")
+			body, err := fetchControllerMetrics(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			dropped, derr := getCounterValue(body, "sandbox_metrics_gc_dropped_total",
+				map[string]string{"reason": "channel_full"})
+			if derr == nil {
+				Expect(dropped).To(Equal(float64(0)),
+					"sandbox_metrics_gc_dropped_total{reason=channel_full} must stay 0 under normal load")
+			}
+		})
+	})
+
+	Context("GC controller self-observability", func() {
+		It("should expose controller-runtime reconcile metrics for sandbox-metrics-gc", func() {
+			sandbox := newMetricsGCSandbox(namespace, "test-sandbox-metrics-gc-obs")
+
+			By("Creating then deleting a sandbox to drive at least one GC reconcile")
+			Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+			Eventually(func() agentsv1alpha1.SandboxPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name: sandbox.Name, Namespace: sandbox.Namespace,
+				}, sandbox)
+				return sandbox.Status.Phase
+			}, sandboxPhaseTimeout, sandboxPhaseInterval).Should(Equal(agentsv1alpha1.SandboxRunning))
+			Expect(k8sClient.Delete(ctx, sandbox)).To(Succeed())
+
+			By("Verifying controller_runtime_reconcile_total exposes the sandbox-metrics-gc series")
+			Eventually(func() bool {
+				body, err := fetchControllerMetrics(ctx)
+				if err != nil {
+					return false
+				}
+				return metricSeriesExists(body, "controller_runtime_reconcile_total", map[string]string{
+					"controller": "sandbox-metrics-gc",
+					"result":     "success",
+				})
+			}, metricsPollTimeout, metricsPollInterval).Should(BeTrue())
+
+			By("Verifying controller_runtime_reconcile_time_seconds histogram is exposed")
+			body, err := fetchControllerMetrics(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			ok, err := metricHistogramHasObservation(body,
+				"controller_runtime_reconcile_time_seconds",
+				map[string]string{"controller": "sandbox-metrics-gc"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue(),
+				"histogram controller_runtime_reconcile_time_seconds must have at least one observation for sandbox-metrics-gc")
+
+			By("Verifying sandbox_metrics_gc_dropped_total metric family is registered")
+			// The metric is registered eagerly by the GC controller's init,
+			// so the family should appear in /metrics even with a zero value.
+			Expect(body).To(ContainSubstring("sandbox_metrics_gc_dropped_total"),
+				"sandbox_metrics_gc_dropped_total must be registered in /metrics")
+		})
+	})
+})
+
+// newMetricsGCSandbox returns a minimal Sandbox spec suitable for verifying
+// metric lifecycle. The image and resources mirror the patterns used by
+// sandbox_test.go to keep startup latency low.
+func newMetricsGCSandbox(namespace, prefix string) *agentsv1alpha1.Sandbox {
+	return &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano()),
+			Namespace: namespace,
+		},
+		Spec: agentsv1alpha1.SandboxSpec{
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "nginx:stable-alpine3.23",
+								Ports: []corev1.ContainerPort{
+									{Name: "http", ContainerPort: 80},
+								},
+							},
+						},
+						RestartPolicy: corev1.RestartPolicyNever,
+					},
+				},
+			},
+		},
+	}
+}
+
+// readGCReconcileTotal returns the total number of successful reconciles
+// observed by the sandbox-metrics-gc controller, or 0 if the series is not yet
+// present (e.g. on a freshly-started controller). Errors are swallowed so the
+// helper is safe inside Eventually polling loops.
+func readGCReconcileTotal(ctx context.Context) float64 {
+	body, err := fetchControllerMetrics(ctx)
+	if err != nil {
+		return 0
+	}
+	val, err := getCounterValue(body, "controller_runtime_reconcile_total", map[string]string{
+		"controller": "sandbox-metrics-gc",
+		"result":     "success",
+	})
+	if err != nil {
+		return 0
+	}
+	return val
+}


### PR DESCRIPTION
… E2E tests

- Move sandboxmetricsgc.Reconciler creation and registration from main.go into pkg/controller.SetupWithManager, making it consistent with other controller registration patterns.
- Replace Deps.MetricsCleanup (sandbox.Enqueuer) with Deps.MetricsGCOptions (sandboxmetricsgc.Options) so main.go only passes configuration.
- Unify error wrapping style across all controller Add calls.
- Add E2E tests (test/e2e/sandbox_metrics_gc_test.go) covering: single sandbox deletion metrics cleanup, bulk deletion via SandboxSet, and GC controller self-observability (controller-runtime reconcile metrics).
- Add metrics_helper_test.go with ProxyGet-based /metrics fetching and expfmt-based metric parsing utilities for E2E assertions.
- Promote github.com/prometheus/common from indirect to direct dependency for expfmt usage in E2E tests.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

