### PR TITLE
feat(sidecarutils): merge user postStart Exec hook into injected envd-run.sh as extra args

### DIFF
--- a/pkg/utils/sidecarutils/sidecar_config_inject.go
+++ b/pkg/utils/sidecarutils/sidecar_config_inject.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -237,19 +238,31 @@ func setMainContainerConfigWhenInjectRuntimeSidecar(ctx context.Context, mainCon
 		config.MainContainer.Lifecycle.PostStart != nil &&
 		hasValidLifecycleHandler(config.MainContainer.Lifecycle.PostStart)
 
-	if mainContainerHasValidPostStart {
-		if configHasValidPostStart {
-			log.V(utils.DebugLogLevel).Info("conflicting postStart hooks detected, main container already has a postStart hook defined",
-				"existingHook", mainContainer.Lifecycle.PostStart,
-				"injectedHook", config.MainContainer.Lifecycle.PostStart)
+	if configHasValidPostStart {
+		if mainContainer.Lifecycle == nil {
+			mainContainer.Lifecycle = &corev1.Lifecycle{}
 		}
-	} else {
-		// Main container doesn't have valid postStart, apply config if available
-		if configHasValidPostStart {
-			// set main container lifecycle
-			if mainContainer.Lifecycle == nil {
-				mainContainer.Lifecycle = &corev1.Lifecycle{}
+		if mainContainerHasValidPostStart {
+			// The user has a postStart hook. Treat their command as a string and append it
+			// to our injected script as an additional argument so the script executes the
+			// user's command after its own initialisation.
+			mergedCmd := mergePostStartExecCommands(config.MainContainer.Lifecycle.PostStart, mainContainer.Lifecycle.PostStart)
+			if mergedCmd != nil {
+				log.V(utils.DebugLogLevel).Info("merging user's postStart command into injected script",
+					"userCommand", mainContainer.Lifecycle.PostStart.Exec.Command,
+					"injectedCommand", config.MainContainer.Lifecycle.PostStart.Exec.Command)
+				mainContainer.Lifecycle.PostStart = &corev1.LifecycleHandler{
+					Exec: &corev1.ExecAction{Command: mergedCmd},
+				}
+			} else {
+				// Cannot merge non-Exec handlers (e.g. HTTPGet/TCPSocket); keep the
+				// existing hook and skip injection of the injected postStart.
+				log.V(utils.DebugLogLevel).Info("cannot merge non-Exec postStart hooks, keeping existing hook",
+					"existingHook", mainContainer.Lifecycle.PostStart,
+					"injectedHook", config.MainContainer.Lifecycle.PostStart)
 			}
+		} else {
+			// Main container doesn't have a valid postStart; apply the config directly.
 			mainContainer.Lifecycle.PostStart = config.MainContainer.Lifecycle.PostStart
 		}
 	}
@@ -319,4 +332,27 @@ func hasValidLifecycleHandler(handler *corev1.LifecycleHandler) bool {
 		return false
 	}
 	return handler.Exec != nil || handler.HTTPGet != nil || handler.TCPSocket != nil
+}
+
+// mergePostStartExecCommands merges the user's postStart Exec command into the injected postStart
+// command. The user's command slice is joined into a single space-separated string and appended as
+// an additional positional argument to the injected script, allowing the script to execute the
+// user's command after its own initialisation (via eval).
+// Returns nil when either handler is not an Exec action, because non-Exec handlers (HTTPGet /
+// TCPSocket) cannot be represented as a command string.
+// Returns the injected command unchanged when the user's command slice is empty.
+func mergePostStartExecCommands(injected, user *corev1.LifecycleHandler) []string {
+	if injected == nil || injected.Exec == nil || user == nil || user.Exec == nil {
+		return nil
+	}
+	// If the user's command is empty, there is nothing to append.
+	if len(user.Exec.Command) == 0 {
+		merged := make([]string, len(injected.Exec.Command))
+		copy(merged, injected.Exec.Command)
+		return merged
+	}
+	userCmdStr := strings.Join(user.Exec.Command, " ")
+	merged := make([]string, len(injected.Exec.Command), len(injected.Exec.Command)+1)
+	copy(merged, injected.Exec.Command)
+	return append(merged, userCmdStr)
 }

--- a/pkg/utils/sidecarutils/sidecar_config_inject_test.go
+++ b/pkg/utils/sidecarutils/sidecar_config_inject_test.go
@@ -358,7 +358,7 @@ func TestSetAgentRuntimeContainer(t *testing.T) {
 			expectedVolumeMountCount: 1,
 		},
 		{
-			name: "existing lifecycle - conflicting postStart should skip env and volumeMounts injection",
+			name: "existing lifecycle - conflicting postStart should only skip postStart injection, env and volumeMounts still injected",
 			template: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
@@ -549,6 +549,9 @@ func TestSetMainContainerConfigWhenInjectRuntimeSidecar(t *testing.T) {
 		expectedVolumeMountCount int
 		hasPostStart             bool
 		postStartCommand         []string
+		// expectHTTPGetPreserved asserts the original HTTPGet hook is preserved (not overwritten)
+		// when a non-Exec user postStart cannot be merged.
+		expectHTTPGetPreserved bool
 	}{
 		{
 			name: "empty container with full config",
@@ -580,7 +583,7 @@ func TestSetMainContainerConfigWhenInjectRuntimeSidecar(t *testing.T) {
 			postStartCommand:         []string{"bash", "-c", "/mnt/envd/envd-run.sh"},
 		},
 		{
-			name: "container with existing lifecycle - conflicting postStart should skip all injection",
+			name: "container with existing Exec postStart - user command merged into injected script as extra arg",
 			mainContainer: &corev1.Container{
 				Name:  "main",
 				Image: "nginx:latest",
@@ -601,16 +604,81 @@ func TestSetMainContainerConfigWhenInjectRuntimeSidecar(t *testing.T) {
 					Lifecycle: &corev1.Lifecycle{
 						PostStart: &corev1.LifecycleHandler{
 							Exec: &corev1.ExecAction{
-								Command: []string{"echo", "new"},
+								Command: []string{"bash", "-c", "/mnt/envd/envd-run.sh"},
 							},
 						},
 					},
 				},
 			},
-			expectedEnvCount:         1, // conflicting postStart only skips postStart injection, env still injected
-			expectedVolumeMountCount: 1, // conflicting postStart only skips postStart injection, volumeMounts still injected
+			expectedEnvCount:         1,
+			expectedVolumeMountCount: 1,
 			hasPostStart:             true,
-			postStartCommand:         []string{"echo", "old"}, // keeps existing, NOT overridden
+			// merged: injected command + user's command joined as a single string argument
+			postStartCommand: []string{"bash", "-c", "/mnt/envd/envd-run.sh", "echo old"},
+		},
+		{
+			name: "container with existing Exec postStart multi-word command - merged correctly",
+			mainContainer: &corev1.Container{
+				Name:  "main",
+				Image: "nginx:latest",
+				Lifecycle: &corev1.Lifecycle{
+					PostStart: &corev1.LifecycleHandler{
+						Exec: &corev1.ExecAction{
+							Command: []string{"bash", "-c", "my-init.sh --setup && echo done"},
+						},
+					},
+				},
+			},
+			config: SidecarInjectConfig{
+				MainContainer: corev1.Container{
+					Env: []corev1.EnvVar{{Name: "ENVD_DIR", Value: "/mnt/envd"}},
+					Lifecycle: &corev1.Lifecycle{
+						PostStart: &corev1.LifecycleHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"bash", "/mnt/envd/envd-run.sh"},
+							},
+						},
+					},
+				},
+			},
+			expectedEnvCount:         1,
+			expectedVolumeMountCount: 0,
+			hasPostStart:             true,
+			// user's three-element command is joined as one space-separated string
+			postStartCommand: []string{"bash", "/mnt/envd/envd-run.sh", "bash -c my-init.sh --setup && echo done"},
+		},
+		{
+			name: "container with existing non-Exec (HTTPGet) postStart - cannot merge, keep existing hook",
+			mainContainer: &corev1.Container{
+				Name:  "main",
+				Image: "nginx:latest",
+				Lifecycle: &corev1.Lifecycle{
+					PostStart: &corev1.LifecycleHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/init",
+							Port: intstr.FromInt(8080),
+						},
+					},
+				},
+			},
+			config: SidecarInjectConfig{
+				MainContainer: corev1.Container{
+					Env: []corev1.EnvVar{{Name: "ENVD_DIR", Value: "/mnt/envd"}},
+					Lifecycle: &corev1.Lifecycle{
+						PostStart: &corev1.LifecycleHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"bash", "/mnt/envd/envd-run.sh"},
+							},
+						},
+					},
+				},
+			},
+			expectedEnvCount:         1,
+			expectedVolumeMountCount: 0,
+			hasPostStart:             true,
+			// non-Exec user hook cannot be merged; existing hook is preserved
+			postStartCommand:       nil, // HTTPGet hook kept, postStartCommand (Exec) check skipped
+			expectHTTPGetPreserved: true,
 		},
 		{
 			name: "config without lifecycle - no override",
@@ -726,9 +794,120 @@ func TestSetMainContainerConfigWhenInjectRuntimeSidecar(t *testing.T) {
 					t.Error("expected PostStart lifecycle handler, got nil")
 				} else if tt.mainContainer.Lifecycle.PostStart.Exec == nil {
 					t.Error("expected Exec action in PostStart, got nil")
-				} else if len(tt.mainContainer.Lifecycle.PostStart.Exec.Command) != len(tt.postStartCommand) {
+				} else if !reflect.DeepEqual(tt.mainContainer.Lifecycle.PostStart.Exec.Command, tt.postStartCommand) {
 					t.Errorf("expected command %v, got %v", tt.postStartCommand, tt.mainContainer.Lifecycle.PostStart.Exec.Command)
 				}
+			}
+			// Verify the original non-Exec hook is preserved when merge is not possible
+			if tt.expectHTTPGetPreserved {
+				if tt.mainContainer.Lifecycle == nil || tt.mainContainer.Lifecycle.PostStart == nil {
+					t.Error("expected PostStart lifecycle handler to be preserved, got nil")
+				} else if tt.mainContainer.Lifecycle.PostStart.HTTPGet == nil {
+					t.Error("expected HTTPGet hook to be preserved, but it was overwritten or removed")
+				}
+			}
+		})
+	}
+}
+
+func TestMergePostStartExecCommands(t *testing.T) {
+	tests := []struct {
+		name            string
+		injected        *corev1.LifecycleHandler
+		user            *corev1.LifecycleHandler
+		expectedCommand []string // nil means the function should return nil
+	}{
+		{
+			name: "both are Exec - user command joined and appended",
+			injected: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"bash", "-c", "/mnt/envd/envd-run.sh"},
+				},
+			},
+			user: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"echo", "hello"},
+				},
+			},
+			expectedCommand: []string{"bash", "-c", "/mnt/envd/envd-run.sh", "echo hello"},
+		},
+		{
+			name: "user command is a single element",
+			injected: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"bash", "/mnt/envd/envd-run.sh"},
+				},
+			},
+			user: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"my-init.sh"},
+				},
+			},
+			expectedCommand: []string{"bash", "/mnt/envd/envd-run.sh", "my-init.sh"},
+		},
+		{
+			name: "user command has multiple elements - joined with space",
+			injected: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"bash", "/mnt/envd/envd-run.sh"},
+				},
+			},
+			user: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"bash", "-c", "setup.sh && echo done"},
+				},
+			},
+			expectedCommand: []string{"bash", "/mnt/envd/envd-run.sh", "bash -c setup.sh && echo done"},
+		},
+		{
+			name: "injected is nil - returns nil",
+			injected:        nil,
+			user:            &corev1.LifecycleHandler{Exec: &corev1.ExecAction{Command: []string{"echo", "hi"}}},
+			expectedCommand: nil,
+		},
+		{
+			name: "user is nil - returns nil",
+			injected:        &corev1.LifecycleHandler{Exec: &corev1.ExecAction{Command: []string{"bash", "run.sh"}}},
+			user:            nil,
+			expectedCommand: nil,
+		},
+		{
+			name: "injected has no Exec (HTTPGet) - returns nil",
+			injected: &corev1.LifecycleHandler{
+				HTTPGet: &corev1.HTTPGetAction{Path: "/init", Port: intstr.FromInt(8080)},
+			},
+			user: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{Command: []string{"echo", "hi"}},
+			},
+			expectedCommand: nil,
+		},
+		{
+			name: "user has no Exec (HTTPGet) - returns nil",
+			injected: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{Command: []string{"bash", "run.sh"}},
+			},
+			user: &corev1.LifecycleHandler{
+				HTTPGet: &corev1.HTTPGetAction{Path: "/init", Port: intstr.FromInt(8080)},
+			},
+			expectedCommand: nil,
+		},
+		{
+			name: "user Exec command is empty slice - injected command returned unchanged",
+			injected: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{Command: []string{"bash", "/mnt/envd/envd-run.sh"}},
+			},
+			user: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{Command: []string{}},
+			},
+			expectedCommand: []string{"bash", "/mnt/envd/envd-run.sh"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergePostStartExecCommands(tt.injected, tt.user)
+			if !reflect.DeepEqual(got, tt.expectedCommand) {
+				t.Errorf("expected command %v, got %v", tt.expectedCommand, got)
 			}
 		})
 	}


