### PR TITLE
docs: add per-user NFS subpath example for OpenClaw

### DIFF
--- a/examples/openclaw/README-zh_CN.md
+++ b/examples/openclaw/README-zh_CN.md
@@ -332,6 +332,11 @@ spec:
 `agent-runtime` 和 `csi`。前文的 SandboxSet 使用了旧式 runtime init container，因此添加上述配置前，
 需要先将其替换为 runtime 注入方式。请勿在同一个 Sandbox 中同时使用两种 runtime 配置。
 
+`agent-runtime` 注入所使用的 runtime 镜像还必须在 `/mnt/envd/sandbox-runtime-storage` 位置包含存储辅助二进制。
+动态 CSI 挂载会在 Sandbox 内通过这个命令执行。如果 `SandboxClaim` 失败并报出
+`sandbox-runtime-storage not found`，请重新构建或替换 runtime 镜像，确保它包含通过 `make build-storage-cli`
+构建的二进制，并将其挂载或拷贝到 `/mnt/envd/sandbox-runtime-storage`。
+
 假设名为 `openclaw-shared-nfs` 的 CSI PV 基础路径为 `/exports/openclaw`，以下 Claim 会将
 `/exports/openclaw/users/alice` 挂载到 OpenClaw 的工作目录：
 

--- a/examples/openclaw/README-zh_CN.md
+++ b/examples/openclaw/README-zh_CN.md
@@ -305,7 +305,70 @@ print("配置已写入，OpenClaw 将自动重启加载新配置")
 python create_sandbox.py
 ```
 
-### 3.3 获取 Sandbox 信息
+### 3.3 为每个用户挂载独立的 NFS 子路径
+
+当多个 OpenClaw 实例共享同一个大型 NFS 导出目录时，可以通过 `SandboxClaim` 为每个用户挂载不同的目录。
+这种场景应使用 `dynamicVolumesMount`；如果每个 Sandbox 都需要独立供应的存储卷，仍建议使用
+`volumeClaimTemplates`。
+
+创建 Claim 前，请确认：
+
+- NFS 卷由 **CSI 类型的 PV**（`spec.csi`）表示，而不是旧式的 `spec.nfs` PV；
+- sandbox-manager 已通过 `DYNAMIC_STORAGE_DRIVER_LIST` 启用该 PV 的 CSI 驱动，并且 Sandbox 已配置对应的
+  CSI sidecar；
+- SandboxSet 已配置 `agent-runtime` 和 `csi` runtime；
+- 如果 NFS CSI 驱动不会自动创建远端用户目录，需要提前创建该目录。
+
+对于使用 runtime 注入的资源池，SandboxSet 中的相关配置如下：
+
+```yaml
+spec:
+  runtimes:
+    - name: agent-runtime
+    - name: csi
+```
+
+集群管理员需要根据已安装的 NFS CSI 驱动，在 `sandbox-injection-config` ConfigMap 中配置
+`agent-runtime` 和 `csi`。前文的 SandboxSet 使用了旧式 runtime init container，因此添加上述配置前，
+需要先将其替换为 runtime 注入方式。请勿在同一个 Sandbox 中同时使用两种 runtime 配置。
+
+假设名为 `openclaw-shared-nfs` 的 CSI PV 基础路径为 `/exports/openclaw`，以下 Claim 会将
+`/exports/openclaw/users/alice` 挂载到 OpenClaw 的工作目录：
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  name: openclaw-alice
+  namespace: default
+spec:
+  templateName: openclaw-sbs
+  replicas: 1
+  dynamicVolumesMount:
+    - pvName: openclaw-shared-nfs
+      mountPath: /home/node/.openclaw/workspace
+      subPath: users/alice
+      readOnly: false
+```
+
+应用 Claim 并等待完成：
+
+```bash
+kubectl apply -f sandboxclaim-alice.yaml
+kubectl wait --for=jsonpath='{.status.phase}'=Completed \
+  sandboxclaim/openclaw-alice --timeout=2m
+kubectl get sandbox \
+  -l agents.kruise.io/claim-name=openclaw-alice
+```
+
+后续 Claim 应使用唯一的 `subPath`，例如 `users/bob`。该路径会相对于 PV 的基础路径解析；试图跳出基础路径的值
+（例如 `../other-user`）会被拒绝。系统会把子路径追加到 PV 的 `spec.csi.volumeAttributes.path`，因此请使用
+能够识别 `path` 属性的 CSI 驱动，并根据该驱动的要求调整 PV 属性。
+
+> **安全提示：** 不同子路径可以避免意外的数据重叠，但不能作为授权边界。对于不受信任的租户，还需通过
+> NFS 导出策略、身份和文件权限实施隔离。
+
+### 3.4 获取 Sandbox 信息
 
 ```python
 print(f"Sandbox ID: {sbx.sandbox_id}")

--- a/examples/openclaw/README.md
+++ b/examples/openclaw/README.md
@@ -312,7 +312,72 @@ Execute:
 python create_sandbox.py
 ```
 
