### PR TITLE
fix(e2b): generalize GetClaimedSandbox into GetSandbox with expected states

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -454,10 +454,10 @@ func TestCache_CountActiveSandboxes(t *testing.T) {
 	sbx3 := &agentsv1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "sbx-3", Namespace: "default",
-			Annotations:     map[string]string{agentsv1alpha1.AnnotationOwner: "user-1"},
-			Labels:          map[string]string{agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.True},
+			Annotations:       map[string]string{agentsv1alpha1.AnnotationOwner: "user-1"},
+			Labels:            map[string]string{agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.True},
 			DeletionTimestamp: &metav1.Time{Time: time.Now()},
-			Finalizers:      []string{"agents.kruise.io/sandbox"},
+			Finalizers:        []string{"agents.kruise.io/sandbox"},
 		},
 	}
 	// Different user
@@ -1056,7 +1056,13 @@ func TestRegression_SameActionConcurrentWaitsConverge(t *testing.T) {
 				agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.True,
 			},
 		},
-		Status: agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRunning},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxRunning,
+			Conditions: []metav1.Condition{{
+				Type:   string(agentsv1alpha1.SandboxConditionReady),
+				Status: metav1.ConditionTrue,
+			}},
+		},
 	}
 	c, fc, err := cachetest.NewTestCache(t, sbx)
 	require.NoError(t, err)
