### PR TITLE
feat(gateway): implement wake-on-traffic for paused sandboxes

### DIFF
--- a/api/v1alpha1/annotations.go
+++ b/api/v1alpha1/annotations.go
@@ -27,6 +27,16 @@ const (
 	// no Sandbox or Checkpoint still references it before performing the actual
 	// deletion.
 	AnnotationCleanupCandidate = InternalPrefix + "cleanup-candidate"
+
+	// AnnotationWakeOnTraffic enables wake-on-traffic for a paused sandbox.
+	// When set to "true", the sandbox-gateway will attempt to resume the sandbox
+	// by patching Spec.Paused=false when traffic arrives.
+	AnnotationWakeOnTraffic = InternalPrefix + "wake-on-traffic"
+
+	// AnnotationWakeTimeoutSeconds stores the auto-pause timeout (in seconds) to
+	// apply when the sandbox is woken by traffic. The gateway reads this to set
+	// ResumeOptions.Timeout.PauseTime, re-arming auto-pause after wake.
+	AnnotationWakeTimeoutSeconds = InternalPrefix + "wake-timeout-seconds"
 )
 
 // E2B annotations

--- a/config/sandbox-gateway/configmap.yaml
+++ b/config/sandbox-gateway/configmap.yaml
@@ -80,6 +80,8 @@ data:
                               sandbox-port-header: "e2b-sandbox-port"
                               default-port: "49983"
                               enable-auth: false
+                              enable-wake-on-traffic: true
+                              wake-timeout-seconds: 60
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/config/sandbox-gateway/rbac.yaml
+++ b/config/sandbox-gateway/rbac.yaml
@@ -8,13 +8,16 @@ metadata:
 rules:
   - apiGroups: ["agents.kruise.io"]
     resources: ["sandboxes"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["agents.kruise.io"]
     resources: ["sandboxes/status"]
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["list"]
+  - apiGroups: ["agents.kruise.io"]
+    resources: ["sandboxsets"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/proposals/20260627-wake-on-traffic-via-spec-patch.md
+++ b/docs/proposals/20260627-wake-on-traffic-via-spec-patch.md
@@ -1,0 +1,101 @@
+# Wake-on-Traffic via Direct Spec Patch (No SystemToken)
+
+## Motivation
+
+PR #495 implements wake-on-traffic by having sandbox-gateway call sandbox-manager's
+`/connect` HTTP API using a scoped system credential (systemtoken). This introduces
+cross-component HTTP coupling, a new credential type, and credential lifecycle
+management. This proposal replaces that mechanism with a direct Go function call,
+eliminating the systemtoken entirely while reusing the exact same resume logic.
+
+## Design
+
+The sandbox-gateway directly calls `sandboxcr.AsSandbox(sbx, cache).Resume(ctx, opts)`
+— a Go function call, not an HTTP call. This reuses the entire sandbox-manager connect
+path: spec patch (`Spec.Paused = false`), wait-for-running (`NewSandboxResumeTask().Wait()`),
+concurrent dedup (first-writer-wins via `retryUpdate`), conflict retries, and post-resume
+refresh (`InplaceRefresh`).
+
+```
+Traffic -> Envoy Filter -> Registry lookup
+  |-> sandbox Running: forward (current behavior)
+  |-> sandbox Paused + WakeOnTraffic enabled:
+       |-> sandboxcr.AsSandbox(sbx, cacheProvider).Resume(ctx, opts)
+       |     ^-- reuses existing sandbox-manager connect implementation:
+       |         1. refreshFromAPIReader (fresh fetch)
+       |         2. IsSandboxResumable check
+       |         3. NewSandboxResumeTask (pre-acquired wait task)
+       |         4. retryUpdate: patches Spec.Paused=false + setTimeout
+       |         5. resumeTask.Wait() -- blocks until Ready condition True
+       |         6. InplaceRefresh + expectations
+       |     Concurrent dedup: first-writer-wins via retryUpdate
+       |-> syncRoute: update local registry + sync to peer gateways
+       |-> Forward request or return 503 on timeout/failure
+  |-> sandbox Paused + WakeOnTraffic disabled: return 502 (current behavior)
+```
+
+## Key Components
+
+### Annotation Lifecycle
+
+- `AnnotationWakeOnTraffic` ("agents.kruise.io/wake-on-traffic"): Set to "true" at
+  creation time when `autoResume=true` is passed in the E2B create request. Updated
+  via connect/resume API when `autoResume` is provided.
+- `AnnotationWakeTimeoutSeconds` ("agents.kruise.io/wake-timeout-seconds"): Stores the
+  auto-pause timeout (in seconds) to apply when the sandbox is woken by traffic. The
+  gateway reads this to set `ResumeOptions.Timeout.PauseTime`, re-arming auto-pause
+  after wake.
+
+### Wake Package (`pkg/sandbox-gateway/wake/`)
+
+The `Waker` struct wraps `sandboxcr.AsSandbox(sbx, cache).Resume()` and syncs the route
+after Resume succeeds. It does NOT reimplement spec patching or wait-for-running — it
+delegates entirely to the existing `Resume()` method.
+
+After Resume succeeds, `syncRoute` mirrors the manager's `syncRoute` flow:
+1. Get route from refreshed sandbox (`sandbox.GetRoute()`)
+2. Update local gateway registry (`registry.GetRegistry().Update`)
+3. Sync route to peer gateways (`proxy.SyncRouteWithPeers`)
+
+### Cache Provider
+
+`cache.NewCache(mgr)` creates the same informer-backed cache + `WaitReconciler` used by
+sandbox-manager. The gateway's controller-runtime manager hosts both the existing
+`SandboxReconciler` (for local registry updates) and the cache provider's wait
+reconciler (for `NewSandboxResumeTask().Wait()`).
+
+### Route Sync
+
+`proxy.SyncRouteWithPeers` was extracted as a package-level function so the gateway can
+call it without creating a full `proxy.Server` instance. The gateway's `server.Server`
+exposes its `peerManager` via `GetPeerManager()` for use by the Waker.
+
+## Authorization
+
+K8s RBAC grants the gateway ServiceAccount `update`/`patch` on `sandboxes` resources.
+No systemtoken, no HTTP call to sandbox-manager.
+
+## Comparison with PR #495
+
+| Aspect | PR #495 | This Proposal |
+|--------|---------|---------------|
+| Wake trigger | Gateway calls manager `/connect` HTTP API | Gateway calls `sandboxcr.Sandbox.Resume()` directly (Go function) |
+| Auth | System key (systemtoken) | K8s RBAC (ServiceAccount) |
+| Resume logic | Manager's `ResumeSandbox` HTTP handler | Same `sandboxcr.Sandbox.Resume()` method (imported, not HTTP) |
+| Wait mechanism | Manager's `NewSandboxResumeTask().Wait()` | Same (reused via Resume call) |
+| Spec patching | Manager's `retryUpdate` inside Resume | Same (reused via Resume call) |
+| Concurrent dedup | Manager's first-writer-wins | Same (reused via Resume call) |
+| Route sync after wake | Manager's `syncRoute` | Gateway mirrors: `registry.Update` + `proxy.SyncRouteWithPeers` |
+| Timeout update | Manager's connect API handles it | Gateway passes `ResumeOptions.Timeout.PauseTime` |
+| New components | `systemkey.go`, `wake/client.go`, `wake/wake.go` | `wake/wake.go` (thin wrapper) |
+| Cross-component deps | Gateway -> Manager HTTP | Gateway imports `pkg/sandbox-manager/infra/sandboxcr` (Go import) |
+| Cache provider | Manager has its own | Gateway creates its own via `cache.NewCache(mgr)` |
+
+## Timeout Handling
+
+The `AnnotationWakeTimeoutSeconds` annotation stores the auto-pause timeout. When the
+gateway wakes a sandbox:
+1. It reads the annotation to determine `PauseTime` (re-arming auto-pause)
+2. If the annotation is absent, it uses the filter's `WakeTimeoutSeconds` config default
+3. The timeout is passed as `ResumeOptions.Timeout.PauseTime`, which is written atomically
+   with `Spec.Paused = false` inside `retryUpdate` — closing the auto-pause race

--- a/hack/run-e2b-e2e-test.sh
+++ b/hack/run-e2b-e2e-test.sh
@@ -260,6 +260,7 @@ pytest_args=(-v -s -x --tb=short)
 if [ "$WITH_GATEWAY" != "true" ]; then
     pytest_args+=(--ignore="$TEST_DIR/test_gateway.py")
     pytest_args+=(--ignore="$TEST_DIR/test_gateway_auth.py")
+    pytest_args+=(--ignore="$TEST_DIR/test_wake_on_traffic.py")
 fi
 if [ "$AUTH_DISABLED" = "true" ]; then
     pytest_args+=(--ignore="$TEST_DIR/test_apikey.py")

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -67,7 +67,11 @@ func (s *Server) SetRoute(ctx context.Context, route Route) {
 	}
 }
 
-func (s *Server) SyncRouteWithPeers(route Route) error {
+// SyncRouteWithPeers sends a route update to all peer gateways via HTTP POST /refresh.
+// This is a package-level function so it can be called by both proxy.Server
+// (sandbox-manager) and the sandbox-gateway Waker without the gateway needing
+// to create a full proxy.Server instance.
+func SyncRouteWithPeers(peersManager peers.Peers, route Route) error {
 	body, err := json.Marshal(route)
 	if err != nil {
 		return err
@@ -75,8 +79,8 @@ func (s *Server) SyncRouteWithPeers(route Route) error {
 
 	// Get peers from Peers - no manual locking needed
 	var peerList []peers.Peer
-	if s.peersManager != nil {
-		peerList = s.peersManager.GetPeers()
+	if peersManager != nil {
+		peerList = peersManager.GetPeers()
 	}
 
 	peerCount.Set(float64(len(peerList)))
@@ -118,6 +122,10 @@ func (s *Server) SyncRouteWithPeers(route Route) error {
 		return nil
 	}
 	return errors.New(strings.Join(errStrings, ";"))
+}
+
+func (s *Server) SyncRouteWithPeers(route Route) error {
+	return SyncRouteWithPeers(s.peersManager, route)
 }
 
 func (s *Server) LoadRoute(id string) (Route, bool) {

--- a/pkg/sandbox-gateway/controller/gateway_controller.go
+++ b/pkg/sandbox-gateway/controller/gateway_controller.go
@@ -28,7 +28,9 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/wake"
 	proxyutils "github.com/openkruise/agents/pkg/utils/proxyutils"
 )
 
@@ -81,6 +83,20 @@ func StartManager(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to create manager: %w", err)
 	}
+
+	// Create cache provider (reuses sandbox-manager's cache + wait infrastructure).
+	// cache.NewCache calls SetupCacheControllersWithManager which registers
+	// the WaitReconciler on the manager — the same reconciler that processes
+	// wait hooks in the sandbox-manager connect path. This enables
+	// sandboxcr.Sandbox.Resume() to use NewSandboxResumeTask().Wait() from
+	// within the gateway process.
+	cacheProvider, err := cache.NewCache(mgr)
+	if err != nil {
+		return fmt.Errorf("unable to create cache provider: %w", err)
+	}
+
+	// Initialize wake waker with the cache provider
+	wake.InitWaker(cacheProvider)
 
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&agentsv1alpha1.Sandbox{}).

--- a/pkg/sandbox-gateway/filter/config.go
+++ b/pkg/sandbox-gateway/filter/config.go
@@ -60,10 +60,10 @@ type Config struct {
 // DefaultConfig returns default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		SandboxHeaderName: DefaultSandboxHeaderName,
-		SandboxPortHeader: DefaultSandboxPortHeader,
-		HostHeaderName:    DefaultHostHeaderName,
-		DefaultPort:       DefaultSandboxPort,
+		SandboxHeaderName:  DefaultSandboxHeaderName,
+		SandboxPortHeader:  DefaultSandboxPortHeader,
+		HostHeaderName:     DefaultHostHeaderName,
+		DefaultPort:        DefaultSandboxPort,
 		WakeTimeoutSeconds: 60,
 	}
 }

--- a/pkg/sandbox-gateway/filter/config.go
+++ b/pkg/sandbox-gateway/filter/config.go
@@ -48,6 +48,13 @@ type Config struct {
 	// EnableAuth enables access token authentication when set to true.
 	// When disabled (default), the gateway skips token validation for backward compatibility.
 	EnableAuth bool `json:"enable-auth,omitempty"`
+	// EnableWakeOnTraffic enables wake-on-traffic for paused sandboxes.
+	// When true, the gateway will attempt to resume a paused sandbox by
+	// patching Spec.Paused=false when traffic arrives.
+	EnableWakeOnTraffic bool `json:"enable-wake-on-traffic,omitempty"`
+	// WakeTimeoutSeconds is the max time (in seconds) to wait for a sandbox
+	// to resume before returning an error. Defaults to 60.
+	WakeTimeoutSeconds int `json:"wake-timeout-seconds,omitempty"`
 }
 
 // DefaultConfig returns default configuration
@@ -57,6 +64,7 @@ func DefaultConfig() *Config {
 		SandboxPortHeader: DefaultSandboxPortHeader,
 		HostHeaderName:    DefaultHostHeaderName,
 		DefaultPort:       DefaultSandboxPort,
+		WakeTimeoutSeconds: 60,
 	}
 }
 
@@ -98,6 +106,14 @@ func (c *Config) GetDefaultPort() int {
 	}
 	p, _ := strconv.Atoi(DefaultSandboxPort)
 	return p
+}
+
+// GetWakeTimeoutSeconds returns the wake timeout in seconds, defaulting to 60.
+func (c *Config) GetWakeTimeoutSeconds() int {
+	if c.WakeTimeoutSeconds > 0 {
+		return c.WakeTimeoutSeconds
+	}
+	return 60
 }
 
 // FilterConfig wraps Config and holds the adapter created from the config
@@ -184,6 +200,12 @@ func (p *ConfigParser) Merge(parent interface{}, child interface{}) interface{} 
 	}
 	if childCfg.EnableAuth {
 		merged.EnableAuth = childCfg.EnableAuth
+	}
+	if childCfg.EnableWakeOnTraffic {
+		merged.EnableWakeOnTraffic = childCfg.EnableWakeOnTraffic
+	}
+	if childCfg.WakeTimeoutSeconds > 0 {
+		merged.WakeTimeoutSeconds = childCfg.WakeTimeoutSeconds
 	}
 
 	return NewFilterConfig(merged)