-### 3.3 Retrieving Sandbox Information
+### 3.3 Mounting a Per-user NFS Subpath
+
+When many OpenClaw instances share one large NFS export, a `SandboxClaim` can mount a different directory for each
+user. Use `dynamicVolumesMount` for this case; `volumeClaimTemplates` is still the better choice when every Sandbox
+should receive an independently provisioned volume.
+
+Before creating the claim, make sure that:
+
+- the NFS volume is represented by a **CSI-backed PV** (`spec.csi`), not a legacy `spec.nfs` PV;
+- the PV's CSI driver is enabled in sandbox-manager through `DYNAMIC_STORAGE_DRIVER_LIST` and the matching CSI
+  sidecar is configured for the Sandbox;
+- the SandboxSet has the `agent-runtime` and `csi` runtimes configured; and
+- the remote user directory already exists if the NFS CSI driver does not create it automatically.
+
+For a runtime-injected pool, the relevant part of the SandboxSet is:
+
+```yaml
+spec:
+  runtimes:
+    - name: agent-runtime
+    - name: csi
+```
+
+The cluster administrator must configure the `agent-runtime` and `csi` entries in the
+`sandbox-injection-config` ConfigMap for the installed NFS CSI driver. The SandboxSet shown earlier embeds a legacy
+runtime init container, so replace that setup with runtime injection before adding these entries. Do not run both
+runtime setups in the same Sandbox.
+
+Assume a CSI-backed PV named `openclaw-shared-nfs` has a base path of `/exports/openclaw`. The following claim mounts
+`/exports/openclaw/users/alice` at OpenClaw's workspace path:
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  name: openclaw-alice
+  namespace: default
+spec:
+  templateName: openclaw-sbs
+  replicas: 1
+  dynamicVolumesMount:
+    - pvName: openclaw-shared-nfs
+      mountPath: /home/node/.openclaw/workspace
+      subPath: users/alice
+      readOnly: false
+```
+
+Apply the claim and wait for it to complete:
+
+```bash
+kubectl apply -f sandboxclaim-alice.yaml
+kubectl wait --for=jsonpath='{.status.phase}'=Completed \
+  sandboxclaim/openclaw-alice --timeout=2m
+kubectl get sandbox \
+  -l agents.kruise.io/claim-name=openclaw-alice
+```
+
+Create subsequent claims with a unique `subPath`, such as `users/bob`. The path is interpreted relative to the PV's
+base path; values that escape it, such as `../other-user`, are rejected. Internally, the subpath is appended to the PV's
+`spec.csi.volumeAttributes.path`, so use a CSI driver that consumes the `path` attribute and adapt the PV attributes
+to that driver's requirements.
+
+> **Security note:** Different subpaths prevent accidental overlap, but they are not an authorization boundary. For
+> untrusted tenants, also enforce isolation with NFS exports, identities, and permissions.
+
+### 3.4 Retrieving Sandbox Information
 
 ```python
 print(f"Sandbox ID: {sbx.sandbox_id}")

--- a/examples/openclaw/README.md
+++ b/examples/openclaw/README.md
@@ -340,6 +340,11 @@ The cluster administrator must configure the `agent-runtime` and `csi` entries i
 runtime init container, so replace that setup with runtime injection before adding these entries. Do not run both
 runtime setups in the same Sandbox.
 
+The runtime image used by the `agent-runtime` injection must also contain the storage helper binary at
+`/mnt/envd/sandbox-runtime-storage`. Dynamic CSI mounts are executed through this command inside the Sandbox. If a
+`SandboxClaim` fails with an error such as `sandbox-runtime-storage not found`, rebuild or replace the runtime image so
+that it includes the binary built by `make build-storage-cli`, and mount/copy it to `/mnt/envd/sandbox-runtime-storage`.
+
 Assume a CSI-backed PV named `openclaw-shared-nfs` has a base path of `/exports/openclaw`. The following claim mounts
 `/exports/openclaw/users/alice` at OpenClaw's workspace path:
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds an English and Chinese OpenClaw guide for mounting an isolated NFS subpath for each `SandboxClaim`.

The guide:

- shows a complete `dynamicVolumesMount` claim for a per-user workspace;
- explains the CSI-backed PV, driver registration, and runtime injection prerequisites;
- documents how `subPath` is resolved against `spec.csi.volumeAttributes.path`;
- includes commands to wait for the claim and find the claimed Sandbox; and
- calls out path validation and the security boundary of subpath-based isolation.

### Ⅱ. Does this pull request fix one issue?

Fixes #507

### Ⅲ. Describe how to verify it

1. Follow the new OpenClaw NFS subpath section with a CSI-backed NFS PV and a SandboxSet configured for agent-runtime and CSI injection.
2. Apply the example `SandboxClaim`.
3. Verify that the claim reaches `Completed` and that the claimed Sandbox mounts the requested user subdirectory at `/home/node/.openclaw/workspace`.

Documentation formatting was checked with:

```bash
git diff --check
```

### Ⅳ. Special notes for reviews

The dynamic mount path requires a CSI-backed PV. A legacy `spec.nfs` PV cannot be used because the implementation builds a CSI `NodePublishVolumeRequest` and resolves `subPath` through the PV's `volumeAttributes.path`.