### PR TITLE
fix(e2b): stabilize pagination for duplicate timestamps

### DIFF
--- a/pkg/servers/e2b/list.go
+++ b/pkg/servers/e2b/list.go
@@ -143,6 +143,9 @@ func (sc *Controller) ListSandboxes(r *http.Request) (web.ApiResponse[[]*models.
 		GetKey: func(sbx infra.Sandbox) string {
 			return sbx.GetAnnotations()[agentsv1alpha1.AnnotationClaimTime]
 		},
+		GetUniqueKey: func(sbx infra.Sandbox) string {
+			return sbx.GetSandboxID()
+		},
 	})
 	var headers map[string]string
 	if nextToken != "" {
@@ -284,6 +287,9 @@ func (sc *Controller) listCheckpointsForUser(ctx context.Context, user *models.C
 		NextToken: nextTokenParam,
 		GetKey: func(cp infra.CheckpointInfo) string {
 			return cp.CreationTimestamp // Sort by creation timestamp
+		},
+		GetUniqueKey: func(cp infra.CheckpointInfo) string {
+			return fmt.Sprintf("%s/%s", cp.Namespace, cp.Name)
 		},
 		Filter: filter,
 	})

--- a/pkg/servers/e2b/list_test.go
+++ b/pkg/servers/e2b/list_test.go
@@ -519,6 +519,151 @@ func TestListSandboxes_Pagination(t *testing.T) {
 	}
 }
 
