### PR TITLE
feat: add E2B-compatible sandbox network APIs

### DIFF
--- a/api/v1alpha1/annotations.go
+++ b/api/v1alpha1/annotations.go
@@ -37,6 +37,9 @@ const (
 
 	AnnotationEnvdAccessToken = E2BPrefix + "envd-access-token"
 	AnnotationEnvdURL         = E2BPrefix + "envd-url"
+	// AnnotationNetworkConfig stores the E2B-compatible network configuration
+	// requested for a sandbox.
+	AnnotationNetworkConfig = E2BPrefix + "network-config"
 	// AnnotationCSIVolumeConfig is the annotation key for CSI mount configuration.
 	AnnotationCSIVolumeConfig = E2BPrefix + "csi-volume-config"
 )

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -252,6 +252,9 @@ func (sc *Controller) parseCreateSandboxRequest(r *http.Request) (models.NewSand
 			Message: fmt.Sprintf("Bad extension param: %s", err.Error()),
 		}
 	}
+	if apiErr := validateSandboxNetwork(request.Network); apiErr != nil {
+		return request, apiErr
+	}
 
 	for k := range request.Metadata {
 		if errLists := validation.IsQualifiedName(k); len(errLists) > 0 {
@@ -318,6 +321,13 @@ func (sc *Controller) basicSandboxCreateModifier(ctx context.Context, sbx infra.
 	}
 	for k, v := range request.Metadata {
 		annotations[k] = v
+	}
+	if request.Network != nil || request.AllowInternetAccess != nil {
+		if raw, err := marshalSandboxNetworkState(networkStateFromCreateRequest(request)); err != nil {
+			log.Error(err, "failed to marshal sandbox network configuration")
+		} else {
+			annotations[agentsv1alpha1.AnnotationNetworkConfig] = raw
+		}
 	}
 	if request.Extensions.ReturnPodIP {
 		annotations[models.ExtensionKeyReturnPodIP] = agentsv1alpha1.True

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -32,31 +32,62 @@ const (
 
 // Sandbox represents an E2B sandbox running as a Kubernetes Pod
 type Sandbox struct {
-	TemplateID      string            `json:"templateID"`
-	SandboxID       string            `json:"sandboxID"`
-	ClientID        string            `json:"clientID"`
-	StartedAt       string            `json:"startedAt"`
-	EndAt           string            `json:"endAt"`
-	EnvdVersion     string            `json:"envdVersion"`
-	EnvdAccessToken string            `json:"envdAccessToken,omitempty"`
-	Domain          string            `json:"domain"`
-	CPUCount        int64             `json:"cpuCount"`
-	MemoryMB        int64             `json:"memoryMB"`
-	DiskSizeMB      int64             `json:"diskSizeMB"`
-	Alias           string            `json:"alias"`
-	Metadata        map[string]string `json:"metadata"`
-	State           string            `json:"state"`
+	TemplateID          string            `json:"templateID"`
+	SandboxID           string            `json:"sandboxID"`
+	ClientID            string            `json:"clientID"`
+	StartedAt           string            `json:"startedAt"`
+	EndAt               string            `json:"endAt"`
+	EnvdVersion         string            `json:"envdVersion"`
+	EnvdAccessToken     string            `json:"envdAccessToken,omitempty"`
+	Domain              string            `json:"domain"`
+	CPUCount            int64             `json:"cpuCount"`
+	MemoryMB            int64             `json:"memoryMB"`
+	DiskSizeMB          int64             `json:"diskSizeMB"`
+	Alias               string            `json:"alias"`
+	Metadata            map[string]string `json:"metadata"`
+	State               string            `json:"state"`
+	AllowInternetAccess bool              `json:"allowInternetAccess"`
+	Network             *SandboxNetwork   `json:"network,omitempty"`
 }
 
 // NewSandboxRequest represents a request to create a new sandbox
 type NewSandboxRequest struct {
-	TemplateID string            `json:"templateID"`
-	Timeout    int               `json:"timeout,omitempty"`
-	AutoPause  bool              `json:"autoPause,omitempty"`
-	Metadata   map[string]string `json:"metadata,omitempty"`
-	EnvVars    EnvVars           `json:"envVars,omitempty"`
+	TemplateID          string            `json:"templateID"`
+	Timeout             int               `json:"timeout,omitempty"`
+	AutoPause           bool              `json:"autoPause,omitempty"`
+	Metadata            map[string]string `json:"metadata,omitempty"`
+	EnvVars             EnvVars           `json:"envVars,omitempty"`
+	AllowInternetAccess *bool             `json:"allow_internet_access,omitempty"`
+	Network             *SandboxNetwork   `json:"network,omitempty"`
 
 	Extensions NewSandboxRequestExtension `json:"-"`
+}
+
+// SandboxNetwork contains the E2B-compatible egress and public ingress
+// configuration for a sandbox.
+type SandboxNetwork struct {
+	AllowOut           []string                        `json:"allowOut,omitempty"`
+	DenyOut            []string                        `json:"denyOut,omitempty"`
+	Rules              map[string][]SandboxNetworkRule `json:"rules,omitempty"`
+	AllowPublicTraffic *bool                           `json:"allowPublicTraffic,omitempty"`
+	MaskRequestHost    string                          `json:"maskRequestHost,omitempty"`
+}
+
+type SandboxNetworkRule struct {
+	Transform *SandboxNetworkTransform `json:"transform,omitempty"`
+}
+
+type SandboxNetworkTransform struct {
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+// UpdateSandboxNetworkRequest replaces the mutable egress configuration.
+// Public traffic and request-host masking are configured only at creation.
+type UpdateSandboxNetworkRequest struct {
+	AllowOut            []string                        `json:"allowOut,omitempty"`
+	DenyOut             []string                        `json:"denyOut,omitempty"`
+	Rules               map[string][]SandboxNetworkRule `json:"rules,omitempty"`
+	AllowInternetAccess *bool                           `json:"allow_internet_access,omitempty"`
 }
 
 type NewSandboxRequestExtension struct {

--- a/pkg/servers/e2b/network.go
+++ b/pkg/servers/e2b/network.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2b
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/netip"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/openkruise/agents/pkg/servers/web"
+)
+
+type sandboxNetworkState struct {
+	AllowInternetAccess bool                   `json:"allowInternetAccess"`
+	Network             *models.SandboxNetwork `json:"network,omitempty"`
+}
+
+func networkStateFromCreateRequest(request models.NewSandboxRequest) sandboxNetworkState {
+	state := sandboxNetworkState{AllowInternetAccess: true}
+	if request.AllowInternetAccess != nil {
+		state.AllowInternetAccess = *request.AllowInternetAccess
+	}
+	if request.Network != nil {
+		network := *request.Network
+		state.Network = &network
+	}
+	if state.Network != nil && state.Network.AllowPublicTraffic == nil {
+		allowPublicTraffic := true
+		state.Network.AllowPublicTraffic = &allowPublicTraffic
+	}
+	return state
+}
+
+func marshalSandboxNetworkState(state sandboxNetworkState) (string, error) {
+	raw, err := json.Marshal(state)
+	return string(raw), err
+}
+
+func unmarshalSandboxNetworkState(raw string) (sandboxNetworkState, error) {
+	state := sandboxNetworkState{AllowInternetAccess: true}
+	if raw == "" {
+		return state, nil
+	}
+	if err := json.Unmarshal([]byte(raw), &state); err != nil {
+		return sandboxNetworkState{AllowInternetAccess: true}, err
+	}
+	return state, nil
+}
+
+func validateSandboxNetwork(network *models.SandboxNetwork) *web.ApiError {
+	if network == nil {
+		return nil
+	}
+	for _, target := range network.AllowOut {
+		if err := validateNetworkTarget(target, true); err != nil {
+			return &web.ApiError{Code: http.StatusBadRequest, Message: fmt.Sprintf("invalid allowOut target %q: %v", target, err)}
+		}
+	}
+	for _, target := range network.DenyOut {
+		if _, err := netip.ParsePrefix(target); err != nil {
+			if _, addrErr := netip.ParseAddr(target); addrErr != nil {
+				return &web.ApiError{Code: http.StatusBadRequest, Message: fmt.Sprintf("invalid denyOut target %q: expected an IP address or CIDR", target)}
+			}
+		}
+	}
+	for target := range network.Rules {
+		if err := validateNetworkTarget(target, true); err != nil {
+			return &web.ApiError{Code: http.StatusBadRequest, Message: fmt.Sprintf("invalid rules target %q: %v", target, err)}
+		}
+	}
+	return nil
+}
+
+func validateNetworkTarget(target string, allowDomain bool) error {
+	if target == "" {
+		return fmt.Errorf("target cannot be empty")
+	}
+	if _, err := netip.ParsePrefix(target); err == nil {
+		return nil
+	}
+	if _, err := netip.ParseAddr(target); err == nil {
+		return nil
+	}
+	if !allowDomain {
+		return fmt.Errorf("expected an IP address or CIDR")
+	}
+	domain := strings.TrimPrefix(target, "*.")
+	if errs := validation.IsDNS1123Subdomain(domain); len(errs) != 0 {
+		return fmt.Errorf("expected an IP address, CIDR, domain, or wildcard domain")
+	}
+	return nil
+}
+
+// UpdateSandboxNetwork atomically replaces a sandbox's mutable egress settings.
+func (sc *Controller) UpdateSandboxNetwork(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
+	var request models.UpdateSandboxNetworkRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		return web.ApiResponse[struct{}]{}, &web.ApiError{Code: http.StatusBadRequest, Message: err.Error()}
+	}
+	requestedNetwork := &models.SandboxNetwork{AllowOut: request.AllowOut, DenyOut: request.DenyOut, Rules: request.Rules}
+	if apiErr := validateSandboxNetwork(requestedNetwork); apiErr != nil {
+		return web.ApiResponse[struct{}]{}, apiErr
+	}
+
+	sbx, apiErr := sc.getSandboxOfUser(r.Context(), r.PathValue("sandboxID"), liveSandboxStates)
+	if apiErr != nil {
+		return web.ApiResponse[struct{}]{}, apiErr
+	}
+	state, _ := sbx.GetState()
+	if state != agentsv1alpha1.SandboxStateRunning {
+		return web.ApiResponse[struct{}]{}, &web.ApiError{Code: http.StatusConflict, Message: fmt.Sprintf("sandbox %s is not running", sbx.GetName())}
+	}
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &agentsv1alpha1.Sandbox{}
+		key := client.ObjectKey{Namespace: sbx.GetNamespace(), Name: sbx.GetName()}
+		if err := sc.cache.GetAPIReader().Get(r.Context(), key, current); err != nil {
+			return err
+		}
+		state, err := unmarshalSandboxNetworkState(current.Annotations[agentsv1alpha1.AnnotationNetworkConfig])
+		if err != nil {
+			return err
+		}
+		if state.Network == nil {
+			state.Network = &models.SandboxNetwork{}
+		}
+		state.Network.AllowOut = request.AllowOut
+		state.Network.DenyOut = request.DenyOut
+		state.Network.Rules = request.Rules
+		if request.AllowInternetAccess != nil {
+			state.AllowInternetAccess = *request.AllowInternetAccess
+		}
+		raw, err := marshalSandboxNetworkState(state)
+		if err != nil {
+			return err
+		}
+		if current.Annotations == nil {
+			current.Annotations = map[string]string{}
+		}
+		current.Annotations[agentsv1alpha1.AnnotationNetworkConfig] = raw
+		return sc.cache.GetClient().Update(r.Context(), current)
+	})
+	if err != nil {
+		code := http.StatusInternalServerError
+		if apierrors.IsNotFound(err) {
+			code = http.StatusNotFound
+		} else if apierrors.IsConflict(err) {
+			code = http.StatusConflict
+		}
+		return web.ApiResponse[struct{}]{}, &web.ApiError{Code: code, Message: fmt.Sprintf("failed to update sandbox network: %v", err)}
+	}
+	return web.ApiResponse[struct{}]{Code: http.StatusNoContent}, nil
+}

--- a/pkg/servers/e2b/network_test.go
+++ b/pkg/servers/e2b/network_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2b
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/servers/e2b/keys"
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+)
+
+func boolPointer(value bool) *bool {
+	return &value
+}
+
+func TestValidateSandboxNetwork(t *testing.T) {
+	tests := []struct {
+		name        string
+		network     *models.SandboxNetwork
+		expectError string
+	}{
+		{
+			name: "accepts supported targets",
+			network: &models.SandboxNetwork{
+				AllowOut: []string{"api.example.com", "*.example.net", "10.0.0.1", "10.0.0.0/8"},
+				DenyOut:  []string{"192.0.2.1", "2001:db8::/32"},
+				Rules: map[string][]models.SandboxNetworkRule{
+					"api.example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-Api-Key": "secret"}}}},
+				},
+			},
+		},
+		{
+			name:        "rejects domains in deny list",
+			network:     &models.SandboxNetwork{DenyOut: []string{"example.com"}},
+			expectError: "invalid denyOut target",
+		},
+		{
+			name:        "rejects malformed allow target",
+			network:     &models.SandboxNetwork{AllowOut: []string{"not a domain"}},
+			expectError: "invalid allowOut target",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiErr := validateSandboxNetwork(tt.network)
+			if tt.expectError == "" {
+				assert.Nil(t, apiErr)
+				return
+			}
+			require.NotNil(t, apiErr)
+			assert.Equal(t, http.StatusBadRequest, apiErr.Code)
+			assert.Contains(t, apiErr.Message, tt.expectError)
+		})
+	}
+}
+
+func TestSandboxNetworkLifecycle(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T, controller *Controller, user *models.CreatedTeamAPIKey)
+	}{
+		{
+			name: "create stores and returns network configuration",
+			run: func(t *testing.T, controller *Controller, user *models.CreatedTeamAPIKey) {
+				cleanup := CreateSandboxPool(t, controller, "network-create", 1)
+				defer cleanup()
+				response, apiErr := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+					TemplateID:          "network-create",
+					AllowInternetAccess: boolPointer(false),
+					Network: &models.SandboxNetwork{
+						AllowOut:           []string{"api.example.com"},
+						AllowPublicTraffic: boolPointer(false),
+						MaskRequestHost:    "sandbox.example.com",
+					},
+					Metadata: map[string]string{models.ExtensionKeySkipInitRuntime: agentsv1alpha1.True},
+				}, nil, user))
+				require.Nil(t, apiErr)
+				assert.False(t, response.Body.AllowInternetAccess)
+				require.NotNil(t, response.Body.Network)
+				assert.Equal(t, []string{"api.example.com"}, response.Body.Network.AllowOut)
+				assert.Equal(t, boolPointer(false), response.Body.Network.AllowPublicTraffic)
+
+				persisted := GetSandbox(t, response.Body.SandboxID, getTestCRClient(controller))
+				state, err := unmarshalSandboxNetworkState(persisted.Annotations[agentsv1alpha1.AnnotationNetworkConfig])
+				require.NoError(t, err)
+				assert.False(t, state.AllowInternetAccess)
+				assert.Equal(t, response.Body.Network, state.Network)
+			},
+		},
+		{
+			name: "update replaces egress and preserves create-only settings",
+			run: func(t *testing.T, controller *Controller, user *models.CreatedTeamAPIKey) {
+				cleanup := CreateSandboxPool(t, controller, "network-update", 1)
+				defer cleanup()
+				createResponse, apiErr := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+					TemplateID: "network-update",
+					Network: &models.SandboxNetwork{
+						AllowOut:           []string{"old.example.com"},
+						DenyOut:            []string{"192.0.2.1"},
+						AllowPublicTraffic: boolPointer(false),
+						MaskRequestHost:    "sandbox.example.com",
+					},
+					Metadata: map[string]string{models.ExtensionKeySkipInitRuntime: agentsv1alpha1.True},
+				}, nil, user))
+				require.Nil(t, apiErr)
+				sandboxID := createResponse.Body.SandboxID
+
+				request := httptest.NewRequest(http.MethodPut, "/sandboxes/"+sandboxID+"/network", bytes.NewBufferString(`{
+					"allowOut":["new.example.com"],
+					"rules":{"new.example.com":[{}]},
+					"allow_internet_access":false
+				}`))
+				request.Header.Set("X-API-Key", InitKey)
+				response := httptest.NewRecorder()
+				controller.mux.ServeHTTP(response, request)
+				assert.Equal(t, http.StatusNoContent, response.Code)
+				assert.Empty(t, response.Body.String())
+
+				persisted := GetSandbox(t, sandboxID, getTestCRClient(controller))
+				state, decodeErr := unmarshalSandboxNetworkState(persisted.Annotations[agentsv1alpha1.AnnotationNetworkConfig])
+				require.NoError(t, decodeErr)
+				assert.False(t, state.AllowInternetAccess)
+				assert.Equal(t, []string{"new.example.com"}, state.Network.AllowOut)
+				assert.Empty(t, state.Network.DenyOut)
+				assert.Equal(t, boolPointer(false), state.Network.AllowPublicTraffic)
+				assert.Equal(t, "sandbox.example.com", state.Network.MaskRequestHost)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller, _, teardown := Setup(t)
+			defer teardown()
+			user := &models.CreatedTeamAPIKey{ID: keys.AdminKeyID, Key: InitKey, Name: "admin"}
+			tt.run(t, controller, user)
+		})
+	}
+}

