### PR TITLE
[codex] fix desktop SandboxSet template mismatch

### DIFF
--- a/examples/desktop/README-zh_CN.md
+++ b/examples/desktop/README-zh_CN.md
@@ -6,51 +6,11 @@
 
 ## 1. 定义模板
 
-类似 code-interpreter 模板，我们可以通过 `SandboxSet` 定义一个使用官方 E2B Desktop 镜像的模板并创建预热池。
+类似 code-interpreter 模板，我们可以使用官方 E2B Desktop 镜像，通过 `SandboxSet` 创建预热池。
+应用 [sandboxset.yaml](sandboxset.yaml) 以创建名为 `desktop` 的模板：
 
-```yaml
-apiVersion: agents.kruise.io/v1alpha1
-kind: SandboxSet
-metadata:
-  annotations:
-    # 启用 SandboxManager 的 Envd 初始化能力
-    e2b.agents.kruise.io/should-init-envd: "true"
-  name: code-interpreter
-  namespace: default
-spec:
-  # 预热池的大小，建议比预估的请求突发量略大
-  replicas: 100
-  template: # 声明一个 Pod 模板
-    spec:
-      initContainers:
-        - name: init # 通过 native sidecar 注入 agent-runtime 组件
-          image: registry-cn-hangzhou.ack.aliyuncs.com/acs/agent-runtime:v0.0.1
-          volumeMounts:
-            - name: agent-runtime-volume
-              mountPath: /mnt/agent-runtime
-          env:
-            - name: AGENT_RUNTIME_WORKSPACE
-              value: /mnt/agent-runtime
-          restartPolicy: Always
-      containers:
-        - name: sandbox
-          image: e2bdev/desktop:latest # 使用 E2B 官方的 desktop 镜像
-          resources:
-            requests:
-              cpu: 1
-              memory: 1Gi
-            limits:
-              cpu: 1
-              memory: 1Gi
-          env:
-            - name: AGENT_RUNTIME_WORKSPACE
-              value: /mnt/agent-runtime
-          volumeMounts:
-            - name: agent-runtime-volume
-              mountPath: /mnt/agent-runtime
-      volumes:
-        - name: agent-runtime-volume # 定义 agent-runtime 与主容器的共享目录
-          emptyDir: { }
+```shell
+kubectl apply -f examples/desktop/sandboxset.yaml
 ```
 
 ## 2. 通过 E2B Python SDK 使用沙箱

--- a/examples/desktop/README.md
+++ b/examples/desktop/README.md
@@ -7,52 +7,11 @@ For basic concepts, please refer to [Running E2B Code Interpreter Sandbox](../co
 
 ## 1. Defining Templates
 
-Similar to the code-interpreter template, we can define a template using the official E2B Desktop image and create a
-pre-warming pool via `SandboxSet`.
+Similar to the code-interpreter template, we can use the official E2B Desktop image to create a pre-warming pool via
+`SandboxSet`. Apply [sandboxset.yaml](sandboxset.yaml) to create a template named `desktop`:
 
-```yaml
-apiVersion: agents.kruise.io/v1alpha1
-kind: SandboxSet
-metadata:
-  annotations:
-    # Enable SandboxManager's Envd initialization capability
-    e2b.agents.kruise.io/should-init-envd: "true"
-  name: code-interpreter
-  namespace: default
-spec:
-  # Pre-warming pool size, recommended to be slightly larger than the estimated request burst volume
-  replicas: 100
-  template: # Declare a Pod template
-    spec:
-      initContainers:
-        - name: init # Inject agent-runtime component through native sidecar
-          image: registry-cn-hangzhou.ack.aliyuncs.com/acs/agent-runtime:v0.0.1
-          volumeMounts:
-            - name: agent-runtime-volume
-              mountPath: /mnt/agent-runtime
-          env:
-            - name: AGENT_RUNTIME_WORKSPACE
-              value: /mnt/agent-runtime
-          restartPolicy: Always
-      containers:
-        - name: sandbox
-          image: e2bdev/desktop:latest # Use the official E2B desktop image
-          resources:
-            requests:
-              cpu: 1
-              memory: 1Gi
-            limits:
-              cpu: 1
-              memory: 1Gi
-          env:
-            - name: AGENT_RUNTIME_WORKSPACE
-              value: /mnt/agent-runtime
-          volumeMounts:
-            - name: agent-runtime-volume
-              mountPath: /mnt/agent-runtime
-      volumes:
-        - name: agent-runtime-volume # Define the shared directory between agent-runtime and main container
-          emptyDir: { }
+```shell
+kubectl apply -f examples/desktop/sandboxset.yaml
 ```
 
 ## 2. Using Sandboxes via E2B Python SDK

