### PR TITLE
Feat/sandbox gateway auth

### DIFF
--- a/config/sandbox-gateway/configmap.yaml
+++ b/config/sandbox-gateway/configmap.yaml
@@ -79,6 +79,7 @@ data:
                               sandbox-header-name: "e2b-sandbox-id"
                               sandbox-port-header: "e2b-sandbox-port"
                               default-port: "49983"
+                              enable-auth: true
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/config/sandbox-gateway/configmap.yaml
+++ b/config/sandbox-gateway/configmap.yaml
@@ -79,7 +79,7 @@ data:
                               sandbox-header-name: "e2b-sandbox-id"
                               sandbox-port-header: "e2b-sandbox-port"
                               default-port: "49983"
-                              enable-auth: true
+                              enable-auth: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/hack/run-e2b-e2e-test.sh
+++ b/hack/run-e2b-e2e-test.sh
@@ -249,7 +249,7 @@ cd "$PROJECT_ROOT"
 if [ "$WITH_GATEWAY" = "true" ]; then
     pytest -v -s -x --tb=short "$TEST_DIR"
 else
-    pytest -v -s -x --tb=short --ignore="$TEST_DIR/test_gateway.py" "$TEST_DIR"
+    pytest -v -s -x --tb=short --ignore="$TEST_DIR/test_gateway.py" --ignore="$TEST_DIR/test_gateway_auth.py" "$TEST_DIR"
 fi
 retVal=$?
 

--- a/pkg/sandbox-gateway/filter/config.go
+++ b/pkg/sandbox-gateway/filter/config.go
@@ -45,6 +45,9 @@ type Config struct {
 	HostHeaderName string `json:"host-header-name,omitempty"`
 	// DefaultPort is the default port if not specified
 	DefaultPort string `json:"default-port,omitempty"`
+	// EnableAuth enables access token authentication when set to true.
+	// When disabled (default), the gateway skips token validation for backward compatibility.
+	EnableAuth bool `json:"enable-auth,omitempty"`
 }
 
 // DefaultConfig returns default configuration
@@ -178,6 +181,9 @@ func (p *ConfigParser) Merge(parent interface{}, child interface{}) interface{} 
 	}
 	if childCfg.DefaultPort != "" {
 		merged.DefaultPort = childCfg.DefaultPort
+	}
+	if childCfg.EnableAuth {
+		merged.EnableAuth = childCfg.EnableAuth
 	}
 
 	return NewFilterConfig(merged)

