### PR TITLE
fix(sandbox-manager): bound create retry behavior

### DIFF
--- a/pkg/sandbox-manager/api.go
+++ b/pkg/sandbox-manager/api.go
@@ -28,6 +28,17 @@ import (
 	"github.com/openkruise/agents/pkg/utils/pagination"
 )
 
+// preserveTypedError keeps an already-classified manager error (e.g. the
+// ErrorBadRequest / ErrorInternal produced by the infra create-error classifier)
+// so its ErrorCode survives up to the HTTP layer and maps to the right status.
+// Only untyped errors are wrapped as ErrorInternal with the given context.
+func preserveTypedError(err error, contextMsg string) error {
+	if errors.GetErrCode(err) != errors.ErrorUnknown {
+		return err
+	}
+	return errors.NewError(errors.ErrorInternal, "%s: %v", contextMsg, err)
+}
+
 // ClaimSandbox attempts to lock a Pod and assign it to the current caller.
 //
 // Two counters are recorded on failure paths and they have distinct semantics
@@ -53,7 +64,7 @@ func (m *SandboxManager) ClaimSandbox(ctx context.Context, opts infra.ClaimSandb
 		}
 		sandboxClaimCreationResponses.WithLabelValues(opts.Namespace, "failure").Inc()
 		sandboxClaimTotal.WithLabelValues(opts.Namespace, "failure", lockType).Inc()
-		return nil, errors.NewError(errors.ErrorInternal, "failed to claim sandbox: %v", err)
+		return nil, preserveTypedError(err, "failed to claim sandbox")
 	}
 
 	// Success: Record metrics
@@ -80,7 +91,7 @@ func (m *SandboxManager) CloneSandbox(ctx context.Context, opts infra.CloneSandb
 	if err != nil {
 		log.Error(err, "failed to clone sandbox", "metrics", cloneMetrics)
 		sandboxCloneTotal.WithLabelValues(opts.Namespace, "failure").Inc()
-		return nil, errors.NewError(errors.ErrorInternal, "failed to clone sandbox: %v", err)
+		return nil, preserveTypedError(err, "failed to clone sandbox")
 	}
 
 	// Clone-specific metrics

--- a/pkg/sandbox-manager/api_test.go
+++ b/pkg/sandbox-manager/api_test.go
@@ -1586,3 +1586,50 @@ func TestSandboxManager_DeleteCheckpoint(t *testing.T) {
 		})
 	}
 }
+
+func TestPreserveTypedError(t *testing.T) {
+	tests := []struct {
+		name            string
+		err             error
+		contextMsg      string
+		expectErrorCode errors.ErrorCode
+		expectContains  string
+	}{
+		{
+			name:            "BadRequest classification is preserved as-is",
+			err:             errors.NewError(errors.ErrorBadRequest, "quota exceeded"),
+			contextMsg:      "failed to claim sandbox",
+			expectErrorCode: errors.ErrorBadRequest,
+			// Preserved verbatim, not re-wrapped with contextMsg.
+			expectContains: "quota exceeded",
+		},
+		{
+			name:            "Internal classification is preserved as-is",
+			err:             errors.NewError(errors.ErrorInternal, "platform issue"),
+			contextMsg:      "failed to claim sandbox",
+			expectErrorCode: errors.ErrorInternal,
+			expectContains:  "platform issue",
+		},
+		{
+			name:            "NotFound classification is preserved as-is",
+			err:             errors.NewError(errors.ErrorNotFound, "template missing"),
+			contextMsg:      "failed to claim sandbox",
+			expectErrorCode: errors.ErrorNotFound,
+			expectContains:  "template missing",
+		},
+		{
+			name:            "untyped error is wrapped as Internal with context",
+			err:             fmt.Errorf("retry exhausted"),
+			contextMsg:      "failed to claim sandbox",
+			expectErrorCode: errors.ErrorInternal,
+			expectContains:  "failed to claim sandbox: retry exhausted",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := preserveTypedError(tt.err, tt.contextMsg)
+			assert.Equal(t, tt.expectErrorCode, errors.GetErrCode(result))
+			assert.Contains(t, result.Error(), tt.expectContains)
+		})
+	}
+}

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -234,38 +234,8 @@ func TryClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions, pickCa
 		log.Info("runtime inited", "cost", metrics.InitRuntime)
 	}
 
