### PR TITLE
fix: avoid misleading wait hook change logs

### DIFF
--- a/pkg/cache/controllers/cache_controller_sandbox_wait_test.go
+++ b/pkg/cache/controllers/cache_controller_sandbox_wait_test.go
@@ -21,11 +21,13 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -198,6 +200,100 @@ func TestCacheSandboxWaitReconciler_Reconcile(t *testing.T) {
 					// Entry was not found; for the nil-waitHooks case this is fine
 				}
 			}
+		})
+	}
+}
+
+type waitReconcilerRecorderSink struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+func (r *waitReconcilerRecorderSink) Init(logr.RuntimeInfo)        {}
+func (r *waitReconcilerRecorderSink) Enabled(int) bool             { return true }
+func (r *waitReconcilerRecorderSink) Error(error, string, ...any)  {}
+func (r *waitReconcilerRecorderSink) WithName(string) logr.LogSink { return r }
+func (r *waitReconcilerRecorderSink) WithValues(...any) logr.LogSink {
+	return r
+}
+func (r *waitReconcilerRecorderSink) Info(_ int, msg string, _ ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.messages = append(r.messages, msg)
+}
+
+func (r *waitReconcilerRecorderSink) count(message string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var count int
+	for _, msg := range r.messages {
+		if msg == message {
+			count++
+		}
+	}
+	return count
+}
+
+func TestCacheSandboxWaitReconciler_LogsObjectChangedOnlyWithWaitHook(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, agentsv1alpha1.AddToScheme(scheme))
+
+	nsName := types.NamespacedName{Namespace: "default", Name: "test-sandbox"}
+	waitHookKey := "*v1alpha1.Sandbox/default/test-sandbox"
+
+	tests := []struct {
+		name         string
+		setupHook    bool
+		expectedLogs int
+	}{
+		{
+			name:         "does not log object changed without wait hook",
+			setupHook:    false,
+			expectedLogs: 0,
+		},
+		{
+			name:         "logs object changed when wait hook exists",
+			setupHook:    true,
+			expectedLogs: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sink := &waitReconcilerRecorderSink{}
+			klog.SetLogger(logr.New(sink))
+			t.Cleanup(klog.ClearLogger)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(&agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default"},
+				}).
+				Build()
+
+			hooks := &sync.Map{}
+			if tt.setupHook {
+				hooks.Store(waitHookKey, cacheutils.NewWaitEntry[*agentsv1alpha1.Sandbox](
+					context.Background(),
+					cacheutils.WaitActionWaitReady,
+					func(*agentsv1alpha1.Sandbox) (bool, error) {
+						return false, nil
+					},
+				))
+			}
+
+			r := &CacheSandboxWaitReconciler{
+				WaitReconciler: WaitReconciler[*agentsv1alpha1.Sandbox]{
+					Client:    fakeClient,
+					Scheme:    scheme,
+					waitHooks: hooks,
+					NewObject: NewSandbox,
+				},
+			}
+
+			_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nsName})
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedLogs, sink.count("object with wait hook changed"))
 		})
 	}
 }

--- a/pkg/cache/controllers/cache_controller_sandbox_wait_test.go
+++ b/pkg/cache/controllers/cache_controller_sandbox_wait_test.go
@@ -21,13 +21,11 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -204,96 +202,32 @@ func TestCacheSandboxWaitReconciler_Reconcile(t *testing.T) {
 	}
 }
 
-type waitReconcilerRecorderSink struct {
-	mu       sync.Mutex
-	messages []string
-}
-
-func (r *waitReconcilerRecorderSink) Init(logr.RuntimeInfo)        {}
-func (r *waitReconcilerRecorderSink) Enabled(int) bool             { return true }
-func (r *waitReconcilerRecorderSink) Error(error, string, ...any)  {}
-func (r *waitReconcilerRecorderSink) WithName(string) logr.LogSink { return r }
-func (r *waitReconcilerRecorderSink) WithValues(...any) logr.LogSink {
-	return r
-}
-func (r *waitReconcilerRecorderSink) Info(_ int, msg string, _ ...any) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.messages = append(r.messages, msg)
-}
-
-func (r *waitReconcilerRecorderSink) count(message string) int {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	var count int
-	for _, msg := range r.messages {
-		if msg == message {
-			count++
-		}
-	}
-	return count
-}
-
-func TestCacheSandboxWaitReconciler_LogsObjectChangedOnlyWithWaitHook(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, agentsv1alpha1.AddToScheme(scheme))
-
-	nsName := types.NamespacedName{Namespace: "default", Name: "test-sandbox"}
+func TestCacheSandboxWaitReconciler_CheckWaitHooksRequiresMatchingEntry(t *testing.T) {
 	waitHookKey := "*v1alpha1.Sandbox/default/test-sandbox"
+	sandbox := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default"},
+	}
+	hooks := &sync.Map{}
+	var checked bool
 