--- a/examples/desktop/sandboxset.yaml
+++ b/examples/desktop/sandboxset.yaml
@@ -1,0 +1,62 @@
+# Note: Currently, OpenKruise Agent Runtime is not yet released. To use E2B related features, you need to manually inject
+# the E2B envd component into the sandbox container for now:
+# 1. Inject envd through the preview agent-runtime image and an emptyDir volume mount.
+# 2. Start envd through the sandbox container's postStart hook.
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxSet
+metadata:
+  name: desktop
+  namespace: default
+  annotations:
+    e2b.agents.kruise.io/should-init-envd: "true"
+spec:
+  replicas: 2
+  template:
+    spec:
+      initContainers:
+        - name: init
+          image: openkruise/agent-runtime:preview-v0.0.2
+          volumeMounts:
+            - name: envd-volume
+              mountPath: /mnt/envd
+          env:
+            - name: ENVD_DIR
+              value: /mnt/envd
+          restartPolicy: Always
+      containers:
+        - name: sandbox
+          image: e2bdev/desktop:latest
+          resources:
+            requests:
+              cpu: 1
+              memory: 1Gi
+            limits:
+              cpu: 1
+              memory: 1Gi
+          env:
+            - name: PORT
+              value: "49999"
+            - name: ENVD_DIR
+              value: /mnt/envd
+          volumeMounts:
+            - name: envd-volume
+              mountPath: /mnt/envd
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - bash
+                  - /mnt/envd/envd-run.sh
+          startupProbe:
+            failureThreshold: 20
+            httpGet:
+              path: /health
+              port: 49999
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            timeoutSeconds: 1
+          imagePullPolicy: IfNotPresent
+      terminationGracePeriodSeconds: 1
+      volumes:
+        - name: envd-volume
+          emptyDir: { }


### PR DESCRIPTION
###  PR does

This PR makes the E2B Desktop example deployable end to end with a consistent template name.

- Adds `examples/desktop/sandboxset.yaml` as an apply-ready Desktop `SandboxSet` named `desktop`.
- Uses the current preview `agent-runtime` envd injection pattern already established by the code-interpreter example.
- Replaces the duplicated, stale inline manifests in the English and Chinese guides with a link and an explicit `kubectl apply` command.
- Keeps the manifest name aligned with every `Sandbox.create(template="desktop")` call in the example.

The mismatch was caused by the Desktop documentation carrying over `metadata.name: code-interpreter` from the code-interpreter example. Because the E2B template parameter resolves to the `SandboxSet` metadata name, following the guide previously resulted in a template-not-found response.

### pull request fix one issue?

Fixes #556

###  verify it

1. Deploy OpenKruise Agents and make `sandbox-manager` reachable by the E2B SDK.
2. Apply the new manifest:

   ```shell
   kubectl apply -f examples/desktop/sandboxset.yaml
   ```

3. Confirm that the template exists:

   ```shell
   kubectl get sandboxset desktop -n default
   ```

4. Configure the customized E2B client as described in the contributing guide, then create a Desktop sandbox:

   ```python
   from e2b_desktop import Sandbox

   desktop = Sandbox.create(template="desktop")
   desktop.kill()
   ```

Local validation performed:

- `git diff --check`
- Parsed `examples/desktop/sandboxset.yaml` as YAML and checked the `SandboxSet` name, Desktop image, README link, apply command, and SDK template name for consistency.

### Ⅳ. Special notes for reviews

The manifest intentionally follows the existing `examples/code_interpreter/sandboxset.yaml` envd setup, but omits its unrelated persistent-volume example. A live cluster verification was not available in the local environment.