-	// Step 4: When SecurityIdentityProvider feature gate is enabled,
-	// the manager attempts to issue a security token via the identity provider, records its refresh status into
-	// sandbox annotations, and propagate the token to the runtime.
-	// Any failure in issuance, status recording, or propagation returns a retriable error so callers can retry.
-	// We deliberately do NOT degrade to a UUID token on issuance failure: a UUID carries no identity and would
-	// be propagated to the runtime as a meaningless credential, masking real provider outages.
-	if utilfeature.DefaultFeatureGate.Enabled(features.SecurityIdentityProviderGate) && identity.IsIdentityProviderRequested(sbx.Sandbox) {
-		opts.SecurityToken = &infra.SecurityTokenOptions{}
-		log.Info("starting to issue security token via identity provider")
-		metrics.SecurityToken, err = issueSecurityToken(ctx, sbx, opts.SecurityToken)
-		if err != nil {
-			log.Error(err, "failed to issue security token")
-			err = retriableError{Message: fmt.Sprintf("security token issuance failed: %s", err)}
-			return
-		}
-		metrics.Total += metrics.SecurityToken
-		// 4.1: to record security token refresh status in sandbox annotations.
-		// At this point modifyPickedSandbox has already persisted the locking
-		// patch, so additional annotation mutations on sbx.Sandbox would only
-		// live in memory. We patch via the apiserver here to actually persist
-		// the refresh status, and keep sbx.Sandbox in sync with the patched object.
-		if err = recordSecurityTokenRefreshStatus(ctx, cache.GetClient(), sbx, opts); err != nil {
-			log.Error(err, "failed to modify picked sandbox for security token status")
-			err = retriableError{Message: fmt.Sprintf("failed to modify picked sandbox for security token status: %s", err)}
-			return
-		}
-
-		// 4.2: to propagate security token to runtime
-		if err = identity.PropagateSandboxToken(ctx, sbx.Sandbox, &opts.SecurityToken.TokenResponse); err != nil {
-			err = retriableError{Message: fmt.Sprintf("security token propagation failed: %s", err)}
-			return
-		}
+	if err = processSecurityToken(ctx, opts, sbx, cache, &metrics); err != nil {
+		return
 	}
 
 	if opts.CSIMount != nil {
@@ -281,6 +251,39 @@ func TryClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions, pickCa
 	}
 
 	return
+}
+
+// processSecurityToken issues and propagates a sandbox security token when the
+// identity provider feature gate and sandbox annotations request it.
+func processSecurityToken(ctx context.Context, opts infra.ClaimSandboxOptions, sbx *Sandbox, cache infracache.Provider, metrics *infra.ClaimMetrics) error {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.SecurityIdentityProviderGate) || !identity.IsIdentityProviderRequested(sbx.Sandbox) {
+		return nil
+	}
+
+	log := klog.FromContext(ctx)
+	opts.SecurityToken = &infra.SecurityTokenOptions{}
+	log.Info("starting to issue security token via identity provider")
+	var err error
+	metrics.SecurityToken, err = issueSecurityToken(ctx, sbx, opts.SecurityToken)
+	if err != nil {
+		log.Error(err, "failed to issue security token")
+		return retriableError{Message: fmt.Sprintf("security token issuance failed: %s", err)}
+	}
+	metrics.Total += metrics.SecurityToken
+
+	// At this point modifyPickedSandbox has already persisted the locking patch,
+	// so additional annotation mutations on sbx.Sandbox would only live in memory.
+	// Patch via the apiserver here to persist the refresh status, and keep
+	// sbx.Sandbox in sync with the patched object.
+	if err = recordSecurityTokenRefreshStatus(ctx, cache.GetClient(), sbx, opts); err != nil {
+		log.Error(err, "failed to modify picked sandbox for security token status")
+		return retriableError{Message: fmt.Sprintf("failed to modify picked sandbox for security token status: %s", err)}
+	}
+
+	if err = identity.PropagateSandboxToken(ctx, sbx.Sandbox, &opts.SecurityToken.TokenResponse); err != nil {
+		return retriableError{Message: fmt.Sprintf("security token propagation failed: %s", err)}
+	}
+	return nil
 }
 
 // clearFailedSandbox cleans up (or reserves) a failed sandbox according to

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -185,7 +185,14 @@ func TryClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions, pickCa
 				UID:             sbx.GetUID(),
 				ResourceVersion: expectations.GetNewerResourceVersion(sbx),
 			})
-			err = retriableError{Message: fmt.Sprintf("failed to lock sandbox: %s", err)}
+		}
+		if lockType == infra.LockTypeCreate {
+			err = classifyCreateError(err, "failed to lock sandbox via create")
+		} else {
+			if apierrors.IsConflict(err) {
+				err = retriableError{Message: fmt.Sprintf("failed to lock sandbox: %s", err)}
+			}
+			// Non-conflict update errors: keep raw (already stops retry loop)
 		}
 		return
 	}

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -2942,9 +2942,11 @@ func TestInfraClaimSandboxAggregatesPickSandboxFailuresInError(t *testing.T) {
 		{
 			name: "aggregates repeated no stock retries",
 			options: infra.ClaimSandboxOptions{
-				User:         "test-user",
-				Template:     "test-template",
-				ClaimTimeout: 100 * time.Millisecond,
+				User:     "test-user",
+				Template: "test-template",
+				// 5s allows multiple retries with the 1s exponential backoff
+				// (attempts at ~0s, ~1s, ~3s) so PickSandboxFailures.Count > 1.
+				ClaimTimeout: 5 * time.Second,
 			},
 			expectKey:   "",
 			expectError: "no stock",
@@ -2969,6 +2971,31 @@ func TestInfraClaimSandboxAggregatesPickSandboxFailuresInError(t *testing.T) {
 			assert.Equal(t, metrics.PickSandboxFailures[0], got[0])
 		})
 	}
