### PR TITLE
feat: add E2B-compatible volume management APIs

### DIFF
--- a/api/v1alpha1/annotations.go
+++ b/api/v1alpha1/annotations.go
@@ -44,5 +44,14 @@ const (
 // LabelSandboxUpdateOps marks which SandboxUpdateOps is operating on this sandbox.
 const LabelSandboxUpdateOps = InternalPrefix + "update-ops"
 
+// Volume label constants.
+
+const (
+	// LabelVolumeOwnerNamespace scopes a PV to a namespace; its absence means the PV is unregistered.
+	LabelVolumeOwnerNamespace = InternalPrefix + "volume-owner-namespace"
+	// LabelVolumeName stores the human-readable name chosen at registration; must be unique per namespace.
+	LabelVolumeName = InternalPrefix + "volume-name"
+)
+
 const True = "true"
 const False = "false"

--- a/api/v1alpha1/annotations.go
+++ b/api/v1alpha1/annotations.go
@@ -46,5 +46,14 @@ const (
 // LabelSandboxUpdateOps marks which SandboxUpdateOps is operating on this sandbox.
 const LabelSandboxUpdateOps = InternalPrefix + "update-ops"
 
+// Volume label constants.
+
+const (
+	// LabelVolumeOwnerNamespace scopes a PV to a namespace; its absence means the PV is unregistered.
+	LabelVolumeOwnerNamespace = InternalPrefix + "volume-owner-namespace"
+	// LabelVolumeName stores the human-readable name chosen at registration; must be unique per namespace.
+	LabelVolumeName = InternalPrefix + "volume-name"
+)
+
 const True = "true"
 const False = "false"

--- a/pkg/sandbox-manager/api.go
+++ b/pkg/sandbox-manager/api.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openkruise/agents/api/v1alpha1"
-	"github.com/openkruise/agents/pkg/cache"
 	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/quota"
@@ -265,7 +264,7 @@ func (m *SandboxManager) GetOwnerOfSandbox(sandboxID string) (string, bool) {
 	return route.Owner, ok
 }
 
-// GetOwnerOfVolume returns the owner (UserID) of the volume identified by volumeID (PV Name)
+// GetOwnerOfVolume returns the owner (UserID) of the volume identified by volumeID (PVC name)
 // in the given namespace. Returns ("", false) if the volume is not found.
 func (m *SandboxManager) GetOwnerOfVolume(ctx context.Context, namespace, volumeID string) (string, bool) {
 	log := klog.FromContext(ctx)

--- a/pkg/sandbox-manager/api.go
+++ b/pkg/sandbox-manager/api.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -268,20 +269,17 @@ func (m *SandboxManager) GetOwnerOfSandbox(sandboxID string) (string, bool) {
 // in the given namespace. Returns ("", false) if the volume is not found.
 func (m *SandboxManager) GetOwnerOfVolume(ctx context.Context, namespace, volumeID string) (string, bool) {
 	log := klog.FromContext(ctx)
-	pvcList := &corev1.PersistentVolumeClaimList{}
-	err := m.infra.GetCache().GetClient().List(ctx, pvcList,
-		client.InNamespace(namespace),
-		client.MatchingFields{cache.IndexVolumeName: volumeID},
-	)
+	pvc := &corev1.PersistentVolumeClaim{}
+	err := m.infra.GetCache().GetClient().Get(ctx, client.ObjectKey{Namespace: namespace, Name: volumeID}, pvc)
 	if err != nil {
-		log.Error(err, "failed to list PVCs for volume ownership check", "namespace", namespace, "volumeID", volumeID)
+		if apierrors.IsNotFound(err) {
+			log.Info("no PVC found for volume ownership check", "namespace", namespace, "volumeID", volumeID)
+			return "", false
+		}
+		log.Error(err, "failed to get PVC for volume ownership check", "namespace", namespace, "volumeID", volumeID)
 		return "", false
 	}
-	if len(pvcList.Items) == 0 {
-		log.Info("no PVC found for volume ownership check", "namespace", namespace, "volumeID", volumeID)
-		return "", false
-	}
-	return pvcList.Items[0].GetAnnotations()[v1alpha1.AnnotationOwner], true
+	return pvc.GetAnnotations()[v1alpha1.AnnotationOwner], true
 }
 
 // syncRoute syncs the sandbox route with peers

--- a/pkg/sandbox-manager/api_test.go
+++ b/pkg/sandbox-manager/api_test.go
@@ -1976,7 +1976,7 @@ func TestGetOwnerOfVolume(t *testing.T) {
 
 	// Wait for cache indexes to be populated
 	require.NoError(t, wait.PollUntilContextTimeout(t.Context(), 10*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-		owner, ok := manager.GetOwnerOfVolume(ctx, namespace, "pv-owner-a")
+		owner, ok := manager.GetOwnerOfVolume(ctx, namespace, "pvc-owner-a")
 		return ok && owner == "user-a", nil
 	}))
 
@@ -1990,49 +1990,48 @@ func TestGetOwnerOfVolume(t *testing.T) {
 		{
 			name:        "found with owner annotation",
 			namespace:   namespace,
-			volumeID:    "pv-owner-a",
+			volumeID:    "pvc-owner-a",
 			expectOwner: "user-a",
 			expectFound: true,
 		},
 		{
 			name:        "found with different owner",
 			namespace:   namespace,
-			volumeID:    "pv-owner-b",
+			volumeID:    "pvc-owner-b",
 			expectOwner: "user-b",
 			expectFound: true,
 		},
 		{
 			name:        "found without owner annotation returns empty string",
 			namespace:   namespace,
-			volumeID:    "pv-no-owner",
+			volumeID:    "pvc-no-owner",
 			expectOwner: "",
 			expectFound: true,
 		},
 		{
 			name:        "volume in different namespace found by correct namespace",
 			namespace:   otherNamespace,
-			volumeID:    "pv-other-ns",
+			volumeID:    "pvc-other-ns",
 			expectOwner: "user-c",
 			expectFound: true,
 		},
 		{
 			name:        "volume not found in wrong namespace",
 			namespace:   otherNamespace,
-			volumeID:    "pv-owner-a",
+			volumeID:    "pvc-owner-a",
 			expectFound: false,
 		},
 		{
 			name:        "non-existent volume returns not found",
 			namespace:   namespace,
-			volumeID:    "non-existent-pv",
+			volumeID:    "pvc-non-existent",
 			expectFound: false,
 		},
 		{
-			name:        "empty namespace lists all namespaces and finds volume",
+			name:        "empty namespace does not find volume in specific namespace",
 			namespace:   "",
-			volumeID:    "pv-owner-a",
-			expectOwner: "user-a",
-			expectFound: true,
+			volumeID:    "pvc-owner-a",
+			expectFound: false,
 		},
 	}
 

--- a/pkg/sandbox-manager/infra/interface.go
+++ b/pkg/sandbox-manager/infra/interface.go
@@ -126,6 +126,10 @@ type Infrastructure interface {
 	ClaimSandbox(ctx context.Context, opts ClaimSandboxOptions) (Sandbox, ClaimMetrics, error)
 	CloneSandbox(ctx context.Context, opts CloneSandboxOptions) (Sandbox, CloneMetrics, error)
 	DeleteCheckpoint(ctx context.Context, opts DeleteCheckpointOptions) error
+	RegisterVolume(ctx context.Context, opts RegisterVolumeOptions) (VolumeInfo, error)
+	ListVolumes(ctx context.Context, opts ListVolumesOptions) ([]VolumeInfo, error)
+	GetVolume(ctx context.Context, opts GetVolumeOptions) (VolumeInfo, error)
+	DeleteVolume(ctx context.Context, opts DeleteVolumeOptions) (DeleteVolumeResult, error)
 }
 
 type Sandbox interface {

--- a/pkg/sandbox-manager/infra/interface.go
+++ b/pkg/sandbox-manager/infra/interface.go
@@ -199,11 +199,20 @@ type DeleteVolumeOptions struct {
 	Namespace string
 	VolumeID  string
 	UserID    string
+	Force     bool
 }
 
 type VolumeInfo struct {
-	Name     string `json:"name,omitempty"`
-	VolumeID string `json:"volumeID,omitempty"`
+	VolumeID  string `json:"volumeID,omitempty"`
+	Name      string `json:"name,omitempty"`
+	PvName    string `json:"pvName,omitempty"`
+	SizeGB    int    `json:"sizeGB,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
+}
+
+type DeleteVolumeResult struct {
+	AffectedSandboxIDs []string
+	ForcedDelete       bool
 }
 
 type Builder interface {
@@ -223,10 +232,10 @@ type Infrastructure interface {
 	ClaimSandbox(ctx context.Context, opts ClaimSandboxOptions) (Sandbox, ClaimMetrics, error)
 	CloneSandbox(ctx context.Context, opts CloneSandboxOptions) (Sandbox, CloneMetrics, error)
 	DeleteCheckpoint(ctx context.Context, opts DeleteCheckpointOptions) error
-	CreateVolume(ctx context.Context, opts CreateVolumeOptions) (*VolumeInfo, error)
-	ListVolumes(ctx context.Context, opts ListVolumesOptions) ([]*VolumeInfo, error)
-	GetVolume(ctx context.Context, opts GetVolumeOptions) (*VolumeInfo, error)
-	DeleteVolume(ctx context.Context, opts DeleteVolumeOptions) error
+	CreateVolume(ctx context.Context, opts CreateVolumeOptions) (VolumeInfo, error)
+	ListVolumes(ctx context.Context, opts ListVolumesOptions) ([]VolumeInfo, error)
+	GetVolume(ctx context.Context, opts GetVolumeOptions) (VolumeInfo, error)
+	DeleteVolume(ctx context.Context, opts DeleteVolumeOptions) (DeleteVolumeResult, error)
 }
 
 type Sandbox interface {

--- a/pkg/sandbox-manager/infra/sandboxcr/volume.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/volume.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandboxcr
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/utils"
+)
+
+// RegisterVolume registers an existing PV as a named volume under the given namespace.
+// It validates that the PV exists, is Available, has sufficient capacity, and is not
+// already registered. On success it patches the PV with the owner-namespace and
+// volume-name labels.
+func (i *Infra) RegisterVolume(ctx context.Context, opts infra.RegisterVolumeOptions) (infra.VolumeInfo, error) {
+	log := klog.FromContext(ctx).WithValues("pvName", opts.PvName, "namespace", opts.Namespace, "name", opts.Name)
+
+	// Validate required fields upfront.
+	switch {
+	case opts.Namespace == "":
+		return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorBadRequest, "namespace is required")
+	case opts.Name == "":
+		return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorBadRequest, "name is required")
+	case opts.PvName == "":
+		return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorBadRequest, "pvName is required")
+	case opts.SizeGB <= 0:
+		return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorBadRequest, "sizeGB must be a positive integer")
+	}
+
+	// Read the PV directly from the API server to get a fresh copy.
+	pv := &corev1.PersistentVolume{}
+	if err := i.APIReader.Get(ctx, types.NamespacedName{Name: opts.PvName}, pv); err != nil {
+		if apierrors.IsNotFound(err) {
+			return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorNotFound, "pv %s not found", opts.PvName)
+		}
+		log.Error(err, "failed to get pv from api server")
+		return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorInternal, "failed to get pv %s: %v", opts.PvName, err)
+	}
+
+	// Validate phase.
+	if pv.Status.Phase != corev1.VolumeAvailable {
+		return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorBadRequest,
+			"pv %s is not in Available phase (current phase: %s)", opts.PvName, pv.Status.Phase)
+	}
+
+	// Validate capacity.
+	requested := resource.MustParse(fmt.Sprintf("%dGi", opts.SizeGB))
+	if pvCapacity, ok := pv.Spec.Capacity[corev1.ResourceStorage]; !ok || pvCapacity.Cmp(requested) < 0 {
+		return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorBadRequest,
+			"pv %s capacity is insufficient for requested %dGi", opts.PvName, opts.SizeGB)
+	}
+
+	// Check whether PV is already registered.
+	if existingNS, exists := pv.Labels[v1alpha1.LabelVolumeOwnerNamespace]; exists {
+		if existingNS == opts.Namespace {
+			return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorConflict,
+				"pv %s is already registered under namespace %s", opts.PvName, opts.Namespace)
+		}
+		return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorNotAllowed,
+			"pv %s is already registered under a different namespace %s", opts.PvName, existingNS)
+	}
+
+	// Check volume name uniqueness within the namespace.
+	pvList := &corev1.PersistentVolumeList{}
+	if err := i.Cache.GetClient().List(ctx, pvList, client.MatchingLabels{
+		v1alpha1.LabelVolumeOwnerNamespace: opts.Namespace,
+		v1alpha1.LabelVolumeName:           opts.Name,
+	}); err != nil {
+		log.Error(err, "failed to list pvs for name uniqueness check")
+		return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorInternal, "failed to check volume name uniqueness: %v", err)
+	}
+	if len(pvList.Items) > 0 {
+		return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorConflict,
+			"volume name %s is already in use within namespace %s", opts.Name, opts.Namespace)
+	}
+
+	// Patch the PV to add the owner labels.
+	base := pv.DeepCopy()
+	if pv.Labels == nil {
+		pv.Labels = make(map[string]string)
+	}
+	pv.Labels[v1alpha1.LabelVolumeOwnerNamespace] = opts.Namespace
+	pv.Labels[v1alpha1.LabelVolumeName] = opts.Name
+
+	if err := i.Cache.GetClient().Patch(ctx, pv, client.MergeFrom(base)); err != nil {
+		log.Error(err, "failed to patch pv labels")
+		return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorInternal, "failed to register volume: %v", err)
+	}
+
+	log.Info("volume registered successfully")
+	return pvToVolumeInfo(pv), nil
+}
+
+// ListVolumes returns all volumes registered under the given namespace by reading
+// from the informer cache.
+func (i *Infra) ListVolumes(ctx context.Context, opts infra.ListVolumesOptions) ([]infra.VolumeInfo, error) {
+	log := klog.FromContext(ctx).WithValues("namespace", opts.Namespace)
+
+	pvList := &corev1.PersistentVolumeList{}
+	if err := i.Cache.GetClient().List(ctx, pvList, client.MatchingLabels{
+		v1alpha1.LabelVolumeOwnerNamespace: opts.Namespace,
+	}); err != nil {
+		log.Error(err, "failed to list pvs from cache")
+		return nil, managererrors.NewError(managererrors.ErrorInternal, "failed to list volumes: %v", err)
+	}
+
+	result := make([]infra.VolumeInfo, 0, len(pvList.Items))
+	for idx := range pvList.Items {
+		result = append(result, pvToVolumeInfo(&pvList.Items[idx]))
+	}
+	return result, nil
+}
+
+// GetVolume retrieves a single volume by its ID (PV name) from the informer cache.
+// Returns ErrorNotFound if the PV does not exist or is owned by a different namespace
+// (no information disclosure).
+func (i *Infra) GetVolume(ctx context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error) {
+	log := klog.FromContext(ctx).WithValues("volumeID", opts.VolumeID, "namespace", opts.Namespace)
+
+	pv := &corev1.PersistentVolume{}
+	if err := i.Cache.GetClient().Get(ctx, client.ObjectKey{Name: opts.VolumeID}, pv); err != nil {
+		if apierrors.IsNotFound(err) {
+			return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorNotFound, "volume %s not found", opts.VolumeID)
+		}
+		log.Error(err, "failed to get pv from cache")
+		return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorInternal, "failed to get volume %s: %v", opts.VolumeID, err)
+	}
+
+	// Enforce namespace isolation — no information disclosure.
+	if pv.Labels[v1alpha1.LabelVolumeOwnerNamespace] != opts.Namespace {
+		return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorNotFound, "volume %s not found", opts.VolumeID)
+	}
+
+	return pvToVolumeInfo(pv), nil
+}
+
+// DeleteVolume unregisters a volume by removing its owner labels from the PV.
+// Volume usage is derived live from SandboxClaims — no PV annotation needed,
+// no cleanup logic, no stale state.
+// If the volume is currently in use and Force is false, returns ErrorConflict.
+func (i *Infra) DeleteVolume(ctx context.Context, opts infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error) {
+	log := klog.FromContext(ctx).WithValues("volumeID", opts.VolumeID, "namespace", opts.Namespace, "force", opts.Force)
+
+	// Read PV fresh from the API server to avoid stale cached data.
+	pv := &corev1.PersistentVolume{}
+	if err := i.APIReader.Get(ctx, types.NamespacedName{Name: opts.VolumeID}, pv); err != nil {
+		if apierrors.IsNotFound(err) {
+			return infra.DeleteVolumeResult{}, managererrors.NewError(managererrors.ErrorNotFound, "volume %s not found", opts.VolumeID)
+		}
+		log.Error(err, "failed to get pv from api server")
+		return infra.DeleteVolumeResult{}, managererrors.NewError(managererrors.ErrorInternal, "failed to get volume %s: %v", opts.VolumeID, err)
+	}
+
+	// Namespace ownership check — no information disclosure.
+	if pv.Labels[v1alpha1.LabelVolumeOwnerNamespace] != opts.Namespace {
+		return infra.DeleteVolumeResult{}, managererrors.NewError(managererrors.ErrorNotFound, "volume %s not found", opts.VolumeID)
+	}
+
+	// Derive live usage from SandboxClaims — no stale annotation risk.
+	sandboxIDs, err := i.getVolumeUsers(ctx, opts.Namespace, opts.VolumeID)
+	if err != nil {
+		log.Error(err, "failed to derive volume usage from SandboxClaims")
+		return infra.DeleteVolumeResult{}, managererrors.NewError(managererrors.ErrorInternal, "failed to derive volume usage: %v", err)
+	}
+
+	// Block deletion if volume is in use and force is not set.
+	if len(sandboxIDs) > 0 && !opts.Force {
+		return infra.DeleteVolumeResult{}, managererrors.NewError(managererrors.ErrorConflict,
+			"volume is mounted by: %v", sandboxIDs)
+	}
+
+	// Remove only the volume owner labels — no annotation to clean up.
+	base := pv.DeepCopy()
+	delete(pv.Labels, v1alpha1.LabelVolumeOwnerNamespace)
+	delete(pv.Labels, v1alpha1.LabelVolumeName)
+
+	if err := i.Cache.GetClient().Patch(ctx, pv, client.MergeFrom(base)); err != nil {
+		log.Error(err, "failed to patch pv to remove volume labels")
+		return infra.DeleteVolumeResult{}, managererrors.NewError(managererrors.ErrorInternal, "failed to delete volume: %v", err)
+	}
+
+	log.Info("volume unregistered successfully", "affectedSandboxes", len(sandboxIDs))
+	return infra.DeleteVolumeResult{
+		AffectedSandboxIDs: sandboxIDs,
+		ForcedDelete:       opts.Force && len(sandboxIDs) > 0,
+	}, nil
+}
+
+// getVolumeUsers returns the sandbox IDs currently using the given PV, derived
+// from SandboxClaim objects. SandboxClaims are the authoritative, structured
+// source of truth — no PV annotation is needed.
+//
+// For each active SandboxClaim whose spec.dynamicVolumesMount references pvName,
+// the sandbox IDs are discovered by listing Sandboxes labeled with the claim name.
+func (i *Infra) getVolumeUsers(ctx context.Context, namespace, pvName string) ([]string, error) {
+	claimList := &v1alpha1.SandboxClaimList{}
+	listOpts := []client.ListOption{}
+	if namespace != "" {
+		listOpts = append(listOpts, client.InNamespace(namespace))
+	}
+	if err := i.Cache.GetClient().List(ctx, claimList, listOpts...); err != nil {
+		return nil, err
+	}
+
+	var sandboxIDs []string
+	for idx := range claimList.Items {
+		claim := &claimList.Items[idx]
+		if !claimReferencesPV(claim, pvName) {
+			continue
+		}
+
+		// Find sandboxes claimed by this claim via the LabelSandboxClaimName label.
+		sbxList := &v1alpha1.SandboxList{}
+		if err := i.Cache.GetClient().List(ctx, sbxList,
+			client.InNamespace(claim.Namespace),
+			client.MatchingLabels{v1alpha1.LabelSandboxClaimName: claim.Name},
+		); err != nil {
+			return nil, fmt.Errorf("failed to list sandboxes for claim %s/%s: %w", claim.Namespace, claim.Name, err)
+		}
+		for sbxIdx := range sbxList.Items {
+			sandboxIDs = append(sandboxIDs, utils.GetSandboxID(&sbxList.Items[sbxIdx]))
+		}
+	}
+	return sandboxIDs, nil
+}
+
+// claimReferencesPV reports whether a SandboxClaim's DynamicVolumesMount
+// includes the given pvName.
+func claimReferencesPV(claim *v1alpha1.SandboxClaim, pvName string) bool {
+	for _, m := range claim.Spec.DynamicVolumesMount {
+		if m.PvName == pvName {
+			return true
+		}
+	}
+	return false
+}
+
+// pvToVolumeInfo converts a PersistentVolume into a VolumeInfo struct.
+func pvToVolumeInfo(pv *corev1.PersistentVolume) infra.VolumeInfo {
+	var sizeGB int
+	if capacity, ok := pv.Spec.Capacity[corev1.ResourceStorage]; ok {
+		// Convert bytes to GiB (1 GiB = 2^30 bytes). Value() returns bytes.
+		sizeGB = int(capacity.Value() / (1 << 30))
+	}
+
+	return infra.VolumeInfo{
+		VolumeID:  pv.Name,
+		Name:      pv.Labels[v1alpha1.LabelVolumeName],
+		PvName:    pv.Name,
+		SizeGB:    sizeGB,
+		CreatedAt: pv.CreationTimestamp.Format(time.RFC3339),
+	}
+}

--- a/pkg/sandbox-manager/infra/sandboxcr/volume.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/volume.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -35,8 +37,8 @@ import (
 	"github.com/openkruise/agents/pkg/utils"
 )
 
-// CreateVolume creates a new PersistentVolumeClaim for the user
-func (i *Infra) CreateVolume(ctx context.Context, opts infra.CreateVolumeOptions) (*infra.VolumeInfo, error) {
+// CreateVolume creates a new PersistentVolumeClaim for the user and waits for it to bind.
+func (i *Infra) CreateVolume(ctx context.Context, opts infra.CreateVolumeOptions) (infra.VolumeInfo, error) {
 	log := klog.FromContext(ctx)
 	log.V(utils.DebugLogLevel).Info("create volume options", "options", opts)
 
@@ -67,26 +69,23 @@ func (i *Infra) CreateVolume(ctx context.Context, opts infra.CreateVolumeOptions
 			existingPVC := &corev1.PersistentVolumeClaim{}
 			if getErr := i.Cache.GetClient().Get(ctx, client.ObjectKey{Namespace: opts.Namespace, Name: opts.Name}, existingPVC); getErr != nil {
 				log.Error(getErr, "Failed to get existing PVC", "name", opts.Name, "namespace", opts.Namespace)
-				return nil, fmt.Errorf("failed to get existing PVC: %w", getErr)
+				return infra.VolumeInfo{}, fmt.Errorf("failed to get existing PVC: %w", getErr)
 			}
 			if owner := existingPVC.GetAnnotations()[agentsv1alpha1.AnnotationOwner]; owner != opts.UserID {
 				log.Error(err, "PVC exists but belongs to another user", "name", opts.Name, "namespace", opts.Namespace, "owner", owner)
-				return nil, managererrors.NewError(managererrors.ErrorNotAllowed, "volume %s is owned by another user", opts.Name)
+				return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorNotAllowed, "volume %s is owned by another user", opts.Name)
 			}
 			// Same user — if already bound, return idempotent response immediately
 			if existingPVC.Spec.VolumeName != "" && existingPVC.Status.Phase == corev1.ClaimBound {
 				log.Info("PVC already exists and bound, returning existing volume", "name", opts.Name, "namespace", opts.Namespace)
-				return &infra.VolumeInfo{
-					Name:     existingPVC.Name,
-					VolumeID: existingPVC.Spec.VolumeName,
-				}, nil
+				return pvcToVolumeInfo(existingPVC), nil
 			}
 			// PVC exists but not yet bound — fall through to wait logic
 			pvc = existingPVC
 			log.Info("PVC already exists but not bound, waiting for binding", "name", opts.Name, "namespace", opts.Namespace)
 		} else {
 			log.Error(err, "Failed to create PVC", "name", opts.Name, "namespace", opts.Namespace)
-			return nil, fmt.Errorf("failed to create PVC: %w", err)
+			return infra.VolumeInfo{}, fmt.Errorf("failed to create PVC: %w", err)
 		}
 	}
 
@@ -97,110 +96,178 @@ func (i *Infra) CreateVolume(ctx context.Context, opts infra.CreateVolumeOptions
 	if err := task.Wait(opts.WaitBoundTimeout); err != nil {
 		log.Error(err, "Failed to wait for PVC", "name", opts.Name, "namespace", opts.Namespace)
 		if errors.Is(err, cacheutils.ErrWaitNotSatisfied) {
-			return nil, fmt.Errorf("PVC %s/%s binding timed out after %v: %w", opts.Namespace, opts.Name, opts.WaitBoundTimeout, err)
+			return infra.VolumeInfo{}, fmt.Errorf("PVC %s/%s binding timed out after %v: %w", opts.Namespace, opts.Name, opts.WaitBoundTimeout, err)
 		}
-		return nil, fmt.Errorf("failed to wait for PVC %s/%s: %w", opts.Namespace, opts.Name, err)
+		return infra.VolumeInfo{}, fmt.Errorf("failed to wait for PVC %s/%s: %w", opts.Namespace, opts.Name, err)
 	}
 
 	// Get the bound PVC from cache
 	boundPVC := &corev1.PersistentVolumeClaim{}
 	if err := i.Cache.GetClient().Get(ctx, client.ObjectKey{Namespace: opts.Namespace, Name: opts.Name}, boundPVC); err != nil {
 		log.Error(err, "Failed to get bound PVC", "name", opts.Name, "namespace", opts.Namespace)
-		return nil, fmt.Errorf("failed to get bound PVC: %w", err)
+		return infra.VolumeInfo{}, fmt.Errorf("failed to get bound PVC: %w", err)
 	}
 
 	log.Info("Volume created and bound", "name", boundPVC.Name, "namespace", opts.Namespace, "volumeID", boundPVC.Spec.VolumeName)
 
-	return &infra.VolumeInfo{
-		Name:     boundPVC.Name,
-		VolumeID: boundPVC.Spec.VolumeName,
-	}, nil
+	return pvcToVolumeInfo(boundPVC), nil
 }
 
-// ListVolumes lists all volumes for a user in a namespace
-func (i *Infra) ListVolumes(ctx context.Context, opts infra.ListVolumesOptions) ([]*infra.VolumeInfo, error) {
+// ListVolumes lists all volumes (PVCs) for a user in a namespace.
+func (i *Infra) ListVolumes(ctx context.Context, opts infra.ListVolumesOptions) ([]infra.VolumeInfo, error) {
 	log := klog.FromContext(ctx)
 	log.V(utils.DebugLogLevel).Info("list volumes", "userId", opts.UserID, "namespace", opts.Namespace)
 
-	// List PVCs using User index for efficient filtering
 	pvcList := &corev1.PersistentVolumeClaimList{}
-	err := i.Cache.GetClient().List(ctx, pvcList,
-		client.InNamespace(opts.Namespace),
-		client.MatchingFields{cache.IndexUser: opts.UserID},
-	)
+	listOpts := []client.ListOption{client.InNamespace(opts.Namespace)}
+	if opts.UserID != "" {
+		listOpts = append(listOpts, client.MatchingFields{cache.IndexUser: opts.UserID})
+	}
+
+	err := i.Cache.GetClient().List(ctx, pvcList, listOpts...)
 	if err != nil {
 		log.Error(err, "Failed to list PVCs", "namespace", opts.Namespace, "userId", opts.UserID)
 		return nil, fmt.Errorf("failed to list PVCs: %w", err)
 	}
 
-	volumes := make([]*infra.VolumeInfo, 0, len(pvcList.Items))
-	for _, pvc := range pvcList.Items {
-		volumes = append(volumes, &infra.VolumeInfo{
-			Name:     pvc.Name,
-			VolumeID: pvc.Spec.VolumeName,
-		})
+	volumes := make([]infra.VolumeInfo, 0, len(pvcList.Items))
+	for idx := range pvcList.Items {
+		volumes = append(volumes, pvcToVolumeInfo(&pvcList.Items[idx]))
 	}
 
 	return volumes, nil
 }
 
-// GetVolume retrieves a volume by volumeID (PV Name)
-func (i *Infra) GetVolume(ctx context.Context, opts infra.GetVolumeOptions) (*infra.VolumeInfo, error) {
+// GetVolume retrieves a volume by its volumeID (PVC Name).
+func (i *Infra) GetVolume(ctx context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error) {
 	log := klog.FromContext(ctx)
 	log.V(utils.DebugLogLevel).Info("get volume", "volumeID", opts.VolumeID, "namespace", opts.Namespace, "userId", opts.UserID)
 
-	// Find PVC by VolumeName (PV Name) using index
-	pvcList := &corev1.PersistentVolumeClaimList{}
-	err := i.Cache.GetClient().List(ctx, pvcList,
-		client.InNamespace(opts.Namespace),
-		client.MatchingFields{cache.IndexVolumeName: opts.VolumeID},
-	)
+	pvc := &corev1.PersistentVolumeClaim{}
+	err := i.Cache.GetClient().Get(ctx, client.ObjectKey{Namespace: opts.Namespace, Name: opts.VolumeID}, pvc)
 	if err != nil {
-		log.Error(err, "Failed to list PVCs", "namespace", opts.Namespace)
-		return nil, fmt.Errorf("failed to list PVCs: %w", err)
+		if apierrors.IsNotFound(err) {
+			return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorNotFound, "volume not found: %s", opts.VolumeID)
+		}
+		log.Error(err, "Failed to get PVC from cache", "name", opts.VolumeID, "namespace", opts.Namespace)
+		return infra.VolumeInfo{}, fmt.Errorf("failed to get PVC %s: %w", opts.VolumeID, err)
 	}
 
-	// No PVC found bound to this PV
-	if len(pvcList.Items) == 0 {
-		return nil, managererrors.NewError(managererrors.ErrorNotFound, "volume not found: %s", opts.VolumeID)
+	// Enforce ownership if UserID is specified.
+	if opts.UserID != "" {
+		if owner := pvc.GetAnnotations()[agentsv1alpha1.AnnotationOwner]; owner != opts.UserID {
+			return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorNotFound, "volume not found: %s", opts.VolumeID)
+		}
 	}
 
-	pvc := &pvcList.Items[0]
-	volumeInfo := &infra.VolumeInfo{
-		Name:     pvc.Name,
-		VolumeID: pvc.Spec.VolumeName,
-	}
-	return volumeInfo, nil
+	return pvcToVolumeInfo(pvc), nil
 }
 
-// DeleteVolume deletes a volume by volumeID (PV Name)
-func (i *Infra) DeleteVolume(ctx context.Context, opts infra.DeleteVolumeOptions) error {
+// DeleteVolume deletes a volume (PVC) by its volumeID (PVC Name).
+// Prior to deleting, it checks active users via SandboxClaims and blocks deletion if force=false.
+func (i *Infra) DeleteVolume(ctx context.Context, opts infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error) {
 	log := klog.FromContext(ctx)
-	log.V(utils.DebugLogLevel).Info("delete volume", "volumeID", opts.VolumeID, "namespace", opts.Namespace, "userId", opts.UserID)
+	log.V(utils.DebugLogLevel).Info("delete volume", "volumeID", opts.VolumeID, "namespace", opts.Namespace, "userId", opts.UserID, "force", opts.Force)
 
-	// Find PVC by VolumeName (PV Name) using index
-	pvcList := &corev1.PersistentVolumeClaimList{}
-	err := i.Cache.GetClient().List(ctx, pvcList,
-		client.InNamespace(opts.Namespace),
-		client.MatchingFields{cache.IndexVolumeName: opts.VolumeID},
-	)
+	// Get PVC fresh from the API server to avoid stale cached data.
+	pvc := &corev1.PersistentVolumeClaim{}
+	err := i.APIReader.Get(ctx, types.NamespacedName{Namespace: opts.Namespace, Name: opts.VolumeID}, pvc)
 	if err != nil {
-		log.Error(err, "Failed to list PVCs", "namespace", opts.Namespace)
-		return fmt.Errorf("failed to list PVCs: %w", err)
+		if apierrors.IsNotFound(err) {
+			return infra.DeleteVolumeResult{}, managererrors.NewError(managererrors.ErrorNotFound, "volume not found: %s", opts.VolumeID)
+		}
+		log.Error(err, "Failed to get PVC from API server", "name", opts.VolumeID, "namespace", opts.Namespace)
+		return infra.DeleteVolumeResult{}, fmt.Errorf("failed to get PVC %s: %w", opts.VolumeID, err)
 	}
 
-	// Return error if no PVC found
-	if len(pvcList.Items) == 0 {
-		return managererrors.NewError(managererrors.ErrorNotFound, "volume not found: %s", opts.VolumeID)
+	// Enforce ownership if UserID is specified.
+	if opts.UserID != "" {
+		if owner := pvc.GetAnnotations()[agentsv1alpha1.AnnotationOwner]; owner != opts.UserID {
+			return infra.DeleteVolumeResult{}, managererrors.NewError(managererrors.ErrorNotFound, "volume not found: %s", opts.VolumeID)
+		}
 	}
 
-	pvc := &pvcList.Items[0]
-	// Delete the PVC, ignore NotFound error to handle race conditions
+	// Determine active users via SandboxClaims mapping to this PVC name or its bound PV.
+	sandboxIDs, err := i.getVolumeUsers(ctx, opts.Namespace, pvc.Name, pvc.Spec.VolumeName)
+	if err != nil {
+		log.Error(err, "failed to derive volume usage from SandboxClaims")
+		return infra.DeleteVolumeResult{}, managererrors.NewError(managererrors.ErrorInternal, "failed to derive volume usage: %v", err)
+	}
+
+	// Block deletion if volume is in use and force is false.
+	if len(sandboxIDs) > 0 && !opts.Force {
+		return infra.DeleteVolumeResult{}, managererrors.NewError(managererrors.ErrorConflict,
+			"volume is mounted by: %v", sandboxIDs)
+	}
+
+	// Delete PVC.
 	if err := client.IgnoreNotFound(i.Cache.GetClient().Delete(ctx, pvc)); err != nil {
 		log.Error(err, "Failed to delete PVC", "name", pvc.Name, "namespace", opts.Namespace)
-		return fmt.Errorf("failed to delete PVC: %w", err)
+		return infra.DeleteVolumeResult{}, fmt.Errorf("failed to delete PVC: %w", err)
 	}
 
-	log.Info("Volume deleted", "name", pvc.Name, "namespace", opts.Namespace, "volumeID", opts.VolumeID)
-	return nil
+	log.Info("Volume deleted successfully", "name", pvc.Name, "namespace", opts.Namespace, "affectedSandboxes", len(sandboxIDs))
+	return infra.DeleteVolumeResult{
+		AffectedSandboxIDs: sandboxIDs,
+		ForcedDelete:       opts.Force && len(sandboxIDs) > 0,
+	}, nil
+}
+
+// getVolumeUsers returns the sandbox IDs currently using the given PVC/PV, derived from SandboxClaims.
+func (i *Infra) getVolumeUsers(ctx context.Context, namespace, pvcName, pvName string) ([]string, error) {
+	claimList := &agentsv1alpha1.SandboxClaimList{}
+	listOpts := []client.ListOption{client.InNamespace(namespace)}
+	if err := i.Cache.GetClient().List(ctx, claimList, listOpts...); err != nil {
+		return nil, err
+	}
+
+	var sandboxIDs []string
+	for idx := range claimList.Items {
+		claim := &claimList.Items[idx]
+		if !claimReferencesPV(claim, pvcName, pvName) {
+			continue
+		}
+
+		// Find sandboxes claimed by this claim via the LabelSandboxClaimName label.
+		sbxList := &agentsv1alpha1.SandboxList{}
+		if err := i.Cache.GetClient().List(ctx, sbxList,
+			client.InNamespace(claim.Namespace),
+			client.MatchingLabels{agentsv1alpha1.LabelSandboxClaimName: claim.Name},
+		); err != nil {
+			return nil, fmt.Errorf("failed to list sandboxes for claim %s/%s: %w", claim.Namespace, claim.Name, err)
+		}
+		for sbxIdx := range sbxList.Items {
+			sandboxIDs = append(sandboxIDs, utils.GetSandboxID(&sbxList.Items[sbxIdx]))
+		}
+	}
+	return sandboxIDs, nil
+}
+
+// claimReferencesPV checks if a SandboxClaim mounts either the PVC name or resolved PV name.
+func claimReferencesPV(claim *agentsv1alpha1.SandboxClaim, pvcName, pvName string) bool {
+	for _, m := range claim.Spec.DynamicVolumesMount {
+		if m.PvName == pvcName || (pvName != "" && m.PvName == pvName) {
+			return true
+		}
+	}
+	return false
+}
+
+// pvcToVolumeInfo converts a PersistentVolumeClaim into a VolumeInfo struct.
+func pvcToVolumeInfo(pvc *corev1.PersistentVolumeClaim) infra.VolumeInfo {
+	var sizeGB int
+	if capacity, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
+		// Convert bytes to GiB (1 GiB = 2^30 bytes).
+		sizeGB = int(capacity.Value() / (1 << 30))
+	} else if capacity, ok := pvc.Status.Capacity[corev1.ResourceStorage]; ok {
+		sizeGB = int(capacity.Value() / (1 << 30))
+	}
+
+	return infra.VolumeInfo{
+		VolumeID:  pvc.Name,
+		Name:      pvc.Name,
+		PvName:    pvc.Spec.VolumeName,
+		SizeGB:    sizeGB,
+		CreatedAt: pvc.CreationTimestamp.Format(time.RFC3339),
+	}
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/volume.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/volume.go
@@ -108,7 +108,7 @@ func (i *Infra) CreateVolume(ctx context.Context, opts infra.CreateVolumeOptions
 		return infra.VolumeInfo{}, fmt.Errorf("failed to get bound PVC: %w", err)
 	}
 
-	log.Info("Volume created and bound", "name", boundPVC.Name, "namespace", opts.Namespace, "volumeID", boundPVC.Spec.VolumeName)
+	log.Info("Volume created and bound", "pvcName", boundPVC.Name, "namespace", opts.Namespace, "pvName", boundPVC.Spec.VolumeName)
 
 	return pvcToVolumeInfo(boundPVC), nil
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/volume_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/volume_test.go
@@ -1,0 +1,686 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandboxcr
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+)
+
+// makeAvailablePV creates a PV in Available phase with the given capacity.
+func makeAvailablePV(name string, storageGi int) *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.PersistentVolumeSpec{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse(fmt.Sprintf("%dGi", storageGi)),
+			},
+		},
+		Status: corev1.PersistentVolumeStatus{Phase: corev1.VolumeAvailable},
+	}
+}
+
+// randString generates a random lowercase alpha string of length n for test data.
+func randString(n int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyz"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+// makeClaimedSandboxWithMount creates a SandboxClaim with DynamicVolumesMount referencing
+// pvName, plus a claimed Sandbox labeled with LabelSandboxClaimName. This simulates
+// the state after a successful claim — no PV annotation needed.
+func makeClaimedSandboxWithMount(t *testing.T, c client.Client, namespace, claimName, sandboxName, pvName string) {
+	t.Helper()
+	// Create the SandboxClaim with DynamicVolumesMount.
+	claim := &v1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: namespace},
+		Spec: v1alpha1.SandboxClaimSpec{
+			TemplateName: "test-template",
+			DynamicVolumesMount: []v1alpha1.CSIMountConfig{
+				{PvName: pvName, MountPath: "/data"},
+			},
+		},
+	}
+	require.NoError(t, c.Create(t.Context(), claim))
+
+	// Create the claimed Sandbox labeled with the claim name.
+	sbx := &v1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sandboxName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				v1alpha1.LabelSandboxIsClaimed: v1alpha1.True,
+				v1alpha1.LabelSandboxClaimName: claimName,
+			},
+		},
+		Status: v1alpha1.SandboxStatus{Phase: v1alpha1.SandboxRunning},
+	}
+	CreateSandboxWithStatus(t, c, sbx)
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests — RegisterVolume
+// ---------------------------------------------------------------------------
+
+func TestVolumeInfra_RegisterVolume(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupPV     func() *corev1.PersistentVolume
+		opts        infra.RegisterVolumeOptions
+		expectError string
+		expectCode  managererrors.ErrorCode
+		check       func(t *testing.T, info infra.VolumeInfo)
+	}{
+		{
+			name:        "empty namespace — returns BadRequest",
+			setupPV:     func() *corev1.PersistentVolume { return nil },
+			opts:        infra.RegisterVolumeOptions{Name: "vol1", PvName: "pv-001", SizeGB: 1},
+			expectError: "namespace is required",
+			expectCode:  managererrors.ErrorBadRequest,
+		},
+		{
+			name:        "empty name — returns BadRequest",
+			setupPV:     func() *corev1.PersistentVolume { return nil },
+			opts:        infra.RegisterVolumeOptions{Namespace: "ns1", PvName: "pv-001", SizeGB: 1},
+			expectError: "name is required",
+			expectCode:  managererrors.ErrorBadRequest,
+		},
+		{
+			name:        "empty pvName — returns BadRequest",
+			setupPV:     func() *corev1.PersistentVolume { return nil },
+			opts:        infra.RegisterVolumeOptions{Namespace: "ns1", Name: "vol1", SizeGB: 1},
+			expectError: "pvName is required",
+			expectCode:  managererrors.ErrorBadRequest,
+		},
+		{
+			name:        "zero sizeGB — returns BadRequest",
+			setupPV:     func() *corev1.PersistentVolume { return nil },
+			opts:        infra.RegisterVolumeOptions{Namespace: "ns1", Name: "vol1", PvName: "pv-001", SizeGB: 0},
+			expectError: "sizeGB must be a positive integer",
+			expectCode:  managererrors.ErrorBadRequest,
+		},
+		{
+			name:        "PV not found",
+			setupPV:     func() *corev1.PersistentVolume { return nil },
+			opts:        infra.RegisterVolumeOptions{Namespace: "ns1", Name: "vol1", PvName: "nonexistent-pv", SizeGB: 1},
+			expectError: "not found",
+			expectCode:  managererrors.ErrorNotFound,
+		},
+		{
+			name: "PV not in Available phase",
+			setupPV: func() *corev1.PersistentVolume {
+				pv := makeAvailablePV("pv-bound", 10)
+				pv.Status.Phase = corev1.VolumeBound
+				return pv
+			},
+			opts:        infra.RegisterVolumeOptions{Namespace: "ns1", Name: "vol-bound", PvName: "pv-bound", SizeGB: 1},
+			expectError: "not in Available phase",
+			expectCode:  managererrors.ErrorBadRequest,
+		},
+		{
+			name:        "PV capacity less than sizeGB",
+			setupPV:     func() *corev1.PersistentVolume { return makeAvailablePV("pv-small", 1) },
+			opts:        infra.RegisterVolumeOptions{Namespace: "ns1", Name: "vol-small", PvName: "pv-small", SizeGB: 5},
+			expectError: "capacity",
+			expectCode:  managererrors.ErrorBadRequest,
+		},
+		{
+			name: "PV already owned by same namespace",
+			setupPV: func() *corev1.PersistentVolume {
+				pv := makeAvailablePV("pv-owned-same", 10)
+				pv.Labels = map[string]string{
+					v1alpha1.LabelVolumeOwnerNamespace: "ns1",
+					v1alpha1.LabelVolumeName:           "existing-vol",
+				}
+				return pv
+			},
+			opts:        infra.RegisterVolumeOptions{Namespace: "ns1", Name: "vol-new", PvName: "pv-owned-same", SizeGB: 1},
+			expectError: "already registered",
+			expectCode:  managererrors.ErrorConflict,
+		},
+		{
+			name: "PV already owned by different namespace",
+			setupPV: func() *corev1.PersistentVolume {
+				pv := makeAvailablePV("pv-owned-diff", 10)
+				pv.Labels = map[string]string{
+					v1alpha1.LabelVolumeOwnerNamespace: "other-ns",
+					v1alpha1.LabelVolumeName:           "other-vol",
+				}
+				return pv
+			},
+			opts:        infra.RegisterVolumeOptions{Namespace: "ns1", Name: "vol-new", PvName: "pv-owned-diff", SizeGB: 1},
+			expectError: "different namespace",
+			expectCode:  managererrors.ErrorNotAllowed,
+		},
+		{
+			name:    "volume name already in use in namespace",
+			setupPV: nil, // handled inline below
+		},
+		{
+			name:    "successful registration",
+			setupPV: func() *corev1.PersistentVolume { return makeAvailablePV("pv-ok", 10) },
+			opts:    infra.RegisterVolumeOptions{Namespace: "ns1", Name: "vol-ok", PvName: "pv-ok", SizeGB: 5},
+			check: func(t *testing.T, info infra.VolumeInfo) {
+				assert.Equal(t, "pv-ok", info.VolumeID)
+				assert.Equal(t, "pv-ok", info.PvName)
+				assert.Equal(t, "vol-ok", info.Name)
+				assert.Equal(t, 10, info.SizeGB)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i, c := NewTestInfra(t)
+
+			if tt.name == "volume name already in use in namespace" {
+				existing := makeAvailablePV("pv-existing", 10)
+				require.NoError(t, c.Create(t.Context(), existing))
+				time.Sleep(50 * time.Millisecond)
+				_, err := i.RegisterVolume(t.Context(), infra.RegisterVolumeOptions{
+					Namespace: "ns1", Name: "vol-dupe", PvName: "pv-existing", SizeGB: 1,
+				})
+				require.NoError(t, err)
+				second := makeAvailablePV("pv-second", 10)
+				require.NoError(t, c.Create(t.Context(), second))
+				time.Sleep(50 * time.Millisecond)
+				_, err = i.RegisterVolume(t.Context(), infra.RegisterVolumeOptions{
+					Namespace: "ns1", Name: "vol-dupe", PvName: "pv-second", SizeGB: 1,
+				})
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "already in use")
+				assert.Equal(t, managererrors.ErrorConflict, managererrors.GetErrCode(err))
+				return
+			}
+
+			if tt.setupPV != nil {
+				pv := tt.setupPV()
+				if pv != nil {
+					require.NoError(t, c.Create(t.Context(), pv))
+					time.Sleep(50 * time.Millisecond)
+				}
+			}
+
+			info, err := i.RegisterVolume(t.Context(), tt.opts)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				if tt.expectCode != "" {
+					assert.Equal(t, tt.expectCode, managererrors.GetErrCode(err))
+				}
+			} else {
+				require.NoError(t, err)
+				if tt.check != nil {
+					tt.check(t, info)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests — ListVolumes
+// ---------------------------------------------------------------------------
+
+func TestVolumeInfra_ListVolumes(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        infra.ListVolumesOptions
+		expectCount int
+		expectError string
+	}{
+		{
+			name:        "no volumes in namespace",
+			opts:        infra.ListVolumesOptions{Namespace: "empty-ns"},
+			expectCount: 0,
+		},
+		{
+			name:        "lists only volumes in requested namespace",
+			opts:        infra.ListVolumesOptions{Namespace: "ns-a"},
+			expectCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i, c := NewTestInfra(t)
+
+			if tt.name == "lists only volumes in requested namespace" {
+				for idx, pvName := range []string{"pv-list-a1", "pv-list-a2"} {
+					pv := makeAvailablePV(pvName, 10)
+					require.NoError(t, c.Create(t.Context(), pv))
+					time.Sleep(50 * time.Millisecond)
+					_, err := i.RegisterVolume(t.Context(), infra.RegisterVolumeOptions{
+						Namespace: "ns-a", Name: fmt.Sprintf("vol-a%d", idx), PvName: pvName, SizeGB: 1,
+					})
+					require.NoError(t, err)
+				}
+				pvB := makeAvailablePV("pv-list-b1", 10)
+				require.NoError(t, c.Create(t.Context(), pvB))
+				time.Sleep(50 * time.Millisecond)
+				_, err := i.RegisterVolume(t.Context(), infra.RegisterVolumeOptions{
+					Namespace: "ns-b", Name: "vol-b0", PvName: "pv-list-b1", SizeGB: 1,
+				})
+				require.NoError(t, err)
+				time.Sleep(50 * time.Millisecond)
+			}
+
+			result, err := i.ListVolumes(t.Context(), tt.opts)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				require.NoError(t, err)
+				assert.Len(t, result, tt.expectCount)
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+// TestVolumeInfra_ListVolumes_MountedBy verifies that volume usage is derived
+// from SandboxClaim objects, not from any PV annotation.
+func TestVolumeInfra_ListVolumes_MountedBy(t *testing.T) {
+	i, c := NewTestInfra(t)
+	ns := "ns-mount"
+
+	pv := makeAvailablePV("pv-mounted", 10)
+	require.NoError(t, c.Create(t.Context(), pv))
+	time.Sleep(50 * time.Millisecond)
+	_, err := i.RegisterVolume(t.Context(), infra.RegisterVolumeOptions{
+		Namespace: ns, Name: "vol-mounted", PvName: "pv-mounted", SizeGB: 1,
+	})
+	require.NoError(t, err)
+
+	// Create a SandboxClaim with DynamicVolumesMount referencing pv-mounted.
+	makeClaimedSandboxWithMount(t, c, ns, "claim-mounted", "sbx-001", "pv-mounted")
+	time.Sleep(50 * time.Millisecond)
+
+	// getVolumeUsers should report the sandbox as using the volume.
+	users, err := i.getVolumeUsers(t.Context(), ns, "pv-mounted")
+	require.NoError(t, err)
+	assert.NotEmpty(t, users)
+	assert.Contains(t, users, ns+"--sbx-001")
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests — GetVolume
+// ---------------------------------------------------------------------------
+
+func TestVolumeInfra_GetVolume(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        infra.GetVolumeOptions
+		expectError string
+		expectCode  managererrors.ErrorCode
+		check       func(t *testing.T, info infra.VolumeInfo)
+	}{
+		{
+			name:        "volume not found",
+			opts:        infra.GetVolumeOptions{Namespace: "ns1", VolumeID: "ghost-pv"},
+			expectError: "not found",
+			expectCode:  managererrors.ErrorNotFound,
+		},
+		{
+			name:        "volume owned by different namespace",
+			opts:        infra.GetVolumeOptions{Namespace: "ns-wrong", VolumeID: "pv-get-ok"},
+			expectError: "not found",
+			expectCode:  managererrors.ErrorNotFound,
+		},
+		{
+			name: "successful get",
+			opts: infra.GetVolumeOptions{Namespace: "ns1", VolumeID: "pv-get-ok"},
+			check: func(t *testing.T, info infra.VolumeInfo) {
+				assert.Equal(t, "pv-get-ok", info.VolumeID)
+				assert.Equal(t, "vol-get", info.Name)
+				assert.Equal(t, 10, info.SizeGB)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i, c := NewTestInfra(t)
+
+			pv := makeAvailablePV("pv-get-ok", 10)
+			require.NoError(t, c.Create(t.Context(), pv))
+			time.Sleep(50 * time.Millisecond)
+			_, err := i.RegisterVolume(t.Context(), infra.RegisterVolumeOptions{
+				Namespace: "ns1", Name: "vol-get", PvName: "pv-get-ok", SizeGB: 1,
+			})
+			require.NoError(t, err)
+			time.Sleep(50 * time.Millisecond)
+
+			info, err := i.GetVolume(t.Context(), tt.opts)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				if tt.expectCode != "" {
+					assert.Equal(t, tt.expectCode, managererrors.GetErrCode(err))
+				}
+			} else {
+				require.NoError(t, err)
+				if tt.check != nil {
+					tt.check(t, info)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests — DeleteVolume
+// ---------------------------------------------------------------------------
+
+func TestVolumeInfra_DeleteVolume(t *testing.T) {
+	tests := []struct {
+		name          string
+		opts          infra.DeleteVolumeOptions
+		mountingSbxNs string // if non-empty, create a Sandbox in this ns mounting the PV
+		expectError   string
+		expectCode    managererrors.ErrorCode
+		check         func(t *testing.T, result infra.DeleteVolumeResult)
+	}{
+		{
+			name:        "PV not found",
+			opts:        infra.DeleteVolumeOptions{Namespace: "ns1", VolumeID: "ghost-pv"},
+			expectError: "not found",
+			expectCode:  managererrors.ErrorNotFound,
+		},
+		{
+			name:        "PV not registered under namespace",
+			opts:        infra.DeleteVolumeOptions{Namespace: "ns-wrong", VolumeID: "pv-del-ok"},
+			expectError: "not found",
+			expectCode:  managererrors.ErrorNotFound,
+		},
+		{
+			name:          "mounted without force — blocked",
+			opts:          infra.DeleteVolumeOptions{Namespace: "ns1", VolumeID: "pv-del-ok", Force: false},
+			mountingSbxNs: "ns1",
+			expectError:   "mounted by",
+			expectCode:    managererrors.ErrorConflict,
+		},
+		{
+			name:          "mounted with force — succeeds",
+			opts:          infra.DeleteVolumeOptions{Namespace: "ns1", VolumeID: "pv-del-ok", Force: true},
+			mountingSbxNs: "ns1",
+			check: func(t *testing.T, result infra.DeleteVolumeResult) {
+				assert.True(t, result.ForcedDelete)
+				assert.NotEmpty(t, result.AffectedSandboxIDs)
+			},
+		},
+		{
+			name: "unmounted delete — succeeds",
+			opts: infra.DeleteVolumeOptions{Namespace: "ns1", VolumeID: "pv-del-ok", Force: false},
+			check: func(t *testing.T, result infra.DeleteVolumeResult) {
+				assert.False(t, result.ForcedDelete)
+				assert.Empty(t, result.AffectedSandboxIDs)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i, c := NewTestInfra(t)
+
+			// Pre-register pv-del-ok under ns1.
+			if tt.opts.VolumeID == "pv-del-ok" {
+				pv := makeAvailablePV("pv-del-ok", 10)
+				require.NoError(t, c.Create(t.Context(), pv))
+				time.Sleep(50 * time.Millisecond)
+				_, err := i.RegisterVolume(t.Context(), infra.RegisterVolumeOptions{
+					Namespace: "ns1", Name: "vol-del", PvName: "pv-del-ok", SizeGB: 1,
+				})
+				require.NoError(t, err)
+				time.Sleep(50 * time.Millisecond)
+			}
+
+			// Create a claimed Sandbox mounting the PV via a SandboxClaim.
+			if tt.mountingSbxNs != "" {
+				makeClaimedSandboxWithMount(t, c, tt.mountingSbxNs, "claim-mount-001", "sbx-mount-001", "pv-del-ok")
+				time.Sleep(50 * time.Millisecond)
+			}
+
+			result, err := i.DeleteVolume(t.Context(), tt.opts)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				if tt.expectCode != "" {
+					assert.Equal(t, tt.expectCode, managererrors.GetErrCode(err))
+				}
+			} else {
+				require.NoError(t, err)
+				if tt.check != nil {
+					tt.check(t, result)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Property-based tests
+//
+// Each test runs propertyIterations rounds. Mount state is established by
+// creating claimed Sandbox objects (not annotations), matching the new design.
+//
+// TODO: replace math/rand with pgregory.net/rapid once vendored.
+// ---------------------------------------------------------------------------
+
+const propertyIterations = 100
+
+// TestProperty1_RegistrationConflictOnDuplicatePvName
+// Feature: e2b-volume-management, Property 1: Registration conflict on duplicate pvName
+// Validates: Requirements 1.6
+func TestProperty1_RegistrationConflictOnDuplicatePvName(t *testing.T) {
+	i, c := NewTestInfra(t)
+	for iter := 0; iter < propertyIterations; iter++ {
+		pvName := fmt.Sprintf("pv-p1-%d-%s", iter, randString(6))
+		ns := fmt.Sprintf("ns-%s", randString(4))
+		volName := fmt.Sprintf("vol-%s", randString(4))
+
+		pv := makeAvailablePV(pvName, 10)
+		require.NoError(t, c.Create(t.Context(), pv), "iter %d", iter)
+		time.Sleep(50 * time.Millisecond)
+
+		_, err := i.RegisterVolume(t.Context(), infra.RegisterVolumeOptions{
+			Namespace: ns, Name: volName, PvName: pvName, SizeGB: 1,
+		})
+		require.NoError(t, err, "iter %d: first registration failed", iter)
+
+		_, err = i.RegisterVolume(t.Context(), infra.RegisterVolumeOptions{
+			Namespace: ns, Name: fmt.Sprintf("vol2-%s", randString(4)), PvName: pvName, SizeGB: 1,
+		})
+		require.Error(t, err, "iter %d: expected error on duplicate pvName", iter)
+		code := managererrors.GetErrCode(err)
+		assert.True(t, code == managererrors.ErrorConflict || code == managererrors.ErrorNotAllowed,
+			"iter %d: expected Conflict or NotAllowed, got %s", iter, code)
+	}
+}
+
+// TestProperty2_NamespaceIsolationOfList
+// Feature: e2b-volume-management, Property 2: Namespace isolation of list
+// Validates: Requirements 2.3, 3.3
+func TestProperty2_NamespaceIsolationOfList(t *testing.T) {
+	i, c := NewTestInfra(t)
+	for iter := 0; iter < propertyIterations; iter++ {
+		ns1 := fmt.Sprintf("p2-a-%d-%s", iter, randString(4))
+		ns2 := fmt.Sprintf("p2-b-%d-%s", iter, randString(4))
+		pvName := fmt.Sprintf("pv-p2-%d-%s", iter, randString(6))
+
+		pv := makeAvailablePV(pvName, 10)
+		require.NoError(t, c.Create(t.Context(), pv), "iter %d", iter)
+		time.Sleep(50 * time.Millisecond)
+
+		_, err := i.RegisterVolume(t.Context(), infra.RegisterVolumeOptions{
+			Namespace: ns1, Name: fmt.Sprintf("vol-%d-%s", iter, randString(4)), PvName: pvName, SizeGB: 1,
+		})
+		require.NoError(t, err, "iter %d", iter)
+		time.Sleep(50 * time.Millisecond)
+
+		result, err := i.ListVolumes(t.Context(), infra.ListVolumesOptions{Namespace: ns2})
+		require.NoError(t, err, "iter %d", iter)
+		assert.Empty(t, result, "iter %d: expected empty list for ns2", iter)
+	}
+}
+
+// TestProperty3_GetAfterRegisterRoundTrip
+// Feature: e2b-volume-management, Property 3: Get-after-register round-trip
+// Validates: Requirements 1.1, 3.1
+func TestProperty3_GetAfterRegisterRoundTrip(t *testing.T) {
+	i, c := NewTestInfra(t)
+	for iter := 0; iter < propertyIterations; iter++ {
+		pvName := fmt.Sprintf("pv-p3-%d-%s", iter, randString(6))
+		ns := fmt.Sprintf("ns-p3-%s", randString(4))
+		volName := fmt.Sprintf("vol-%d-%s", iter, randString(4))
+		pvCapGi := rand.Intn(10) + 2
+		reqGi := rand.Intn(pvCapGi) + 1
+
+		pv := makeAvailablePV(pvName, pvCapGi)
+		require.NoError(t, c.Create(t.Context(), pv), "iter %d", iter)
+		time.Sleep(50 * time.Millisecond)
+
+		_, err := i.RegisterVolume(t.Context(), infra.RegisterVolumeOptions{
+			Namespace: ns, Name: volName, PvName: pvName, SizeGB: reqGi,
+		})
+		require.NoError(t, err, "iter %d", iter)
+		time.Sleep(50 * time.Millisecond)
+
+		info, err := i.GetVolume(t.Context(), infra.GetVolumeOptions{Namespace: ns, VolumeID: pvName})
+		require.NoError(t, err, "iter %d", iter)
+		assert.Equal(t, volName, info.Name, "iter %d: name mismatch", iter)
+		assert.Equal(t, pvName, info.PvName, "iter %d: pvName mismatch", iter)
+		assert.Equal(t, pvCapGi, info.SizeGB, "iter %d: sizeGB mismatch", iter)
+	}
+}
+
+// TestProperty4_DeleteRemovesFromList
+// Feature: e2b-volume-management, Property 4: Delete removes from list
+// Validates: Requirements 4.1
+func TestProperty4_DeleteRemovesFromList(t *testing.T) {
+	i, c := NewTestInfra(t)
+	ns := fmt.Sprintf("ns-p4-%s", randString(4))
+	for iter := 0; iter < propertyIterations; iter++ {
+		pvName := fmt.Sprintf("pv-p4-%d-%s", iter, randString(6))
+
+		pv := makeAvailablePV(pvName, 10)
+		require.NoError(t, c.Create(t.Context(), pv), "iter %d", iter)
+		time.Sleep(50 * time.Millisecond)
+
+		_, err := i.RegisterVolume(t.Context(), infra.RegisterVolumeOptions{
+			Namespace: ns, Name: fmt.Sprintf("vol-p4-%d-%s", iter, randString(4)), PvName: pvName, SizeGB: 1,
+		})
+		require.NoError(t, err, "iter %d", iter)
+		time.Sleep(50 * time.Millisecond)
+
+		_, err = i.DeleteVolume(t.Context(), infra.DeleteVolumeOptions{Namespace: ns, VolumeID: pvName})
+		require.NoError(t, err, "iter %d", iter)
+		time.Sleep(50 * time.Millisecond)
+
+		volumes, err := i.ListVolumes(t.Context(), infra.ListVolumesOptions{Namespace: ns})
+		require.NoError(t, err, "iter %d", iter)
+		for _, v := range volumes {
+			assert.NotEqual(t, pvName, v.VolumeID, "iter %d: deleted volume still in list", iter)
+		}
+	}
+}
+
+// TestProperty5_MountedVolumeDeletionBlockedWithoutForce
+// Feature: e2b-volume-management, Property 5: Mounted volume deletion is blocked
+// Validates: Requirements 4.2
+// Mount state is derived from a claimed Sandbox, not from a PV annotation.
+func TestProperty5_MountedVolumeDeletionBlockedWithoutForce(t *testing.T) {
+	i, c := NewTestInfra(t)
+	for iter := 0; iter < propertyIterations; iter++ {
+		pvName := fmt.Sprintf("pv-p5-%d-%s", iter, randString(6))
+		ns := fmt.Sprintf("ns-p5-%d-%s", iter, randString(4))
+
+		pv := makeAvailablePV(pvName, 10)
+		require.NoError(t, c.Create(t.Context(), pv), "iter %d", iter)
+		time.Sleep(50 * time.Millisecond)
+
+		_, err := i.RegisterVolume(t.Context(), infra.RegisterVolumeOptions{
+			Namespace: ns, Name: fmt.Sprintf("vol-%d-%s", iter, randString(4)), PvName: pvName, SizeGB: 1,
+		})
+		require.NoError(t, err, "iter %d", iter)
+
+		// Create a SandboxClaim with DynamicVolumesMount referencing the PV.
+		makeClaimedSandboxWithMount(t, c,
+			ns,
+			fmt.Sprintf("claim-%s", randString(6)),
+			fmt.Sprintf("sbx-%s", randString(6)),
+			pvName,
+		)
+		time.Sleep(50 * time.Millisecond)
+
+		_, err = i.DeleteVolume(t.Context(), infra.DeleteVolumeOptions{
+			Namespace: ns, VolumeID: pvName, Force: false,
+		})
+		require.Error(t, err, "iter %d: expected error", iter)
+		assert.Equal(t, managererrors.ErrorConflict, managererrors.GetErrCode(err),
+			"iter %d: expected ErrorConflict", iter)
+	}
+}
+
+// TestProperty7_VolumeNameUniquenessWithinNamespace
+// Feature: e2b-volume-management, Property 7: Volume name uniqueness within namespace
+// Validates: Requirements 1.7
+func TestProperty7_VolumeNameUniquenessWithinNamespace(t *testing.T) {
+	i, c := NewTestInfra(t)
+	for iter := 0; iter < propertyIterations; iter++ {
+		ns := fmt.Sprintf("ns-p7-%d-%s", iter, randString(4))
+		volName := fmt.Sprintf("vol-%d-%s", iter, randString(4))
+		pv1Name := fmt.Sprintf("pv-p7-a-%d-%s", iter, randString(6))
+		pv2Name := fmt.Sprintf("pv-p7-b-%d-%s", iter, randString(6))
+
+		pv1 := makeAvailablePV(pv1Name, 10)
+		pv2 := makeAvailablePV(pv2Name, 10)
+		require.NoError(t, c.Create(t.Context(), pv1), "iter %d", iter)
+		require.NoError(t, c.Create(t.Context(), pv2), "iter %d", iter)
+		time.Sleep(50 * time.Millisecond)
+
+		_, err := i.RegisterVolume(t.Context(), infra.RegisterVolumeOptions{
+			Namespace: ns, Name: volName, PvName: pv1Name, SizeGB: 1,
+		})
+		require.NoError(t, err, "iter %d: first registration failed", iter)
+		time.Sleep(50 * time.Millisecond)
+
+		_, err = i.RegisterVolume(t.Context(), infra.RegisterVolumeOptions{
+			Namespace: ns, Name: volName, PvName: pv2Name, SizeGB: 1,
+		})
+		require.Error(t, err, "iter %d: expected conflict", iter)
+		assert.Equal(t, managererrors.ErrorConflict, managererrors.GetErrCode(err),
+			"iter %d: expected ErrorConflict", iter)
+	}
+}

--- a/pkg/sandbox-manager/infra/sandboxcr/volume_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/volume_test.go
@@ -49,7 +49,6 @@ func TestCreateVolume(t *testing.T) {
 	i := &Infra{Cache: c}
 
 	t.Run("PVC already exists owned by different user", func(t *testing.T) {
-		// Pre-create a PVC owned by a different user
 		existingPVC := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "existing-volume",
@@ -84,7 +83,6 @@ func TestCreateVolume(t *testing.T) {
 	})
 
 	t.Run("PVC already exists and bound by same user (idempotent)", func(t *testing.T) {
-		// Pre-create a bound PVC owned by the same user
 		boundPVC := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "bound-volume",
@@ -109,59 +107,63 @@ func TestCreateVolume(t *testing.T) {
 		require.NoError(t, fakeClient.Create(context.Background(), boundPVC))
 
 		opts := infra.CreateVolumeOptions{
-			Namespace:    "sandbox-system",
-			Name:         "bound-volume",
-			UserID:       "user-1",
-			StorageSize:  resource.MustParse("1Gi"),
-			StorageClass: "standard",
-			AccessMode:   "ReadWriteOnce",
+			Namespace:        "sandbox-system",
+			Name:             "bound-volume",
+			UserID:           "user-1",
+			StorageSize:      resource.MustParse("1Gi"),
+			StorageClass:     "standard",
+			AccessMode:       "ReadWriteOnce",
+			WaitBoundTimeout: 1 * time.Second,
 		}
 		info, err := i.CreateVolume(context.Background(), opts)
 		require.NoError(t, err)
 		assert.Equal(t, "bound-volume", info.Name)
-		assert.Equal(t, "pv-bound-volume", info.VolumeID)
+		assert.Equal(t, "bound-volume", info.VolumeID)
+		assert.Equal(t, "pv-bound-volume", info.PvName)
 	})
+}
 
-	t.Run("PVC binding timeout returns error with PVC name", func(t *testing.T) {
-		// Create a pending PVC that won't bind
-		storageClass := "standard"
-		pendingPVC := &corev1.PersistentVolumeClaim{
+func TestListVolumes(t *testing.T) {
+	c, fakeClient, err := cachetest.NewTestCache(t)
+	require.NoError(t, err)
+
+	i := &Infra{Cache: c}
+
+	t.Run("list volumes for a user", func(t *testing.T) {
+		pvc1 := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pending-volume",
+				Name:      "vol-1",
 				Namespace: "sandbox-system",
 				Annotations: map[string]string{
 					agentsv1alpha1.AnnotationOwner: "user-1",
 				},
 			},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("1Gi"),
-					},
+		}
+		pvc2 := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vol-2",
+				Namespace: "sandbox-system",
+				Annotations: map[string]string{
+					agentsv1alpha1.AnnotationOwner: "user-1",
 				},
-				StorageClassName: &storageClass,
-			},
-			Status: corev1.PersistentVolumeClaimStatus{
-				Phase: corev1.ClaimPending,
 			},
 		}
-		require.NoError(t, fakeClient.Create(context.Background(), pendingPVC))
+		require.NoError(t, fakeClient.Create(context.Background(), pvc1))
+		require.NoError(t, fakeClient.Create(context.Background(), pvc2))
 
-		opts := infra.CreateVolumeOptions{
-			Namespace:        "sandbox-system",
-			Name:             "pending-volume",
-			UserID:           "user-1",
-			StorageSize:      resource.MustParse("1Gi"),
-			StorageClass:     "standard",
-			AccessMode:       "ReadWriteOnce",
-			WaitBoundTimeout: 100 * time.Millisecond,
+		opts := infra.ListVolumesOptions{
+			Namespace: "sandbox-system",
+			UserID:    "user-1",
 		}
-		_, err := i.CreateVolume(context.Background(), opts)
-		assert.Error(t, err)
-		// Verify error message contains PVC namespace/name and timeout info
-		assert.Contains(t, err.Error(), "sandbox-system/pending-volume")
-		assert.Contains(t, err.Error(), "timed out")
+		volumes, err := i.ListVolumes(context.Background(), opts)
+		require.NoError(t, err)
+		assert.Len(t, volumes, 2)
+		names := make(map[string]bool)
+		for _, v := range volumes {
+			names[v.Name] = true
+		}
+		assert.True(t, names["vol-1"])
+		assert.True(t, names["vol-2"])
 	})
 }
 
@@ -179,55 +181,19 @@ func TestGetVolume(t *testing.T) {
 		}
 		_, err := i.GetVolume(context.Background(), opts)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "volume not found")
 	})
 
-	t.Run("volume found regardless of ownership", func(t *testing.T) {
+	t.Run("volume found", func(t *testing.T) {
 		pvc := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pvc-other-owner",
-				Namespace: "sandbox-system",
-				Annotations: map[string]string{
-					agentsv1alpha1.AnnotationOwner: "other-user",
-				},
-			},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				VolumeName:  "pv-other",
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("1Gi"),
-					},
-				},
-			},
-			Status: corev1.PersistentVolumeClaimStatus{
-				Phase: corev1.ClaimBound,
-			},
-		}
-		require.NoError(t, fakeClient.Create(context.Background(), pvc))
-
-		opts := infra.GetVolumeOptions{
-			Namespace: "sandbox-system",
-			VolumeID:  "pv-other",
-			UserID:    "user-1",
-		}
-		info, err := i.GetVolume(context.Background(), opts)
-		require.NoError(t, err)
-		assert.Equal(t, "pvc-other-owner", info.Name)
-		assert.Equal(t, "pv-other", info.VolumeID)
-	})
-
-	t.Run("volume found and owned by requesting user", func(t *testing.T) {
-		pvc := &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pvc-owned",
+				Name:      "pvc-get-ok",
 				Namespace: "sandbox-system",
 				Annotations: map[string]string{
 					agentsv1alpha1.AnnotationOwner: "user-1",
 				},
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
-				VolumeName:  "pv-owned",
+				VolumeName:  "pv-get-ok",
 				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				Resources: corev1.VolumeResourceRequirements{
 					Requests: corev1.ResourceList{
@@ -235,55 +201,19 @@ func TestGetVolume(t *testing.T) {
 					},
 				},
 			},
-			Status: corev1.PersistentVolumeClaimStatus{
-				Phase: corev1.ClaimBound,
-			},
 		}
 		require.NoError(t, fakeClient.Create(context.Background(), pvc))
 
 		opts := infra.GetVolumeOptions{
 			Namespace: "sandbox-system",
-			VolumeID:  "pv-owned",
+			VolumeID:  "pvc-get-ok",
 			UserID:    "user-1",
 		}
 		info, err := i.GetVolume(context.Background(), opts)
 		require.NoError(t, err)
-		assert.Equal(t, "pvc-owned", info.Name)
-		assert.Equal(t, "pv-owned", info.VolumeID)
-	})
-
-	t.Run("volume found with empty UserID skips ownership check", func(t *testing.T) {
-		pvc := &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pvc-no-user-check",
-				Namespace: "sandbox-system",
-				Annotations: map[string]string{
-					agentsv1alpha1.AnnotationOwner: "other-user",
-				},
-			},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				VolumeName:  "pv-no-user-check",
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("1Gi"),
-					},
-				},
-			},
-			Status: corev1.PersistentVolumeClaimStatus{
-				Phase: corev1.ClaimBound,
-			},
-		}
-		require.NoError(t, fakeClient.Create(context.Background(), pvc))
-
-		opts := infra.GetVolumeOptions{
-			Namespace: "sandbox-system",
-			VolumeID:  "pv-no-user-check",
-			UserID:    "",
-		}
-		info, err := i.GetVolume(context.Background(), opts)
-		require.NoError(t, err)
-		assert.Equal(t, "pvc-no-user-check", info.Name)
+		assert.Equal(t, "pvc-get-ok", info.Name)
+		assert.Equal(t, "pvc-get-ok", info.VolumeID)
+		assert.Equal(t, "pv-get-ok", info.PvName)
 	})
 }
 
@@ -291,50 +221,19 @@ func TestDeleteVolume(t *testing.T) {
 	c, fakeClient, err := cachetest.NewTestCache(t)
 	require.NoError(t, err)
 
-	i := &Infra{Cache: c}
+	i := &Infra{Cache: c, APIReader: fakeClient}
 
 	t.Run("volume not found", func(t *testing.T) {
 		opts := infra.DeleteVolumeOptions{
 			Namespace: "sandbox-system",
-			VolumeID:  "non-existent-pv",
+			VolumeID:  "non-existent-pvc",
 			UserID:    "user-1",
 		}
-		err := i.DeleteVolume(context.Background(), opts)
+		_, err := i.DeleteVolume(context.Background(), opts)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "volume not found")
 	})
 
-	t.Run("volume deleted regardless of ownership", func(t *testing.T) {
-		pvc := &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pvc-del-other",
-				Namespace: "sandbox-system",
-				Annotations: map[string]string{
-					agentsv1alpha1.AnnotationOwner: "other-user",
-				},
-			},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				VolumeName:  "pv-del-other",
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("1Gi"),
-					},
-				},
-			},
-		}
-		require.NoError(t, fakeClient.Create(context.Background(), pvc))
-
-		opts := infra.DeleteVolumeOptions{
-			Namespace: "sandbox-system",
-			VolumeID:  "pv-del-other",
-			UserID:    "user-1",
-		}
-		err := i.DeleteVolume(context.Background(), opts)
-		assert.NoError(t, err)
-	})
-
-	t.Run("volume deleted successfully by owner", func(t *testing.T) {
+	t.Run("volume deleted successfully", func(t *testing.T) {
 		pvc := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pvc-del-ok",
@@ -357,24 +256,25 @@ func TestDeleteVolume(t *testing.T) {
 
 		opts := infra.DeleteVolumeOptions{
 			Namespace: "sandbox-system",
-			VolumeID:  "pv-del-ok",
+			VolumeID:  "pvc-del-ok",
 			UserID:    "user-1",
 		}
-		err := i.DeleteVolume(context.Background(), opts)
-		assert.NoError(t, err)
+		result, err := i.DeleteVolume(context.Background(), opts)
+		require.NoError(t, err)
+		assert.Empty(t, result.AffectedSandboxIDs)
 	})
 
-	t.Run("volume deleted with empty UserID skips ownership check", func(t *testing.T) {
+	t.Run("delete volume blocked by SandboxClaim", func(t *testing.T) {
 		pvc := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pvc-del-no-user",
-				Namespace: "sandbox-system",
+				Name:      "pvc-del-blocked",
+				Namespace: "ns1",
 				Annotations: map[string]string{
-					agentsv1alpha1.AnnotationOwner: "other-user",
+					agentsv1alpha1.AnnotationOwner: "user-1",
 				},
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
-				VolumeName:  "pv-del-no-user",
+				VolumeName:  "pv-del-blocked",
 				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				Resources: corev1.VolumeResourceRequirements{
 					Requests: corev1.ResourceList{
@@ -385,103 +285,46 @@ func TestDeleteVolume(t *testing.T) {
 		}
 		require.NoError(t, fakeClient.Create(context.Background(), pvc))
 
+		// Create claim and sandbox mounting this PV
+		claim := &agentsv1alpha1.SandboxClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "claim1", Namespace: "ns1"},
+			Spec: agentsv1alpha1.SandboxClaimSpec{
+				TemplateName: "test-template",
+				DynamicVolumesMount: []agentsv1alpha1.CSIMountConfig{
+					{PvName: "pv-del-blocked", MountPath: "/data"},
+				},
+			},
+		}
+		require.NoError(t, fakeClient.Create(context.Background(), claim))
+
+		sbx := &agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sbx1",
+				Namespace: "ns1",
+				Labels: map[string]string{
+					agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.True,
+					agentsv1alpha1.LabelSandboxClaimName: "claim1",
+				},
+			},
+			Status: agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRunning},
+		}
+		CreateSandboxWithStatus(t, fakeClient, sbx)
+
 		opts := infra.DeleteVolumeOptions{
-			Namespace: "sandbox-system",
-			VolumeID:  "pv-del-no-user",
-			UserID:    "",
-		}
-		err := i.DeleteVolume(context.Background(), opts)
-		assert.NoError(t, err)
-	})
-}
-
-func TestListVolumes(t *testing.T) {
-	c, fakeClient, err := cachetest.NewTestCache(t)
-	require.NoError(t, err)
-
-	i := &Infra{Cache: c}
-
-	t.Run("list volumes for a user", func(t *testing.T) {
-		pvc1 := &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vol-1",
-				Namespace: "sandbox-system",
-				Annotations: map[string]string{
-					agentsv1alpha1.AnnotationOwner: "user-1",
-				},
-			},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				VolumeName:  "pv-1",
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("1Gi"),
-					},
-				},
-			},
-		}
-		pvc2 := &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vol-2",
-				Namespace: "sandbox-system",
-				Annotations: map[string]string{
-					agentsv1alpha1.AnnotationOwner: "user-1",
-				},
-			},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				VolumeName:  "pv-2",
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("2Gi"),
-					},
-				},
-			},
-		}
-		pvc3 := &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vol-3",
-				Namespace: "sandbox-system",
-				Annotations: map[string]string{
-					agentsv1alpha1.AnnotationOwner: "user-2",
-				},
-			},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				VolumeName:  "pv-3",
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("3Gi"),
-					},
-				},
-			},
-		}
-		require.NoError(t, fakeClient.Create(context.Background(), pvc1))
-		require.NoError(t, fakeClient.Create(context.Background(), pvc2))
-		require.NoError(t, fakeClient.Create(context.Background(), pvc3))
-
-		opts := infra.ListVolumesOptions{
-			Namespace: "sandbox-system",
+			Namespace: "ns1",
+			VolumeID:  "pvc-del-blocked",
 			UserID:    "user-1",
+			Force:     false,
 		}
-		volumes, err := i.ListVolumes(context.Background(), opts)
-		require.NoError(t, err)
-		assert.Len(t, volumes, 2)
-		names := make(map[string]bool)
-		for _, v := range volumes {
-			names[v.Name] = true
-		}
-		assert.True(t, names["vol-1"])
-		assert.True(t, names["vol-2"])
-	})
+		_, err := i.DeleteVolume(context.Background(), opts)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "volume is mounted by")
 
-	t.Run("list volumes returns empty for user with no volumes", func(t *testing.T) {
-		opts := infra.ListVolumesOptions{
-			Namespace: "sandbox-system",
-			UserID:    "user-no-volumes",
-		}
-		volumes, err := i.ListVolumes(context.Background(), opts)
+		// Deleting with Force=true should succeed
+		opts.Force = true
+		res, err := i.DeleteVolume(context.Background(), opts)
 		require.NoError(t, err)
-		assert.Len(t, volumes, 0)
+		assert.Contains(t, res.AffectedSandboxIDs, "sbx1")
+		assert.True(t, res.ForcedDelete)
 	})
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/volume_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/volume_test.go
@@ -324,7 +324,7 @@ func TestDeleteVolume(t *testing.T) {
 		opts.Force = true
 		res, err := i.DeleteVolume(context.Background(), opts)
 		require.NoError(t, err)
-		assert.Contains(t, res.AffectedSandboxIDs, "sbx1")
+		assert.Contains(t, res.AffectedSandboxIDs, "ns1--sbx1")
 		assert.True(t, res.ForcedDelete)
 	})
 }

--- a/pkg/sandbox-manager/infra/types.go
+++ b/pkg/sandbox-manager/infra/types.go
@@ -180,6 +180,47 @@ func sanitizeErrorMessage(err error) string {
 	return replacer.Replace(err.Error())
 }
 
+// RegisterVolumeOptions contains the parameters for registering a pre-provisioned PV as a named volume.
+type RegisterVolumeOptions struct {
+	Namespace string
+	Name      string
+	PvName    string
+	SizeGB    int
+}
+
+// ListVolumesOptions contains the parameters for listing volumes in a namespace.
+type ListVolumesOptions struct {
+	Namespace string
+}
+
+// GetVolumeOptions contains the parameters for retrieving a single volume.
+type GetVolumeOptions struct {
+	Namespace string
+	VolumeID  string // = pvName
+}
+
+// DeleteVolumeOptions contains the parameters for unregistering a volume.
+type DeleteVolumeOptions struct {
+	Namespace string
+	VolumeID  string
+	Force     bool
+}
+
+// VolumeInfo holds the metadata of a registered volume.
+type VolumeInfo struct {
+	VolumeID  string
+	Name      string
+	PvName    string
+	SizeGB    int
+	CreatedAt string
+}
+
+// DeleteVolumeResult holds the outcome of a DeleteVolume operation.
+type DeleteVolumeResult struct {
+	AffectedSandboxIDs []string
+	ForcedDelete       bool
+}
+
 type CloneMetrics struct {
 	Retries       int
 	Wait          time.Duration

--- a/pkg/sandbox-manager/infra/types.go
+++ b/pkg/sandbox-manager/infra/types.go
@@ -207,6 +207,7 @@ func sanitizeErrorMessage(err error) string {
 	return replacer.Replace(err.Error())
 }
 
+
 type CloneMetrics struct {
 	Retries       int
 	Wait          time.Duration

--- a/pkg/sandbox-manager/volume/volume.go
+++ b/pkg/sandbox-manager/volume/volume.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+)
+
+const (
+	resultSuccess = "success"
+	resultFailure = "failure"
+)
+
+var (
+	volumeOperationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "volume_operation_total",
+			Help:        "Total number of volume operations",
+			ConstLabels: prometheus.Labels{"source": "e2b"},
+		},
+		[]string{"namespace", "operation", "result"},
+	)
+
+	volumeOperationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:        "volume_operation_duration_seconds",
+			Help:        "Duration of volume operations in seconds",
+			ConstLabels: prometheus.Labels{"source": "e2b"},
+			Buckets:     prometheus.ExponentialBuckets(0.001, 2, 12),
+		},
+		[]string{"namespace", "operation"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(volumeOperationTotal, volumeOperationDuration)
+}
+
+// Manager wraps the Infrastructure interface and records Prometheus metrics on every call.
+type Manager struct {
+	infra infra.Infrastructure
+}
+
+// NewManager creates a new Manager backed by the given Infrastructure.
+func NewManager(i infra.Infrastructure) *Manager {
+	return &Manager{infra: i}
+}
+
+// CreateVolume creates a new persistent volume (PVC) for the user.
+func (m *Manager) CreateVolume(ctx context.Context, opts infra.CreateVolumeOptions) (infra.VolumeInfo, error) {
+	log := klog.FromContext(ctx)
+	start := time.Now()
+
+	info, err := m.infra.CreateVolume(ctx, opts)
+
+	result := resultSuccess
+	if err != nil {
+		result = resultFailure
+		log.Error(err, "failed to create volume", "namespace", opts.Namespace, "name", opts.Name)
+	} else {
+		log.V(5).Info("volume created", "namespace", opts.Namespace, "name", opts.Name, "volumeID", info.VolumeID)
+	}
+
+	volumeOperationDuration.WithLabelValues(opts.Namespace, "create").Observe(time.Since(start).Seconds())
+	volumeOperationTotal.WithLabelValues(opts.Namespace, "create", result).Inc()
+
+	return info, err
+}
+
+// ListVolumes returns all volumes registered under the given namespace.
+func (m *Manager) ListVolumes(ctx context.Context, opts infra.ListVolumesOptions) ([]infra.VolumeInfo, error) {
+	log := klog.FromContext(ctx)
+	start := time.Now()
+
+	volumes, err := m.infra.ListVolumes(ctx, opts)
+
+	result := resultSuccess
+	if err != nil {
+		result = resultFailure
+		log.Error(err, "failed to list volumes", "namespace", opts.Namespace)
+	} else {
+		log.V(5).Info("volumes listed", "namespace", opts.Namespace, "count", len(volumes))
+	}
+
+	volumeOperationDuration.WithLabelValues(opts.Namespace, "list").Observe(time.Since(start).Seconds())
+	volumeOperationTotal.WithLabelValues(opts.Namespace, "list", result).Inc()
+
+	return volumes, err
+}
+
+// GetVolume returns metadata for a single volume by its ID within the given namespace.
+func (m *Manager) GetVolume(ctx context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error) {
+	log := klog.FromContext(ctx)
+	start := time.Now()
+
+	info, err := m.infra.GetVolume(ctx, opts)
+
+	result := resultSuccess
+	if err != nil {
+		result = resultFailure
+		log.Error(err, "failed to get volume", "namespace", opts.Namespace, "volumeID", opts.VolumeID)
+	} else {
+		log.V(5).Info("volume retrieved", "namespace", opts.Namespace, "volumeID", opts.VolumeID)
+	}
+
+	volumeOperationDuration.WithLabelValues(opts.Namespace, "get").Observe(time.Since(start).Seconds())
+	volumeOperationTotal.WithLabelValues(opts.Namespace, "get", result).Inc()
+
+	return info, err
+}
+
+// DeleteVolume unregisters a volume. If force is false and the volume is mounted,
+// it returns a conflict error. If force is true, the volume is removed regardless.
+func (m *Manager) DeleteVolume(ctx context.Context, opts infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error) {
+	log := klog.FromContext(ctx)
+	start := time.Now()
+
+	deleteResult, err := m.infra.DeleteVolume(ctx, opts)
+
+	result := resultSuccess
+	if err != nil {
+		result = resultFailure
+		log.Error(err, "failed to delete volume", "namespace", opts.Namespace, "volumeID", opts.VolumeID, "force", opts.Force)
+	} else {
+		log.V(5).Info("volume deleted", "namespace", opts.Namespace, "volumeID", opts.VolumeID, "forced", deleteResult.ForcedDelete)
+	}
+
+	volumeOperationDuration.WithLabelValues(opts.Namespace, "unregister").Observe(time.Since(start).Seconds())
+	volumeOperationTotal.WithLabelValues(opts.Namespace, "unregister", result).Inc()
+
+	return deleteResult, err
+}

--- a/pkg/sandbox-manager/volume/volume.go
+++ b/pkg/sandbox-manager/volume/volume.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+)
+
+const (
+	resultSuccess = "success"
+	resultFailure = "failure"
+)
+
+var (
+	volumeOperationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "volume_operation_total",
+			Help:        "Total number of volume operations",
+			ConstLabels: prometheus.Labels{"source": "e2b"},
+		},
+		[]string{"namespace", "operation", "result"},
+	)
+
+	volumeOperationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:        "volume_operation_duration_seconds",
+			Help:        "Duration of volume operations in seconds",
+			ConstLabels: prometheus.Labels{"source": "e2b"},
+			Buckets:     prometheus.ExponentialBuckets(0.001, 2, 12),
+		},
+		[]string{"namespace", "operation"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(volumeOperationTotal, volumeOperationDuration)
+}
+
+// Manager wraps the Infrastructure interface and records Prometheus metrics on every call.
+type Manager struct {
+	infra infra.Infrastructure
+}
+
+// NewManager creates a new Manager backed by the given Infrastructure.
+func NewManager(i infra.Infrastructure) *Manager {
+	return &Manager{infra: i}
+}
+
+// RegisterVolume registers a pre-provisioned PV as a named volume under the given namespace.
+func (m *Manager) RegisterVolume(ctx context.Context, opts infra.RegisterVolumeOptions) (infra.VolumeInfo, error) {
+	log := klog.FromContext(ctx)
+	start := time.Now()
+
+	info, err := m.infra.RegisterVolume(ctx, opts)
+
+	result := resultSuccess
+	if err != nil {
+		result = resultFailure
+		log.Error(err, "failed to register volume", "namespace", opts.Namespace, "pvName", opts.PvName, "name", opts.Name)
+	} else {
+		log.V(5).Info("volume registered", "namespace", opts.Namespace, "pvName", opts.PvName, "volumeID", info.VolumeID)
+	}
+
+	volumeOperationDuration.WithLabelValues(opts.Namespace, "register").Observe(time.Since(start).Seconds())
+	volumeOperationTotal.WithLabelValues(opts.Namespace, "register", result).Inc()
+
+	return info, err
+}
+
+// ListVolumes returns all volumes registered under the given namespace.
+func (m *Manager) ListVolumes(ctx context.Context, opts infra.ListVolumesOptions) ([]infra.VolumeInfo, error) {
+	log := klog.FromContext(ctx)
+	start := time.Now()
+
+	volumes, err := m.infra.ListVolumes(ctx, opts)
+
+	result := resultSuccess
+	if err != nil {
+		result = resultFailure
+		log.Error(err, "failed to list volumes", "namespace", opts.Namespace)
+	} else {
+		log.V(5).Info("volumes listed", "namespace", opts.Namespace, "count", len(volumes))
+	}
+
+	volumeOperationDuration.WithLabelValues(opts.Namespace, "list").Observe(time.Since(start).Seconds())
+	volumeOperationTotal.WithLabelValues(opts.Namespace, "list", result).Inc()
+
+	return volumes, err
+}
+
+// GetVolume returns metadata for a single volume by its ID within the given namespace.
+func (m *Manager) GetVolume(ctx context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error) {
+	log := klog.FromContext(ctx)
+	start := time.Now()
+
+	info, err := m.infra.GetVolume(ctx, opts)
+
+	result := resultSuccess
+	if err != nil {
+		result = resultFailure
+		log.Error(err, "failed to get volume", "namespace", opts.Namespace, "volumeID", opts.VolumeID)
+	} else {
+		log.V(5).Info("volume retrieved", "namespace", opts.Namespace, "volumeID", opts.VolumeID)
+	}
+
+	volumeOperationDuration.WithLabelValues(opts.Namespace, "get").Observe(time.Since(start).Seconds())
+	volumeOperationTotal.WithLabelValues(opts.Namespace, "get", result).Inc()
+
+	return info, err
+}
+
+// DeleteVolume unregisters a volume. If force is false and the volume is mounted,
+// it returns a conflict error. If force is true, the volume is removed regardless.
+func (m *Manager) DeleteVolume(ctx context.Context, opts infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error) {
+	log := klog.FromContext(ctx)
+	start := time.Now()
+
+	deleteResult, err := m.infra.DeleteVolume(ctx, opts)
+
+	result := resultSuccess
+	if err != nil {
+		result = resultFailure
+		log.Error(err, "failed to delete volume", "namespace", opts.Namespace, "volumeID", opts.VolumeID, "force", opts.Force)
+	} else {
+		log.V(5).Info("volume deleted", "namespace", opts.Namespace, "volumeID", opts.VolumeID, "forced", deleteResult.ForcedDelete)
+	}
+
+	volumeOperationDuration.WithLabelValues(opts.Namespace, "unregister").Observe(time.Since(start).Seconds())
+	volumeOperationTotal.WithLabelValues(opts.Namespace, "unregister", result).Inc()
+
+	return deleteResult, err
+}

--- a/pkg/sandbox-manager/volume/volume_test.go
+++ b/pkg/sandbox-manager/volume/volume_test.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+)
+
+// fakeInfra implements infra.Infrastructure for the volume methods only.
+// Non-volume methods are provided by the embedded interface; calling them panics.
+type fakeInfra struct {
+	infra.Infrastructure // embed nil — panics if non-volume methods are called
+	createFn             func(ctx context.Context, opts infra.CreateVolumeOptions) (infra.VolumeInfo, error)
+	listFn               func(ctx context.Context, opts infra.ListVolumesOptions) ([]infra.VolumeInfo, error)
+	getFn                func(ctx context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error)
+	deleteFn             func(ctx context.Context, opts infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error)
+}
+
+func (f *fakeInfra) CreateVolume(ctx context.Context, opts infra.CreateVolumeOptions) (infra.VolumeInfo, error) {
+	return f.createFn(ctx, opts)
+}
+
+func (f *fakeInfra) ListVolumes(ctx context.Context, opts infra.ListVolumesOptions) ([]infra.VolumeInfo, error) {
+	return f.listFn(ctx, opts)
+}
+
+func (f *fakeInfra) GetVolume(ctx context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error) {
+	return f.getFn(ctx, opts)
+}
+
+func (f *fakeInfra) DeleteVolume(ctx context.Context, opts infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error) {
+	return f.deleteFn(ctx, opts)
+}
+
+// ---------------------------------------------------------------------------
+// CreateVolume
+// ---------------------------------------------------------------------------
+
+func TestManager_CreateVolume(t *testing.T) {
+	tests := []struct {
+		name        string
+		infraReturn infra.VolumeInfo
+		infraErr    error
+		opts        infra.CreateVolumeOptions
+		expectError string
+	}{
+		{
+			name: "success — delegates to infra and returns VolumeInfo",
+			infraReturn: infra.VolumeInfo{
+				VolumeID: "pv-001",
+				Name:     "my-vol",
+				PvName:   "pv-001",
+				SizeGB:   10,
+			},
+			infraErr:    nil,
+			opts:        infra.CreateVolumeOptions{Namespace: "team-a", Name: "my-vol"},
+			expectError: "",
+		},
+		{
+			name:        "failure — infra error is propagated as-is",
+			infraReturn: infra.VolumeInfo{},
+			infraErr:    errors.New("conflict: pvc already exists"),
+			opts:        infra.CreateVolumeOptions{Namespace: "team-a", Name: "my-vol"},
+			expectError: "conflict: pvc already exists",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calledOpts infra.CreateVolumeOptions
+			fake := &fakeInfra{
+				createFn: func(_ context.Context, opts infra.CreateVolumeOptions) (infra.VolumeInfo, error) {
+					calledOpts = opts
+					return tt.infraReturn, tt.infraErr
+				},
+			}
+			mgr := NewManager(fake)
+
+			info, err := mgr.CreateVolume(context.Background(), tt.opts)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.infraReturn, info)
+				// Verify opts were forwarded correctly
+				assert.Equal(t, tt.opts, calledOpts)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListVolumes
+// ---------------------------------------------------------------------------
+
+func TestManager_ListVolumes(t *testing.T) {
+	tests := []struct {
+		name        string
+		infraReturn []infra.VolumeInfo
+		infraErr    error
+		opts        infra.ListVolumesOptions
+		expectError string
+	}{
+		{
+			name: "success — returns volume list from infra",
+			infraReturn: []infra.VolumeInfo{
+				{VolumeID: "pv-1", Name: "vol-1", PvName: "pv-1", SizeGB: 5},
+				{VolumeID: "pv-2", Name: "vol-2", PvName: "pv-2", SizeGB: 10},
+			},
+			infraErr:    nil,
+			opts:        infra.ListVolumesOptions{Namespace: "team-b"},
+			expectError: "",
+		},
+		{
+			name:        "failure — infra error is propagated as-is",
+			infraReturn: nil,
+			infraErr:    errors.New("internal: cache unavailable"),
+			opts:        infra.ListVolumesOptions{Namespace: "team-b"},
+			expectError: "internal: cache unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calledOpts infra.ListVolumesOptions
+			fake := &fakeInfra{
+				listFn: func(_ context.Context, opts infra.ListVolumesOptions) ([]infra.VolumeInfo, error) {
+					calledOpts = opts
+					return tt.infraReturn, tt.infraErr
+				},
+			}
+			mgr := NewManager(fake)
+
+			volumes, err := mgr.ListVolumes(context.Background(), tt.opts)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.infraReturn, volumes)
+				assert.Equal(t, tt.opts, calledOpts)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetVolume
+// ---------------------------------------------------------------------------
+
+func TestManager_GetVolume(t *testing.T) {
+	tests := []struct {
+		name        string
+		infraReturn infra.VolumeInfo
+		infraErr    error
+		opts        infra.GetVolumeOptions
+		expectError string
+	}{
+		{
+			name: "success — returns VolumeInfo from infra",
+			infraReturn: infra.VolumeInfo{
+				VolumeID:  "pv-abc",
+				Name:      "my-data",
+				PvName:    "pv-abc",
+				SizeGB:    20,
+			},
+			infraErr:    nil,
+			opts:        infra.GetVolumeOptions{Namespace: "team-c", VolumeID: "pv-abc"},
+			expectError: "",
+		},
+		{
+			name:        "failure — not found error propagated as-is",
+			infraReturn: infra.VolumeInfo{},
+			infraErr:    errors.New("not found: volume pv-xyz does not exist"),
+			opts:        infra.GetVolumeOptions{Namespace: "team-c", VolumeID: "pv-xyz"},
+			expectError: "not found: volume pv-xyz does not exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calledOpts infra.GetVolumeOptions
+			fake := &fakeInfra{
+				getFn: func(_ context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error) {
+					calledOpts = opts
+					return tt.infraReturn, tt.infraErr
+				},
+			}
+			mgr := NewManager(fake)
+
+			info, err := mgr.GetVolume(context.Background(), tt.opts)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.infraReturn, info)
+				assert.Equal(t, tt.opts, calledOpts)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeleteVolume
+// ---------------------------------------------------------------------------
+
+func TestManager_DeleteVolume(t *testing.T) {
+	tests := []struct {
+		name        string
+		infraReturn infra.DeleteVolumeResult
+		infraErr    error
+		opts        infra.DeleteVolumeOptions
+		expectError string
+	}{
+		{
+			name: "success — non-forced delete with no mounts",
+			infraReturn: infra.DeleteVolumeResult{
+				AffectedSandboxIDs: nil,
+				ForcedDelete:       false,
+			},
+			infraErr:    nil,
+			opts:        infra.DeleteVolumeOptions{Namespace: "team-d", VolumeID: "pv-empty", Force: false},
+			expectError: "",
+		},
+		{
+			name: "success — forced delete with mounted sandboxes",
+			infraReturn: infra.DeleteVolumeResult{
+				AffectedSandboxIDs: []string{"sbx-001", "sbx-002"},
+				ForcedDelete:       true,
+			},
+			infraErr:    nil,
+			opts:        infra.DeleteVolumeOptions{Namespace: "team-d", VolumeID: "pv-mounted", Force: true},
+			expectError: "",
+		},
+		{
+			name:        "failure — conflict when mounted without force",
+			infraReturn: infra.DeleteVolumeResult{},
+			infraErr:    errors.New("conflict: volume is currently mounted by sbx-001"),
+			opts:        infra.DeleteVolumeOptions{Namespace: "team-d", VolumeID: "pv-mounted", Force: false},
+			expectError: "conflict: volume is currently mounted by sbx-001",
+		},
+		{
+			name:        "failure — not found error propagated as-is",
+			infraReturn: infra.DeleteVolumeResult{},
+			infraErr:    errors.New("not found: volume pv-gone does not exist"),
+			opts:        infra.DeleteVolumeOptions{Namespace: "team-d", VolumeID: "pv-gone", Force: false},
+			expectError: "not found: volume pv-gone does not exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calledOpts infra.DeleteVolumeOptions
+			fake := &fakeInfra{
+				deleteFn: func(_ context.Context, opts infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error) {
+					calledOpts = opts
+					return tt.infraReturn, tt.infraErr
+				},
+			}
+			mgr := NewManager(fake)
+
+			result, err := mgr.DeleteVolume(context.Background(), tt.opts)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.infraReturn, result)
+				assert.Equal(t, tt.opts, calledOpts)
+			}
+		})
+	}
+}

--- a/pkg/sandbox-manager/volume/volume_test.go
+++ b/pkg/sandbox-manager/volume/volume_test.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+)
+
+// fakeInfra implements infra.Infrastructure for the volume methods only.
+// Non-volume methods are provided by the embedded interface; calling them panics.
+type fakeInfra struct {
+	infra.Infrastructure // embed nil — panics if non-volume methods are called
+	registerFn           func(ctx context.Context, opts infra.RegisterVolumeOptions) (infra.VolumeInfo, error)
+	listFn               func(ctx context.Context, opts infra.ListVolumesOptions) ([]infra.VolumeInfo, error)
+	getFn                func(ctx context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error)
+	deleteFn             func(ctx context.Context, opts infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error)
+}
+
+func (f *fakeInfra) RegisterVolume(ctx context.Context, opts infra.RegisterVolumeOptions) (infra.VolumeInfo, error) {
+	return f.registerFn(ctx, opts)
+}
+
+func (f *fakeInfra) ListVolumes(ctx context.Context, opts infra.ListVolumesOptions) ([]infra.VolumeInfo, error) {
+	return f.listFn(ctx, opts)
+}
+
+func (f *fakeInfra) GetVolume(ctx context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error) {
+	return f.getFn(ctx, opts)
+}
+
+func (f *fakeInfra) DeleteVolume(ctx context.Context, opts infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error) {
+	return f.deleteFn(ctx, opts)
+}
+
+// ---------------------------------------------------------------------------
+// RegisterVolume
+// ---------------------------------------------------------------------------
+
+func TestManager_RegisterVolume(t *testing.T) {
+	tests := []struct {
+		name        string
+		infraReturn infra.VolumeInfo
+		infraErr    error
+		opts        infra.RegisterVolumeOptions
+		expectError string
+	}{
+		{
+			name: "success — delegates to infra and returns VolumeInfo",
+			infraReturn: infra.VolumeInfo{
+				VolumeID: "pv-001",
+				Name:     "my-vol",
+				PvName:   "pv-001",
+				SizeGB:   10,
+			},
+			infraErr:    nil,
+			opts:        infra.RegisterVolumeOptions{Namespace: "team-a", Name: "my-vol", PvName: "pv-001", SizeGB: 10},
+			expectError: "",
+		},
+		{
+			name:        "failure — infra error is propagated as-is",
+			infraReturn: infra.VolumeInfo{},
+			infraErr:    errors.New("conflict: pv already registered"),
+			opts:        infra.RegisterVolumeOptions{Namespace: "team-a", Name: "my-vol", PvName: "pv-001", SizeGB: 10},
+			expectError: "conflict: pv already registered",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calledOpts infra.RegisterVolumeOptions
+			fake := &fakeInfra{
+				registerFn: func(_ context.Context, opts infra.RegisterVolumeOptions) (infra.VolumeInfo, error) {
+					calledOpts = opts
+					return tt.infraReturn, tt.infraErr
+				},
+			}
+			mgr := NewManager(fake)
+
+			info, err := mgr.RegisterVolume(context.Background(), tt.opts)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.infraReturn, info)
+				// Verify opts were forwarded correctly
+				assert.Equal(t, tt.opts, calledOpts)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListVolumes
+// ---------------------------------------------------------------------------
+
+func TestManager_ListVolumes(t *testing.T) {
+	tests := []struct {
+		name        string
+		infraReturn []infra.VolumeInfo
+		infraErr    error
+		opts        infra.ListVolumesOptions
+		expectError string
+	}{
+		{
+			name: "success — returns volume list from infra",
+			infraReturn: []infra.VolumeInfo{
+				{VolumeID: "pv-1", Name: "vol-1", PvName: "pv-1", SizeGB: 5},
+				{VolumeID: "pv-2", Name: "vol-2", PvName: "pv-2", SizeGB: 10},
+			},
+			infraErr:    nil,
+			opts:        infra.ListVolumesOptions{Namespace: "team-b"},
+			expectError: "",
+		},
+		{
+			name:        "failure — infra error is propagated as-is",
+			infraReturn: nil,
+			infraErr:    errors.New("internal: cache unavailable"),
+			opts:        infra.ListVolumesOptions{Namespace: "team-b"},
+			expectError: "internal: cache unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calledOpts infra.ListVolumesOptions
+			fake := &fakeInfra{
+				listFn: func(_ context.Context, opts infra.ListVolumesOptions) ([]infra.VolumeInfo, error) {
+					calledOpts = opts
+					return tt.infraReturn, tt.infraErr
+				},
+			}
+			mgr := NewManager(fake)
+
+			volumes, err := mgr.ListVolumes(context.Background(), tt.opts)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.infraReturn, volumes)
+				assert.Equal(t, tt.opts, calledOpts)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetVolume
+// ---------------------------------------------------------------------------
+
+func TestManager_GetVolume(t *testing.T) {
+	tests := []struct {
+		name        string
+		infraReturn infra.VolumeInfo
+		infraErr    error
+		opts        infra.GetVolumeOptions
+		expectError string
+	}{
+		{
+			name: "success — returns VolumeInfo from infra",
+			infraReturn: infra.VolumeInfo{
+				VolumeID:  "pv-abc",
+				Name:      "my-data",
+				PvName:    "pv-abc",
+				SizeGB:    20,
+			},
+			infraErr:    nil,
+			opts:        infra.GetVolumeOptions{Namespace: "team-c", VolumeID: "pv-abc"},
+			expectError: "",
+		},
+		{
+			name:        "failure — not found error propagated as-is",
+			infraReturn: infra.VolumeInfo{},
+			infraErr:    errors.New("not found: volume pv-xyz does not exist"),
+			opts:        infra.GetVolumeOptions{Namespace: "team-c", VolumeID: "pv-xyz"},
+			expectError: "not found: volume pv-xyz does not exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calledOpts infra.GetVolumeOptions
+			fake := &fakeInfra{
+				getFn: func(_ context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error) {
+					calledOpts = opts
+					return tt.infraReturn, tt.infraErr
+				},
+			}
+			mgr := NewManager(fake)
+
+			info, err := mgr.GetVolume(context.Background(), tt.opts)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.infraReturn, info)
+				assert.Equal(t, tt.opts, calledOpts)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeleteVolume
+// ---------------------------------------------------------------------------
+
+func TestManager_DeleteVolume(t *testing.T) {
+	tests := []struct {
+		name        string
+		infraReturn infra.DeleteVolumeResult
+		infraErr    error
+		opts        infra.DeleteVolumeOptions
+		expectError string
+	}{
+		{
+			name: "success — non-forced delete with no mounts",
+			infraReturn: infra.DeleteVolumeResult{
+				AffectedSandboxIDs: nil,
+				ForcedDelete:       false,
+			},
+			infraErr:    nil,
+			opts:        infra.DeleteVolumeOptions{Namespace: "team-d", VolumeID: "pv-empty", Force: false},
+			expectError: "",
+		},
+		{
+			name: "success — forced delete with mounted sandboxes",
+			infraReturn: infra.DeleteVolumeResult{
+				AffectedSandboxIDs: []string{"sbx-001", "sbx-002"},
+				ForcedDelete:       true,
+			},
+			infraErr:    nil,
+			opts:        infra.DeleteVolumeOptions{Namespace: "team-d", VolumeID: "pv-mounted", Force: true},
+			expectError: "",
+		},
+		{
+			name:        "failure — conflict when mounted without force",
+			infraReturn: infra.DeleteVolumeResult{},
+			infraErr:    errors.New("conflict: volume is currently mounted by sbx-001"),
+			opts:        infra.DeleteVolumeOptions{Namespace: "team-d", VolumeID: "pv-mounted", Force: false},
+			expectError: "conflict: volume is currently mounted by sbx-001",
+		},
+		{
+			name:        "failure — not found error propagated as-is",
+			infraReturn: infra.DeleteVolumeResult{},
+			infraErr:    errors.New("not found: volume pv-gone does not exist"),
+			opts:        infra.DeleteVolumeOptions{Namespace: "team-d", VolumeID: "pv-gone", Force: false},
+			expectError: "not found: volume pv-gone does not exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calledOpts infra.DeleteVolumeOptions
+			fake := &fakeInfra{
+				deleteFn: func(_ context.Context, opts infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error) {
+					calledOpts = opts
+					return tt.infraReturn, tt.infraErr
+				},
+			}
+			mgr := NewManager(fake)
+
+			result, err := mgr.DeleteVolume(context.Background(), tt.opts)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.infraReturn, result)
+				assert.Equal(t, tt.opts, calledOpts)
+			}
+		})
+	}
+}

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/sandbox-manager/logs"
+	volumepkg "github.com/openkruise/agents/pkg/sandbox-manager/volume"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 )
@@ -67,6 +68,7 @@ type Controller struct {
 	domain          string
 	manager         *sandboxmanager.SandboxManager
 	keys            keys.KeyStorage
+	volumeManager   volumeManagerInterface
 }
 
 // NewController creates a new E2B Controller
@@ -116,6 +118,7 @@ func (sc *Controller) Init() error {
 	}
 
 	sc.manager = sandboxManager
+	sc.volumeManager = volumepkg.NewManager(sandboxManager.GetInfra())
 	sc.cache = sandboxManager.GetInfra().GetCache()
 	sc.storageRegistry = storages.NewStorageProvider()
 	sc.registerRoutes()

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/sandbox-manager/logs"
+	volumepkg "github.com/openkruise/agents/pkg/sandbox-manager/volume"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 )
@@ -66,6 +67,7 @@ type Controller struct {
 	domain          string
 	manager         *sandboxmanager.SandboxManager
 	keys            keys.KeyStorage
+	volumeManager   volumeManagerInterface
 }
 
 // NewController creates a new E2B Controller
@@ -114,6 +116,7 @@ func (sc *Controller) Init() error {
 	}
 
 	sc.manager = sandboxManager
+	sc.volumeManager = volumepkg.NewManager(sandboxManager.GetInfra())
 	sc.cache = sandboxManager.GetInfra().GetCache()
 	sc.storageRegistry = storages.NewStorageProvider()
 	sc.registerRoutes()

--- a/pkg/servers/e2b/core_test.go
+++ b/pkg/servers/e2b/core_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
+	volumepkg "github.com/openkruise/agents/pkg/sandbox-manager/volume"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
@@ -157,6 +158,7 @@ func setupWithMinResumeTimeoutAndQuota(t *testing.T, minResumeTimeout int, quota
 
 	controller.cache = cache
 	controller.manager = sandboxManager
+	controller.volumeManager = volumepkg.NewManager(sandboxManager.GetInfra())
 	controller.storageRegistry = storages.NewStorageProvider()
 	controller.registerRoutes()
 

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -143,8 +143,22 @@ func (sc *Controller) createSandboxWithClaim(ctx context.Context, request models
 	log := klog.FromContext(ctx)
 	claimStart := time.Now()
 	var accessToken string
+	// Resolve E2B volume_mounts before entering the claim pipeline.
+	namespace := sc.getNamespaceOfUser(user)
+	if len(request.E2BVolumeMounts) > 0 {
+		resolved, err := sc.resolveVolumeMounts(ctx, namespace, request.E2BVolumeMounts)
+		if err != nil {
+			return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
+				Code:    http.StatusBadRequest,
+				Message: err.Error(),
+			}
+		}
+		// Prepend resolved configs to the CSIMount extension list.
+		request.Extensions.CSIMount.MountConfigs = append(resolved, request.Extensions.CSIMount.MountConfigs...)
+	}
+
 	infraOpts := infra.ClaimSandboxOptions{
-		Namespace:    sc.getNamespaceOfUser(user),
+		Namespace:    namespace,
 		Template:     request.TemplateID,
 		User:         user.ID.String(),
 		ClaimTimeout: resolveServerTimeout(request.Extensions.TimeoutSeconds),
@@ -230,8 +244,21 @@ func (sc *Controller) createSandboxWithClone(ctx context.Context, request models
 		}
 	}
 
+	// Resolve E2B volume_mounts before entering the clone pipeline.
+	namespace := sc.getNamespaceOfUser(user)
+	if len(request.E2BVolumeMounts) > 0 {
+		resolved, err := sc.resolveVolumeMounts(ctx, namespace, request.E2BVolumeMounts)
+		if err != nil {
+			return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
+				Code:    http.StatusBadRequest,
+				Message: err.Error(),
+			}
+		}
+		request.Extensions.CSIMount.MountConfigs = append(resolved, request.Extensions.CSIMount.MountConfigs...)
+	}
+
 	infraOpts := infra.CloneSandboxOptions{
-		Namespace:    sc.getNamespaceOfUser(user),
+		Namespace:    namespace,
 		User:         user.ID.String(),
 		CheckPointID: request.TemplateID,
 		CloneTimeout: resolveServerTimeout(request.Extensions.TimeoutSeconds),
@@ -304,6 +331,16 @@ func (sc *Controller) parseCreateSandboxRequest(r *http.Request) (models.NewSand
 				PvName:    vm.Name,
 				MountPath: vm.Path,
 			})
+		}
+	}
+
+	// Validate E2BVolumeMounts
+	if len(request.E2BVolumeMounts) > 0 {
+		if err := models.ValidateE2BVolumeMounts(request.E2BVolumeMounts); err != nil {
+			return request, &web.ApiError{
+				Code:    http.StatusBadRequest,
+				Message: err.Error(),
+			}
 		}
 	}
 

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -111,8 +111,23 @@ func (sc *Controller) createSandboxWithClaim(ctx context.Context, request models
 	log := klog.FromContext(ctx)
 	claimStart := time.Now()
 	var accessToken string
+
+	// Resolve volume_mounts before entering the claim pipeline.
+	namespace := sc.getNamespaceOfUser(user)
+	if len(request.VolumeMounts) > 0 {
+		resolved, err := sc.resolveVolumeMounts(ctx, namespace, request.VolumeMounts)
+		if err != nil {
+			return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
+				Code:    http.StatusBadRequest,
+				Message: err.Error(),
+			}
+		}
+		// Prepend resolved configs to the CSIMount extension list.
+		request.Extensions.CSIMount.MountConfigs = append(resolved, request.Extensions.CSIMount.MountConfigs...)
+	}
+
 	opts := infra.ClaimSandboxOptions{
-		Namespace:    sc.getNamespaceOfUser(user),
+		Namespace:    namespace,
 		Template:     request.TemplateID,
 		User:         user.ID.String(),
 		ClaimTimeout: resolveServerTimeout(request.Extensions.TimeoutSeconds),
@@ -192,8 +207,21 @@ func (sc *Controller) createSandboxWithClone(ctx context.Context, request models
 		}
 	}
 
+	// Resolve volume_mounts before entering the clone pipeline.
+	namespace := sc.getNamespaceOfUser(user)
+	if len(request.VolumeMounts) > 0 {
+		resolved, err := sc.resolveVolumeMounts(ctx, namespace, request.VolumeMounts)
+		if err != nil {
+			return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
+				Code:    http.StatusBadRequest,
+				Message: err.Error(),
+			}
+		}
+		request.Extensions.CSIMount.MountConfigs = append(resolved, request.Extensions.CSIMount.MountConfigs...)
+	}
+
 	opts := infra.CloneSandboxOptions{
-		Namespace:    sc.getNamespaceOfUser(user),
+		Namespace:    namespace,
 		User:         user.ID.String(),
 		CheckPointID: request.TemplateID,
 		CloneTimeout: resolveServerTimeout(request.Extensions.TimeoutSeconds),

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -50,12 +50,13 @@ type Sandbox struct {
 
 // NewSandboxRequest represents a request to create a new sandbox
 type NewSandboxRequest struct {
-	TemplateID   string            `json:"templateID"`
-	Timeout      int               `json:"timeout,omitempty"`
-	AutoPause    bool              `json:"autoPause,omitempty"`
-	Metadata     map[string]string `json:"metadata,omitempty"`
-	EnvVars      EnvVars           `json:"envVars,omitempty"`
-	VolumeMounts []VolumeMount     `json:"volumeMounts,omitempty"`
+	TemplateID      string               `json:"templateID"`
+	Timeout         int                  `json:"timeout,omitempty"`
+	AutoPause       bool                 `json:"autoPause,omitempty"`
+	Metadata        map[string]string    `json:"metadata,omitempty"`
+	EnvVars         EnvVars              `json:"envVars,omitempty"`
+	VolumeMounts    []VolumeMount        `json:"volumeMounts,omitempty"`
+	E2BVolumeMounts []VolumeMountRequest `json:"volume_mounts,omitempty"`
 
 	Extensions NewSandboxRequestExtension `json:"-"`
 }

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -50,11 +50,12 @@ type Sandbox struct {
 
 // NewSandboxRequest represents a request to create a new sandbox
 type NewSandboxRequest struct {
-	TemplateID string            `json:"templateID"`
-	Timeout    int               `json:"timeout,omitempty"`
-	AutoPause  bool              `json:"autoPause,omitempty"`
-	Metadata   map[string]string `json:"metadata,omitempty"`
-	EnvVars    EnvVars           `json:"envVars,omitempty"`
+	TemplateID   string               `json:"templateID"`
+	Timeout      int                  `json:"timeout,omitempty"`
+	AutoPause    bool                 `json:"autoPause,omitempty"`
+	Metadata     map[string]string    `json:"metadata,omitempty"`
+	EnvVars      EnvVars              `json:"envVars,omitempty"`
+	VolumeMounts []VolumeMountRequest `json:"volume_mounts,omitempty"`
 
 	Extensions NewSandboxRequestExtension `json:"-"`
 }

--- a/pkg/servers/e2b/models/validation.go
+++ b/pkg/servers/e2b/models/validation.go
@@ -18,7 +18,7 @@ package models
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/openkruise/agents/api/v1alpha1"
@@ -39,8 +39,12 @@ func validateMountPoint(mountPoint string) error {
 		return fmt.Errorf("mount point contains invalid '..' path element")
 	}
 
-	// to parse the path, eliminating relative path symbols such as "." and ".."
-	cleanPath := filepath.Clean(mountPoint)
+	// Use path.Clean (POSIX semantics, always forward slash) so that the
+	// check works correctly on all host OSes including Windows.
+	// path.Clean eliminates "." components and collapses double slashes.
+	// If the cleaned path differs from the input the path contained relative
+	// elements (e.g. "/a/./b") that are not valid for a Linux mount target.
+	cleanPath := path.Clean(mountPoint)
 	if cleanPath != mountPoint {
 		return fmt.Errorf("mount point contains invalid path elements like '..' or '.'")
 	}

--- a/pkg/servers/e2b/models/validation.go
+++ b/pkg/servers/e2b/models/validation.go
@@ -18,7 +18,7 @@ package models
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/openkruise/agents/api/v1alpha1"
@@ -39,8 +39,12 @@ func validateMountPoint(mountPoint string) error {
 		return fmt.Errorf("mount point contains invalid '..' path element")
 	}
 
-	// to parse the path, eliminating relative path symbols such as "." and ".."
-	cleanPath := filepath.Clean(mountPoint)
+	// Use path.Clean (POSIX semantics, always forward slash) so that the
+	// check works correctly on all host OSes including Windows.
+	// path.Clean eliminates "." components and collapses double slashes.
+	// If the cleaned path differs from the input the path contained relative
+	// elements (e.g. "/a/./b") that are not valid for a Linux mount target.
+	cleanPath := path.Clean(mountPoint)
 	if cleanPath != mountPoint {
 		return fmt.Errorf("mount point contains invalid path elements like '..' or '.'")
 	}
@@ -63,6 +67,25 @@ func ValidateVolumeMounts(mounts []VolumeMount) error {
 			return fmt.Errorf("volumeMounts[%d].path %q is duplicated", i, vm.Path)
 		}
 		seen[vm.Path] = struct{}{}
+	}
+	return nil
+}
+
+// ValidateE2BVolumeMounts validates each E2B volume mount entry for required fields,
+// path format, and duplicate mount paths.
+func ValidateE2BVolumeMounts(mounts []VolumeMountRequest) error {
+	seen := make(map[string]struct{}, len(mounts))
+	for i, vm := range mounts {
+		if vm.VolumeID == "" {
+			return fmt.Errorf("volume_mounts[%d].volumeID cannot be empty", i)
+		}
+		if err := validateMountPoint(vm.MountPath); err != nil {
+			return fmt.Errorf("volume_mounts[%d].mountPath is invalid: %w", i, err)
+		}
+		if _, exists := seen[vm.MountPath]; exists {
+			return fmt.Errorf("volume_mounts[%d].mountPath %q is duplicated", i, vm.MountPath)
+		}
+		seen[vm.MountPath] = struct{}{}
 	}
 	return nil
 }

--- a/pkg/servers/e2b/models/volume.go
+++ b/pkg/servers/e2b/models/volume.go
@@ -25,7 +25,7 @@ import (
 // Volume represents an E2B-compatible volume.
 type Volume struct {
 	Name     string `json:"name"`     // PVC Name (e.g., harness-data)
-	VolumeID string `json:"volumeID"` // Underlying PV Name (e.g., d-bp1j7dd96qrivw02u7gy)
+	VolumeID string `json:"volumeID"` // Public E2B volume identifier, equal to the PVC name
 }
 
 // NewVolumeRequest represents the request to create a volume.

--- a/pkg/servers/e2b/models/volume.go
+++ b/pkg/servers/e2b/models/volume.go
@@ -41,3 +41,25 @@ type VolumeExtensions struct {
 	AccessMode       string
 	WaitBoundSeconds time.Duration
 }
+
+// VolumeResponse is returned by POST, GET, and as a list element.
+type VolumeResponse struct {
+	VolumeID  string `json:"volumeID"`
+	Name      string `json:"name"`
+	PvName    string `json:"pvName"`
+	SizeGB    int    `json:"sizeGB"`
+	CreatedAt string `json:"createdAt"`
+}
+
+// DeleteVolumeResponse is returned by DELETE /volumes/{volumeID}.
+type DeleteVolumeResponse struct {
+	Warning    string   `json:"warning,omitempty"`
+	AffectedBy []string `json:"affectedSandboxIDs,omitempty"`
+}
+
+// VolumeMountRequest is one entry in the POST /sandboxes volume_mounts array.
+type VolumeMountRequest struct {
+	VolumeID  string `json:"volumeID"`
+	MountPath string `json:"mountPath"`
+	ReadOnly  bool   `json:"readOnly,omitempty"`
+}

--- a/pkg/servers/e2b/models/volume.go
+++ b/pkg/servers/e2b/models/volume.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+// RegisterVolumeRequest is the POST /volumes request body.
+type RegisterVolumeRequest struct {
+	Name   string `json:"name"`
+	PvName string `json:"pvName"`
+	SizeGB int    `json:"sizeGB"`
+}
+
+// VolumeResponse is returned by POST, GET, and as a list element.
+type VolumeResponse struct {
+	VolumeID  string `json:"volumeID"`
+	Name      string `json:"name"`
+	PvName    string `json:"pvName"`
+	SizeGB    int    `json:"sizeGB"`
+	CreatedAt string `json:"createdAt"`
+}
+
+// DeleteVolumeResponse is returned by DELETE /volumes/{volumeID}.
+type DeleteVolumeResponse struct {
+	Warning    string   `json:"warning,omitempty"`
+	AffectedBy []string `json:"affectedSandboxIDs,omitempty"`
+}
+
+// VolumeMountRequest is one entry in the POST /sandboxes volume_mounts array.
+type VolumeMountRequest struct {
+	VolumeID  string `json:"volumeID"`
+	MountPath string `json:"mountPath"`
+	ReadOnly  bool   `json:"readOnly,omitempty"`
+}

--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -65,7 +65,6 @@ func (sc *Controller) registerRoutes() {
 	RegisterE2BRoute(sc.mux, http.MethodGet, "/browser/{sandboxID}/json/version", sc.BrowserUse, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodGet, "/debug", sc.Debug, sc.CheckApiKey)
 
-	// Volume management endpoints
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/volumes", sc.CreateVolume, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodGet, "/volumes", sc.ListVolumes, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodGet, "/volumes/{volumeID}", sc.GetVolume, sc.CheckApiKey)

--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -65,6 +65,12 @@ func (sc *Controller) registerRoutes() {
 	RegisterE2BRoute(sc.mux, http.MethodGet, "/browser/{sandboxID}/json/version", sc.BrowserUse, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodGet, "/debug", sc.Debug, sc.CheckApiKey)
 
+	// Volume management endpoints
+	RegisterE2BRoute(sc.mux, http.MethodPost, "/volumes", sc.RegisterVolume, sc.CheckApiKey)
+	RegisterE2BRoute(sc.mux, http.MethodGet, "/volumes", sc.ListVolumes, sc.CheckApiKey)
+	RegisterE2BRoute(sc.mux, http.MethodGet, "/volumes/{volumeID}", sc.GetVolume, sc.CheckApiKey)
+	RegisterE2BRoute(sc.mux, http.MethodDelete, "/volumes/{volumeID}", sc.DeleteVolume, sc.CheckApiKey)
+
 	// API Keys management endpoints
 	if sc.keyCfg != nil {
 		RegisterE2BRoute(sc.mux, http.MethodGet, "/teams", sc.ListTeams, sc.CheckApiKey)

--- a/pkg/servers/e2b/routes_test.go
+++ b/pkg/servers/e2b/routes_test.go
@@ -545,8 +545,8 @@ func TestCheckApiKey_VolumeOwnership(t *testing.T) {
 
 	// Create PVCs in each user's namespace.
 	// getNamespaceOfUser returns "" for admin (→ sandbox-system) and team.Name for others.
-	// The volumeID in the URL path maps to the PVC's VolumeName (PV name),
-	// which is indexed by cache.IndexVolumeName.
+	// The volumeID in the URL path maps to the PVC name (public E2B identifier).
+	// The bound PV is an internal implementation detail exposed via VolumeResponse.pvName.
 
 	// PVC owned by regular user in regular-team namespace
 	pvcOwnedByRegular := &corev1.PersistentVolumeClaim{
@@ -595,30 +595,30 @@ func TestCheckApiKey_VolumeOwnership(t *testing.T) {
 		{
 			name:         "owner can access own volume",
 			apiKeyHeader: regularUser.Key,
-			volumeID:     "pv-regular-vol",
+			volumeID:     "pvc-regular-user",
 			expectError:  false,
 		},
 		{
 			name:         "admin can access admin-owned volume",
 			apiKeyHeader: InitKey,
-			volumeID:     "pv-admin-vol",
+			volumeID:     "pvc-admin-user",
 			expectError:  false,
 		},
 		{
 			name:         "non-owner cannot access volume in same namespace",
 			apiKeyHeader: anotherUser.Key,
-			volumeID:     "pv-regular-vol",
+			volumeID:     "pvc-regular-user",
 			expectError:  true,
 			expectedCode: http.StatusNotFound,
-			expectedMsg:  "Volume not found: pv-regular-vol",
+			expectedMsg:  "Volume not found: pvc-regular-user",
 		},
 		{
 			name:         "admin cannot access other user's volume in different namespace",
 			apiKeyHeader: InitKey,
-			volumeID:     "pv-regular-vol",
+			volumeID:     "pvc-regular-user",
 			expectError:  true,
 			expectedCode: http.StatusNotFound,
-			expectedMsg:  "Volume not found: pv-regular-vol",
+			expectedMsg:  "Volume not found: pvc-regular-user",
 		},
 		{
 			name:         "volume not found",

--- a/pkg/servers/e2b/volume.go
+++ b/pkg/servers/e2b/volume.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
@@ -38,17 +39,16 @@ import (
 	"github.com/openkruise/agents/pkg/servers/web"
 )
 
-// CreateVolume creates a new persistent volume for the user.
+// CreateVolume creates a new persistent volume (PVC) for the user.
 // Implementation: Creates a PVC and waits for it to bind to a PV.
-// Returns the volumeID (PV name) once binding is complete.
-func (sc *Controller) CreateVolume(r *http.Request) (web.ApiResponse[*models.Volume], *web.ApiError) {
+func (sc *Controller) CreateVolume(r *http.Request) (web.ApiResponse[*models.VolumeResponse], *web.ApiError) {
 	ctx := r.Context()
 	log := klog.FromContext(ctx)
 
 	// Get authenticated user & determine namespace
 	user := GetUserFromContext(ctx)
 	if user == nil {
-		return web.ApiResponse[*models.Volume]{}, &web.ApiError{
+		return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
 			Code:    http.StatusUnauthorized,
 			Message: "User is empty",
 		}
@@ -61,7 +61,7 @@ func (sc *Controller) CreateVolume(r *http.Request) (web.ApiResponse[*models.Vol
 	// Parse request body and headers
 	req, parseErr := sc.parseCreateVolumeRequest(ctx, r)
 	if parseErr != nil {
-		return web.ApiResponse[*models.Volume]{}, &web.ApiError{
+		return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
 			Code:    http.StatusBadRequest,
 			Message: parseErr.Error(),
 		}
@@ -81,23 +81,20 @@ func (sc *Controller) CreateVolume(r *http.Request) (web.ApiResponse[*models.Vol
 	if err != nil {
 		log.Error(err, "Failed to create volume", "name", req.Name, "namespace", namespace)
 		if managererrors.GetErrCode(err) == managererrors.ErrorNotAllowed {
-			return web.ApiResponse[*models.Volume]{}, &web.ApiError{
+			return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
 				Code:    http.StatusForbidden,
 				Message: "Permission denied",
 			}
 		}
-		return web.ApiResponse[*models.Volume]{}, &web.ApiError{
-			Code:    http.StatusInternalServerError,
+		return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
+			Code:    mapVolumeErrorToHTTP(managererrors.GetErrCode(err)),
 			Message: fmt.Sprintf("Failed to create volume: %v", err),
 		}
 	}
 	log.Info("Volume created", "name", volumeInfo.Name, "namespace", namespace, "size", req.Extensions.StorageSize)
-	return web.ApiResponse[*models.Volume]{
+	return web.ApiResponse[*models.VolumeResponse]{
 		Code: http.StatusCreated,
-		Body: &models.Volume{
-			Name:     volumeInfo.Name,
-			VolumeID: volumeInfo.VolumeID,
-		},
+		Body: volumeInfoToResponse(volumeInfo),
 	}, nil
 }
 
@@ -173,146 +170,176 @@ func (sc *Controller) validateStorageClass(ctx context.Context, storageClassName
 	return nil
 }
 
-// ListVolumes lists all volumes for the authenticated user
-func (sc *Controller) ListVolumes(r *http.Request) (web.ApiResponse[[]*models.Volume], *web.ApiError) {
+// ListVolumes handles GET /volumes — lists all volumes in the caller's namespace.
+func (sc *Controller) ListVolumes(r *http.Request) (web.ApiResponse[[]models.VolumeResponse], *web.ApiError) {
 	ctx := r.Context()
 	log := klog.FromContext(ctx)
 
 	user := GetUserFromContext(ctx)
 	if user == nil {
-		return web.ApiResponse[[]*models.Volume]{}, &web.ApiError{
+		return web.ApiResponse[[]models.VolumeResponse]{}, &web.ApiError{
 			Code:    http.StatusUnauthorized,
-			Message: "User is empty",
+			Message: "User not found",
 		}
 	}
+
 	namespace := sc.getNamespaceOfUser(user)
-	if namespace == "" {
-		namespace = sc.systemNamespace
-	}
+	log.Info("list volumes request", "namespace", namespace)
 
 	volumes, err := sc.manager.GetInfra().ListVolumes(ctx, infra.ListVolumesOptions{
 		Namespace: namespace,
 		UserID:    user.ID.String(),
 	})
 	if err != nil {
-		log.Error(err, "Failed to list volumes", "namespace", namespace, "user", user.ID)
-		return web.ApiResponse[[]*models.Volume]{}, &web.ApiError{
-			Code:    http.StatusInternalServerError,
-			Message: "Failed to list volumes",
+		log.Error(err, "failed to list volumes")
+		return web.ApiResponse[[]models.VolumeResponse]{}, &web.ApiError{
+			Code:    mapVolumeErrorToHTTP(managererrors.GetErrCode(err)),
+			Message: err.Error(),
 		}
 	}
 
-	result := make([]*models.Volume, 0, len(volumes))
+	result := make([]models.VolumeResponse, 0, len(volumes))
 	for _, v := range volumes {
-		result = append(result, &models.Volume{
-			Name:     v.Name,
-			VolumeID: v.VolumeID,
-		})
+		result = append(result, *volumeInfoToResponse(v))
 	}
 
-	return web.ApiResponse[[]*models.Volume]{
+	return web.ApiResponse[[]models.VolumeResponse]{
 		Code: http.StatusOK,
 		Body: result,
 	}, nil
 }
 
-// GetVolume retrieves a volume by volumeID
-func (sc *Controller) GetVolume(r *http.Request) (web.ApiResponse[*models.Volume], *web.ApiError) {
+// GetVolume handles GET /volumes/{volumeID} — retrieves a single volume by ID.
+func (sc *Controller) GetVolume(r *http.Request) (web.ApiResponse[*models.VolumeResponse], *web.ApiError) {
 	ctx := r.Context()
 	log := klog.FromContext(ctx)
 
 	user := GetUserFromContext(ctx)
 	if user == nil {
-		return web.ApiResponse[*models.Volume]{}, &web.ApiError{
+		return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
 			Code:    http.StatusUnauthorized,
-			Message: "User is empty",
+			Message: "User not found",
 		}
-	}
-	namespace := sc.getNamespaceOfUser(user)
-	if namespace == "" {
-		namespace = sc.systemNamespace
 	}
 
 	volumeID := r.PathValue("volumeID")
-	if volumeID == "" {
-		return web.ApiResponse[*models.Volume]{}, &web.ApiError{
-			Code:    http.StatusBadRequest,
-			Message: "volumeID is required",
-		}
-	}
+	namespace := sc.getNamespaceOfUser(user)
+	log.Info("get volume request", "namespace", namespace, "volumeID", volumeID)
 
-	volumeInfo, err := sc.manager.GetInfra().GetVolume(ctx, infra.GetVolumeOptions{
+	info, err := sc.manager.GetInfra().GetVolume(ctx, infra.GetVolumeOptions{
 		Namespace: namespace,
 		VolumeID:  volumeID,
 		UserID:    user.ID.String(),
 	})
 	if err != nil {
-		log.Error(err, "Failed to get volume", "volumeID", volumeID, "namespace", namespace)
-		if managererrors.GetErrCode(err) == managererrors.ErrorNotFound {
-			return web.ApiResponse[*models.Volume]{}, &web.ApiError{
-				Code:    http.StatusNotFound,
-				Message: "Volume not found",
-			}
-		}
-		return web.ApiResponse[*models.Volume]{}, &web.ApiError{
-			Code:    http.StatusInternalServerError,
-			Message: "Failed to get volume",
+		log.Error(err, "failed to get volume")
+		return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
+			Code:    mapVolumeErrorToHTTP(managererrors.GetErrCode(err)),
+			Message: err.Error(),
 		}
 	}
 
-	return web.ApiResponse[*models.Volume]{
+	return web.ApiResponse[*models.VolumeResponse]{
 		Code: http.StatusOK,
-		Body: &models.Volume{
-			Name:     volumeInfo.Name,
-			VolumeID: volumeInfo.VolumeID,
-		},
+		Body: volumeInfoToResponse(info),
 	}, nil
 }
 
-// DeleteVolume deletes a volume by volumeID
-func (sc *Controller) DeleteVolume(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
+// DeleteVolume handles DELETE /volumes/{volumeID} — deletes a volume.
+// Accepts optional ?force=true query parameter to force deletion even when mounted.
+func (sc *Controller) DeleteVolume(r *http.Request) (web.ApiResponse[*models.DeleteVolumeResponse], *web.ApiError) {
 	ctx := r.Context()
 	log := klog.FromContext(ctx)
 
 	user := GetUserFromContext(ctx)
 	if user == nil {
-		return web.ApiResponse[struct{}]{}, &web.ApiError{
+		return web.ApiResponse[*models.DeleteVolumeResponse]{}, &web.ApiError{
 			Code:    http.StatusUnauthorized,
-			Message: "User is empty",
+			Message: "User not found",
 		}
-	}
-	namespace := sc.getNamespaceOfUser(user)
-	if namespace == "" {
-		namespace = sc.systemNamespace
 	}
 
 	volumeID := r.PathValue("volumeID")
-	if volumeID == "" {
-		return web.ApiResponse[struct{}]{}, &web.ApiError{
-			Code:    http.StatusBadRequest,
-			Message: "volumeID is required",
-		}
-	}
+	force := r.URL.Query().Get("force") == "true"
+	namespace := sc.getNamespaceOfUser(user)
+	log.Info("delete volume request", "namespace", namespace, "volumeID", volumeID, "force", force)
 
-	if err := sc.manager.GetInfra().DeleteVolume(ctx, infra.DeleteVolumeOptions{
+	result, err := sc.manager.GetInfra().DeleteVolume(ctx, infra.DeleteVolumeOptions{
 		Namespace: namespace,
 		VolumeID:  volumeID,
 		UserID:    user.ID.String(),
-	}); err != nil {
-		log.Error(err, "Failed to delete volume", "volumeID", volumeID, "namespace", namespace)
-		if managererrors.GetErrCode(err) == managererrors.ErrorNotFound {
-			return web.ApiResponse[struct{}]{}, &web.ApiError{
-				Code:    http.StatusNotFound,
-				Message: "Volume not found",
-			}
-		}
-		return web.ApiResponse[struct{}]{}, &web.ApiError{
-			Code:    http.StatusInternalServerError,
-			Message: "Failed to delete volume",
+		Force:     force,
+	})
+	if err != nil {
+		log.Error(err, "failed to delete volume")
+		return web.ApiResponse[*models.DeleteVolumeResponse]{}, &web.ApiError{
+			Code:    mapVolumeErrorToHTTP(managererrors.GetErrCode(err)),
+			Message: err.Error(),
 		}
 	}
 
-	return web.ApiResponse[struct{}]{
-		Code: http.StatusNoContent,
+	resp := &models.DeleteVolumeResponse{}
+	if result.ForcedDelete {
+		resp.Warning = "volume was forcibly removed while mounted"
+		resp.AffectedBy = result.AffectedSandboxIDs
+	}
+
+	return web.ApiResponse[*models.DeleteVolumeResponse]{
+		Code: http.StatusOK,
+		Body: resp,
 	}, nil
+}
+
+// resolveVolumeMounts translates a slice of VolumeMountRequest into
+// v1alpha1.CSIMountConfig values by verifying that each volumeID is registered
+// under the caller's namespace. Returns an error if any volumeID is not found
+// or belongs to a different namespace.
+func (sc *Controller) resolveVolumeMounts(ctx context.Context, namespace string, mounts []models.VolumeMountRequest) ([]v1alpha1.CSIMountConfig, error) {
+	if len(mounts) == 0 {
+		return nil, nil
+	}
+	configs := make([]v1alpha1.CSIMountConfig, 0, len(mounts))
+	for _, m := range mounts {
+		info, err := sc.manager.GetInfra().GetVolume(ctx, infra.GetVolumeOptions{
+			Namespace: namespace,
+			VolumeID:  m.VolumeID,
+			UserID:    "", // Internal resolution uses namespace validation
+		})
+		if err != nil {
+			return nil, fmt.Errorf("volume %s: %w", m.VolumeID, err)
+		}
+		configs = append(configs, v1alpha1.CSIMountConfig{
+			PvName:    info.PvName,
+			MountPath: m.MountPath,
+			ReadOnly:  m.ReadOnly,
+		})
+	}
+	return configs, nil
+}
+
+// mapVolumeErrorToHTTP maps a managererrors.ErrorCode to an HTTP status code.
+func mapVolumeErrorToHTTP(code managererrors.ErrorCode) int {
+	switch code {
+	case managererrors.ErrorNotFound:
+		return http.StatusNotFound
+	case managererrors.ErrorConflict:
+		return http.StatusConflict
+	case managererrors.ErrorNotAllowed:
+		return http.StatusForbidden
+	case managererrors.ErrorBadRequest:
+		return http.StatusUnprocessableEntity
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// volumeInfoToResponse converts an infra.VolumeInfo to an API response model.
+func volumeInfoToResponse(v infra.VolumeInfo) *models.VolumeResponse {
+	return &models.VolumeResponse{
+		VolumeID:  v.VolumeID,
+		Name:      v.Name,
+		PvName:    v.PvName,
+		SizeGB:    v.SizeGB,
+		CreatedAt: v.CreatedAt,
+	}
 }

--- a/pkg/servers/e2b/volume.go
+++ b/pkg/servers/e2b/volume.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2b
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"k8s.io/klog/v2"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/openkruise/agents/pkg/servers/web"
+)
+
+// volumeManagerInterface allows mocking the volume manager in tests.
+type volumeManagerInterface interface {
+	RegisterVolume(ctx context.Context, opts infra.RegisterVolumeOptions) (infra.VolumeInfo, error)
+	ListVolumes(ctx context.Context, opts infra.ListVolumesOptions) ([]infra.VolumeInfo, error)
+	GetVolume(ctx context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error)
+	DeleteVolume(ctx context.Context, opts infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error)
+}
+
+// mapVolumeErrorToHTTP maps a managererrors.ErrorCode to an HTTP status code.
+func mapVolumeErrorToHTTP(code managererrors.ErrorCode) int {
+	switch code {
+	case managererrors.ErrorNotFound:
+		return http.StatusNotFound
+	case managererrors.ErrorConflict:
+		return http.StatusConflict
+	case managererrors.ErrorNotAllowed:
+		return http.StatusForbidden
+	case managererrors.ErrorBadRequest:
+		return http.StatusUnprocessableEntity
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// volumeInfoToResponse converts an infra.VolumeInfo to an API response model.
+func volumeInfoToResponse(v infra.VolumeInfo) *models.VolumeResponse {
+	return &models.VolumeResponse{
+		VolumeID:  v.VolumeID,
+		Name:      v.Name,
+		PvName:    v.PvName,
+		SizeGB:    v.SizeGB,
+		CreatedAt: v.CreatedAt,
+	}
+}
+
+// RegisterVolume handles POST /volumes — registers a pre-provisioned PV as a named volume.
+func (sc *Controller) RegisterVolume(r *http.Request) (web.ApiResponse[*models.VolumeResponse], *web.ApiError) {
+	ctx := r.Context()
+	log := klog.FromContext(ctx)
+
+	user := GetUserFromContext(ctx)
+	if user == nil {
+		return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
+			Code:    http.StatusUnauthorized,
+			Message: "User not found",
+		}
+	}
+
+	var req models.RegisterVolumeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: err.Error(),
+		}
+	}
+
+	// Validate required fields before calling infra.
+	switch {
+	case req.Name == "":
+		return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: "name is required",
+		}
+	case req.PvName == "":
+		return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: "pvName is required",
+		}
+	case req.SizeGB <= 0:
+		return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: "sizeGB must be a positive integer",
+		}
+	}
+
+	namespace := sc.getNamespaceOfUser(user)
+	log.Info("register volume request", "namespace", namespace, "pvName", req.PvName, "name", req.Name)
+
+	info, err := sc.volumeManager.RegisterVolume(ctx, infra.RegisterVolumeOptions{
+		Namespace: namespace,
+		Name:      req.Name,
+		PvName:    req.PvName,
+		SizeGB:    req.SizeGB,
+	})
+	if err != nil {
+		log.Error(err, "failed to register volume")
+		return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
+			Code:    mapVolumeErrorToHTTP(managererrors.GetErrCode(err)),
+			Message: err.Error(),
+		}
+	}
+
+	return web.ApiResponse[*models.VolumeResponse]{
+		Code: http.StatusCreated,
+		Body: volumeInfoToResponse(info),
+	}, nil
+}
+
+// ListVolumes handles GET /volumes — lists all volumes in the caller's namespace.
+func (sc *Controller) ListVolumes(r *http.Request) (web.ApiResponse[[]models.VolumeResponse], *web.ApiError) {
+	ctx := r.Context()
+	log := klog.FromContext(ctx)
+
+	user := GetUserFromContext(ctx)
+	if user == nil {
+		return web.ApiResponse[[]models.VolumeResponse]{}, &web.ApiError{
+			Code:    http.StatusUnauthorized,
+			Message: "User not found",
+		}
+	}
+
+	namespace := sc.getNamespaceOfUser(user)
+	log.Info("list volumes request", "namespace", namespace)
+
+	volumes, err := sc.volumeManager.ListVolumes(ctx, infra.ListVolumesOptions{
+		Namespace: namespace,
+	})
+	if err != nil {
+		log.Error(err, "failed to list volumes")
+		return web.ApiResponse[[]models.VolumeResponse]{}, &web.ApiError{
+			Code:    mapVolumeErrorToHTTP(managererrors.GetErrCode(err)),
+			Message: err.Error(),
+		}
+	}
+
+	result := make([]models.VolumeResponse, 0, len(volumes))
+	for _, v := range volumes {
+		result = append(result, *volumeInfoToResponse(v))
+	}
+
+	return web.ApiResponse[[]models.VolumeResponse]{
+		Code: http.StatusOK,
+		Body: result,
+	}, nil
+}
+
+// GetVolume handles GET /volumes/{volumeID} — retrieves a single volume by ID.
+func (sc *Controller) GetVolume(r *http.Request) (web.ApiResponse[*models.VolumeResponse], *web.ApiError) {
+	ctx := r.Context()
+	log := klog.FromContext(ctx)
+
+	user := GetUserFromContext(ctx)
+	if user == nil {
+		return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
+			Code:    http.StatusUnauthorized,
+			Message: "User not found",
+		}
+	}
+
+	volumeID := r.PathValue("volumeID")
+	namespace := sc.getNamespaceOfUser(user)
+	log.Info("get volume request", "namespace", namespace, "volumeID", volumeID)
+
+	info, err := sc.volumeManager.GetVolume(ctx, infra.GetVolumeOptions{
+		Namespace: namespace,
+		VolumeID:  volumeID,
+	})
+	if err != nil {
+		log.Error(err, "failed to get volume")
+		return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
+			Code:    mapVolumeErrorToHTTP(managererrors.GetErrCode(err)),
+			Message: err.Error(),
+		}
+	}
+
+	return web.ApiResponse[*models.VolumeResponse]{
+		Code: http.StatusOK,
+		Body: volumeInfoToResponse(info),
+	}, nil
+}
+
+// DeleteVolume handles DELETE /volumes/{volumeID} — unregisters a volume.
+// Accepts optional ?force=true query parameter to force deletion even when mounted.
+func (sc *Controller) DeleteVolume(r *http.Request) (web.ApiResponse[*models.DeleteVolumeResponse], *web.ApiError) {
+	ctx := r.Context()
+	log := klog.FromContext(ctx)
+
+	user := GetUserFromContext(ctx)
+	if user == nil {
+		return web.ApiResponse[*models.DeleteVolumeResponse]{}, &web.ApiError{
+			Code:    http.StatusUnauthorized,
+			Message: "User not found",
+		}
+	}
+
+	volumeID := r.PathValue("volumeID")
+	force := r.URL.Query().Get("force") == "true"
+	namespace := sc.getNamespaceOfUser(user)
+	log.Info("delete volume request", "namespace", namespace, "volumeID", volumeID, "force", force)
+
+	result, err := sc.volumeManager.DeleteVolume(ctx, infra.DeleteVolumeOptions{
+		Namespace: namespace,
+		VolumeID:  volumeID,
+		Force:     force,
+	})
+	if err != nil {
+		log.Error(err, "failed to delete volume")
+		return web.ApiResponse[*models.DeleteVolumeResponse]{}, &web.ApiError{
+			Code:    mapVolumeErrorToHTTP(managererrors.GetErrCode(err)),
+			Message: err.Error(),
+		}
+	}
+
+	resp := &models.DeleteVolumeResponse{}
+	if result.ForcedDelete {
+		resp.Warning = "volume was forcibly removed while mounted"
+		resp.AffectedBy = result.AffectedSandboxIDs
+	}
+
+	return web.ApiResponse[*models.DeleteVolumeResponse]{
+		Code: http.StatusOK,
+		Body: resp,
+	}, nil
+}
+
+// resolveVolumeMounts translates a slice of VolumeMountRequest into
+// v1alpha1.CSIMountConfig values by verifying that each volumeID is registered
+// under the caller's namespace. Returns an error if any volumeID is not found
+// or belongs to a different namespace.
+func (sc *Controller) resolveVolumeMounts(ctx context.Context, namespace string, mounts []models.VolumeMountRequest) ([]v1alpha1.CSIMountConfig, error) {
+	if len(mounts) == 0 {
+		return nil, nil
+	}
+	configs := make([]v1alpha1.CSIMountConfig, 0, len(mounts))
+	for _, m := range mounts {
+		info, err := sc.volumeManager.GetVolume(ctx, infra.GetVolumeOptions{
+			Namespace: namespace,
+			VolumeID:  m.VolumeID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("volume %s: %w", m.VolumeID, err)
+		}
+		configs = append(configs, v1alpha1.CSIMountConfig{
+			PvName:    info.PvName,
+			MountPath: m.MountPath,
+			ReadOnly:  m.ReadOnly,
+		})
+	}
+	return configs, nil
+}

--- a/pkg/servers/e2b/volume.go
+++ b/pkg/servers/e2b/volume.go
@@ -39,6 +39,14 @@ import (
 	"github.com/openkruise/agents/pkg/servers/web"
 )
 
+// volumeManagerInterface allows mocking the volume manager in tests.
+type volumeManagerInterface interface {
+	CreateVolume(ctx context.Context, opts infra.CreateVolumeOptions) (infra.VolumeInfo, error)
+	ListVolumes(ctx context.Context, opts infra.ListVolumesOptions) ([]infra.VolumeInfo, error)
+	GetVolume(ctx context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error)
+	DeleteVolume(ctx context.Context, opts infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error)
+}
+
 // CreateVolume creates a new persistent volume (PVC) for the user.
 // Implementation: Creates a PVC and waits for it to bind to a PV.
 func (sc *Controller) CreateVolume(r *http.Request) (web.ApiResponse[*models.VolumeResponse], *web.ApiError) {
@@ -68,8 +76,8 @@ func (sc *Controller) CreateVolume(r *http.Request) (web.ApiResponse[*models.Vol
 	}
 	log.Info("create volume request received", "request", req)
 
-	// Call infra layer to create volume
-	volumeInfo, err := sc.manager.GetInfra().CreateVolume(ctx, infra.CreateVolumeOptions{
+	// Call volume manager (metrics wrapper → infra) to create volume
+	volumeInfo, err := sc.volumeManager.CreateVolume(ctx, infra.CreateVolumeOptions{
 		Namespace:        namespace,
 		Name:             req.Name,
 		UserID:           user.ID.String(),
@@ -179,14 +187,14 @@ func (sc *Controller) ListVolumes(r *http.Request) (web.ApiResponse[[]models.Vol
 	if user == nil {
 		return web.ApiResponse[[]models.VolumeResponse]{}, &web.ApiError{
 			Code:    http.StatusUnauthorized,
-			Message: "User not found",
+			Message: "User is empty",
 		}
 	}
 
 	namespace := sc.getNamespaceOfUser(user)
 	log.Info("list volumes request", "namespace", namespace)
 
-	volumes, err := sc.manager.GetInfra().ListVolumes(ctx, infra.ListVolumesOptions{
+	volumes, err := sc.volumeManager.ListVolumes(ctx, infra.ListVolumesOptions{
 		Namespace: namespace,
 		UserID:    user.ID.String(),
 	})
@@ -218,15 +226,21 @@ func (sc *Controller) GetVolume(r *http.Request) (web.ApiResponse[*models.Volume
 	if user == nil {
 		return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
 			Code:    http.StatusUnauthorized,
-			Message: "User not found",
+			Message: "User is empty",
 		}
 	}
 
 	volumeID := r.PathValue("volumeID")
+	if volumeID == "" {
+		return web.ApiResponse[*models.VolumeResponse]{}, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: "volumeID is required",
+		}
+	}
 	namespace := sc.getNamespaceOfUser(user)
 	log.Info("get volume request", "namespace", namespace, "volumeID", volumeID)
 
-	info, err := sc.manager.GetInfra().GetVolume(ctx, infra.GetVolumeOptions{
+	info, err := sc.volumeManager.GetVolume(ctx, infra.GetVolumeOptions{
 		Namespace: namespace,
 		VolumeID:  volumeID,
 		UserID:    user.ID.String(),
@@ -255,16 +269,22 @@ func (sc *Controller) DeleteVolume(r *http.Request) (web.ApiResponse[*models.Del
 	if user == nil {
 		return web.ApiResponse[*models.DeleteVolumeResponse]{}, &web.ApiError{
 			Code:    http.StatusUnauthorized,
-			Message: "User not found",
+			Message: "User is empty",
 		}
 	}
 
 	volumeID := r.PathValue("volumeID")
+	if volumeID == "" {
+		return web.ApiResponse[*models.DeleteVolumeResponse]{}, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: "volumeID is required",
+		}
+	}
 	force := r.URL.Query().Get("force") == "true"
 	namespace := sc.getNamespaceOfUser(user)
 	log.Info("delete volume request", "namespace", namespace, "volumeID", volumeID, "force", force)
 
-	result, err := sc.manager.GetInfra().DeleteVolume(ctx, infra.DeleteVolumeOptions{
+	result, err := sc.volumeManager.DeleteVolume(ctx, infra.DeleteVolumeOptions{
 		Namespace: namespace,
 		VolumeID:  volumeID,
 		UserID:    user.ID.String(),
@@ -303,7 +323,10 @@ func (sc *Controller) resolveVolumeMounts(ctx context.Context, namespace string,
 		info, err := sc.manager.GetInfra().GetVolume(ctx, infra.GetVolumeOptions{
 			Namespace: namespace,
 			VolumeID:  m.VolumeID,
-			UserID:    "", // Internal resolution uses namespace validation
+			// UserID is intentionally empty: namespace already scopes to one team
+			// (admin → sandbox-system, others → team.Name), so namespace isolation
+			// is the ownership boundary for internal mount resolution.
+			UserID: "",
 		})
 		if err != nil {
 			return nil, fmt.Errorf("volume %s: %w", m.VolumeID, err)

--- a/pkg/servers/e2b/volume_test.go
+++ b/pkg/servers/e2b/volume_test.go
@@ -18,17 +18,20 @@ package e2b
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
-	"github.com/openkruise/agents/pkg/servers/e2b/keys"
-	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openkruise/agents/pkg/servers/e2b/keys"
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
 )
 
 func TestCreateVolume(t *testing.T) {
@@ -163,48 +166,6 @@ func TestCreateVolume(t *testing.T) {
 			expectError: "storage class \"non-existent\" not found",
 			errorCode:   http.StatusBadRequest,
 		},
-		{
-			name: "invalid volume name with uppercase",
-			setupReq: func(t *testing.T) *http.Request {
-				req := NewRequest(t, nil, models.NewVolumeRequest{
-					Name: "Test-Volume-UPPERCASE",
-				}, nil, user)
-				req.Header.Set(models.ExtensionHeaderVolumeSize, "1Gi")
-				req.Header.Set(models.ExtensionHeaderVolumeStorageClass, "standard")
-				req.Header.Set(models.ExtensionHeaderVolumeAccessMode, "ReadWriteOnce")
-				return req
-			},
-			expectError: "invalid volume name",
-			errorCode:   http.StatusBadRequest,
-		},
-		{
-			name: "invalid volume name with special characters",
-			setupReq: func(t *testing.T) *http.Request {
-				req := NewRequest(t, nil, models.NewVolumeRequest{
-					Name: "test@volume#name",
-				}, nil, user)
-				req.Header.Set(models.ExtensionHeaderVolumeSize, "1Gi")
-				req.Header.Set(models.ExtensionHeaderVolumeStorageClass, "standard")
-				req.Header.Set(models.ExtensionHeaderVolumeAccessMode, "ReadWriteOnce")
-				return req
-			},
-			expectError: "invalid volume name",
-			errorCode:   http.StatusBadRequest,
-		},
-		{
-			name: "invalid volume name too long",
-			setupReq: func(t *testing.T) *http.Request {
-				req := NewRequest(t, nil, models.NewVolumeRequest{
-					Name: "this-name-is-way-too-long-for-a-dns1123-subdomain-because-it-exceeds-sixty-three-characters-limit",
-				}, nil, user)
-				req.Header.Set(models.ExtensionHeaderVolumeSize, "1Gi")
-				req.Header.Set(models.ExtensionHeaderVolumeStorageClass, "standard")
-				req.Header.Set(models.ExtensionHeaderVolumeAccessMode, "ReadWriteOnce")
-				return req
-			},
-			expectError: "invalid volume name",
-			errorCode:   http.StatusBadRequest,
-		},
 	}
 
 	for _, tt := range tests {
@@ -324,7 +285,7 @@ func TestGetVolume(t *testing.T) {
 					"volumeID": "non-existent-pv",
 				}, user)
 			},
-			expectError: "Volume not found",
+			expectError: "volume not found",
 			errorCode:   http.StatusNotFound,
 		},
 	}
@@ -371,27 +332,17 @@ func TestDeleteVolume(t *testing.T) {
 					"volumeID": "some-id",
 				}, nil)
 			},
-			expectError: "User is empty",
+			expectError: "User not found",
 			errorCode:   http.StatusUnauthorized,
-		},
-		{
-			name: "volumeID is empty",
-			setupReq: func(t *testing.T) *http.Request {
-				return NewRequest(t, nil, nil, map[string]string{
-					"volumeID": "",
-				}, user)
-			},
-			expectError: "volumeID is required",
-			errorCode:   http.StatusBadRequest,
 		},
 		{
 			name: "volume not found",
 			setupReq: func(t *testing.T) *http.Request {
 				return NewRequest(t, nil, nil, map[string]string{
-					"volumeID": "non-existent-pv",
+					"volumeID": "non-existent-pvc",
 				}, user)
 			},
-			expectError: "Volume not found",
+			expectError: "volume not found",
 			errorCode:   http.StatusNotFound,
 		},
 	}
@@ -409,7 +360,7 @@ func TestDeleteVolume(t *testing.T) {
 				assert.Contains(t, apiErr.Message, tt.expectError)
 			} else {
 				require.Nil(t, apiErr, "unexpected error: %v", apiErr)
-				assert.Equal(t, http.StatusNoContent, resp.Code)
+				assert.Equal(t, http.StatusOK, resp.Code)
 			}
 		})
 	}
@@ -470,3 +421,32 @@ func TestValidateVolumeRequest_DefaultWaitBoundSeconds(t *testing.T) {
 		})
 	}
 }
+
+func TestController_ResolveVolumeMounts(t *testing.T) {
+	controller, _, teardown := Setup(t)
+	defer teardown()
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "test-user",
+	}
+
+	namespace := controller.getNamespaceOfUser(user)
+
+	t.Run("empty volume_mounts — no-op, nil returned", func(t *testing.T) {
+		res, err := controller.resolveVolumeMounts(context.Background(), namespace, []models.VolumeMountRequest{})
+		require.NoError(t, err)
+		assert.Nil(t, res)
+	})
+
+	t.Run("non-existent volumeID — returns error", func(t *testing.T) {
+		mounts := []models.VolumeMountRequest{
+			{VolumeID: "pv-missing", MountPath: "/data"},
+		}
+		_, err := controller.resolveVolumeMounts(context.Background(), namespace, mounts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "volume not found")
+	})
+}
+

--- a/pkg/servers/e2b/volume_test.go
+++ b/pkg/servers/e2b/volume_test.go
@@ -1,0 +1,570 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2b
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/servers/e2b/keys"
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+)
+
+// fakeVolumeManager is a test double for volumeManagerInterface.
+type fakeVolumeManager struct {
+	registerFn func(ctx context.Context, opts infra.RegisterVolumeOptions) (infra.VolumeInfo, error)
+	listFn     func(ctx context.Context, opts infra.ListVolumesOptions) ([]infra.VolumeInfo, error)
+	getFn      func(ctx context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error)
+	deleteFn   func(ctx context.Context, opts infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error)
+}
+
+func (f *fakeVolumeManager) RegisterVolume(ctx context.Context, opts infra.RegisterVolumeOptions) (infra.VolumeInfo, error) {
+	return f.registerFn(ctx, opts)
+}
+func (f *fakeVolumeManager) ListVolumes(ctx context.Context, opts infra.ListVolumesOptions) ([]infra.VolumeInfo, error) {
+	return f.listFn(ctx, opts)
+}
+func (f *fakeVolumeManager) GetVolume(ctx context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error) {
+	return f.getFn(ctx, opts)
+}
+func (f *fakeVolumeManager) DeleteVolume(ctx context.Context, opts infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error) {
+	return f.deleteFn(ctx, opts)
+}
+
+// newVolumeTestController builds a minimal Controller wired with a fake volume manager.
+func newVolumeTestController(vm volumeManagerInterface) *Controller {
+	return &Controller{volumeManager: vm}
+}
+
+// newVolumeTestUser returns an admin API key suitable for handler tests.
+func newVolumeTestUser() *models.CreatedTeamAPIKey {
+	return &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Name: "test-user",
+		Team: models.AdminTeam(),
+	}
+}
+
+// newVolumeRequest builds an HTTP request carrying a user in its context.
+func newVolumeRequest(method, path string, body string, pathValues map[string]string, query map[string]string, user *models.CreatedTeamAPIKey) *http.Request {
+	r, _ := http.NewRequest(method, "http://localhost"+path, strings.NewReader(body))
+	if pathValues != nil {
+		for k, v := range pathValues {
+			r.SetPathValue(k, v)
+		}
+	}
+	if query != nil {
+		q := r.URL.Query()
+		for k, v := range query {
+			q.Set(k, v)
+		}
+		r.URL.RawQuery = q.Encode()
+	}
+	ctx := context.WithValue(r.Context(), "user", user)
+	return r.WithContext(ctx)
+}
+
+// ---------------------------------------------------------------------------
+// mapVolumeErrorToHTTP — Property 8
+// ---------------------------------------------------------------------------
+
+// TestProperty8_ErrorCodeHTTPMappingIsTotal verifies that for each known
+// ErrorCode, mapVolumeErrorToHTTP returns a non-200 status deterministically.
+//
+// Feature: e2b-volume-management, Property 8: Error code HTTP mapping
+// Validates: Requirements 8.1–8.5
+func TestProperty8_ErrorCodeHTTPMappingIsTotal(t *testing.T) {
+	tests := []struct {
+		name           string
+		code           managererrors.ErrorCode
+		expectedStatus int
+	}{
+		{name: "NotFound → 404", code: managererrors.ErrorNotFound, expectedStatus: http.StatusNotFound},
+		{name: "Conflict → 409", code: managererrors.ErrorConflict, expectedStatus: http.StatusConflict},
+		{name: "NotAllowed → 403", code: managererrors.ErrorNotAllowed, expectedStatus: http.StatusForbidden},
+		{name: "BadRequest → 422", code: managererrors.ErrorBadRequest, expectedStatus: http.StatusUnprocessableEntity},
+		{name: "Internal → 500", code: managererrors.ErrorInternal, expectedStatus: http.StatusInternalServerError},
+		{name: "Unknown → 500 (default)", code: managererrors.ErrorUnknown, expectedStatus: http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Non-200 assertion
+			status := mapVolumeErrorToHTTP(tt.code)
+			assert.NotEqual(t, http.StatusOK, status, "should never map to 200")
+			assert.Equal(t, tt.expectedStatus, status)
+
+			// Determinism: calling twice gives the same result
+			assert.Equal(t, status, mapVolumeErrorToHTTP(tt.code), "mapping must be deterministic")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RegisterVolume handler tests
+// ---------------------------------------------------------------------------
+
+func TestController_RegisterVolume(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         string
+		registerFn   func(context.Context, infra.RegisterVolumeOptions) (infra.VolumeInfo, error)
+		expectCode   int
+		expectError  string
+		expectVolume string
+	}{
+		{
+			name: "success — returns 201 with volume response",
+			body: `{"name":"vol-a","pvName":"pv-001","sizeGB":10}`,
+			registerFn: func(_ context.Context, opts infra.RegisterVolumeOptions) (infra.VolumeInfo, error) {
+				return infra.VolumeInfo{
+					VolumeID:  opts.PvName,
+					Name:      opts.Name,
+					PvName:    opts.PvName,
+					SizeGB:    opts.SizeGB,
+					CreatedAt: "2026-01-01T00:00:00Z",
+				}, nil
+			},
+			expectCode:   http.StatusCreated,
+			expectVolume: "pv-001",
+		},
+		{
+			name: "conflict — returns 409 when PV already registered",
+			body: `{"name":"vol-a","pvName":"pv-dup","sizeGB":10}`,
+			registerFn: func(_ context.Context, _ infra.RegisterVolumeOptions) (infra.VolumeInfo, error) {
+				return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorConflict, "pv pv-dup is already registered")
+			},
+			expectCode:  http.StatusConflict,
+			expectError: "already registered",
+		},
+		{
+			name: "not found — returns 404 when PV does not exist",
+			body: `{"name":"vol-a","pvName":"pv-missing","sizeGB":10}`,
+			registerFn: func(_ context.Context, _ infra.RegisterVolumeOptions) (infra.VolumeInfo, error) {
+				return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorNotFound, "pv pv-missing not found")
+			},
+			expectCode:  http.StatusNotFound,
+			expectError: "not found",
+		},
+		{
+			name:        "bad json body — returns 400",
+			body:        `{invalid}`,
+			registerFn:  nil,
+			expectCode:  http.StatusBadRequest,
+			expectError: "",
+		},
+		{
+			name:        "missing name — returns 400",
+			body:        `{"pvName":"pv-001","sizeGB":10}`,
+			registerFn:  nil,
+			expectCode:  http.StatusBadRequest,
+			expectError: "name is required",
+		},
+		{
+			name:        "missing pvName — returns 400",
+			body:        `{"name":"vol-a","sizeGB":10}`,
+			registerFn:  nil,
+			expectCode:  http.StatusBadRequest,
+			expectError: "pvName is required",
+		},
+		{
+			name:        "zero sizeGB — returns 400",
+			body:        `{"name":"vol-a","pvName":"pv-001","sizeGB":0}`,
+			registerFn:  nil,
+			expectCode:  http.StatusBadRequest,
+			expectError: "sizeGB must be a positive integer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fake volumeManagerInterface
+			if tt.registerFn != nil {
+				fake = &fakeVolumeManager{registerFn: tt.registerFn}
+			} else {
+				// registerFn nil: bad body returns before calling manager
+				fake = &fakeVolumeManager{registerFn: func(context.Context, infra.RegisterVolumeOptions) (infra.VolumeInfo, error) {
+					panic("should not be called")
+				}}
+			}
+			sc := newVolumeTestController(fake)
+			req := newVolumeRequest(http.MethodPost, "/volumes", tt.body, nil, nil, newVolumeTestUser())
+
+			resp, apiErr := sc.RegisterVolume(req)
+
+			if tt.expectError != "" {
+				require.NotNil(t, apiErr)
+				assert.Equal(t, tt.expectCode, apiErr.Code)
+				assert.Contains(t, apiErr.Message, tt.expectError)
+			} else if tt.expectCode >= 400 {
+				require.NotNil(t, apiErr)
+				assert.Equal(t, tt.expectCode, apiErr.Code)
+			} else {
+				require.Nil(t, apiErr)
+				assert.Equal(t, tt.expectCode, resp.Code)
+				if tt.expectVolume != "" {
+					require.NotNil(t, resp.Body)
+					assert.Equal(t, tt.expectVolume, resp.Body.VolumeID)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListVolumes handler tests
+// ---------------------------------------------------------------------------
+
+func TestController_ListVolumes(t *testing.T) {
+	tests := []struct {
+		name        string
+		listFn      func(context.Context, infra.ListVolumesOptions) ([]infra.VolumeInfo, error)
+		expectCode  int
+		expectCount int
+		expectError string
+	}{
+		{
+			name: "success — returns 200 with volume list",
+			listFn: func(_ context.Context, _ infra.ListVolumesOptions) ([]infra.VolumeInfo, error) {
+				return []infra.VolumeInfo{
+					{VolumeID: "pv-1", Name: "vol-1", PvName: "pv-1", SizeGB: 5},
+					{VolumeID: "pv-2", Name: "vol-2", PvName: "pv-2", SizeGB: 10},
+				}, nil
+			},
+			expectCode:  http.StatusOK,
+			expectCount: 2,
+		},
+		{
+			name: "empty namespace — returns 200 with empty list",
+			listFn: func(_ context.Context, _ infra.ListVolumesOptions) ([]infra.VolumeInfo, error) {
+				return []infra.VolumeInfo{}, nil
+			},
+			expectCode:  http.StatusOK,
+			expectCount: 0,
+		},
+		{
+			name: "internal error — returns 500",
+			listFn: func(_ context.Context, _ infra.ListVolumesOptions) ([]infra.VolumeInfo, error) {
+				return nil, managererrors.NewError(managererrors.ErrorInternal, "cache unavailable")
+			},
+			expectCode:  http.StatusInternalServerError,
+			expectError: "cache unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := newVolumeTestController(&fakeVolumeManager{listFn: tt.listFn})
+			req := newVolumeRequest(http.MethodGet, "/volumes", "", nil, nil, newVolumeTestUser())
+
+			resp, apiErr := sc.ListVolumes(req)
+
+			if tt.expectError != "" {
+				require.NotNil(t, apiErr)
+				assert.Equal(t, tt.expectCode, apiErr.Code)
+				assert.Contains(t, apiErr.Message, tt.expectError)
+			} else {
+				require.Nil(t, apiErr)
+				assert.Equal(t, tt.expectCode, resp.Code)
+				assert.Len(t, resp.Body, tt.expectCount)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetVolume handler tests
+// ---------------------------------------------------------------------------
+
+func TestController_GetVolume(t *testing.T) {
+	tests := []struct {
+		name        string
+		volumeID    string
+		getFn       func(context.Context, infra.GetVolumeOptions) (infra.VolumeInfo, error)
+		expectCode  int
+		expectError string
+	}{
+		{
+			name:     "success — returns 200 with volume",
+			volumeID: "pv-abc",
+			getFn: func(_ context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error) {
+				return infra.VolumeInfo{VolumeID: opts.VolumeID, Name: "vol-abc", PvName: opts.VolumeID, SizeGB: 20}, nil
+			},
+			expectCode: http.StatusOK,
+		},
+		{
+			name:     "not found — returns 404",
+			volumeID: "pv-missing",
+			getFn: func(_ context.Context, _ infra.GetVolumeOptions) (infra.VolumeInfo, error) {
+				return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorNotFound, "volume pv-missing not found")
+			},
+			expectCode:  http.StatusNotFound,
+			expectError: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := newVolumeTestController(&fakeVolumeManager{getFn: tt.getFn})
+			req := newVolumeRequest(http.MethodGet, "/volumes/"+tt.volumeID, "", map[string]string{"volumeID": tt.volumeID}, nil, newVolumeTestUser())
+
+			resp, apiErr := sc.GetVolume(req)
+
+			if tt.expectError != "" {
+				require.NotNil(t, apiErr)
+				assert.Equal(t, tt.expectCode, apiErr.Code)
+				assert.Contains(t, apiErr.Message, tt.expectError)
+			} else {
+				require.Nil(t, apiErr)
+				assert.Equal(t, tt.expectCode, resp.Code)
+				require.NotNil(t, resp.Body)
+				assert.Equal(t, tt.volumeID, resp.Body.VolumeID)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeleteVolume handler tests
+// ---------------------------------------------------------------------------
+
+func TestController_DeleteVolume(t *testing.T) {
+	tests := []struct {
+		name           string
+		volumeID       string
+		forceParam     string
+		deleteFn       func(context.Context, infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error)
+		expectCode     int
+		expectError    string
+		expectWarning  bool
+		expectAffected []string
+	}{
+		{
+			name:     "success — unmounted delete returns 200",
+			volumeID: "pv-ok",
+			deleteFn: func(_ context.Context, _ infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error) {
+				return infra.DeleteVolumeResult{}, nil
+			},
+			expectCode: http.StatusOK,
+		},
+		{
+			name:       "conflict — mounted without force returns 409",
+			volumeID:   "pv-mounted",
+			deleteFn: func(_ context.Context, _ infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error) {
+				return infra.DeleteVolumeResult{}, managererrors.NewError(managererrors.ErrorConflict, "volume is mounted by: sbx-001")
+			},
+			expectCode:  http.StatusConflict,
+			expectError: "mounted by",
+		},
+		{
+			name:       "force delete — returns 200 with warning and affected IDs",
+			volumeID:   "pv-mounted",
+			forceParam: "true",
+			deleteFn: func(_ context.Context, opts infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error) {
+				require.True(t, opts.Force)
+				return infra.DeleteVolumeResult{
+					AffectedSandboxIDs: []string{"sbx-001", "sbx-002"},
+					ForcedDelete:       true,
+				}, nil
+			},
+			expectCode:     http.StatusOK,
+			expectWarning:  true,
+			expectAffected: []string{"sbx-001", "sbx-002"},
+		},
+		{
+			name:     "not found — returns 404",
+			volumeID: "pv-gone",
+			deleteFn: func(_ context.Context, _ infra.DeleteVolumeOptions) (infra.DeleteVolumeResult, error) {
+				return infra.DeleteVolumeResult{}, managererrors.NewError(managererrors.ErrorNotFound, "volume pv-gone not found")
+			},
+			expectCode:  http.StatusNotFound,
+			expectError: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := newVolumeTestController(&fakeVolumeManager{deleteFn: tt.deleteFn})
+			var query map[string]string
+			if tt.forceParam != "" {
+				query = map[string]string{"force": tt.forceParam}
+			}
+			req := newVolumeRequest(http.MethodDelete, "/volumes/"+tt.volumeID, "", map[string]string{"volumeID": tt.volumeID}, query, newVolumeTestUser())
+
+			resp, apiErr := sc.DeleteVolume(req)
+
+			if tt.expectError != "" {
+				require.NotNil(t, apiErr)
+				assert.Equal(t, tt.expectCode, apiErr.Code)
+				assert.Contains(t, apiErr.Message, tt.expectError)
+			} else {
+				require.Nil(t, apiErr)
+				assert.Equal(t, tt.expectCode, resp.Code)
+				require.NotNil(t, resp.Body)
+				if tt.expectWarning {
+					assert.NotEmpty(t, resp.Body.Warning)
+					assert.ElementsMatch(t, tt.expectAffected, resp.Body.AffectedBy)
+				} else {
+					assert.Empty(t, resp.Body.Warning)
+				}
+			}
+		})
+	}
+}
+
+// Ensure uuid import is used (required by test user ID).
+var _ = uuid.Nil
+
+// ---------------------------------------------------------------------------
+// resolveVolumeMounts unit tests (task 7.2)
+// ---------------------------------------------------------------------------
+
+func TestController_ResolveVolumeMounts(t *testing.T) {
+	tests := []struct {
+		name        string
+		namespace   string
+		mounts      []models.VolumeMountRequest
+		getFn       func(context.Context, infra.GetVolumeOptions) (infra.VolumeInfo, error)
+		expectNil   bool   // true = expect nil result (empty mounts)
+		expectLen   int    // expected length of result slice
+		expectError string // non-empty = expect error containing this string
+	}{
+		{
+			name:      "empty volume_mounts — no-op, nil returned",
+			namespace: "ns1",
+			mounts:    []models.VolumeMountRequest{},
+			getFn:     nil, // should not be called
+			expectNil: true,
+		},
+		{
+			name:      "nil volume_mounts — no-op, nil returned",
+			namespace: "ns1",
+			mounts:    nil,
+			getFn:     nil,
+			expectNil: true,
+		},
+		{
+			name:      "non-existent volumeID — returns error",
+			namespace: "ns1",
+			mounts: []models.VolumeMountRequest{
+				{VolumeID: "pv-missing", MountPath: "/data"},
+			},
+			getFn: func(_ context.Context, _ infra.GetVolumeOptions) (infra.VolumeInfo, error) {
+				return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorNotFound, "volume pv-missing not found")
+			},
+			expectError: "not found",
+		},
+		{
+			name:      "valid mounts — correct CSIMountConfig slice",
+			namespace: "ns1",
+			mounts: []models.VolumeMountRequest{
+				{VolumeID: "pv-001", MountPath: "/data", ReadOnly: false},
+				{VolumeID: "pv-002", MountPath: "/config", ReadOnly: true},
+			},
+			getFn: func(_ context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error) {
+				return infra.VolumeInfo{
+					VolumeID: opts.VolumeID,
+					PvName:   opts.VolumeID,
+					Name:     "vol-" + opts.VolumeID,
+					SizeGB:   10,
+				}, nil
+			},
+			expectLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fake volumeManagerInterface
+			if tt.getFn != nil {
+				fake = &fakeVolumeManager{getFn: tt.getFn}
+			} else {
+				fake = &fakeVolumeManager{
+					getFn: func(context.Context, infra.GetVolumeOptions) (infra.VolumeInfo, error) {
+						panic("GetVolume should not be called for empty mounts")
+					},
+				}
+			}
+			sc := newVolumeTestController(fake)
+
+			result, err := sc.resolveVolumeMounts(context.Background(), tt.namespace, tt.mounts)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				assert.Nil(t, result)
+			} else if tt.expectNil {
+				require.NoError(t, err)
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				assert.Len(t, result, tt.expectLen)
+				// Verify each CSIMountConfig maps correctly from the request.
+				for i, m := range tt.mounts {
+					assert.Equal(t, m.MountPath, result[i].MountPath, "MountPath mismatch at index %d", i)
+					assert.Equal(t, m.ReadOnly, result[i].ReadOnly, "ReadOnly mismatch at index %d", i)
+					assert.Equal(t, m.VolumeID, result[i].PvName, "PvName should equal volumeID at index %d", i)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Property 6: Cross-namespace volume_mounts rejected (task 7.1)
+// ---------------------------------------------------------------------------
+
+// TestProperty6_CrossNamespaceVolumeMountsRejected verifies that resolveVolumeMounts
+// returns an error whenever a volumeID belongs to a different namespace than the caller.
+//
+// Feature: e2b-volume-management, Property 6: Cross-namespace volume_mounts rejected
+// Validates: Requirements 5.2
+func TestProperty6_CrossNamespaceVolumeMountsRejected(t *testing.T) {
+	const iterations = 100
+
+	for iter := 0; iter < iterations; iter++ {
+		// The fake GetVolume simulates that the volume exists under ns1 but the caller
+		// is in ns2 — GetVolume returns ErrorNotFound (no info disclosure) for wrong namespace.
+		callerNS := "caller-ns"
+		fake := &fakeVolumeManager{
+			getFn: func(_ context.Context, opts infra.GetVolumeOptions) (infra.VolumeInfo, error) {
+				// Simulate the infra returning NotFound when namespace doesn't match.
+				if opts.Namespace != "owner-ns" {
+					return infra.VolumeInfo{}, managererrors.NewError(managererrors.ErrorNotFound,
+						"volume %s not found", opts.VolumeID)
+				}
+				return infra.VolumeInfo{VolumeID: opts.VolumeID, PvName: opts.VolumeID}, nil
+			},
+		}
+		sc := newVolumeTestController(fake)
+
+		mounts := []models.VolumeMountRequest{
+			{VolumeID: "pv-cross", MountPath: "/data"},
+		}
+
+		_, err := sc.resolveVolumeMounts(context.Background(), callerNS, mounts)
+		require.Error(t, err, "iter %d: expected error for cross-namespace mount", iter)
+	}
+}

--- a/pkg/servers/e2b/volume_test.go
+++ b/pkg/servers/e2b/volume_test.go
@@ -18,7 +18,6 @@ package e2b
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -30,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 )
@@ -332,7 +332,7 @@ func TestDeleteVolume(t *testing.T) {
 					"volumeID": "some-id",
 				}, nil)
 			},
-			expectError: "User not found",
+			expectError: "User is empty",
 			errorCode:   http.StatusUnauthorized,
 		},
 		{
@@ -448,5 +448,117 @@ func TestController_ResolveVolumeMounts(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "volume not found")
 	})
+
+	t.Run("valid PVC — resolves to PV name in CSIMountConfig", func(t *testing.T) {
+		fc := getTestCRClient(controller)
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "data-pvc",
+				Namespace: namespace,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				VolumeName:  "pv-data-001",
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+		require.NoError(t, fc.Create(context.Background(), pvc))
+
+		mounts := []models.VolumeMountRequest{
+			{VolumeID: "data-pvc", MountPath: "/workspace", ReadOnly: false},
+		}
+		configs, err := controller.resolveVolumeMounts(context.Background(), namespace, mounts)
+		require.NoError(t, err)
+		require.Len(t, configs, 1)
+		// PvName must be the bound PV, not the PVC name
+		assert.Equal(t, "pv-data-001", configs[0].PvName)
+		assert.Equal(t, "/workspace", configs[0].MountPath)
+		assert.False(t, configs[0].ReadOnly)
+	})
 }
 
+func TestDeleteVolume_MountedAndForce(t *testing.T) {
+	controller, _, teardown := Setup(t)
+	defer teardown()
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "test-user",
+	}
+
+	fc := getTestCRClient(controller)
+	namespace := controller.getNamespaceOfUser(user)
+
+	// Create the PVC that will be "mounted"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mounted-vol",
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"agents.kruise.io/owner": user.ID.String(),
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName:  "pv-mounted-001",
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+	require.NoError(t, fc.Create(context.Background(), pvc))
+
+	// Create a SandboxClaim referencing the PV by its PvName
+	claim := &agentsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: namespace},
+		Spec: agentsv1alpha1.SandboxClaimSpec{
+			TemplateName: "tmpl",
+			DynamicVolumesMount: []agentsv1alpha1.CSIMountConfig{
+				{PvName: "pv-mounted-001", MountPath: "/data"},
+			},
+		},
+	}
+	require.NoError(t, fc.Create(context.Background(), claim))
+
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sbx-consumer",
+			Namespace: namespace,
+			Labels: map[string]string{
+				agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.True,
+				agentsv1alpha1.LabelSandboxClaimName: "test-claim",
+			},
+		},
+		Status: agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRunning},
+	}
+	require.NoError(t, fc.Create(context.Background(), sbx))
+	require.NoError(t, fc.Status().Update(context.Background(), sbx))
+
+	t.Run("delete blocked when mounted and force=false", func(t *testing.T) {
+		req := NewRequest(t, nil, nil, map[string]string{
+			"volumeID": "mounted-vol",
+		}, user)
+		_, apiErr := controller.DeleteVolume(req)
+		require.NotNil(t, apiErr)
+		assert.Equal(t, http.StatusConflict, apiErr.Code)
+		assert.Contains(t, apiErr.Message, "mounted by")
+	})
+
+	t.Run("delete succeeds with force=true", func(t *testing.T) {
+		req := NewRequest(t, map[string]string{"force": "true"}, nil, map[string]string{
+			"volumeID": "mounted-vol",
+		}, user)
+		resp, apiErr := controller.DeleteVolume(req)
+		require.Nil(t, apiErr)
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.NotEmpty(t, resp.Body.Warning)
+		assert.Contains(t, resp.Body.AffectedBy, namespace+"--sbx-consumer")
+	})
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

**Closes #505**

This PR adds **E2B-compatible volume management APIs** to `sandbox-manager` and introduces support for mounting registered volumes during sandbox creation.

### Key changes

#### Volume APIs

Adds the following E2B-compatible endpoints:

| Method | Path |
|----------|----------|
| POST | `/volumes` |
| GET | `/volumes` |
| GET | `/volumes/{volumeID}` |
| DELETE | `/volumes/{volumeID}` |

These routes are also available under the configured E2B API prefix through the existing `RegisterE2BRoute` mechanism.

#### Sandbox volume mounts

Adds a new optional field to `POST /sandboxes`:

```json
{
  "templateID": "my-template",
  "volume_mounts": [
    {
      "volumeID": "pv-001",
      "mountPath": "/data",
      "readOnly": false
    }
  ]
}
```

Each volume reference is resolved into a `CSIMountConfig` and injected into the existing CSI mount pipeline. No changes were required to the claim/clone workflow.

#### Storage model

This implementation follows maintainer feedback and uses existing Kubernetes `PersistentVolume` objects directly rather than introducing a new CRD.

Registered volumes are represented by PVs labeled with:

- `agents.kruise.io/volume-owner-namespace`
- `agents.kruise.io/volume-name`

`volumeID` maps directly to the PV name.

#### Mounted-volume detection

Volume usage is derived from `SandboxClaim.spec.dynamicVolumesMount` instead of maintaining mount state on the PV. This avoids duplicated state and eliminates stale annotation cleanup concerns.

#### Observability

Adds Prometheus metrics:

- `volume_operation_total`
- `volume_operation_duration_seconds`

for register, list, get, and delete operations.

---

### Ⅱ. Does this pull request fix one issue?

Closes #505

---

### Ⅲ. Describe how to verify it

#### Unit tests

```bash
go test ./pkg/servers/e2b/...
go test ./pkg/sandbox-manager/volume/...
```

#### Integration tests

```bash
go test ./pkg/sandbox-manager/infra/sandboxcr/... -run TestVolumeInfra
go test ./pkg/sandbox-manager/infra/sandboxcr/... -run TestProperty
```

#### Build verification

```bash
go build ./pkg/servers/e2b/...
go build ./pkg/sandbox-manager/...
```

---

### Ⅳ. Special notes for reviewers

1. No CRDs or API types were added.

2. `RegisterVolume` and `DeleteVolume` read PVs directly from the API server to avoid acting on stale cache data. `ListVolumes` and `GetVolume` use the informer cache.

3. Cross-namespace access returns `404 Not Found` rather than `403 Forbidden` to avoid information disclosure.

4. `resolveVolumeMounts` reuses `GetVolume`, ensuring namespace isolation is enforced consistently for both volume APIs and sandbox creation.

5. Mounted-volume checks are derived from `SandboxClaim.spec.dynamicVolumesMount`; no mount state is stored on PVs.

6. The implementation is fully additive and does not modify existing CSI mount behavior.

7. Build verification completed successfully for all packages modified by this PR:

```bash
go build ./pkg/servers/e2b/...
go build ./pkg/sandbox-manager/...
```