--- a/pkg/sandbox-gateway/filter/config_test.go
+++ b/pkg/sandbox-gateway/filter/config_test.go
@@ -388,3 +388,62 @@ func TestConfigParserMerge(t *testing.T) {
 		})
 	}
 }
+
+func TestGetWakeTimeoutSeconds(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want int
+	}{
+		{
+			name: "default config returns 60",
+			cfg:  DefaultConfig(),
+			want: 60,
+		},
+		{
+			name: "custom wake timeout",
+			cfg:  &Config{WakeTimeoutSeconds: 300},
+			want: 300,
+		},
+		{
+			name: "zero returns default 60",
+			cfg:  &Config{},
+			want: 60,
+		},
+		{
+			name: "negative returns default 60",
+			cfg:  &Config{WakeTimeoutSeconds: -1},
+			want: 60,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.GetWakeTimeoutSeconds()
+			if got != tt.want {
+				t.Errorf("GetWakeTimeoutSeconds() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeWakeOnTraffic(t *testing.T) {
+	parser := &ConfigParser{}
+	parent := DefaultConfig()
+	child := &Config{
+		EnableWakeOnTraffic: true,
+		WakeTimeoutSeconds:  120,
+	}
+
+	result := parser.Merge(NewFilterConfig(parent), NewFilterConfig(child))
+	fc, ok := result.(*FilterConfig)
+	if !ok {
+		t.Fatalf("Merge() returned %T, want *FilterConfig", result)
+	}
+	if !fc.EnableWakeOnTraffic {
+		t.Error("Merge() did not propagate EnableWakeOnTraffic from child")
+	}
+	if fc.WakeTimeoutSeconds != 120 {
+		t.Errorf("WakeTimeoutSeconds = %d, want 120", fc.WakeTimeoutSeconds)
+	}
+}

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -17,8 +17,11 @@ limitations under the License.
 package filter
 
 import (
+	"context"
 	"crypto/subtle"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
 	"go.uber.org/zap"
@@ -26,6 +29,7 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/wake"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 )
 
@@ -100,15 +104,65 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 	}
 
 	if route.State != agentsv1alpha1.SandboxStateRunning {
-		logger.Warn("Sandbox is not running", zap.String("sandboxID", sandboxID), zap.String("state", route.State))
-		f.callbacks.DecoderFilterCallbacks().SendLocalReply(
-			502,
-			"healthy sandbox not found: "+sandboxID,
-			nil,
-			-1,
-			"sandbox_not_running",
-		)
-		return api.LocalReply
+		// Check if wake-on-traffic is enabled for this sandbox
+		if f.config.EnableWakeOnTraffic && route.WakeOnTraffic && route.State == agentsv1alpha1.SandboxStatePaused {
+			waker := wake.GetWaker()
+			if waker != nil {
+				// Split sandbox ID "namespace--name" into namespace and name
+				parts := strings.SplitN(sandboxID, "--", 2)
+				if len(parts) == 2 {
+					waitTimeout := time.Duration(f.config.GetWakeTimeoutSeconds()) * time.Second
+					ctx, cancel := context.WithTimeout(context.Background(), waitTimeout)
+					err := waker.Wake(ctx, parts[0], parts[1], waitTimeout)
+					cancel()
+					if err != nil {
+						logger.Warn("Sandbox wake failed",
+							zap.String("sandboxID", sandboxID),
+							zap.Error(err))
+						f.callbacks.DecoderFilterCallbacks().SendLocalReply(
+							503,
+							"sandbox wake failed: "+err.Error(),
+							nil,
+							-1,
+							"sandbox_wake_failed",
+						)
+						return api.LocalReply
+					}
+					// Wake succeeded — sandbox is now Running.
+					// The Waker has already updated the local registry via syncRoute.
+					route, ok = registry.GetRegistry().Get(sandboxID)
+					if !ok || route.State != agentsv1alpha1.SandboxStateRunning {
+						logger.Warn("Sandbox not running after wake",
+							zap.String("sandboxID", sandboxID))
+						f.callbacks.DecoderFilterCallbacks().SendLocalReply(
+							502,
+							"healthy sandbox not found: "+sandboxID,
+							nil,
+							-1,
+							"sandbox_not_running",
+						)
+						return api.LocalReply
+					}
+					logger.Info("Sandbox woken successfully", zap.String("sandboxID", sandboxID))
+					// Fall through to normal forwarding (auth + upstream override)
+				} else {
+					logger.Warn("Invalid sandbox ID format for wake",
+						zap.String("sandboxID", sandboxID))
+				}
+			}
+		}
+		// Not running and not wakeable -> 502 (existing behavior)
+		if route.State != agentsv1alpha1.SandboxStateRunning {
+			logger.Warn("Sandbox is not running", zap.String("sandboxID", sandboxID), zap.String("state", route.State))
+			f.callbacks.DecoderFilterCallbacks().SendLocalReply(
+				502,
+				"healthy sandbox not found: "+sandboxID,
+				nil,
+				-1,
+				"sandbox_not_running",
+			)
+			return api.LocalReply
+		}
 	}
 
 	// Authenticate the request if auth is enabled and the sandbox has an access token configured.

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -104,12 +104,20 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 	}
 
 	if route.State != agentsv1alpha1.SandboxStateRunning {
-		// Check if wake-on-traffic is enabled for this sandbox
-		if f.config.EnableWakeOnTraffic && route.WakeOnTraffic && route.State == agentsv1alpha1.SandboxStatePaused {
-			waker := wake.GetWaker()
+		// Check if wake-on-traffic should be attempted for this sandbox.
+		// route.WakeOnTraffic is the primary check (fast, from registry).
+		// HasWakeAnnotation is a fallback that reads the informer cache
+		// directly, covering the window between kubectl annotate and the
+		// gateway controller reconciling the change into the route registry.
+		waker := wake.GetWaker()
+		parts := strings.SplitN(sandboxID, "--", 2)
+		shouldWake := route.WakeOnTraffic
+		if !shouldWake && f.config.EnableWakeOnTraffic && waker != nil &&
+			len(parts) == 2 && route.State == agentsv1alpha1.SandboxStatePaused {
+			shouldWake = waker.HasWakeAnnotation(context.Background(), parts[0], parts[1])
+		}
+		if f.config.EnableWakeOnTraffic && shouldWake && route.State == agentsv1alpha1.SandboxStatePaused {
 			if waker != nil {
-				// Split sandbox ID "namespace--name" into namespace and name
-				parts := strings.SplitN(sandboxID, "--", 2)
 				if len(parts) == 2 {
 					waitTimeout := time.Duration(f.config.GetWakeTimeoutSeconds()) * time.Second
 					ctx, cancel := context.WithTimeout(context.Background(), waitTimeout)

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -21,10 +21,13 @@ import (
 
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/cache/cachetest"
 	"github.com/openkruise/agents/pkg/proxy"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/wake"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 )
 
@@ -1249,4 +1252,107 @@ func TestDecodeHeadersAuthDisabled(t *testing.T) {
 	metadata := mockCallbacks.streamInfo.dynamicMetadata.data["envoy.lb.original_dst"]
 	assert.NotNil(t, metadata)
 	assert.Equal(t, "10.0.0.5:49983", metadata["host"])
+}
+
+// TestDecodeHeadersWakeOnTrafficCacheFallback verifies that when
+// route.WakeOnTraffic is false (registry not yet synced) but the informer
+// cache has the wake-on-traffic annotation, the filter still attempts wake.
+// The wake fails because the sandbox is not actually resumable in this test
+// setup, so we get 503 (wake failed) instead of 502 (not wakeable).
+func TestDecodeHeadersWakeOnTrafficCacheFallback(t *testing.T) {
+	r := registry.GetRegistry()
+	defer r.Clear()
+	// Registry has WakeOnTraffic=false (simulating sync delay)
+	r.Update("default--cache-fallback", proxy.Route{
+		IP:              "10.0.0.1",
+		State:           agentsv1alpha1.SandboxStatePaused,
+		WakeOnTraffic:   false,
+		ResourceVersion: "1",
+	})
+
+	// Create sandbox with wake annotation in the informer cache
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cache-fallback",
+			Namespace: "default",
+			Annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: agentsv1alpha1.True,
+			},
+		},
+	}
+	cacheProvider, _, err := cachetest.NewTestCache(t, sbx)
+	if err != nil {
+		t.Fatalf("failed to create test cache: %v", err)
+	}
+
+	// Initialize the package-level waker with the test cache
+	wake.InitWaker(cacheProvider)
+	t.Cleanup(func() {
+		wake.InitWaker(nil)
+	})
+
+	cfg := DefaultConfig()
+	cfg.EnableWakeOnTraffic = true
+	cfg.WakeTimeoutSeconds = 5
+	mockCallbacks := newMockFilterCallbackHandler()
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: cfg, adapter: defaultTestAdapter()}
+
+	header := newMockRequestHeaderMap()
+	header.Set(DefaultSandboxHeaderName, "default--cache-fallback")
+
+	status := filter.DecodeHeaders(header, true)
+
+	// The filter should attempt wake via the cache fallback.
+	// Wake fails (sandbox not resumable in test) -> 503 wake_failed.
+	// Without the fallback, the filter would return 502 (not_running).
+	assert.Equal(t, api.LocalReply, status)
+	assert.Equal(t, 503, mockCallbacks.decoderCallbacks.replyStatusCode)
+	assert.Equal(t, "sandbox_wake_failed", mockCallbacks.decoderCallbacks.replyDetails)
+}
+
+// TestDecodeHeadersWakeOnTrafficCacheFallbackNoAnnotation verifies that when
+// both route.WakeOnTraffic is false and the informer cache does NOT have the
+// annotation, the filter does NOT attempt wake and returns 502.
+func TestDecodeHeadersWakeOnTrafficCacheFallbackNoAnnotation(t *testing.T) {
+	r := registry.GetRegistry()
+	defer r.Clear()
+	r.Update("default--no-annot-fallback", proxy.Route{
+		IP:              "10.0.0.1",
+		State:           agentsv1alpha1.SandboxStatePaused,
+		WakeOnTraffic:   false,
+		ResourceVersion: "1",
+	})
+
+	// Create sandbox WITHOUT wake annotation in the informer cache
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-annot-fallback",
+			Namespace: "default",
+		},
+	}
+	cacheProvider, _, err := cachetest.NewTestCache(t, sbx)
+	if err != nil {
+		t.Fatalf("failed to create test cache: %v", err)
+	}
+
+	wake.InitWaker(cacheProvider)
+	t.Cleanup(func() {
+		wake.InitWaker(nil)
+	})
+
+	cfg := DefaultConfig()
+	cfg.EnableWakeOnTraffic = true
+	cfg.WakeTimeoutSeconds = 5
+	mockCallbacks := newMockFilterCallbackHandler()
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: cfg, adapter: defaultTestAdapter()}
+
+	header := newMockRequestHeaderMap()
+	header.Set(DefaultSandboxHeaderName, "default--no-annot-fallback")
+
+	status := filter.DecodeHeaders(header, true)
+
+	// No annotation in cache -> no wake attempt -> 502 not_running
+	assert.Equal(t, api.LocalReply, status)
+	assert.Equal(t, 502, mockCallbacks.decoderCallbacks.replyStatusCode)
+	assert.Equal(t, "sandbox_not_running", mockCallbacks.decoderCallbacks.replyDetails)
 }

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -1072,6 +1072,154 @@ func TestDecodeHeadersAccessTokenAuthKruiseProtocol(t *testing.T) {
 	assert.Equal(t, 401, mockCallbacks2.decoderCallbacks.replyStatusCode)
 }
 
+// TestDecodeHeadersWakeOnTrafficDisabled verifies that when EnableWakeOnTraffic
+// is false, a paused sandbox with WakeOnTraffic=true is NOT woken and returns 502.
+func TestDecodeHeadersWakeOnTrafficDisabled(t *testing.T) {
+	r := registry.GetRegistry()
+	defer r.Clear()
+	r.Update("default--paused-sbx", proxy.Route{
+		IP:              "10.0.0.1",
+		State:           agentsv1alpha1.SandboxStatePaused,
+		WakeOnTraffic:   true,
+		ResourceVersion: "1",
+	})
+
+	cfg := DefaultConfig()
+	// EnableWakeOnTraffic is false by default
+	mockCallbacks := newMockFilterCallbackHandler()
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: cfg, adapter: defaultTestAdapter()}
+
+	header := newMockRequestHeaderMap()
+	header.Set(DefaultSandboxHeaderName, "default--paused-sbx")
+
+	status := filter.DecodeHeaders(header, true)
+
+	assert.Equal(t, api.LocalReply, status)
+	assert.True(t, mockCallbacks.decoderCallbacks.sendLocalReplyCalled)
+	assert.Equal(t, 502, mockCallbacks.decoderCallbacks.replyStatusCode)
+	assert.Equal(t, "sandbox_not_running", mockCallbacks.decoderCallbacks.replyDetails)
+}
+
+// TestDecodeHeadersWakeOnTrafficRouteNotEnabled verifies that when the route's
+// WakeOnTraffic flag is false, a paused sandbox is NOT woken even if the filter
+// has EnableWakeOnTraffic=true.
+func TestDecodeHeadersWakeOnTrafficRouteNotEnabled(t *testing.T) {
+	r := registry.GetRegistry()
+	defer r.Clear()
+	r.Update("default--paused-sbx", proxy.Route{
+		IP:              "10.0.0.1",
+		State:           agentsv1alpha1.SandboxStatePaused,
+		WakeOnTraffic:   false,
+		ResourceVersion: "1",
+	})
+
+	cfg := DefaultConfig()
+	cfg.EnableWakeOnTraffic = true
+	mockCallbacks := newMockFilterCallbackHandler()
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: cfg, adapter: defaultTestAdapter()}
+
+	header := newMockRequestHeaderMap()
+	header.Set(DefaultSandboxHeaderName, "default--paused-sbx")
+
+	status := filter.DecodeHeaders(header, true)
+
+	assert.Equal(t, api.LocalReply, status)
+	assert.Equal(t, 502, mockCallbacks.decoderCallbacks.replyStatusCode)
+	assert.Equal(t, "sandbox_not_running", mockCallbacks.decoderCallbacks.replyDetails)
+}
+
+// TestDecodeHeadersWakeOnTrafficNoWaker verifies that when EnableWakeOnTraffic
+// is true and the route has WakeOnTraffic=true but the waker is nil (not
+// initialized), the filter falls through to the 502 "not running" path.
+func TestDecodeHeadersWakeOnTrafficNoWaker(t *testing.T) {
+	r := registry.GetRegistry()
+	defer r.Clear()
+	r.Update("default--paused-sbx", proxy.Route{
+		IP:              "10.0.0.1",
+		State:           agentsv1alpha1.SandboxStatePaused,
+		WakeOnTraffic:   true,
+		ResourceVersion: "1",
+	})
+
+	cfg := DefaultConfig()
+	cfg.EnableWakeOnTraffic = true
+	cfg.WakeTimeoutSeconds = 30
+	mockCallbacks := newMockFilterCallbackHandler()
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: cfg, adapter: defaultTestAdapter()}
+
+	header := newMockRequestHeaderMap()
+	header.Set(DefaultSandboxHeaderName, "default--paused-sbx")
+
+	// Waker is nil (default state when InitWaker hasn't been called)
+	status := filter.DecodeHeaders(header, true)
+
+	assert.Equal(t, api.LocalReply, status)
+	assert.Equal(t, 502, mockCallbacks.decoderCallbacks.replyStatusCode)
+	assert.Equal(t, "sandbox_not_running", mockCallbacks.decoderCallbacks.replyDetails)
+}
+
+// TestDecodeHeadersWakeOnTrafficInvalidSandboxID verifies that when wake-on-traffic
+// is triggered but the sandbox ID cannot be split into namespace--name (no "--"
+// separator), the filter falls through to the 502 "not running" path.
+func TestDecodeHeadersWakeOnTrafficInvalidSandboxID(t *testing.T) {
+	r := registry.GetRegistry()
+	defer r.Clear()
+	// Sandbox ID without "--" separator — unusual but tests the SplitN branch
+	r.Update("invalid-id-no-separator", proxy.Route{
+		IP:              "10.0.0.1",
+		State:           agentsv1alpha1.SandboxStatePaused,
+		WakeOnTraffic:   true,
+		ResourceVersion: "1",
+	})
+
+	cfg := DefaultConfig()
+	cfg.EnableWakeOnTraffic = true
+	cfg.WakeTimeoutSeconds = 30
+	mockCallbacks := newMockFilterCallbackHandler()
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: cfg, adapter: defaultTestAdapter()}
+
+	header := newMockRequestHeaderMap()
+	header.Set(DefaultSandboxHeaderName, "invalid-id-no-separator")
+
+	status := filter.DecodeHeaders(header, true)
+
+	// Falls through because SplitN returns only 1 part (no "--"), waker nil, or both
+	assert.Equal(t, api.LocalReply, status)
+	assert.Equal(t, 502, mockCallbacks.decoderCallbacks.replyStatusCode)
+	assert.Equal(t, "sandbox_not_running", mockCallbacks.decoderCallbacks.replyDetails)
+}
+
+// TestDecodeHeadersWakeOnTrafficPausedWithRunning verifies that a running sandbox
+// with WakeOnTraffic=true passes through without attempting wake.
+func TestDecodeHeadersWakeOnTrafficPausedWithRunning(t *testing.T) {
+	r := registry.GetRegistry()
+	defer r.Clear()
+	r.Update("default--running-wakeable", proxy.Route{
+		IP:              "10.0.0.5",
+		State:           agentsv1alpha1.SandboxStateRunning,
+		WakeOnTraffic:   true,
+		ResourceVersion: "1",
+	})
+
+	cfg := DefaultConfig()
+	cfg.EnableWakeOnTraffic = true
+	mockCallbacks := newMockFilterCallbackHandler()
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: cfg, adapter: defaultTestAdapter()}
+
+	header := newMockRequestHeaderMap()
+	header.Set(DefaultSandboxHeaderName, "default--running-wakeable")
+
+	status := filter.DecodeHeaders(header, true)
+
+	// Already running → no wake attempt, continue
+	assert.Equal(t, api.Continue, status)
+	assert.False(t, mockCallbacks.decoderCallbacks.sendLocalReplyCalled)
+
+	metadata := mockCallbacks.streamInfo.dynamicMetadata.data["envoy.lb.original_dst"]
+	assert.NotNil(t, metadata)
+	assert.Equal(t, "10.0.0.5:49983", metadata["host"])
+}
+
 // TestDecodeHeadersAuthDisabled verifies that when EnableAuth is false,
 // token validation is skipped even if the route has a token configured.
 func TestDecodeHeadersAuthDisabled(t *testing.T) {

--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -44,6 +44,17 @@ const (
 	EnvMemberlistBindPort = "MEMBERLIST_BIND_PORT"
 )
 
+// globalPeerManager is set when server.Start() creates the peerManager.
+// It allows other packages (e.g. wake) to access the peer manager for
+// SyncRouteWithPeers without creating a full Server instance.
+var globalPeerManager peers.Peers
+
+// GetPeerManager returns the peer manager for use by the wake package.
+// Returns nil if the server has not been started yet.
+func GetPeerManager() peers.Peers {
+	return globalPeerManager
+}
+
 // getMemberlistBindPort reads the memberlist bind port from environment variable
 // Returns the default port if not set or invalid
 func getMemberlistBindPort() int {
@@ -110,6 +121,7 @@ func (s *Server) Start(ctx context.Context) error {
 	labelSelector := os.Getenv(EnvLabelSelector)
 
 	s.peerManager = peers.NewMemberlistPeers(s.client, peers.NodePrefixSandboxGateway+nodeName, namespace, labelSelector)
+	globalPeerManager = s.peerManager
 
 	if err := s.peerManager.Start(ctx, s.memberlistBindPort); err != nil {
 		return err

--- a/pkg/sandbox-gateway/wake/wake.go
+++ b/pkg/sandbox-gateway/wake/wake.go
@@ -56,6 +56,22 @@ func GetWaker() *Waker {
 	return defaultWaker.Load()
 }
 
+// HasWakeAnnotation checks the informer cache for the wake-on-traffic annotation.
+// This is a fallback for when the gateway controller's route registry hasn't
+// yet synced the annotation change. Returns false if the waker is nil or the
+// sandbox cannot be read from cache.
+func (w *Waker) HasWakeAnnotation(ctx context.Context, namespace, name string) bool {
+	if w == nil {
+		return false
+	}
+	cli := w.cache.GetClient()
+	var sbx agentsv1alpha1.Sandbox
+	if err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &sbx); err != nil {
+		return false
+	}
+	return sbx.GetAnnotations()[agentsv1alpha1.AnnotationWakeOnTraffic] == agentsv1alpha1.True
+}
+
 // Wake resumes a paused sandbox by calling the existing sandbox-manager
 // connect Resume implementation, then syncs the route locally and to peers.
 // It does NOT reimplement spec patching or wait-for-running — it delegates

--- a/pkg/sandbox-gateway/wake/wake.go
+++ b/pkg/sandbox-gateway/wake/wake.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wake
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/cache"
+	"github.com/openkruise/agents/pkg/proxy"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/server"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
+	"github.com/openkruise/agents/pkg/utils/timeout"
+)
+
+// Waker resumes paused sandboxes by reusing the existing sandbox-manager
+// connect Resume implementation (sandboxcr.Sandbox.Resume), then syncs the
+// route locally and to peer gateways.
+type Waker struct {
+	cache cache.Provider
+}
+
+var defaultWaker atomic.Pointer[Waker]
+
+// InitWaker initializes the package-level Waker with the given cache provider.
+// Must be called once during gateway startup before any Wake calls.
+func InitWaker(cacheProvider cache.Provider) {
+	defaultWaker.Store(&Waker{cache: cacheProvider})
+}
+
+// GetWaker returns the package-level Waker. Returns nil if InitWaker has not
+// been called yet.
+func GetWaker() *Waker {
+	return defaultWaker.Load()
+}
+
+// Wake resumes a paused sandbox by calling the existing sandbox-manager
+// connect Resume implementation, then syncs the route locally and to peers.
+// It does NOT reimplement spec patching or wait-for-running — it delegates
+// entirely to sandboxcr.Sandbox.Resume().
+//
+// Resume internally handles:
+//   - refreshFromAPIReader (fresh fetch from API server)
+//   - IsSandboxResumable validation
+//   - NewSandboxResumeTask (pre-acquired wait task)
+//   - retryUpdate: patches Spec.Paused=false + setTimeout(PauseTime)
+//   - resumeTask.Wait() — blocks until Ready condition is True
+//   - InplaceRefresh + expectations
+//   - Concurrent dedup: first-writer-wins via retryUpdate optimistic lock
+//
+// After Resume succeeds, syncRoute mirrors the manager's syncRoute flow:
+//   - Get updated route from the refreshed sandbox (sandbox.GetRoute())
+//   - Update local gateway registry (registry.GetRegistry().Update)
+//   - Sync route to peer gateways (proxy.SyncRouteWithPeers)
+func (w *Waker) Wake(ctx context.Context, namespace, name string, defaultWakeTimeout time.Duration) error {
+	log := klog.FromContext(ctx).WithValues("sandbox", klog.KRef(namespace, name))
+
+	cli := w.cache.GetClient()
+
+	// Read sandbox from informer cache (fast) to get annotations.
+	var sbx agentsv1alpha1.Sandbox
+	if err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &sbx); err != nil {
+		return err
+	}
+
+	// Determine wake timeout: prefer annotation, fall back to filter default.
+	wakeTimeout := defaultWakeTimeout
+	if timeoutStr := sbx.Annotations[agentsv1alpha1.AnnotationWakeTimeoutSeconds]; timeoutStr != "" {
+		if secs, err := strconv.Atoi(timeoutStr); err == nil && secs > 0 {
+			wakeTimeout = time.Duration(secs) * time.Second
+		}
+	}
+
+	// Reuse the existing sandbox-manager connect Resume implementation.
+	// AsSandbox wraps the sandbox with the cache provider + storage registry.
+	// Resume refreshes from API reader, so the sandbox object is re-fetched
+	// with the latest state before patching.
+	sandbox := sandboxcr.AsSandbox(&sbx, w.cache)
+
+	var opts infra.ResumeOptions
+	if wakeTimeout > 0 {
+		opts.Timeout = &timeout.Options{
+			PauseTime: time.Now().Add(wakeTimeout),
+		}
+		// Preserve existing ShutdownTime so timed sandboxes retain their
+		// auto-delete deadline after wake. Without this, setTimeout()
+		// inside Resume would nil out ShutdownTime, causing resource leaks.
+		if sbx.Spec.ShutdownTime != nil {
+			opts.Timeout.ShutdownTime = sbx.Spec.ShutdownTime.Time
+		}
+	}
+	log.Info("waking sandbox via traffic", "wakeTimeout", wakeTimeout)
+	if err := sandbox.Resume(ctx, opts); err != nil {
+		return err
+	}
+	log.Info("sandbox resumed successfully")
+
+	// After Resume succeeds, sync route locally and with peers.
+	// This mirrors the manager's syncRoute flow:
+	//   1. Get route from refreshed sandbox
+	//   2. Update local registry
+	//   3. Sync to peer gateways
+	route := sandbox.GetRoute()
+	sandboxID := sandbox.GetSandboxID()
+	registry.GetRegistry().Update(sandboxID, route)
+
+	if pm := server.GetPeerManager(); pm != nil {
+		if err := proxy.SyncRouteWithPeers(pm, route); err != nil {
+			// Log but don't fail the wake — the local registry is updated,
+			// and peers will eventually catch up via their own informers.
+			log.Error(err, "failed to sync route with peers after wake")
+		}
+	}
+
+	return nil
+}

--- a/pkg/sandbox-gateway/wake/wake_test.go
+++ b/pkg/sandbox-gateway/wake/wake_test.go
@@ -57,6 +57,88 @@ func TestInitWakerAndGetWaker(t *testing.T) {
 	defaultWaker = zero
 }
 
+func TestHasWakeAnnotation(t *testing.T) {
+	tests := []struct {
+		name        string
+		sandboxName string
+		sandboxNS   string
+		annotations map[string]string
+		createSbx   bool
+		wakerNil    bool
+		want        bool
+	}{
+		{
+			name:        "annotation present true",
+			sandboxName: "sbx-wake",
+			sandboxNS:   "default",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: agentsv1alpha1.True,
+			},
+			createSbx: true,
+			want:      true,
+		},
+		{
+			name:        "annotation present false",
+			sandboxName: "sbx-no-wake",
+			sandboxNS:   "default",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "false",
+			},
+			createSbx: true,
+			want:      false,
+		},
+		{
+			name:        "annotation absent",
+			sandboxName: "sbx-no-annot",
+			sandboxNS:   "default",
+			annotations: nil,
+			createSbx:   true,
+			want:        false,
+		},
+		{
+			name:        "sandbox not found",
+			sandboxName: "sbx-missing",
+			sandboxNS:   "default",
+			createSbx:   false,
+			want:        false,
+		},
+		{
+			name:     "nil waker returns false",
+			wakerNil: true,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wakerNil {
+				var nilWaker *Waker
+				assert.False(t, nilWaker.HasWakeAnnotation(context.Background(), "default", "sbx"))
+				return
+			}
+
+			var initObjs []ctrl.Object
+			if tt.createSbx {
+				sbx := &agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        tt.sandboxName,
+						Namespace:   tt.sandboxNS,
+						Annotations: tt.annotations,
+					},
+				}
+				initObjs = append(initObjs, sbx)
+			}
+
+			cacheProvider, _, err := cachetest.NewTestCache(t, initObjs...)
+			require.NoError(t, err)
+
+			waker := &Waker{cache: cacheProvider}
+			got := waker.HasWakeAnnotation(context.Background(), tt.sandboxNS, tt.sandboxName)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // newPausedSandbox creates a Sandbox CR in Paused state with Paused condition True.
 func newPausedSandbox(name, namespace string, annotations map[string]string, shutdownTime *metav1.Time) *agentsv1alpha1.Sandbox {
 	sbx := &agentsv1alpha1.Sandbox{
@@ -163,10 +245,10 @@ func TestWake(t *testing.T) {
 			expectError:    "",
 		},
 		{
-			name:        "zero default timeout still resumes",
-			sandboxName: "sbx-zero-timeout",
-			sandboxNS:   "default",
-			annotations: map[string]string{},
+			name:           "zero default timeout still resumes",
+			sandboxName:    "sbx-zero-timeout",
+			sandboxNS:      "default",
+			annotations:    map[string]string{},
 			shutdownTime:   &metav1.Time{Time: shutdownTime},
 			pauseTime:      &metav1.Time{Time: pauseTime},
 			defaultTimeout: 0,

--- a/pkg/sandbox-gateway/wake/wake_test.go
+++ b/pkg/sandbox-gateway/wake/wake_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wake
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+func TestInitWakerAndGetWaker(t *testing.T) {
+	// Reset before test
+	var zero atomic.Pointer[Waker]
+	defaultWaker = zero
+
+	// Before init, GetWaker returns nil
+	if w := GetWaker(); w != nil {
+		t.Error("GetWaker() should return nil before InitWaker is called")
+	}
+
+	// After init with nil cache, GetWaker returns non-nil (but Wake would fail)
+	InitWaker(nil)
+	w := GetWaker()
+	if w == nil {
+		t.Error("GetWaker() should return non-nil after InitWaker is called")
+	}
+
+	// The waker's cache field should be nil
+	if w.cache != nil {
+		t.Error("Waker.cache should be nil when initialized with nil cache")
+	}
+
+	// Reset for other tests
+	defaultWaker = zero
+}

--- a/pkg/sandbox-gateway/wake/wake_test.go
+++ b/pkg/sandbox-gateway/wake/wake_test.go
@@ -17,8 +17,18 @@ limitations under the License.
 package wake
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/cache/cachetest"
 )
 
 func TestInitWakerAndGetWaker(t *testing.T) {
@@ -45,4 +55,208 @@ func TestInitWakerAndGetWaker(t *testing.T) {
 
 	// Reset for other tests
 	defaultWaker = zero
+}
+
+// newPausedSandbox creates a Sandbox CR in Paused state with Paused condition True.
+func newPausedSandbox(name, namespace string, annotations map[string]string, shutdownTime *metav1.Time) *agentsv1alpha1.Sandbox {
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+			Labels: map[string]string{
+				agentsv1alpha1.LabelSandboxIsClaimed: "true",
+			},
+		},
+		Spec: agentsv1alpha1.SandboxSpec{
+			Paused:       true,
+			ShutdownTime: shutdownTime,
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxPaused,
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(agentsv1alpha1.SandboxConditionPaused),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			PodInfo: agentsv1alpha1.PodInfo{
+				PodIP: "10.0.0.1",
+			},
+		},
+	}
+	return sbx
+}
+
+func TestWake(t *testing.T) {
+	shutdownTime := time.Now().Add(2 * time.Hour)
+	pauseTime := time.Now().Add(1 * time.Hour)
+
+	tests := []struct {
+		name           string
+		sandboxName    string
+		sandboxNS      string
+		annotations    map[string]string
+		shutdownTime   *metav1.Time
+		pauseTime      *metav1.Time
+		defaultTimeout time.Duration
+		skipCreate     bool
+		simulateResume bool
+		expectError    string
+	}{
+		{
+			name:           "sandbox not found returns error",
+			sandboxName:    "nonexistent",
+			sandboxNS:      "default",
+			defaultTimeout: 60 * time.Second,
+			skipCreate:     true,
+			expectError:    "not found",
+		},
+		{
+			name:           "successful wake with default timeout",
+			sandboxName:    "sbx-default",
+			sandboxNS:      "default",
+			annotations:    map[string]string{},
+			shutdownTime:   &metav1.Time{Time: shutdownTime},
+			pauseTime:      &metav1.Time{Time: pauseTime},
+			defaultTimeout: 60 * time.Second,
+			simulateResume: true,
+			expectError:    "",
+		},
+		{
+			name:        "wake with annotation timeout",
+			sandboxName: "sbx-annot",
+			sandboxNS:   "default",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "120",
+			},
+			shutdownTime:   &metav1.Time{Time: shutdownTime},
+			pauseTime:      &metav1.Time{Time: pauseTime},
+			defaultTimeout: 60 * time.Second,
+			simulateResume: true,
+			expectError:    "",
+		},
+		{
+			name:        "invalid annotation falls back to default",
+			sandboxName: "sbx-invalid",
+			sandboxNS:   "default",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "abc",
+			},
+			shutdownTime:   &metav1.Time{Time: shutdownTime},
+			pauseTime:      &metav1.Time{Time: pauseTime},
+			defaultTimeout: 60 * time.Second,
+			simulateResume: true,
+			expectError:    "",
+		},
+		{
+			name:        "negative annotation falls back to default",
+			sandboxName: "sbx-negative",
+			sandboxNS:   "default",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "-5",
+			},
+			shutdownTime:   &metav1.Time{Time: shutdownTime},
+			pauseTime:      &metav1.Time{Time: pauseTime},
+			defaultTimeout: 60 * time.Second,
+			simulateResume: true,
+			expectError:    "",
+		},
+		{
+			name:        "zero default timeout still resumes",
+			sandboxName: "sbx-zero-timeout",
+			sandboxNS:   "default",
+			annotations: map[string]string{},
+			shutdownTime:   &metav1.Time{Time: shutdownTime},
+			pauseTime:      &metav1.Time{Time: pauseTime},
+			defaultTimeout: 0,
+			simulateResume: true,
+			expectError:    "",
+		},
+		{
+			name:           "wake preserves nil ShutdownTime",
+			sandboxName:    "sbx-nil-shutdown",
+			sandboxNS:      "default",
+			annotations:    map[string]string{},
+			shutdownTime:   nil,
+			pauseTime:      nil,
+			defaultTimeout: 30 * time.Second,
+			simulateResume: true,
+			expectError:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.skipCreate {
+				// Test with no sandbox in the cluster
+				cacheProvider, _, err := cachetest.NewTestCache(t)
+				require.NoError(t, err)
+				require.NoError(t, cacheProvider.Run(t.Context()))
+				t.Cleanup(func() { cacheProvider.Stop(t.Context()) })
+
+				waker := &Waker{cache: cacheProvider}
+				ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+				defer cancel()
+				err = waker.Wake(ctx, tt.sandboxNS, tt.sandboxName, tt.defaultTimeout)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+
+			sbx := newPausedSandbox(tt.sandboxName, tt.sandboxNS, tt.annotations, tt.shutdownTime)
+			if tt.pauseTime != nil {
+				sbx.Spec.PauseTime = tt.pauseTime
+			}
+
+			cacheProvider, fc, err := cachetest.NewTestCache(t)
+			require.NoError(t, err)
+			require.NoError(t, cacheProvider.Run(t.Context()))
+			t.Cleanup(func() { cacheProvider.Stop(t.Context()) })
+
+			// Create sandbox with status
+			require.NoError(t, fc.Create(t.Context(), sbx))
+			require.NoError(t, fc.Status().Update(t.Context(), sbx))
+			time.Sleep(10 * time.Millisecond)
+
+			waker := &Waker{cache: cacheProvider}
+
+			if tt.simulateResume {
+				mockMgr := cacheProvider.GetMockManager()
+				mockMgr.AddWaitReconcileKey(sbx)
+
+				modified := sbx.DeepCopy()
+				mergeFrom := ctrl.MergeFrom(sbx)
+				time.AfterFunc(20*time.Millisecond, func() {
+					modified.Status.Phase = agentsv1alpha1.SandboxRunning
+					modified.Status.Conditions = []metav1.Condition{
+						{Type: string(agentsv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Resume"},
+					}
+					_ = fc.Status().Patch(t.Context(), modified, mergeFrom)
+				})
+			}
+
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+
+			err = waker.Wake(ctx, tt.sandboxNS, tt.sandboxName, tt.defaultTimeout)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+			require.NoError(t, err)
+
+			// Verify the sandbox was unpaused
+			var updated agentsv1alpha1.Sandbox
+			require.NoError(t, fc.Get(t.Context(), ctrl.ObjectKey{Namespace: tt.sandboxNS, Name: tt.sandboxName}, &updated))
+			assert.False(t, updated.Spec.Paused, "sandbox should be unpaused after wake")
+
+			// Verify ShutdownTime is preserved
+			if tt.shutdownTime != nil {
+				require.NotNil(t, updated.Spec.ShutdownTime, "ShutdownTime should be preserved")
+				assert.WithinDuration(t, tt.shutdownTime.Time, updated.Spec.ShutdownTime.Time, time.Second)
+			}
+		})
+	}
 }

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -296,7 +296,7 @@ func (sc *Controller) parseCreateSandboxRequest(r *http.Request) (models.NewSand
 
 	// autoResume requires autoPause: wake-on-traffic only makes sense for
 	// sandboxes that auto-pause on timeout.
-	if request.AutoResume && !request.AutoPause {
+	if request.AutoResume.Enabled && !request.AutoPause {
 		return request, &web.ApiError{
 			Code:    http.StatusBadRequest,
 			Message: "autoResume requires autoPause to be true",
@@ -304,7 +304,7 @@ func (sc *Controller) parseCreateSandboxRequest(r *http.Request) (models.NewSand
 	}
 
 	// Propagate AutoResume to extensions for downstream consumers.
-	request.Extensions.AutoResume = request.AutoResume
+	request.Extensions.AutoResume = request.AutoResume.Enabled
 
 	return request, nil
 }
@@ -351,7 +351,7 @@ func (sc *Controller) basicSandboxCreateModifier(ctx context.Context, sbx infra.
 	// Set wake-on-traffic annotations when autoResume is enabled.
 	// The gateway reads these to decide whether to wake a paused sandbox
 	// and how long to re-arm the auto-pause timeout after wake.
-	if request.AutoResume {
+	if request.AutoResume.Enabled {
 		annotations[agentsv1alpha1.AnnotationWakeOnTraffic] = agentsv1alpha1.True
 		annotations[agentsv1alpha1.AnnotationWakeTimeoutSeconds] = strconv.Itoa(request.Timeout)
 	}

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -293,6 +294,18 @@ func (sc *Controller) parseCreateSandboxRequest(r *http.Request) (models.NewSand
 		}
 	}
 
+	// autoResume requires autoPause: wake-on-traffic only makes sense for
+	// sandboxes that auto-pause on timeout.
+	if request.AutoResume && !request.AutoPause {
+		return request, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: "autoResume requires autoPause to be true",
+		}
+	}
+
+	// Propagate AutoResume to extensions for downstream consumers.
+	request.Extensions.AutoResume = request.AutoResume
+
 	return request, nil
 }
 
@@ -334,6 +347,13 @@ func (sc *Controller) basicSandboxCreateModifier(ctx context.Context, sbx infra.
 	}
 	if request.Extensions.ReturnPodIP {
 		annotations[models.ExtensionKeyReturnPodIP] = agentsv1alpha1.True
+	}
+	// Set wake-on-traffic annotations when autoResume is enabled.
+	// The gateway reads these to decide whether to wake a paused sandbox
+	// and how long to re-arm the auto-pause timeout after wake.
+	if request.AutoResume {
+		annotations[agentsv1alpha1.AnnotationWakeOnTraffic] = agentsv1alpha1.True
+		annotations[agentsv1alpha1.AnnotationWakeTimeoutSeconds] = strconv.Itoa(request.Timeout)
 	}
 	sbx.SetAnnotations(annotations)
 

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -640,6 +640,189 @@ func TestParseCreateSandboxRequest(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, apiErr.Code)
 		assert.Contains(t, apiErr.Message, "timeout should between")
 	})
