### PR TITLE
feat(sidecarutils): merge postStart hooks using -- separator instead of skipping

### DIFF
--- a/pkg/utils/sidecarutils/sidecar_config_inject.go
+++ b/pkg/utils/sidecarutils/sidecar_config_inject.go
@@ -237,19 +237,30 @@ func setMainContainerConfigWhenInjectRuntimeSidecar(ctx context.Context, mainCon
 		config.MainContainer.Lifecycle.PostStart != nil &&
 		hasValidLifecycleHandler(config.MainContainer.Lifecycle.PostStart)
 
-	if mainContainerHasValidPostStart {
-		if configHasValidPostStart {
-			log.V(utils.DebugLogLevel).Info("conflicting postStart hooks detected, main container already has a postStart hook defined",
-				"existingHook", mainContainer.Lifecycle.PostStart,
-				"injectedHook", config.MainContainer.Lifecycle.PostStart)
+	if configHasValidPostStart {
+		if mainContainer.Lifecycle == nil {
+			mainContainer.Lifecycle = &corev1.Lifecycle{}
 		}
-	} else {
-		// Main container doesn't have valid postStart, apply config if available
-		if configHasValidPostStart {
-			// set main container lifecycle
-			if mainContainer.Lifecycle == nil {
-				mainContainer.Lifecycle = &corev1.Lifecycle{}
+		if mainContainerHasValidPostStart {
+			// The user has a postStart hook. Merge using "--" separator so that
+			// envd-run.sh executes the user's command after its own initialisation.
+			mergedCmd := mergePostStartExecCommands(config.MainContainer.Lifecycle.PostStart, mainContainer.Lifecycle.PostStart)
+			if mergedCmd != nil {
+				log.V(utils.DebugLogLevel).Info("merging user's postStart command into injected script",
+					"userCommand", mainContainer.Lifecycle.PostStart.Exec.Command,
+					"injectedCommand", config.MainContainer.Lifecycle.PostStart.Exec.Command)
+				mainContainer.Lifecycle.PostStart = &corev1.LifecycleHandler{
+					Exec: &corev1.ExecAction{Command: mergedCmd},
+				}
+			} else {
+				// Cannot merge non-Exec handlers (e.g. HTTPGet/TCPSocket); keep the
+				// existing hook and skip injection of the injected postStart.
+				log.Error(nil, "cannot merge non-Exec postStart hooks, keeping existing hook",
+					"existingHook", mainContainer.Lifecycle.PostStart,
+					"injectedHook", config.MainContainer.Lifecycle.PostStart)
 			}
+		} else {
+			// Main container doesn't have a valid postStart; apply the config directly.
 			mainContainer.Lifecycle.PostStart = config.MainContainer.Lifecycle.PostStart
 		}
 	}
@@ -265,6 +276,34 @@ func setMainContainerConfigWhenInjectRuntimeSidecar(ctx context.Context, mainCon
 		mainContainer.VolumeMounts = make([]corev1.VolumeMount, 0, len(config.MainContainer.VolumeMounts))
 	}
 	mainContainer.VolumeMounts = append(mainContainer.VolumeMounts, config.MainContainer.VolumeMounts...)
+}
+
+// mergePostStartExecCommands merges the injected postStart Exec command with the user's
+// postStart Exec command using the "--" separator pattern. Everything after "--" is passed
+// to envd-run.sh as individual arguments representing the user command, executed directly
+// without shell interpretation. This follows the kubectl exec convention.
+//
+// Precondition: the caller has already verified that both the injected config and the main
+// container have valid postStart hooks (configHasValidPostStart && mainContainerHasValidPostStart),
+// so neither handler is nil and both have a non-nil action. Consequently, the nil checks below
+// are defensive; the only realistic failure mode is a non-Exec handler, which returns nil.
+// Returns nil if either handler is non-Exec (cannot be merged).
+func mergePostStartExecCommands(injected, user *corev1.LifecycleHandler) []string {
+	if injected == nil || injected.Exec == nil || user == nil || user.Exec == nil {
+		return nil
+	}
+	// If the user's command is empty, there is nothing to append.
+	if len(user.Exec.Command) == 0 {
+		return injected.Exec.Command
+	}
+	// Use "--" separator following the kubectl exec pattern. Everything after "--"
+	// is passed as individual arguments to envd-run.sh which executes the command
+	// directly without shell interpretation.
+	merged := make([]string, 0, len(injected.Exec.Command)+1+len(user.Exec.Command))
+	merged = append(merged, injected.Exec.Command...)
+	merged = append(merged, "--")
+	merged = append(merged, user.Exec.Command...)
+	return merged
 }
 
 func findVolumeMountByName(volumeMounts []corev1.VolumeMount, name string) bool {

--- a/pkg/utils/sidecarutils/sidecar_config_inject_test.go
+++ b/pkg/utils/sidecarutils/sidecar_config_inject_test.go
@@ -549,6 +549,7 @@ func TestSetMainContainerConfigWhenInjectRuntimeSidecar(t *testing.T) {
 		expectedVolumeMountCount int
 		hasPostStart             bool
 		postStartCommand         []string
+		expectedPostStartHandler *corev1.LifecycleHandler // if set, compare full handler instead of postStartCommand
 	}{
 		{
 			name: "empty container with full config",
@@ -580,7 +581,7 @@ func TestSetMainContainerConfigWhenInjectRuntimeSidecar(t *testing.T) {
 			postStartCommand:         []string{"bash", "-c", "/mnt/envd/envd-run.sh"},
 		},
 		{
-			name: "container with existing lifecycle - conflicting postStart should skip all injection",
+			name: "container with existing lifecycle - merge postStart with -- separator",
 			mainContainer: &corev1.Container{
 				Name:  "main",
 				Image: "nginx:latest",
@@ -601,16 +602,16 @@ func TestSetMainContainerConfigWhenInjectRuntimeSidecar(t *testing.T) {
 					Lifecycle: &corev1.Lifecycle{
 						PostStart: &corev1.LifecycleHandler{
 							Exec: &corev1.ExecAction{
-								Command: []string{"echo", "new"},
+								Command: []string{"bash", "/mnt/envd/envd-run.sh"},
 							},
 						},
 					},
 				},
 			},
-			expectedEnvCount:         1, // conflicting postStart only skips postStart injection, env still injected
-			expectedVolumeMountCount: 1, // conflicting postStart only skips postStart injection, volumeMounts still injected
+			expectedEnvCount:         1,
+			expectedVolumeMountCount: 1,
 			hasPostStart:             true,
-			postStartCommand:         []string{"echo", "old"}, // keeps existing, NOT overridden
+			postStartCommand:         []string{"bash", "/mnt/envd/envd-run.sh", "--", "echo", "old"}, // merged with -- separator
 		},
 		{
 			name: "config without lifecycle - no override",
@@ -704,6 +705,79 @@ func TestSetMainContainerConfigWhenInjectRuntimeSidecar(t *testing.T) {
 			hasPostStart:             false, // config has empty handler, should not apply
 			postStartCommand:         nil,
 		},
+		{
+			name: "existing HTTPGet postStart preserved when config injects Exec hook",
+			mainContainer: &corev1.Container{
+				Name:  "main",
+				Image: "nginx:latest",
+				Lifecycle: &corev1.Lifecycle{
+					PostStart: &corev1.LifecycleHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/healthz",
+							Port: intstr.FromInt32(8080),
+						},
+					},
+				},
+			},
+			config: SidecarInjectConfig{
+				MainContainer: corev1.Container{
+					Env: []corev1.EnvVar{{Name: "ENV1", Value: "value1"}},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "vol1", MountPath: "/vol1"},
+					},
+					Lifecycle: &corev1.Lifecycle{
+						PostStart: &corev1.LifecycleHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"bash", "/mnt/envd/envd-run.sh"},
+							},
+						},
+					},
+				},
+			},
+			expectedEnvCount:         1,
+			expectedVolumeMountCount: 1,
+			hasPostStart:             true,
+			expectedPostStartHandler: &corev1.LifecycleHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.FromInt32(8080),
+				},
+			},
+		},
+		{
+			name: "existing TCPSocket postStart preserved when config injects Exec hook",
+			mainContainer: &corev1.Container{
+				Name:  "main",
+				Image: "nginx:latest",
+				Lifecycle: &corev1.Lifecycle{
+					PostStart: &corev1.LifecycleHandler{
+						TCPSocket: &corev1.TCPSocketAction{
+							Port: intstr.FromInt32(3306),
+						},
+					},
+				},
+			},
+			config: SidecarInjectConfig{
+				MainContainer: corev1.Container{
+					Env: []corev1.EnvVar{{Name: "ENV1", Value: "value1"}},
+					Lifecycle: &corev1.Lifecycle{
+						PostStart: &corev1.LifecycleHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"bash", "/mnt/envd/envd-run.sh"},
+							},
+						},
+					},
+				},
+			},
+			expectedEnvCount:         1,
+			expectedVolumeMountCount: 0,
+			hasPostStart:             true,
+			expectedPostStartHandler: &corev1.LifecycleHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt32(3306),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -721,12 +795,18 @@ func TestSetMainContainerConfigWhenInjectRuntimeSidecar(t *testing.T) {
 			}
 
 			// Verify PostStart lifecycle