--- a/pkg/servers/e2b/network_test.go
+++ b/pkg/servers/e2b/network_test.go
@@ -18,14 +18,19 @@ package e2b
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 )
@@ -60,6 +65,14 @@ func TestValidateSandboxNetwork(t *testing.T) {
 			network:     &models.SandboxNetwork{AllowOut: []string{"not a domain"}},
 			expectError: "invalid allowOut target",
 		},
+		{
+			name:        "rejects malformed rule target",
+			network:     &models.SandboxNetwork{Rules: map[string][]models.SandboxNetworkRule{"": {{}}}},
+			expectError: "invalid rules target",
+		},
+		{
+			name: "accepts nil network",
+		},
 	}
 
 	for _, tt := range tests {
@@ -74,6 +87,12 @@ func TestValidateSandboxNetwork(t *testing.T) {
 			assert.Contains(t, apiErr.Message, tt.expectError)
 		})
 	}
+
+	t.Run("rejects domains when disabled", func(t *testing.T) {
+		err := validateNetworkTarget("example.com", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected an IP address or CIDR")
+	})
 }
 
 func TestSandboxNetworkLifecycle(t *testing.T) {
@@ -148,6 +167,83 @@ func TestSandboxNetworkLifecycle(t *testing.T) {
 				assert.Equal(t, "sandbox.example.com", state.Network.MaskRequestHost)
 			},
 		},