+
+	t.Run("autoResume with autoPause succeeds", func(t *testing.T) {
+		raw, err := json.Marshal(models.NewSandboxRequest{
+			TemplateID: "t1",
+			Timeout:    300,
+			AutoPause:  true,
+			AutoResume: models.AutoResumeConfig{Enabled: true},
+		})
+		require.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/sandboxes", bytes.NewReader(raw))
+
+		got, apiErr := ctrl.parseCreateSandboxRequest(req)
+		require.Nil(t, apiErr)
+		assert.True(t, got.AutoResume.Enabled)
+		assert.True(t, got.Extensions.AutoResume, "Extensions.AutoResume should be propagated")
+	})
+
+	t.Run("autoResume without autoPause returns 400", func(t *testing.T) {
+		raw, err := json.Marshal(models.NewSandboxRequest{
+			TemplateID: "t1",
+			Timeout:    300,
+			AutoResume: models.AutoResumeConfig{Enabled: true},
+		})
+		require.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/sandboxes", bytes.NewReader(raw))
+
+		_, apiErr := ctrl.parseCreateSandboxRequest(req)
+		require.NotNil(t, apiErr)
+		assert.Equal(t, http.StatusBadRequest, apiErr.Code)
+		assert.Contains(t, apiErr.Message, "autoResume requires autoPause")
+	})
+
+	t.Run("autoResume false is always valid", func(t *testing.T) {
+		raw, err := json.Marshal(models.NewSandboxRequest{
+			TemplateID: "t1",
+			Timeout:    300,
+			AutoResume: models.AutoResumeConfig{Enabled: false},
+		})
+		require.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/sandboxes", bytes.NewReader(raw))
+
+		_, apiErr := ctrl.parseCreateSandboxRequest(req)
+		require.Nil(t, apiErr)
+	})
+
+	t.Run("autoResume SDK object format decodes correctly", func(t *testing.T) {
+		// The E2B SDK sends autoResume as {"enabled": true}, not a plain bool.
+		body := `{"templateID":"t1","timeout":300,"autoPause":true,"autoResume":{"enabled":true}}`
+		req := httptest.NewRequest(http.MethodPost, "/sandboxes", strings.NewReader(body))
+
+		got, apiErr := ctrl.parseCreateSandboxRequest(req)
+		require.Nil(t, apiErr)
+		assert.True(t, got.AutoResume.Enabled)
+		assert.True(t, got.Extensions.AutoResume)
+	})
+}
+
+func TestBasicSandboxCreateModifier(t *testing.T) {
+	tests := []struct {
+		name                string
+		request             models.NewSandboxRequest
+		initialAnnotations  map[string]string
+		initialLabels       map[string]string
+		maxTimeout          int
+		expectAnnotations   map[string]string
+		expectNoAnnotations []string
+		expectLabels        map[string]string
+	}{
+		{
+			name: "autoResume sets wake annotations",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    300,
+				AutoPause:  true,
+				AutoResume: models.AutoResumeConfig{Enabled: true},
+			},
+			maxTimeout: 3600,
+			expectAnnotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic:      agentsv1alpha1.True,
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "300",
+			},
+		},
+		{
+			name: "autoResume false does not set wake annotations",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    300,
+				AutoPause:  true,
+				AutoResume: models.AutoResumeConfig{Enabled: false},
+			},
+			maxTimeout: 3600,
+			expectNoAnnotations: []string{
+				agentsv1alpha1.AnnotationWakeOnTraffic,
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds,
+			},
+		},
+		{
+			name: "metadata propagated to annotations",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    300,
+				Metadata:   map[string]string{"user-key": "user-val"},
+			},
+			maxTimeout:        3600,
+			expectAnnotations: map[string]string{"user-key": "user-val"},
+		},
+		{
+			name: "returnPodIP extension sets annotation",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    300,
+				Extensions: models.NewSandboxRequestExtension{ReturnPodIP: true},
+			},
+			maxTimeout: 3600,
+			expectAnnotations: map[string]string{
+				models.ExtensionKeyReturnPodIP: agentsv1alpha1.True,
+			},
+		},
+		{
+			name: "labels propagated from extensions",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    300,
+				Extensions: models.NewSandboxRequestExtension{
+					Labels: map[string]string{"env": "test"},
+				},
+			},
+			maxTimeout:     3600,
+			expectLabels:   map[string]string{"env": "test"},
+		},
+		{
+			name: "wake annotations coexist with metadata",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    600,
+				AutoPause:  true,
+				AutoResume: models.AutoResumeConfig{Enabled: true},
+				Metadata:   map[string]string{"app": "myapp"},
+			},
+			maxTimeout: 3600,
+			expectAnnotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic:      agentsv1alpha1.True,
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "600",
+				"app": "myapp",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSbx := &sandboxcr.Sandbox{
+				Sandbox: &agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-sandbox",
+						Namespace:   "default",
+						Annotations: tt.initialAnnotations,
+						Labels:      tt.initialLabels,
+					},
+				},
+			}
+
+			c := &Controller{maxTimeout: tt.maxTimeout}
+			c.basicSandboxCreateModifier(context.Background(), mockSbx, tt.request)
+
+			annotations := mockSbx.GetAnnotations()
+			for k, v := range tt.expectAnnotations {
+				got, ok := annotations[k]
+				assert.True(t, ok, "expected annotation %q to exist", k)
+				assert.Equal(t, v, got, "annotation %q value mismatch", k)
+			}
+			for _, k := range tt.expectNoAnnotations {
+				_, ok := annotations[k]
+				assert.False(t, ok, "expected annotation %q to NOT exist", k)
+			}
+
+			labels := mockSbx.GetLabels()
+			for k, v := range tt.expectLabels {
+				got, ok := labels[k]
+				assert.True(t, ok, "expected label %q to exist", k)
+				assert.Equal(t, v, got, "label %q value mismatch", k)
+			}
+		})
+	}
 }
 
 func TestMapInfraErrorToApiError(t *testing.T) {

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -53,6 +53,7 @@ type NewSandboxRequest struct {
 	TemplateID string            `json:"templateID"`
 	Timeout    int               `json:"timeout,omitempty"`
 	AutoPause  bool              `json:"autoPause,omitempty"`
+	AutoResume bool              `json:"autoResume,omitempty"`
 	Metadata   map[string]string `json:"metadata,omitempty"`
 	EnvVars    EnvVars           `json:"envVars,omitempty"`
 
@@ -72,6 +73,7 @@ type NewSandboxRequestExtension struct {
 	Labels                  map[string]string
 	Name                    string
 	GenerateName            string
+	AutoResume              bool
 }
 
 type InplaceUpdateExtension struct {
@@ -95,7 +97,8 @@ type SandboxMetadata map[string]string
 type EnvVars map[string]string
 
 type SetTimeoutRequest struct {
-	TimeoutSeconds int `json:"timeout"`
+	TimeoutSeconds int  `json:"timeout"`
+	AutoResume     bool `json:"autoResume,omitempty"`
 }
 
 type NewSnapshotRequest struct {

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -48,12 +48,18 @@ type Sandbox struct {
 	State           string            `json:"state"`
 }
 
+// AutoResumeConfig is the auto-resume configuration for paused sandboxes.
+// The E2B SDK sends this as a JSON object: {"enabled": true}.
+type AutoResumeConfig struct {
+	Enabled bool `json:"enabled"`
+}
+
 // NewSandboxRequest represents a request to create a new sandbox
 type NewSandboxRequest struct {
 	TemplateID string            `json:"templateID"`
 	Timeout    int               `json:"timeout,omitempty"`
 	AutoPause  bool              `json:"autoPause,omitempty"`
-	AutoResume bool              `json:"autoResume,omitempty"`
+	AutoResume AutoResumeConfig  `json:"autoResume,omitempty"`
 	Metadata   map[string]string `json:"metadata,omitempty"`
 	EnvVars    EnvVars           `json:"envVars,omitempty"`
 

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -18,13 +18,18 @@ package e2b
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openkruise/agents/api/v1alpha1"
 	cacheutils "github.com/openkruise/agents/pkg/cache/utils"
@@ -144,6 +149,13 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 	if apiErr := sc.updateConnectTimeout(ctx, sbx, effectiveTimeout, state, autoPause, currentEndAt); apiErr != nil {
 		return web.ApiResponse[struct{}]{}, apiErr
 	}
+
+	// Update wake-on-traffic annotations if autoResume is requested or if
+	// timeout changes while wake-on-traffic is already enabled.
+	if err := sc.updateWakeAnnotations(ctx, sbx, request.AutoResume, request.TimeoutSeconds); err != nil {
+		log.Error(err, "failed to update wake-on-traffic annotations")
+	}
+
 	return web.ApiResponse[struct{}]{
 		Code: http.StatusNoContent,
 	}, nil
@@ -233,6 +245,12 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 	}
 	log.Info("sandbox timeout updated")
 
+	// Update wake-on-traffic annotations if autoResume is requested or if
+	// timeout changes while wake-on-traffic is already enabled.
+	if err := sc.updateWakeAnnotations(ctx, sbx, request.AutoResume, request.TimeoutSeconds); err != nil {
+		log.Error(err, "failed to update wake-on-traffic annotations")
+	}
+
 	return web.ApiResponse[*models.Sandbox]{
 		Code: statusCode,
 		Body: sc.convertToE2BSandbox(sbx, utils.GetAccessToken(sbx)),
@@ -271,4 +289,43 @@ func (sc *Controller) updateConnectTimeout(ctx context.Context, sbx infra.Sandbo
 		log.Info("timeout updated", "requestedTimeoutSeconds", timeoutSeconds)
 	}
 	return nil
+}
+
+// updateWakeAnnotations patches the wake-on-traffic annotations on the sandbox
+// CR. When autoResume is true, it sets AnnotationWakeOnTraffic=true and (if
+// timeoutSeconds > 0) AnnotationWakeTimeoutSeconds. When autoResume is false
+// but timeoutSeconds is provided and wake-on-traffic is already enabled, it
+// only updates AnnotationWakeTimeoutSeconds.
+func (sc *Controller) updateWakeAnnotations(ctx context.Context, sbx infra.Sandbox, autoResume bool, timeoutSeconds int) error {
+	annotations := make(map[string]string)
+	existingAnnotations := sbx.GetAnnotations()
+	wakeEnabled := existingAnnotations[v1alpha1.AnnotationWakeOnTraffic] == v1alpha1.True
+
+	if autoResume {
+		annotations[v1alpha1.AnnotationWakeOnTraffic] = v1alpha1.True
+	}
+	if timeoutSeconds > 0 && (autoResume || wakeEnabled) {
+		annotations[v1alpha1.AnnotationWakeTimeoutSeconds] = strconv.Itoa(timeoutSeconds)
+	}
+
+	if len(annotations) == 0 {
+		return nil
+	}
+
+	patchData, err := json.Marshal(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": annotations,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	patchObj := &v1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: sbx.GetNamespace(),
+			Name:      sbx.GetName(),
+		},
+	}
+	return sc.cache.GetClient().Patch(ctx, patchObj, client.RawPatch(types.MergePatchType, patchData))
 }

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -31,8 +31,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/cache/cachetest"
 	cacheutils "github.com/openkruise/agents/pkg/cache/utils"
 	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1125,6 +1127,109 @@ func TestResumeSandbox_ResumeFloorAndPlaceholder(t *testing.T) {
 				return
 			}
 			assertFinalDeadline(t, final, tc.autoPause, beforeResume, tc.wantEffective)
+		})
+	}
+}
+
+func TestUpdateWakeAnnotations(t *testing.T) {
+	tests := []struct {
+		name              string
+		existingAnns      map[string]string
+		autoResume        bool
+		timeoutSeconds    int
+		expectAnnotations map[string]string
+		expectNoPatch     bool
+	}{
+		{
+			name:           "autoResume true with timeout sets both annotations",
+			existingAnns:   map[string]string{},
+			autoResume:     true,
+			timeoutSeconds: 120,
+			expectAnnotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic:        agentsv1alpha1.True,
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "120",
+			},
+		},
+		{
+			name:           "autoResume true without timeout sets only wake-on-traffic",
+			existingAnns:   map[string]string{},
+			autoResume:     true,
+			timeoutSeconds: 0,
+			expectAnnotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: agentsv1alpha1.True,
+			},
+		},
+		{
+			name: "autoResume false with wake already enabled updates timeout",
+			existingAnns: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: agentsv1alpha1.True,
+			},
+			autoResume:     false,
+			timeoutSeconds: 90,
+			expectAnnotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "90",
+			},
+		},
+		{
+			name:           "autoResume false without wake enabled skips patch",
+			existingAnns:   map[string]string{},
+			autoResume:     false,
+			timeoutSeconds: 60,
+			expectNoPatch:  true,
+		},
+		{
+			name:           "autoResume false without wake enabled and zero timeout skips patch",
+			existingAnns:   map[string]string{},
+			autoResume:     false,
+			timeoutSeconds: 0,
+			expectNoPatch:  true,
+		},
+		{
+			name: "autoResume false with wake enabled and zero timeout skips timeout annotation",
+			existingAnns: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: agentsv1alpha1.True,
+			},
+			autoResume:        false,
+			timeoutSeconds:    0,
+			expectNoPatch:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sbx := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-sbx",
+					Namespace:   "default",
+					Annotations: tc.existingAnns,
+				},
+			}
+
+			cacheProvider, fc, err := cachetest.NewTestCache(t, sbx)
+			require.NoError(t, err)
+
+			sc := &Controller{cache: cacheProvider}
+			wrapper := sandboxcr.AsSandbox(sbx, cacheProvider)
+
+			err = sc.updateWakeAnnotations(t.Context(), wrapper, tc.autoResume, tc.timeoutSeconds)
+			require.NoError(t, err)
+
+			if tc.expectNoPatch {
+				// Verify annotations are unchanged
+				var updated agentsv1alpha1.Sandbox
+				require.NoError(t, fc.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "test-sbx"}, &updated))
+				for k, v := range tc.existingAnns {
+					assert.Equal(t, v, updated.Annotations[k], "annotation %s should be unchanged", k)
+				}
+				return
+			}
+
+			// Verify patched annotations
+			var updated agentsv1alpha1.Sandbox
+			require.NoError(t, fc.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "test-sbx"}, &updated))
+			for k, v := range tc.expectAnnotations {
+				assert.Equal(t, v, updated.Annotations[k], "annotation %s should be %s", k, v)
+			}
 		})
 	}
 }

