### PR TITLE
fix(updateops): handle deletion before mutual-exclusion check

### DIFF
--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
@@ -103,7 +103,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// 2. Check if another SandboxUpdateOps in the same namespace is already Updating
+	// 2. Handle deletion: clean up sandbox labels.
+	// This must run before the mutual-exclusion check so that a deleting ops
+	// is not blocked by an active one — it only removes the finalizer and
+	// never performs updates on sandboxes.
+	if !ops.DeletionTimestamp.IsZero() {
+		return r.handleDeletion(ctx, ops)
+	}
+
+	// 3. Check if another SandboxUpdateOps in the same namespace is already Updating
 	// TODO: This is a short-term solution to prevent concurrent ops in the same namespace.
 	//  A more robust approach would be using a webhook to reject creation when an active ops exists,
 	//  or implementing a queue/priority-based scheduling mechanism.
@@ -120,12 +128,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	// 3. Handle deletion: clean up sandbox labels
-	if !ops.DeletionTimestamp.IsZero() {
-		return r.handleDeletion(ctx, ops)
-	}
-
-	// 3. Ensure finalizer is present
+	// 4. Ensure finalizer is present
 	if !controllerutil.ContainsFinalizer(ops, finalizerName) {
 		controllerutil.AddFinalizer(ops, finalizerName)
 		if err := r.Update(ctx, ops); err != nil {
@@ -133,13 +136,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	// 4. Terminal state, return directly
+	// 5. Terminal state, return directly
 	if ops.Status.Phase == agentsv1alpha1.SandboxUpdateOpsCompleted ||
 		ops.Status.Phase == agentsv1alpha1.SandboxUpdateOpsFailed {
 		return ctrl.Result{}, nil
 	}
 
-	// 3. Convert selector to labels.Selector
+	// 6. Convert selector to labels.Selector
 	selector, err := metav1.LabelSelectorAsSelector(ops.Spec.Selector)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
@@ -1349,6 +1349,46 @@ func TestReconcile_ConcurrentOpsInNamespace(t *testing.T) {
 	assert.Empty(t, updatedSbx.Labels[agentsv1alpha1.LabelSandboxUpdateOps])
 }
 
+func TestReconcile_DeletionNotBlockedByActiveOps(t *testing.T) {
+	// An actively Updating ops in the same namespace must NOT block a
+	// deleting ops from removing its finalizer and completing deletion.
+	opsActive := newSandboxUpdateOps("ops-active", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil)
+	opsDeleting := newSandboxUpdateOps("ops-deleting", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil)
+	opsDeleting.Finalizers = []string{finalizerName}
+	sbx := newSandbox("sbx-1", "default", "ops-deleting", agentsv1alpha1.SandboxRunning, nil)
+
+	r := newTestReconciler(opsActive, opsDeleting, sbx)
+
+	// Mark ops-deleting for deletion
+	err := r.Delete(context.Background(), opsDeleting)
+	assert.NoError(t, err)
+
+	// Reconcile the deleting ops — should NOT be blocked by ops-active
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "ops-deleting", Namespace: "default"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// Verify sandbox label was cleaned up
+	updatedSbx := &agentsv1alpha1.Sandbox{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "sbx-1", Namespace: "default"}, updatedSbx)
+	assert.NoError(t, err)
+	assert.Empty(t, updatedSbx.Labels[agentsv1alpha1.LabelSandboxUpdateOps],
+		"sandbox ops label should be removed after deletion")
+
+	// Verify ops-deleting is fully deleted (finalizer removed)
+	updatedOps := &agentsv1alpha1.SandboxUpdateOps{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "ops-deleting", Namespace: "default"}, updatedOps)
+	assert.True(t, errors.IsNotFound(err), "ops-deleting should be fully deleted")
+
+	// Verify ops-active is still present and unchanged
+	activeOps := &agentsv1alpha1.SandboxUpdateOps{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "ops-active", Namespace: "default"}, activeOps)
+	assert.NoError(t, err)
+	assert.Equal(t, agentsv1alpha1.SandboxUpdateOpsUpdating, activeOps.Status.Phase)
+}
+
 func TestSandboxUpdateStateString_Unknown(t *testing.T) {
 	unknownState := sandboxUpdateState(99)
 	assert.Equal(t, "Unknown", unknownState.String())

--- a/test/e2e/sandboxupdateops_test.go
+++ b/test/e2e/sandboxupdateops_test.go
@@ -1251,5 +1251,99 @@ var _ = Describe("SandboxUpdateOps E2E", func() {
 			klog.InfoS("Verified: only Running sandbox upgraded, Paused sandbox skipped")
 		})
 
+		It("should delete ops promptly even when another ops is actively updating in the same namespace", func() {
+			labelA := fmt.Sprintf("batch-block-a-%d", time.Now().UnixNano())
+			labelB := fmt.Sprintf("batch-block-b-%d", time.Now().UnixNano())
+
+			By("Creating 2 sandboxes for label-A and 1 sandbox for label-B, waiting for Running")
+			sbxA := make([]*agentsv1alpha1.Sandbox, 2)
+			for i := 0; i < 2; i++ {
+				sbxA[i] = newOpsSandbox(
+					fmt.Sprintf("ops-block-a-%s-%d", labelA[:10], i),
+					labelA, nil, nil,
+				)
+				Expect(k8sClient.Create(ctx, sbxA[i])).To(Succeed())
+			}
+			sbxB := newOpsSandbox(fmt.Sprintf("ops-block-b-%s-0", labelB[:10]), labelB, nil, nil)
+			Expect(k8sClient.Create(ctx, sbxB)).To(Succeed())
+			for _, s := range append(sbxA, sbxB) {
+				waitSandboxRunning(s)
+			}
+
+			// Create ops-B FIRST and wait for it to complete, so that the mutual-exclusion
+			// check does not block it. Then create ops-A which gets stuck in Updating.
+			// Finally, delete ops-B while ops-A is still active to verify that deletion
+			// is not blocked by the mutual-exclusion check.
+			By("Creating ops-B targeting label-B and waiting for Completed")
+			opsB := &agentsv1alpha1.SandboxUpdateOps{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("ops-block-b-%s", labelB[:10]),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxUpdateOpsSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{batchLabel: labelB},
+					},
+					Patch: mustMarshalPatch(corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "test-container", Image: updateImage},
+							},
+						},
+					}),
+				},
+			}
+			Expect(k8sClient.Create(ctx, opsB)).To(Succeed())
+			waitOpsPhase(opsB, agentsv1alpha1.SandboxUpdateOpsCompleted, 3*time.Minute)
+			klog.InfoS("ops-B completed", "name", opsB.Name)
+
+			By("Creating ops-A with preUpgrade=exit 1 so it gets stuck in Updating with failedReplicas")
+			maxUnavailable := intstr.FromInt(1)
+			opsA := &agentsv1alpha1.SandboxUpdateOps{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("ops-block-a-%s", labelA[:10]),
+					Namespace: namespace,
+				},
+				Spec: agentsv1alpha1.SandboxUpdateOpsSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{batchLabel: labelA},
+					},
+					UpdateStrategy: agentsv1alpha1.SandboxUpdateOpsStrategy{
+						MaxUnavailable: &maxUnavailable,
+					},
+					Patch: mustMarshalPatch(corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "test-container", Image: updateImage},
+							},
+						},
+					}),
+					Lifecycle: &agentsv1alpha1.SandboxLifecycle{
+						PreUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec:           &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "exit 1"}},
+							TimeoutSeconds: 30,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, opsA)).To(Succeed())
+			klog.InfoS("Created ops-A (will get stuck)", "name", opsA.Name)
+
+			By("Waiting for ops-A to be stuck in Updating with failedReplicas >= 1")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(opsA), opsA)).To(Succeed())
+				g.Expect(opsA.Status.Phase).To(Equal(agentsv1alpha1.SandboxUpdateOpsUpdating))
+				g.Expect(opsA.Status.FailedReplicas).To(BeNumerically(">=", int32(1)))
+			}, 60*time.Second, time.Second).Should(Succeed())
+
+			By("Deleting ops-B while ops-A is still Updating — deletion should NOT be blocked")
+			Expect(k8sClient.Delete(ctx, opsB)).To(Succeed())
+			waitOpsDeleted(opsB)
+			klog.InfoS("ops-B deleted promptly while ops-A was still active", "opsA", opsA.Name, "opsB", opsB.Name)
+
+			By("Cleanup: deleting ops-A")
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, opsA))).To(Succeed())
+		})
+
 	})
 })


### PR DESCRIPTION
## Summary
- Move the `DeletionTimestamp` check before the mutual-exclusion check in `SandboxUpdateOps` reconciler, so that a deleting ops is not blocked from finalizer removal by another active ops in the same namespace.
- Previously, when another `SandboxUpdateOps` was in `Updating` phase, the controller would skip reconciliation entirely — including deletion handling. This caused finalizer removal to be delayed until the active ops completed (up to hours in production).

## Test plan
- [x] Unit test `TestReconcile_DeletionNotBlockedByActiveOps`: verifies deletion proceeds while another ops is Updating
- [x] E2E test: creates two ops in the same namespace, verifies the completed one can be deleted promptly while the other is stuck in Updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)