+		{
+			name: "update creates network state from existing empty config",
+			run: func(t *testing.T, controller *Controller, user *models.CreatedTeamAPIKey) {
+				sbx := CreateClaimedSandboxCR(t, controller, Namespace, "network-empty", "network-empty", user.ID.String(), nil)
+				sandboxID := sbx.Namespace + "--" + sbx.Name
+
+				request := NewRequest(t, nil, models.UpdateSandboxNetworkRequest{
+					AllowOut:            []string{"api.example.com"},
+					AllowInternetAccess: boolPointer(false),
+				}, map[string]string{"sandboxID": sandboxID}, user)
+				response, apiErr := controller.UpdateSandboxNetwork(request)
+				require.Nil(t, apiErr)
+				assert.Equal(t, http.StatusNoContent, response.Code)
+
+				persisted := GetSandbox(t, sandboxID, getTestCRClient(controller))
+				state, decodeErr := unmarshalSandboxNetworkState(persisted.Annotations[agentsv1alpha1.AnnotationNetworkConfig])
+				require.NoError(t, decodeErr)
+				assert.False(t, state.AllowInternetAccess)
+				require.NotNil(t, state.Network)
+				assert.Equal(t, []string{"api.example.com"}, state.Network.AllowOut)
+			},
+		},
+		{
+			name: "update rejects invalid and unavailable sandboxes",
+			run: func(t *testing.T, controller *Controller, user *models.CreatedTeamAPIKey) {
+				badJSON := httptest.NewRequest(http.MethodPut, "/sandboxes/missing/network", bytes.NewBufferString("{"))
+				badJSON.SetPathValue("sandboxID", "missing")
+				badJSON = badJSON.WithContext(context.WithValue(badJSON.Context(), "user", user))
+				_, apiErr := controller.UpdateSandboxNetwork(badJSON)
+				require.NotNil(t, apiErr)
+				assert.Equal(t, http.StatusBadRequest, apiErr.Code)
+
+				invalidNetwork := NewRequest(t, nil, models.UpdateSandboxNetworkRequest{
+					AllowOut: []string{"not a domain"},
+				}, map[string]string{"sandboxID": "missing"}, user)
+				_, apiErr = controller.UpdateSandboxNetwork(invalidNetwork)
+				require.NotNil(t, apiErr)
+				assert.Equal(t, http.StatusBadRequest, apiErr.Code)
+
+			},
+		},
+		{
+			name: "update rejects non-running sandboxes and bad stored config",
+			run: func(t *testing.T, controller *Controller, user *models.CreatedTeamAPIKey) {
+				fc := getTestCRClient(controller)
+				paused := CreateClaimedSandboxCR(t, controller, Namespace, "network-paused", "network-paused", user.ID.String(), nil)
+				pausedID := paused.Namespace + "--" + paused.Name
+				UpdateSandboxWhen(t, fc, pausedID, Immediately, DoSetSandboxStatus(agentsv1alpha1.SandboxPaused, metav1.ConditionTrue, metav1.ConditionFalse))
+				ctx := context.WithValue(t.Context(), "user", user)
+				require.Eventually(t, func() bool {
+					cached, apiErr := controller.getSandboxOfUser(ctx, pausedID, liveSandboxStates)
+					if apiErr != nil {
+						return false
+					}
+					state, _ := cached.GetState()
+					return state == agentsv1alpha1.SandboxStatePaused
+				}, time.Second, 10*time.Millisecond)
+
+				request := NewRequest(t, nil, models.UpdateSandboxNetworkRequest{
+					AllowOut: []string{"api.example.com"},
+				}, map[string]string{"sandboxID": pausedID}, user)
+				_, apiErr := controller.UpdateSandboxNetwork(request)
+				require.NotNil(t, apiErr)
+				assert.Equal(t, http.StatusConflict, apiErr.Code)
+
+				corrupt := CreateClaimedSandboxCR(t, controller, Namespace, "network-corrupt", "network-corrupt", user.ID.String(), map[string]string{
+					agentsv1alpha1.AnnotationNetworkConfig: "{",
+				})
+				corruptID := corrupt.Namespace + "--" + corrupt.Name
+				request = NewRequest(t, nil, models.UpdateSandboxNetworkRequest{
+					AllowOut: []string{"api.example.com"},
+				}, map[string]string{"sandboxID": corruptID}, user)
+				_, apiErr = controller.UpdateSandboxNetwork(request)
+				require.NotNil(t, apiErr)
+				assert.Equal(t, http.StatusInternalServerError, apiErr.Code)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -158,4 +254,80 @@ func TestSandboxNetworkLifecycle(t *testing.T) {
 			tt.run(t, controller, user)
 		})
 	}