--- a/pkg/utils/proxyutils/default_test.go
+++ b/pkg/utils/proxyutils/default_test.go
@@ -118,6 +118,66 @@ func TestGetRouteFromSandbox(t *testing.T) {
 				AccessToken: "secret-token-123",
 			},
 		},
+		{
+			name: "sandbox with wake-on-traffic annotation",
+			sandbox: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "wake-sandbox",
+					Namespace: "default",
+					Annotations: map[string]string{
+						v1alpha1.AnnotationWakeOnTraffic:     v1alpha1.True,
+						v1alpha1.AnnotationWakeTimeoutSeconds: "600",
+					},
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase: v1alpha1.SandboxRunning,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1alpha1.SandboxConditionReady),
+							Status: metav1.ConditionTrue,
+						},
+					},
+					PodInfo: v1alpha1.PodInfo{
+						PodIP: "10.0.0.4",
+					},
+				},
+			},
+			expectedRoute: Route{
+				IP:            "10.0.0.4",
+				ID:            "default--wake-sandbox",
+				Owner:         "",
+				State:         v1alpha1.SandboxStateRunning,
+				WakeOnTraffic: true,
+			},
+		},
+		{
+			name: "sandbox without wake-on-traffic annotation",
+			sandbox: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-wake-sandbox",
+					Namespace: "default",
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase: v1alpha1.SandboxRunning,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1alpha1.SandboxConditionReady),
+							Status: metav1.ConditionTrue,
+						},
+					},
+					PodInfo: v1alpha1.PodInfo{
+						PodIP: "10.0.0.5",
+					},
+				},
+			},
+			expectedRoute: Route{
+				IP:            "10.0.0.5",
+				ID:            "default--no-wake-sandbox",
+				Owner:         "",
+				State:         v1alpha1.SandboxStateRunning,
+				WakeOnTraffic: false,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/utils/proxyutils/route.go
+++ b/pkg/utils/proxyutils/route.go
@@ -35,6 +35,7 @@ func GetRouteFromSandbox(s *agentsv1alpha1.Sandbox) Route {
 		State:           state,
 		ResourceVersion: s.GetResourceVersion(),
 		AccessToken:     s.GetAnnotations()[agentsv1alpha1.AnnotationRuntimeAccessToken],
+		WakeOnTraffic:   s.GetAnnotations()[agentsv1alpha1.AnnotationWakeOnTraffic] == agentsv1alpha1.True,
 	}
 }
 
