### PR TITLE
fix: fence sandbox creates after api key deletion

### DIFF
--- a/pkg/servers/e2b/api_key.go
+++ b/pkg/servers/e2b/api_key.go
@@ -168,6 +168,7 @@ func (sc *Controller) DeleteAPIKey(r *http.Request) (web.ApiResponse[struct{}], 
 				Message: fmt.Sprintf("Failed to delete API key: %v", err),
 			}
 		}
+		sc.deletedAPIKeys.Add(key.ID.String())
 		if key.QuotaSpec != nil && key.QuotaSpec.IsLimited() {
 			// Deleted-key quota cleanup is bounded best-effort. If Redis stays
 			// unavailable past the retry window, the leftover q:live/q:sum keys become

--- a/pkg/servers/e2b/api_key_test.go
+++ b/pkg/servers/e2b/api_key_test.go
@@ -660,6 +660,7 @@ func TestDeleteAPIKeyPermissionMiddleware(t *testing.T) {
 			}
 			require.Nil(t, apiError)
 			assert.Equal(t, tt.expectCode, resp.Code)
+			assert.True(t, controller.deletedAPIKeys.Contains(tt.targetID))
 		})
 	}
 }

--- a/pkg/servers/e2b/api_key_tombstone.go
+++ b/pkg/servers/e2b/api_key_tombstone.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2b
+
+import (
+	"sync"
+	"time"
+)
+
+const defaultAPIKeyDeletionTombstoneTTL = 10 * time.Minute
+
+type apiKeyDeletionTombstones struct {
+	ttl     time.Duration
+	entries sync.Map
+}
+
+func newAPIKeyDeletionTombstones(ttl time.Duration) *apiKeyDeletionTombstones {
+	return &apiKeyDeletionTombstones{ttl: ttl}
+}
+
+func (t *apiKeyDeletionTombstones) Add(id string) {
+	if t == nil || id == "" {
+		return
+	}
+	t.entries.Store(id, time.Now().Add(t.ttl))
+}
+
+func (t *apiKeyDeletionTombstones) Contains(id string) bool {
+	if t == nil || id == "" {
+		return false
+	}
+	value, ok := t.entries.Load(id)
+	if !ok {
+		return false
+	}
+	expiresAt, ok := value.(time.Time)
+	if !ok || time.Now().After(expiresAt) {
+		t.entries.Delete(id)
+		return false
+	}
+	return true
+}

--- a/pkg/servers/e2b/api_key_tombstone_test.go
+++ b/pkg/servers/e2b/api_key_tombstone_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2b
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIKeyDeletionTombstones(t *testing.T) {
+	t.Run("nil and empty id are ignored", func(t *testing.T) {
+		var tombstones *apiKeyDeletionTombstones
+
+		tombstones.Add("deleted-key")
+		assert.False(t, tombstones.Contains("deleted-key"))
+
+		tombstones = newAPIKeyDeletionTombstones(time.Minute)
+		tombstones.Add("")
+		assert.False(t, tombstones.Contains(""))
+	})
+
+	t.Run("active tombstone is visible", func(t *testing.T) {
+		tombstones := newAPIKeyDeletionTombstones(time.Minute)
+
+		tombstones.Add("deleted-key")
+
+		assert.True(t, tombstones.Contains("deleted-key"))
+		assert.False(t, tombstones.Contains("other-key"))
+	})
+
+	t.Run("expired tombstone is removed", func(t *testing.T) {
+		tombstones := newAPIKeyDeletionTombstones(-time.Second)
+		tombstones.Add("deleted-key")
+
+		assert.False(t, tombstones.Contains("deleted-key"))
+		assert.False(t, tombstones.Contains("deleted-key"))
+	})
+}

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -67,6 +67,7 @@ type Controller struct {
 	domain          string
 	manager         *sandboxmanager.SandboxManager
 	keys            keys.KeyStorage
+	deletedAPIKeys  *apiKeyDeletionTombstones
 }
 
 // NewController creates a new E2B Controller