+}
+
+func TestSandboxNetworkState(t *testing.T) {
+	t.Run("create request defaults network fields", func(t *testing.T) {
+		state := networkStateFromCreateRequest(models.NewSandboxRequest{
+			Network: &models.SandboxNetwork{AllowOut: []string{"api.example.com"}},
+		})
+		assert.True(t, state.AllowInternetAccess)
+		require.NotNil(t, state.Network)
+		assert.Equal(t, boolPointer(true), state.Network.AllowPublicTraffic)
+	})
+
+	t.Run("create request preserves explicit internet access", func(t *testing.T) {
+		state := networkStateFromCreateRequest(models.NewSandboxRequest{
+			AllowInternetAccess: boolPointer(false),
+		})
+		assert.False(t, state.AllowInternetAccess)
+		assert.Nil(t, state.Network)
+	})
+
+	t.Run("empty and invalid persisted state keep safe defaults", func(t *testing.T) {
+		state, err := unmarshalSandboxNetworkState("")
+		require.NoError(t, err)
+		assert.True(t, state.AllowInternetAccess)
+		assert.Nil(t, state.Network)
+
+		state, err = unmarshalSandboxNetworkState("{")
+		require.Error(t, err)
+		assert.True(t, state.AllowInternetAccess)
+		assert.Nil(t, state.Network)
+	})
+
+	t.Run("marshal round trip", func(t *testing.T) {
+		raw, err := marshalSandboxNetworkState(sandboxNetworkState{
+			AllowInternetAccess: false,
+			Network:             &models.SandboxNetwork{AllowOut: []string{"api.example.com"}},
+		})
+		require.NoError(t, err)
+
+		var decoded sandboxNetworkState
+		require.NoError(t, json.Unmarshal([]byte(raw), &decoded))
+		assert.False(t, decoded.AllowInternetAccess)
+		require.NotNil(t, decoded.Network)
+		assert.Equal(t, []string{"api.example.com"}, decoded.Network.AllowOut)
+	})
+}
+
+func TestParseCreateSandboxRequestRejectsInvalidNetwork(t *testing.T) {
+	ctrl := &Controller{maxTimeout: 3600}
+	request := NewRequest(t, nil, models.NewSandboxRequest{
+		TemplateID: "test-template",
+		Network:    &models.SandboxNetwork{Rules: map[string][]models.SandboxNetworkRule{"": {{}}}},
+	}, nil, nil)
+
+	_, apiErr := ctrl.parseCreateSandboxRequest(request)
+	require.NotNil(t, apiErr)
+	assert.Equal(t, http.StatusBadRequest, apiErr.Code)
+	assert.Contains(t, apiErr.Message, "invalid rules target")
+}
+
+func TestConvertToE2BSandboxHandlesInvalidNetworkState(t *testing.T) {
+	sbx := &sandboxcr.Sandbox{
+		Sandbox: &agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sandbox-1",
+				Namespace: "default",
+				Annotations: map[string]string{
+					agentsv1alpha1.AnnotationNetworkConfig: "{",
+				},
+			},
+		},
+	}
+
+	got := (&Controller{}).convertToE2BSandbox(sbx, "")
+	assert.True(t, got.AllowInternetAccess)
+	assert.Nil(t, got.Network)
 }