### PR DESCRIPTION
…-run.sh as extra arg

Previously, when a user defined a postStart Exec hook on their main container, the platform injection would detect a conflict and skip injecting our envd-run.sh script entirely, leaving platform initialisation unexecuted.

This commit changes the behaviour: if both the user container and the injection config have a valid Exec postStart hook, the user's command slice is joined into a single space-separated string and appended as an additional positional argument to the injected script command, e.g.

  ["bash", "-c", "/mnt/envd/envd-run.sh", "user-init.sh --flag"]

envd-run.sh can then eval the extra argument after its own initialisation.

Non-Exec hooks (HTTPGet / TCPSocket) cannot be represented as a command string and are therefore left in place; the platform postStart is skipped in that case with a debug log entry.

Changes:
- Refactor setMainContainerConfigWhenInjectRuntimeSidecar to perform merge instead of skipping on conflict
- Add mergePostStartExecCommands helper; guard empty Command slice to avoid appending a spurious empty-string argument
- Add TestMergePostStartExecCommands table-driven test covering nil, HTTPGet, empty-command and multi-word-command edge cases
- Extend TestSetMainContainerConfigWhenInjectRuntimeSidecar with merge, multi-word, HTTPGet-preserved and empty-command cases
- Add expectHTTPGetPreserved assertion field to verify non-Exec hook is not overwritten after a failed merge
- Fix assertion from length comparison to reflect.DeepEqual
- Fix misleading test name in TestSetAgentRuntimeContainer

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

