### PR TITLE
fix: return registry secret lookup errors from resolveRegistrySecretName

### DIFF
--- a/pkg/controller/commit/core/common_control.go
+++ b/pkg/controller/commit/core/common_control.go
@@ -86,7 +86,11 @@ func (r *commonControl) EnsureCommitRunning(ctx context.Context, args *EnsureFun
 
 	// Generate Job spec — permanent errors (bad input, missing config) mark Failed.
 	g := &jobutil.JobGenerator{Commit: commit, Pod: pod}
-	g.DockerConfigSecretName = r.resolveRegistrySecretName(ctx, commit)
+	secretName, err := r.resolveRegistrySecretName(ctx, commit)
+	if err != nil {
+		return 0, err
+	}
+	g.DockerConfigSecretName = secretName
 	job, err := g.GenerateCommitJob()
 	if err != nil {
 		log.Error(err, "failed to generate commit job", "commit", klog.KObj(commit))
@@ -186,7 +190,9 @@ func (r *commonControl) EnsureCommitDeleted(ctx context.Context, args *EnsureFun
 
 // resolveRegistrySecretName resolves the registry auth secret from user-specified
 // spec.registryAuth.secrets. Returns the secret name, or empty string if none found.
-func (r *commonControl) resolveRegistrySecretName(ctx context.Context, commit *agentsv1alpha1.Commit) string {
+// A transient API error (anything other than NotFound) is returned so the caller
+// can retry rather than silently falling back to anonymous push.
+func (r *commonControl) resolveRegistrySecretName(ctx context.Context, commit *agentsv1alpha1.Commit) (string, error) {
 	log := log.FromContext(ctx)
 	ns := commit.Namespace
 
@@ -194,18 +200,21 @@ func (r *commonControl) resolveRegistrySecretName(ctx context.Context, commit *a
 		for _, name := range commit.Spec.RegistryAuth.Secrets {
 			secret := &corev1.Secret{}
 			if err := r.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, secret); err != nil {
-				log.V(4).Info("Failed to get registryAuth secret, trying next", "namespace", ns, "name", name, "err", err)
+				if !errors.IsNotFound(err) {
+					return "", fmt.Errorf("failed to get registry secret %s/%s: %w", ns, name, err)
+				}
+				log.V(4).Info("Registry secret not found, trying next", "namespace", ns, "name", name)
 				continue
 			}
 			if secret.Type == corev1.SecretTypeDockerConfigJson {
 				log.Info("Using registryAuth secret for registry auth", "namespace", ns, "name", name)
-				return name
+				return name, nil
 			}
 		}
 	}
 
 	log.Info("No registry secret found, commit will attempt anonymous push", "commit", klog.KObj(commit))
-	return ""
+	return "", nil
 }
 
 func (r *commonControl) listCRJobPods(ctx context.Context, commit *agentsv1alpha1.Commit) (*corev1.PodList, error) {

--- a/pkg/controller/commit/core/common_control_test.go
+++ b/pkg/controller/commit/core/common_control_test.go
@@ -135,7 +135,10 @@ func TestResolveRegistrySecretName_Tier1(t *testing.T) {
 		"push-secret",
 	}}
 
-	name := ctrl.resolveRegistrySecretName(context.TODO(), commit)
+	name, err := ctrl.resolveRegistrySecretName(context.TODO(), commit)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if name != "push-secret" {
 		t.Errorf("expected 'push-secret', got %q", name)
 	}
@@ -151,7 +154,10 @@ func TestResolveRegistrySecretName_Tier1_NotFound(t *testing.T) {
 		"nonexistent-secret",
 	}}
 
-	name := ctrl.resolveRegistrySecretName(context.TODO(), commit)
+	name, err := ctrl.resolveRegistrySecretName(context.TODO(), commit)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if name != "" {
 		t.Errorf("expected empty, got %q", name)
 	}
@@ -171,7 +177,10 @@ func TestResolveRegistrySecretName_Tier1_WrongType(t *testing.T) {
 		"opaque-secret",
 	}}
 
-	name := ctrl.resolveRegistrySecretName(context.TODO(), commit)
+	name, err := ctrl.resolveRegistrySecretName(context.TODO(), commit)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if name != "" {
 		t.Errorf("expected empty for wrong secret type, got %q", name)
 	}
@@ -184,7 +193,10 @@ func TestResolveRegistrySecretName_NoSecret(t *testing.T) {
 
 	commit := newTestCommit("test-commit", "default")
 
-	name := ctrl.resolveRegistrySecretName(context.TODO(), commit)
+	name, err := ctrl.resolveRegistrySecretName(context.TODO(), commit)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if name != "" {
 		t.Errorf("expected empty when no secret specified, got %q", name)
 	}


### PR DESCRIPTION
## SUMMARY

This PR updates registry secret resolution to distinguish transient API errors from missing secrets during Commit job creation. Instead of silently falling back to anonymous pushes on any lookup failure, transient errors are now returned so the controller can retry the reconciliation.

The changes primarily affect `pkg/controller/commit/core/common_control.go` and its associated unit tests.

## FIX

```go
// Before
g.DockerConfigSecretName = r.resolveRegistrySecretName(ctx, commit)

// After
secretName, err := r.resolveRegistrySecretName(ctx, commit)
if err != nil {
    return 0, err
}
g.DockerConfigSecretName = secretName
```