--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -57,6 +57,7 @@ func (sc *Controller) registerRoutes() {
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/resume", sc.ResumeSandbox, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/connect", sc.ConnectSandbox, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/timeout", sc.SetSandboxTimeout, sc.CheckApiKey)
+	RegisterE2BRoute(sc.mux, http.MethodPut, "/sandboxes/{sandboxID}/network", sc.UpdateSandboxNetwork, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/snapshots", sc.CreateSnapshot, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodGet, "/snapshots", sc.ListSnapshots, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodGet, "/templates", sc.ListTemplates, sc.CheckApiKey)

--- a/pkg/servers/e2b/sandbox.go
+++ b/pkg/servers/e2b/sandbox.go
@@ -87,6 +87,12 @@ func (sc *Controller) convertToE2BSandbox(sbx infra.Sandbox, accessToken string)
 	}
 	sandbox.State, _ = sbx.GetState()
 	annotations := sbx.GetAnnotations()
+	networkState, err := unmarshalSandboxNetworkState(annotations[agentsv1alpha1.AnnotationNetworkConfig])
+	if err != nil {
+		klog.ErrorS(err, "failed to decode sandbox network configuration", "sandbox", klog.KObj(sbx))
+	}
+	sandbox.AllowInternetAccess = networkState.AllowInternetAccess
+	sandbox.Network = networkState.Network
 	labels := sbx.GetLabels()
 
 	sandbox.Metadata = make(map[string]string, len(annotations)+len(labels))


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds the E2B-compatible sandbox network API surface introduced by the E2B Python SDK 2.25.0.

It:

- accepts `allow_internet_access` and `network` when creating a sandbox;
- returns `allowInternetAccess` and `network` in sandbox responses;
- registers `PUT /sandboxes/{sandboxID}/network` for both native and customized E2B paths;
- validates allow-list domains/IPs/CIDRs and restricts deny-list entries to IPs/CIDRs;
- atomically replaces mutable egress settings while preserving create-only public-traffic and host-masking settings; and
- persists the desired network configuration on the Sandbox so it survives subsequent reads and can be consumed by policy integration.

Updates use the latest Sandbox object and retry resource-version conflicts. Missing, paused, and concurrently modified sandboxes return the corresponding E2B-compatible status codes.

### Ⅱ. Does this pull request fix one issue?

Fixes #504

### Ⅲ. Describe how to verify it

```bash
go test -count=1 ./pkg/servers/e2b -run 'Test(ValidateSandboxNetwork|SandboxNetworkLifecycle)$'
go test -count=1 ./pkg/servers/e2b/models -run '^$'
```

The lifecycle coverage verifies create-time persistence and response fields, the authenticated `PUT` route, replacement semantics, and preservation of create-only settings.

### Ⅳ. Special notes for reviews

This change implements the E2B API and desired-state layer. Concrete L4/L7 enforcement remains part of the separate traffic-policy data-plane work described by the provisional network policy proposal.

On Windows, the broader E2B suite still encounters existing CSI tests that validate Unix absolute mount paths. The focused network tests and package compilation pass locally.