@@ -1083,10 +1089,10 @@ func TestRegression_SameActionConcurrentWaitsConverge(t *testing.T) {
 
 	fresh := &agentsv1alpha1.Sandbox{}
 	require.NoError(t, fc.Get(t.Context(), ctrlclient.ObjectKeyFromObject(sbx), fresh))
-	fresh.Status.Conditions = []metav1.Condition{{
+	fresh.Status.Conditions = append(fresh.Status.Conditions, metav1.Condition{
 		Type:   string(agentsv1alpha1.SandboxConditionPaused),
 		Status: metav1.ConditionTrue,
-	}}
+	})
 	require.NoError(t, fc.Status().Update(t.Context(), fresh))
 
 	key := cacheutils.WaitHookKey[*agentsv1alpha1.Sandbox](sbx)

--- a/pkg/sandbox-manager/api.go
+++ b/pkg/sandbox-manager/api.go
@@ -97,6 +97,10 @@ func (m *SandboxManager) CloneSandbox(ctx context.Context, opts infra.CloneSandb
 	return sandbox, nil
 }
 
+// GetSandbox returns a sandbox owned by user and optionally filters it by state.
+// When expectedStates is empty, ownership is still checked but any claimed state
+// is accepted. When expectedStates is non-empty, the sandbox state must match one
+// of the provided values.
 func (m *SandboxManager) GetSandbox(ctx context.Context, user string, expectedStates []string, opts infra.GetSandboxOptions) (infra.Sandbox, error) {
 	log := klog.FromContext(ctx).WithValues("sandboxID", opts.SandboxID)
 	if user == "" {

--- a/pkg/sandbox-manager/api.go
+++ b/pkg/sandbox-manager/api.go
@@ -97,35 +97,35 @@ func (m *SandboxManager) CloneSandbox(ctx context.Context, opts infra.CloneSandb
 	return sandbox, nil
 }
 
-func (m *SandboxManager) GetClaimedSandbox(ctx context.Context, user string, opts infra.GetClaimedSandboxOptions) (infra.Sandbox, error) {
+func (m *SandboxManager) GetSandbox(ctx context.Context, user string, expectedStates []string, opts infra.GetSandboxOptions) (infra.Sandbox, error) {
 	log := klog.FromContext(ctx).WithValues("sandboxID", opts.SandboxID)
 	if user == "" {
 		return nil, errors.NewError(errors.ErrorBadRequest, "user is required")
 	}
 	log.Info("try to get claimed sandbox")
-	sbx, err := m.infra.GetClaimedSandbox(ctx, opts)
+	sbx, err := m.infra.GetSandbox(ctx, opts)
 	if err != nil {
 		log.Error(err, "failed to get sandbox from cache")
 		return nil, errors.NewError(errors.ErrorNotFound, "sandbox %s not found", opts.SandboxID)
 	}
 
 	state, reason := sbx.GetState()
-	if state == v1alpha1.SandboxStateAvailable || state == v1alpha1.SandboxStateCreating {
-		// not claimed sandbox should return not found
-		log.Error(nil, "sandbox is not claimed", "state", state, "reason", reason)
-		return nil, errors.NewError(errors.ErrorNotFound, "sandbox %s not found", opts.SandboxID)
-	}
 
 	if sbx.GetRoute().Owner != user {
 		log.Error(nil, "sandbox is not owned by user")
 		return nil, errors.NewError(errors.ErrorNotAllowed, "sandbox %s is not owned", opts.SandboxID)
 	}
 
-	if state != v1alpha1.SandboxStatePaused && state != v1alpha1.SandboxStateRunning {
-		log.Error(nil, "sandbox is not healthy", "state", state, "reason", reason)
-		return nil, errors.NewError(errors.ErrorBadRequest, "sandbox %s is not healthy (state %s, reason %s)", opts.SandboxID, state, reason)
+	if len(expectedStates) == 0 {
+		return sbx, nil
 	}
-	return sbx, nil
+	for _, expectedState := range expectedStates {
+		if state == expectedState {
+			return sbx, nil
+		}
+	}
+	log.Error(nil, "sandbox state is not expected", "state", state, "reason", reason, "expectedStates", expectedStates)
+	return nil, errors.NewError(errors.ErrorBadRequest, "sandbox %s is not healthy (state %s, reason %s)", opts.SandboxID, state, reason)
 }
 
 func (m *SandboxManager) ListSandboxes(ctx context.Context, opts infra.SelectSandboxesOptions, p *pagination.Paginator[infra.Sandbox]) ([]infra.Sandbox, string, error) {

--- a/pkg/sandbox-manager/api_test.go
+++ b/pkg/sandbox-manager/api_test.go
@@ -362,7 +362,7 @@ func TestSandboxManager_NamespaceAwareSandboxOptions(t *testing.T) {
 	assert.Equal(t, "team-a", list[0].GetNamespace())
 	assert.Equal(t, "sandbox-a", list[0].GetName())
 
-	got, err := manager.GetClaimedSandbox(t.Context(), testUser, infra.GetClaimedSandboxOptions{
+	got, err := manager.GetSandbox(t.Context(), testUser, []string{agentsv1alpha1.SandboxStateRunning, agentsv1alpha1.SandboxStatePaused}, infra.GetSandboxOptions{
 		Namespace: "team-b",
 		SandboxID: utils.GetSandboxID(sandboxes[1]),
 	})
@@ -372,7 +372,7 @@ func TestSandboxManager_NamespaceAwareSandboxOptions(t *testing.T) {
 
 	getCtx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 	defer cancel()
-	_, err = manager.GetClaimedSandbox(getCtx, testUser, infra.GetClaimedSandboxOptions{
+	_, err = manager.GetSandbox(getCtx, testUser, []string{agentsv1alpha1.SandboxStateRunning, agentsv1alpha1.SandboxStatePaused}, infra.GetSandboxOptions{
 		Namespace: "team-a",
 		SandboxID: utils.GetSandboxID(sandboxes[1]),
 	})
@@ -506,7 +506,7 @@ func TestSandboxManager_GetClaimedSandbox(t *testing.T) {
 			name:              "Get available pod should return error",
 			sandboxID:         "default--available-pod",
 			expectError:       true,
-			expectedErrorCode: errors.ErrorNotFound,
+			expectedErrorCode: errors.ErrorNotAllowed,
 			expectedState:     "",
 		},
 		{
@@ -529,7 +529,9 @@ func TestSandboxManager_GetClaimedSandbox(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 			defer cancel()
-			sbx, err := manager.GetClaimedSandbox(ctx, testUser, infra.GetClaimedSandboxOptions{SandboxID: tt.sandboxID})
+			sbx, err := manager.GetSandbox(ctx, testUser, []string{agentsv1alpha1.SandboxStateRunning, agentsv1alpha1.SandboxStatePaused}, infra.GetSandboxOptions{
+				SandboxID: tt.sandboxID,
+			})
 
 			if tt.expectError {
 				if err == nil {
@@ -547,6 +549,87 @@ func TestSandboxManager_GetClaimedSandbox(t *testing.T) {
 					t.Errorf("Expected pod state %s, got %s(%s)", tt.expectedState, state, reason)
 				}
 			}
+		})
+	}
+}
+
+func TestSandboxManager_GetClaimedSandboxExpectedStates(t *testing.T) {
+	manager, client := setupTestManager(t)
+
+	notReadySbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "not-ready-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				agentsv1alpha1.LabelSandboxIsClaimed: "true",
+			},
+			Annotations: map[string]string{
+				agentsv1alpha1.AnnotationOwner: testUser,
+			},
+			CreationTimestamp: metav1.Now(),
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxRunning,
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(agentsv1alpha1.SandboxConditionReady),
+					Status: metav1.ConditionFalse,
+				},
+			},
+		},
+	}
+	CreateSandboxWithStatus(t, client, notReadySbx)
+
+	tests := []struct {
+		name              string
+		user              string
+		sandboxID         string
+		expectError       string
+		expectedErrorCode errors.ErrorCode
+		expectedState     string
+		expectedReason    string
+	}{
+		{
+			name:           "owned not-ready running sandbox is returned",
+			user:           testUser,
+			sandboxID:      utils.GetSandboxID(notReadySbx),
+			expectedState:  agentsv1alpha1.SandboxStateDead,
+			expectedReason: "RunningResourceClaimedButNotReady",
+		},
+		{
+			name:              "non-owner is rejected",
+			user:              "other-user",
+			sandboxID:         utils.GetSandboxID(notReadySbx),
+			expectError:       "not owned",
+			expectedErrorCode: errors.ErrorNotAllowed,
+		},
+		{
+			name:              "missing sandbox is not found",
+			user:              testUser,
+			sandboxID:         "default--missing-pod",
+			expectError:       "not found",
+			expectedErrorCode: errors.ErrorNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+			defer cancel()
+			sbx, err := manager.GetSandbox(ctx, tt.user, nil, infra.GetSandboxOptions{
+				SandboxID: tt.sandboxID,
+			})
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				assert.Equal(t, tt.expectedErrorCode, errors.GetErrCode(err))
+				return
+			}
+
+			require.NoError(t, err)
+			state, reason := sbx.GetState()
+			assert.Equal(t, tt.expectedState, state)
+			assert.Equal(t, tt.expectedReason, reason)
 		})
 	}
 }
@@ -614,7 +697,7 @@ func TestSandboxManager_PauseSandbox(t *testing.T) {
 			CreateSandboxWithStatus(t, client, sandbox)
 
 			// Get sandbox
-			sbx, err := manager.GetClaimedSandbox(t.Context(), testUser, infra.GetClaimedSandboxOptions{
+			sbx, err := manager.GetSandbox(t.Context(), testUser, []string{agentsv1alpha1.SandboxStateRunning, agentsv1alpha1.SandboxStatePaused}, infra.GetSandboxOptions{
 				SandboxID: utils.GetSandboxID(sandbox),
 			})
 			if err != nil {
@@ -654,7 +737,7 @@ func TestSandboxManager_PauseSandbox(t *testing.T) {
 			assert.Equal(t, testUser, route.Owner)
 			// Verify sandbox state matches expected
 			if tt.expectedState != "" {
-				actualSbx, err := manager.GetClaimedSandbox(t.Context(), testUser, infra.GetClaimedSandboxOptions{
+				actualSbx, err := manager.GetSandbox(t.Context(), testUser, []string{agentsv1alpha1.SandboxStateRunning, agentsv1alpha1.SandboxStatePaused}, infra.GetSandboxOptions{
 					SandboxID: utils.GetSandboxID(sandbox),
 				})
 				if err == nil {
@@ -745,7 +828,7 @@ func TestSandboxManager_ResumeSandbox(t *testing.T) {
 			mgr.AddWaitReconcileKey(sandbox)
 
 			// Get sandbox
-			sbx, err := manager.GetClaimedSandbox(t.Context(), testUser, infra.GetClaimedSandboxOptions{
+			sbx, err := manager.GetSandbox(t.Context(), testUser, []string{agentsv1alpha1.SandboxStateRunning, agentsv1alpha1.SandboxStatePaused}, infra.GetSandboxOptions{
 				SandboxID: utils.GetSandboxID(sandbox),
 			})
 			if err != nil {
@@ -1184,7 +1267,7 @@ func TestSandboxManager_DeleteSandbox(t *testing.T) {
 			CreateSandboxWithStatus(t, client, sandbox)
 
 			// Get sandbox
-			sbx, err := manager.GetClaimedSandbox(t.Context(), testUser, infra.GetClaimedSandboxOptions{
+			sbx, err := manager.GetSandbox(t.Context(), testUser, []string{agentsv1alpha1.SandboxStateRunning, agentsv1alpha1.SandboxStatePaused}, infra.GetSandboxOptions{
 				SandboxID: utils.GetSandboxID(sandbox),
 			})
 			if err != nil {
@@ -1216,7 +1299,7 @@ func TestSandboxManager_DeleteSandbox(t *testing.T) {
 				// Use a short timeout context to avoid long retry in GetClaimedSandbox
 				ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 				defer cancel()
-				_, getErr := manager.GetClaimedSandbox(ctx, testUser, infra.GetClaimedSandboxOptions{
+				_, getErr := manager.GetSandbox(ctx, testUser, []string{agentsv1alpha1.SandboxStateRunning, agentsv1alpha1.SandboxStatePaused}, infra.GetSandboxOptions{
 					SandboxID: utils.GetSandboxID(sandbox),
 				})
 				assert.Error(t, getErr, "sandbox should not be found after deletion")

--- a/pkg/sandbox-manager/api_test.go
+++ b/pkg/sandbox-manager/api_test.go
@@ -380,7 +380,7 @@ func TestSandboxManager_NamespaceAwareSandboxOptions(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
-func TestSandboxManager_GetClaimedSandbox(t *testing.T) {
+func TestSandboxManager_GetSandbox(t *testing.T) {
 	manager, client := setupTestManager(t)
 
 	runningSbx := &agentsv1alpha1.Sandbox{
@@ -553,7 +553,7 @@ func TestSandboxManager_GetClaimedSandbox(t *testing.T) {
 	}
 }
 
-func TestSandboxManager_GetClaimedSandboxExpectedStates(t *testing.T) {
+func TestSandboxManager_GetSandboxExpectedStates(t *testing.T) {
 	manager, client := setupTestManager(t)
 
 	notReadySbx := &agentsv1alpha1.Sandbox{
@@ -1296,7 +1296,7 @@ func TestSandboxManager_DeleteSandbox(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				// After successful deletion, verify sandbox is not found
-				// Use a short timeout context to avoid long retry in GetClaimedSandbox
+				// Use a short timeout context to avoid long retry in GetSandbox
 				ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 				defer cancel()
 				_, getErr := manager.GetSandbox(ctx, testUser, []string{agentsv1alpha1.SandboxStateRunning, agentsv1alpha1.SandboxStatePaused}, infra.GetSandboxOptions{

--- a/pkg/sandbox-manager/infra/interface.go
+++ b/pkg/sandbox-manager/infra/interface.go
@@ -86,7 +86,7 @@ type HasCheckpointOptions struct {
 	CheckpointID string
 }
 
-type GetClaimedSandboxOptions struct {
+type GetSandboxOptions struct {
 	Namespace string
 	SandboxID string
 }
@@ -121,7 +121,7 @@ type Infrastructure interface {
 	GetCache() cache.Provider // Get the CacheProvider for the infra
 	LoadDebugInfo() map[string]any
 	SelectSandboxes(ctx context.Context, opts SelectSandboxesOptions) ([]Sandbox, error)
-	GetClaimedSandbox(ctx context.Context, opts GetClaimedSandboxOptions) (Sandbox, error)
+	GetSandbox(ctx context.Context, opts GetSandboxOptions) (Sandbox, error)
 	SelectSucceededCheckpoints(ctx context.Context, opts SelectSucceededCheckpointsOptions) ([]CheckpointInfo, error)
 	ClaimSandbox(ctx context.Context, opts ClaimSandboxOptions) (Sandbox, ClaimMetrics, error)
 	CloneSandbox(ctx context.Context, opts CloneSandboxOptions) (Sandbox, CloneMetrics, error)

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -351,10 +351,10 @@ type claimedSandboxLookup struct {
 	hasRoute bool
 }
 
-// lookupClaimedSandbox waits until the informer cache returns the claimed Sandbox.
+// lookupSandbox waits until the informer cache returns the claimed Sandbox.
 // Route state is loaded only after a cache hit and is used later as a staleness
 // signal, not as a cache-miss fallback trigger.
-func (i *Infra) lookupClaimedSandbox(ctx context.Context, opts infra.GetClaimedSandboxOptions) (claimedSandboxLookup, error) {
+func (i *Infra) lookupSandbox(ctx context.Context, opts infra.GetSandboxOptions) (claimedSandboxLookup, error) {
 	var lookup claimedSandboxLookup
 	err := wait.PollUntilContextCancel(ctx, RetryInterval, true, func(ctx context.Context) (bool, error) {
 		got, err := i.Cache.GetClaimedSandbox(ctx, cache.GetClaimedSandboxOptions{Namespace: opts.Namespace, SandboxID: opts.SandboxID})
@@ -410,7 +410,7 @@ func isSandboxStale(ctx context.Context, lookup claimedSandboxLookup) bool {
 	return false
 }
 
-func (i *Infra) getClaimedSandboxFromAPIReader(ctx context.Context, key client.ObjectKey, sandboxID string) (*v1alpha1.Sandbox, error) {
+func (i *Infra) getSandboxFromAPIReader(ctx context.Context, key client.ObjectKey, sandboxID string) (*v1alpha1.Sandbox, error) {
 	fresh := &v1alpha1.Sandbox{}
 	if err := i.APIReader.Get(ctx, key, fresh); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -424,8 +424,8 @@ func (i *Infra) getClaimedSandboxFromAPIReader(ctx context.Context, key client.O
 	return fresh, nil
 }
 
-func (i *Infra) GetClaimedSandbox(ctx context.Context, opts infra.GetClaimedSandboxOptions) (infra.Sandbox, error) {
-	lookup, err := i.lookupClaimedSandbox(ctx, opts)
+func (i *Infra) GetSandbox(ctx context.Context, opts infra.GetSandboxOptions) (infra.Sandbox, error) {
+	lookup, err := i.lookupSandbox(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +435,7 @@ func (i *Infra) GetClaimedSandbox(ctx context.Context, opts infra.GetClaimedSand
 	}
 
 	key := client.ObjectKey{Namespace: lookup.sandbox.Namespace, Name: lookup.sandbox.Name}
-	fresh, err := i.getClaimedSandboxFromAPIReader(ctx, key, opts.SandboxID)
+	fresh, err := i.getSandboxFromAPIReader(ctx, key, opts.SandboxID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
@@ -256,7 +256,9 @@ func TestInfra_GetSandbox(t *testing.T) {
 			// Test GetClaimedSandbox
 			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 			defer cancel()
-			result, err := infraInstance.GetClaimedSandbox(ctx, infra.GetClaimedSandboxOptions{SandboxID: tt.sandboxID})
+			result, err := infraInstance.GetSandbox(ctx, infra.GetSandboxOptions{
+				SandboxID:      tt.sandboxID,
+			})
 			if tt.expectError {
 				assert.Error(t, err)
 				assert.Nil(t, result)
@@ -286,9 +288,9 @@ func TestInfra_GetClaimedSandboxWithOptions_NamespaceScoped(t *testing.T) {
 	CreateSandboxWithStatus(t, fc, sbx)
 	sandboxID := utils.GetSandboxID(sbx)
 
-	got, err := infraInstance.GetClaimedSandbox(t.Context(), infra.GetClaimedSandboxOptions{
-		Namespace: "team-a",
-		SandboxID: sandboxID,
+	got, err := infraInstance.GetSandbox(t.Context(), infra.GetSandboxOptions{
+		Namespace:      "team-a",
+		SandboxID:      sandboxID,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "team-a", got.GetNamespace())
@@ -296,9 +298,9 @@ func TestInfra_GetClaimedSandboxWithOptions_NamespaceScoped(t *testing.T) {
 
 	getCtx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 	defer cancel()
-	_, err = infraInstance.GetClaimedSandbox(getCtx, infra.GetClaimedSandboxOptions{
-		Namespace: "team-b",
-		SandboxID: sandboxID,
+	_, err = infraInstance.GetSandbox(getCtx, infra.GetSandboxOptions{
+		Namespace:      "team-b",
+		SandboxID:      sandboxID,
 	})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
@@ -350,9 +352,9 @@ func TestInfra_GetClaimedSandbox_CacheMiss_WaitsUntilCacheHit(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 			defer cancel()
-			got, err := infraInstance.GetClaimedSandbox(ctx, infra.GetClaimedSandboxOptions{
-				Namespace: "team-a",
-				SandboxID: id,
+			got, err := infraInstance.GetSandbox(ctx, infra.GetSandboxOptions{
+				Namespace:      "team-a",
+				SandboxID:      id,
 			})
 
 			require.NoError(t, err)
@@ -401,9 +403,9 @@ func TestInfra_GetClaimedSandbox_SharedContextError_RetriesWhileContextLive(t *t
 
 			ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 			defer cancel()
-			got, err := infraInstance.GetClaimedSandbox(ctx, infra.GetClaimedSandboxOptions{
-				Namespace: "team-a",
-				SandboxID: id,
+			got, err := infraInstance.GetSandbox(ctx, infra.GetSandboxOptions{
+				Namespace:      "team-a",
+				SandboxID:      id,
 			})
 
 			if tt.expectError != "" {
@@ -451,9 +453,9 @@ func TestInfra_GetClaimedSandbox_CacheMiss_ReturnsContextError(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(t.Context(), 75*time.Millisecond)
 			defer cancel()
-			got, err := infraInstance.GetClaimedSandbox(ctx, infra.GetClaimedSandboxOptions{
-				Namespace: "team-a",
-				SandboxID: id,
+			got, err := infraInstance.GetSandbox(ctx, infra.GetSandboxOptions{
+				Namespace:      "team-a",
+				SandboxID:      id,
 			})
 
 			require.Error(t, err)
@@ -483,9 +485,9 @@ func TestInfra_GetClaimedSandbox_RouteRVNewerThanCache_FallsBackToAPIReader(t *t
 		ResourceVersion: "777",
 	})
 
-	got, err := infraInstance.GetClaimedSandbox(t.Context(), infra.GetClaimedSandboxOptions{
-		Namespace: "team-a",
-		SandboxID: id,
+	got, err := infraInstance.GetSandbox(t.Context(), infra.GetSandboxOptions{
+		Namespace:      "team-a",
+		SandboxID:      id,
 	})
 
 	require.NoError(t, err)
@@ -517,9 +519,9 @@ func TestInfra_GetClaimedSandbox_CacheRVEqualsRouteRV_NoFallback(t *testing.T) {
 		ResourceVersion: rv,
 	})
 
-	got, err := infraInstance.GetClaimedSandbox(t.Context(), infra.GetClaimedSandboxOptions{
-		Namespace: "team-a",
-		SandboxID: id,
+	got, err := infraInstance.GetSandbox(t.Context(), infra.GetSandboxOptions{
+		Namespace:      "team-a",
+		SandboxID:      id,
 	})
 
 	require.NoError(t, err)
@@ -568,9 +570,9 @@ func TestInfra_GetClaimedSandbox_StaleCacheFallback_APIReaderRequiresClaimedLabe
 
 			ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 			defer cancel()
-			got, err := infraInstance.GetClaimedSandbox(ctx, infra.GetClaimedSandboxOptions{
-				Namespace: "team-a",
-				SandboxID: id,
+			got, err := infraInstance.GetSandbox(ctx, infra.GetSandboxOptions{
+				Namespace:      "team-a",
+				SandboxID:      id,
 			})
 
 			require.Error(t, err)
@@ -598,9 +600,9 @@ func TestInfra_GetClaimedSandbox_StaleCacheFallback_APIReaderNotFound_WrapsCache
 
 	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 	defer cancel()
-	got, err := infraInstance.GetClaimedSandbox(ctx, infra.GetClaimedSandboxOptions{
-		Namespace: "team-a",
-		SandboxID: id,
+	got, err := infraInstance.GetSandbox(ctx, infra.GetSandboxOptions{
+		Namespace:      "team-a",
+		SandboxID:      id,
 	})
 
 	require.Error(t, err)

--- a/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
@@ -1638,7 +1638,7 @@ func TestSandbox_ResumeMutatorAtomicity(t *testing.T) {
 func TestSandbox_ResumeExtendOnlyConcurrent(t *testing.T) {
 	utestutils.InitLogOutput()
 
-	now := time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)
+	now := time.Now().UTC().Truncate(time.Second)
 	staleOpts := timeout.Options{
 		PauseTime:    now.Add(-5 * time.Minute),
 		ShutdownTime: now.Add(24 * time.Hour),

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
@@ -175,9 +175,9 @@ func TestSandbox_SaveTimeoutWithPolicy(t *testing.T) {
 			var sandbox infra.Sandbox
 			require.Eventually(t, func() bool {
 				var err error
-				sandbox, err = infraInstance.GetClaimedSandbox(t.Context(), infra.GetClaimedSandboxOptions{
-					SandboxID: utils.GetSandboxID(sbx),
-					Namespace: sbx.Namespace,
+				sandbox, err = infraInstance.GetSandbox(t.Context(), infra.GetSandboxOptions{
+					SandboxID:      utils.GetSandboxID(sbx),
+					Namespace:      sbx.Namespace,
 				})
 				return err == nil
 			}, time.Second, 10*time.Millisecond)
@@ -263,16 +263,16 @@ func TestSandbox_SaveTimeoutWithPolicy_OnConflict(t *testing.T) {
 	var sandboxB infra.Sandbox
 	require.Eventually(t, func() bool {
 		var getErr error
-		sandboxA, getErr = infraImpl.GetClaimedSandbox(t.Context(), infra.GetClaimedSandboxOptions{
-			SandboxID: utils.GetSandboxID(sbx),
-			Namespace: sbx.Namespace,
+		sandboxA, getErr = infraImpl.GetSandbox(t.Context(), infra.GetSandboxOptions{
+			SandboxID:      utils.GetSandboxID(sbx),
+			Namespace:      sbx.Namespace,
 		})
 		if getErr != nil {
 			return false
 		}
-		sandboxB, getErr = infraImpl.GetClaimedSandbox(t.Context(), infra.GetClaimedSandboxOptions{
-			SandboxID: utils.GetSandboxID(sbx),
-			Namespace: sbx.Namespace,
+		sandboxB, getErr = infraImpl.GetSandbox(t.Context(), infra.GetSandboxOptions{
+			SandboxID:      utils.GetSandboxID(sbx),
+			Namespace:      sbx.Namespace,
 		})
 		return getErr == nil
 	}, time.Second, 10*time.Millisecond)

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -188,7 +188,7 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 		return web.ApiResponse[*models.Sandbox]{}, apiErr
 	}
 
-	sbx, apiErr := sc.getSandboxOfUser(ctx, id, claimedSandboxStates)
+	sbx, apiErr := sc.getSandboxOfUser(ctx, id, liveSandboxStates)
 	if apiErr != nil {
 		return web.ApiResponse[*models.Sandbox]{}, apiErr
 	}

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -40,7 +40,7 @@ func (sc *Controller) PauseSandbox(r *http.Request) (web.ApiResponse[struct{}], 
 	id := r.PathValue("sandboxID")
 	ctx := r.Context()
 	log := klog.FromContext(ctx).WithValues("sandboxID", id)
-	sbx, apiErr := sc.getSandboxOfUser(ctx, id)
+	sbx, apiErr := sc.getSandboxOfUser(ctx, id, claimedSandboxStates)
 	if apiErr != nil {
 		return web.ApiResponse[struct{}]{}, apiErr
 	}
@@ -124,7 +124,7 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 		return web.ApiResponse[struct{}]{}, apiErr
 	}
 
-	sbx, apiErr := sc.getSandboxOfUser(ctx, id)
+	sbx, apiErr := sc.getSandboxOfUser(ctx, id, claimedSandboxStates)
 	if apiErr != nil {
 		return web.ApiResponse[struct{}]{}, apiErr
 	}
@@ -188,7 +188,7 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 		return web.ApiResponse[*models.Sandbox]{}, apiErr
 	}
 
-	sbx, apiErr := sc.getSandboxOfUser(ctx, id)
+	sbx, apiErr := sc.getSandboxOfUser(ctx, id, claimedSandboxStates)
 	if apiErr != nil {
 		return web.ApiResponse[*models.Sandbox]{}, apiErr
 	}

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -124,7 +124,7 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 		return web.ApiResponse[struct{}]{}, apiErr
 	}
 
-	sbx, apiErr := sc.getSandboxOfUser(ctx, id, claimedSandboxStates)
+	sbx, apiErr := sc.getSandboxOfUser(ctx, id, liveSandboxStates)
 	if apiErr != nil {
 		return web.ApiResponse[struct{}]{}, apiErr
 	}

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -610,6 +610,7 @@ func TestResumeSandbox(t *testing.T) {
 		paused       bool   // if sandbox is set paused
 		pausing      bool   // if sandbox is performing pausing
 		resuming     bool   // if sandbox is performing resuming (Ready condition is false)
+		notReady     bool   // if running sandbox is not ready and therefore dead
 		sandboxID    string // if not set, use the created sandbox ID
 		timeout      int
 		expectStatus int
@@ -647,6 +648,12 @@ func TestResumeSandbox(t *testing.T) {
 			resuming:     true,
 			timeout:      300,
 			expectStatus: http.StatusNoContent,
+		},
+		{
+			name:         "running not-ready sandbox",
+			notReady:     true,
+			timeout:      300,
+			expectStatus: http.StatusNotFound,
 		},
 		{
 			name:         "not found",
@@ -689,6 +696,10 @@ func TestResumeSandbox(t *testing.T) {
 
 			if tt.paused {
 				pauseSandboxHelper(t, controller, fc, createResp.Body.SandboxID, tt.pausing, tt.resuming, user)
+			}
+			if tt.notReady {
+				UpdateSandboxWhen(t, fc, createResp.Body.SandboxID, Immediately,
+					DoSetSandboxStatus(agentsv1alpha1.SandboxRunning, "", metav1.ConditionFalse))
 			}
 			var inFlightResumeEndAt time.Time
 			if tt.resuming {

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -841,7 +841,7 @@ func TestUpdateConnectTimeout(t *testing.T) {
 			req := NewRequest(t, nil, nil, map[string]string{
 				"sandboxID": createResp.Body.SandboxID,
 			}, user)
-			sbx, apiErr := controller.getSandboxOfUser(req.Context(), createResp.Body.SandboxID)
+			sbx, apiErr := controller.getSandboxOfUser(req.Context(), createResp.Body.SandboxID, claimedSandboxStates)
 			require.Nil(t, apiErr)
 			require.NotNil(t, sbx)
 

--- a/pkg/servers/e2b/sandbox.go
+++ b/pkg/servers/e2b/sandbox.go
@@ -36,9 +36,11 @@ import (
 
 var (
 	browserWebSocketReplacer = regexp.MustCompile(`^ws://[^/]+`)
+	claimedSandboxStates     = []string{agentsv1alpha1.SandboxStateRunning, agentsv1alpha1.SandboxStatePaused, agentsv1alpha1.SandboxStateDead}
+	liveSandboxStates        = []string{agentsv1alpha1.SandboxStateRunning, agentsv1alpha1.SandboxStatePaused}
 )
 
-func (sc *Controller) getSandboxOfUser(ctx context.Context, sandboxID string) (infra.Sandbox, *web.ApiError) {
+func (sc *Controller) getSandboxOfUser(ctx context.Context, sandboxID string, expectedStates []string) (infra.Sandbox, *web.ApiError) {
 	log := klog.FromContext(ctx).WithValues("sandboxID", sandboxID)
 	log.Info("getting sandbox of user")
 	user := GetUserFromContext(ctx)
@@ -50,12 +52,13 @@ func (sc *Controller) getSandboxOfUser(ctx context.Context, sandboxID string) (i
 	}
 	getCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
-	sbx, err := sc.manager.GetClaimedSandbox(getCtx, user.ID.String(), infra.GetClaimedSandboxOptions{
+	opts := infra.GetSandboxOptions{
 		Namespace: sc.getNamespaceOfUser(user),
 		SandboxID: sandboxID,
-	})
+	}
+	sbx, err := sc.manager.GetSandbox(getCtx, user.ID.String(), expectedStates, opts)
 	if err != nil {
-		log.Error(err, "sandbox not found")
+		log.Error(err, "failed to get sandbox")
 		return nil, &web.ApiError{
 			Code:    http.StatusNotFound,
 			Message: fmt.Sprintf("Cannot get sandbox %s: %v", sandboxID, err),

--- a/pkg/servers/e2b/services.go
+++ b/pkg/servers/e2b/services.go
@@ -44,7 +44,7 @@ func (sc *Controller) DescribeSandbox(r *http.Request) (web.ApiResponse[*models.
 	log := klog.FromContext(r.Context())
 	log.Info("describe sandbox", "id", id)
 
-	sbx, err := sc.getSandboxOfUser(r.Context(), id, claimedSandboxStates)
+	sbx, err := sc.getSandboxOfUser(r.Context(), id, liveSandboxStates)
 	if err != nil {
 		log.Error(err, "failed to get sandbox", "id", id)
 		return web.ApiResponse[*models.Sandbox]{}, err

--- a/pkg/servers/e2b/services.go
+++ b/pkg/servers/e2b/services.go
@@ -44,7 +44,7 @@ func (sc *Controller) DescribeSandbox(r *http.Request) (web.ApiResponse[*models.
 	log := klog.FromContext(r.Context())
 	log.Info("describe sandbox", "id", id)
 
-	sbx, err := sc.getSandboxOfUser(r.Context(), id)
+	sbx, err := sc.getSandboxOfUser(r.Context(), id, claimedSandboxStates)
 	if err != nil {
 		log.Error(err, "failed to get sandbox", "id", id)
 		return web.ApiResponse[*models.Sandbox]{}, err
@@ -59,7 +59,7 @@ func (sc *Controller) DescribeSandbox(r *http.Request) (web.ApiResponse[*models.
 func (sc *Controller) DeleteSandbox(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
 	id := r.PathValue("sandboxID")
 	log := klog.FromContext(r.Context())
-	sbx, apiError := sc.getSandboxOfUser(r.Context(), id)
+	sbx, apiError := sc.getSandboxOfUser(r.Context(), id, claimedSandboxStates)
 	if apiError != nil {
 		log.Error(apiError, "failed to get sandbox, just return success", "id", id)
 		return web.ApiResponse[struct{}]{
@@ -117,7 +117,7 @@ func (sc *Controller) BrowserUse(r *http.Request) (web.ApiResponse[*browserHandS
 	if apiErr != nil {
 		return web.ApiResponse[*browserHandShake]{}, apiErr
 	}
-	sbx, apiErr := sc.getSandboxOfUser(r.Context(), sandboxID)
+	sbx, apiErr := sc.getSandboxOfUser(r.Context(), sandboxID, liveSandboxStates)
 	if apiErr != nil {
 		return web.ApiResponse[*browserHandShake]{}, apiErr
 	}

--- a/pkg/servers/e2b/services.go
+++ b/pkg/servers/e2b/services.go
@@ -44,7 +44,7 @@ func (sc *Controller) DescribeSandbox(r *http.Request) (web.ApiResponse[*models.
 	log := klog.FromContext(r.Context())
 	log.Info("describe sandbox", "id", id)
 
-	sbx, err := sc.getSandboxOfUser(r.Context(), id, liveSandboxStates)
+	sbx, err := sc.getSandboxOfUser(r.Context(), id, claimedSandboxStates)
 	if err != nil {
 		log.Error(err, "failed to get sandbox", "id", id)
 		return web.ApiResponse[*models.Sandbox]{}, err

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -1550,6 +1550,7 @@ func TestDeleteSandboxDeadClaimedSandbox(t *testing.T) {
 	sandbox := CreateClaimedSandboxCR(t, controller, Namespace, "dead-delete-sandbox", "test-template", user.ID.String(), nil)
 	sandboxID := fmt.Sprintf("%s--%s", sandbox.Namespace, sandbox.Name)
 	UpdateSandboxWhen(t, fc, sandboxID, Immediately, DoSetSandboxStatus(v1alpha1.SandboxRunning, "", metav1.ConditionFalse))
+	require.NoError(t, fc.Get(t.Context(), ctrlclient.ObjectKey{Namespace: sandbox.Namespace, Name: sandbox.Name}, &v1alpha1.Sandbox{}))
 
 	deleteCalls := 0
 	origDeleteSandbox := sandboxcr.DefaultDeleteSandbox
@@ -1565,12 +1566,14 @@ func TestDeleteSandboxDeadClaimedSandbox(t *testing.T) {
 
 	require.Nil(t, apiErr)
 	assert.Equal(t, http.StatusNoContent, deleteResp.Code)
-	assert.Equal(t, 1, deleteCalls)
+	require.Equal(t, 1, deleteCalls)
+	var getErr error
 	require.Eventually(t, func() bool {
 		got := &v1alpha1.Sandbox{}
-		err := fc.Get(t.Context(), ctrlclient.ObjectKey{Namespace: sandbox.Namespace, Name: sandbox.Name}, got)
-		return apierrors.IsNotFound(err)
+		getErr = fc.Get(t.Context(), ctrlclient.ObjectKey{Namespace: sandbox.Namespace, Name: sandbox.Name}, got)
+		return apierrors.IsNotFound(getErr)
 	}, time.Second, 10*time.Millisecond)
+	require.True(t, apierrors.IsNotFound(getErr), "expected sandbox to be deleted, got error: %v", getErr)
 }
 
 func TestDescribeSandboxDeadClaimedSandbox(t *testing.T) {

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -51,7 +51,7 @@ import (
 
 func imageChecker(image string, controller *Controller) func(t *testing.T, resp *models.Sandbox) {
 	return func(t *testing.T, resp *models.Sandbox) {
-		sbx, err := controller.manager.GetClaimedSandbox(t.Context(), keys.AdminKeyID.String(), infra.GetClaimedSandboxOptions{
+		sbx, err := controller.manager.GetSandbox(t.Context(), keys.AdminKeyID.String(), []string{v1alpha1.SandboxStateRunning, v1alpha1.SandboxStatePaused}, infra.GetSandboxOptions{
 			SandboxID: resp.SandboxID,
 		})
 		assert.NoError(t, err)
@@ -252,7 +252,7 @@ func TestCreateSandbox(t *testing.T) {
 			},
 			postCheck: func(t *testing.T, resp *models.Sandbox) {
 				assert.Equal(t, "0001-01-01T00:00:00Z", resp.EndAt)
-				sbx, err := controller.manager.GetClaimedSandbox(t.Context(), keys.AdminKeyID.String(), infra.GetClaimedSandboxOptions{
+				sbx, err := controller.manager.GetSandbox(t.Context(), keys.AdminKeyID.String(), []string{v1alpha1.SandboxStateRunning, v1alpha1.SandboxStatePaused}, infra.GetSandboxOptions{
 					SandboxID: resp.SandboxID,
 				})
 				assert.NoError(t, err)
@@ -380,7 +380,7 @@ func TestCreateSandbox(t *testing.T) {
 
 				assert.NotContains(t, sbx.Spec.Template.Labels, "regular-metadata-key")
 
-				sandboxFromManager, err := controller.manager.GetClaimedSandbox(t.Context(), keys.AdminKeyID.String(), infra.GetClaimedSandboxOptions{
+				sandboxFromManager, err := controller.manager.GetSandbox(t.Context(), keys.AdminKeyID.String(), []string{v1alpha1.SandboxStateRunning, v1alpha1.SandboxStatePaused}, infra.GetSandboxOptions{
 					SandboxID: resp.SandboxID,
 				})
 				assert.NoError(t, err)
@@ -928,7 +928,7 @@ func TestCloneSandbox(t *testing.T) {
 			},
 			postCheck: func(t *testing.T, resp *models.Sandbox, controller *Controller) {
 				assert.Equal(t, "0001-01-01T00:00:00Z", resp.EndAt)
-				sbx, err := controller.manager.GetClaimedSandbox(t.Context(), keys.AdminKeyID.String(), infra.GetClaimedSandboxOptions{
+				sbx, err := controller.manager.GetSandbox(t.Context(), keys.AdminKeyID.String(), []string{v1alpha1.SandboxStateRunning, v1alpha1.SandboxStatePaused}, infra.GetSandboxOptions{
 					SandboxID: resp.SandboxID,
 				})
 				assert.NoError(t, err)
@@ -943,7 +943,7 @@ func TestCloneSandbox(t *testing.T) {
 				AutoPause:  true,
 			},
 			postCheck: func(t *testing.T, resp *models.Sandbox, controller *Controller) {
-				sbx, err := controller.manager.GetClaimedSandbox(t.Context(), keys.AdminKeyID.String(), infra.GetClaimedSandboxOptions{
+				sbx, err := controller.manager.GetSandbox(t.Context(), keys.AdminKeyID.String(), []string{v1alpha1.SandboxStateRunning, v1alpha1.SandboxStatePaused}, infra.GetSandboxOptions{
 					SandboxID: resp.SandboxID,
 				})
 				assert.NoError(t, err)
@@ -1535,6 +1535,91 @@ func TestDeleteSandbox(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeleteSandboxDeadClaimedSandbox(t *testing.T) {
+	controller, fc, teardown := Setup(t)
+	defer teardown()
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+		Team: models.AdminTeam(),
+	}
+	sandbox := CreateClaimedSandboxCR(t, controller, Namespace, "dead-delete-sandbox", "test-template", user.ID.String(), nil)
+	sandboxID := fmt.Sprintf("%s--%s", sandbox.Namespace, sandbox.Name)
+	UpdateSandboxWhen(t, fc, sandboxID, Immediately, DoSetSandboxStatus(v1alpha1.SandboxRunning, "", metav1.ConditionFalse))
+
+	deleteCalls := 0
+	origDeleteSandbox := sandboxcr.DefaultDeleteSandbox
+	sandboxcr.DefaultDeleteSandbox = func(ctx context.Context, sbx *v1alpha1.Sandbox, client ctrlclient.Client) error {
+		deleteCalls++
+		return origDeleteSandbox(ctx, sbx, client)
+	}
+	t.Cleanup(func() { sandboxcr.DefaultDeleteSandbox = origDeleteSandbox })
+
+	deleteResp, apiErr := controller.DeleteSandbox(NewRequest(t, nil, nil, map[string]string{
+		"sandboxID": sandboxID,
+	}, user))
+
+	require.Nil(t, apiErr)
+	assert.Equal(t, http.StatusNoContent, deleteResp.Code)
+	assert.Equal(t, 1, deleteCalls)
+	require.Eventually(t, func() bool {
+		got := &v1alpha1.Sandbox{}
+		err := fc.Get(t.Context(), ctrlclient.ObjectKey{Namespace: sandbox.Namespace, Name: sandbox.Name}, got)
+		return apierrors.IsNotFound(err)
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestDescribeSandboxDeadClaimedSandbox(t *testing.T) {
+	controller, fc, teardown := Setup(t)
+	defer teardown()
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+		Team: models.AdminTeam(),
+	}
+	sandbox := CreateClaimedSandboxCR(t, controller, Namespace, "dead-describe-sandbox", "test-template", user.ID.String(), nil)
+	sandboxID := fmt.Sprintf("%s--%s", sandbox.Namespace, sandbox.Name)
+	UpdateSandboxWhen(t, fc, sandboxID, Immediately, DoSetSandboxStatus(v1alpha1.SandboxRunning, "", metav1.ConditionFalse))
+
+	describeResp, apiErr := controller.DescribeSandbox(NewRequest(t, nil, nil, map[string]string{
+		"sandboxID": sandboxID,
+	}, user))
+
+	require.Nil(t, apiErr)
+	assert.Equal(t, sandboxID, describeResp.Body.SandboxID)
+	assert.Equal(t, v1alpha1.SandboxStateDead, describeResp.Body.State)
+}
+
+func TestConnectSandboxDeadClaimedSandboxReturnsDeadState(t *testing.T) {
+	controller, fc, teardown := Setup(t)
+	defer teardown()
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+		Team: models.AdminTeam(),
+	}
+	sandbox := CreateClaimedSandboxCR(t, controller, Namespace, "dead-connect-sandbox", "test-template", user.ID.String(), nil)
+	sandboxID := fmt.Sprintf("%s--%s", sandbox.Namespace, sandbox.Name)
+	UpdateSandboxWhen(t, fc, sandboxID, Immediately, DoSetSandboxStatus(v1alpha1.SandboxRunning, "", metav1.ConditionFalse))
+
+	connectResp, apiErr := controller.ConnectSandbox(NewRequest(t, nil, models.SetTimeoutRequest{
+		TimeoutSeconds: 60,
+	}, map[string]string{
+		"sandboxID": sandboxID,
+	}, user))
+
+	require.Nil(t, apiErr)
+	assert.Equal(t, http.StatusOK, connectResp.Code)
+	assert.Equal(t, sandboxID, connectResp.Body.SandboxID)
+	assert.Equal(t, v1alpha1.SandboxStateDead, connectResp.Body.State)
 }
 
 func TestSandboxNamespaceIsolationWithSameName(t *testing.T) {

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -1591,12 +1591,13 @@ func TestDescribeSandboxDeadClaimedSandbox(t *testing.T) {
 		"sandboxID": sandboxID,
 	}, user))
 
-	require.Nil(t, apiErr)
-	assert.Equal(t, sandboxID, describeResp.Body.SandboxID)
-	assert.Equal(t, v1alpha1.SandboxStateDead, describeResp.Body.State)
+	assert.Equal(t, web.ApiResponse[*models.Sandbox]{}, describeResp)
+	require.NotNil(t, apiErr)
+	assert.Equal(t, http.StatusNotFound, apiErr.Code)
+	assert.Contains(t, apiErr.Message, "is not healthy")
 }
 
-func TestConnectSandboxDeadClaimedSandboxReturnsDeadState(t *testing.T) {
+func TestConnectSandboxDeadClaimedSandbox(t *testing.T) {
 	controller, fc, teardown := Setup(t)
 	defer teardown()
 
@@ -1616,10 +1617,10 @@ func TestConnectSandboxDeadClaimedSandboxReturnsDeadState(t *testing.T) {
 		"sandboxID": sandboxID,
 	}, user))
 
-	require.Nil(t, apiErr)
-	assert.Equal(t, http.StatusOK, connectResp.Code)
-	assert.Equal(t, sandboxID, connectResp.Body.SandboxID)
-	assert.Equal(t, v1alpha1.SandboxStateDead, connectResp.Body.State)
+	assert.Equal(t, web.ApiResponse[*models.Sandbox]{}, connectResp)
+	require.NotNil(t, apiErr)
+	assert.Equal(t, http.StatusNotFound, apiErr.Code)
+	assert.Contains(t, apiErr.Message, "is not healthy")
 }
 
 func TestSandboxNamespaceIsolationWithSameName(t *testing.T) {

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -1591,10 +1591,10 @@ func TestDescribeSandboxDeadClaimedSandbox(t *testing.T) {
 		"sandboxID": sandboxID,
 	}, user))
 
-	assert.Equal(t, web.ApiResponse[*models.Sandbox]{}, describeResp)
-	require.NotNil(t, apiErr)
-	assert.Equal(t, http.StatusNotFound, apiErr.Code)
-	assert.Contains(t, apiErr.Message, "is not healthy")
+	require.Nil(t, apiErr)
+	require.NotNil(t, describeResp.Body)
+	assert.Equal(t, sandboxID, describeResp.Body.SandboxID)
+	assert.Equal(t, v1alpha1.SandboxStateDead, describeResp.Body.State)
 }
 
 func TestConnectSandboxDeadClaimedSandbox(t *testing.T) {

--- a/pkg/servers/e2b/snapshot.go
+++ b/pkg/servers/e2b/snapshot.go
@@ -40,7 +40,7 @@ func (sc *Controller) CreateSnapshot(r *http.Request) (web.ApiResponse[*models.S
 		return web.ApiResponse[*models.Snapshot]{}, parseErr
 	}
 	log.Info("create snapshot request received", "request", request)
-	sbx, apiErr := sc.getSandboxOfUser(ctx, sandboxID)
+	sbx, apiErr := sc.getSandboxOfUser(ctx, sandboxID, liveSandboxStates)
 	if apiErr != nil {
 		return web.ApiResponse[*models.Snapshot]{}, apiErr
 	}

--- a/pkg/servers/e2b/timeout.go
+++ b/pkg/servers/e2b/timeout.go
@@ -56,7 +56,7 @@ func (sc *Controller) setSandboxTimeout(r *http.Request) *web.ApiError {
 	}
 
 	id := r.PathValue("sandboxID")
-	sbx, apiErr := sc.getSandboxOfUser(ctx, id)
+	sbx, apiErr := sc.getSandboxOfUser(ctx, id, liveSandboxStates)
 	if apiErr != nil {
 		return apiErr
 	}

--- a/pkg/servers/e2b/timeout_test.go
+++ b/pkg/servers/e2b/timeout_test.go
@@ -356,7 +356,7 @@ func TestResumeSandboxExtendOnlyPreventsStaleConnectTimeout(t *testing.T) {
 			require.NotNil(t, afterFirstCall.Spec.ShutdownTime)
 			assert.WithinDuration(t, beforeFirstCall.Add(time.Duration(tt.resumeTimeoutSeconds)*time.Second), afterFirstCall.Spec.ShutdownTime.Time, 5*time.Second)
 
-			wrapped, getErr := controller.getSandboxOfUser(req.Context(), createResp.Body.SandboxID)
+			wrapped, getErr := controller.getSandboxOfUser(req.Context(), createResp.Body.SandboxID, claimedSandboxStates)
 			require.Nil(t, getErr)
 			errResp := controller.updateConnectTimeout(req.Context(), wrapped, tt.connectTimeoutSeconds,
 				v1alpha1.SandboxStatePaused, false, afterFirstCall.Spec.ShutdownTime.Time)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -343,6 +343,8 @@ func IsSandboxPausable(sbx *agentsv1alpha1.Sandbox) (bool, string) {
 		if IsSandboxReady(sbx) {
 			return true, "SandboxIsRunningAndReady"
 		}
+		// Running-but-not-ready claimed sandboxes are reported as dead by
+		// GetSandboxState, so pause must not accept them as live sandboxes.
 		return false, "SandboxIsRunningButNotReady"
 	default:
 		return false, "SandboxPhaseNotAllowed"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -337,8 +337,13 @@ func IsSandboxPausable(sbx *agentsv1alpha1.Sandbox) (bool, string) {
 		}
 	}
 	switch sbx.Status.Phase {
-	case agentsv1alpha1.SandboxRunning, agentsv1alpha1.SandboxPaused:
-		return true, "SandboxIsRunningOrPaused"
+	case agentsv1alpha1.SandboxPaused:
+		return true, "SandboxIsPaused"
+	case agentsv1alpha1.SandboxRunning:
+		if IsSandboxReady(sbx) {
+			return true, "SandboxIsRunningAndReady"
+		}
+		return false, "SandboxIsRunningButNotReady"
 	default:
 		return false, "SandboxPhaseNotAllowed"
 	}
@@ -346,6 +351,15 @@ func IsSandboxPausable(sbx *agentsv1alpha1.Sandbox) (bool, string) {
 
 // IsSandboxResumable returns true when the resuming operation will not cause any conflict.
 func IsSandboxResumable(sbx *agentsv1alpha1.Sandbox) (bool, string) {
+	// Reject resume on sandboxes that are being deleted or have exceeded their shutdown time.
+	// These are the same pre-checks GetSandboxState performs before evaluating phase-based states.
+	if sbx.DeletionTimestamp != nil {
+		return false, "SandboxIsTerminating"
+	}
+	if sbx.Spec.ShutdownTime != nil && nowFunc().After(sbx.Spec.ShutdownTime.Time) {
+		return false, "ShutdownTimeReached"
+	}
+
 	switch sbx.Status.Phase {
 	case agentsv1alpha1.SandboxRunning:
 		if sbx.Spec.Paused {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1585,14 +1585,36 @@ func TestIsSandboxPausable(t *testing.T) {
 		expectedReason string
 	}{
 		{
-			name: "Running sandbox is pausable",
+			name: "Running ready sandbox is pausable",
 			sandbox: &agentsv1alpha1.Sandbox{
 				Status: agentsv1alpha1.SandboxStatus{
 					Phase: agentsv1alpha1.SandboxRunning,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(agentsv1alpha1.SandboxConditionReady),
+							Status: metav1.ConditionTrue,
+						},
+					},
 				},
 			},
 			expectedResult: true,
-			expectedReason: "SandboxIsRunningOrPaused",
+			expectedReason: "SandboxIsRunningAndReady",
+		},
+		{
+			name: "Running not-ready sandbox is not pausable",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(agentsv1alpha1.SandboxConditionReady),
+							Status: metav1.ConditionFalse,
+						},
+					},
+				},
+			},
+			expectedResult: false,
+			expectedReason: "SandboxIsRunningButNotReady",
 		},
 		{
 			name: "Paused sandbox is pausable",
@@ -1602,7 +1624,7 @@ func TestIsSandboxPausable(t *testing.T) {
 				},
 			},
 			expectedResult: true,
-			expectedReason: "SandboxIsRunningOrPaused",
+			expectedReason: "SandboxIsPaused",
 		},
 		{
 			name: "Pending sandbox is not pausable",
@@ -1700,6 +1722,64 @@ func TestIsSandboxResumable(t *testing.T) {
 			},
 			expectedResult: false,
 			expectedReason: "SandboxPhaseNotAllowed",
+		},
+		{
+			name: "Deleting sandbox is not resumable",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now().Add(-time.Minute)},
+					Finalizers:        []string{"test-finalizer"},
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxPaused,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(agentsv1alpha1.SandboxConditionPaused),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expectedResult: false,
+			expectedReason: "SandboxIsTerminating",
+		},
+		{
+			name: "ShutdownTime reached sandbox is not resumable",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					ShutdownTime: &metav1.Time{Time: time.Now().Add(-time.Minute)},
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxPaused,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(agentsv1alpha1.SandboxConditionPaused),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expectedResult: false,
+			expectedReason: "ShutdownTimeReached",
+		},
+		{
+			name: "ShutdownTime not reached falls through to phase check",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					ShutdownTime: &metav1.Time{Time: time.Now().Add(time.Hour)},
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxPaused,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(agentsv1alpha1.SandboxConditionPaused),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expectedResult: true,
+			expectedReason: "SandboxIsPaused",
 		},
 	}
 


### PR DESCRIPTION
## Summary
fixes #535 
- Rename `GetClaimedSandbox` → `GetSandbox` across the manager/infra layers and let callers pass the acceptable sandbox states explicitly, instead of hard-coding the claimed/healthy check.
- Dead-but-claimed sandboxes (e.g. running-but-not-ready) now flow through Describe/Delete/Connect so they report their real `Dead` state.
- Resume requires live (`Running`/`Paused`) states and now rejects a dead (running-but-not-ready) sandbox; snapshot/timeout/browser-use likewise keep requiring live states.
- `IsSandboxPausable` now rejects a running-but-not-ready sandbox; `IsSandboxResumable` gains deletion/shutdown-time pre-checks mirroring `GetSandboxState`.
- Removed an ineffective `DeleteSandbox` branch: `getSandboxOfUser` collapses all `GetSandbox` errors to 404, so the `apiError.Code != http.StatusNotFound` guard could never fire — delete stays idempotent (silent 204) on get failure.

## Test Plan
- [ ] \`go test ./pkg/servers/e2b/... ./pkg/sandbox-manager/... ./pkg/utils/... ./pkg/cache/...\` (passing locally)
- [ ] Verify Describe/Delete/Connect on a running-but-not-ready (Dead) claimed sandbox report \`Dead\` state
- [ ] Verify Resume rejects a dead (running-but-not-ready) sandbox
- [ ] Verify snapshot/timeout/browser-use still reject non-live sandboxes