-			if tt.hasPostStart && tt.postStartCommand != nil {
+			if tt.expectedPostStartHandler != nil {
+				if tt.mainContainer.Lifecycle == nil || tt.mainContainer.Lifecycle.PostStart == nil {
+					t.Error("expected PostStart lifecycle handler, got nil")
+				} else if !reflect.DeepEqual(tt.mainContainer.Lifecycle.PostStart, tt.expectedPostStartHandler) {
+					t.Errorf("expected handler %v, got %v", tt.expectedPostStartHandler, tt.mainContainer.Lifecycle.PostStart)
+				}
+			} else if tt.hasPostStart && tt.postStartCommand != nil {
 				if tt.mainContainer.Lifecycle == nil || tt.mainContainer.Lifecycle.PostStart == nil {
 					t.Error("expected PostStart lifecycle handler, got nil")
 				} else if tt.mainContainer.Lifecycle.PostStart.Exec == nil {
 					t.Error("expected Exec action in PostStart, got nil")
-				} else if len(tt.mainContainer.Lifecycle.PostStart.Exec.Command) != len(tt.postStartCommand) {
+				} else if !reflect.DeepEqual(tt.mainContainer.Lifecycle.PostStart.Exec.Command, tt.postStartCommand) {
 					t.Errorf("expected command %v, got %v", tt.postStartCommand, tt.mainContainer.Lifecycle.PostStart.Exec.Command)
 				}
 			}
@@ -1200,6 +1280,123 @@ func TestHasValidLifecycleHandler(t *testing.T) {
 			result := hasValidLifecycleHandler(tt.handler)
 			if result != tt.expected {
 				t.Errorf("hasValidLifecycleHandler() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMergePostStartExecCommands(t *testing.T) {
+	tests := []struct {
+		name            string
+		injected        *corev1.LifecycleHandler
+		user            *corev1.LifecycleHandler
+		expectedCommand []string
+	}{
+		{
+			name: "both have Exec commands - merged with -- separator",
+			injected: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"bash", "/mnt/envd/envd-run.sh"},
+				},
+			},
+			user: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"echo", "hello"},
+				},
+			},
+			expectedCommand: []string{"bash", "/mnt/envd/envd-run.sh", "--", "echo", "hello"},
+		},
+		{
+			name: "user command is a single element",
+			injected: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"bash", "/mnt/envd/envd-run.sh"},
+				},
+			},
+			user: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"my-init.sh"},
+				},
+			},
+			expectedCommand: []string{"bash", "/mnt/envd/envd-run.sh", "--", "my-init.sh"},
+		},
+		{
+			name: "user command has multiple elements - each preserved as individual arg",
+			injected: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"bash", "/mnt/envd/envd-run.sh"},
+				},
+			},
+			user: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"bash", "-c", "setup.sh && echo done"},
+				},
+			},
+			expectedCommand: []string{"bash", "/mnt/envd/envd-run.sh", "--", "bash", "-c", "setup.sh && echo done"},
+		},
+		{
+			name:            "injected is nil - returns nil",
+			injected:        nil,
+			user:            &corev1.LifecycleHandler{Exec: &corev1.ExecAction{Command: []string{"echo"}}},
+			expectedCommand: nil,
+		},
+		{
+			name:            "user is nil - returns nil",
+			injected:        &corev1.LifecycleHandler{Exec: &corev1.ExecAction{Command: []string{"bash", "/mnt/envd/envd-run.sh"}}},
+			user:            nil,
+			expectedCommand: nil,
+		},
+		{
+			name:     "injected has HTTPGet - returns nil",
+			injected: &corev1.LifecycleHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/"}},
+			user: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{Command: []string{"echo"}},
+			},
+			expectedCommand: nil,
+		},
+		{
+			name: "user has HTTPGet - returns nil",
+			injected: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{Command: []string{"bash", "/mnt/envd/envd-run.sh"}},
+			},
+			user:            &corev1.LifecycleHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/"}},
+			expectedCommand: nil,
+		},
+		{
+			name: "user command is empty - returns injected only",
+			injected: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"bash", "/mnt/envd/envd-run.sh"},
+				},
+			},
+			user: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{},
+				},
+			},
+			expectedCommand: []string{"bash", "/mnt/envd/envd-run.sh"},
+		},
+		{
+			name: "injected with --nolog flag - user command appended after --",
+			injected: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"bash", "/mnt/envd/envd-run.sh", "--nolog"},
+				},
+			},
+			user: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"/path/to/script", "arg1", "arg2"},
+				},
+			},
+			expectedCommand: []string{"bash", "/mnt/envd/envd-run.sh", "--nolog", "--", "/path/to/script", "arg1", "arg2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergePostStartExecCommands(tt.injected, tt.user)
+			if !reflect.DeepEqual(result, tt.expectedCommand) {
+				t.Errorf("mergePostStartExecCommands() = %v, expected %v", result, tt.expectedCommand)
 			}
 		})
 	}


### PR DESCRIPTION
…of skipping

When the user's main container already has a postStart Exec hook, the previous behavior was to skip injection entirely. This change merges the injected envd-run.sh command with the user's command using the "--" separator pattern, following the kubectl exec convention.

The merged result preserves each user command element as an individual argument (no shell interpretation), e.g.:
  injected: ["bash", "/mnt/envd/envd-run.sh"]
  user:     ["/path/to/script", "arg1", "arg2"]
  merged:   ["bash", "/mnt/envd/envd-run.sh", "--", "/path/to/script", "arg1", "arg2"]

For non-Exec handlers (HTTPGet/TCPSocket), the existing hook is preserved and injection is skipped since they cannot be merged.

- Add mergePostStartExecCommands helper with "--" separator logic
- Update setMainContainerConfigWhenInjectRuntimeSidecar to call merge
- Add TestMergePostStartExecCommands covering 8 boundary scenarios

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