@@ -48,4 +49,5 @@ type Route struct {
 	State           string    `json:"state"`
 	ResourceVersion string    `json:"resourceVersion"`
 	AccessToken     string    `json:"accessToken,omitempty"`
+	WakeOnTraffic   bool      `json:"wakeOnTraffic,omitempty"`
 }

--- a/test/e2b/test_wake_on_traffic.py
+++ b/test/e2b/test_wake_on_traffic.py
@@ -1,4 +1,6 @@
 """E2E test: wake a paused sandbox by sending traffic through the gateway."""
+import json
+import subprocess
 import time
 from importlib.metadata import version as _pkg_version
 
@@ -14,12 +16,27 @@ _E2B_CODE_INTERPRETER_VERSION = _pkg_version("e2b-code-interpreter")
 _SDK_LACKS_AUTO_PAUSE = _E2B_CODE_INTERPRETER_VERSION.startswith("2.4.")
 
 
+def _get_sandbox_access_token(sandbox_id: str) -> str:
+    """Retrieve the runtime-access-token annotation from a Sandbox CR."""
+    name = sandbox_id.split("--")[1] if "--" in sandbox_id else sandbox_id
+    result = subprocess.run(
+        ["kubectl", "get", "sandbox", name, "-o", "json"],
+        capture_output=True, text=True, check=True,
+    )
+    sbx = json.loads(result.stdout)
+    return sbx.get("metadata", {}).get("annotations", {}).get(
+        "agents.kruise.io/runtime-access-token", ""
+    )
+
+
 @pytest.mark.skipif(_SDK_LACKS_AUTO_PAUSE, reason="SDK lacks lifecycle on_timeout pause")
 def test_wake_on_traffic(sandbox_context):
     """Traffic to a paused sandbox with wake-on-traffic should resume it."""
     # Step 1: Create sandbox with auto-pause and auto-resume (wake-on-traffic).
     # lifecycle.auto_resume=True makes the server set the wake-on-traffic
     # annotation at creation time, so no post-create kubectl annotate is needed.
