### PR TITLE
fix: register scaleUpExpectation before creating sandbox

### DIFF
--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -383,12 +383,13 @@ func (r *Reconciler) createSandbox(ctx context.Context, sbs *agentsv1alpha1.Sand
 	if err := ctrl.SetControllerReference(sbs, sbx, r.Scheme); err != nil {
 		return nil, err
 	}
+	scaleUpExpectation.ExpectScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
 	if err := r.Create(ctx, sbx); err != nil {
+		scaleUpExpectation.ObserveScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
 		r.Recorder.Eventf(sbs, corev1.EventTypeWarning, EventCreateSandboxFailed, "Failed to create sandbox: %s", err)
 		return nil, err
 	}
 	sandboxSetSandboxesCreatedTotal.WithLabelValues(sbs.Namespace, sbs.Name).Inc()
-	scaleUpExpectation.ExpectScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
 	r.Recorder.Eventf(sbs, corev1.EventTypeNormal, EventSandboxCreated, "Sandbox %s created", klog.KObj(sbx))
 	return sbx, nil
 }


### PR DESCRIPTION
## SUMMARY

This PR fixes a race condition in the SandboxSet controller where scale-up expectations could be registered after a sandbox creation event was already observed. In certain timing scenarios, this left an unresolved expectation that blocked further scale-up operations until the expectation timeout expired.

The change updates `pkg/controller/sandboxset/sandboxset_controller.go` by aligning `createSandbox()` with the expectation handling pattern already used elsewhere in the codebase.

## FIX

```go
// Before
if err := r.Create(ctx, sbx); err != nil {
    return nil, err
}
scaleUpExpectation.ExpectScale(GetControllerKey(sbs), expectations.Create, sbx.Name)

// After
scaleUpExpectation.ExpectScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
if err := r.Create(ctx, sbx); err != nil {
    scaleUpExpectation.ObserveScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
    return nil, err
}
```


