### PR TITLE
fix(sandbox-manager): reduce log volume in proxy and infra reconciler

### DIFF
--- a/pkg/cache/controllers/cache_controllers.go
+++ b/pkg/cache/controllers/cache_controllers.go
@@ -50,7 +50,6 @@ func (c *CustomReconciler[T]) Reconcile(ctx context.Context, req ctrl.Request) (
 	log := klog.FromContext(ctx)
 
 	if len(c.handlers) == 0 {
-		log.V(utils.DebugLogLevel).Info("reconcile skipped for no handlers")
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -37,7 +37,7 @@ import (
 	"github.com/openkruise/agents/pkg/peers"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
-	"github.com/openkruise/agents/pkg/servers/web"
+	"github.com/openkruise/agents/pkg/utils"
 )
 
 const (
@@ -107,7 +107,7 @@ func (s *Server) Run() error {
 
 	// HTTP
 	mux := http.NewServeMux()
-	web.RegisterRoute(mux, http.MethodPost, RefreshAPI, s.handleRefresh)
+	mux.HandleFunc(fmt.Sprintf("%s %s", http.MethodPost, RefreshAPI), s.handleRefresh)
 	s.httpSrv = &http.Server{
 		Addr:              fmt.Sprintf(":%d", SystemPort),
 		Handler:           mux,
@@ -153,24 +153,21 @@ func (s *Server) Stop(ctx context.Context) {
 	}
 }
 
-func (s *Server) handleRefresh(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
+func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := klog.FromContext(ctx)
 	var route Route
 	if err := json.NewDecoder(r.Body).Decode(&route); err != nil {
-		return web.ApiResponse[struct{}]{}, &web.ApiError{
-			Code:    http.StatusBadRequest,
-			Message: fmt.Sprintf("failed to unmarshal body: %s", err.Error()),
-		}
+		log.Error(err, "failed to unmarshal refresh request body")
+		http.Error(w, fmt.Sprintf("failed to unmarshal body: %s", err.Error()), http.StatusBadRequest)
+		return
 	}
 	if route.State == v1alpha1.SandboxStateDead {
 		s.DeleteRoute(route.ID)
-		log.Info("route deleted")
+		log.V(utils.DebugLogLevel + 1).Info("route deleted")
 	} else {
 		s.SetRoute(ctx, route)
-		log.Info("route refreshed", "route", route)
+		log.V(utils.DebugLogLevel+1).Info("route refreshed", "route", route)
 	}
-	return web.ApiResponse[struct{}]{
-		Code: http.StatusNoContent,
-	}, nil
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -71,10 +71,10 @@ func TestHandleRefresh_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodPost, RefreshAPI, bytes.NewReader(body))
-	resp, apiErr := s.handleRefresh(req)
+	rr := httptest.NewRecorder()
+	s.handleRefresh(rr, req)
 
-	assert.Nil(t, apiErr)
-	assert.Equal(t, http.StatusNoContent, resp.Code)
+	assert.Equal(t, http.StatusNoContent, rr.Code)
 
 	// Verify the route was actually stored
 	got, ok := s.LoadRoute("sb-refresh")
@@ -86,21 +86,20 @@ func TestHandleRefresh_InvalidBody(t *testing.T) {
 	s := newTestServer(nil)
 
 	req := httptest.NewRequest(http.MethodPost, RefreshAPI, bytes.NewBufferString("not-json"))
-	resp, apiErr := s.handleRefresh(req)
+	rr := httptest.NewRecorder()
+	s.handleRefresh(rr, req)
 
-	assert.NotNil(t, apiErr)
-	assert.Equal(t, http.StatusBadRequest, apiErr.Code)
-	assert.Empty(t, resp.Code)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
 func TestHandleRefresh_EmptyBody(t *testing.T) {
 	s := newTestServer(nil)
 
 	req := httptest.NewRequest(http.MethodPost, RefreshAPI, bytes.NewBufferString("{}"))
-	resp, apiErr := s.handleRefresh(req)
+	rr := httptest.NewRecorder()
+	s.handleRefresh(rr, req)
 
-	assert.Nil(t, apiErr)
-	assert.Equal(t, http.StatusNoContent, resp.Code)
+	assert.Equal(t, http.StatusNoContent, rr.Code)
 }
 
 func TestHandleRefresh_ContextPropagated(t *testing.T) {
@@ -112,9 +111,10 @@ func TestHandleRefresh_ContextPropagated(t *testing.T) {
 
 	ctx := context.WithValue(context.Background(), "test-key", "test-value")
 	req := httptest.NewRequest(http.MethodPost, RefreshAPI, bytes.NewReader(body)).WithContext(ctx)
-	_, apiErr := s.handleRefresh(req)
+	rr := httptest.NewRecorder()
+	s.handleRefresh(rr, req)
 
-	assert.Nil(t, apiErr)
+	assert.Equal(t, http.StatusNoContent, rr.Code)
 	got, ok := s.LoadRoute("sb-ctx")
 	require.True(t, ok)
 	assert.Equal(t, "9.9.9.9", got.IP)
@@ -131,9 +131,10 @@ func TestHandleRefresh_OverwritesExistingRoute(t *testing.T) {
 	newer := Route{ID: "sb-over", IP: "2.2.2.2", ResourceVersion: "2"}
 	body, _ := json.Marshal(newer)
 	req := httptest.NewRequest(http.MethodPost, RefreshAPI, bytes.NewReader(body))
-	_, apiErr := s.handleRefresh(req)
+	rr := httptest.NewRecorder()
+	s.handleRefresh(rr, req)
 
-	assert.Nil(t, apiErr)
+	assert.Equal(t, http.StatusNoContent, rr.Code)
 	got, _ := s.LoadRoute("sb-over")
 	assert.Equal(t, "2.2.2.2", got.IP)
 }
@@ -143,15 +144,13 @@ func TestServer_handleRefresh(t *testing.T) {
 		name           string
 		body           string
 		expectedCode   int
-		expectedError  bool
 		expectDeleted  bool
 		expectRouteSet bool
 	}{
 		{
-			name:          "invalid json body",
-			body:          "invalid json",
-			expectedCode:  http.StatusBadRequest,
-			expectedError: true,
+			name:         "invalid json body",
+			body:         "invalid json",
+			expectedCode: http.StatusBadRequest,
 		},
 		{
 			name: "dead state should delete route",
@@ -162,7 +161,6 @@ func TestServer_handleRefresh(t *testing.T) {
 				ResourceVersion: "1",
 			}),
 			expectedCode:  http.StatusNoContent,
-			expectedError: false,
 			expectDeleted: true,
 		},
 		{
@@ -174,7 +172,6 @@ func TestServer_handleRefresh(t *testing.T) {
 				ResourceVersion: "1",
 			}),
 			expectedCode:   http.StatusNoContent,
-			expectedError:  false,
 			expectRouteSet: true,
 		},
 		{
@@ -186,7 +183,6 @@ func TestServer_handleRefresh(t *testing.T) {
 				ResourceVersion: "1",
 			}),
 			expectedCode:   http.StatusNoContent,
-			expectedError:  false,
 			expectRouteSet: true,
 		},
 	}
@@ -209,18 +205,13 @@ func TestServer_handleRefresh(t *testing.T) {
 
 			// Create request
 			req := httptest.NewRequest(http.MethodPost, RefreshAPI, strings.NewReader(tt.body))
+			rr := httptest.NewRecorder()
 
 			// Call handleRefresh
-			resp, apiErr := s.handleRefresh(req)
+			s.handleRefresh(rr, req)
 
 			// Verify response
-			if tt.expectedError {
-				assert.NotNil(t, apiErr)
-				assert.Equal(t, tt.expectedCode, apiErr.Code)
-			} else {
-				assert.Nil(t, apiErr)
-				assert.Equal(t, tt.expectedCode, resp.Code)
-			}
+			assert.Equal(t, tt.expectedCode, rr.Code)
 
 			// Verify route deletion
 			if tt.expectDeleted {
@@ -255,10 +246,9 @@ func TestServer_handleRefresh_EmptyBody(t *testing.T) {
 	s := NewServer(config.SandboxManagerOptions{})
 
 	req := httptest.NewRequest(http.MethodPost, RefreshAPI, bytes.NewReader([]byte{}))
-	resp, apiErr := s.handleRefresh(req)
+	rr := httptest.NewRecorder()
+	s.handleRefresh(rr, req)
 
-	assert.NotNil(t, apiErr)
-	assert.Equal(t, http.StatusBadRequest, apiErr.Code)
-	assert.Contains(t, apiErr.Message, "failed to unmarshal body")
-	assert.Equal(t, 0, resp.Code)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "failed to unmarshal body")
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -491,17 +491,20 @@ func (i *Infra) reconcileSandbox(ctx context.Context, sbx *v1alpha1.Sandbox, not
 	}
 
 	// Sandbox exists, refresh route
-	i.refreshRoute(sbx)
-	log.V(utils.DebugLogLevel).Info("sandbox route refreshed during reconciliation")
+	if i.refreshRoute(sbx) {
+		log.V(utils.DebugLogLevel).Info("sandbox route refreshed during reconciliation")
+	}
 	return ctrl.Result{}, nil
 }
 
-func (i *Infra) refreshRoute(sbx *v1alpha1.Sandbox) {
-	oldRoute, exists := i.Proxy.LoadRoute(sbx.GetName())
+func (i *Infra) refreshRoute(sbx *v1alpha1.Sandbox) bool {
+	oldRoute, exists := i.Proxy.LoadRoute(utils.GetSandboxID(sbx))
 	newRoute := proxyutils.DefaultGetRouteFunc(sbx)
 	if !exists || newRoute.State != oldRoute.State || newRoute.IP != oldRoute.IP {
 		i.Proxy.SetRoute(logs.NewContext(), newRoute)
+		return true
 	}
+	return false
 }
 
 const (


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Reduces unnecessary log noise in the sandbox-manager process by:

1. **Proxy `handleRefresh`**: Replaced `web.RegisterRoute` framework with plain `http.HandlerFunc` for the internal system port (7789). This endpoint only serves inter-pod route refresh calls and doesn't need request ID generation, panic recovery wrapper, or the full web framework overhead. Log verbosity raised to `V(DebugLogLevel+1)`.

2. **Infra `refreshRoute`**: Changed to return a `bool` indicating whether the route actually changed, so the "route refreshed" debug log only fires on real updates — not on every reconcile cycle where the route is already current.

3. **Cache controller**: Removed a debug log that fired on every reconcile when no handlers are registered — a normal steady-state condition that doesn't need logging.

4. **Bug fix**: `refreshRoute` was using `sbx.GetName()` to look up routes, but routes are keyed by `utils.GetSandboxID(sbx)` (namespace + name). Fixed to use the correct key.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run affected unit tests:
   ```bash
   go test ./pkg/proxy/... ./pkg/cache/controllers/... ./pkg/sandbox-manager/infra/... -count=1
   ```
2. Deploy and observe log output — route refresh logs should only appear when state/IP actually changes.

### Ⅳ. Special notes for reviews

- The `handleRefresh` endpoint is internal-only (port 7789, used for peer route sync). Removing the `web.RegisterRoute` wrapper is safe — Go's `net/http` server has built-in per-connection panic recovery.
- The sandbox ID bug fix (item 4) is the most impactful change — in multi-namespace deployments, `GetName()` alone could miss routes that are keyed with the full `namespace/name` format.
