### PR TITLE
feat(sandbox): check init container image consistency before post-resume initialization

### DIFF
--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -263,6 +263,10 @@ func (r *commonControl) EnsureSandboxResumed(ctx context.Context, args EnsureFun
 		// Delete all Checkpoint CRs after successful resume (pod is running and ready)
 		r.checkpointControl.Cleanup(ctx, box)
 
+		if !isContainersConsistent(pod, box) {
+			return nil
+		}
+
 		// re-initialize sandbox after resuming or upgrading (includes runtime re-init and CSI storage re-mount)
 		if err := r.initializer.Initialize(ctx, box, newStatus); err != nil {
 			klog.ErrorS(err, "post-resume initialization failed", "sandbox", klog.KObj(box))
@@ -296,6 +300,34 @@ func (r *commonControl) EnsureSandboxResumed(ctx context.Context, args EnsureFun
 		utils.SetSandboxCondition(newStatus, *rCond)
 	}
 	return nil
+}
+
+// isContainersConsistent verifies that every init container's image in pod.Spec
+// matches the corresponding image reported in pod.Status. Returns false if any mismatch or
+// missing status is found, indicating the caller should wait for the status to converge.
+func isContainersConsistent(pod *corev1.Pod, box *agentsv1alpha1.Sandbox) bool {
+	initStatusImages := make(map[string]string, len(pod.Status.InitContainerStatuses))
+	for _, initStatus := range pod.Status.InitContainerStatuses {
+		initStatusImages[initStatus.Name] = initStatus.Image
+	}
+	for _, initContainer := range pod.Spec.InitContainers {
+		statusImage, found := initStatusImages[initContainer.Name]
+		if !found {
+			klog.InfoS("init container status not found, waiting",
+				"sandbox", klog.KObj(box),
+				"container", initContainer.Name)
+			return false
+		}
+		if statusImage != initContainer.Image {
+			klog.InfoS("init container image mismatch between spec and status, waiting",
+				"sandbox", klog.KObj(box),
+				"container", initContainer.Name,
+				"specImage", initContainer.Image,
+				"statusImage", statusImage)
+			return false
+		}
+	}
+	return true
 }
 
 // hasUpgradeAction checks if the sandbox has a non-empty upgrade action configured.

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -2472,6 +2472,288 @@ func TestCommonControl_performRecreateUpgrade_PodReadyFalse(t *testing.T) {
 	}
 }
 
