### PR TITLE
test(e2b): add E2B E2E test for sandbox creation with labels and command execution

### DIFF
--- a/test/e2b/test_sandbox.py
+++ b/test/e2b/test_sandbox.py
@@ -712,6 +712,15 @@ def test_sandbox_with_labels_and_command(sandbox_context):
     ))
     print(f"sandbox-id: {sbx.sandbox_id}")
 
+    # Run a shell command immediately after create returns to confirm the
+    # sandbox is operational before any further API calls.
+    result = sbx.commands.run("echo 'hello from labeled sandbox'")
+    assert not result.error, f"command failed: {result.error}"
+    assert "hello from labeled sandbox" in result.stdout
+
+    # Also exercise run_code to confirm the code interpreter is functional.
+    run_code_sandbox(sbx, "print('labels work')")
+
     # Verify the labels are reflected back in the sandbox metadata.
     # The label: prefix is stripped before the key is stored as a K8s label,
     # and labels are returned as plain metadata (without the label: prefix).
@@ -726,11 +735,3 @@ def test_sandbox_with_labels_and_command(sandbox_context):
     # The label: prefixed keys must not leak into metadata.
     assert "label:app" not in info.metadata
     assert "label:env" not in info.metadata
-
-    # Run a shell command inside the sandbox to confirm it is operational.
-    result = sbx.commands.run("echo 'hello from labeled sandbox'")
-    assert not result.error, f"command failed: {result.error}"
-    assert "hello from labeled sandbox" in result.stdout
-
-    # Also exercise run_code to confirm the code interpreter is functional.
-    run_code_sandbox(sbx, "print('labels work')")

--- a/test/e2b/test_sandbox.py
+++ b/test/e2b/test_sandbox.py
@@ -693,3 +693,44 @@ def test_concurrent_pause_resume_on_running_sandbox(sandbox_context):
     info = sbx.get_info()
     print(f"Final state: {info.state}")
     assert info.state == SandboxState.PAUSED
+
+
+def test_sandbox_with_labels_and_command(sandbox_context):
+    """Create a sandbox with labels via label: prefix metadata, verify labels
+    are present in the returned sandbox metadata, then run a command inside."""
+    sbx: Sandbox = sandbox_context.add(Sandbox.create(
+        template="code-interpreter",
+        timeout=30,
+        metadata={
+            "test_case": "test_sandbox_with_labels_and_command",
+            "label:app": "my-test-app",
+            "label:env": "e2e",
+        },
+        headers={
+            "x-request-id": sandbox_context.request_id,
+        },
+    ))
+    print(f"sandbox-id: {sbx.sandbox_id}")
+
+    # Verify the labels are reflected back in the sandbox metadata.
+    # The label: prefix is stripped before the key is stored as a K8s label,
+    # and labels are returned as plain metadata (without the label: prefix).
+    info = sbx.get_info()
+    print(info)
+    assert info.metadata.get("app") == "my-test-app", (
+        f"expected label 'app=my-test-app' in metadata, got: {info.metadata}"
+    )
+    assert info.metadata.get("env") == "e2e", (
+        f"expected label 'env=e2e' in metadata, got: {info.metadata}"
+    )
+    # The label: prefixed keys must not leak into metadata.
+    assert "label:app" not in info.metadata
+    assert "label:env" not in info.metadata
+
+    # Run a shell command inside the sandbox to confirm it is operational.
+    result = sbx.commands.run("echo 'hello from labeled sandbox'")
+    assert not result.error, f"command failed: {result.error}"
+    assert "hello from labeled sandbox" in result.stdout
+
+    # Also exercise run_code to confirm the code interpreter is functional.
+    run_code_sandbox(sbx, "print('labels work')")


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Adds `test_sandbox_with_labels_and_command` to `test/e2b/test_sandbox.py`, covering the `label:` prefix metadata convention for assigning Kubernetes labels to a Sandbox CR via the E2B-compatible API.

The test:
- Creates a sandbox with two labels (`label:app`, `label:env`) in metadata
- Immediately runs a shell command via `sbx.commands.run()` to confirm the sandbox is operational right after `Sandbox.create()` returns
- Exercises `run_code` to confirm the code interpreter is functional
- Calls `get_info()` and verifies labels appear in `metadata` with the `label:` prefix stripped, and that the prefixed keys do not leak through

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Deploy sandbox-manager and agent-sandbox-controller on a Kind cluster
2. Run: `cd test/e2b && pytest test_sandbox.py::test_sandbox_with_labels_and_command -v`
3. Verify the test passes and labels are correctly reflected in sandbox metadata

### Ⅳ. Special notes for reviews

- The `label:` prefix is parsed by `parseExtensionLabels()` in `pkg/servers/e2b/models/extensions.go`, which strips the prefix, validates the key/value, and propagates them as K8s labels on the Sandbox CR.
- Command execution is placed **before** `get_info()` intentionally, to verify the sandbox is usable immediately after `Sandbox.create()` returns.