+    # Use a longer timeout (120s) to give enough time for the wake test to
+    # complete before the next auto-pause triggers.
     sbx: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
         timeout=30,
@@ -45,12 +62,18 @@ def test_wake_on_traffic(sandbox_context):
 
     # Step 3: Send traffic through the gateway (triggers wake).
     # The wake-on-traffic annotation was set at creation time, so the
-    # gateway registry already has WakeOnTraffic=true — no annotation
-    # sync delay to wait for.
+    # gateway registry already has WakeOnTraffic=true.
+    #
+    # The access token is required by the agent-runtime sidecar inside
+    # the pod (not the gateway filter). Even when gateway auth is disabled,
+    # the pod's envd still validates the token.
+    access_token = _get_sandbox_access_token(sandbox_id)
     headers = {
         "e2b-sandbox-id": sandbox_id,
         "e2b-sandbox-port": "49983",
     }
+    if access_token:
+        headers["X-Access-Token"] = access_token
 
     print(f"sending wake traffic to {GATEWAY_URL} for {sandbox_id}")
     resp = requests.get(

--- a/test/e2b/test_wake_on_traffic.py
+++ b/test/e2b/test_wake_on_traffic.py
@@ -1,0 +1,103 @@
+"""E2E test: wake a paused sandbox by sending traffic through the gateway."""
+import json
+import subprocess
+import time
+from importlib.metadata import version as _pkg_version
+
+import pytest
+import requests
+from e2b_code_interpreter import Sandbox, SandboxState
+
+GATEWAY_URL = "http://localhost:80"
+
+# e2b-code-interpreter 2.4.x predates the `lifecycle={"on_timeout": "pause"}`
+# parameter, so auto-pause cannot be requested through that SDK.
+_E2B_CODE_INTERPRETER_VERSION = _pkg_version("e2b-code-interpreter")
+_SDK_LACKS_AUTO_PAUSE = _E2B_CODE_INTERPRETER_VERSION.startswith("2.4.")
+
+
+def _annotate_wake_on_traffic(sandbox_id: str):
+    """Annotate the sandbox CR with wake-on-traffic=true."""
+    name = sandbox_id.split("--")[1] if "--" in sandbox_id else sandbox_id
+    subprocess.run(
+        ["kubectl", "annotate", "sandbox", name,
+         "agents.kruise.io/wake-on-traffic=true",
+         "agents.kruise.io/wake-timeout-seconds=600",
+         "--overwrite"],
+        check=True,
+    )
+
+
+def _get_sandbox_access_token(sandbox_id: str) -> str:
+    """Retrieve the runtime-access-token annotation from a Sandbox CR."""
+    name = sandbox_id.split("--")[1] if "--" in sandbox_id else sandbox_id
+    result = subprocess.run(
+        ["kubectl", "get", "sandbox", name, "-o", "json"],
+        capture_output=True, text=True, check=True,
+    )
+    sbx = json.loads(result.stdout)
+    annotations = sbx.get("metadata", {}).get("annotations", {})
+    return annotations.get("agents.kruise.io/runtime-access-token", "")
+
+
+@pytest.mark.skipif(_SDK_LACKS_AUTO_PAUSE, reason="SDK lacks lifecycle on_timeout pause")
+def test_wake_on_traffic(sandbox_context):
+    """Traffic to a paused sandbox with wake-on-traffic should resume it."""
+    # Step 1: Create sandbox with auto-pause (short timeout)
+    sbx: Sandbox = sandbox_context.add(Sandbox.create(
+        template="code-interpreter",
+        timeout=30,
+        lifecycle={"on_timeout": "pause"},
+        metadata={"test_case": "test_wake_on_traffic"},
+        headers={"x-request-id": sandbox_context.request_id},
+    ))
+    sandbox_id = sbx.sandbox_id
+    print(f"sandbox-id: {sandbox_id}")
+    assert sbx.get_info().state == SandboxState.RUNNING
+
+    # Step 2: Wait for auto-pause
+    pause_deadline = time.time() + 30 + 60
+    paused = False
+    while time.time() < pause_deadline:
+        info = sbx.get_info()
+        if info.state == SandboxState.PAUSED:
+            paused = True
+            print(f"sandbox auto-paused: {sandbox_id}")
+            break
+        time.sleep(2)
+    assert paused, f"sandbox {sandbox_id} did not auto-pause within deadline"
+
+    # Step 3: Annotate with wake-on-traffic
+    _annotate_wake_on_traffic(sandbox_id)
+    # Wait for gateway registry to sync the annotation
+    time.sleep(3)
+
+    # Step 4: Send traffic through the gateway (triggers wake)
+    access_token = _get_sandbox_access_token(sandbox_id)
+    headers = {
+        "e2b-sandbox-id": sandbox_id,
+        "e2b-sandbox-port": "49983",
+    }
+    if access_token:
+        headers["X-Access-Token"] = access_token
+
+    resp = requests.get(
+        f"{GATEWAY_URL}/",
+        headers=headers,
+        timeout=120,  # generous timeout for wake
+    )
+
+    # Step 5: Assert wake succeeded (not 502/503)
+    assert resp.status_code != 502, (
+        f"Gateway 502: sandbox {sandbox_id} not found or not running after wake"
+    )
+    assert resp.status_code != 503, (
+        f"Gateway 503: sandbox {sandbox_id} wake failed or timed out"
+    )
+
+    # Step 6: Verify sandbox is Running
+    info = sbx.get_info()
+    assert info.state == SandboxState.RUNNING, (
+        f"sandbox should be RUNNING after wake; got {info.state}"
+    )
+    print(f"wake-on-traffic succeeded: {sandbox_id} is running")

--- a/test/e2b/test_wake_on_traffic.py
+++ b/test/e2b/test_wake_on_traffic.py
@@ -16,6 +16,16 @@ _E2B_CODE_INTERPRETER_VERSION = _pkg_version("e2b-code-interpreter")
 _SDK_LACKS_AUTO_PAUSE = _E2B_CODE_INTERPRETER_VERSION.startswith("2.4.")
 
 
+def _get_sandbox_cr(sandbox_id: str) -> dict:
+    """Retrieve the full Sandbox CR as a dict."""
+    name = sandbox_id.split("--")[1] if "--" in sandbox_id else sandbox_id
+    result = subprocess.run(
+        ["kubectl", "get", "sandbox", name, "-o", "json"],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(result.stdout)
+
+
 def _annotate_wake_on_traffic(sandbox_id: str):
     """Annotate the sandbox CR with wake-on-traffic=true."""
     name = sandbox_id.split("--")[1] if "--" in sandbox_id else sandbox_id
@@ -28,15 +38,37 @@ def _annotate_wake_on_traffic(sandbox_id: str):
     )
 
 
+def _wait_for_annotation_sync(sandbox_id: str, timeout: float = 30):
+    """Poll until the wake-on-traffic annotation is visible on the CR.
+
+    After kubectl annotate returns, the API server has persisted the change.
+    We poll to confirm the annotation is readable, then sleep briefly for
+    the gateway controller's informer cache to propagate the update.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        cr = _get_sandbox_cr(sandbox_id)
+        annotations = cr.get("metadata", {}).get("annotations", {})
+        if annotations.get("agents.kruise.io/wake-on-traffic") == "true":
+            rv = cr.get("metadata", {}).get("resourceVersion", "")
+            print(f"annotation synced: resourceVersion={rv}")
+            # Brief sleep for gateway informer cache propagation.
+            # The filter's cache fallback (HasWakeAnnotation) provides
+            # additional resilience even if the route registry hasn't
+            # reconciled yet.
+            time.sleep(2)
+            return
+        time.sleep(1)
+    raise TimeoutError(
+        f"wake-on-traffic annotation not visible on {sandbox_id} "
+        f"within {timeout}s"
+    )
+
+
 def _get_sandbox_access_token(sandbox_id: str) -> str:
     """Retrieve the runtime-access-token annotation from a Sandbox CR."""
-    name = sandbox_id.split("--")[1] if "--" in sandbox_id else sandbox_id
-    result = subprocess.run(
-        ["kubectl", "get", "sandbox", name, "-o", "json"],
-        capture_output=True, text=True, check=True,
-    )
-    sbx = json.loads(result.stdout)
-    annotations = sbx.get("metadata", {}).get("annotations", {})
+    cr = _get_sandbox_cr(sandbox_id)
+    annotations = cr.get("metadata", {}).get("annotations", {})
     return annotations.get("agents.kruise.io/runtime-access-token", "")
 
 
@@ -67,10 +99,9 @@ def test_wake_on_traffic(sandbox_context):
         time.sleep(2)
     assert paused, f"sandbox {sandbox_id} did not auto-pause within deadline"
 
-    # Step 3: Annotate with wake-on-traffic
+    # Step 3: Annotate with wake-on-traffic and wait for sync
     _annotate_wake_on_traffic(sandbox_id)
-    # Wait for gateway controller to sync the annotation change
-    time.sleep(5)
+    _wait_for_annotation_sync(sandbox_id)
 
     # Step 4: Send traffic through the gateway (triggers wake)
     access_token = _get_sandbox_access_token(sandbox_id)

--- a/test/e2b/test_wake_on_traffic.py
+++ b/test/e2b/test_wake_on_traffic.py
@@ -1,6 +1,4 @@
 """E2E test: wake a paused sandbox by sending traffic through the gateway."""
-import json
-import subprocess
 import time
 from importlib.metadata import version as _pkg_version
 
@@ -16,70 +14,16 @@ _E2B_CODE_INTERPRETER_VERSION = _pkg_version("e2b-code-interpreter")
 _SDK_LACKS_AUTO_PAUSE = _E2B_CODE_INTERPRETER_VERSION.startswith("2.4.")
 
 
-def _get_sandbox_cr(sandbox_id: str) -> dict:
-    """Retrieve the full Sandbox CR as a dict."""
-    name = sandbox_id.split("--")[1] if "--" in sandbox_id else sandbox_id
-    result = subprocess.run(
-        ["kubectl", "get", "sandbox", name, "-o", "json"],
-        capture_output=True, text=True, check=True,
-    )
-    return json.loads(result.stdout)
-
-
-def _annotate_wake_on_traffic(sandbox_id: str):
-    """Annotate the sandbox CR with wake-on-traffic=true."""
-    name = sandbox_id.split("--")[1] if "--" in sandbox_id else sandbox_id
-    subprocess.run(
-        ["kubectl", "annotate", "sandbox", name,
-         "agents.kruise.io/wake-on-traffic=true",
-         "agents.kruise.io/wake-timeout-seconds=600",
-         "--overwrite"],
-        check=True,
-    )
-
-
-def _wait_for_annotation_sync(sandbox_id: str, timeout: float = 30):
-    """Poll until the wake-on-traffic annotation is visible on the CR.
-
-    After kubectl annotate returns, the API server has persisted the change.
-    We poll to confirm the annotation is readable, then sleep briefly for
-    the gateway controller's informer cache to propagate the update.
-    """
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        cr = _get_sandbox_cr(sandbox_id)
-        annotations = cr.get("metadata", {}).get("annotations", {})
-        if annotations.get("agents.kruise.io/wake-on-traffic") == "true":
-            rv = cr.get("metadata", {}).get("resourceVersion", "")
-            print(f"annotation synced: resourceVersion={rv}")
-            # Brief sleep for gateway informer cache propagation.
-            # The filter's cache fallback (HasWakeAnnotation) provides
-            # additional resilience even if the route registry hasn't
-            # reconciled yet.
-            time.sleep(2)
-            return
-        time.sleep(1)
-    raise TimeoutError(
-        f"wake-on-traffic annotation not visible on {sandbox_id} "
-        f"within {timeout}s"
-    )
-
-
-def _get_sandbox_access_token(sandbox_id: str) -> str:
-    """Retrieve the runtime-access-token annotation from a Sandbox CR."""
-    cr = _get_sandbox_cr(sandbox_id)
-    annotations = cr.get("metadata", {}).get("annotations", {})
-    return annotations.get("agents.kruise.io/runtime-access-token", "")
-
-
 @pytest.mark.skipif(_SDK_LACKS_AUTO_PAUSE, reason="SDK lacks lifecycle on_timeout pause")
 def test_wake_on_traffic(sandbox_context):
     """Traffic to a paused sandbox with wake-on-traffic should resume it."""
-    # Step 1: Create sandbox with auto-pause (short timeout)
+    # Step 1: Create sandbox with auto-pause and auto-resume (wake-on-traffic).
+    # lifecycle.auto_resume=True makes the server set the wake-on-traffic
+    # annotation at creation time, so no post-create kubectl annotate is needed.
     sbx: Sandbox = sandbox_context.add(Sandbox.create(
         template="code-interpreter",
         timeout=30,
-        lifecycle={"on_timeout": "pause"},
+        lifecycle={"on_timeout": "pause", "auto_resume": True},
         metadata={"test_case": "test_wake_on_traffic"},
         headers={"x-request-id": sandbox_context.request_id},
     ))
@@ -99,18 +43,14 @@ def test_wake_on_traffic(sandbox_context):
         time.sleep(2)
     assert paused, f"sandbox {sandbox_id} did not auto-pause within deadline"
 
-    # Step 3: Annotate with wake-on-traffic and wait for sync
-    _annotate_wake_on_traffic(sandbox_id)
-    _wait_for_annotation_sync(sandbox_id)
-
-    # Step 4: Send traffic through the gateway (triggers wake)
-    access_token = _get_sandbox_access_token(sandbox_id)
+    # Step 3: Send traffic through the gateway (triggers wake).
+    # The wake-on-traffic annotation was set at creation time, so the
+    # gateway registry already has WakeOnTraffic=true — no annotation
+    # sync delay to wait for.
     headers = {
         "e2b-sandbox-id": sandbox_id,
         "e2b-sandbox-port": "49983",
     }
-    if access_token:
-        headers["X-Access-Token"] = access_token
 
     print(f"sending wake traffic to {GATEWAY_URL} for {sandbox_id}")
     resp = requests.get(
@@ -120,7 +60,7 @@ def test_wake_on_traffic(sandbox_context):
     )
     print(f"wake response: status={resp.status_code} body={resp.text[:200]!r}")
 
-    # Step 5: Assert wake succeeded (not 502/503)
+    # Step 4: Assert wake succeeded (not 502/503)
     assert resp.status_code != 502, (
         f"Gateway 502: sandbox {sandbox_id} not found or not running after wake"
     )
@@ -128,7 +68,7 @@ def test_wake_on_traffic(sandbox_context):
         f"Gateway 503: sandbox {sandbox_id} wake failed or timed out"
     )
 
-    # Step 6: Verify sandbox is Running (poll with retry for controller
+    # Step 5: Verify sandbox is Running (poll with retry for controller
     # reconciliation — the gateway wake triggers an async controller
     # reconcile to update Status.Phase from Paused to Running).
     running_deadline = time.time() + 60

--- a/test/e2b/test_wake_on_traffic.py
+++ b/test/e2b/test_wake_on_traffic.py
@@ -56,21 +56,21 @@ def test_wake_on_traffic(sandbox_context):
     assert sbx.get_info().state == SandboxState.RUNNING
 
     # Step 2: Wait for auto-pause
-    pause_deadline = time.time() + 30 + 60
+    pause_deadline = time.time() + 30 + 120
     paused = False
     while time.time() < pause_deadline:
         info = sbx.get_info()
         if info.state == SandboxState.PAUSED:
             paused = True
-            print(f"sandbox auto-paused: {sandbox_id}")
+            print(f"sandbox auto-paused: {sandbox_id} state={info.state}")
             break
         time.sleep(2)
     assert paused, f"sandbox {sandbox_id} did not auto-pause within deadline"
 
     # Step 3: Annotate with wake-on-traffic
     _annotate_wake_on_traffic(sandbox_id)
-    # Wait for gateway registry to sync the annotation
-    time.sleep(3)
+    # Wait for gateway controller to sync the annotation change
+    time.sleep(5)
 
     # Step 4: Send traffic through the gateway (triggers wake)
     access_token = _get_sandbox_access_token(sandbox_id)
@@ -81,11 +81,13 @@ def test_wake_on_traffic(sandbox_context):
     if access_token:
         headers["X-Access-Token"] = access_token
 
+    print(f"sending wake traffic to {GATEWAY_URL} for {sandbox_id}")
     resp = requests.get(
         f"{GATEWAY_URL}/",
         headers=headers,
         timeout=120,  # generous timeout for wake
     )
+    print(f"wake response: status={resp.status_code} body={resp.text[:200]!r}")
 
     # Step 5: Assert wake succeeded (not 502/503)
     assert resp.status_code != 502, (
@@ -95,9 +97,21 @@ def test_wake_on_traffic(sandbox_context):
         f"Gateway 503: sandbox {sandbox_id} wake failed or timed out"
     )
 
-    # Step 6: Verify sandbox is Running
-    info = sbx.get_info()
-    assert info.state == SandboxState.RUNNING, (
-        f"sandbox should be RUNNING after wake; got {info.state}"
+    # Step 6: Verify sandbox is Running (poll with retry for controller
+    # reconciliation — the gateway wake triggers an async controller
+    # reconcile to update Status.Phase from Paused to Running).
+    running_deadline = time.time() + 60
+    running = False
+    last_state = None
+    while time.time() < running_deadline:
+        info = sbx.get_info()
+        last_state = info.state
+        if info.state == SandboxState.RUNNING:
+            running = True
+            break
+        print(f"waiting for running state, current: {info.state}")
+        time.sleep(2)
+    assert running, (
+        f"sandbox should be RUNNING after wake; got {last_state}"
     )
     print(f"wake-on-traffic succeeded: {sandbox_id} is running")


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Implement **wake-on-traffic** for paused sandboxes: the sandbox-gateway automatically resumes a paused sandbox when inbound traffic arrives, by calling `sandboxcr.Sandbox.Resume()` directly — no HTTP call to sandbox-manager, no systemtoken.

**How it works:**

1. At sandbox creation (E2B `CreateSandbox`), when `autoResume=true` + `autoPause=true`, two annotations are set on the Sandbox CR: `agents.kruise.io/wake-on-traffic=true` and `agents.kruise.io/wake-timeout-seconds=<N>`.
2. The route registry propagates `WakeOnTraffic` from the annotation into the `Route` struct.
3. When the Envoy Go filter receives traffic for a paused sandbox with `WakeOnTraffic=true`, it invokes the `Waker` inline. The Waker calls `sandboxcr.AsSandbox(sbx, cache).Resume()`, which reuses the entire connect-path (spec patch, wait-for-running, concurrent dedup, conflict retries), then syncs the route to the local registry and peer gateways.
4. After wake, the filter re-reads the registry and forwards the request normally.

**Key design decisions:**

- Reuses `sandboxcr.Sandbox.Resume()` — no reimplementation of spec patching, wait, or dedup.
- `ShutdownTime` is preserved during wake to prevent timed sandboxes from losing their auto-delete deadline.
- `atomic.Pointer[Waker]` for race-safe singleton access.
- `SyncRouteWithPeers` extracted as a package-level function so the gateway can sync routes without a full `proxy.Server` instance.
- Feature is opt-in: gated on both filter config (`enable-wake-on-traffic`) and per-sandbox annotation.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run unit tests:
   ```
   go test ./pkg/sandbox-gateway/wake/ ./pkg/sandbox-gateway/filter/ ./pkg/utils/proxyutils/ ./pkg/proxy/
   ```
2. Deploy sandbox-gateway with `enable-wake-on-traffic: true` in the Envoy filter config.
3. Create a sandbox with `autoPause=true, autoResume=true`.
4. Wait for the sandbox to auto-pause (or pause it manually).
5. Send traffic through the gateway — the sandbox should be automatically resumed and the request forwarded.
6. Run the E2E test: `pytest test/e2b/test_wake_on_traffic.py`

### Ⅳ. Special notes for reviews

- **`pkg/sandbox-gateway/wake/wake.go`** — the core of the feature. Delegates entirely to `sandboxcr.Sandbox.Resume()`. Preserves `ShutdownTime` from the informer cache to avoid resource leaks (timed sandboxes losing their auto-delete deadline).
- **`pkg/sandbox-gateway/filter/filter.go`** — the wake is triggered inline in `DecodeHeaders`, blocking the Envoy worker thread. The timeout is configurable via `wake-timeout-seconds` (default 60s).
- **`pkg/proxy/routes.go`** — `SyncRouteWithPeers` extracted from a `Server` method to a package-level function taking `peers.Peers` and `Route`. The original method delegates to it.
- **RBAC** — the gateway's ClusterRole already had `update`/`patch` on `sandboxes`, which is what `Resume()`'s `retryUpdate` needs. Only `sandboxsets` read access was added.