+func Test_isContainersConsistent(t *testing.T) {
+	box := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected bool
+	}{
+		{
+			name: "no init containers - consistent",
+			pod: &corev1.Pod{
+				Spec:   corev1.PodSpec{},
+				Status: corev1.PodStatus{},
+			},
+			expected: true,
+		},
+		{
+			name: "single init container - images match",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "init-a", Image: "busybox:1.0"},
+					},
+				},
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "init-a", Image: "busybox:1.0"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "single init container - status not found",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "init-a", Image: "busybox:1.0"},
+					},
+				},
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "single init container - image mismatch",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "init-a", Image: "busybox:2.0"},
+					},
+				},
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "init-a", Image: "busybox:1.0"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "multiple init containers - all match",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "init-a", Image: "busybox:1.0"},
+						{Name: "init-b", Image: "alpine:3.18"},
+					},
+				},
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "init-a", Image: "busybox:1.0"},
+						{Name: "init-b", Image: "alpine:3.18"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "multiple init containers - second mismatches",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "init-a", Image: "busybox:1.0"},
+						{Name: "init-b", Image: "alpine:3.19"},
+					},
+				},
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "init-a", Image: "busybox:1.0"},
+						{Name: "init-b", Image: "alpine:3.18"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "multiple init containers - one status missing",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "init-a", Image: "busybox:1.0"},
+						{Name: "init-b", Image: "alpine:3.18"},
+					},
+				},
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "init-a", Image: "busybox:1.0"},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isContainersConsistent(tt.pod, box)
+			if result != tt.expected {
+				t.Errorf("isContainersConsistent() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCommonControl_EnsureSandboxResumed_InitContainerInconsistent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	now := metav1.Now()
+
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		expectPhase   agentsv1alpha1.SandboxPhase
+		expectInitCon bool // expect RuntimeInitialized condition to be set
+	}{
+		{
+			name: "init container image mismatch - should wait and not initialize",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+					UID:       "pod-uid",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node-1",
+					InitContainers: []corev1.Container{
+						{Name: "init-a", Image: "busybox:2.0"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					PodIP: "10.0.0.1",
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: now},
+					},
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "init-a", Image: "busybox:1.0"},
+					},
+				},
+			},
+			expectPhase:   agentsv1alpha1.SandboxRunning,
+			expectInitCon: false,
+		},
+		{
+			name: "init container status missing - should wait and not initialize",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+					UID:       "pod-uid",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node-1",
+					InitContainers: []corev1.Container{
+						{Name: "init-a", Image: "busybox:1.0"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					PodIP: "10.0.0.1",
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: now},
+					},
+					InitContainerStatuses: []corev1.ContainerStatus{},
+				},
+			},
+			expectPhase:   agentsv1alpha1.SandboxRunning,
+			expectInitCon: false,
+		},
+		{
+			name: "init containers consistent - should proceed to initialize",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+					UID:       "pod-uid",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node-1",
+					InitContainers: []corev1.Container{
+						{Name: "init-a", Image: "busybox:1.0"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					PodIP: "10.0.0.1",
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: now},
+					},
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "init-a", Image: "busybox:1.0"},
+					},
+				},
+			},
+			expectPhase:   agentsv1alpha1.SandboxRunning,
+			expectInitCon: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+			control := &commonControl{
+				Client:               fc,
+				recorder:             record.NewFakeRecorder(10),
+				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fc, inplaceupdate.DefaultGeneratePatchBodyFunc),
+				initializer:          &mockSandboxInitializer{err: nil},
+				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+			}
+
+			newStatus := &agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxResuming,
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionReady),
+						Status:             metav1.ConditionFalse,
+						LastTransitionTime: now,
+						Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
+					},
+				},
+			}
+
+			box := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+				},
+			}
+
+			err := control.EnsureSandboxResumed(context.TODO(), EnsureFuncArgs{Pod: tt.pod, Box: box, NewStatus: newStatus})
+			if err != nil {
+				t.Fatalf("EnsureSandboxResumed() unexpected error: %v", err)
+			}
+
+			if newStatus.Phase != tt.expectPhase {
+				t.Errorf("expected phase %s, got %s", tt.expectPhase, newStatus.Phase)
+			}
+
+			initCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.RuntimeInitialized))
+			if tt.expectInitCon {
+				if initCond == nil {
+					t.Error("expected RuntimeInitialized condition to be set, but it was not")
+				}
+			} else {
+				if initCond != nil {
+					t.Error("expected RuntimeInitialized condition to NOT be set, but it was")
+				}
+			}
+		})
+	}
+}
+
 // mockSandboxInitializer is a test double for SandboxInitializer.
 type mockSandboxInitializer struct {
 	err error

--- a/pkg/controller/sandbox/pod_event_handler.go
+++ b/pkg/controller/sandbox/pod_event_handler.go
@@ -85,6 +85,9 @@ func isActivePodUpdate(oldObj, newObj *corev1.Pod) bool {
 	if oldObj.Status.Phase != newObj.Status.Phase || oldObj.Status.PodIP != newObj.Status.PodIP {
 		return true
 	}
+	if !isContainerStatusImageEqual(oldObj.Status.InitContainerStatuses, newObj.Status.InitContainerStatuses) {
+		return true
+	}
 	rCond1 := utils.GetPodCondition(&oldObj.Status, corev1.PodReady)
 	rCond2 := utils.GetPodCondition(&newObj.Status, corev1.PodReady)
 	if !isPodConditionEqual(rCond1, rCond2) {
@@ -134,4 +137,23 @@ func isPodConditionEqual(a, b *corev1.PodCondition) bool {
 		return false
 	}
 	return a.Status == b.Status && a.Reason == b.Reason && a.Message == b.Message
+}
+
+// isContainerStatusImageEqual checks whether the Image field of each
+// init container status is the same between old and new. It matches by
+// container name so that ordering differences are tolerated.
+func isContainerStatusImageEqual(old, new []corev1.ContainerStatus) bool {
+	if len(old) != len(new) {
+		return false
+	}
+	oldImages := make(map[string]string, len(old))
+	for _, cs := range old {
+		oldImages[cs.Name] = cs.Image
+	}
+	for _, cs := range new {
+		if oldImages[cs.Name] != cs.Image {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/controller/sandbox/pod_event_handler_test.go
+++ b/pkg/controller/sandbox/pod_event_handler_test.go
@@ -631,6 +631,70 @@ func TestIsActivePodUpdate(t *testing.T) {
 			description: "should ignore changes in non-tracked conditions",
 		},
 		{
+			name: "InitContainerStatuses - image changed triggers update",
+			oldPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "init-a", Image: "busybox:1.0"},
+					},
+				},
+			},
+			newPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "init-a", Image: "busybox:2.0"},
+					},
+				},
+			},
+			expected:    true,
+			description: "should return true when init container status image changes",
+		},
+		{
+			name: "InitContainerStatuses - count changed triggers update",
+			oldPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "init-a", Image: "busybox:1.0"},
+					},
+				},
+			},
+			newPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "init-a", Image: "busybox:1.0"},
+						{Name: "init-b", Image: "alpine:3.18"},
+					},
+				},
+			},
+			expected:    true,
+			description: "should return true when init container status count changes",
+		},
+		{
+			name: "InitContainerStatuses - unchanged does not trigger",
+			oldPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "init-a", Image: "busybox:1.0"},
+					},
+				},
+			},
+			newPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "init-a", Image: "busybox:1.0"},
+					},
+				},
+			},
+			expected:    false,
+			description: "should return false when init container statuses are unchanged",
+		},
+		{
 			name: "ContainerStatuses - container added",
 			oldPod: &corev1.Pod{
 				Status: corev1.PodStatus{
@@ -1031,6 +1095,98 @@ func TestIsActivePodUpdate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := isActivePodUpdate(tt.oldPod, tt.newPod)
 			assert.Equal(t, tt.expected, result, tt.description)
+		})
+	}
+}
+
+func TestIsContainerStatusImageEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		old      []corev1.ContainerStatus
+		new      []corev1.ContainerStatus
+		expected bool
+	}{
+		{
+			name:     "both empty",
+			old:      []corev1.ContainerStatus{},
+			new:      []corev1.ContainerStatus{},
+			expected: true,
+		},
+		{
+			name:     "both nil",
+			old:      nil,
+			new:      nil,
+			expected: true,
+		},
+		{
+			name: "single container - images match",
+			old:  []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:1.0"}},
+			new:  []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:1.0"}},
+			expected: true,
+		},
+		{
+			name: "single container - images differ",
+			old:  []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:1.0"}},
+			new:  []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:2.0"}},
+			expected: false,
+		},
+		{
+			name: "different count",
+			old:  []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:1.0"}},
+			new: []corev1.ContainerStatus{
+				{Name: "init-a", Image: "busybox:1.0"},
+				{Name: "init-b", Image: "alpine:3.18"},
+			},
+			expected: false,
+		},
+		{
+			name: "multiple containers - all match",
+			old: []corev1.ContainerStatus{
+				{Name: "init-a", Image: "busybox:1.0"},
+				{Name: "init-b", Image: "alpine:3.18"},
+			},
+			new: []corev1.ContainerStatus{
+				{Name: "init-a", Image: "busybox:1.0"},
+				{Name: "init-b", Image: "alpine:3.18"},
+			},
+			expected: true,
+		},
+		{
+			name: "multiple containers - second differs",
+			old: []corev1.ContainerStatus{
+				{Name: "init-a", Image: "busybox:1.0"},
+				{Name: "init-b", Image: "alpine:3.18"},
+			},
+			new: []corev1.ContainerStatus{
+				{Name: "init-a", Image: "busybox:1.0"},
+				{Name: "init-b", Image: "alpine:3.19"},
+			},
+			expected: false,
+		},
+		{
+			name: "different order - still equal",
+			old: []corev1.ContainerStatus{
+				{Name: "init-b", Image: "alpine:3.18"},
+				{Name: "init-a", Image: "busybox:1.0"},
+			},
+			new: []corev1.ContainerStatus{
+				{Name: "init-a", Image: "busybox:1.0"},
+				{Name: "init-b", Image: "alpine:3.18"},
+			},
+			expected: true,
+		},
+		{
+			name: "same count but different names",
+			old:  []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:1.0"}},
+			new:  []corev1.ContainerStatus{{Name: "init-b", Image: "busybox:1.0"}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isContainerStatusImageEqual(tt.old, tt.new)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Extract init container spec/status image consistency check into `isContainersConsistent` function in `EnsureSandboxResumed`, preventing post-resume initialization from running before kubelet updates init container status images.
- Add `isContainerStatusImageEqual` to pod event handler so that init container image status changes trigger sandbox reconciliation.
- Add unit tests for `isContainersConsistent` (7 cases) and integration tests for `EnsureSandboxResumed` init container consistency path (3 cases).

## Test plan
- [x] `Test_isContainersConsistent` covers all branches: no init containers, match, mismatch, status missing, multiple containers
- [x] `TestCommonControl_EnsureSandboxResumed_InitContainerInconsistent` covers integration path: mismatch waits, missing waits, consistent proceeds
- [x] All tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)