@@ -88,6 +89,7 @@ func NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSe
 		memberlistBindPort:    memberlistBindPort,
 		keyCfg:                keyCfg,
 		quotaOpts:             quotaOpts,
+		deletedAPIKeys:        newAPIKeyDeletionTombstones(defaultAPIKeyDeletionTombstoneTTL),
 	}
 
 	sc.server = &http.Server{

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -35,6 +35,7 @@ import (
 	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
+	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
 	"github.com/openkruise/agents/pkg/utils"
@@ -111,6 +112,9 @@ func (sc *Controller) CreateSandbox(r *http.Request) (web.ApiResponse[*models.Sa
 	if validateErr := validateCreateResourceOverride(request); validateErr != nil {
 		return web.ApiResponse[*models.Sandbox]{}, validateErr
 	}
+	if apiErr := sc.ensureCreateAPIKeyActive(user); apiErr != nil {
+		return web.ApiResponse[*models.Sandbox]{}, apiErr
+	}
 	namespace := sc.getNamespaceOfUser(user)
 	log.Info("create sandbox request received", "request", request)
 	if sc.manager.GetInfra().HasTemplate(ctx, infra.HasTemplateOptions{
@@ -129,6 +133,32 @@ func (sc *Controller) CreateSandbox(r *http.Request) (web.ApiResponse[*models.Sa
 	return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
 		Code:    http.StatusBadRequest,
 		Message: "Template or Checkpoint not found",
+	}
+}
+
+func (sc *Controller) ensureCreateAPIKeyActive(user *models.CreatedTeamAPIKey) *web.ApiError {
+	if sc.keys == nil || user == nil || user.ID == keys.AdminKeyID {
+		return nil
+	}
+	if sc.deletedAPIKeys.Contains(user.ID.String()) {
+		return &web.ApiError{
+			Code:    http.StatusUnauthorized,
+			Message: "API key is no longer active",
+		}
+	}
+	return nil
+}
+
+func (sc *Controller) cleanupSandboxForDeletedAPIKey(ctx context.Context, sbx infra.Sandbox) {
+	if sbx == nil {
+		return
+	}
+	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cleanupCtx = klog.NewContext(cleanupCtx, log)
+	if err := sc.manager.DeleteSandbox(cleanupCtx, sbx); err != nil {
+		log.Error(err, "failed to cleanup sandbox after API key deletion")
 	}
 }
 
@@ -211,6 +241,11 @@ func (sc *Controller) createSandboxWithClaim(ctx context.Context, request models
 		log.Error(err, "sandbox creation failed")
 		return web.ApiResponse[*models.Sandbox]{}, mapInfraErrorToApiError(err)
 	}
+	if apiErr := sc.ensureCreateAPIKeyActive(user); apiErr != nil {
+		log.Info("API key was deleted while sandbox was being created, cleaning up sandbox", "id", sbx.GetSandboxID())
+		sc.cleanupSandboxForDeletedAPIKey(ctx, sbx)
+		return web.ApiResponse[*models.Sandbox]{}, apiErr
+	}
 	log.Info("sandbox created", "id", sbx.GetSandboxID(), "sbx", klog.KObj(sbx),
 		"resourceVersion", sbx.GetResourceVersion(), "totalCost", time.Since(claimStart))
 	return web.ApiResponse[*models.Sandbox]{
@@ -274,6 +309,11 @@ func (sc *Controller) createSandboxWithClone(ctx context.Context, request models
 	if err != nil {
 		log.Error(err, "sandbox clone failed")
 		return web.ApiResponse[*models.Sandbox]{}, mapInfraErrorToApiError(err)
+	}
+	if apiErr := sc.ensureCreateAPIKeyActive(user); apiErr != nil {
+		log.Info("API key was deleted while sandbox was being cloned, cleaning up sandbox", "id", sbx.GetSandboxID())
+		sc.cleanupSandboxForDeletedAPIKey(ctx, sbx)
+		return web.ApiResponse[*models.Sandbox]{}, apiErr
 	}
 	log.Info("sandbox cloned", "id", sbx.GetSandboxID(), "sbx", klog.KObj(sbx),
 		"resourceVersion", sbx.GetResourceVersion(), "totalCost", time.Since(start))

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -35,6 +35,7 @@ import (
 	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
+	quotaspec "github.com/openkruise/agents/pkg/sandbox-manager/quota/spec"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
@@ -149,15 +150,28 @@ func (sc *Controller) ensureCreateAPIKeyActive(user *models.CreatedTeamAPIKey) *
 	return nil
 }
 
-func (sc *Controller) cleanupSandboxForDeletedAPIKey(ctx context.Context, sbx infra.Sandbox) {
+func (sc *Controller) cleanupSandboxForDeletedAPIKey(ctx context.Context, sbx infra.Sandbox, user *models.CreatedTeamAPIKey) {
 	if sbx == nil {
 		return
+	}
+	var userID string
+	var quotaSpec *quotaspec.QuotaSpec
+	if user != nil {
+		userID = user.ID.String()
+		quotaSpec = user.QuotaSpec
+		if quotaSpec != nil {
+			quotaSpec = quotaSpec.DeepCopy()
+		}
 	}
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	cleanupCtx = klog.NewContext(cleanupCtx, log)
-	if err := sc.manager.DeleteSandbox(cleanupCtx, sbx); err != nil {
+	if err := sc.manager.DeleteSandbox(cleanupCtx, sandboxmanager.DeleteSandboxOptions{
+		Sandbox: sbx,
+		User:    userID,
+		Quota:   quotaSpec,
+	}); err != nil {
 		log.Error(err, "failed to cleanup sandbox after API key deletion")
 	}
 }
@@ -243,7 +257,7 @@ func (sc *Controller) createSandboxWithClaim(ctx context.Context, request models
 	}
 	if apiErr := sc.ensureCreateAPIKeyActive(user); apiErr != nil {
 		log.Info("API key was deleted while sandbox was being created, cleaning up sandbox", "id", sbx.GetSandboxID())
-		sc.cleanupSandboxForDeletedAPIKey(ctx, sbx)
+		sc.cleanupSandboxForDeletedAPIKey(ctx, sbx, user)
 		return web.ApiResponse[*models.Sandbox]{}, apiErr
 	}
 	log.Info("sandbox created", "id", sbx.GetSandboxID(), "sbx", klog.KObj(sbx),
@@ -312,7 +326,7 @@ func (sc *Controller) createSandboxWithClone(ctx context.Context, request models
 	}
 	if apiErr := sc.ensureCreateAPIKeyActive(user); apiErr != nil {
 		log.Info("API key was deleted while sandbox was being cloned, cleaning up sandbox", "id", sbx.GetSandboxID())
-		sc.cleanupSandboxForDeletedAPIKey(ctx, sbx)
+		sc.cleanupSandboxForDeletedAPIKey(ctx, sbx, user)
 		return web.ApiResponse[*models.Sandbox]{}, apiErr
 	}
 	log.Info("sandbox cloned", "id", sbx.GetSandboxID(), "sbx", klog.KObj(sbx),

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -682,6 +682,87 @@ func TestCreateSandboxCleansUpWhenAPIKeyDeletedDuringCreate(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestCreateSandboxCleanupDeletedAPIKeyIgnoresNilSandbox(t *testing.T) {
+	controller, _, teardown := Setup(t)
+	defer teardown()
+
+	controller.cleanupSandboxForDeletedAPIKey(t.Context(), nil)
+}
+
+func TestCreateSandboxReturnsUnauthorizedWhenDeletedKeyCleanupFails(t *testing.T) {
+	controller, fc, teardown := Setup(t)
+	defer teardown()
+
+	templateName := "deleted-key-cleanup-error-template"
+	user := &models.CreatedTeamAPIKey{
+		ID:   uuid.New(),
+		Key:  "cleanup-error-key",
+		Name: "cleanup-error-key",
+		Team: &models.Team{Name: "team-a"},
+	}
+	cleanup := CreateSandboxPool(t, controller, templateName, 0, CreateSandboxPoolOptions{Namespace: user.Team.Name})
+	defer cleanup()
+
+	origCreateSandbox := sandboxcr.DefaultCreateSandbox
+	t.Cleanup(func() { sandboxcr.DefaultCreateSandbox = origCreateSandbox })
+	sandboxcr.DefaultCreateSandbox = func(ctx context.Context, sbx *v1alpha1.Sandbox, c ctrlclient.Client) (*v1alpha1.Sandbox, error) {
+		if sbx.Name == "" && sbx.GenerateName != "" {
+			sbx.Name = sbx.GenerateName + rand.String(5)
+		}
+		created, err := origCreateSandbox(ctx, sbx, c)
+		if err != nil {
+			return nil, err
+		}
+		created.Status = v1alpha1.SandboxStatus{
+			Phase:              v1alpha1.SandboxRunning,
+			ObservedGeneration: created.Generation,
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(v1alpha1.SandboxConditionReady),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "Ready",
+				},
+			},
+			PodInfo: v1alpha1.PodInfo{
+				PodIP: "1.2.3.4",
+			},
+		}
+		if err = c.Status().Update(ctx, created); err != nil {
+			return nil, err
+		}
+		controller.deletedAPIKeys.Add(user.ID.String())
+		return created, nil
+	}
+
+	origDeleteSandbox := sandboxcr.DefaultDeleteSandbox
+	sandboxcr.DefaultDeleteSandbox = func(context.Context, *v1alpha1.Sandbox, ctrlclient.Client) error {
+		return fmt.Errorf("cleanup failed")
+	}
+	t.Cleanup(func() { sandboxcr.DefaultDeleteSandbox = origDeleteSandbox })
+
+	resp, apiError := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+		TemplateID: templateName,
+		Metadata: map[string]string{
+			models.ExtensionKeyCreateOnNoStock: v1alpha1.True,
+			models.ExtensionKeySkipInitRuntime: v1alpha1.True,
+		},
+	}, nil, user))
+
+	require.NotNil(t, apiError)
+	assert.Nil(t, resp.Body)
+	assert.Equal(t, http.StatusUnauthorized, apiError.Code)
+
+	sandboxcr.DefaultDeleteSandbox = origDeleteSandbox
+	var list v1alpha1.SandboxList
+	require.NoError(t, fc.List(t.Context(), &list))
+	for i := range list.Items {
+		if list.Items[i].Annotations[v1alpha1.AnnotationOwner] == user.ID.String() {
+			assert.NoError(t, fc.Delete(t.Context(), &list.Items[i]))
+		}
+	}
+}
+
 func TestCreateSandbox_QuotaExceededReturns403WithoutRetry(t *testing.T) {
 	fakeQuota := &fakeQuotaManager{acquireErr: quota.ErrQuotaExceeded}
 	controller, _, teardown := SetupWithQuota(t, fakeQuota)
@@ -1602,6 +1683,74 @@ func TestCloneSandbox(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCloneSandboxCleansUpWhenAPIKeyDeletedDuringClone(t *testing.T) {
+	controller, fc, teardown := Setup(t)
+	defer teardown()
+
+	checkpointID := "deleted-key-race-checkpoint"
+	user := &models.CreatedTeamAPIKey{
+		ID:   uuid.New(),
+		Key:  "soon-deleted-clone-key",
+		Name: "soon-deleted-clone-key",
+		Team: &models.Team{Name: "team-a"},
+	}
+	cleanup := CreateCheckpointAndTemplateInNamespace(t, controller, user.Team.Name, checkpointID, checkpointID, user.ID.String(), "source-sandbox", "2024-07-01T00:00:01Z")
+	defer cleanup()
+
+	origCreateSandbox := sandboxcr.DefaultCreateSandbox
+	t.Cleanup(func() { sandboxcr.DefaultCreateSandbox = origCreateSandbox })
+	sandboxcr.DefaultCreateSandbox = func(ctx context.Context, sbx *v1alpha1.Sandbox, c ctrlclient.Client) (*v1alpha1.Sandbox, error) {
+		if sbx.Name == "" && sbx.GenerateName != "" {
+			sbx.Name = sbx.GenerateName + rand.String(5)
+		}
+		created, err := origCreateSandbox(ctx, sbx, c)
+		if err != nil {
+			return nil, err
+		}
+		created.Status = v1alpha1.SandboxStatus{
+			Phase:              v1alpha1.SandboxRunning,
+			ObservedGeneration: created.Generation,
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(v1alpha1.SandboxConditionReady),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "Ready",
+				},
+			},
+			PodInfo: v1alpha1.PodInfo{
+				PodIP: "1.2.3.4",
+			},
+		}
+		if err = c.Status().Update(ctx, created); err != nil {
+			return nil, err
+		}
+		controller.deletedAPIKeys.Add(user.ID.String())
+		return created, nil
+	}
+
+	resp, apiError := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+		TemplateID: checkpointID,
+		Metadata: map[string]string{
+			models.ExtensionKeySkipInitRuntime: v1alpha1.True,
+		},
+	}, nil, user))
+
+	require.NotNil(t, apiError)
+	assert.Nil(t, resp.Body)
+	assert.Equal(t, http.StatusUnauthorized, apiError.Code)
+	require.Eventually(t, func() bool {
+		var list v1alpha1.SandboxList
+		require.NoError(t, fc.List(t.Context(), &list))
+		for _, sbx := range list.Items {
+			if sbx.Annotations[v1alpha1.AnnotationOwner] == user.ID.String() {
+				return false
+			}
+		}
+		return true
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestCloneSandboxWithCSIMountFromCheckpointAnnotation(t *testing.T) {

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -686,7 +686,7 @@ func TestCreateSandboxCleanupDeletedAPIKeyIgnoresNilSandbox(t *testing.T) {
 	controller, _, teardown := Setup(t)
 	defer teardown()
 
-	controller.cleanupSandboxForDeletedAPIKey(t.Context(), nil)
+	controller.cleanupSandboxForDeletedAPIKey(t.Context(), nil, nil)
 }
 
 func TestCreateSandboxReturnsUnauthorizedWhenDeletedKeyCleanupFails(t *testing.T) {

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -591,6 +591,97 @@ func TestCreateSandboxReturnsImmediatelyWhenCreateOnNoStockHitsQuota(t *testing.
 	assert.Less(t, elapsed, sandboxcr.CreateRetryInterval, "terminal quota denial must return before retry backoff")
 }
 
+func TestCreateSandboxRejectsDeletedAPIKeyTombstone(t *testing.T) {
+	controller, _, teardown := Setup(t)
+	defer teardown()
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   uuid.New(),
+		Key:  "deleted-key",
+		Name: "deleted-key",
+		Team: &models.Team{Name: "team-a"},
+	}
+	controller.deletedAPIKeys.Add(user.ID.String())
+
+	resp, apiError := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+		TemplateID: "any-template",
+	}, nil, user))
+
+	require.NotNil(t, apiError)
+	assert.Nil(t, resp.Body)
+	assert.Equal(t, http.StatusUnauthorized, apiError.Code)
+	assert.Contains(t, apiError.Message, "no longer active")
+}
+
+func TestCreateSandboxCleansUpWhenAPIKeyDeletedDuringCreate(t *testing.T) {
+	controller, fc, teardown := Setup(t)
+	defer teardown()
+
+	templateName := "deleted-key-race-template"
+	user := &models.CreatedTeamAPIKey{
+		ID:   uuid.New(),
+		Key:  "soon-deleted-key",
+		Name: "soon-deleted-key",
+		Team: &models.Team{Name: "team-a"},
+	}
+	cleanup := CreateSandboxPool(t, controller, templateName, 0, CreateSandboxPoolOptions{Namespace: user.Team.Name})
+	defer cleanup()
+
+	origCreateSandbox := sandboxcr.DefaultCreateSandbox
+	t.Cleanup(func() { sandboxcr.DefaultCreateSandbox = origCreateSandbox })
+	sandboxcr.DefaultCreateSandbox = func(ctx context.Context, sbx *v1alpha1.Sandbox, c ctrlclient.Client) (*v1alpha1.Sandbox, error) {
+		if sbx.Name == "" && sbx.GenerateName != "" {
+			sbx.Name = sbx.GenerateName + rand.String(5)
+		}
+		created, err := origCreateSandbox(ctx, sbx, c)
+		if err != nil {
+			return nil, err
+		}
+		created.Status = v1alpha1.SandboxStatus{
+			Phase:              v1alpha1.SandboxRunning,
+			ObservedGeneration: created.Generation,
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(v1alpha1.SandboxConditionReady),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "Ready",
+				},
+			},
+			PodInfo: v1alpha1.PodInfo{
+				PodIP: "1.2.3.4",
+			},
+		}
+		if err = c.Status().Update(ctx, created); err != nil {
+			return nil, err
+		}
+		controller.deletedAPIKeys.Add(user.ID.String())
+		return created, nil
+	}
+
+	resp, apiError := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+		TemplateID: templateName,
+		Metadata: map[string]string{
+			models.ExtensionKeyCreateOnNoStock: v1alpha1.True,
+			models.ExtensionKeySkipInitRuntime: v1alpha1.True,
+		},
+	}, nil, user))
+
+	require.NotNil(t, apiError)
+	assert.Nil(t, resp.Body)
+	assert.Equal(t, http.StatusUnauthorized, apiError.Code)
+	require.Eventually(t, func() bool {
+		var list v1alpha1.SandboxList
+		require.NoError(t, fc.List(t.Context(), &list))
+		for _, sbx := range list.Items {
+			if sbx.Annotations[v1alpha1.AnnotationOwner] == user.ID.String() {
+				return false
+			}
+		}
+		return true
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestCreateSandbox_QuotaExceededReturns403WithoutRetry(t *testing.T) {
 	fakeQuota := &fakeQuotaManager{acquireErr: quota.ErrQuotaExceeded}
 	controller, _, teardown := SetupWithQuota(t, fakeQuota)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR prevents sandbox create requests from leaving resources owned by an API key that has just been deleted.

The change adds a short-lived deleted API-key fence in the E2B controller. When an API key is deleted, its ID is recorded in the fence. `CreateSandbox` checks that fence before creating a sandbox and checks it again after claim/clone returns. If the key is deleted while creation is in flight, the newly created sandbox is cleaned up and the request returns unauthorized instead of leaving an inaccessible sandbox behind.

The tests cover:

- recording the deleted API-key ID after a successful delete;
- rejecting create requests for a tombstoned API key before any sandbox is created; and
- cleaning up a sandbox when the API key is deleted while create is in progress.

### Ⅱ. Does this pull request fix one issue?

Fixes #570

### Ⅲ. Describe how to verify it

- `gofmt` on the changed Go files
- `git diff --check`

The focused Go test command could not be run locally because the local Go executable is blocked by the machine's application-control policy. The added tests are intended to run in repository CI:

```bash
go test ./pkg/servers/e2b -run 'Test(DeleteAPIKeyPermissionMiddleware|CreateSandboxRejectsDeletedAPIKeyTombstone|CreateSandboxCleansUpWhenAPIKeyDeletedDuringCreate)$'
```

### Ⅳ. Special notes for reviews

The fence is intentionally bounded in memory. It closes the local race window around deletion and late create completion without changing persistent API-key storage semantics.