--- a/pkg/sandbox-gateway/filter/config_test.go
+++ b/pkg/sandbox-gateway/filter/config_test.go
@@ -148,38 +148,26 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
-// helperTypedStructAny creates an *anypb.Any wrapping a v3.TypedStruct with given fields.
-func helperTypedStructAny(t *testing.T, fields map[string]interface{}) *anypb.Any {
-	t.Helper()
-	ts := &v3.TypedStruct{}
-	if fields != nil {
-		s, err := structpb.NewStruct(fields)
-		if err != nil {
-			t.Fatalf("failed to create structpb.Struct: %v", err)
-		}
-		ts.Value = s
-	}
-	a, err := anypb.New(ts)
-	if err != nil {
-		t.Fatalf("failed to marshal TypedStruct to Any: %v", err)
-	}
-	return a
-}
-
 func TestConfigParserParse(t *testing.T) {
 	parser := &ConfigParser{}
 
 	tests := []struct {
 		name              string
-		any               *anypb.Any
+		input             *anypb.Any
 		wantErr           bool
 		wantSandboxHeader string
 		wantHostHeader    string
 		wantPortHeader    string
 		wantDefaultPort   string
+		wantEnableAuth    bool
 	}{
 		{
-			name:              "nil value in TypedStruct returns defaults",
+			name: "nil value in TypedStruct returns defaults",
+			input: func() *anypb.Any {
+				ts := &v3.TypedStruct{}
+				a, _ := anypb.New(ts)
+				return a
+			}(),
 			wantErr:           false,
 			wantSandboxHeader: DefaultSandboxHeaderName,
 			wantHostHeader:    DefaultHostHeaderName,
@@ -187,7 +175,13 @@ func TestConfigParserParse(t *testing.T) {
 			wantDefaultPort:   DefaultSandboxPort,
 		},
 		{
-			name:              "empty struct returns defaults",
+			name: "empty struct returns defaults",
+			input: func() *anypb.Any {
+				s, _ := structpb.NewStruct(map[string]any{})
+				ts := &v3.TypedStruct{Value: s}
+				a, _ := anypb.New(ts)
+				return a
+			}(),
 			wantErr:           false,
 			wantSandboxHeader: DefaultSandboxHeaderName,
 			wantHostHeader:    DefaultHostHeaderName,
@@ -195,7 +189,15 @@ func TestConfigParserParse(t *testing.T) {
 			wantDefaultPort:   DefaultSandboxPort,
 		},
 		{
-			name:              "custom sandbox header",
+			name: "custom sandbox header",
+			input: func() *anypb.Any {
+				s, _ := structpb.NewStruct(map[string]any{
+					"sandbox-header-name": "x-custom-sandbox",
+				})
+				ts := &v3.TypedStruct{Value: s}
+				a, _ := anypb.New(ts)
+				return a
+			}(),
 			wantErr:           false,
 			wantSandboxHeader: "x-custom-sandbox",
 			wantHostHeader:    DefaultHostHeaderName,
@@ -203,7 +205,18 @@ func TestConfigParserParse(t *testing.T) {
 			wantDefaultPort:   DefaultSandboxPort,
 		},
 		{
-			name:              "all custom values",
+			name: "all custom values",
+			input: func() *anypb.Any {
+				s, _ := structpb.NewStruct(map[string]any{
+					"sandbox-header-name": "x-sandbox",
+					"host-header-name":    "X-Forwarded-Host",
+					"sandbox-port-header": "x-port",
+					"default-port":        "8080",
+				})
+				ts := &v3.TypedStruct{Value: s}
+				a, _ := anypb.New(ts)
+				return a
+			}(),
 			wantErr:           false,
 			wantSandboxHeader: "x-sandbox",
 			wantHostHeader:    "X-Forwarded-Host",
@@ -211,40 +224,27 @@ func TestConfigParserParse(t *testing.T) {
 			wantDefaultPort:   "8080",
 		},
 		{
-			name:              "enable-auth parsed correctly",
+			name: "enable-auth parsed correctly",
+			input: func() *anypb.Any {
+				s, _ := structpb.NewStruct(map[string]any{
+					"enable-auth": true,
+				})
+				ts := &v3.TypedStruct{Value: s}
+				a, _ := anypb.New(ts)
+				return a
+			}(),
 			wantErr:           false,
 			wantSandboxHeader: DefaultSandboxHeaderName,
 			wantHostHeader:    DefaultHostHeaderName,
 			wantPortHeader:    DefaultSandboxPortHeader,
 			wantDefaultPort:   DefaultSandboxPort,
+			wantEnableAuth:    true,
 		},
 	}
 
-	// Build the Any payloads based on test expectations
-	tests[0].any = func() *anypb.Any {
-		ts := &v3.TypedStruct{}
-		a, _ := anypb.New(ts)
-		return a
-	}()
-	tests[1].any = func() *anypb.Any {
-		return helperTypedStructAny(t, map[string]interface{}{})
-	}()
-	tests[2].any = helperTypedStructAny(t, map[string]interface{}{
-		"sandbox-header-name": "x-custom-sandbox",
-	})
-	tests[3].any = helperTypedStructAny(t, map[string]interface{}{
-		"sandbox-header-name": "x-sandbox",
-		"host-header-name":    "X-Forwarded-Host",
-		"sandbox-port-header": "x-port",
-		"default-port":        "8080",
-	})
-	tests[4].any = helperTypedStructAny(t, map[string]interface{}{
-		"enable-auth": true,
-	})
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := parser.Parse(tt.any, nil)
+			result, err := parser.Parse(tt.input, nil)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Parse() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -267,10 +267,8 @@ func TestConfigParserParse(t *testing.T) {
 			if fc.DefaultPort != tt.wantDefaultPort && tt.wantDefaultPort != "" {
 				t.Errorf("DefaultPort = %q, want %q", fc.DefaultPort, tt.wantDefaultPort)
 			}
-			if tt.name == "enable-auth parsed correctly" {
-				if !fc.EnableAuth {
-					t.Error("EnableAuth = false, want true")
-				}
+			if fc.EnableAuth != tt.wantEnableAuth {
+				t.Errorf("EnableAuth = %v, want %v", fc.EnableAuth, tt.wantEnableAuth)
 			}
 			if fc.Adapter == nil {
 				t.Error("Parse() returned FilterConfig with nil Adapter")

--- a/pkg/sandbox-gateway/filter/config_test.go
+++ b/pkg/sandbox-gateway/filter/config_test.go
@@ -210,6 +210,14 @@ func TestConfigParserParse(t *testing.T) {
 			wantPortHeader:    "x-port",
 			wantDefaultPort:   "8080",
 		},
+		{
+			name:              "enable-auth parsed correctly",
+			wantErr:           false,
+			wantSandboxHeader: DefaultSandboxHeaderName,
+			wantHostHeader:    DefaultHostHeaderName,
+			wantPortHeader:    DefaultSandboxPortHeader,
+			wantDefaultPort:   DefaultSandboxPort,
+		},
 	}
 
 	// Build the Any payloads based on test expectations
@@ -229,6 +237,9 @@ func TestConfigParserParse(t *testing.T) {
 		"host-header-name":    "X-Forwarded-Host",
 		"sandbox-port-header": "x-port",
 		"default-port":        "8080",
+	})
+	tests[4].any = helperTypedStructAny(t, map[string]interface{}{
+		"enable-auth": true,
 	})
 
 	for _, tt := range tests {
@@ -255,6 +266,11 @@ func TestConfigParserParse(t *testing.T) {
 			}
 			if fc.DefaultPort != tt.wantDefaultPort && tt.wantDefaultPort != "" {
 				t.Errorf("DefaultPort = %q, want %q", fc.DefaultPort, tt.wantDefaultPort)
+			}
+			if tt.name == "enable-auth parsed correctly" {
+				if !fc.EnableAuth {
+					t.Error("EnableAuth = false, want true")
+				}
 			}
 			if fc.Adapter == nil {
 				t.Error("Parse() returned FilterConfig with nil Adapter")
@@ -289,24 +305,27 @@ func TestConfigParserMerge(t *testing.T) {
 		wantHostHeader    string
 		wantPortHeader    string
 		wantDefaultPort   string
+		wantEnableAuth    bool
 	}{
 		{
 			name:              "child overrides all parent fields",
 			parent:            DefaultConfig(),
-			child:             &Config{SandboxHeaderName: "child-sbx", HostHeaderName: "child-host", SandboxPortHeader: "child-port", DefaultPort: "9999"},
+			child:             &Config{SandboxHeaderName: "child-sbx", HostHeaderName: "child-host", SandboxPortHeader: "child-port", DefaultPort: "9999", EnableAuth: true},
 			wantSandboxHeader: "child-sbx",
 			wantHostHeader:    "child-host",
 			wantPortHeader:    "child-port",
 			wantDefaultPort:   "9999",
+			wantEnableAuth:    true,
 		},
 		{
 			name:              "empty child preserves parent",
-			parent:            &Config{SandboxHeaderName: "parent-sbx", HostHeaderName: "parent-host", SandboxPortHeader: "parent-port", DefaultPort: "1234"},
+			parent:            &Config{SandboxHeaderName: "parent-sbx", HostHeaderName: "parent-host", SandboxPortHeader: "parent-port", DefaultPort: "1234", EnableAuth: true},
 			child:             &Config{},
 			wantSandboxHeader: "parent-sbx",
 			wantHostHeader:    "parent-host",
 			wantPortHeader:    "parent-port",
 			wantDefaultPort:   "1234",
+			wantEnableAuth:    true,
 		},
 		{
 			name:              "partial child override",
@@ -316,6 +335,7 @@ func TestConfigParserMerge(t *testing.T) {
 			wantHostHeader:    DefaultHostHeaderName,
 			wantPortHeader:    DefaultSandboxPortHeader,
 			wantDefaultPort:   DefaultSandboxPort,
+			wantEnableAuth:    false,
 		},
 		{
 			name:              "both defaults",
@@ -325,6 +345,17 @@ func TestConfigParserMerge(t *testing.T) {
 			wantHostHeader:    DefaultHostHeaderName,
 			wantPortHeader:    DefaultSandboxPortHeader,
 			wantDefaultPort:   DefaultSandboxPort,
+			wantEnableAuth:    false,
+		},
+		{
+			name:              "child enables auth overriding parent disabled",
+			parent:            &Config{SandboxHeaderName: DefaultSandboxHeaderName, DefaultPort: DefaultSandboxPort, EnableAuth: false},
+			child:             &Config{EnableAuth: true},
+			wantSandboxHeader: DefaultSandboxHeaderName,
+			wantHostHeader:    DefaultHostHeaderName,
+			wantPortHeader:    DefaultSandboxPortHeader,
+			wantDefaultPort:   DefaultSandboxPort,
+			wantEnableAuth:    true,
 		},
 	}
 
@@ -349,6 +380,9 @@ func TestConfigParserMerge(t *testing.T) {
 			}
 			if fc.DefaultPort != tt.wantDefaultPort {
 				t.Errorf("DefaultPort = %q, want %q", fc.DefaultPort, tt.wantDefaultPort)
+			}
+			if fc.EnableAuth != tt.wantEnableAuth {
+				t.Errorf("EnableAuth = %v, want %v", fc.EnableAuth, tt.wantEnableAuth)
 			}
 			if fc.Adapter == nil {
 				t.Error("Merge() returned FilterConfig with nil Adapter")

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -114,7 +114,7 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 	// Authenticate the request if auth is enabled and the sandbox has an access token configured.
 	// When EnableAuth is false (default), the gateway skips token validation for backward compatibility.
 	if f.config.EnableAuth && route.AccessToken != "" {
-		requestToken := headers[accessTokenHeader]
+		requestToken, _ := header.Get(accessTokenHeader)
 		if subtle.ConstantTimeCompare([]byte(requestToken), []byte(route.AccessToken)) != 1 {
 			logger.Warn("Access token mismatch",
 				zap.String("sandboxID", sandboxID))

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -129,9 +129,6 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 		}
 	}
 
-	// Strip the access token header before forwarding to prevent token leakage to upstream sandbox
-	header.Del(accessTokenHeader)
-
 	// Apply extra headers from the adapter (e.g., :path rewrite for kruise custom protocol)
 	for k, v := range extraHeaders {
 		header.Set(k, v)

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package filter
 
 import (
+	"crypto/subtle"
 	"fmt"
 
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
@@ -35,6 +36,12 @@ func init() {
 	config.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
 	logger, _ = config.Build()
 }
+
+const (
+	// accessTokenHeader is the HTTP header name that clients must set
+	// to carry the sandbox access token for authentication.
+	accessTokenHeader = "x-access-token"
+)
 
 func FilterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
 	cfg := c.(*FilterConfig)
@@ -103,6 +110,27 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 		)
 		return api.LocalReply
 	}
+
+	// Authenticate the request if the sandbox has an access token configured.
+	// Sandboxes without a token (empty string) skip authentication for backward compatibility.
+	if route.AccessToken != "" {
+		requestToken := headers[accessTokenHeader]
+		if subtle.ConstantTimeCompare([]byte(requestToken), []byte(route.AccessToken)) != 1 {
+			logger.Warn("Access token mismatch",
+				zap.String("sandboxID", sandboxID))
+			f.callbacks.DecoderFilterCallbacks().SendLocalReply(
+				401,
+				"unauthorized: invalid or missing access token",
+				nil,
+				-1,
+				"unauthorized",
+			)
+			return api.LocalReply
+		}
+	}
+
+	// Strip the access token header before forwarding to prevent token leakage to upstream sandbox
+	header.Del(accessTokenHeader)
 
 	// Apply extra headers from the adapter (e.g., :path rewrite for kruise custom protocol)
 	for k, v := range extraHeaders {

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -111,9 +111,9 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 		return api.LocalReply
 	}
 
-	// Authenticate the request if the sandbox has an access token configured.
-	// Sandboxes without a token (empty string) skip authentication for backward compatibility.
-	if route.AccessToken != "" {
+	// Authenticate the request if auth is enabled and the sandbox has an access token configured.
+	// When EnableAuth is false (default), the gateway skips token validation for backward compatibility.
+	if f.config.EnableAuth && route.AccessToken != "" {
 		requestToken := headers[accessTokenHeader]
 		if subtle.ConstantTimeCompare([]byte(requestToken), []byte(route.AccessToken)) != 1 {
 			logger.Warn("Access token mismatch",

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -1024,9 +1024,6 @@ func TestDecodeHeadersAccessTokenAuth(t *testing.T) {
 				assert.NotNil(t, metadata)
 				assert.Equal(t, "10.0.0.1:49983", metadata["host"])
 
-				// Verify x-access-token header was stripped before forwarding
-				_, tokenExists := header.Get("x-access-token")
-				assert.False(t, tokenExists, "x-access-token header should be stripped before forwarding")
 			}
 		})
 	}

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -1001,6 +1001,7 @@ func TestDecodeHeadersAccessTokenAuth(t *testing.T) {
 			})
 
 			cfg := DefaultConfig()
+			cfg.EnableAuth = true
 			mockCallbacks := newMockFilterCallbackHandler()
 			filter := &sandboxFilter{callbacks: mockCallbacks, config: cfg, adapter: defaultTestAdapter()}
 
@@ -1041,6 +1042,7 @@ func TestDecodeHeadersAccessTokenAuthKruiseProtocol(t *testing.T) {
 	})
 
 	cfg := DefaultConfig()
+	cfg.EnableAuth = true
 
 	// Valid token via kruise protocol
 	mockCallbacks := newMockFilterCallbackHandler()
@@ -1068,4 +1070,35 @@ func TestDecodeHeadersAccessTokenAuthKruiseProtocol(t *testing.T) {
 	assert.Equal(t, api.LocalReply, status2)
 	assert.True(t, mockCallbacks2.decoderCallbacks.sendLocalReplyCalled)
 	assert.Equal(t, 401, mockCallbacks2.decoderCallbacks.replyStatusCode)
+}
+
+// TestDecodeHeadersAuthDisabled verifies that when EnableAuth is false,
+// token validation is skipped even if the route has a token configured.
+func TestDecodeHeadersAuthDisabled(t *testing.T) {
+	r := registry.GetRegistry()
+	defer r.Clear()
+	r.Update("default--auth-disabled", proxy.Route{
+		IP:              "10.0.0.5",
+		State:           agentsv1alpha1.SandboxStateRunning,
+		ResourceVersion: "1",
+		AccessToken:     "secret-token",
+	})
+
+	cfg := DefaultConfig()
+	// EnableAuth is false by default
+	mockCallbacks := newMockFilterCallbackHandler()
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: cfg, adapter: defaultTestAdapter()}
+
+	header := newMockRequestHeaderMap()
+	header.Set(DefaultSandboxHeaderName, "default--auth-disabled")
+	// No token header set — should still pass because auth is disabled
+
+	status := filter.DecodeHeaders(header, true)
+	assert.Equal(t, api.Continue, status)
+	assert.False(t, mockCallbacks.decoderCallbacks.sendLocalReplyCalled)
+
+	// Verify upstream was set
+	metadata := mockCallbacks.streamInfo.dynamicMetadata.data["envoy.lb.original_dst"]
+	assert.NotNil(t, metadata)
+	assert.Equal(t, "10.0.0.5:49983", metadata["host"])
 }

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -930,3 +930,145 @@ func TestDecodeHeadersKruiseCustomProtocolInvalidPath(t *testing.T) {
 	assert.Equal(t, api.Continue, status)
 	assert.False(t, mockCallbacks.decoderCallbacks.sendLocalReplyCalled)
 }
+
+// TestDecodeHeadersAccessTokenAuth tests access token authentication logic
+func TestDecodeHeadersAccessTokenAuth(t *testing.T) {
+	tests := []struct {
+		name                string
+		routeAccessToken    string
+		requestToken        string
+		setTokenHeader      bool
+		expectedStatus      api.StatusType
+		expectLocalReply    bool
+		expectedStatusCode  int
+		expectedReplyDetail string
+	}{
+		{
+			name:             "valid token - request matches route token",
+			routeAccessToken: "secret-token-123",
+			requestToken:     "secret-token-123",
+			setTokenHeader:   true,
+			expectedStatus:   api.Continue,
+			expectLocalReply: false,
+		},
+		{
+			name:                "invalid token - request token does not match",
+			routeAccessToken:    "secret-token-123",
+			requestToken:        "wrong-token",
+			setTokenHeader:      true,
+			expectedStatus:      api.LocalReply,
+			expectLocalReply:    true,
+			expectedStatusCode:  401,
+			expectedReplyDetail: "unauthorized",
+		},
+		{
+			name:                "missing token - route requires token but request has none",
+			routeAccessToken:    "secret-token-123",
+			requestToken:        "",
+			setTokenHeader:      false,
+			expectedStatus:      api.LocalReply,
+			expectLocalReply:    true,
+			expectedStatusCode:  401,
+			expectedReplyDetail: "unauthorized",
+		},
+		{
+			name:             "no token configured - backward compatible, skip auth",
+			routeAccessToken: "",
+			requestToken:     "",
+			setTokenHeader:   false,
+			expectedStatus:   api.Continue,
+			expectLocalReply: false,
+		},
+		{
+			name:             "no token configured - request carries token anyway, still allowed",
+			routeAccessToken: "",
+			requestToken:     "some-token",
+			setTokenHeader:   true,
+			expectedStatus:   api.Continue,
+			expectLocalReply: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := registry.GetRegistry()
+			defer r.Clear()
+			r.Update("default--auth-sandbox", proxy.Route{
+				IP:              "10.0.0.1",
+				State:           agentsv1alpha1.SandboxStateRunning,
+				ResourceVersion: "1",
+				AccessToken:     tt.routeAccessToken,
+			})
+
+			cfg := DefaultConfig()
+			mockCallbacks := newMockFilterCallbackHandler()
+			filter := &sandboxFilter{callbacks: mockCallbacks, config: cfg, adapter: defaultTestAdapter()}
+
+			header := newMockRequestHeaderMap()
+			header.Set(DefaultSandboxHeaderName, "default--auth-sandbox")
+			if tt.setTokenHeader {
+				header.Set("x-access-token", tt.requestToken)
+			}
+
+			status := filter.DecodeHeaders(header, true)
+
+			assert.Equal(t, tt.expectedStatus, status)
+			assert.Equal(t, tt.expectLocalReply, mockCallbacks.decoderCallbacks.sendLocalReplyCalled)
+			if tt.expectLocalReply {
+				assert.Equal(t, tt.expectedStatusCode, mockCallbacks.decoderCallbacks.replyStatusCode)
+				assert.Equal(t, tt.expectedReplyDetail, mockCallbacks.decoderCallbacks.replyDetails)
+				assert.Contains(t, mockCallbacks.decoderCallbacks.replyBody, "unauthorized")
+			} else {
+				// Verify upstream was set correctly for successful cases
+				metadata := mockCallbacks.streamInfo.dynamicMetadata.data["envoy.lb.original_dst"]
+				assert.NotNil(t, metadata)
+				assert.Equal(t, "10.0.0.1:49983", metadata["host"])
+
+				// Verify x-access-token header was stripped before forwarding
+				_, tokenExists := header.Get("x-access-token")
+				assert.False(t, tokenExists, "x-access-token header should be stripped before forwarding")
+			}
+		})
+	}
+}
+
+// TestDecodeHeadersAccessTokenAuthKruiseProtocol tests access token auth with kruise custom protocol
+func TestDecodeHeadersAccessTokenAuthKruiseProtocol(t *testing.T) {
+	r := registry.GetRegistry()
+	defer r.Clear()
+	r.Update("ns--mysandbox", proxy.Route{
+		IP:              "10.0.0.10",
+		State:           agentsv1alpha1.SandboxStateRunning,
+		ResourceVersion: "1",
+		AccessToken:     "kruise-secret",
+	})
+
+	cfg := DefaultConfig()
+
+	// Valid token via kruise protocol
+	mockCallbacks := newMockFilterCallbackHandler()
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: cfg, adapter: defaultTestAdapter()}
+	header := &mockRequestHeaderMapCustom{
+		mockRequestHeaderMap: *newMockRequestHeaderMap(),
+		pathValue:            "/kruise/ns--mysandbox/3000/api/v1/data",
+	}
+	header.Set("x-access-token", "kruise-secret")
+
+	status := filter.DecodeHeaders(header, true)
+	assert.Equal(t, api.Continue, status)
+	assert.False(t, mockCallbacks.decoderCallbacks.sendLocalReplyCalled)
+
+	// Invalid token via kruise protocol
+	mockCallbacks2 := newMockFilterCallbackHandler()
+	filter2 := &sandboxFilter{callbacks: mockCallbacks2, config: cfg, adapter: defaultTestAdapter()}
+	header2 := &mockRequestHeaderMapCustom{
+		mockRequestHeaderMap: *newMockRequestHeaderMap(),
+		pathValue:            "/kruise/ns--mysandbox/3000/api/v1/data",
+	}
+	header2.Set("x-access-token", "wrong-token")
+
+	status2 := filter2.DecodeHeaders(header2, true)
+	assert.Equal(t, api.LocalReply, status2)
+	assert.True(t, mockCallbacks2.decoderCallbacks.sendLocalReplyCalled)
+	assert.Equal(t, 401, mockCallbacks2.decoderCallbacks.replyStatusCode)
+}

--- a/pkg/utils/proxyutils/default_test.go
+++ b/pkg/utils/proxyutils/default_test.go
@@ -87,6 +87,37 @@ func TestGetRouteFromSandbox(t *testing.T) {
 				State: v1alpha1.SandboxStateCreating,
 			},
 		},
+		{
+			name: "sandbox with runtime access token annotation",
+			sandbox: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "token-sandbox",
+					Namespace: "default",
+					Annotations: map[string]string{
+						v1alpha1.AnnotationRuntimeAccessToken: "secret-token-123",
+					},
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase: v1alpha1.SandboxRunning,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1alpha1.SandboxConditionReady),
+							Status: metav1.ConditionTrue,
+						},
+					},
+					PodInfo: v1alpha1.PodInfo{
+						PodIP: "10.0.0.3",
+					},
+				},
+			},
+			expectedRoute: Route{
+				IP:          "10.0.0.3",
+				ID:          "default--token-sandbox",
+				Owner:       "",
+				State:       v1alpha1.SandboxStateRunning,
+				AccessToken: "secret-token-123",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/utils/proxyutils/route.go
+++ b/pkg/utils/proxyutils/route.go
@@ -34,6 +34,7 @@ func GetRouteFromSandbox(s *agentsv1alpha1.Sandbox) Route {
 		Owner:           s.GetAnnotations()[agentsv1alpha1.AnnotationOwner],
 		State:           state,
 		ResourceVersion: s.GetResourceVersion(),
+		AccessToken:     s.GetAnnotations()[agentsv1alpha1.AnnotationRuntimeAccessToken],
 	}
 }
 
@@ -46,4 +47,5 @@ type Route struct {
 	Owner           string    `json:"owner"`
 	State           string    `json:"state"`
 	ResourceVersion string    `json:"resourceVersion"`
+	AccessToken     string    `json:"accessToken,omitempty"`
 }

--- a/test/e2b/test_gateway.py
+++ b/test/e2b/test_gateway.py
@@ -1,4 +1,6 @@
 """Tests for sandbox-gateway routing methods (header-based and host-based)."""
+import json
+import subprocess
 import time
 
 import requests
@@ -6,6 +8,20 @@ from e2b_code_interpreter import Sandbox
 
 
 GATEWAY_URL = "http://localhost:80"
+
+
+def get_sandbox_access_token(sandbox_id: str) -> str:
+    """Retrieve the runtime-access-token annotation from a Sandbox CR via kubectl."""
+    name = sandbox_id.split("--")[1] if "--" in sandbox_id else sandbox_id
+    result = subprocess.run(
+        ["kubectl", "get", "sandbox", name, "-o", "json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    sbx = json.loads(result.stdout)
+    annotations = sbx.get("metadata", {}).get("annotations", {})
+    return annotations.get("agents.kruise.io/runtime-access-token", "")
 
 
 def test_gateway_header_based_routing(sandbox_context):
@@ -22,15 +38,24 @@ def test_gateway_header_based_routing(sandbox_context):
 
     # Wait for gateway registry to sync
     time.sleep(3)
+
+    # Retrieve access token for authentication
+    access_token = get_sandbox_access_token(sandbox_id)
+
+    headers = {
+        "e2b-sandbox-id": sandbox_id,
+        "e2b-sandbox-port": "49983",
+    }
+    if access_token:
+        headers["X-Access-Token"] = access_token
+
     resp = requests.get(
         f"{GATEWAY_URL}/",
-        headers={
-            "e2b-sandbox-id": sandbox_id,
-            "e2b-sandbox-port": "49983",
-        },
+        headers=headers,
         timeout=10,
     )
     assert resp.status_code != 502, f"Gateway 502: sandbox {sandbox_id} not found or not running"
+    assert resp.status_code != 401, f"Gateway 401: access token mismatch for sandbox {sandbox_id}"
 
 
 def test_gateway_host_based_routing(sandbox_context):
@@ -47,11 +72,20 @@ def test_gateway_host_based_routing(sandbox_context):
 
     # Wait for gateway registry to sync
     time.sleep(3)
+
+    # Retrieve access token for authentication
+    access_token = get_sandbox_access_token(sandbox_id)
+
     # Native E2B host format: {port}-{namespace}--{name}.example.com
     host = f"49983-{sandbox_id}.example.com"
+    headers = {"Host": host}
+    if access_token:
+        headers["X-Access-Token"] = access_token
+
     resp = requests.get(
         f"{GATEWAY_URL}/",
-        headers={"Host": host},
+        headers=headers,
         timeout=10,
     )
     assert resp.status_code != 502, f"Gateway 502: sandbox {sandbox_id} not found or not running"
+    assert resp.status_code != 401, f"Gateway 401: access token mismatch for sandbox {sandbox_id}"

--- a/test/e2b/test_gateway_auth.py
+++ b/test/e2b/test_gateway_auth.py
@@ -19,10 +19,16 @@ def get_sandbox_access_token(sandbox_id: str) -> str:
     Returns:
         The access token string, or empty string if not set.
     """
-    # sandbox_id format is "namespace--name", extract the name part
-    name = sandbox_id.split("--")[1] if "--" in sandbox_id else sandbox_id
+    # sandbox_id format is "namespace--name", extract both parts
+    if "--" in sandbox_id:
+        parts = sandbox_id.split("--")
+        namespace = parts[0]
+        name = parts[1]
+    else:
+        namespace = "default"
+        name = sandbox_id
     result = subprocess.run(
-        ["kubectl", "get", "sandbox", name, "-o", "json"],
+        ["kubectl", "get", "sandbox", name, "-n", namespace, "-o", "json"],
         capture_output=True,
         text=True,
         check=True,

--- a/test/e2b/test_gateway_auth.py
+++ b/test/e2b/test_gateway_auth.py
@@ -1,0 +1,185 @@
+"""Tests for sandbox-gateway access token authentication."""
+import json
+import subprocess
+import time
+
+import requests
+from e2b_code_interpreter import Sandbox
+
+
+GATEWAY_URL = "http://localhost:80"
+
+
+def get_sandbox_access_token(sandbox_id: str) -> str:
+    """Retrieve the runtime-access-token annotation from a Sandbox CR via kubectl.
+
+    Args:
+        sandbox_id: The sandbox ID in namespace--name format (e.g., default--my-sandbox).
+
+    Returns:
+        The access token string, or empty string if not set.
+    """
+    # sandbox_id format is "namespace--name", extract the name part
+    name = sandbox_id.split("--")[1] if "--" in sandbox_id else sandbox_id
+    result = subprocess.run(
+        ["kubectl", "get", "sandbox", name, "-o", "json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    sbx = json.loads(result.stdout)
+    annotations = sbx.get("metadata", {}).get("annotations", {})
+    return annotations.get("agents.kruise.io/runtime-access-token", "")
+
+
+def test_gateway_auth_valid_token(sandbox_context):
+    """Test that request with valid X-Access-Token header is forwarded successfully."""
+    sandbox: Sandbox = sandbox_context.add(Sandbox.create(
+        template="code-interpreter",
+        timeout=120,
+        headers={
+            "x-request-id": sandbox_context.request_id
+        }
+    ))
+    sandbox_id = sandbox.sandbox_id
+    print(f"sandbox-id: {sandbox_id}")
+
+    # Wait for gateway registry to sync
+    time.sleep(3)
+
+    # Retrieve the access token from the Sandbox CR annotation
+    access_token = get_sandbox_access_token(sandbox_id)
+    print(f"access-token: {access_token[:8]}..." if access_token else "access-token: (empty)")
+    assert access_token != "", "Sandbox should have a runtime-access-token annotation"
+
+    # Request with valid token should succeed (not 401 or 502)
+    resp = requests.get(
+        f"{GATEWAY_URL}/",
+        headers={
+            "e2b-sandbox-id": sandbox_id,
+            "e2b-sandbox-port": "49983",
+            "X-Access-Token": access_token,
+        },
+        timeout=10,
+    )
+    assert resp.status_code != 401, (
+        f"Gateway returned 401 with valid token for sandbox {sandbox_id}"
+    )
+    assert resp.status_code != 502, (
+        f"Gateway returned 502: sandbox {sandbox_id} not found or not running"
+    )
+
+
+def test_gateway_auth_missing_token(sandbox_context):
+    """Test that request without X-Access-Token header returns 401."""
+    sandbox: Sandbox = sandbox_context.add(Sandbox.create(
+        template="code-interpreter",
+        timeout=120,
+        headers={
+            "x-request-id": sandbox_context.request_id
+        }
+    ))
+    sandbox_id = sandbox.sandbox_id
+    print(f"sandbox-id: {sandbox_id}")
+
+    # Wait for gateway registry to sync
+    time.sleep(3)
+
+    # Verify sandbox has an access token configured
+    access_token = get_sandbox_access_token(sandbox_id)
+    assert access_token != "", "Sandbox should have a runtime-access-token annotation"
+
+    # Request without token should be rejected with 401
+    resp = requests.get(
+        f"{GATEWAY_URL}/",
+        headers={
+            "e2b-sandbox-id": sandbox_id,
+            "e2b-sandbox-port": "49983",
+        },
+        timeout=10,
+    )
+    assert resp.status_code == 401, (
+        f"Expected 401 without token, got {resp.status_code} for sandbox {sandbox_id}"
+    )
+
+
+def test_gateway_auth_invalid_token(sandbox_context):
+    """Test that request with wrong X-Access-Token header returns 401."""
+    sandbox: Sandbox = sandbox_context.add(Sandbox.create(
+        template="code-interpreter",
+        timeout=120,
+        headers={
+            "x-request-id": sandbox_context.request_id
+        }
+    ))
+    sandbox_id = sandbox.sandbox_id
+    print(f"sandbox-id: {sandbox_id}")
+
+    # Wait for gateway registry to sync
+    time.sleep(3)
+
+    # Verify sandbox has an access token configured
+    access_token = get_sandbox_access_token(sandbox_id)
+    assert access_token != "", "Sandbox should have a runtime-access-token annotation"
+
+    # Request with wrong token should be rejected with 401
+    resp = requests.get(
+        f"{GATEWAY_URL}/",
+        headers={
+            "e2b-sandbox-id": sandbox_id,
+            "e2b-sandbox-port": "49983",
+            "X-Access-Token": "wrong-token-value",
+        },
+        timeout=10,
+    )
+    assert resp.status_code == 401, (
+        f"Expected 401 with invalid token, got {resp.status_code} for sandbox {sandbox_id}"
+    )
+
+
+def test_gateway_auth_host_based_routing_with_token(sandbox_context):
+    """Test that host-based routing also enforces access token authentication."""
+    sandbox: Sandbox = sandbox_context.add(Sandbox.create(
+        template="code-interpreter",
+        timeout=120,
+        headers={
+            "x-request-id": sandbox_context.request_id
+        }
+    ))
+    sandbox_id = sandbox.sandbox_id
+    print(f"sandbox-id: {sandbox_id}")
+
+    # Wait for gateway registry to sync
+    time.sleep(3)
+
+    # Retrieve the access token
+    access_token = get_sandbox_access_token(sandbox_id)
+    assert access_token != "", "Sandbox should have a runtime-access-token annotation"
+
+    host = f"49983-{sandbox_id}.example.com"
+
+    # Without token -> 401
+    resp_no_token = requests.get(
+        f"{GATEWAY_URL}/",
+        headers={"Host": host},
+        timeout=10,
+    )
+    assert resp_no_token.status_code == 401, (
+        f"Expected 401 without token via host routing, got {resp_no_token.status_code}"
+    )
+
+    # With valid token -> success
+    resp_valid = requests.get(
+        f"{GATEWAY_URL}/",
+        headers={
+            "Host": host,
+            "X-Access-Token": access_token,
+        },
+        timeout=10,
+    )
+    assert resp_valid.status_code != 401, (
+        f"Gateway returned 401 with valid token via host routing for sandbox {sandbox_id}"
+    )
+    assert resp_valid.status_code != 502, (
+        f"Gateway returned 502 via host routing: sandbox {sandbox_id} not found or not running"
+    )


### PR DESCRIPTION

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Add inbound request authentication to sandbox-gateway via `X-Access-Token` header validation.

**Core Changes:**
- Add `AccessToken` field to `Route` struct, extracted from the Sandbox CR annotation `agents.kruise.io/runtime-access-token`
- Implement token validation in the Envoy Go HTTP filter's `DecodeHeaders` method using `crypto/subtle.ConstantTimeCompare` to prevent timing attacks
- Return HTTP 401 when the token is missing or invalid
- Keep `X-Access-Token` header forwarded to upstream envd for downstream re-validation (layered auth)

**Configuration:**
- Add `enable-auth` boolean config field to the filter `Config`. Authentication is **disabled by default** for backward compatibility, and must be explicitly enabled via Envoy filter configuration.

**Testing:**
- Unit tests covering: valid token, invalid token, missing token, no-token-configured (backward compat), and auth-disabled scenarios
- Unit test for `Route.AccessToken` extraction from Sandbox annotations
- E2E tests (`test/e2b/test_gateway_auth.py`): 4 scenarios testing valid/missing/invalid token and host-based routing with auth
- Updated existing gateway E2E tests to include access token header
- Updated `hack/run-e2b-e2e-test.sh` to skip gateway auth tests when not running in gateway mode

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. **Unit tests:**
   ```bash
   go test ./pkg/sandbox-gateway/filter/ -run "TestDecodeHeadersAccessToken|TestDecodeHeadersAuthDisabled" -v
   go test ./pkg/utils/proxyutils/ -run "TestGetRouteFromSandbox" -v
   ```

2. **E2E tests** (requires cluster with gateway deployed and `enable-auth: true` in filter config):
   ```bash
   WITH_GATEWAY=true ./hack/run-e2b-e2e-test.sh
   ```

3. **Manual verification:**
   - Deploy sandbox-gateway with `"enable-auth": true` in filter config
   - Create a sandbox (it should get `agents.kruise.io/runtime-access-token` annotation)
   - Request without `X-Access-Token` → expect HTTP 401
   - Request with wrong token → expect HTTP 401
   - Request with correct token → expect forwarded to upstream

### Ⅳ. Special notes for reviews

- Token comparison uses `crypto/subtle.ConstantTimeCompare` to prevent timing side-channel attacks
- `EnableAuth` defaults to `false` — no behavioral change for existing deployments until explicitly enabled
- The `X-Access-Token` header is intentionally **not** stripped before forwarding, because envd performs a second validation
- When `Route.AccessToken` is empty (sandbox has no token annotation), auth is skipped regardless of `EnableAuth`, maintaining compatibility with legacy sandboxes