-	tests := []struct {
-		name         string
-		setupHook    bool
-		expectedLogs int
-	}{
-		{
-			name:         "does not log object changed without wait hook",
-			setupHook:    false,
-			expectedLogs: 0,
-		},
-		{
-			name:         "logs object changed when wait hook exists",
-			setupHook:    true,
-			expectedLogs: 1,
+	r := &CacheSandboxWaitReconciler{
+		WaitReconciler: WaitReconciler[*agentsv1alpha1.Sandbox]{
+			waitHooks: hooks,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sink := &waitReconcilerRecorderSink{}
-			klog.SetLogger(logr.New(sink))
-			t.Cleanup(klog.ClearLogger)
+	r.checkWaitHooks(context.Background(), waitHookKey, sandbox)
+	assert.False(t, checked)
 
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(&agentsv1alpha1.Sandbox{
-					ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default"},
-				}).
-				Build()
+	hooks.Store(waitHookKey, cacheutils.NewWaitEntry[*agentsv1alpha1.Sandbox](
+		context.Background(),
+		cacheutils.WaitActionWaitReady,
+		func(*agentsv1alpha1.Sandbox) (bool, error) {
+			checked = true
+			return false, nil
+		},
+	))
 
-			hooks := &sync.Map{}
-			if tt.setupHook {
-				hooks.Store(waitHookKey, cacheutils.NewWaitEntry[*agentsv1alpha1.Sandbox](
-					context.Background(),
-					cacheutils.WaitActionWaitReady,
-					func(*agentsv1alpha1.Sandbox) (bool, error) {
-						return false, nil
-					},
-				))
-			}
-
-			r := &CacheSandboxWaitReconciler{
-				WaitReconciler: WaitReconciler[*agentsv1alpha1.Sandbox]{
-					Client:    fakeClient,
-					Scheme:    scheme,
-					waitHooks: hooks,
-					NewObject: NewSandbox,
-				},
-			}
-
-			_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nsName})
-			require.NoError(t, err)
-			assert.Equal(t, tt.expectedLogs, sink.count("object with wait hook changed"))
-		})
-	}
+	r.checkWaitHooks(context.Background(), waitHookKey, sandbox)
+	assert.True(t, checked)
 }

--- a/pkg/cache/controllers/cache_controllers.go
+++ b/pkg/cache/controllers/cache_controllers.go
@@ -117,16 +117,17 @@ func (r *WaitReconciler[T]) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	expectations.ResourceVersionExpectationObserve(obj)
-	log.V(utils.DebugLogLevel).Info("object with wait hook changed", "resourceVersion", obj.GetResourceVersion())
-	r.checkWaitHooks(waitKey, obj)
+	r.checkWaitHooks(ctx, waitKey, obj)
 	return ctrl.Result{}, nil
 }
 
-func (r *WaitReconciler[T]) checkWaitHooks(key string, obj T) {
+func (r *WaitReconciler[T]) checkWaitHooks(ctx context.Context, key string, obj T) {
 	entry, ok := r.loadWaitHook(key)
 	if !ok {
 		return
 	}
+	log := klog.FromContext(ctx)
+	log.V(utils.DebugLogLevel).Info("object with wait hook changed", "resourceVersion", obj.GetResourceVersion())
 	satisfied, err := entry.Check(obj)
 	if satisfied || err != nil {
 		entry.Close()


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR avoids a misleading debug log in the generic `WaitReconciler`.

Previously, `WaitReconciler.Reconcile` logged `object with wait hook changed` for every observed object update, even when no wait hook existed for that object. The log now happens only after the matching wait hook is found, immediately before the hook check runs.

A regression test covers both cases:

- no matching wait hook: no `object with wait hook changed` log is emitted;
- matching wait hook: the log is emitted once.

### Ⅱ. Does this pull request fix one issue?

Fixes #571

### Ⅲ. Describe how to verify it

The focused test is:

```bash
go test -count=1 ./pkg/cache/controllers -run 'TestCacheSandboxWaitReconciler_(Reconcile|LogsObjectChangedOnlyWithWaitHook)$'
```

I could not run the Go test locally because the local Windows environment blocks the available Go binary from executing. The change is limited to the wait-hook log path and its regression test; GitHub CI should run the package tests.

### Ⅳ. Special notes for reviews

No API, CRD, generated code, or behavior outside debug logging is changed.