+func TestListSandboxes_PaginationDuplicateClaimTime(t *testing.T) {
+	tests := []struct {
+		name         string
+		sandboxCount int
+		limit        int
+		claimTime    string
+	}{
+		{
+			name:         "same claim time across page boundary",
+			sandboxCount: 5,
+			limit:        2,
+			claimTime:    "2024-01-01T00:00:01Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			templateName := "pagination-duplicate-template"
+			controller, fc, teardown := Setup(t)
+			defer teardown()
+			user := &models.CreatedTeamAPIKey{
+				ID:   keys.AdminKeyID,
+				Key:  InitKey,
+				Name: "admin",
+			}
+
+			tmpl := agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "main",
+								Image: "test-image",
+							},
+						},
+					},
+				},
+			}
+			sbs := &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      templateName,
+					Namespace: Namespace,
+					UID:       types.UID(uuid.NewString()),
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					EmbeddedSandboxTemplate: tmpl,
+				},
+			}
+			require.NoError(t, fc.Create(t.Context(), sbs))
+			defer func() {
+				_ = fc.Delete(context.Background(), sbs)
+			}()
+
+			expectedSandboxIDs := make([]string, 0, tt.sandboxCount)
+			now := metav1.Now()
+			for i := 0; i < tt.sandboxCount; i++ {
+				sbxName := fmt.Sprintf("%s-%d", templateName, i)
+				sbx := &agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sbxName,
+						Namespace: Namespace,
+						Labels: map[string]string{
+							agentsv1alpha1.LabelSandboxTemplate:  templateName,
+							agentsv1alpha1.LabelSandboxIsClaimed: "true",
+						},
+						Annotations: map[string]string{
+							agentsv1alpha1.AnnotationClaimTime: tt.claimTime,
+							agentsv1alpha1.AnnotationOwner:     user.ID.String(),
+						},
+						UID:               types.UID(uuid.NewString()),
+						CreationTimestamp: now,
+					},
+					Spec: agentsv1alpha1.SandboxSpec{
+						EmbeddedSandboxTemplate: tmpl,
+					},
+					Status: agentsv1alpha1.SandboxStatus{
+						Phase: agentsv1alpha1.SandboxRunning,
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(agentsv1alpha1.SandboxConditionReady),
+								Status: metav1.ConditionTrue,
+							},
+							{
+								Type:   string(agentsv1alpha1.SandboxConditionPaused),
+								Status: metav1.ConditionFalse,
+							},
+							{
+								Type:   string(agentsv1alpha1.SandboxConditionResumed),
+								Status: metav1.ConditionTrue,
+							},
+						},
+						PodInfo: agentsv1alpha1.PodInfo{
+							PodIP: "1.2.3.4",
+						},
+					},
+				}
+				CreateSandboxWithStatus(t, fc, sbx)
+				expectedSandboxIDs = append(expectedSandboxIDs, fmt.Sprintf("%s--%s", Namespace, sbxName))
+			}
+
+			assert.Eventually(t, func() bool {
+				resp, apiError := controller.ListSandboxes(NewRequest(t, nil, nil, nil, user))
+				return apiError == nil && len(resp.Body) >= len(expectedSandboxIDs)
+			}, 2*time.Second, 50*time.Millisecond, "sandboxes should be available in cache")
+
+			defer func() {
+				for i := 0; i < tt.sandboxCount; i++ {
+					sbxName := fmt.Sprintf("%s-%d", templateName, i)
+					sbx := &agentsv1alpha1.Sandbox{}
+					sbx.Name = sbxName
+					sbx.Namespace = Namespace
+					_ = fc.Delete(context.Background(), sbx)
+				}
+			}()
+
+			var nextToken string
+			var gotSandboxIDs []string
+			for page := 0; page < 10; page++ {
+				query := map[string]string{"limit": fmt.Sprintf("%d", tt.limit)}
+				if nextToken != "" {
+					query["nextToken"] = nextToken
+				}
+
+				resp, apiError := controller.ListSandboxes(NewRequest(t, query, nil, nil, user))
+				require.Nil(t, apiError, "page %d should not return error", page)
+				require.NotEmpty(t, resp.Body, "page %d should return at least one sandbox", page)
+
+				for _, sbx := range resp.Body {
+					gotSandboxIDs = append(gotSandboxIDs, sbx.SandboxID)
+					assert.Equal(t, tt.claimTime, sbx.StartedAt, "sandbox should keep duplicate claim time")
+				}
+
+				nextToken = resp.Headers["x-next-token"]
+				if nextToken == "" {
+					break
+				}
+			}
+
+			assert.Empty(t, nextToken, "pagination should finish")
+			assert.Len(t, gotSandboxIDs, len(expectedSandboxIDs))
+			assert.ElementsMatch(t, expectedSandboxIDs, gotSandboxIDs)
+		})
+	}
+}
+
 func TestListSnapshots(t *testing.T) {
 	controller, fc, teardown := Setup(t)
 	defer teardown()
@@ -536,13 +681,12 @@ func TestListSnapshots(t *testing.T) {
 		Name: "other",
 	}
 
-	// Helper to create a checkpoint with given parameters
-	createCheckpoint := func(name, owner, sandboxID, checkpointID, creationTime string) *agentsv1alpha1.Checkpoint {
+	createCheckpointInNamespace := func(namespace, name, owner, sandboxID, checkpointID, creationTime string) *agentsv1alpha1.Checkpoint {
 		parsedTime, _ := time.Parse(time.RFC3339, creationTime)
 		cp := &agentsv1alpha1.Checkpoint{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              name,
-				Namespace:         Namespace,
+				Namespace:         namespace,
 				UID:               types.UID(uuid.NewString()),
 				CreationTimestamp: metav1.NewTime(parsedTime),
 				Annotations: map[string]string{
@@ -561,6 +705,11 @@ func TestListSnapshots(t *testing.T) {
 		err = fc.Status().Update(t.Context(), cp)
 		assert.NoError(t, err)
 		return cp
+	}
+
+	// Helper to create a checkpoint with given parameters
+	createCheckpoint := func(name, owner, sandboxID, checkpointID, creationTime string) *agentsv1alpha1.Checkpoint {
+		return createCheckpointInNamespace(Namespace, name, owner, sandboxID, checkpointID, creationTime)
 	}
 
 	// pageExpectation defines the expected result for each page in pagination
@@ -625,6 +774,68 @@ func TestListSnapshots(t *testing.T) {
 						cp := &agentsv1alpha1.Checkpoint{}
 						cp.Name = fmt.Sprintf("cp-chain-%d", i)
 						cp.Namespace = Namespace
+						_ = fc.Delete(context.Background(), cp)
+					}
+				}
+			},
+			user:  adminUser,
+			query: map[string]string{"limit": "2"},
+			pages: []pageExpectation{
+				{count: 2, hasNextToken: true},
+				{count: 2, hasNextToken: true},
+				{count: 1, hasNextToken: false},
+			},
+			expectedTotal: 5,
+		},
+		{
+			name: "pagination chain with duplicate creation timestamps",
+			setup: func() func() {
+				for i := 0; i < 5; i++ {
+					createCheckpoint(
+						fmt.Sprintf("cp-duplicate-time-%d", i),
+						adminUser.ID.String(),
+						fmt.Sprintf("sandbox-duplicate-time-%d", i),
+						fmt.Sprintf("duplicate-time-checkpoint-id-%d", i),
+						"2024-02-02T00:00:01Z",
+					)
+				}
+				return func() {
+					for i := 0; i < 5; i++ {
+						cp := &agentsv1alpha1.Checkpoint{}
+						cp.Name = fmt.Sprintf("cp-duplicate-time-%d", i)
+						cp.Namespace = Namespace
+						_ = fc.Delete(context.Background(), cp)
+					}
+				}
+			},
+			user:  adminUser,
+			query: map[string]string{"limit": "2"},
+			pages: []pageExpectation{
+				{count: 2, hasNextToken: true},
+				{count: 2, hasNextToken: true},
+				{count: 1, hasNextToken: false},
+			},
+			expectedTotal: 5,
+		},
+		{
+			name: "pagination chain with duplicate creation timestamps and checkpoint ids",
+			setup: func() func() {
+				namespaces := []string{"team-a", "team-b", "team-c", "team-d", "team-e"}
+				for i, namespace := range namespaces {
+					createCheckpointInNamespace(
+						namespace,
+						fmt.Sprintf("cp-duplicate-id-%d", i),
+						adminUser.ID.String(),
+						fmt.Sprintf("sandbox-duplicate-id-%d", i),
+						"shared-checkpoint-id",
+						"2024-02-03T00:00:01Z",
+					)
+				}
+				return func() {
+					for i, namespace := range namespaces {
+						cp := &agentsv1alpha1.Checkpoint{}
+						cp.Name = fmt.Sprintf("cp-duplicate-id-%d", i)
+						cp.Namespace = namespace
 						_ = fc.Delete(context.Background(), cp)
 					}
 				}

--- a/pkg/utils/pagination/pagination.go
+++ b/pkg/utils/pagination/pagination.go
@@ -17,8 +17,16 @@ limitations under the License.
 package pagination
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"sort"
+	"strconv"
 )
+
+type cursorToken struct {
+	Key string `json:"key"`
+	ID  string `json:"id"`
+}
 
 // Paginator pages the selected objects.
 type Paginator[T any] struct {
@@ -26,6 +34,8 @@ type Paginator[T any] struct {
 	NextToken string
 	// All objects are sorted by the key, and the key of the last object is used as next token. If the key is empty, the object is not included.
 	GetKey func(T) string
+	// GetUniqueKey is an optional stable tiebreaker for objects with the same sort key.
+	GetUniqueKey func(T) string
 	// Return true if the object should be included
 	Filter func(T) bool
 }
@@ -34,6 +44,9 @@ func (p *Paginator[T]) Apply(objs []T) ([]T, string) {
 	sortable := make([]T, 0, len(objs))
 	for _, obj := range objs {
 		if !p.Filter(obj) || p.GetKey(obj) == "" {
+			continue
+		}
+		if p.hasStableCursor() && p.GetUniqueKey(obj) == "" {
 			continue
 		}
 		sortable = append(sortable, obj)
@@ -48,6 +61,9 @@ func (p *Paginator[T]) sortObjects(items []T) []T {
 	sort.Slice(items, func(i, j int) bool {
 		iSortKey := p.GetKey(items[i])
 		jSortKey := p.GetKey(items[j])
+		if p.hasStableCursor() && iSortKey == jSortKey {
+			return p.GetUniqueKey(items[i]) < p.GetUniqueKey(items[j])
+		}
 		return iSortKey < jSortKey
 	})
 
@@ -56,6 +72,10 @@ func (p *Paginator[T]) sortObjects(items []T) []T {
 
 // paginateResults applies pagination to a sorted slice of items. The sortKey of the last item is used as next token.
 func (p *Paginator[T]) paginateResults(items []T) ([]T, string) {
+	if p.hasStableCursor() {
+		return p.paginateStableResults(items)
+	}
+
 	// If limit <= 0, return all items without pagination
 	if p.Limit <= 0 {
 		return items, ""
@@ -90,4 +110,72 @@ func (p *Paginator[T]) paginateResults(items []T) ([]T, string) {
 	}
 
 	return paged, nextToken
+}
+
+func (p *Paginator[T]) paginateStableResults(items []T) ([]T, string) {
+	if p.Limit <= 0 {
+		return items, ""
+	}
+
+	startIdx := 0
+	if p.NextToken != "" {
+		if token, ok := decodeCursorToken(p.NextToken); ok {
+			startIdx = sort.Search(len(items), func(i int) bool {
+				itemKey := p.GetKey(items[i])
+				if itemKey != token.Key {
+					return itemKey > token.Key
+				}
+				return p.GetUniqueKey(items[i]) > token.ID
+			})
+		} else {
+			// Backward compatibility with tokens generated before stable cursors.
+			startIdx = sort.Search(len(items), func(i int) bool {
+				return p.GetKey(items[i]) > p.NextToken
+			})
+		}
+	}
+
+	if startIdx >= len(items) {
+		return []T{}, ""
+	}
+
+	endIdx := startIdx + p.Limit
+	if endIdx > len(items) {
+		endIdx = len(items)
+	}
+
+	paged := items[startIdx:endIdx]
+
+	var nextToken string
+	if endIdx < len(items) && len(paged) > 0 {
+		last := paged[len(paged)-1]
+		nextToken = encodeCursorToken(p.GetKey(last), p.GetUniqueKey(last))
+	}
+
+	return paged, nextToken
+}
+
+func (p *Paginator[T]) hasStableCursor() bool {
+	return p.GetUniqueKey != nil
+}
+
+func encodeCursorToken(key, id string) string {
+	raw := `{"key":` + strconv.Quote(key) + `,"id":` + strconv.Quote(id) + `}`
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
+}
+
+func decodeCursorToken(token string) (cursorToken, bool) {
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return cursorToken{}, false
+	}
+
+	var decoded cursorToken
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return cursorToken{}, false
+	}
+	if decoded.Key == "" || decoded.ID == "" {
+		return cursorToken{}, false
+	}
+	return decoded, true
 }

--- a/pkg/utils/pagination/pagination_test.go
+++ b/pkg/utils/pagination/pagination_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pagination
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,12 @@ func newSandbox(name string) *v1alpha1.Sandbox {
 			Name: name,
 		},
 	}
+}
+
+func newSandboxWithSortKey(name, sortKey string) *v1alpha1.Sandbox {
+	sbx := newSandbox(name)
+	sbx.Annotations = map[string]string{"sort-key": sortKey}
+	return sbx
 }
 
 func TestPaginator_Apply(t *testing.T) {
@@ -182,6 +189,201 @@ func TestPaginator_Apply(t *testing.T) {
 
 			assert.Equal(t, tt.expectedNames, getNames(result), "returned objects mismatch")
 			assert.Equal(t, tt.expectedToken, nextToken, "nextToken mismatch")
+		})
+	}
+}
+
+func TestPaginator_ApplyWithUniqueKey(t *testing.T) {
+	getNames := func(sbxs []*v1alpha1.Sandbox) []string {
+		names := make([]string, len(sbxs))
+		for i, sbx := range sbxs {
+			names[i] = sbx.GetName()
+		}
+		return names
+	}
+
+	getKey := func(sbx *v1alpha1.Sandbox) string {
+		return sbx.GetAnnotations()["sort-key"]
+	}
+	getUniqueKey := func(sbx *v1alpha1.Sandbox) string {
+		return sbx.GetName()
+	}
+	filter := func(sbx *v1alpha1.Sandbox) bool {
+		return true
+	}
+
+	tests := []struct {
+		name      string
+		input     []*v1alpha1.Sandbox
+		limit     int
+		nextToken string
+		pages     [][]string
+	}{
+		{
+			name: "duplicate sort keys do not skip objects across pages",
+			input: []*v1alpha1.Sandbox{
+				newSandboxWithSortKey("c", "2024-01-01T00:00:01Z"),
+				newSandboxWithSortKey("a", "2024-01-01T00:00:01Z"),
+				newSandboxWithSortKey("d", "2024-01-01T00:00:02Z"),
+				newSandboxWithSortKey("b", "2024-01-01T00:00:01Z"),
+			},
+			limit: 2,
+			pages: [][]string{
+				{"a", "b"},
+				{"c", "d"},
+			},
+		},
+		{
+			name: "legacy raw token keeps previous sort-key semantics",
+			input: []*v1alpha1.Sandbox{
+				newSandboxWithSortKey("a", "2024-01-01T00:00:01Z"),
+				newSandboxWithSortKey("b", "2024-01-01T00:00:01Z"),
+				newSandboxWithSortKey("c", "2024-01-01T00:00:01Z"),
+				newSandboxWithSortKey("d", "2024-01-01T00:00:02Z"),
+				newSandboxWithSortKey("e", "2024-01-01T00:00:02Z"),
+			},
+			limit:     2,
+			nextToken: "2024-01-01T00:00:01Z",
+			pages: [][]string{
+				{"d", "e"},
+			},
+		},
+		{
+			name: "limit less than or equal to zero returns all stable-sorted objects",
+			input: []*v1alpha1.Sandbox{
+				newSandboxWithSortKey("c", "2024-01-01T00:00:01Z"),
+				newSandboxWithSortKey("a", "2024-01-01T00:00:01Z"),
+				newSandboxWithSortKey("b", "2024-01-01T00:00:01Z"),
+			},
+			limit: 0,
+			pages: [][]string{
+				{"a", "b", "c"},
+			},
+		},
+		{
+			name: "empty unique key excludes object from stable cursor results",
+			input: []*v1alpha1.Sandbox{
+				newSandboxWithSortKey("a", "2024-01-01T00:00:01Z"),
+				newSandboxWithSortKey("", "2024-01-01T00:00:01Z"),
+				newSandboxWithSortKey("b", "2024-01-01T00:00:02Z"),
+			},
+			limit: 10,
+			pages: [][]string{
+				{"a", "b"},
+			},
+		},
+		{
+			name: "encoded cursor resumes at next sort key when id is past same-key objects",
+			input: []*v1alpha1.Sandbox{
+				newSandboxWithSortKey("a", "2024-01-01T00:00:01Z"),
+				newSandboxWithSortKey("b", "2024-01-01T00:00:01Z"),
+				newSandboxWithSortKey("c", "2024-01-01T00:00:02Z"),
+				newSandboxWithSortKey("d", "2024-01-01T00:00:02Z"),
+			},
+			limit:     2,
+			nextToken: encodeCursorToken("2024-01-01T00:00:01Z", "z"),
+			pages: [][]string{
+				{"c", "d"},
+			},
+		},
+		{
+			name: "encoded cursor beyond all objects returns empty page",
+			input: []*v1alpha1.Sandbox{
+				newSandboxWithSortKey("a", "2024-01-01T00:00:01Z"),
+				newSandboxWithSortKey("b", "2024-01-01T00:00:02Z"),
+			},
+			limit:     2,
+			nextToken: encodeCursorToken("2024-01-01T00:00:02Z", "z"),
+			pages: [][]string{
+				{},
+			},
+		},
+		{
+			name: "encoded cursor with fewer remaining objects than limit has no next token",
+			input: []*v1alpha1.Sandbox{
+				newSandboxWithSortKey("a", "2024-01-01T00:00:01Z"),
+				newSandboxWithSortKey("b", "2024-01-01T00:00:01Z"),
+				newSandboxWithSortKey("c", "2024-01-01T00:00:02Z"),
+			},
+			limit:     10,
+			nextToken: encodeCursorToken("2024-01-01T00:00:01Z", "a"),
+			pages: [][]string{
+				{"b", "c"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nextToken := tt.nextToken
+			for i, expectedNames := range tt.pages {
+				p := &Paginator[*v1alpha1.Sandbox]{
+					Limit:        tt.limit,
+					NextToken:    nextToken,
+					GetKey:       getKey,
+					GetUniqueKey: getUniqueKey,
+					Filter:       filter,
+				}
+
+				result, token := p.Apply(tt.input)
+
+				assert.Equal(t, expectedNames, getNames(result), "page %d returned objects mismatch", i)
+				if i < len(tt.pages)-1 {
+					assert.NotEmpty(t, token, "page %d should have next token", i)
+					decoded, ok := decodeCursorToken(token)
+					assert.True(t, ok, "page %d should return an encoded cursor token", i)
+					assert.NotEmpty(t, decoded.Key, "page %d token key should not be empty", i)
+					assert.NotEmpty(t, decoded.ID, "page %d token id should not be empty", i)
+				} else {
+					assert.Empty(t, token, "last page should not have next token")
+				}
+				nextToken = token
+			}
+		})
+	}
+}
+
+func TestDecodeCursorToken(t *testing.T) {
+	tests := []struct {
+		name       string
+		token      string
+		expected   cursorToken
+		expectedOK bool
+	}{
+		{
+			name:       "valid token",
+			token:      encodeCursorToken("2024-01-01T00:00:01Z", "sandbox-a"),
+			expected:   cursorToken{Key: "2024-01-01T00:00:01Z", ID: "sandbox-a"},
+			expectedOK: true,
+		},
+		{
+			name:       "invalid base64 token",
+			token:      "not a base64 token",
+			expectedOK: false,
+		},
+		{
+			name:       "invalid json token",
+			token:      base64.RawURLEncoding.EncodeToString([]byte("{")),
+			expectedOK: false,
+		},
+		{
+			name:       "missing key",
+			token:      base64.RawURLEncoding.EncodeToString([]byte(`{"id":"sandbox-a"}`)),
+			expectedOK: false,
+		},
+		{
+			name:       "missing id",
+			token:      base64.RawURLEncoding.EncodeToString([]byte(`{"key":"2024-01-01T00:00:01Z"}`)),
+			expectedOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := decodeCursorToken(tt.token)
+
+			assert.Equal(t, tt.expectedOK, ok)
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does

Fixes pagination for `GET /v2/sandboxes` and snapshot listing when multiple objects share the same timestamp sort key.

The previous cursor only stored the timestamp of the last returned item. Since claim timestamps and checkpoint creation timestamps can collide, the next page searched for the first item strictly after that timestamp and skipped remaining objects with the same timestamp.

This PR adds an optional stable cursor to the internal paginator. When a unique key is configured, pagination now sorts and resumes by `(sort key, unique key)`, encodes the cursor as an opaque base64 JSON token, and keeps raw sort-key tokens compatible for existing clients.

#### Changes

- Add optional `GetUniqueKey` support to `pkg/utils/pagination.Paginator`.
- Use sandbox ID as the tiebreaker for sandbox listing.
- Use Kubernetes object identity (`namespace/name`) as the tiebreaker for snapshot listing while keeping the response `SnapshotID` unchanged.
- Add regression coverage for duplicate sandbox claim timestamps, duplicate checkpoint creation timestamps, and duplicate checkpoint IDs across different checkpoint objects.

#### Tests

```bash
go test ./pkg/utils/pagination
go test ./pkg/sandbox-manager -run 'TestSandboxManager_ListSandboxes|TestSandboxManager_ListCheckpoints'
go test ./pkg/servers/e2b -run 'TestListSandboxes_Pagination|TestListSandboxes_PaginationDuplicateClaimTime|TestListSnapshots'
go test ./pkg/utils/pagination ./pkg/sandbox-manager ./pkg/servers/e2b
git diff --check
```

Fixes #439