+}
+
+// TestInfraClaimSandboxContextCancelInterruptsBackoff verifies the create-retry
+// backoff is context-aware: a ClaimTimeout shorter than the first backoff
+// interval (CreateRetryInterval) must interrupt the sleep instead of waiting a
+// full step, so the call returns promptly rather than after ~1s.
+func TestInfraClaimSandboxContextCancelInterruptsBackoff(t *testing.T) {
+	utestutils.InitLogOutput()
+	testInfra, _ := NewTestInfra(t)
+
+	start := time.Now()
+	// Empty pool -> NoAvailableError (retriable). The first attempt fails fast,
+	// then the loop would sleep CreateRetryInterval (1s) before retrying; the
+	// 100ms ClaimTimeout must cut that sleep short.
+	_, metrics, err := testInfra.ClaimSandbox(t.Context(), infra.ClaimSandboxOptions{
+		User:         "test-user",
+		Template:     "test-template",
+		ClaimTimeout: 100 * time.Millisecond,
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no stock")
+	assert.Less(t, elapsed, CreateRetryInterval, "backoff sleep should be interrupted by claimCtx, not run the full interval")
+	assert.Equal(t, 0, metrics.Retries, "only the initial attempt should run before the timeout fires")
 }
 
 func TestInfra_ClaimSandboxWithNamespace(t *testing.T) {

--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -104,7 +104,7 @@ func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache inf
 	sbx, initRuntimeOpts, metrics, err := createSandboxFromCheckpoint(ctx, opts, tmpl, cp, cache, metrics)
 	if err != nil {
 		if !wait.Interrupted(err) {
-			err = retriableError{Message: fmt.Sprintf("failed to create sandbox from checkpoint: %s", err)}
+			err = classifyCreateError(err, "failed to create sandbox from checkpoint")
 		}
 		return nil, metrics, err
 	}

--- a/pkg/sandbox-manager/infra/sandboxcr/config.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/config.go
@@ -25,6 +25,9 @@ var (
 	DefaultCloneTimeout            = time.Minute
 	DefaultReserveFailedSandboxFor = 30 * time.Minute
 	RetryInterval                  = 25 * time.Millisecond
-	LockBackoffFactor              = 1.0
-	LockJitter                     = 0.2
+	CreateRetryInterval            = 1 * time.Second
+	CreateRetryBackoffFactor       = 2.0
+	CreateRetryJitter              = 0.3
+	CreateRetryIntervalCap         = 16 * time.Second
+	CreateMaxRetrySteps            = 10
 )

--- a/pkg/sandbox-manager/infra/sandboxcr/errors.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/errors.go
@@ -46,7 +46,7 @@ func NoAvailableError(template, reason string) error {
 	return retriableError{Message: fmt.Sprintf("no available sandboxes for template %s (%s)", template, reason)}
 }
 
-// classifyCreateError classifies a Kubernetes API error from a Create/Update
+// classifyCreateError classifies a Kubernetes API error from a Create
 // operation into one of three categories:
 // - retryable: transient server errors, conflicts, network errors -> retriableError
 // - terminal bad request: schema/validation errors -> managererrors.Error{ErrorBadRequest}
@@ -68,9 +68,14 @@ func classifyCreateError(err error, contextMsg string) error {
 		return retriableError{Message: fmt.Sprintf("%s: %s", contextMsg, err)}
 	}
 
-	// Conflict / AlreadyExists - retryable (optimistic locking or create name collision)
-	if apierrors.IsConflict(err) || apierrors.IsAlreadyExists(err) {
+	// Conflict - retryable (optimistic locking)
+	if apierrors.IsConflict(err) {
 		return retriableError{Message: fmt.Sprintf("%s: %s", contextMsg, err)}
+	}
+
+	// AlreadyExists - terminal conflict (create name collision)
+	if apierrors.IsAlreadyExists(err) {
+		return managererrors.NewError(managererrors.ErrorConflict, "%s: %s", contextMsg, err)
 	}
 
 	// Invalid / BadRequest - terminal user error

--- a/pkg/sandbox-manager/infra/sandboxcr/errors.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/errors.go
@@ -75,7 +75,7 @@ func classifyCreateError(err error, contextMsg string) error {
 
 	// Invalid / BadRequest - terminal user error
 	if apierrors.IsInvalid(err) || apierrors.IsBadRequest(err) {
-		return managererrors.NewError(managererrors.ErrorBadRequest, "%s: %s", contextMsg, sanitizeCreateErrorMessage(err))
+		return managererrors.NewError(managererrors.ErrorBadRequest, "%s: %s", contextMsg, err)
 	}
 
 	// Forbidden - always a platform issue. The sandbox-manager service account
@@ -83,35 +83,33 @@ func classifyCreateError(err error, contextMsg string) error {
 	// admission webhook, PodSecurity, etc.) denied the operation. Either way
 	// this is a server-side misconfiguration, not the HTTP caller's fault.
 	if apierrors.IsForbidden(err) {
-		return managererrors.NewError(managererrors.ErrorInternal, "%s: sandbox creation failed due to platform configuration issue", contextMsg)
+		return newPlatformCreateError(err, contextMsg)
 	}
 
 	// Unauthorized - platform issue
 	if apierrors.IsUnauthorized(err) {
-		return managererrors.NewError(managererrors.ErrorInternal, "%s: sandbox creation failed due to platform configuration issue", contextMsg)
+		return newPlatformCreateError(err, contextMsg)
 	}
 
 	// NotFound (CRD/namespace missing) - platform issue
 	if apierrors.IsNotFound(err) {
-		return managererrors.NewError(managererrors.ErrorInternal, "%s: sandbox creation failed due to platform configuration issue", contextMsg)
+		return newPlatformCreateError(err, contextMsg)
 	}
 
 	// MethodNotSupported - platform issue
 	if apierrors.IsMethodNotSupported(err) {
-		return managererrors.NewError(managererrors.ErrorInternal, "%s: sandbox creation failed due to platform configuration issue", contextMsg)
+		return newPlatformCreateError(err, contextMsg)
 	}
 
 	// Non-StatusError (network errors, etc.) - retryable (conservative)
 	return retriableError{Message: fmt.Sprintf("%s: %s", contextMsg, err)}
 }
 
-// sanitizeCreateErrorMessage returns a user-facing error message that preserves
-// quota/admission denial reasons but strips internal Kubernetes details like
-// namespace paths and service account names.
-func sanitizeCreateErrorMessage(err error) string {
-	var statusErr *apierrors.StatusError
-	if !errors.As(err, &statusErr) {
-		return err.Error()
-	}
-	return statusErr.Status().Message
+func newPlatformCreateError(err error, contextMsg string) error {
+	return managererrors.NewError(
+		managererrors.ErrorInternal,
+		"%s: sandbox creation failed due to platform configuration issue: %s",
+		contextMsg,
+		err,
+	)
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/errors.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/errors.go
@@ -68,8 +68,8 @@ func classifyCreateError(err error, contextMsg string) error {
 		return retriableError{Message: fmt.Sprintf("%s: %s", contextMsg, err)}
 	}
 
-	// Conflict - retryable (optimistic locking)
-	if apierrors.IsConflict(err) {
+	// Conflict / AlreadyExists - retryable (optimistic locking or create name collision)
+	if apierrors.IsConflict(err) || apierrors.IsAlreadyExists(err) {
 		return retriableError{Message: fmt.Sprintf("%s: %s", contextMsg, err)}
 	}
 

--- a/pkg/sandbox-manager/infra/sandboxcr/errors.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/errors.go
@@ -20,20 +20,11 @@ import (
 	"errors"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
-)
 
-// preserveInterruptedError keeps the original error message when the outer
-// retry.OnError loop would otherwise rewrite an interrupted error to the last
-// retriable one. Context cancellation is interrupted but non-retriable, so
-// keep its message while intentionally avoiding %w; wrapping would still let
-// wait.Interrupted identify and rewrite it.
-func preserveInterruptedError(err error) error {
-	if wait.Interrupted(err) {
-		return fmt.Errorf("%v", err)
-	}
-	return err
-}
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
+)
 
 type retriableError struct {
 	Message string
@@ -53,4 +44,74 @@ func (e retriableError) Is(target error) bool {
 
 func NoAvailableError(template, reason string) error {
 	return retriableError{Message: fmt.Sprintf("no available sandboxes for template %s (%s)", template, reason)}
+}
+
+// classifyCreateError classifies a Kubernetes API error from a Create/Update
+// operation into one of three categories:
+// - retryable: transient server errors, conflicts, network errors -> retriableError
+// - terminal bad request: schema/validation errors -> managererrors.Error{ErrorBadRequest}
+// - terminal internal: Forbidden/auth/platform misconfig -> managererrors.Error{ErrorInternal}
+func classifyCreateError(err error, contextMsg string) error {
+	if err == nil {
+		return nil
+	}
+
+	// Context interrupted - return as-is so the retry loop stops (non-retriable).
+	if wait.Interrupted(err) {
+		return err
+	}
+
+	// Transient server errors - retryable
+	if apierrors.IsServerTimeout(err) || apierrors.IsTimeout(err) ||
+		apierrors.IsServiceUnavailable(err) || apierrors.IsTooManyRequests(err) ||
+		apierrors.IsInternalError(err) {
+		return retriableError{Message: fmt.Sprintf("%s: %s", contextMsg, err)}
+	}
+
+	// Conflict - retryable (optimistic locking)
+	if apierrors.IsConflict(err) {
+		return retriableError{Message: fmt.Sprintf("%s: %s", contextMsg, err)}
+	}
+
+	// Invalid / BadRequest - terminal user error
+	if apierrors.IsInvalid(err) || apierrors.IsBadRequest(err) {
+		return managererrors.NewError(managererrors.ErrorBadRequest, "%s: %s", contextMsg, sanitizeCreateErrorMessage(err))
+	}
+
+	// Forbidden - always a platform issue. The sandbox-manager service account
+	// lacks the required RBAC permissions, or a cluster-level policy (quota,
+	// admission webhook, PodSecurity, etc.) denied the operation. Either way
+	// this is a server-side misconfiguration, not the HTTP caller's fault.
+	if apierrors.IsForbidden(err) {
+		return managererrors.NewError(managererrors.ErrorInternal, "%s: sandbox creation failed due to platform configuration issue", contextMsg)
+	}
+
+	// Unauthorized - platform issue
+	if apierrors.IsUnauthorized(err) {
+		return managererrors.NewError(managererrors.ErrorInternal, "%s: sandbox creation failed due to platform configuration issue", contextMsg)
+	}
+
+	// NotFound (CRD/namespace missing) - platform issue
+	if apierrors.IsNotFound(err) {
+		return managererrors.NewError(managererrors.ErrorInternal, "%s: sandbox creation failed due to platform configuration issue", contextMsg)
+	}
+
+	// MethodNotSupported - platform issue
+	if apierrors.IsMethodNotSupported(err) {
+		return managererrors.NewError(managererrors.ErrorInternal, "%s: sandbox creation failed due to platform configuration issue", contextMsg)
+	}
+
+	// Non-StatusError (network errors, etc.) - retryable (conservative)
+	return retriableError{Message: fmt.Sprintf("%s: %s", contextMsg, err)}
+}
+
+// sanitizeCreateErrorMessage returns a user-facing error message that preserves
+// quota/admission denial reasons but strips internal Kubernetes details like
+// namespace paths and service account names.
+func sanitizeCreateErrorMessage(err error) string {
+	var statusErr *apierrors.StatusError
+	if !errors.As(err, &statusErr) {
+		return err.Error()
+	}
+	return statusErr.Status().Message
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/errors_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/errors_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 )
@@ -45,6 +46,14 @@ func TestClassifyCreateError(t *testing.T) {
 			err:             nil,
 			contextMsg:      "create sandbox",
 			expectRetryable: false,
+		},
+		{
+			name:            "interrupted wait returns original error",
+			err:             wait.ErrWaitTimeout,
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorUnknown,
+			expectContains:  wait.ErrWaitTimeout.Error(),
 		},
 		{
 			name:            "quota exceeded (Forbidden) is terminal Internal (platform issue)",
@@ -111,6 +120,22 @@ func TestClassifyCreateError(t *testing.T) {
 			expectContains:  "create sandbox",
 		},
 		{
+			name:            "BadRequest is terminal BadRequest",
+			err:             apierrors.NewBadRequest("metadata.labels: Invalid value: unsupported label"),
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorBadRequest,
+			expectContains:  "create sandbox",
+		},
+		{
+			name:            "wrapped BadRequest is terminal BadRequest",
+			err:             fmt.Errorf("create request rejected: %w", apierrors.NewBadRequest("metadata.labels: Invalid value: unsupported label")),
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorBadRequest,
+			expectContains:  "create sandbox",
+		},
+		{
 			name:            "Server timeout is retryable",
 			err:             apierrors.NewServerTimeout(gr, "create", 1),
 			contextMsg:      "create sandbox",
@@ -162,6 +187,14 @@ func TestClassifyCreateError(t *testing.T) {
 			expectContains:  "platform configuration",
 		},
 		{
+			name:            "MethodNotSupported is terminal Internal (platform issue)",
+			err:             apierrors.NewMethodNotSupported(gr, "create"),
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorInternal,
+			expectContains:  "platform configuration",
+		},
+		{
 			name:            "non-StatusError network error is retryable",
 			err:             fmt.Errorf("connection refused"),
 			contextMsg:      "create sandbox",
@@ -186,6 +219,7 @@ func TestClassifyCreateError(t *testing.T) {
 			if tt.expectContains != "" {
 				assert.Contains(t, result.Error(), tt.expectContains)
 			}
+			assert.Contains(t, result.Error(), tt.err.Error())
 		})
 	}
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/errors_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/errors_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sandboxcr
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -171,6 +172,13 @@ func TestClassifyCreateError(t *testing.T) {
 			expectContains:  "create sandbox",
 		},
 		{
+			name:            "AlreadyExists is retryable",
+			err:             apierrors.NewAlreadyExists(gr, "test-sbx"),
+			contextMsg:      "create sandbox",
+			expectRetryable: true,
+			expectContains:  "create sandbox",
+		},
+		{
 			name:            "Unauthorized is terminal Internal (platform issue)",
 			err:             apierrors.NewUnauthorized("missing token"),
 			contextMsg:      "create sandbox",
@@ -200,6 +208,14 @@ func TestClassifyCreateError(t *testing.T) {
 			contextMsg:      "create sandbox",
 			expectRetryable: true,
 			expectContains:  "create sandbox",
+		},
+		{
+			name:            "context canceled before creating sandbox returns original error",
+			err:             fmt.Errorf("context canceled before creating sandbox: %w", context.Canceled),
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorUnknown,
+			expectContains:  "context canceled before creating sandbox",
 		},
 	}
 

--- a/pkg/sandbox-manager/infra/sandboxcr/errors_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/errors_test.go
@@ -172,10 +172,11 @@ func TestClassifyCreateError(t *testing.T) {
 			expectContains:  "create sandbox",
 		},
 		{
-			name:            "AlreadyExists is retryable",
+			name:            "AlreadyExists is terminal Conflict",
 			err:             apierrors.NewAlreadyExists(gr, "test-sbx"),
 			contextMsg:      "create sandbox",
-			expectRetryable: true,
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorConflict,
 			expectContains:  "create sandbox",
 		},
 		{

--- a/pkg/sandbox-manager/infra/sandboxcr/errors_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/errors_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandboxcr
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
+)
+
+func TestClassifyCreateError(t *testing.T) {
+	gr := schema.GroupResource{Group: "agents.kruise.io", Resource: "sandboxes"}
+	gk := schema.GroupKind{Group: "agents.kruise.io", Kind: "Sandbox"}
+
+	tests := []struct {
+		name            string
+		err             error
+		contextMsg      string
+		expectRetryable bool
+		expectErrorCode managererrors.ErrorCode // empty if retryable
+		expectContains  string
+	}{
+		{
+			name:            "nil error returns nil",
+			err:             nil,
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+		},
+		{
+			name:            "quota exceeded (Forbidden) is terminal Internal (platform issue)",
+			err:             apierrors.NewForbidden(gr, "test-sbx", fmt.Errorf("exceeded quota: cpu-quota, requested: cpu=2, used: cpu=10, limited: cpu=10")),
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorInternal,
+			expectContains:  "platform configuration",
+		},
+		{
+			name:            "limitrange Forbidden is terminal Internal (platform issue)",
+			err:             apierrors.NewForbidden(gr, "test-sbx", fmt.Errorf("maximum cpu usage per Container is 1; limitrange max-resources")),
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorInternal,
+			expectContains:  "platform configuration",
+		},
+		{
+			name:            "RBAC forbidden is terminal Internal (platform issue)",
+			err:             apierrors.NewForbidden(gr, "test-sbx", fmt.Errorf("User \"system:serviceaccount:default:manager\" cannot create resource \"sandboxes\" in API group \"agents.kruise.io\"")),
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorInternal,
+			expectContains:  "platform configuration",
+		},
+		{
+			name:            "PodSecurity forbidden is terminal Internal (platform issue)",
+			err:             apierrors.NewForbidden(gr, "test-sbx", fmt.Errorf("violates PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false")),
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorInternal,
+			expectContains:  "platform configuration",
+		},
+		{
+			name:            "validating admission policy forbidden is terminal Internal (platform issue)",
+			err:             apierrors.NewForbidden(gr, "test-sbx", fmt.Errorf("ValidatingAdmissionPolicy 'sandbox-policy' denied the request")),
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorInternal,
+			expectContains:  "platform configuration",
+		},
+		{
+			name:            "validating webhook forbidden is terminal Internal (platform issue)",
+			err:             apierrors.NewForbidden(gr, "test-sbx", fmt.Errorf("admission webhook \"sandbox.example.com\" denied the request: image is not allowed")),
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorInternal,
+			expectContains:  "platform configuration",
+		},
+		{
+			name:            "generic Forbidden is terminal Internal (platform issue)",
+			err:             apierrors.NewForbidden(gr, "test-sbx", fmt.Errorf("some random policy reason")),
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorInternal,
+			expectContains:  "platform configuration",
+		},
+		{
+			name:            "Invalid (schema) is terminal BadRequest",
+			err:             apierrors.NewInvalid(gk, "test-sbx", nil),
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorBadRequest,
+			expectContains:  "create sandbox",
+		},
+		{
+			name:            "Server timeout is retryable",
+			err:             apierrors.NewServerTimeout(gr, "create", 1),
+			contextMsg:      "create sandbox",
+			expectRetryable: true,
+			expectContains:  "create sandbox",
+		},
+		{
+			name:            "Service unavailable is retryable",
+			err:             apierrors.NewServiceUnavailable("apiserver is down"),
+			contextMsg:      "create sandbox",
+			expectRetryable: true,
+			expectContains:  "create sandbox",
+		},
+		{
+			name:            "Too many requests is retryable",
+			err:             apierrors.NewTooManyRequests("rate limited", 1),
+			contextMsg:      "create sandbox",
+			expectRetryable: true,
+			expectContains:  "create sandbox",
+		},
+		{
+			name:            "Internal server error is retryable",
+			err:             apierrors.NewInternalError(fmt.Errorf("etcd boom")),
+			contextMsg:      "create sandbox",
+			expectRetryable: true,
+			expectContains:  "create sandbox",
+		},
+		{
+			name:            "Conflict is retryable (optimistic locking)",
+			err:             apierrors.NewConflict(gr, "test-sbx", fmt.Errorf("object was modified")),
+			contextMsg:      "create sandbox",
+			expectRetryable: true,
+			expectContains:  "create sandbox",
+		},
+		{
+			name:            "Unauthorized is terminal Internal (platform issue)",
+			err:             apierrors.NewUnauthorized("missing token"),
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorInternal,
+			expectContains:  "platform configuration",
+		},
+		{
+			name:            "NotFound is terminal Internal (platform issue)",
+			err:             apierrors.NewNotFound(gr, "test-sbx"),
+			contextMsg:      "create sandbox",
+			expectRetryable: false,
+			expectErrorCode: managererrors.ErrorInternal,
+			expectContains:  "platform configuration",
+		},
+		{
+			name:            "non-StatusError network error is retryable",
+			err:             fmt.Errorf("connection refused"),
+			contextMsg:      "create sandbox",
+			expectRetryable: true,
+			expectContains:  "create sandbox",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := classifyCreateError(tt.err, tt.contextMsg)
+			if tt.err == nil {
+				assert.Nil(t, result)
+				return
+			}
+			if tt.expectRetryable {
+				assert.True(t, errors.As(result, &retriableError{}), "expected retriableError, got %T: %v", result, result)
+			} else {
+				code := managererrors.GetErrCode(result)
+				assert.Equal(t, tt.expectErrorCode, code, "expected ErrorCode mismatch for %v", result)
+			}
+			if tt.expectContains != "" {
+				assert.Contains(t, result.Error(), tt.expectContains)
+			}
+		})
+	}
+}

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -28,7 +28,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -123,6 +122,19 @@ func (i *Infra) Stop(ctx context.Context) {
 	i.Cache.Stop(ctx)
 }
 
+// createRetryBackoff returns the bounded, context-aware exponential backoff
+// shared by the ClaimSandbox and CloneSandbox create-retry loops. The step
+// count caps how many sandbox creations a single operation may trigger.
+func createRetryBackoff() wait.Backoff {
+	return wait.Backoff{
+		Steps:    CreateMaxRetrySteps,
+		Duration: CreateRetryInterval,
+		Factor:   CreateRetryBackoffFactor,
+		Jitter:   CreateRetryJitter,
+		Cap:      CreateRetryIntervalCap,
+	}
+}
+
 func (i *Infra) ClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions) (infra.Sandbox, infra.ClaimMetrics, error) {
 	log := klog.FromContext(ctx)
 	metrics := infra.ClaimMetrics{}
@@ -140,14 +152,12 @@ func (i *Infra) ClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions
 	log.V(utils.DebugLogLevel).Info("claim sandbox options", "options", opts)
 	metrics.Retries = -1 // starts from 0
 	var claimedSandbox infra.Sandbox
-	err = retry.OnError(wait.Backoff{
-		Steps:    retrySteps(opts.ClaimTimeout),
-		Duration: RetryInterval,
-		Factor:   LockBackoffFactor,
-		Jitter:   LockJitter,
-	}, func(err error) bool {
-		return errors.As(err, &retriableError{})
-	}, func() error {
+	// The create retry budget is intentionally bounded (CreateMaxRetrySteps) to
+	// cap how many sandbox creations a single claim may trigger. The backoff is
+	// context-aware: a sleep between attempts is interrupted as soon as claimCtx
+	// is cancelled or reaches ClaimTimeout.
+	var lastErr error
+	waitErr := wait.ExponentialBackoffWithContext(claimCtx, createRetryBackoff(), func(context.Context) (bool, error) {
 		metrics.Retries++
 		log.Info("try to claim sandbox", "retries", metrics.Retries)
 		claimed, tryMetrics, claimErr := TryClaimSandbox(claimCtx, opts, &i.pickCache, i.Cache, i.claimLockChannel, i.createLimiter)
@@ -164,27 +174,46 @@ func (i *Infra) ClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions
 		}
 		if claimErr == nil {
 			claimedSandbox = claimed
-		} else {
-			metrics.RetryCost += tryMetrics.Total
+			return true, nil
 		}
-		return preserveInterruptedError(claimErr)
+		metrics.RetryCost += tryMetrics.Total
+		lastErr = claimErr
+		if errors.As(claimErr, &retriableError{}) {
+			return false, nil
+		}
+		// Terminal error (e.g. classified BadRequest/Internal): stop retrying so
+		// buildClaimError can preserve its ErrorCode for HTTP status mapping.
+		return false, claimErr
 	})
-	return claimedSandbox, metrics, buildClaimError(err, metrics.LastError, metrics.PickSandboxFailures)
+	// When the retry budget is exhausted (steps used up while claimCtx is still
+	// live), surface the last retriable attempt error instead of the generic
+	// wait sentinel. On context cancellation/timeout keep the context error.
+	finalErr := waitErr
+	if waitErr != nil && claimCtx.Err() == nil && lastErr != nil {
+		finalErr = lastErr
+	}
+	return claimedSandbox, metrics, buildClaimError(finalErr, metrics.LastError, metrics.PickSandboxFailures)
 }
 
 func buildClaimError(err error, lastError error, failures []infra.PickSandboxFailure) error {
 	if err == nil {
 		return nil
 	}
+	// Preserve terminal error type (ErrorBadRequest / ErrorInternal) from the classifier.
+	// These errors were not retried and carry the correct ErrorCode for HTTP status mapping.
+	var mErr *managererrors.Error
+	if errors.As(err, &mErr) {
+		return mErr
+	}
+	// Retry exhausted or interrupted: wrap as Internal
 	base := fmt.Sprintf("%v, last error: %v", err, lastError)
-	if len(failures) == 0 {
-		return fmt.Errorf("%s", base)
+	if len(failures) > 0 {
+		raw, marshalErr := json.Marshal(failures)
+		if marshalErr == nil {
+			base = fmt.Sprintf("%s, pick sandbox failures: %s", base, string(raw))
+		}
 	}
-	raw, marshalErr := json.Marshal(failures)
-	if marshalErr != nil {
-		return fmt.Errorf("%s, pick sandbox failures marshal error: %v", base, marshalErr)
-	}
-	return fmt.Errorf("%s, pick sandbox failures: %s", base, string(raw))
+	return managererrors.NewError(managererrors.ErrorInternal, "%s", base)
 }
 
 func (i *Infra) CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions) (infra.Sandbox, infra.CloneMetrics, error) {
@@ -207,41 +236,49 @@ func (i *Infra) CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions
 
 	metrics.Retries = -1 // starts from 0
 	var clonedSandbox infra.Sandbox
-	err = retry.OnError(wait.Backoff{
-		Steps:    retrySteps(opts.CloneTimeout),
-		Duration: RetryInterval,
-		Factor:   LockBackoffFactor,
-		Jitter:   LockJitter,
-	}, func(err error) bool {
-		return errors.As(err, &retriableError{})
-	}, func() error {
+	// Bounded, context-aware create retry (see ClaimSandbox for the rationale).
+	var lastErr error
+	waitErr := wait.ExponentialBackoffWithContext(cloneCtx, createRetryBackoff(), func(context.Context) (bool, error) {
 		metrics.Retries++
 		cloned, tryMetrics, cloneErr := CloneSandbox(cloneCtx, attemptOpts, i.Cache)
 		metrics.Merge(tryMetrics)
 		if cloneErr == nil {
 			clonedSandbox = cloned
-		} else {
-			metrics.LastError = cloneErr
+			return true, nil
 		}
-		return preserveInterruptedError(cloneErr)
+		metrics.LastError = cloneErr
+		lastErr = cloneErr
+		if errors.As(cloneErr, &retriableError{}) {
+			return false, nil
+		}
+		// Terminal error: stop retrying and preserve its ErrorCode.
+		return false, cloneErr
 	})
-	if err != nil {
-		log.Error(err, "failed to clone sandbox", "metrics", metrics.String())
-		return nil, metrics, err
+	if waitErr != nil {
+		// On retry-budget exhaustion (cloneCtx still live) surface the last
+		// attempt error; on context cancellation/timeout keep the context error.
+		finalErr := waitErr
+		if cloneCtx.Err() == nil && lastErr != nil {
+			finalErr = lastErr
+		}
+		log.Error(finalErr, "failed to clone sandbox", "metrics", metrics.String())
+		return nil, metrics, buildCloneError(finalErr)
 	}
 	log.Info("sandbox cloned", "sandbox", klog.KObj(clonedSandbox), "metrics", metrics.String())
 	return clonedSandbox, metrics, nil
 }
 
-// retrySteps converts a total timeout into the Steps value for wait.Backoff.
-// It clamps to at least one attempt so a sub-RetryInterval timeout still runs
-// the closure once.
-func retrySteps(timeout time.Duration) int {
-	steps := int(timeout / RetryInterval)
-	if steps < 1 {
-		return 1
+// buildCloneError keeps an already-classified manager error (so its
+// ErrorCode reaches the HTTP layer) and wraps any other error as ErrorInternal.
+func buildCloneError(err error) error {
+	if err == nil {
+		return nil
 	}
-	return steps
+	var mErr *managererrors.Error
+	if errors.As(err, &mErr) {
+		return mErr
+	}
+	return managererrors.NewError(managererrors.ErrorInternal, "%v", err)
 }
 
 func (i *Infra) DeleteCheckpoint(ctx context.Context, opts infra.DeleteCheckpointOptions) error {

--- a/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/openkruise/agents/pkg/cache/cachetest"
 	"github.com/openkruise/agents/pkg/proxy"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/runtime"
@@ -348,6 +349,8 @@ func TestInfra_GetClaimedSandbox_CacheMiss_WaitsUntilCacheHit(t *testing.T) {
 				})
 			}
 
+			// Cache propagation should be polled with a short interval. With
+			// succeedAfter=3 this should complete well under 500ms.
 			ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 			defer cancel()
 			got, err := infraInstance.GetClaimedSandbox(ctx, infra.GetClaimedSandboxOptions{
@@ -399,6 +402,9 @@ func TestInfra_GetClaimedSandbox_SharedContextError_RetriesWhileContextLive(t *t
 				WithProxy(proxy.NewServer(options)).
 				Build().(*Infra)
 
+			// Shared context sentinel errors can be returned by cache helpers
+			// before this request's context has actually ended. Keep retrying
+			// quickly while the request context is still live.
 			ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 			defer cancel()
 			got, err := infraInstance.GetClaimedSandbox(ctx, infra.GetClaimedSandboxOptions{
@@ -1159,10 +1165,13 @@ func TestInfra_CloneSandboxRetriesWaitReadyFailure(t *testing.T) {
 	t.Cleanup(func() { DefaultCreateSandbox = origCreateSandbox })
 
 	opts := infra.CloneSandboxOptions{
-		User:                    "test-user",
-		CheckPointID:            checkpointID,
-		WaitReadyTimeout:        20 * time.Millisecond,
-		CloneTimeout:            300 * time.Millisecond,
+		User:             "test-user",
+		CheckPointID:     checkpointID,
+		WaitReadyTimeout: 20 * time.Millisecond,
+		// 5s allows the second attempt to run after the 1s exponential
+		// backoff initial wait, while the first attempt fails fast on
+		// WaitReady (20ms).
+		CloneTimeout:            5 * time.Second,
 		ReserveFailedSandboxFor: ptr.To(consts.ReserveFailedSandboxNever),
 	}
 	sbx, metrics, err := infraInstance.CloneSandbox(t.Context(), opts)
@@ -1239,10 +1248,13 @@ func TestInfra_CloneSandboxRetriesCreateFailure(t *testing.T) {
 			t.Cleanup(func() { DefaultCreateSandbox = origCreateSandbox })
 
 			opts := infra.CloneSandboxOptions{
-				User:                    "test-user",
-				CheckPointID:            checkpointID,
-				WaitReadyTimeout:        30 * time.Second,
-				CloneTimeout:            300 * time.Millisecond,
+				User:             "test-user",
+				CheckPointID:     checkpointID,
+				WaitReadyTimeout: 30 * time.Second,
+				// 8s accommodates exponential backoff (1s, 2s, 4s) so
+				// transient retries succeed and the always-failing case
+				// still hits the deadline after multiple attempts.
+				CloneTimeout:            8 * time.Second,
 				ReserveFailedSandboxFor: ptr.To(consts.ReserveFailedSandboxNever),
 			}
 			sbx, metrics, err := infraInstance.CloneSandbox(t.Context(), opts)
@@ -1800,6 +1812,51 @@ func TestInfra_DeleteCheckpoint_IgnoresNotFoundDuringDeletes(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectCheckpoint, deleteCpCount)
 			assert.Equal(t, tt.expectTemplate, deleteTmplCount)
+		})
+	}
+}
+
+func TestBuildClaimError_PreservesTerminalError(t *testing.T) {
+	tests := []struct {
+		name            string
+		err             error
+		lastError       error
+		failures        []infra.PickSandboxFailure
+		expectErrorCode managererrors.ErrorCode
+	}{
+		{
+			name:            "nil error returns nil",
+			err:             nil,
+			expectErrorCode: "",
+		},
+		{
+			name:            "terminal ErrorBadRequest preserved",
+			err:             managererrors.NewError(managererrors.ErrorBadRequest, "quota exceeded"),
+			lastError:       nil,
+			expectErrorCode: managererrors.ErrorBadRequest,
+		},
+		{
+			name:            "terminal ErrorInternal preserved",
+			err:             managererrors.NewError(managererrors.ErrorInternal, "RBAC issue"),
+			lastError:       nil,
+			expectErrorCode: managererrors.ErrorInternal,
+		},
+		{
+			name:            "non-terminal error wrapped as Internal",
+			err:             fmt.Errorf("retry exhausted"),
+			lastError:       fmt.Errorf("last attempt failed"),
+			expectErrorCode: managererrors.ErrorInternal,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildClaimError(tt.err, tt.lastError, tt.failures)
+			if tt.err == nil {
+				assert.Nil(t, result)
+				return
+			}
+			code := managererrors.GetErrCode(result)
+			assert.Equal(t, tt.expectErrorCode, code)
 		})
 	}
 }

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -29,6 +29,7 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
@@ -45,6 +46,20 @@ import (
 // unchanged. ~100 years is indistinguishable from unlimited for any real
 // request and stays well within time.Duration's int64 range (max ~292 years).
 const noServerTimeout = 100 * 365 * 24 * time.Hour
+
+// mapInfraErrorToApiError converts an infra-layer error to an ApiError with the
+// appropriate HTTP status code based on managererrors.ErrorCode.
+func mapInfraErrorToApiError(err error) *web.ApiError {
+	// The E2B POST /sandboxes spec only defines 400/401/500, so client-side
+	// errors (bad request, not found) map to 400 and everything else to 500.
+	switch managererrors.GetErrCode(err) {
+	case managererrors.ErrorBadRequest, managererrors.ErrorNotFound:
+		return &web.ApiError{Code: http.StatusBadRequest, Message: err.Error()}
+	default:
+		// ErrorInternal, ErrorUnknown, or untyped errors (e.g., retry exhausted) → 500
+		return &web.ApiError{Code: http.StatusInternalServerError, Message: err.Error()}
+	}
+}
 
 // resolveServerTimeout maps an extension-provided seconds value to a server-side
 // timeout. A positive value yields a finite timeout; an absent (zero) or
@@ -156,9 +171,7 @@ func (sc *Controller) createSandboxWithClaim(ctx context.Context, request models
 	sbx, err := sc.manager.ClaimSandbox(ctx, opts)
 	if err != nil {
 		log.Error(err, "sandbox creation failed")
-		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
-			Message: err.Error(),
-		}
+		return web.ApiResponse[*models.Sandbox]{}, mapInfraErrorToApiError(err)
 	}
 	log.Info("sandbox created", "id", sbx.GetSandboxID(), "sbx", klog.KObj(sbx),
 		"resourceVersion", sbx.GetResourceVersion(), "totalCost", time.Since(claimStart))
@@ -215,9 +228,7 @@ func (sc *Controller) createSandboxWithClone(ctx context.Context, request models
 	sbx, err := sc.manager.CloneSandbox(ctx, opts)
 	if err != nil {
 		log.Error(err, "sandbox clone failed")
-		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
-			Message: err.Error(),
-		}
+		return web.ApiResponse[*models.Sandbox]{}, mapInfraErrorToApiError(err)
 	}
 	log.Info("sandbox cloned", "id", sbx.GetSandboxID(), "sbx", klog.KObj(sbx),
 		"resourceVersion", sbx.GetResourceVersion(), "totalCost", time.Since(start))

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -34,6 +35,7 @@ import (
 
 	"github.com/openkruise/agents/api/v1alpha1"
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 )
@@ -503,4 +505,40 @@ func TestParseCreateSandboxRequest(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, apiErr.Code)
 		assert.Contains(t, apiErr.Message, "timeout should between")
 	})
+}
+
+func TestMapInfraErrorToApiError(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		expectedCode int
+	}{
+		{
+			name:         "ErrorBadRequest maps to 400",
+			err:          managererrors.NewError(managererrors.ErrorBadRequest, "quota exceeded"),
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "ErrorNotFound maps to 400",
+			err:          managererrors.NewError(managererrors.ErrorNotFound, "template not found"),
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "ErrorInternal maps to 500",
+			err:          managererrors.NewError(managererrors.ErrorInternal, "platform issue"),
+			expectedCode: http.StatusInternalServerError,
+		},
+		{
+			name:         "plain error maps to 500",
+			err:          fmt.Errorf("some unknown error"),
+			expectedCode: http.StatusInternalServerError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiErr := mapInfraErrorToApiError(tt.err)
+			assert.Equal(t, tt.expectedCode, apiErr.Code)
+			assert.Contains(t, apiErr.Message, tt.err.Error())
+		})
+	}
 }

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -208,7 +210,7 @@ func TestCreateSandbox(t *testing.T) {
 				},
 			},
 			expectError: &web.ApiError{
-				Code:    0,
+				Code:    500,
 				Message: "no available sandboxes for template test-template (no stock)",
 			},
 		},
@@ -536,6 +538,54 @@ func TestCreateSandbox(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreateSandboxReturnsImmediatelyWhenCreateOnNoStockHitsQuota(t *testing.T) {
+	controller, _, teardown := Setup(t)
+	defer teardown()
+
+	templateName := "quota-denied-template"
+	cleanup := CreateSandboxPool(t, controller, templateName, 0)
+	defer cleanup()
+
+	// This simulates the create-on-no-stock path reaching the apiserver and
+	// being rejected by ResourceQuota. Forbidden create failures are classified
+	// as terminal platform errors, so CreateSandbox must return immediately
+	// instead of sleeping and retrying sandbox creation.
+	quotaError := apierrors.NewForbidden(
+		schema.GroupResource{Group: "agents.kruise.io", Resource: "sandboxes"},
+		"quota-denied-sandbox",
+		fmt.Errorf("exceeded quota: cpu-quota, requested: cpu=2, used: cpu=10, limited: cpu=10"),
+	)
+	origCreateSandbox := sandboxcr.DefaultCreateSandbox
+	var createCalls atomic.Int32
+	sandboxcr.DefaultCreateSandbox = func(context.Context, *v1alpha1.Sandbox, ctrlclient.Client) (*v1alpha1.Sandbox, error) {
+		createCalls.Add(1)
+		return nil, quotaError
+	}
+	t.Cleanup(func() { sandboxcr.DefaultCreateSandbox = origCreateSandbox })
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "test-user",
+	}
+	start := time.Now()
+	resp, apiError := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+		TemplateID: templateName,
+		Metadata: map[string]string{
+			models.ExtensionKeyCreateOnNoStock: v1alpha1.True,
+			models.ExtensionKeyClaimTimeout:    "10",
+		},
+	}, nil, user))
+	elapsed := time.Since(start)
+
+	require.NotNil(t, apiError)
+	assert.Nil(t, resp.Body)
+	assert.Equal(t, http.StatusInternalServerError, apiError.Code)
+	assert.Contains(t, apiError.Message, "platform configuration issue")
+	assert.Equal(t, int32(1), createCalls.Load(), "terminal quota denial must not retry sandbox creation")
+	assert.Less(t, elapsed, sandboxcr.CreateRetryInterval, "terminal quota denial must return before retry backoff")
 }
 
 func TestCreateSandboxAlwaysCreatesAccessToken(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add bounded, context-aware create retry backoff for sandbox claim and clone paths.
- Classify Kubernetes create/update errors so terminal bad requests and platform failures keep the right manager error code.
- Map infra-layer create failures to E2B 400/500 responses and expand unit coverage for retry/error behavior.

## Design Notes
- Kubernetes Forbidden responses from create/update, including ResourceQuota, LimitRange, PodSecurity, validating admission policy/webhook, and RBAC denials, are treated as sandbox-manager/platform configuration failures. E2B API users cannot fix these directly, so Create Sandbox intentionally returns 500 rather than 403/429.
- When failed sandbox reservation is enabled, each failed attempt from the bounded create retry loop is preserved for debugging. This intentionally keeps per-attempt failure evidence instead of only retaining the last failed sandbox in a server-side operation; the upper bound is controlled by exponential backoff and CreateMaxRetrySteps.

## Test Plan
- go test ./pkg/sandbox-manager ./pkg/sandbox-manager/infra/sandboxcr ./pkg/servers/e2b

## Notes
- Pushed branch: AiRanthem:feature/optimize-create-retry-260612
- Commit: ce28b0ea fix(sandbox-manager): bound create retry behavior