### PR TITLE
fix: nil guard SandboxConditionPaused in calculateStatus

### DIFF
--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -510,7 +510,7 @@ func (r *SandboxReconciler) calculateStatus(ctx context.Context, args core.Ensur
 
 		cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
 		// sandbox will only enter the resuming state after successful paused
-		if cond.Status == metav1.ConditionTrue && !box.Spec.Paused {
+		if cond != nil && cond.Status == metav1.ConditionTrue && !box.Spec.Paused {
 			// delete paused condition
 			utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
 			newStatus.Phase = agentsv1alpha1.SandboxResuming
@@ -521,7 +521,7 @@ func (r *SandboxReconciler) calculateStatus(ctx context.Context, args core.Ensur
 				LastTransitionTime: metav1.Now(),
 			}
 			utils.SetSandboxCondition(newStatus, rCond)
-		} else if !box.Spec.Paused && cond.Status == metav1.ConditionFalse {
+		} else if cond != nil && !box.Spec.Paused && cond.Status == metav1.ConditionFalse {
 			klog.InfoS("sandbox pause not completed, cannot enter resume state temporarily", "sandbox", klog.KObj(box))
 		}
 

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -503,27 +503,37 @@ func (r *SandboxReconciler) calculateStatus(ctx context.Context, args core.Ensur
 		}
 
 	case agentsv1alpha1.SandboxPaused:
-		// Paused state does not support recycle; reject immediately.
-		if isRecycleTriggered(box) {
-			r.rejectRecycle(box, newStatus, "recycle is not supported in Paused state")
-		}
+// Paused state does not support recycle; reject immediately.
+if isRecycleTriggered(box) {
+	r.rejectRecycle(box, newStatus, "recycle is not supported in Paused state")
+}
 
-		cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
-		// sandbox will only enter the resuming state after successful paused
-		if cond != nil && cond.Status == metav1.ConditionTrue && !box.Spec.Paused {
-			// delete paused condition
-			utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
-			newStatus.Phase = agentsv1alpha1.SandboxResuming
-			rCond := metav1.Condition{
-				Type:               string(agentsv1alpha1.SandboxConditionResumed),
-				Status:             metav1.ConditionFalse,
-				Reason:             agentsv1alpha1.SandboxResumeReasonCreatePod,
-				LastTransitionTime: metav1.Now(),
-			}
-			utils.SetSandboxCondition(newStatus, rCond)
-		} else if cond != nil && !box.Spec.Paused && cond.Status == metav1.ConditionFalse {
-			klog.InfoS("sandbox pause not completed, cannot enter resume state temporarily", "sandbox", klog.KObj(box))
-		}
+cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
+
+// sandbox will only enter the resuming state after successful paused
+if cond == nil {
+	klog.InfoS(
+		"SandboxPaused condition missing while sandbox is in Paused phase",
+		"sandbox", klog.KObj(box),
+	)
+} else if cond.Status == metav1.ConditionTrue && !box.Spec.Paused {
+	// delete paused condition
+	utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
+	newStatus.Phase = agentsv1alpha1.SandboxResuming
+
+	rCond := metav1.Condition{
+		Type:               string(agentsv1alpha1.SandboxConditionResumed),
+		Status:             metav1.ConditionFalse,
+		Reason:             agentsv1alpha1.SandboxResumeReasonCreatePod,
+		LastTransitionTime: metav1.Now(),
+	}
+	utils.SetSandboxCondition(newStatus, rCond)
+} else if !box.Spec.Paused && cond.Status == metav1.ConditionFalse {
+	klog.InfoS(
+		"sandbox pause not completed, cannot enter resume state temporarily",
+		"sandbox", klog.KObj(box),
+	)
+}
 
 	case agentsv1alpha1.SandboxRecycling:
 		// Recycle lifecycle (progress checking, grace period, success/failure

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -3037,6 +3037,41 @@ func TestCalculateStatus(t *testing.T) {
 			expectedShouldReq: false,
 		},
 		{
+			name: "paused phase without paused condition should stay paused",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-sandbox",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused: false,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+							},
+						},
+					},
+				},
+			},
+			initStatus: &agentsv1alpha1.SandboxStatus{
+    			Phase:      agentsv1alpha1.SandboxPaused,
+    			Conditions: []metav1.Condition{},
+			},
+			expectedPhase:     agentsv1alpha1.SandboxPaused,
+			expectedShouldReq: false,
+		},
+		{
 			name: "running phase with running pod should stay running",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## SUMMARY

This PR adds nil checks before accessing `SandboxConditionPaused` in the Sandbox controller's status calculation logic. It prevents a potential nil pointer dereference when a Sandbox is in the `Paused` phase but the corresponding paused condition is absent.

The change is limited to `pkg/controller/sandbox/sandbox_controller.go`, specifically the `calculateStatus()` logic for the `SandboxPaused` state.

## FIX

```go
// Before
if cond.Status == metav1.ConditionTrue && !box.Spec.Paused {
    ...
} else if !box.Spec.Paused && cond.Status == metav1.ConditionFalse {
    ...
}

// After
if cond != nil && cond.Status == metav1.ConditionTrue && !box.Spec.Paused {
    ...
} else if cond != nil && !box.Spec.Paused && cond.Status == metav1.ConditionFalse {
    ...
}
```


