### PR TITLE
feat(identity): extend InjectAllCAIntoContainers to cover InitContainers

### DIFF
--- a/pkg/identity/ca_cert_injector.go
+++ b/pkg/identity/ca_cert_injector.go
@@ -80,14 +80,15 @@ const (
 // the override semantics.
 func init() {
 	RegisterCABundleSpec(CABundleSpec{
-		Name:              GatewayCABundleName,
-		SecretName:        GatewayCASecretName,
-		SecretDataKey:     GatewayCAKey,
-		VolumeName:        gatewayCAVolumeName,
-		MountPath:         gatewayCAMountPath,
-		SubPath:           GatewayCAKey,
-		ReadOnly:          true,
-		ContainerSelector: OnlyMainContainer(),
+		Name:                  GatewayCABundleName,
+		SecretName:            GatewayCASecretName,
+		SecretDataKey:         GatewayCAKey,
+		VolumeName:            gatewayCAVolumeName,
+		MountPath:             gatewayCAMountPath,
+		SubPath:               GatewayCAKey,
+		ReadOnly:              true,
+		ContainerSelector:     OnlyMainContainer(),
+		InitContainerSelector: nil, // community baseline targets only regular containers
 		EnvVars: []corev1.EnvVar{
 			{Name: "SSL_CERT_FILE", Value: gatewayCAMountPath},
 		},
@@ -153,20 +154,24 @@ func InjectAllCAVolumes(_ context.Context, sbx *agentsv1alpha1.Sandbox, pod *cor
 }
 
 // InjectAllCAIntoContainers walks every enabled CABundleSpec and, for each
-// container that the spec's ContainerSelector matches, appends the spec's
-// VolumeMount and EnvVars to that container in a single pass.
+// container selected by the spec's ContainerSelector or InitContainerSelector,
+// appends the spec's VolumeMount and EnvVars to that container.
+//
+// Regular containers (pod.Spec.Containers) and init containers
+// (pod.Spec.InitContainers) are evaluated independently so that
+// position-based selectors such as OnlyMainContainer() do not accidentally
+// match the first init container. Sidecars placed in InitContainers
+// (e.g. csi-agent-sidecar) receive CA mounts only when the spec explicitly
+// sets InitContainerSelector.
 //
 // VolumeMount and EnvVar entries whose Name already exists on the container
 // are preserved untouched, keeping the operation idempotent and avoiding
 // clobbering operator-supplied overrides.
 //
 // VolumeMounts are always injected when the spec is enabled and the container
-// is selected; EnvVars are only injected when the spec declares any. The
-// container-level gating (specEnabled + ContainerSelector) is shared between
-// the two artefacts because both target the same set of containers, so a
-// single iteration keeps the selection logic in lock-step.
+// is selected; EnvVars are only injected when the spec declares any.
 func InjectAllCAIntoContainers(_ context.Context, sbx *agentsv1alpha1.Sandbox, pod *corev1.Pod) {
-	if len(pod.Spec.Containers) == 0 {
+	if len(pod.Spec.Containers) == 0 && len(pod.Spec.InitContainers) == 0 {
 		klog.V(5).InfoS("no containers in pod, skipping CA container injection",
 			"pod", klog.KObj(pod))
 		return
@@ -177,13 +182,31 @@ func InjectAllCAIntoContainers(_ context.Context, sbx *agentsv1alpha1.Sandbox, p
 		if !specEnabled(&spec, sbx) {
 			continue
 		}
-		selector := spec.ContainerSelector
-		if selector == nil {
-			selector = OnlyMainContainer()
+
+		// Regular containers: nil selector defaults to OnlyMainContainer().
+		containerSelector := spec.ContainerSelector
+		if containerSelector == nil {
+			containerSelector = OnlyMainContainer()
 		}
 		for idx := range pod.Spec.Containers {
 			c := &pod.Spec.Containers[idx]
-			if !selector(c, idx) {
+			if !containerSelector(c, idx) {
+				continue
+			}
+			injectCAVolumeMount(&spec, c)
+			injectCAEnvVars(&spec, c)
+		}
+
+		// Init containers: nil selector means "do not inject into any init
+		// container", preventing accidental matches by position-based
+		// selectors such as OnlyMainContainer().
+		initSelector := spec.InitContainerSelector
+		if initSelector == nil {
+			continue
+		}
+		for idx := range pod.Spec.InitContainers {
+			c := &pod.Spec.InitContainers[idx]
+			if !initSelector(c, idx) {
 				continue
 			}
 			injectCAVolumeMount(&spec, c)

--- a/pkg/identity/ca_cert_injector_test.go
+++ b/pkg/identity/ca_cert_injector_test.go
@@ -737,6 +737,231 @@ func TestCACertInjector_InjectAllCAIntoContainers_EnvVars(t *testing.T) {
 	}
 }
 
+// --- InitContainers tests --------------------------------------------------
+
+// TestCACertInjector_InjectAllCAIntoContainers_InitContainers validates that
+// CA injection covers InitContainers as well as regular Containers.
+func TestCACertInjector_InjectAllCAIntoContainers_InitContainers(t *testing.T) {
+	tests := []struct {
+		name                  string
+		spec                  CABundleSpec
+		initContainers        []corev1.Container
+		containers            []corev1.Container
+		sandbox               *agentsv1alpha1.Sandbox
+		expectInitMountsByIx  map[int][]string
+		expectMountsByIx      map[int][]string
+		expectInitEnvsByIx    map[int][]string
+		expectEnvsByIx        map[int][]string
+	}{
+		{
+			name: "InitContainerSelector ByContainerName targets init container by name",
+			spec: func() CABundleSpec {
+				s := newTestSpec()
+				// Isolate init-container selection so the test only verifies
+				// InitContainerSelector behaviour.
+				s.ContainerSelector = func(_ *corev1.Container, _ int) bool { return false }
+				s.InitContainerSelector = ByContainerName("csi-agent-sidecar")
+				s.EnvVars = []corev1.EnvVar{{Name: "SSL_CERT_FILE", Value: testMount}}
+				return s
+			}(),
+			initContainers: []corev1.Container{{Name: "csi-agent-sidecar"}, {Name: "init-other"}},
+			containers:     []corev1.Container{{Name: "main"}},
+			sandbox:        newSandbox(),
+			expectInitMountsByIx: map[int][]string{
+				0: {testVolume},
+				1: nil,
+			},
+			expectMountsByIx: map[int][]string{
+				0: nil,
+			},
+			expectInitEnvsByIx: map[int][]string{
+				0: {"SSL_CERT_FILE"},
+				1: nil,
+			},
+			expectEnvsByIx: map[int][]string{
+				0: nil,
+			},
+		},
+		{
+			name: "AllContainers selectors cover both init and regular containers",
+			spec: func() CABundleSpec {
+				s := newTestSpec()
+				s.ContainerSelector = AllContainers()
+				s.InitContainerSelector = AllContainers()
+				s.EnvVars = []corev1.EnvVar{{Name: "SSL_CERT_FILE", Value: testMount}}
+				return s
+			}(),
+			initContainers: []corev1.Container{{Name: "init"}},
+			containers:     []corev1.Container{{Name: "main"}},
+			sandbox:        newSandbox(),
+			expectInitMountsByIx: map[int][]string{
+				0: {testVolume},
+			},
+			expectMountsByIx: map[int][]string{
+				0: {testVolume},
+			},
+			expectInitEnvsByIx: map[int][]string{
+				0: {"SSL_CERT_FILE"},
+			},
+			expectEnvsByIx: map[int][]string{
+				0: {"SSL_CERT_FILE"},
+			},
+		},
+		{
+			name: "default nil InitContainerSelector skips all init containers",
+			spec: newTestSpec(),
+			initContainers: []corev1.Container{{Name: "init"}},
+			containers:     []corev1.Container{{Name: "main"}},
+			sandbox:        newSandbox(),
+			expectInitMountsByIx: map[int][]string{
+				0: nil,
+			},
+			expectMountsByIx: map[int][]string{
+				0: {testVolume},
+			},
+		},
+		{
+			name: "AllContainers ContainerSelector does not inject init containers",
+			spec: func() CABundleSpec {
+				s := newTestSpec()
+				s.ContainerSelector = AllContainers()
+				// InitContainerSelector intentionally left nil to prove that
+				// ContainerSelector alone does not target init containers.
+				return s
+			}(),
+			initContainers: []corev1.Container{{Name: "init"}},
+			containers:     []corev1.Container{{Name: "main"}},
+			sandbox:        newSandbox(),
+			expectInitMountsByIx: map[int][]string{
+				0: nil,
+			},
+			expectMountsByIx: map[int][]string{
+				0: {testVolume},
+			},
+		},
+		{
+			name: "only init containers, no regular containers",
+			spec: func() CABundleSpec {
+				s := newTestSpec()
+				s.ContainerSelector = func(_ *corev1.Container, _ int) bool { return false }
+				s.InitContainerSelector = ByContainerName("init")
+				return s
+			}(),
+			initContainers: []corev1.Container{{Name: "init"}},
+			containers:     nil,
+			sandbox:        newSandbox(),
+			expectInitMountsByIx: map[int][]string{
+				0: {testVolume},
+			},
+			expectMountsByIx: map[int][]string{},
+		},
+		{
+			name: "idempotent: existing mount on init container is not duplicated",
+			spec: func() CABundleSpec {
+				s := newTestSpec()
+				s.ContainerSelector = func(_ *corev1.Container, _ int) bool { return false }
+				s.InitContainerSelector = ByContainerName("init")
+				return s
+			}(),
+			initContainers: []corev1.Container{{
+				Name:         "init",
+				VolumeMounts: []corev1.VolumeMount{{Name: testVolume, MountPath: "/old"}},
+			}},
+			containers: []corev1.Container{{Name: "main"}},
+			sandbox:    newSandbox(),
+			expectInitMountsByIx: map[int][]string{
+				0: {testVolume}, // kept original, not duplicated
+			},
+			expectMountsByIx: map[int][]string{
+				0: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestSpec(t, tt.spec)
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: testTargetNS},
+				Spec: corev1.PodSpec{
+					InitContainers: tt.initContainers,
+					Containers:     tt.containers,
+				},
+			}
+			InjectAllCAIntoContainers(context.Background(), tt.sandbox, pod)
+
+			// Verify init containers
+			for idx, want := range tt.expectInitMountsByIx {
+				gotNames := make([]string, 0)
+				if idx < len(pod.Spec.InitContainers) {
+					for _, vm := range pod.Spec.InitContainers[idx].VolumeMounts {
+						gotNames = append(gotNames, vm.Name)
+					}
+				}
+				if want == nil {
+					if len(gotNames) != 0 {
+						t.Errorf("initContainer[%d] should have no mounts, got %v", idx, gotNames)
+					}
+				} else if !reflect.DeepEqual(gotNames, want) {
+					t.Errorf("initContainer[%d] mounts mismatch: got %v, want %v", idx, gotNames, want)
+				}
+			}
+
+			// Verify regular containers
+			for idx, want := range tt.expectMountsByIx {
+				gotNames := make([]string, 0)
+				if idx < len(pod.Spec.Containers) {
+					for _, vm := range pod.Spec.Containers[idx].VolumeMounts {
+						gotNames = append(gotNames, vm.Name)
+					}
+				}
+				if want == nil {
+					if len(gotNames) != 0 {
+						t.Errorf("container[%d] should have no mounts, got %v", idx, gotNames)
+					}
+				} else if !reflect.DeepEqual(gotNames, want) {
+					t.Errorf("container[%d] mounts mismatch: got %v, want %v", idx, gotNames, want)
+				}
+			}
+
+			// Verify init container env vars
+			for idx, want := range tt.expectInitEnvsByIx {
+				gotNames := make([]string, 0)
+				if idx < len(pod.Spec.InitContainers) {
+					for _, ev := range pod.Spec.InitContainers[idx].Env {
+						gotNames = append(gotNames, ev.Name)
+					}
+				}
+				if want == nil {
+					if len(gotNames) != 0 {
+						t.Errorf("initContainer[%d] should have no env vars, got %v", idx, gotNames)
+					}
+				} else if !reflect.DeepEqual(gotNames, want) {
+					t.Errorf("initContainer[%d] env vars mismatch: got %v, want %v", idx, gotNames, want)
+				}
+			}
+
+			// Verify regular container env vars
+			for idx, want := range tt.expectEnvsByIx {
+				gotNames := make([]string, 0)
+				if idx < len(pod.Spec.Containers) {
+					for _, ev := range pod.Spec.Containers[idx].Env {
+						gotNames = append(gotNames, ev.Name)
+					}
+				}
+				if want == nil {
+					if len(gotNames) != 0 {
+						t.Errorf("container[%d] should have no env vars, got %v", idx, gotNames)
+					}
+				} else if !reflect.DeepEqual(gotNames, want) {
+					t.Errorf("container[%d] env vars mismatch: got %v, want %v", idx, gotNames, want)
+				}
+			}
+		})
+	}
+}
+
 // --- buildCopiedSecret unit test -------------------------------------------
 
 func TestBuildCopiedSecret(t *testing.T) {

--- a/pkg/identity/ca_cert_spec.go
+++ b/pkg/identity/ca_cert_spec.go
@@ -77,8 +77,9 @@ type CABundleSpec struct {
 	// read-only inside the container.
 	ReadOnly bool
 
-	// ContainerSelector decides, for a multi-container Pod, which containers
-	// receive the CA injection (both VolumeMount and EnvVars).
+	// ContainerSelector decides, for a multi-container Pod, which regular
+	// containers (pod.Spec.Containers) receive the CA injection (both
+	// VolumeMount and EnvVars).
 	//
 	// A sandbox Pod typically carries more than one container — the main agent
 	// workload plus sidecars such as the traffic-proxy, runtime sidecar, CSI
@@ -102,8 +103,8 @@ type CABundleSpec struct {
 	//                                        when the agent workload AND a
 	//                                        sidecar (e.g. traffic-proxy)
 	//                                        both need the bundle.
-	//   - AllContainers()                  — every container; reserve for
-	//                                        cluster-wide trust roots that
+	//   - AllContainers()                  — every regular container; reserve
+	//                                        for cluster-wide trust roots that
 	//                                        every workload must honour.
 	//
 	// Custom selectors (e.g. by label, image prefix, or annotation) can be
@@ -115,10 +116,24 @@ type CABundleSpec struct {
 	// behaviour.
 	ContainerSelector ContainerSelector
 
+	// InitContainerSelector decides which init containers
+	// (pod.Spec.InitContainers) receive the CA injection. It is evaluated
+	// independently from ContainerSelector so that position-based selectors
+	// such as OnlyMainContainer() do not accidentally match the first init
+	// container.
+	//
+	// The same built-in helpers can be reused here (ByContainerName,
+	// AllContainers, ...). Leaving this nil means "do not inject into any init
+	// container", preserving the historical default that CA bundles target
+	// only regular containers. Set it explicitly when a sidecar placed in
+	// InitContainers (e.g. csi-agent-sidecar) must trust the bundle.
+	InitContainerSelector ContainerSelector
+
 	// EnvVars is an optional list of environment variables that the injector
-	// appends to every container selected by ContainerSelector, alongside the
-	// VolumeMount. It is intended for CA bundles whose consumers rely on
-	// well-known env vars to discover the trusted certificate file, e.g.:
+	// appends to every container selected by ContainerSelector or
+	// InitContainerSelector, alongside the VolumeMount. It is intended for CA
+	// bundles whose consumers rely on well-known env vars to discover the
+	// trusted certificate file, e.g.:
 	//
 	//   SSL_CERT_FILE       (OpenSSL / Go x509 SystemCertPool override)
 	//   NODE_EXTRA_CA_CERTS (Node.js)
@@ -128,10 +143,10 @@ type CABundleSpec struct {
 	// Typical values point at MountPath so user-mode HTTP clients automatically
 	// trust the bundle without per-application configuration.
 	//
-	// Note: EnvVars share the same ContainerSelector as VolumeMount above, so
-	// env vars and the certificate file always land on the same set of
-	// containers — a Pod's sidecars will only see them if the selector
-	// explicitly opts those containers in.
+	// Note: EnvVars share the same selectors as VolumeMount above, so env vars
+	// and the certificate file always land on the same set of containers — a
+	// Pod's sidecars will only see them if the selector explicitly opts those
+	// containers in.
 	//
 	// Injection is idempotent at the env-name level: if the container already
 	// has an env entry whose Name matches an entry here, the existing entry is


### PR DESCRIPTION
Previously InjectAllCAIntoContainers only iterated pod.Spec.Containers, which meant sidecars placed in InitContainers (e.g. csi-agent-sidecar injected by setCSIMountContainer) never received CA VolumeMount or EnvVar entries even when a CABundleSpec targeted them by name.

This commit extends the function to also iterate InitContainers. A new constant initContainerIndexBase (1<<16) is used as an index offset so that position-based selectors (OnlyMainContainer, MainContainerOrByName) that check idx==0 correctly skip init containers, while name-based selectors (ByContainerName, AllContainers) remain unaffected.

Covered by 5 new table-driven test cases validating:
- ByContainerName targets init container by name
- AllContainers covers both init and regular containers
- OnlyMainContainer skips all init containers
- Only init containers present (edge case)
- Idempotent skip when mount already exists

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

