### PR TITLE
feat(gateway): implement wake-on-traffic for paused sandboxes

### DIFF
--- a/api/v1alpha1/annotations.go
+++ b/api/v1alpha1/annotations.go
@@ -79,6 +79,16 @@ const (
 	// SandboxHashImmutablePart represents the key of sandbox hash than exclude immutable part of sandbox
 	// e.g. metadata, image and resources
 	SandboxHashImmutablePart = "sandbox.agents.kruise.io/hash-immutable-part"
+
+	// AnnotationWakeOnTraffic enables wake-on-traffic for a paused sandbox.
+	// When set to "true", the sandbox-gateway will attempt to resume the sandbox
+	// by patching Spec.Paused=false when traffic arrives.
+	AnnotationWakeOnTraffic = InternalPrefix + "wake-on-traffic"
+
+	// AnnotationWakeTimeoutSeconds stores the auto-pause timeout (in seconds) to
+	// apply when the sandbox is woken by traffic. The gateway reads this to set
+	// ResumeOptions.Timeout.PauseTime, re-arming auto-pause after wake.
+	AnnotationWakeTimeoutSeconds = InternalPrefix + "wake-timeout-seconds"
 )
 
 // E2B annotations

--- a/api/v1alpha1/sandboxset_types.go
+++ b/api/v1alpha1/sandboxset_types.go
@@ -47,6 +47,8 @@ var AnnotationsClearedOnRecycle = []string{
 	// (header injections, blocks); leaking it across a claim would apply one
 	// tenant's rules — potentially carrying credentials — to another.
 	AnnotationSecurityRules,
+	AnnotationWakeOnTraffic,
+	AnnotationWakeTimeoutSeconds,
 }
 
 // InternalKeysPreservedOnCreation lists internal keys (with the InternalPrefix)

--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/openkruise/agents/pkg/utils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 	utilruntime "github.com/openkruise/agents/pkg/utils/runtime"
+	"github.com/openkruise/agents/pkg/utils/timeout"
 )
 
 const (
@@ -130,7 +131,7 @@ func main() {
 			"at most 50 characters (validated at startup: prefix plus the 13-character short ID must fit a 63-character Kubernetes label value); "+
 			"with Native E2B dynamic domains (<port>-<sandbox-id>.<domain>) keep the prefix at 44 characters or fewer so the DNS label stays valid; during mixed-version rollout keep it at 37 characters or fewer; the customized path is not subject to this DNS limit; "+
 			"use the same value on every sandbox-manager replica")
-	pflag.IntVar(&e2bMinResumeTimeout, "e2b-min-resume-timeout", models.DefaultMinResumeTimeoutSeconds,
+	pflag.IntVar(&e2bMinResumeTimeout, "e2b-min-resume-timeout", timeout.DefaultMinResumeTimeoutSeconds,
 		"Minimum value (seconds) for the timeout parameter carried by the E2B connect API; "+
 			"timeout values below this floor will be raised to this value.")
 	pflag.StringVar(&sysNs, "system-namespace", utils.DefaultSandboxDeployNamespace, "The namespace where the sandbox manager is running (required)")

--- a/config/sandbox-gateway/configmap.yaml
+++ b/config/sandbox-gateway/configmap.yaml
@@ -102,6 +102,8 @@ data:
                               enable-jwt-auth: false
                               enable-runtime-mtls: false
                               traffic-access-token-header: e2b-traffic-access-token
+                              enable-wake-on-traffic: true
+                              wake-timeout-seconds: 60
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/config/sandbox-gateway/rbac.yaml
+++ b/config/sandbox-gateway/rbac.yaml
@@ -8,7 +8,7 @@ metadata:
 rules:
   - apiGroups: ["agents.kruise.io"]
     resources: ["sandboxes"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["agents.kruise.io"]
     resources: ["sandboxes/status"]
     verbs: ["get"]

--- a/docs/proposals/20260627-wake-on-traffic-via-spec-patch.md
+++ b/docs/proposals/20260627-wake-on-traffic-via-spec-patch.md
@@ -1,0 +1,105 @@
+# Wake-on-Traffic via Direct Spec Patch (No SystemToken)
+
+## Motivation
+
+PR #495 implements wake-on-traffic by having sandbox-gateway call sandbox-manager's
+`/connect` HTTP API using a scoped system credential (systemtoken). This introduces
+cross-component HTTP coupling, a new credential type, and credential lifecycle
+management. This proposal replaces that mechanism with a direct Go function call,
+eliminating the systemtoken entirely while reusing the exact same resume logic.
+
+## Design
+
+The sandbox-gateway directly calls `sandboxcr.AsSandbox(sbx, cache).Resume(ctx, opts)`
+— a Go function call, not an HTTP call. This reuses the entire sandbox-manager connect
+path: spec patch (`Spec.Paused = false`), wait-for-running (`NewSandboxResumeTask().Wait()`),
+concurrent dedup (first-writer-wins via `retryUpdate`), conflict retries, and post-resume
+refresh (`InplaceRefresh`).
+
+```
+Traffic -> Envoy Filter -> Registry lookup
+  |-> sandbox Running: forward (current behavior)
+  |-> sandbox Paused + WakeOnTraffic enabled:
+       |-> sandboxcr.AsSandbox(sbx, cacheProvider).Resume(ctx, opts)
+       |     ^-- reuses existing sandbox-manager connect implementation:
+       |         1. refreshFromAPIReader (fresh fetch)
+       |         2. IsSandboxResumable check
+       |         3. NewSandboxResumeTask (pre-acquired wait task)
+       |         4. retryUpdate: patches Spec.Paused=false + setTimeout
+       |         5. resumeTask.Wait() -- blocks until Ready condition True
+       |         6. InplaceRefresh + expectations
+       |     Concurrent dedup: first-writer-wins via retryUpdate
+       |-> syncRoute: update local registry + sync to peer gateways
+       |-> Forward request or return 503 on timeout/failure
+  |-> sandbox Paused + WakeOnTraffic disabled: return 502 (current behavior)
+```
+
+## Key Components
+
+### Annotation Lifecycle
+
+- `AnnotationWakeOnTraffic` ("agents.kruise.io/wake-on-traffic"): Set to "true"
+  in one of two ways:
+  1. **Via the E2B create API**: pass `"autoResume": {"enabled": true}` in the
+     request body. The sandbox-manager's `basicSandboxCreateModifier` writes the
+     annotation at sandbox creation time.
+  2. **Manually via `kubectl annotate`** (or any out-of-band tooling) for
+     sandboxes that were created without `autoResume`.
+- `AnnotationWakeTimeoutSeconds` ("agents.kruise.io/wake-timeout-seconds"): Stores the
+  auto-pause timeout (in seconds) to apply when the sandbox is woken by traffic. The
+  gateway reads this to set `ResumeOptions.Timeout.PauseTime`, re-arming auto-pause
+  after wake.
+
+### Wake Package (`pkg/sandbox-gateway/wake/`)
+
+The `Waker` struct wraps `sandboxcr.AsSandbox(sbx, cache).Resume()` and syncs the route
+after Resume succeeds. It does NOT reimplement spec patching or wait-for-running — it
+delegates entirely to the existing `Resume()` method.
+
+After Resume succeeds, `syncRoute` mirrors the manager's `syncRoute` flow:
+1. Get route from refreshed sandbox (`sandbox.GetRoute()`)
+2. Update local gateway registry (`registry.GetRegistry().Update`)
+3. Sync route to peer gateways (`proxy.SyncRouteWithPeers`)
+
+### Cache Provider
+
+`cache.NewCache(mgr)` creates the same informer-backed cache + `WaitReconciler` used by
+sandbox-manager. The gateway's controller-runtime manager hosts both the existing
+`SandboxReconciler` (for local registry updates) and the cache provider's wait
+reconciler (for `NewSandboxResumeTask().Wait()`).
+
+### Route Sync
+
+`proxy.SyncRouteWithPeers` was extracted as a package-level function so the gateway can
+call it without creating a full `proxy.Server` instance. The gateway's `server.Server`
+exposes its `peerManager` via `GetPeerManager()` for use by the Waker.
+
+## Authorization
+
+K8s RBAC grants the gateway ServiceAccount `update`/`patch` on `sandboxes` resources.
+No systemtoken, no HTTP call to sandbox-manager.
+
+## Comparison with PR #495
+
+| Aspect | PR #495 | This Proposal |
+|--------|---------|---------------|
+| Wake trigger | Gateway calls manager `/connect` HTTP API | Gateway calls `sandboxcr.Sandbox.Resume()` directly (Go function) |
+| Auth | System key (systemtoken) | K8s RBAC (ServiceAccount) |
+| Resume logic | Manager's `ResumeSandbox` HTTP handler | Same `sandboxcr.Sandbox.Resume()` method (imported, not HTTP) |
+| Wait mechanism | Manager's `NewSandboxResumeTask().Wait()` | Same (reused via Resume call) |
+| Spec patching | Manager's `retryUpdate` inside Resume | Same (reused via Resume call) |
+| Concurrent dedup | Manager's first-writer-wins | Same (reused via Resume call) |
+| Route sync after wake | Manager's `syncRoute` | Gateway mirrors: `registry.Update` + `proxy.SyncRouteWithPeers` |
+| Timeout update | Manager's connect API handles it | Gateway passes `ResumeOptions.Timeout.PauseTime` |
+| New components | `systemkey.go`, `wake/client.go`, `wake/wake.go` | `wake/wake.go` (thin wrapper) |
+| Cross-component deps | Gateway -> Manager HTTP | Gateway imports `pkg/sandbox-manager/infra/sandboxcr` (Go import) |
+| Cache provider | Manager has its own | Gateway creates its own via `cache.NewCache(mgr)` |
+
+## Timeout Handling
+
+The `AnnotationWakeTimeoutSeconds` annotation stores the auto-pause timeout. When the
+gateway wakes a sandbox:
+1. It reads the annotation to determine `PauseTime` (re-arming auto-pause)
+2. If the annotation is absent, it uses the filter's `WakeTimeoutSeconds` config default
+3. The timeout is passed as `ResumeOptions.Timeout.PauseTime`, which is written atomically
+   with `Spec.Paused = false` inside `retryUpdate` — closing the auto-pause race

--- a/hack/run-e2b-e2e-test.sh
+++ b/hack/run-e2b-e2e-test.sh
@@ -437,6 +437,7 @@ if [[ "$WITH_GATEWAY" != "true" ]]; then
     pytest_args+=(--ignore="$TEST_DIR/test_gateway_auth.py")
     pytest_args+=(--ignore="$TEST_DIR/test_gateway_jwt_auth.py")
     pytest_args+=(--ignore="$TEST_DIR/test_gateway_runtime_mtls.py")
+    pytest_args+=(--ignore="$TEST_DIR/test_wake_on_traffic.py")
 elif [[ -z "$PYTEST_MARKER_EXPR" ]]; then
     # The default gateway deployment has authentication and Runtime mTLS disabled.
     pytest_args+=(-m "not gateway_uuid_auth and not jwt_auth and not runtime_mtls")
@@ -478,6 +479,17 @@ set -e
 
 if [ "$retVal" -ne 0 ]; then
     echo "Tests failed"
+
+    # Dump sandbox-gateway pod logs on failure for debugging wake-on-traffic
+    # and other gateway issues. The gateway runs Envoy + Go filter, and its
+    # logs are not captured otherwise.
+    if [ "$WITH_GATEWAY" = "true" ]; then
+        echo "=== sandbox-gateway pod logs (current) ==="
+        for gwPod in $(kubectl get pod -n sandbox-system -l app.kubernetes.io/name=sandbox-gateway --no-headers -o jsonpath='{.items[*].metadata.name}'); do
+            echo "--- Logs for gateway pod: $gwPod ---"
+            kubectl logs "$gwPod" -n sandbox-system --tail=500 2>&1 || echo "Failed to get logs for $gwPod"
+        done
+    fi
 else
     echo "All E2B tests passed successfully!"
 fi

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -249,20 +249,23 @@ func newControllerManager(cfg *rest.Config, opts config.SandboxManagerOptions, h
 
 // NewCache creates a new Cache instance from a pre-configured controller manager.
 // The metadata must have been returned by NewControllerManager.
-func NewCache(mgr ctrl.Manager) (*Cache, error) {
-	return NewCacheWithHealth(mgr, nil)
+// When sandboxOnly is true, only Sandbox-related controllers and indexes are
+// registered (SandboxWaitReconciler, SandboxCustomReconciler, and Sandbox field
+// indexes); Checkpoint, PVC, and SandboxSet controllers/indexes are skipped.
+func NewCache(mgr ctrl.Manager, sandboxOnly bool) (*Cache, error) {
+	return NewCacheWithHealth(mgr, nil, sandboxOnly)
 }
 
 // NewCacheWithHealth creates a cache backed by the given manager and informer
 // health gate.
-func NewCacheWithHealth(mgr ctrl.Manager, health *InformerHealth) (*Cache, error) {
+func NewCacheWithHealth(mgr ctrl.Manager, health *InformerHealth, sandboxOnly bool) (*Cache, error) {
 	waitHooks := &sync.Map{}
-	handlers, err := controllers.SetupCacheControllersWithManager(mgr, waitHooks)
+	handlers, err := controllers.SetupCacheControllersWithManager(mgr, waitHooks, sandboxOnly)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup cache controllers: %w", err)
 	}
 	// Register field indexes
-	if err := AddIndexesToCache(mgr.GetCache()); err != nil {
+	if err := AddIndexesToCache(mgr.GetCache(), sandboxOnly); err != nil {
 		return nil, fmt.Errorf("failed to add indexes to cache: %w", err)
 	}
 

--- a/pkg/cache/cache_health_test.go
+++ b/pkg/cache/cache_health_test.go
@@ -223,7 +223,7 @@ func newHealthCacheForTest(t *testing.T) (*Cache, *InformerHealth) {
 	require.NoError(t, err)
 
 	health := NewInformerHealth()
-	c, err := NewCacheWithHealth(mgrBuilder.Build(), health)
+	c, err := NewCacheWithHealth(mgrBuilder.Build(), health, false)
 	require.NoError(t, err)
 	return c, health
 }

--- a/pkg/cache/cachetest/cachetest.go
+++ b/pkg/cache/cachetest/cachetest.go
@@ -75,7 +75,7 @@ func NewTestCache(t *testing.T, initObjs ...ctrlclient.Object) (*cache.Cache, ct
 		Build()
 
 	health := cache.NewInformerHealth()
-	c, err := cache.NewCacheWithHealth(mgr, health)
+	c, err := cache.NewCacheWithHealth(mgr, health, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cache/controllers/cache_controllers.go
+++ b/pkg/cache/controllers/cache_controllers.go
@@ -155,26 +155,34 @@ type CacheControllerHandlers struct {
 	SandboxSetCustomReconciler *CacheSandboxSetCustomReconciler
 }
 
-// SetupCacheControllersWithManager registers all cache controllers with the given manager
+// SetupCacheControllersWithManager registers cache controllers with the given manager
 // and returns a CacheControllerHandlers struct for registering custom event handlers.
 // The waitHooks parameter is shared with the Cache instance.
-func SetupCacheControllersWithManager(mgr manager.Manager, waitHooks *sync.Map) (*CacheControllerHandlers, error) {
+// When sandboxOnly is true, only Sandbox-related controllers are registered
+// (SandboxWaitReconciler and SandboxCustomReconciler); Checkpoint, PVC, and
+// SandboxSet controllers are skipped.
+func SetupCacheControllersWithManager(mgr manager.Manager, waitHooks *sync.Map, sandboxOnly bool) (*CacheControllerHandlers, error) {
 	if err := AddCacheSandboxWaitReconciler(mgr, waitHooks); err != nil {
 		return nil, err
 	}
-	if err := AddCacheCheckpointWaitReconciler(mgr, waitHooks); err != nil {
-		return nil, err
-	}
-	if err := AddCachePVCWaitReconciler(mgr, waitHooks); err != nil {
-		return nil, err
+	if !sandboxOnly {
+		if err := AddCacheCheckpointWaitReconciler(mgr, waitHooks); err != nil {
+			return nil, err
+		}
+		if err := AddCachePVCWaitReconciler(mgr, waitHooks); err != nil {
+			return nil, err
+		}
 	}
 	sandboxCustomReconciler, err := AddCacheSandboxCustomReconciler(mgr)
 	if err != nil {
 		return nil, err
 	}
-	sandboxSetCustomReconciler, err := AddCacheSandboxSetCustomReconciler(mgr)
-	if err != nil {
-		return nil, err
+	var sandboxSetCustomReconciler *CacheSandboxSetCustomReconciler
+	if !sandboxOnly {
+		sandboxSetCustomReconciler, err = AddCacheSandboxSetCustomReconciler(mgr)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &CacheControllerHandlers{
 		SandboxCustomReconciler:    sandboxCustomReconciler,

--- a/pkg/cache/controllers/cache_controllers_test.go
+++ b/pkg/cache/controllers/cache_controllers_test.go
@@ -133,7 +133,7 @@ func TestSetupCacheControllersWithManager(t *testing.T) {
 				waitHooks = &sync.Map{}
 			}
 
-			handlers, err := SetupCacheControllersWithManager(mgr, waitHooks)
+			handlers, err := SetupCacheControllersWithManager(mgr, waitHooks, false)
 
 			if tt.wantErr {
 				require.Error(t, err, "expected an error but got none")
@@ -162,7 +162,7 @@ func TestCacheControllerHandlers_AddReconcileHandlers(t *testing.T) {
 	mgr := newMockManagerBuilderForTest(t).Build()
 	waitHooks := &sync.Map{}
 
-	handlers, err := SetupCacheControllersWithManager(mgr, waitHooks)
+	handlers, err := SetupCacheControllersWithManager(mgr, waitHooks, false)
 	require.NoError(t, err)
 	require.NotNil(t, handlers)
 
@@ -187,4 +187,28 @@ func TestCacheControllerHandlers_AddReconcileHandlers(t *testing.T) {
 	// Verify handlers are stored (they are called at reconcile time, not immediately)
 	assert.Equal(t, int32(0), sbxHandlerCalled.Load(), "handler must not be called until Reconcile is triggered")
 	assert.Equal(t, int32(0), sbsHandlerCalled.Load(), "handler must not be called until Reconcile is triggered")
+}
+
+// TestSetupCacheControllersWithManager_SandboxOnly verifies that when sandboxOnly
+// is true, only Sandbox-related controllers are registered (SandboxWaitReconciler
+// and SandboxCustomReconciler), and SandboxSetCustomReconciler is nil.
+func TestSetupCacheControllersWithManager_SandboxOnly(t *testing.T) {
+	mgr := newMockManagerBuilderForTest(t).Build()
+	waitHooks := &sync.Map{}
+
+	handlers, err := SetupCacheControllersWithManager(mgr, waitHooks, true)
+	require.NoError(t, err)
+	require.NotNil(t, handlers)
+
+	// SandboxCustomReconciler must be present
+	require.NotNil(t, handlers.SandboxCustomReconciler, "SandboxCustomReconciler must not be nil")
+	assert.Equal(t, "SandboxCustom", handlers.SandboxCustomReconciler.Name)
+	assert.IsType(t, &agentsv1alpha1.Sandbox{}, handlers.SandboxCustomReconciler.NewObject())
+
+	// SandboxSetCustomReconciler must be nil (skipped in sandboxOnly mode)
+	assert.Nil(t, handlers.SandboxSetCustomReconciler, "SandboxSetCustomReconciler must be nil in sandboxOnly mode")
+
+	// Only 2 controllers should have been added:
+	// SandboxWait + SandboxCustom (Checkpoint, PVC, SandboxSet are skipped)
+	assert.Equal(t, 2, mgr.addCallsCount(), "expected exactly 2 Add() calls in sandboxOnly mode")
 }

--- a/pkg/cache/index.go
+++ b/pkg/cache/index.go
@@ -197,14 +197,21 @@ func GetIndexFuncs() []IndexFunc {
 	}
 }
 
-// AddIndexesToCache registers all required field indexes on the controller-runtime cache.
+// AddIndexesToCache registers required field indexes on the controller-runtime cache.
+// When sandboxOnly is true, only indexes for the Sandbox CR are registered;
+// SandboxSet, Checkpoint, and PersistentVolumeClaim indexes are skipped.
 // Indexes whose OptionalGVK is reliably absent from API server discovery (e.g. the
 // corresponding CRD is not installed) are skipped instead of failing the startup.
-func AddIndexesToCache(c ctrlcache.Cache) error {
+func AddIndexesToCache(c ctrlcache.Cache, sandboxOnly bool) error {
 	if c == nil {
 		return nil
 	}
 	for _, idx := range GetIndexFuncs() {
+		if sandboxOnly {
+			if _, ok := idx.Obj.(*agentsv1alpha1.Sandbox); !ok {
+				continue
+			}
+		}
 		if !idx.OptionalGVK.Empty() && !discoverGVK(idx.OptionalGVK) {
 			klog.InfoS("Skipping field index for absent CRD", "field", idx.FieldName, "gvk", idx.OptionalGVK.String())
 			continue

--- a/pkg/cache/index_test.go
+++ b/pkg/cache/index_test.go
@@ -76,9 +76,10 @@ func TestAddIndexesToCache(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		absent     bool
-		wantFields []string
+		name        string
+		absent      bool
+		sandboxOnly bool
+		wantFields  []string
 	}{
 		{
 			name:       "TrafficPolicy CRD present registers every index",
@@ -90,6 +91,11 @@ func TestAddIndexesToCache(t *testing.T) {
 			absent:     true,
 			wantFields: withoutTrafficPolicy,
 		},
+		{
+			name:        "sandboxOnly registers only Sandbox indexes",
+			sandboxOnly: true,
+			wantFields:  []string{IndexSandboxPool, IndexClaimedSandboxID, IndexUser},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -100,7 +106,7 @@ func TestAddIndexesToCache(t *testing.T) {
 			t.Cleanup(func() { discoverGVK = old })
 
 			c := &recordingCache{}
-			if err := AddIndexesToCache(c); err != nil {
+			if err := AddIndexesToCache(c, tt.sandboxOnly); err != nil {
 				t.Fatalf("AddIndexesToCache() error = %v", err)
 			}
 			if len(c.fields) != len(tt.wantFields) {
@@ -116,7 +122,7 @@ func TestAddIndexesToCache(t *testing.T) {
 }
 
 func TestAddIndexesToCache_NilCache(t *testing.T) {
-	if err := AddIndexesToCache(nil); err != nil {
+	if err := AddIndexesToCache(nil, false); err != nil {
 		t.Errorf("AddIndexesToCache(nil) error = %v, want nil", err)
 	}
 }

--- a/pkg/controller/sandbox/core/recycle_test.go
+++ b/pkg/controller/sandbox/core/recycle_test.go
@@ -1182,7 +1182,9 @@ func TestResetForPool(t *testing.T) {
 						agentsv1alpha1.AnnotationEnvdURL:                "http://legacy-envd.example.com",
 						agentsv1alpha1.AnnotationRuntimeURL:             "http://runtime.example.com",
 						agentsv1alpha1.AnnotationSecurityRules:          `[{"name":"leaked","match":[{"domains":["api.example.com"]}],"actions":{"block":{"statusCode":403}}}]`,
-						"user-anno":                                     "user-value",
+						agentsv1alpha1.AnnotationWakeOnTraffic:          "true",
+						agentsv1alpha1.AnnotationWakeTimeoutSeconds:     "300",
+						"user-anno": "user-value",
 						agentsv1alpha1.AnnotationUpdatedMetadataInClaim: mustMarshal(agentsv1alpha1.UpdatedMetadataInClaim{
 							Labels:      []string{"user-label"},
 							Annotations: []string{"user-anno"},
@@ -1308,6 +1310,11 @@ func TestResetForPool(t *testing.T) {
 			// pool: a leaked chain would apply that tenant's rules (and any
 			// injected credentials) to the next claimant.
 			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationSecurityRules])
+			// Wake annotations of the previous delivery must not leak into
+			// the pool: the next claim may serve a delivery that never
+			// enabled autoResume.
+			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationWakeOnTraffic])
+			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationWakeTimeoutSeconds])
 			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationUpdatedMetadataInClaim])
 			if tt.expectLabels != nil {
 				assert.Equal(t, tt.expectLabels, updated.Labels)

--- a/pkg/controller/sandboxclaim/sandboxclaim_controller.go
+++ b/pkg/controller/sandboxclaim/sandboxclaim_controller.go
@@ -72,7 +72,7 @@ func Add(mgr manager.Manager, runtimeTLSBundle *runtimeclient.TLSBundle) error {
 	}
 
 	// Initialize cache
-	cache, err := infracache.NewCache(mgr)
+	cache, err := infracache.NewCache(mgr, false)
 	if err != nil {
 		return fmt.Errorf("failed to create cache: %w", err)
 	}

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -35,7 +35,11 @@ func (s *Server) SetRoute(route sandboxroute.Route) sandboxroute.MutationResult 
 	return result
 }
 
-func (s *Server) SyncRouteWithPeers(ctx context.Context, route sandboxroute.Route) error {
+// SyncRouteWithPeers sends a route update to all peer gateways via HTTP POST /refresh.
+// This is a package-level function so it can be called by both proxy.Server
+// (sandbox-manager) and the sandbox-gateway Waker without the gateway needing
+// to create a full proxy.Server instance.
+func SyncRouteWithPeers(ctx context.Context, peersManager peers.Peers, route sandboxroute.Route) error {
 	body, err := json.Marshal(route)
 	if err != nil {
 		return err
@@ -43,8 +47,8 @@ func (s *Server) SyncRouteWithPeers(ctx context.Context, route sandboxroute.Rout
 
 	// Get peers from Peers - no manual locking needed
 	var peerList []peers.Peer
-	if s.peersManager != nil {
-		peerList = s.peersManager.GetPeers()
+	if peersManager != nil {
+		peerList = peersManager.GetPeers()
 	}
 
 	peerCount.Set(float64(len(peerList)))
@@ -73,6 +77,10 @@ func (s *Server) SyncRouteWithPeers(ctx context.Context, route sandboxroute.Rout
 	wg.Wait()
 
 	return errors.Join(peerErrs...)
+}
+
+func (s *Server) SyncRouteWithPeers(ctx context.Context, route sandboxroute.Route) error {
+	return SyncRouteWithPeers(ctx, s.peersManager, route)
 }
 
 func (s *Server) LoadRoute(id string) (sandboxroute.Route, bool) {

--- a/pkg/sandbox-gateway/controller/gateway_controller.go
+++ b/pkg/sandbox-gateway/controller/gateway_controller.go
@@ -33,8 +33,10 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/jwtauth"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/wake"
 	"github.com/openkruise/agents/pkg/sandboxroute"
 )
 
@@ -139,6 +141,20 @@ func StartManager(ctx context.Context, options ManagerOptions) error {
 	if err != nil {
 		return fmt.Errorf("unable to create manager: %w", err)
 	}
+
+	// Create cache provider (reuses sandbox-manager's cache + wait infrastructure).
+	// cache.NewCache calls SetupCacheControllersWithManager which registers
+	// the WaitReconciler on the manager — the same reconciler that processes
+	// wait hooks in the sandbox-manager connect path. This enables
+	// sandboxcr.Sandbox.Resume() to use NewSandboxResumeTask().Wait() from
+	// within the gateway process.
+	cacheProvider, err := cache.NewCache(mgr, true)
+	if err != nil {
+		return fmt.Errorf("unable to create cache provider: %w", err)
+	}
+
+	// Initialize wake waker with the cache provider
+	wake.InitWaker(cacheProvider)
 
 	informer, err := mgr.GetCache().GetInformer(ctx, &agentsv1alpha1.Sandbox{})
 	if err != nil {

--- a/pkg/sandbox-gateway/filter/config.go
+++ b/pkg/sandbox-gateway/filter/config.go
@@ -64,6 +64,13 @@ type Config struct {
 	TrafficAccessTokenHeader string `json:"traffic-access-token-header,omitempty"`
 	// EnableRuntimeMTLS routes requests to the agent-runtime port through the mTLS upstream cluster.
 	EnableRuntimeMTLS bool `json:"enable-runtime-mtls,omitempty"`
+	// EnableWakeOnTraffic enables wake-on-traffic for paused sandboxes.
+	// When true, the gateway will attempt to resume a paused sandbox by
+	// patching Spec.Paused=false when traffic arrives.
+	EnableWakeOnTraffic bool `json:"enable-wake-on-traffic,omitempty"`
+	// WakeTimeoutSeconds is the max time (in seconds) to wait for a sandbox
+	// to resume before returning an error. Defaults to 60.
+	WakeTimeoutSeconds int `json:"wake-timeout-seconds,omitempty"`
 }
 
 // DefaultConfig returns default configuration
@@ -74,6 +81,7 @@ func DefaultConfig() *Config {
 		HostHeaderName:           DefaultHostHeaderName,
 		DefaultPort:              DefaultSandboxPort,
 		TrafficAccessTokenHeader: DefaultTrafficAccessTokenHeader,
+		WakeTimeoutSeconds:       60,
 	}
 }
 
@@ -133,6 +141,14 @@ func (c *Config) GetTrafficAccessTokenHeader() string {
 		return strings.ToLower(c.TrafficAccessTokenHeader)
 	}
 	return DefaultTrafficAccessTokenHeader
+}
+
+// GetWakeTimeoutSeconds returns the wake timeout in seconds, defaulting to 60.
+func (c *Config) GetWakeTimeoutSeconds() int {
+	if c.WakeTimeoutSeconds > 0 {
+		return c.WakeTimeoutSeconds
+	}
+	return 60
 }
 
 // FilterConfig wraps Config and holds the adapter created from the config
@@ -276,6 +292,12 @@ func (p *ConfigParser) Merge(parent interface{}, child interface{}) interface{} 
 	}
 	if childCfg.trafficAccessTokenHeaderExplicit {
 		merged.TrafficAccessTokenHeader = childCfg.TrafficAccessTokenHeader
+	}
+	if childCfg.EnableWakeOnTraffic {
+		merged.EnableWakeOnTraffic = childCfg.EnableWakeOnTraffic
+	}
+	if childCfg.WakeTimeoutSeconds > 0 {
+		merged.WakeTimeoutSeconds = childCfg.WakeTimeoutSeconds
 	}
 
 	jwtAuthManager := parentCfg.jwtAuthManager

--- a/pkg/sandbox-gateway/filter/config.go
+++ b/pkg/sandbox-gateway/filter/config.go
@@ -67,9 +67,15 @@ type Config struct {
 	// EnableWakeOnTraffic enables wake-on-traffic for paused sandboxes.
 	// When true, the gateway will attempt to resume a paused sandbox by
 	// patching Spec.Paused=false when traffic arrives.
+	// Listener-level only: per-route configuration is NOT supported. Merge
+	// only lets an explicit true override the listener value, so a
+	// per-route false cannot disable wake enabled at the listener level.
 	EnableWakeOnTraffic bool `json:"enable-wake-on-traffic,omitempty"`
 	// WakeTimeoutSeconds is the max time (in seconds) to wait for a sandbox
 	// to resume before returning an error. Defaults to 60.
+	// Listener-level only: per-route configuration is NOT supported. Every
+	// parsed config carries the default 60, so any per-route config block
+	// would unintentionally reset a listener-level timeout.
 	WakeTimeoutSeconds int `json:"wake-timeout-seconds,omitempty"`
 }
 
@@ -293,6 +299,9 @@ func (p *ConfigParser) Merge(parent interface{}, child interface{}) interface{} 
 	if childCfg.trafficAccessTokenHeaderExplicit {
 		merged.TrafficAccessTokenHeader = childCfg.TrafficAccessTokenHeader
 	}
+	// Wake-on-traffic is listener-level configuration: per-route overrides
+	// are not supported. Only an explicit true / positive value propagates;
+	// a per-route config can neither disable wake nor reset the timeout.
 	if childCfg.EnableWakeOnTraffic {
 		merged.EnableWakeOnTraffic = childCfg.EnableWakeOnTraffic
 	}

--- a/pkg/sandbox-gateway/filter/config_test.go
+++ b/pkg/sandbox-gateway/filter/config_test.go
@@ -688,3 +688,62 @@ func TestConfigParserMergeJWT(t *testing.T) {
 		t.Error("merged JWT manager was not preserved")
 	}
 }
+
+func TestGetWakeTimeoutSeconds(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want int
+	}{
+		{
+			name: "default config returns 60",
+			cfg:  DefaultConfig(),
+			want: 60,
+		},
+		{
+			name: "custom wake timeout",
+			cfg:  &Config{WakeTimeoutSeconds: 300},
+			want: 300,
+		},
+		{
+			name: "zero returns default 60",
+			cfg:  &Config{},
+			want: 60,
+		},
+		{
+			name: "negative returns default 60",
+			cfg:  &Config{WakeTimeoutSeconds: -1},
+			want: 60,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.GetWakeTimeoutSeconds()
+			if got != tt.want {
+				t.Errorf("GetWakeTimeoutSeconds() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeWakeOnTraffic(t *testing.T) {
+	parser := &ConfigParser{}
+	parent := DefaultConfig()
+	child := &Config{
+		EnableWakeOnTraffic: true,
+		WakeTimeoutSeconds:  120,
+	}
+
+	result := parser.Merge(NewFilterConfig(parent), NewFilterConfig(child))
+	fc, ok := result.(*FilterConfig)
+	if !ok {
+		t.Fatalf("Merge() returned %T, want *FilterConfig", result)
+	}
+	if !fc.EnableWakeOnTraffic {
+		t.Error("Merge() did not propagate EnableWakeOnTraffic from child")
+	}
+	if fc.WakeTimeoutSeconds != 120 {
+		t.Errorf("WakeTimeoutSeconds = %d, want 120", fc.WakeTimeoutSeconds)
+	}
+}

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -292,7 +292,8 @@ func (f *sandboxFilter) verifierUnavailable(sandboxID string) api.StatusType {
 // shouldWakeSandbox determines whether a non-Running sandbox should be woken
 // by traffic. Returns true only when wake-on-traffic is enabled, the sandbox
 // is Paused, the waker is initialized, the route carries a full ObjectKey,
-// and either the route registry already has WakeOnTraffic set or the
+// the informer still holds a sandbox with the route's UID (stale-route
+// fence), and either the route registry already has WakeOnTraffic set or the
 // annotation fallback check succeeds.
 func (f *sandboxFilter) shouldWakeSandbox(route sandboxroute.Route, waker *wake.Waker) bool {
 	if route.State != agentsv1alpha1.SandboxStatePaused {
@@ -306,6 +307,19 @@ func (f *sandboxFilter) shouldWakeSandbox(route sandboxroute.Route, waker *wake.
 	}
 	key, ok := route.ObjectKey()
 	if !ok {
+		return false
+	}
+	// UID fence: the route registry can lag behind deletions, so the route
+	// may reference a sandbox that was deleted and recreated under the same
+	// name. The request was authenticated against the route's identity, so a
+	// stale route must neither wake the new object nor inherit its wake
+	// configuration. Verify the informer still holds the exact object.
+	if !waker.SandboxUIDMatches(context.Background(), key.Namespace, key.Name, route.UID) {
+		logger.Warn("Stale wake route: sandbox UID mismatch or object gone",
+			zap.String("sandboxID", route.ID),
+			zap.String("namespace", key.Namespace),
+			zap.String("name", key.Name),
+			zap.String("routeUID", string(route.UID)))
 		return false
 	}
 	// route.WakeOnTraffic is the primary check (fast, from registry).

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -17,8 +17,13 @@ limitations under the License.
 package filter
 
 import (
+	"context"
 	"crypto/subtle"
+	"errors"
 	"fmt"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
 	"go.uber.org/zap"
@@ -26,6 +31,7 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/wake"
 	"github.com/openkruise/agents/pkg/sandboxroute"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 	"github.com/openkruise/agents/pkg/utils"
@@ -48,6 +54,12 @@ const (
 	runtimeMTLSMetadataKey       = "upstream-mtls"
 )
 
+// Compile-time assertion that sandboxFilter implements the api.StreamFilter interface.
+// This catches mismatches like implementing Destroy() (Config interface) instead of
+// OnDestroy(DestroyReason) (StreamFilter interface).
+var _ api.StreamFilter = (*sandboxFilter)(nil)
+
+// FilterFactory creates a new sandbox filter instance for each stream.
 func FilterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
 	cfg := c.(*FilterConfig)
 	return &sandboxFilter{
@@ -64,6 +76,13 @@ type sandboxFilter struct {
 	config         *Config
 	adapter        *adapters.E2BAdapter
 	jwtAuthManager JWTAuthManager
+
+	// Async wake completion state. Protected by mu.
+	mu         sync.Mutex
+	completing bool // wakeAndContinue is setting metadata
+	completed  bool // Continue or SendLocalReply already called
+	destroyed  bool // Envoy destroyed the filter (stream gone)
+	cancel     context.CancelFunc
 }
 
 func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream bool) api.StatusType {
@@ -87,8 +106,9 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 		return api.Continue
 	}
 
-	logger.Debug("DecodeHeaders: adapter mapped request",
-		zap.String("sandboxID", sandboxID),
+	log := logger.With(zap.String("sandboxID", sandboxID))
+
+	log.Debug("DecodeHeaders: adapter mapped request",
 		zap.Int("sandboxPort", sandboxPort),
 		zap.Any("extraHeaders", extraHeaders))
 
@@ -111,7 +131,7 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 	}
 	route, ok := routeRegistry.Get(sandboxID)
 	if !ok {
-		logger.Warn("Sandbox not found in registry", zap.String("sandboxID", sandboxID))
+		log.Warn("Sandbox not found in registry")
 		f.callbacks.DecoderFilterCallbacks().SendLocalReply(
 			502,
 			"sandbox not found: "+sandboxID,
@@ -122,8 +142,34 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 		return api.LocalReply
 	}
 
+	// Authenticate the request before any state/wake handling so that
+	// paused sandboxes are not woken by unauthorized requests.
+	if status := f.authenticate(header, route); status != api.Continue {
+		return status
+	}
+
 	if route.State != agentsv1alpha1.SandboxStateRunning {
-		logger.Warn("Sandbox is not running", zap.String("sandboxID", sandboxID), zap.String("state", route.State))
+		waker := wake.GetWaker()
+		if f.shouldWakeSandbox(route, waker) {
+			// Apply extra headers before returning Running so they
+			// are visible to subsequent filter phases.
+			for k, v := range extraHeaders {
+				header.Set(k, v)
+			}
+			// Launch async wake with a detached context. The filter
+			// returns Running to tell Envoy to suspend request
+			// processing. wakeAndContinue will call Continue or
+			// SendLocalReply when the wake completes.
+			waitTimeout := time.Duration(f.config.GetWakeTimeoutSeconds()) * time.Second
+			ctx, cancel := context.WithTimeout(context.Background(), waitTimeout)
+			f.mu.Lock()
+			f.cancel = cancel
+			f.mu.Unlock()
+			go f.wakeAndContinue(ctx, waker, route.Namespace, route.Name, sandboxID, sandboxPort, waitTimeout)
+			return api.Running
+		}
+		// Not running and not wakeable -> 502 (existing behavior)
+		log.Warn("Sandbox is not running", zap.String("state", route.State))
 		f.callbacks.DecoderFilterCallbacks().SendLocalReply(
 			502,
 			"healthy sandbox not found: "+sandboxID,
@@ -132,10 +178,6 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 			"sandbox_not_running",
 		)
 		return api.LocalReply
-	}
-
-	if status := f.authenticate(header, route); status != api.Continue {
-		return status
 	}
 
 	// Apply extra headers from the adapter (e.g., :path rewrite for kruise custom protocol)
@@ -150,7 +192,7 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 		f.callbacks.ClearRouteCache()
 	}
 
-	logger.Debug("Upstream override set successfully", zap.String("upstreamHost", upstreamHost))
+	log.Debug("Upstream override set successfully", zap.String("upstreamHost", upstreamHost))
 	return api.Continue
 }
 
@@ -233,4 +275,205 @@ func (f *sandboxFilter) verifierUnavailable(sandboxID string) api.StatusType {
 		"jwt_verifier_not_ready",
 	)
 	return api.LocalReply
+}
+
+// shouldWakeSandbox determines whether a non-Running sandbox should be woken
+// by traffic. Returns true only when wake-on-traffic is enabled, the sandbox
+// is Paused, the waker is initialized, the route carries a full ObjectKey,
+// and either the route registry already has WakeOnTraffic set or the
+// annotation fallback check succeeds.
+func (f *sandboxFilter) shouldWakeSandbox(route sandboxroute.Route, waker *wake.Waker) bool {
+	if route.State != agentsv1alpha1.SandboxStatePaused {
+		return false
+	}
+	if !f.config.EnableWakeOnTraffic {
+		return false
+	}
+	if waker == nil {
+		return false
+	}
+	key, ok := route.ObjectKey()
+	if !ok {
+		return false
+	}
+	// route.WakeOnTraffic is the primary check (fast, from registry).
+	if route.WakeOnTraffic {
+		return true
+	}
+	// HasWakeAnnotation is a fallback that reads the informer cache
+	// directly, covering the window between kubectl annotate and the
+	// gateway controller reconciling the change into the route registry.
+	return waker.HasWakeAnnotation(context.Background(), key.Namespace, key.Name)
+}
+
+// wakeAndContinue runs the wake operation asynchronously. On success it sets
+// upstream metadata and calls Continue; on failure it sends a LocalReply.
+// This method is launched as a goroutine from DecodeHeaders after returning
+// api.Running.
+func (f *sandboxFilter) wakeAndContinue(
+	ctx context.Context,
+	waker *wake.Waker,
+	namespace, name, sandboxID string,
+	sandboxPort int,
+	waitTimeout time.Duration,
+) {
+	log := logger.With(zap.String("sandboxID", sandboxID))
+
+	defer func() {
+		if r := recover(); r != nil {
+			if isEnvoyStreamGonePanic(r) {
+				return
+			}
+			log.Error("panic during async wake", zap.Any("recover", r))
+			f.sendLocalReplyOnce(500, "wake failed", "wake_panic")
+		}
+	}()
+
+	err := waker.Wake(ctx, namespace, name, waitTimeout)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			// Filter was destroyed; do nothing.
+			return
+		}
+		log.Warn("Sandbox wake failed", zap.Error(err))
+		f.sendLocalReplyOnce(503, "sandbox wake failed: "+err.Error(), "sandbox_wake_failed")
+		return
+	}
+
+	// Wake succeeded — verify the sandbox is now Running in the registry.
+	route, ok := registry.GetRegistry().Get(sandboxID)
+	if !ok || route.State != agentsv1alpha1.SandboxStateRunning {
+		log.Warn("Sandbox not running after wake")
+		f.sendLocalReplyOnce(502, "healthy sandbox not found: "+sandboxID, "sandbox_not_running")
+		return
+	}
+
+	log.Info("Sandbox woken successfully")
+	f.completeWithContinue(route, sandboxPort)
+}
+
+// sendLocalReplyOnce sends a LocalReply, but only if no other completion
+// action has been taken. This prevents double-reply when the async goroutine
+// and Destroy race.
+func (f *sandboxFilter) sendLocalReplyOnce(code int, body string, details string) {
+	if !f.claimCompletion() {
+		return
+	}
+	f.callbacks.DecoderFilterCallbacks().SendLocalReply(code, body, nil, -1, details)
+}
+
+// completeWithContinue sets upstream metadata and calls Continue to resume
+// Envoy request processing after a successful async wake.
+func (f *sandboxFilter) completeWithContinue(route sandboxroute.Route, sandboxPort int) {
+	if !f.beginCompletion() {
+		return
+	}
+
+	// Set upstream metadata. This may panic if Envoy has already destroyed
+	// the stream, so we recover and abort.
+	if !f.setUpstreamMetadata(route, sandboxPort) {
+		return
+	}
+
+	if !f.claimPreparedCompletion() {
+		return
+	}
+	f.callbacks.DecoderFilterCallbacks().Continue(api.Continue)
+}
+
+// setUpstreamMetadata sets the envoy.lb.original_dst dynamic metadata.
+// Returns false if the stream was destroyed during the call.
+func (f *sandboxFilter) setUpstreamMetadata(route sandboxroute.Route, sandboxPort int) (ok bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			if isEnvoyStreamGonePanic(r) {
+				f.abortCompletion(true)
+				ok = false
+				return
+			}
+			logger.Error("panic before async wake continue",
+				zap.String("sandboxID", route.ID), zap.Any("recover", r))
+			if f.abortCompletion(false) {
+				f.sendLocalReplyOnce(500, "wake failed", "wake_panic")
+			}
+			ok = false
+		}
+	}()
+	upstreamHost := fmt.Sprintf("%s:%d", route.IP, sandboxPort)
+	f.callbacks.StreamInfo().DynamicMetadata().Set("envoy.lb.original_dst", "host", upstreamHost)
+	logger.Debug("Upstream override set successfully (async)", zap.String("upstreamHost", upstreamHost))
+	return true
+}
+
+// beginCompletion marks the start of the completion phase.
+// Returns false if the filter is already completed or destroyed.
+func (f *sandboxFilter) beginCompletion() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.destroyed || f.completed || f.completing {
+		return false
+	}
+	f.completing = true
+	return true
+}
+
+// claimPreparedCompletion transitions from completing to completed.
+// Returns false if the filter was destroyed or completed in the meantime.
+func (f *sandboxFilter) claimPreparedCompletion() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.destroyed || f.completed || !f.completing {
+		f.completing = false
+		return false
+	}
+	f.completing = false
+	f.completed = true
+	return true
+}
+
+// claimCompletion atomically marks the filter as completed.
+// Returns false if already completed or destroyed.
+func (f *sandboxFilter) claimCompletion() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.destroyed || f.completed || f.completing {
+		return false
+	}
+	f.completed = true
+	return true
+}
+
+// abortCompletion resets the completing flag. If markDestroyed is true,
+// also marks the filter as destroyed.
+func (f *sandboxFilter) abortCompletion(markDestroyed bool) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.completing = false
+	if markDestroyed {
+		f.destroyed = true
+	}
+	return !f.destroyed && !f.completed
+}
+
+// OnDestroy cancels any in-flight async wake context. Called by Envoy when
+// the filter/stream is destroyed (e.g., stream reset, connection close).
+func (f *sandboxFilter) OnDestroy(reason api.DestroyReason) {
+	f.mu.Lock()
+	cancel := f.cancel
+	f.destroyed = true
+	f.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// isEnvoyStreamGonePanic checks if the recovered value is a known Envoy
+// panic indicating the stream has been finished or the filter destroyed.
+func isEnvoyStreamGonePanic(recovered interface{}) bool {
+	message, ok := recovered.(string)
+	if !ok {
+		return false
+	}
+	return strings.Contains(message, "request has been finished") ||
+		strings.Contains(message, "golang filter has been destroyed")
 }

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -160,6 +160,9 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 			// returns Running to tell Envoy to suspend request
 			// processing. wakeAndContinue will call Continue or
 			// SendLocalReply when the wake completes.
+			//
+			// This context carries the sole wake deadline; Wake receives
+			// waitTimeout only as the annotation-fallback default.
 			waitTimeout := time.Duration(f.config.GetWakeTimeoutSeconds()) * time.Second
 			ctx, cancel := context.WithTimeout(context.Background(), waitTimeout)
 			f.mu.Lock()

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -345,7 +345,10 @@ func (f *sandboxFilter) wakeAndContinue(
 			return
 		}
 		log.Warn("Sandbox wake failed", zap.Error(err))
-		f.sendLocalReplyOnce(503, "sandbox wake failed: "+err.Error(), "sandbox_wake_failed")
+		// Keep the reply body generic: err can carry Kubernetes API error
+		// strings (namespaces, names, conflict details) that must not be
+		// echoed to external callers. The detail is logged above.
+		f.sendLocalReplyOnce(503, "sandbox wake failed", "sandbox_wake_failed")
 		return
 	}
 

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -185,15 +185,24 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 		header.Set(k, v)
 	}
 
+	f.applyUpstreamOverrides(route, sandboxPort)
+	return api.Continue
+}
+
+// applyUpstreamOverrides routes the request to the sandbox upstream: it sets
+// the envoy.lb.original_dst override and, for runtime-port traffic when
+// runtime mTLS is enabled, selects the mTLS upstream cluster and re-resolves
+// the route. The normal Running path and the async wake completion path must
+// apply identical overrides so a request that triggered a wake continues
+// exactly like a request that arrived on a Running sandbox.
+func (f *sandboxFilter) applyUpstreamOverrides(route sandboxroute.Route, sandboxPort int) {
 	upstreamHost := fmt.Sprintf("%s:%d", route.IP, sandboxPort)
 	f.callbacks.StreamInfo().DynamicMetadata().Set("envoy.lb.original_dst", "host", upstreamHost)
 	if f.config.EnableRuntimeMTLS && sandboxPort == utils.RuntimePort {
 		f.callbacks.StreamInfo().DynamicMetadata().Set(runtimeMTLSMetadataNamespace, runtimeMTLSMetadataKey, true)
 		f.callbacks.ClearRouteCache()
 	}
-
-	log.Debug("Upstream override set successfully", zap.String("upstreamHost", upstreamHost))
-	return api.Continue
+	logger.Debug("Upstream override set successfully", zap.String("upstreamHost", upstreamHost))
 }
 
 func (f *sandboxFilter) authenticate(header api.RequestHeaderMap, route sandboxroute.Route) api.StatusType {
@@ -381,8 +390,9 @@ func (f *sandboxFilter) completeWithContinue(route sandboxroute.Route, sandboxPo
 	f.callbacks.DecoderFilterCallbacks().Continue(api.Continue)
 }
 
-// setUpstreamMetadata sets the envoy.lb.original_dst dynamic metadata.
-// Returns false if the stream was destroyed during the call.
+// setUpstreamMetadata applies the upstream overrides (original_dst and, when
+// applicable, the runtime mTLS selection) for a request resumed after an
+// async wake. Returns false if the stream was destroyed during the call.
 func (f *sandboxFilter) setUpstreamMetadata(route sandboxroute.Route, sandboxPort int) (ok bool) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -399,9 +409,7 @@ func (f *sandboxFilter) setUpstreamMetadata(route sandboxroute.Route, sandboxPor
 			ok = false
 		}
 	}()
-	upstreamHost := fmt.Sprintf("%s:%d", route.IP, sandboxPort)
-	f.callbacks.StreamInfo().DynamicMetadata().Set("envoy.lb.original_dst", "host", upstreamHost)
-	logger.Debug("Upstream override set successfully (async)", zap.String("upstreamHost", upstreamHost))
+	f.applyUpstreamOverrides(route, sandboxPort)
 	return true
 }
 

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -1304,6 +1304,9 @@ func TestDecodeHeadersWakeOnTrafficCacheFallback(t *testing.T) {
 	assert.True(t, mockCallbacks.decoderCallbacks.sendLocalReplyCalled)
 	assert.Equal(t, 503, mockCallbacks.decoderCallbacks.replyStatusCode)
 	assert.Equal(t, "sandbox_wake_failed", mockCallbacks.decoderCallbacks.replyDetails)
+	// The body must stay generic: Kubernetes API error details must not be
+	// echoed to external callers.
+	assert.Equal(t, "sandbox wake failed", mockCallbacks.decoderCallbacks.replyBody)
 }
 
 // TestDecodeHeadersWakeOnTrafficCacheFallbackNoAnnotation verifies that when

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -978,9 +978,15 @@ func TestDecodeHeadersWakeOnTrafficRouteNotEnabled(t *testing.T) {
 		WakeOnTraffic: false,
 	})
 
-	// No wake annotation in the cache, so the fallback also fails.
+	// No wake annotation in the cache, so the fallback also fails. The UID
+	// matches putTestRoute's default ("test-"+id) so the stale-route fence
+	// passes and the test exercises the annotation branch.
 	cacheProvider, _, err := cachetest.NewTestCache(t, &agentsv1alpha1.Sandbox{
-		ObjectMeta: metav1.ObjectMeta{Name: "paused-sbx", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "paused-sbx",
+			Namespace: "default",
+			UID:       types.UID("test-default--paused-sbx"),
+		},
 	})
 	require.NoError(t, err)
 	wake.InitWaker(cacheProvider)
@@ -1253,11 +1259,14 @@ func TestDecodeHeadersWakeOnTrafficCacheFallback(t *testing.T) {
 		WakeOnTraffic: false,
 	})
 
-	// Create sandbox with wake annotation in the informer cache
+	// Create sandbox with wake annotation in the informer cache. The UID
+	// matches putTestRoute's default ("test-"+id) so the stale-route fence
+	// passes.
 	sbx := &agentsv1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cache-fallback",
 			Namespace: "default",
+			UID:       types.UID("test-default--cache-fallback"),
 			Annotations: map[string]string{
 				agentsv1alpha1.AnnotationWakeOnTraffic: agentsv1alpha1.True,
 			},
@@ -1322,11 +1331,14 @@ func TestDecodeHeadersWakeOnTrafficCacheFallbackNoAnnotation(t *testing.T) {
 		WakeOnTraffic: false,
 	})
 
-	// Create sandbox WITHOUT wake annotation in the informer cache
+	// Create sandbox WITHOUT wake annotation in the informer cache. The UID
+	// matches putTestRoute's default ("test-"+id) so the stale-route fence
+	// passes and the test exercises the annotation branch.
 	sbx := &agentsv1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "no-annot-fallback",
 			Namespace: "default",
+			UID:       types.UID("test-default--no-annot-fallback"),
 		},
 	}
 	cacheProvider, _, err := cachetest.NewTestCache(t, sbx)
@@ -1454,11 +1466,13 @@ func TestOnDestroyCancelsContext(t *testing.T) {
 func TestWakeAndContinueSuccess(t *testing.T) {
 	r := useTestRegistry(t)
 
-	// Add paused route to registry (wake-on-traffic enabled)
+	// Add paused route to registry (wake-on-traffic enabled). The explicit
+	// UID matches the sandbox below so the stale-route fence passes.
 	putTestRoute(t, r, "default--async-success", sandboxroute.Route{
 		IP:            "10.0.0.1",
 		Namespace:     "default",
 		Name:          "async-success",
+		UID:           types.UID("uid-async-success"),
 		State:         agentsv1alpha1.SandboxStatePaused,
 		WakeOnTraffic: true,
 	})
@@ -1574,12 +1588,21 @@ func TestWakeAndContinueSuccess(t *testing.T) {
 	assert.Equal(t, 1, mockCallbacks.clearRouteCalls)
 }
 
-// TestShouldWakeSandbox tests the pure branches of shouldWakeSandbox that
-// do not require a real cache provider.
+// TestShouldWakeSandbox tests the branches of shouldWakeSandbox that do not
+// require a real sandbox route registry.
 func TestShouldWakeSandbox(t *testing.T) {
-	// Initialize a waker backed by an empty cache; the cases below return
-	// before reaching HasWakeAnnotation.
-	cacheProvider, _, err := cachetest.NewTestCache(t)
+	// Initialize a waker backed by a cache holding the sandbox the valid
+	// routes below point at; the UID fence compares the route UID against
+	// this object.
+	sbxUID := types.UID("sbx-uid")
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sbx",
+			Namespace: "default",
+			UID:       sbxUID,
+		},
+	}
+	cacheProvider, _, err := cachetest.NewTestCache(t, sbx)
 	require.NoError(t, err)
 	wake.InitWaker(cacheProvider)
 	t.Cleanup(func() { wake.InitWaker(nil) })
@@ -1587,6 +1610,7 @@ func TestShouldWakeSandbox(t *testing.T) {
 	pausedRoute := sandboxroute.Route{
 		Namespace:     "default",
 		Name:          "sbx",
+		UID:           sbxUID,
 		State:         agentsv1alpha1.SandboxStatePaused,
 		WakeOnTraffic: true,
 	}
@@ -1641,6 +1665,48 @@ func TestShouldWakeSandbox(t *testing.T) {
 			waker:      waker,
 			want:       true,
 		},
+		{
+			// Sandbox A was deleted and recreated under the same name:
+			// the registry still holds A's route (UID, WakeOnTraffic),
+			// but the informer now holds B. The stale route must not
+			// wake B.
+			name: "stale route with mismatched UID returns false",
+			route: sandboxroute.Route{
+				Namespace:     "default",
+				Name:          "sbx",
+				UID:           types.UID("deleted-sandbox-uid"),
+				State:         agentsv1alpha1.SandboxStatePaused,
+				WakeOnTraffic: true,
+			},
+			enableWake: true,
+			waker:      waker,
+			want:       false,
+		},
+		{
+			name: "route pointing at absent sandbox returns false",
+			route: sandboxroute.Route{
+				Namespace:     "default",
+				Name:          "gone",
+				UID:           types.UID("gone-uid"),
+				State:         agentsv1alpha1.SandboxStatePaused,
+				WakeOnTraffic: true,
+			},
+			enableWake: true,
+			waker:      waker,
+			want:       false,
+		},
+		{
+			name: "route with empty UID returns false",
+			route: sandboxroute.Route{
+				Namespace:     "default",
+				Name:          "sbx",
+				State:         agentsv1alpha1.SandboxStatePaused,
+				WakeOnTraffic: true,
+			},
+			enableWake: true,
+			waker:      waker,
+			want:       false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1665,6 +1731,7 @@ func TestShouldWakeSandboxAnnotationFallback(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "with-annot",
 				Namespace: "default",
+				UID:       types.UID("with-annot-uid"),
 				Annotations: map[string]string{
 					agentsv1alpha1.AnnotationWakeOnTraffic: agentsv1alpha1.True,
 				},
@@ -1679,6 +1746,7 @@ func TestShouldWakeSandboxAnnotationFallback(t *testing.T) {
 		route := sandboxroute.Route{
 			Namespace:     "default",
 			Name:          "with-annot",
+			UID:           types.UID("with-annot-uid"),
 			State:         agentsv1alpha1.SandboxStatePaused,
 			WakeOnTraffic: false, // Force annotation fallback
 		}
@@ -1691,6 +1759,7 @@ func TestShouldWakeSandboxAnnotationFallback(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "no-annot",
 				Namespace: "default",
+				UID:       types.UID("no-annot-uid"),
 			},
 		}
 		cacheProvider, _, err := cachetest.NewTestCache(t, sbx)
@@ -1702,6 +1771,39 @@ func TestShouldWakeSandboxAnnotationFallback(t *testing.T) {
 		route := sandboxroute.Route{
 			Namespace:     "default",
 			Name:          "no-annot",
+			UID:           types.UID("no-annot-uid"),
+			State:         agentsv1alpha1.SandboxStatePaused,
+			WakeOnTraffic: false, // Force annotation fallback
+		}
+		f := &sandboxFilter{config: cfg}
+		assert.False(t, f.shouldWakeSandbox(route, wake.GetWaker()))
+	})
+
+	t.Run("annotation present but stale route UID returns false", func(t *testing.T) {
+		// The recreated sandbox B carries the wake annotation, but the
+		// route still references deleted sandbox A's UID. The UID fence
+		// must reject the wake even though the annotation check would
+		// pass.
+		sbx := &agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "recreated",
+				Namespace: "default",
+				UID:       types.UID("new-sandbox-uid"),
+				Annotations: map[string]string{
+					agentsv1alpha1.AnnotationWakeOnTraffic: agentsv1alpha1.True,
+				},
+			},
+		}
+		cacheProvider, _, err := cachetest.NewTestCache(t, sbx)
+		require.NoError(t, err)
+
+		wake.InitWaker(cacheProvider)
+		t.Cleanup(func() { wake.InitWaker(nil) })
+
+		route := sandboxroute.Route{
+			Namespace:     "default",
+			Name:          "recreated",
+			UID:           types.UID("deleted-sandbox-uid"),
 			State:         agentsv1alpha1.SandboxStatePaused,
 			WakeOnTraffic: false, // Force annotation fallback
 		}

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -1525,6 +1525,10 @@ func TestWakeAndContinueSuccess(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.EnableWakeOnTraffic = true
 	cfg.WakeTimeoutSeconds = 30
+	// The wake request targets the runtime port, so with runtime mTLS
+	// enabled the resumed request must take the same mTLS path a normal
+	// Running request would.
+	cfg.EnableRuntimeMTLS = true
 
 	done := make(chan struct{}, 1)
 	mockCallbacks := &mockFilterCallbackHandler{
@@ -1558,6 +1562,13 @@ func TestWakeAndContinueSuccess(t *testing.T) {
 	metadata := mockCallbacks.streamInfo.dynamicMetadata.data["envoy.lb.original_dst"]
 	assert.NotNil(t, metadata)
 	assert.Equal(t, "10.0.0.1:49983", metadata["host"])
+
+	// Verify the resumed request takes the runtime mTLS path like a
+	// normal Running request: mTLS dynamic metadata set and route cache
+	// cleared.
+	mtlsMetadata := mockCallbacks.streamInfo.dynamicMetadata.data[runtimeMTLSMetadataNamespace]
+	assert.Equal(t, true, mtlsMetadata[runtimeMTLSMetadataKey])
+	assert.Equal(t, 1, mockCallbacks.clearRouteCalls)
 }
 
 // TestShouldWakeSandbox tests the pure branches of shouldWakeSandbox that

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -17,18 +17,24 @@ limitations under the License.
 package filter
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/cache/cachetest"
 	"github.com/openkruise/agents/pkg/identity/oidc"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/wake"
 	"github.com/openkruise/agents/pkg/sandboxroute"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 )
@@ -352,15 +358,37 @@ type mockDecoderFilterCallbacks struct {
 	replyStatusCode      int
 	replyBody            string
 	replyDetails         string
+
+	continueCalled bool
+	continueStatus api.StatusType
+
+	// done is signalled when Continue or SendLocalReply is called,
+	// allowing tests to synchronize with async wake goroutines.
+	done chan struct{}
 }
 
-func (m *mockDecoderFilterCallbacks) Continue(statusType api.StatusType) {}
+func (m *mockDecoderFilterCallbacks) Continue(statusType api.StatusType) {
+	m.continueCalled = true
+	m.continueStatus = statusType
+	if m.done != nil {
+		select {
+		case m.done <- struct{}{}:
+		default:
+		}
+	}
+}
 
 func (m *mockDecoderFilterCallbacks) SendLocalReply(responseCode int, bodyText string, headers map[string][]string, grpcStatus int64, details string) {
 	m.sendLocalReplyCalled = true
 	m.replyStatusCode = responseCode
 	m.replyBody = bodyText
 	m.replyDetails = details
+	if m.done != nil {
+		select {
+		case m.done <- struct{}{}:
+		default:
+		}
+	}
 }
 
 func (m *mockDecoderFilterCallbacks) RecoverPanic() {}
@@ -913,6 +941,118 @@ func TestDecodeHeadersAccessTokenAuth(t *testing.T) {
 	}
 }
 
+// TestDecodeHeadersWakeOnTrafficDisabled verifies that when EnableWakeOnTraffic
+// is false, a paused sandbox with WakeOnTraffic=true is NOT woken and returns 502.
+func TestDecodeHeadersWakeOnTrafficDisabled(t *testing.T) {
+	r := useTestRegistry(t)
+	putTestRoute(t, r, "default--paused-sbx", sandboxroute.Route{
+		IP:            "10.0.0.1",
+		Namespace:     "default",
+		Name:          "paused-sbx",
+		State:         agentsv1alpha1.SandboxStatePaused,
+		WakeOnTraffic: true,
+	})
+
+	cfg := DefaultConfig()
+	// EnableWakeOnTraffic is false by default
+	filter, mockCallbacks := newTestFilter(cfg)
+
+	status := filter.DecodeHeaders(newSandboxHeader("default--paused-sbx"), true)
+
+	assert.Equal(t, api.LocalReply, status)
+	assert.True(t, mockCallbacks.decoderCallbacks.sendLocalReplyCalled)
+	assert.Equal(t, 502, mockCallbacks.decoderCallbacks.replyStatusCode)
+	assert.Equal(t, "sandbox_not_running", mockCallbacks.decoderCallbacks.replyDetails)
+}
+
+// TestDecodeHeadersWakeOnTrafficRouteNotEnabled verifies that when the route's
+// WakeOnTraffic flag is false and no wake annotation exists in the cache, a
+// paused sandbox is NOT woken even if the filter has EnableWakeOnTraffic=true.
+func TestDecodeHeadersWakeOnTrafficRouteNotEnabled(t *testing.T) {
+	r := useTestRegistry(t)
+	putTestRoute(t, r, "default--paused-sbx", sandboxroute.Route{
+		IP:            "10.0.0.1",
+		Namespace:     "default",
+		Name:          "paused-sbx",
+		State:         agentsv1alpha1.SandboxStatePaused,
+		WakeOnTraffic: false,
+	})
+
+	// No wake annotation in the cache, so the fallback also fails.
+	cacheProvider, _, err := cachetest.NewTestCache(t, &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "paused-sbx", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	wake.InitWaker(cacheProvider)
+	t.Cleanup(func() { wake.InitWaker(nil) })
+
+	cfg := DefaultConfig()
+	cfg.EnableWakeOnTraffic = true
+	filter, mockCallbacks := newTestFilter(cfg)
+
+	status := filter.DecodeHeaders(newSandboxHeader("default--paused-sbx"), true)
+
+	assert.Equal(t, api.LocalReply, status)
+	assert.Equal(t, 502, mockCallbacks.decoderCallbacks.replyStatusCode)
+	assert.Equal(t, "sandbox_not_running", mockCallbacks.decoderCallbacks.replyDetails)
+}
+
+// TestDecodeHeadersWakeOnTrafficNoWaker verifies that when EnableWakeOnTraffic
+// is true and the route has WakeOnTraffic=true but the waker is nil (not
+// initialized), the filter falls through to the 502 "not running" path.
+func TestDecodeHeadersWakeOnTrafficNoWaker(t *testing.T) {
+	wake.InitWaker(nil)
+	t.Cleanup(func() { wake.InitWaker(nil) })
+
+	r := useTestRegistry(t)
+	putTestRoute(t, r, "default--paused-sbx", sandboxroute.Route{
+		IP:            "10.0.0.1",
+		Namespace:     "default",
+		Name:          "paused-sbx",
+		State:         agentsv1alpha1.SandboxStatePaused,
+		WakeOnTraffic: true,
+	})
+
+	cfg := DefaultConfig()
+	cfg.EnableWakeOnTraffic = true
+	cfg.WakeTimeoutSeconds = 30
+	filter, mockCallbacks := newTestFilter(cfg)
+
+	// Waker is nil (default state when InitWaker hasn't been called)
+	status := filter.DecodeHeaders(newSandboxHeader("default--paused-sbx"), true)
+
+	assert.Equal(t, api.LocalReply, status)
+	assert.Equal(t, 502, mockCallbacks.decoderCallbacks.replyStatusCode)
+	assert.Equal(t, "sandbox_not_running", mockCallbacks.decoderCallbacks.replyDetails)
+}
+
+// TestDecodeHeadersWakeOnTrafficPausedWithRunning verifies that a running sandbox
+// with WakeOnTraffic=true passes through without attempting wake.
+func TestDecodeHeadersWakeOnTrafficPausedWithRunning(t *testing.T) {
+	r := useTestRegistry(t)
+	putTestRoute(t, r, "default--running-wakeable", sandboxroute.Route{
+		IP:            "10.0.0.5",
+		Namespace:     "default",
+		Name:          "running-wakeable",
+		State:         agentsv1alpha1.SandboxStateRunning,
+		WakeOnTraffic: true,
+	})
+
+	cfg := DefaultConfig()
+	cfg.EnableWakeOnTraffic = true
+	filter, mockCallbacks := newTestFilter(cfg)
+
+	status := filter.DecodeHeaders(newSandboxHeader("default--running-wakeable"), true)
+
+	// Already running → no wake attempt, continue
+	assert.Equal(t, api.Continue, status)
+	assert.False(t, mockCallbacks.decoderCallbacks.sendLocalReplyCalled)
+
+	metadata := mockCallbacks.streamInfo.dynamicMetadata.data["envoy.lb.original_dst"]
+	assert.NotNil(t, metadata)
+	assert.Equal(t, "10.0.0.5:49983", metadata["host"])
+}
+
 func TestDecodeHeadersJWTAuthentication(t *testing.T) {
 	const (
 		sandboxID  = "default--jwt-sandbox"
@@ -1095,4 +1235,463 @@ func TestDecodeHeadersRequiredJWTWithoutJWTMode(t *testing.T) {
 			assert.Equal(t, "jwt_verifier_not_ready", callbacks.decoderCallbacks.replyDetails)
 		})
 	}
+}
+
+// TestDecodeHeadersWakeOnTrafficCacheFallback verifies that when
+// route.WakeOnTraffic is false (registry not yet synced) but the informer
+// cache has the wake-on-traffic annotation, the filter still attempts wake
+// asynchronously. Returns api.Running, and the goroutine sends 503 on
+// wake failure.
+func TestDecodeHeadersWakeOnTrafficCacheFallback(t *testing.T) {
+	r := useTestRegistry(t)
+	// Registry has WakeOnTraffic=false (simulating sync delay)
+	putTestRoute(t, r, "default--cache-fallback", sandboxroute.Route{
+		IP:            "10.0.0.1",
+		Namespace:     "default",
+		Name:          "cache-fallback",
+		State:         agentsv1alpha1.SandboxStatePaused,
+		WakeOnTraffic: false,
+	})
+
+	// Create sandbox with wake annotation in the informer cache
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cache-fallback",
+			Namespace: "default",
+			Annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: agentsv1alpha1.True,
+			},
+		},
+	}
+	cacheProvider, _, err := cachetest.NewTestCache(t, sbx)
+	if err != nil {
+		t.Fatalf("failed to create test cache: %v", err)
+	}
+
+	// Initialize the package-level waker with the test cache
+	wake.InitWaker(cacheProvider)
+	t.Cleanup(func() {
+		wake.InitWaker(nil)
+	})
+
+	cfg := DefaultConfig()
+	cfg.EnableWakeOnTraffic = true
+	cfg.WakeTimeoutSeconds = 5
+	done := make(chan struct{}, 1)
+	mockCallbacks := &mockFilterCallbackHandler{
+		streamInfo:       newMockStreamInfo(),
+		decoderCallbacks: &mockDecoderFilterCallbacks{done: done},
+	}
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: cfg, adapter: defaultTestAdapter()}
+
+	header := newMockRequestHeaderMap()
+	header.Set(DefaultSandboxHeaderName, "default--cache-fallback")
+
+	status := filter.DecodeHeaders(header, true)
+
+	// DecodeHeaders should return Running (async wake in progress).
+	assert.Equal(t, api.Running, status)
+
+	// Wait for the async goroutine to complete.
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for async wake completion")
+	}
+
+	// The filter should have sent a 503 (wake failed) because the sandbox
+	// is not actually resumable in this test setup.
+	assert.True(t, mockCallbacks.decoderCallbacks.sendLocalReplyCalled)
+	assert.Equal(t, 503, mockCallbacks.decoderCallbacks.replyStatusCode)
+	assert.Equal(t, "sandbox_wake_failed", mockCallbacks.decoderCallbacks.replyDetails)
+}
+
+// TestDecodeHeadersWakeOnTrafficCacheFallbackNoAnnotation verifies that when
+// both route.WakeOnTraffic is false and the informer cache does NOT have the
+// annotation, the filter does NOT attempt wake and returns 502.
+func TestDecodeHeadersWakeOnTrafficCacheFallbackNoAnnotation(t *testing.T) {
+	r := useTestRegistry(t)
+	putTestRoute(t, r, "default--no-annot-fallback", sandboxroute.Route{
+		IP:            "10.0.0.1",
+		Namespace:     "default",
+		Name:          "no-annot-fallback",
+		State:         agentsv1alpha1.SandboxStatePaused,
+		WakeOnTraffic: false,
+	})
+
+	// Create sandbox WITHOUT wake annotation in the informer cache
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-annot-fallback",
+			Namespace: "default",
+		},
+	}
+	cacheProvider, _, err := cachetest.NewTestCache(t, sbx)
+	if err != nil {
+		t.Fatalf("failed to create test cache: %v", err)
+	}
+
+	wake.InitWaker(cacheProvider)
+	t.Cleanup(func() {
+		wake.InitWaker(nil)
+	})
+
+	cfg := DefaultConfig()
+	cfg.EnableWakeOnTraffic = true
+	cfg.WakeTimeoutSeconds = 5
+	mockCallbacks := newMockFilterCallbackHandler()
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: cfg, adapter: defaultTestAdapter()}
+
+	header := newMockRequestHeaderMap()
+	header.Set(DefaultSandboxHeaderName, "default--no-annot-fallback")
+
+	status := filter.DecodeHeaders(header, true)
+
+	// No annotation in cache -> no wake attempt -> 502 not_running
+	assert.Equal(t, api.LocalReply, status)
+	assert.Equal(t, 502, mockCallbacks.decoderCallbacks.replyStatusCode)
+	assert.Equal(t, "sandbox_not_running", mockCallbacks.decoderCallbacks.replyDetails)
+}
+
+// TestIsEnvoyStreamGonePanic tests the pure function that detects known
+// Envoy panic messages indicating the stream has been finished or the
+// filter destroyed.
+func TestIsEnvoyStreamGonePanic(t *testing.T) {
+	tests := []struct {
+		name      string
+		recovered interface{}
+		want      bool
+	}{
+		{
+			name:      "request finished panic",
+			recovered: "request has been finished",
+			want:      true,
+		},
+		{
+			name:      "filter destroyed panic",
+			recovered: "golang filter has been destroyed",
+			want:      true,
+		},
+		{
+			name:      "partial match request finished",
+			recovered: "error: request has been finished unexpectedly",
+			want:      true,
+		},
+		{
+			name:      "unrelated panic message",
+			recovered: "something else went wrong",
+			want:      false,
+		},
+		{
+			name:      "non-string panic",
+			recovered: 42,
+			want:      false,
+		},
+		{
+			name:      "nil panic",
+			recovered: nil,
+			want:      false,
+		},
+		{
+			name:      "empty string",
+			recovered: "",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isEnvoyStreamGonePanic(tt.recovered)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestOnDestroyCancelsContext verifies that OnDestroy() cancels the in-flight
+// wake context, causing the async goroutine to exit via context.Canceled.
+func TestOnDestroyCancelsContext(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.EnableWakeOnTraffic = true
+	mockCallbacks := newMockFilterCallbackHandler()
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: cfg, adapter: defaultTestAdapter()}
+
+	// Simulate the state after DecodeHeaders launches async wake
+	ctx, cancel := context.WithCancel(context.Background())
+	filter.mu.Lock()
+	filter.cancel = cancel
+	filter.mu.Unlock()
+
+	// Verify context is not yet canceled
+	select {
+	case <-ctx.Done():
+		t.Fatal("context should not be canceled before OnDestroy")
+	default:
+	}
+
+	// Call OnDestroy (simulates Envoy destroying the filter/stream)
+	filter.OnDestroy(api.Normal)
+
+	// Verify context is now canceled
+	select {
+	case <-ctx.Done():
+		// expected
+	default:
+		t.Fatal("context should be canceled after OnDestroy")
+	}
+
+	// Verify destroyed flag is set
+	filter.mu.Lock()
+	assert.True(t, filter.destroyed)
+	filter.mu.Unlock()
+}
+
+// TestWakeAndContinueSuccess verifies the async wake success path:
+// wake succeeds, route becomes Running, Continue is called with upstream
+// metadata set.
+func TestWakeAndContinueSuccess(t *testing.T) {
+	r := useTestRegistry(t)
+
+	// Add paused route to registry (wake-on-traffic enabled)
+	putTestRoute(t, r, "default--async-success", sandboxroute.Route{
+		IP:            "10.0.0.1",
+		Namespace:     "default",
+		Name:          "async-success",
+		State:         agentsv1alpha1.SandboxStatePaused,
+		WakeOnTraffic: true,
+	})
+
+	// Create a paused sandbox that will be woken
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "async-success",
+			Namespace: "default",
+			UID:       "uid-async-success",
+			Annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: agentsv1alpha1.True,
+			},
+			Labels: map[string]string{
+				agentsv1alpha1.LabelSandboxIsClaimed: "true",
+			},
+		},
+		Spec: agentsv1alpha1.SandboxSpec{
+			Paused: true,
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxPaused,
+			Conditions: []metav1.Condition{
+				{Type: string(agentsv1alpha1.SandboxConditionPaused), Status: metav1.ConditionTrue},
+			},
+			PodInfo: agentsv1alpha1.PodInfo{PodIP: "10.0.0.1"},
+		},
+	}
+
+	cacheProvider, fc, err := cachetest.NewTestCache(t)
+	if err != nil {
+		t.Fatalf("failed to create test cache: %v", err)
+	}
+	require.NoError(t, cacheProvider.Run(t.Context()))
+	t.Cleanup(func() { cacheProvider.Stop(t.Context()) })
+
+	require.NoError(t, fc.Create(t.Context(), sbx))
+	require.NoError(t, fc.Status().Update(t.Context(), sbx))
+	time.Sleep(10 * time.Millisecond)
+
+	// Set up mock to simulate successful resume
+	mockMgr := cacheProvider.GetMockManager()
+	mockMgr.AddWaitReconcileKey(sbx)
+
+	// Delay the status update to simulate async resume
+	modified := sbx.DeepCopy()
+	mergeFrom := ctrl.MergeFrom(sbx)
+	time.AfterFunc(50*time.Millisecond, func() {
+		modified.Status.Phase = agentsv1alpha1.SandboxRunning
+		modified.Status.Conditions = []metav1.Condition{
+			{Type: string(agentsv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Resume"},
+		}
+		_ = fc.Status().Patch(t.Context(), modified, mergeFrom)
+		// Also update registry to Running (simulating controller reconciliation)
+		putTestRoute(t, r, "default--async-success", sandboxroute.Route{
+			IP:              "10.0.0.1",
+			Namespace:       "default",
+			Name:            "async-success",
+			State:           agentsv1alpha1.SandboxStateRunning,
+			ResourceVersion: "2",
+		})
+	})
+
+	wake.InitWaker(cacheProvider)
+	t.Cleanup(func() { wake.InitWaker(nil) })
+
+	cfg := DefaultConfig()
+	cfg.EnableWakeOnTraffic = true
+	cfg.WakeTimeoutSeconds = 30
+
+	done := make(chan struct{}, 1)
+	mockCallbacks := &mockFilterCallbackHandler{
+		streamInfo:       newMockStreamInfo(),
+		decoderCallbacks: &mockDecoderFilterCallbacks{done: done},
+	}
+	filter := &sandboxFilter{callbacks: mockCallbacks, config: cfg, adapter: defaultTestAdapter()}
+
+	// Launch async wake
+	header := newMockRequestHeaderMap()
+	header.Set(DefaultSandboxHeaderName, "default--async-success")
+
+	status := filter.DecodeHeaders(header, true)
+	assert.Equal(t, api.Running, status)
+
+	// Wait for async completion
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for async wake completion")
+	}
+
+	// Verify Continue was called (not SendLocalReply)
+	assert.True(t, mockCallbacks.decoderCallbacks.continueCalled,
+		"Continue should be called on successful wake")
+	assert.Equal(t, api.Continue, mockCallbacks.decoderCallbacks.continueStatus)
+	assert.False(t, mockCallbacks.decoderCallbacks.sendLocalReplyCalled,
+		"SendLocalReply should not be called on successful wake")
+
+	// Verify upstream metadata was set
+	metadata := mockCallbacks.streamInfo.dynamicMetadata.data["envoy.lb.original_dst"]
+	assert.NotNil(t, metadata)
+	assert.Equal(t, "10.0.0.1:49983", metadata["host"])
+}
+
+// TestShouldWakeSandbox tests the pure branches of shouldWakeSandbox that
+// do not require a real cache provider.
+func TestShouldWakeSandbox(t *testing.T) {
+	// Initialize a waker backed by an empty cache; the cases below return
+	// before reaching HasWakeAnnotation.
+	cacheProvider, _, err := cachetest.NewTestCache(t)
+	require.NoError(t, err)
+	wake.InitWaker(cacheProvider)
+	t.Cleanup(func() { wake.InitWaker(nil) })
+	waker := wake.GetWaker()
+	pausedRoute := sandboxroute.Route{
+		Namespace:     "default",
+		Name:          "sbx",
+		State:         agentsv1alpha1.SandboxStatePaused,
+		WakeOnTraffic: true,
+	}
+
+	tests := []struct {
+		name       string
+		route      sandboxroute.Route
+		enableWake bool
+		waker      *wake.Waker
+		want       bool
+	}{
+		{
+			name: "state not paused returns false",
+			route: sandboxroute.Route{
+				Namespace:     "default",
+				Name:          "sbx",
+				State:         agentsv1alpha1.SandboxStateCreating,
+				WakeOnTraffic: true,
+			},
+			enableWake: true,
+			waker:      waker,
+			want:       false,
+		},
+		{
+			name:       "wake on traffic disabled returns false",
+			route:      pausedRoute,
+			enableWake: false,
+			waker:      waker,
+			want:       false,
+		},
+		{
+			name:       "nil waker returns false",
+			route:      pausedRoute,
+			enableWake: true,
+			waker:      nil,
+			want:       false,
+		},
+		{
+			name: "route without object key returns false",
+			route: sandboxroute.Route{
+				State:         agentsv1alpha1.SandboxStatePaused,
+				WakeOnTraffic: true,
+			},
+			enableWake: true,
+			waker:      waker,
+			want:       false,
+		},
+		{
+			name:       "route wake on traffic true returns true",
+			route:      pausedRoute,
+			enableWake: true,
+			waker:      waker,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.EnableWakeOnTraffic = tt.enableWake
+			f := &sandboxFilter{config: cfg}
+			got := f.shouldWakeSandbox(tt.route, tt.waker)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestShouldWakeSandboxAnnotationFallback tests the HasWakeAnnotation fallback
+// path in shouldWakeSandbox using a real informer cache.
+func TestShouldWakeSandboxAnnotationFallback(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.EnableWakeOnTraffic = true
+
+	t.Run("annotation present returns true", func(t *testing.T) {
+		sbx := &agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "with-annot",
+				Namespace: "default",
+				Annotations: map[string]string{
+					agentsv1alpha1.AnnotationWakeOnTraffic: agentsv1alpha1.True,
+				},
+			},
+		}
+		cacheProvider, _, err := cachetest.NewTestCache(t, sbx)
+		require.NoError(t, err)
+
+		wake.InitWaker(cacheProvider)
+		t.Cleanup(func() { wake.InitWaker(nil) })
+
+		route := sandboxroute.Route{
+			Namespace:     "default",
+			Name:          "with-annot",
+			State:         agentsv1alpha1.SandboxStatePaused,
+			WakeOnTraffic: false, // Force annotation fallback
+		}
+		f := &sandboxFilter{config: cfg}
+		assert.True(t, f.shouldWakeSandbox(route, wake.GetWaker()))
+	})
+
+	t.Run("annotation absent returns false", func(t *testing.T) {
+		sbx := &agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "no-annot",
+				Namespace: "default",
+			},
+		}
+		cacheProvider, _, err := cachetest.NewTestCache(t, sbx)
+		require.NoError(t, err)
+
+		wake.InitWaker(cacheProvider)
+		t.Cleanup(func() { wake.InitWaker(nil) })
+
+		route := sandboxroute.Route{
+			Namespace:     "default",
+			Name:          "no-annot",
+			State:         agentsv1alpha1.SandboxStatePaused,
+			WakeOnTraffic: false, // Force annotation fallback
+		}
+		f := &sandboxFilter{config: cfg}
+		assert.False(t, f.shouldWakeSandbox(route, wake.GetWaker()))
+	})
 }

--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -46,6 +47,30 @@ const (
 
 // ReadinessCheck reports whether the gateway is ready to receive traffic.
 type ReadinessCheck func() error
+
+// globalPeerManager is set when server.Start() creates the peerManager.
+// It allows other packages (e.g. wake) to access the peer manager for
+// SyncRouteWithPeers without creating a full Server instance.
+// Protected by globalPeerManagerMu for concurrent read/write safety.
+var (
+	globalPeerManagerMu sync.RWMutex
+	globalPeerManager   peers.Peers
+)
+
+// setPeerManager sets the global peer manager. Called during Start.
+func setPeerManager(pm peers.Peers) {
+	globalPeerManagerMu.Lock()
+	defer globalPeerManagerMu.Unlock()
+	globalPeerManager = pm
+}
+
+// GetPeerManager returns the peer manager for use by the wake package.
+// Returns nil if the server has not been started yet.
+func GetPeerManager() peers.Peers {
+	globalPeerManagerMu.RLock()
+	defer globalPeerManagerMu.RUnlock()
+	return globalPeerManager
+}
 
 // getMemberlistBindPort reads the memberlist bind port from environment variable
 // Returns the default port if not set or invalid
@@ -140,6 +165,7 @@ func (s *Server) Start(ctx context.Context) error {
 	labelSelector := os.Getenv(EnvLabelSelector)
 
 	s.peerManager = peers.NewMemberlistPeers(s.client, peers.NodePrefixSandboxGateway+nodeName, namespace, labelSelector)
+	setPeerManager(s.peerManager)
 
 	if err := s.peerManager.Start(ctx, s.memberlistBindPort); err != nil {
 		return err
@@ -199,6 +225,7 @@ func (s *Server) Stop(ctx context.Context) error {
 		if err := s.peerManager.Stop(); err != nil {
 			errs = append(errs, err)
 		}
+		setPeerManager(nil)
 	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)

--- a/pkg/sandbox-gateway/wake/wake.go
+++ b/pkg/sandbox-gateway/wake/wake.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -62,6 +63,23 @@ func InitWaker(cacheProvider cache.Provider) {
 // been called yet.
 func GetWaker() *Waker {
 	return defaultWaker.Load()
+}
+
+// SandboxUIDMatches reports whether the informer cache holds a sandbox at
+// namespace/name whose UID equals uid. It returns false when uid is empty,
+// the waker is nil, or the object cannot be read: a registry route pointing
+// at a deleted object must never trigger a wake, and a recreated same-name
+// sandbox carries a different UID.
+func (w *Waker) SandboxUIDMatches(ctx context.Context, namespace, name string, uid types.UID) bool {
+	if w == nil || uid == "" {
+		return false
+	}
+	cli := w.cache.GetClient()
+	var sbx agentsv1alpha1.Sandbox
+	if err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &sbx); err != nil {
+		return false
+	}
+	return sbx.UID == uid
 }
 
 // HasWakeAnnotation checks the informer cache for the wake-on-traffic annotation.

--- a/pkg/sandbox-gateway/wake/wake.go
+++ b/pkg/sandbox-gateway/wake/wake.go
@@ -85,13 +85,15 @@ func (w *Waker) HasWakeAnnotation(ctx context.Context, namespace, name string) b
 // for this caller only, without affecting other concurrent or future callers.
 // Resume itself provides first-writer-wins dedup via retryUpdate.
 //
-// defaultWakeTimeout must be positive.  The caller (typically the filter) is
-// responsible for providing a valid timeout via Config.GetWakeTimeoutSeconds()
-// which defaults to 60s when the configured value is <= 0.
+// The caller derives the wake deadline itself (the filter wraps a detached
+// context with Config.GetWakeTimeoutSeconds()); Wake does not wrap ctx
+// again. defaultWakeTimeout is only the fallback timeout used when the
+// sandbox carries no wake-timeout-seconds annotation, and must be positive.
 func (w *Waker) Wake(ctx context.Context, namespace, name string, defaultWakeTimeout time.Duration) error {
-	wakeCtx, wakeCancel := context.WithTimeout(ctx, defaultWakeTimeout)
-	defer wakeCancel()
-	return w.wakeInternal(wakeCtx, namespace, name, defaultWakeTimeout)
+	if defaultWakeTimeout <= 0 {
+		return fmt.Errorf("wake default timeout must be positive, got %v", defaultWakeTimeout)
+	}
+	return w.wakeInternal(ctx, namespace, name, defaultWakeTimeout)
 }
 
 // wakeInternal performs the actual wake work: reads annotations from cache,

--- a/pkg/sandbox-gateway/wake/wake.go
+++ b/pkg/sandbox-gateway/wake/wake.go
@@ -121,19 +121,34 @@ func (w *Waker) wakeInternal(ctx context.Context, namespace, name string, defaul
 	// with the latest state before patching.
 	sandbox := sandboxcr.AsSandbox(&sbx, w.cache)
 
+	// Determine the sandbox timeout mode, mirroring ParseTimeout in the
+	// E2B connect path. This ensures we only set PauseTime for auto-pause
+	// sandboxes and never convert never-timeout or shutdown-only sandboxes
+	// into auto-pause mode.
+	autoPause := sbx.Spec.PauseTime != nil
+	hasDeadline := autoPause || sbx.Spec.ShutdownTime != nil
+
 	var opts infra.ResumeOptions
-	if wakeTimeout > 0 {
+	if hasDeadline && autoPause && wakeTimeout > 0 {
+		// Auto-pause sandbox: set a fresh PauseTime so the sandbox has
+		// running time before its next auto-pause, and preserve the existing
+		// ShutdownTime so the auto-delete deadline is not lost. Without this,
+		// setTimeout() inside Resume would nil out ShutdownTime, causing
+		// resource leaks.
 		opts.Timeout = &timeout.Options{
 			PauseTime: time.Now().Add(wakeTimeout),
 		}
-		// Preserve existing ShutdownTime so timed sandboxes retain their
-		// auto-delete deadline after wake. Without this, setTimeout()
-		// inside Resume would nil out ShutdownTime, causing resource leaks.
 		if sbx.Spec.ShutdownTime != nil {
 			opts.Timeout.ShutdownTime = sbx.Spec.ShutdownTime.Time
 		}
 	}
-	log.Info("waking sandbox via traffic", "wakeTimeout", wakeTimeout)
+	// For never-timeout sandboxes (no PauseTime, no ShutdownTime) and
+	// non-auto-pause sandboxes (ShutdownTime only, no PauseTime), we skip
+	// setting a timeout. This preserves never-timeout semantics and avoids
+	// injecting a PauseTime that would convert a shutdown-only sandbox into
+	// auto-pause mode.
+	log.Info("waking sandbox via traffic", "wakeTimeout", wakeTimeout,
+		"autoPause", autoPause, "hasDeadline", hasDeadline)
 	if err := sandbox.Resume(ctx, opts); err != nil {
 		return err
 	}

--- a/pkg/sandbox-gateway/wake/wake.go
+++ b/pkg/sandbox-gateway/wake/wake.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wake
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/cache"
+	"github.com/openkruise/agents/pkg/proxy"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/server"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
+	"github.com/openkruise/agents/pkg/sandboxroute"
+	"github.com/openkruise/agents/pkg/utils/timeout"
+)
+
+// Waker resumes paused sandboxes by reusing the existing sandbox-manager
+// connect Resume implementation (sandboxcr.Sandbox.Resume), then syncs the
+// route locally and to peer gateways.
+type Waker struct {
+	cache cache.Provider
+}
+
+var defaultWaker atomic.Pointer[Waker]
+
+// InitWaker initializes the package-level Waker with the given cache provider.
+// Gateway startup guarantees a non-nil cacheProvider after cache.NewCache
+// succeeds; passing nil clears the Waker (used by tests to restore the
+// default state).
+func InitWaker(cacheProvider cache.Provider) {
+	if cacheProvider == nil {
+		defaultWaker.Store(nil)
+		return
+	}
+	defaultWaker.Store(&Waker{cache: cacheProvider})
+}
+
+// GetWaker returns the package-level Waker. Returns nil if InitWaker has not
+// been called yet.
+func GetWaker() *Waker {
+	return defaultWaker.Load()
+}
+
+// HasWakeAnnotation checks the informer cache for the wake-on-traffic annotation.
+// This is a fallback for when the gateway controller's route registry hasn't
+// yet synced the annotation change. Returns false if the waker is nil or the
+// sandbox cannot be read from cache.
+func (w *Waker) HasWakeAnnotation(ctx context.Context, namespace, name string) bool {
+	if w == nil {
+		return false
+	}
+	cli := w.cache.GetClient()
+	var sbx agentsv1alpha1.Sandbox
+	if err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &sbx); err != nil {
+		return false
+	}
+	return sbx.GetAnnotations()[agentsv1alpha1.AnnotationWakeOnTraffic] == agentsv1alpha1.True
+}
+
+// Wake resumes a paused sandbox by delegating to sandboxcr.Sandbox.Resume().
+// The caller's context is used directly so that cancellation stops the wait
+// for this caller only, without affecting other concurrent or future callers.
+// Resume itself provides first-writer-wins dedup via retryUpdate.
+//
+// defaultWakeTimeout must be positive.  The caller (typically the filter) is
+// responsible for providing a valid timeout via Config.GetWakeTimeoutSeconds()
+// which defaults to 60s when the configured value is <= 0.
+func (w *Waker) Wake(ctx context.Context, namespace, name string, defaultWakeTimeout time.Duration) error {
+	wakeCtx, wakeCancel := context.WithTimeout(ctx, defaultWakeTimeout)
+	defer wakeCancel()
+	return w.wakeInternal(wakeCtx, namespace, name, defaultWakeTimeout)
+}
+
+// wakeInternal performs the actual wake work: reads annotations from cache,
+// calls sandbox.Resume, and syncs the route.
+func (w *Waker) wakeInternal(ctx context.Context, namespace, name string, defaultWakeTimeout time.Duration) error {
+	log := klog.FromContext(ctx).WithValues("sandbox", klog.KRef(namespace, name))
+
+	cli := w.cache.GetClient()
+
+	// Read sandbox from informer cache (fast) to get annotations.
+	var sbx agentsv1alpha1.Sandbox
+	if err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &sbx); err != nil {
+		return err
+	}
+
+	// Determine wake timeout: prefer annotation, fall back to filter default.
+	wakeTimeout := defaultWakeTimeout
+	if timeoutStr := sbx.Annotations[agentsv1alpha1.AnnotationWakeTimeoutSeconds]; timeoutStr != "" {
+		if secs, err := strconv.Atoi(timeoutStr); err == nil && secs > 0 {
+			wakeTimeout = time.Duration(secs) * time.Second
+		}
+	}
+
+	// Reuse the existing sandbox-manager connect Resume implementation.
+	// AsSandbox wraps the sandbox with the cache provider + storage registry.
+	// Resume refreshes from API reader, so the sandbox object is re-fetched
+	// with the latest state before patching.
+	sandbox := sandboxcr.AsSandbox(&sbx, w.cache)
+
+	var opts infra.ResumeOptions
+	if wakeTimeout > 0 {
+		opts.Timeout = &timeout.Options{
+			PauseTime: time.Now().Add(wakeTimeout),
+		}
+		// Preserve existing ShutdownTime so timed sandboxes retain their
+		// auto-delete deadline after wake. Without this, setTimeout()
+		// inside Resume would nil out ShutdownTime, causing resource leaks.
+		if sbx.Spec.ShutdownTime != nil {
+			opts.Timeout.ShutdownTime = sbx.Spec.ShutdownTime.Time
+		}
+	}
+	log.Info("waking sandbox via traffic", "wakeTimeout", wakeTimeout)
+	if err := sandbox.Resume(ctx, opts); err != nil {
+		return err
+	}
+	log.Info("sandbox resumed successfully")
+
+	// After Resume succeeds, sync route locally and with peers.
+	// This mirrors the manager's syncRoute flow:
+	//   1. Get route from refreshed sandbox
+	//   2. Update local registry
+	//   3. Sync to peer gateways
+	route, err := sandbox.GetRoute()
+	if err != nil {
+		return fmt.Errorf("project route after wake: %w", err)
+	}
+	result := registry.GetRegistry().Upsert(route)
+	sandboxroute.LogMutation(log, "upsert", route, result)
+
+	if pm := server.GetPeerManager(); pm != nil {
+		if err := proxy.SyncRouteWithPeers(ctx, pm, route); err != nil {
+			// Log but don't fail the wake — the local registry is updated,
+			// and peers will eventually catch up via their own informers.
+			log.Error(err, "failed to sync route with peers after wake")
+		}
+	}
+
+	return nil
+}

--- a/pkg/sandbox-gateway/wake/wake.go
+++ b/pkg/sandbox-gateway/wake/wake.go
@@ -135,8 +135,21 @@ func (w *Waker) wakeInternal(ctx context.Context, namespace, name string, defaul
 		// ShutdownTime so the auto-delete deadline is not lost. Without this,
 		// setTimeout() inside Resume would nil out ShutdownTime, causing
 		// resource leaks.
+		//
+		// The create API allows wake timeouts as short as 30s; reuse the same
+		// Resume timeout floor the E2B Connect/Resume paths apply so the
+		// fresh PauseTime cannot expire while the sandbox is still resuming
+		// (the controller checks PauseTime before Resume handling and would
+		// re-pause it mid-resume).
+		requestedSeconds := int(wakeTimeout / time.Second)
+		effectiveSeconds := timeout.ApplyResumeTimeoutFloor(requestedSeconds, timeout.DefaultMinResumeTimeoutSeconds)
+		if effectiveSeconds != requestedSeconds {
+			log.Info("wake timeout floor applied",
+				"requestedSeconds", requestedSeconds,
+				"effectiveSeconds", effectiveSeconds)
+		}
 		opts.Timeout = &timeout.Options{
-			PauseTime: time.Now().Add(wakeTimeout),
+			PauseTime: time.Now().Add(time.Duration(effectiveSeconds) * time.Second),
 		}
 		if sbx.Spec.ShutdownTime != nil {
 			opts.Timeout.ShutdownTime = sbx.Spec.ShutdownTime.Time

--- a/pkg/sandbox-gateway/wake/wake.go
+++ b/pkg/sandbox-gateway/wake/wake.go
@@ -151,10 +151,12 @@ func (w *Waker) wakeInternal(ctx context.Context, namespace, name string, defaul
 	var opts infra.ResumeOptions
 	if hasDeadline && autoPause && wakeTimeout > 0 {
 		// Auto-pause sandbox: set a fresh PauseTime so the sandbox has
-		// running time before its next auto-pause, and preserve the existing
-		// ShutdownTime so the auto-delete deadline is not lost. Without this,
-		// setTimeout() inside Resume would nil out ShutdownTime, causing
-		// resource leaks.
+		// running time before its next auto-pause. ShutdownTime is set
+		// directly to the "forever" retention horizon (now + 100 years):
+		// traffic woke the sandbox, so it must not be auto-deleted by a
+		// stale or soon-to-expire retained ShutdownTime; the next pause
+		// recomputes ShutdownTime from the paused-retention policy. Without
+		// a ShutdownTime here, setTimeout() inside Resume would nil it out.
 		//
 		// The create API allows wake timeouts as short as 30s; reuse the same
 		// Resume timeout floor the E2B Connect/Resume paths apply so the
@@ -169,10 +171,8 @@ func (w *Waker) wakeInternal(ctx context.Context, namespace, name string, defaul
 				"effectiveSeconds", effectiveSeconds)
 		}
 		opts.Timeout = &timeout.Options{
-			PauseTime: time.Now().Add(time.Duration(effectiveSeconds) * time.Second),
-		}
-		if sbx.Spec.ShutdownTime != nil {
-			opts.Timeout.ShutdownTime = sbx.Spec.ShutdownTime.Time
+			PauseTime:    time.Now().Add(time.Duration(effectiveSeconds) * time.Second),
+			ShutdownTime: time.Now().Add(timeout.ForeverReservePausedSandboxDuration),
 		}
 	}
 	// For never-timeout sandboxes (no PauseTime, no ShutdownTime) and

--- a/pkg/sandbox-gateway/wake/wake_test.go
+++ b/pkg/sandbox-gateway/wake/wake_test.go
@@ -29,6 +29,7 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/cache/cachetest"
+	"github.com/openkruise/agents/pkg/utils/timeout"
 )
 
 func TestInitWakerAndGetWaker(t *testing.T) {
@@ -392,8 +393,15 @@ func TestWake(t *testing.T) {
 			require.NoError(t, fc.Get(t.Context(), ctrl.ObjectKey{Namespace: tt.sandboxNS, Name: tt.sandboxName}, &updated))
 			assert.False(t, updated.Spec.Paused, "sandbox should be unpaused after wake")
 
-			// Verify ShutdownTime is preserved
-			if tt.shutdownTime != nil {
+			// Auto-pause wakes overwrite ShutdownTime with the "forever"
+			// retention horizon (now + 100 years); other modes leave it
+			// untouched.
+			if tt.pauseTime != nil && tt.shutdownTime != nil {
+				require.NotNil(t, updated.Spec.ShutdownTime, "ShutdownTime should be set for auto-pause wakes")
+				wantShutdown := time.Now().Add(timeout.ForeverReservePausedSandboxDuration)
+				assert.WithinDuration(t, wantShutdown, updated.Spec.ShutdownTime.Time, 10*time.Second,
+					"auto-pause wake must set ShutdownTime to the forever retention horizon")
+			} else if tt.shutdownTime != nil {
 				require.NotNil(t, updated.Spec.ShutdownTime, "ShutdownTime should be preserved")
 				assert.WithinDuration(t, tt.shutdownTime.Time, updated.Spec.ShutdownTime.Time, time.Second)
 			}

--- a/pkg/sandbox-gateway/wake/wake_test.go
+++ b/pkg/sandbox-gateway/wake/wake_test.go
@@ -191,6 +191,18 @@ func TestWake(t *testing.T) {
 			expectError:    "not found",
 		},
 		{
+			// Wake must reject a non-positive fallback timeout explicitly
+			// instead of relying on an instant context deadline.
+			name:           "non-positive default timeout rejected",
+			sandboxName:    "sbx-zero-timeout",
+			sandboxNS:      "default",
+			annotations:    map[string]string{},
+			shutdownTime:   &metav1.Time{Time: shutdownTime},
+			pauseTime:      &metav1.Time{Time: pauseTime},
+			defaultTimeout: 0,
+			expectError:    "must be positive",
+		},
+		{
 			name:           "successful wake with default timeout",
 			sandboxName:    "sbx-default",
 			sandboxNS:      "default",

--- a/pkg/sandbox-gateway/wake/wake_test.go
+++ b/pkg/sandbox-gateway/wake/wake_test.go
@@ -258,6 +258,19 @@ func TestWake(t *testing.T) {
 			simulateResume: true,
 			expectError:    "",
 		},
+		{
+			// Shutdown-only sandbox (no PauseTime): wake must not inject a
+			// PauseTime that would convert it into auto-pause mode.
+			name:           "wake shutdown-only sandbox preserves nil PauseTime",
+			sandboxName:    "sbx-shutdown-only",
+			sandboxNS:      "default",
+			annotations:    map[string]string{},
+			shutdownTime:   &metav1.Time{Time: shutdownTime},
+			pauseTime:      nil,
+			defaultTimeout: 30 * time.Second,
+			simulateResume: true,
+			expectError:    "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -330,6 +343,11 @@ func TestWake(t *testing.T) {
 			if tt.shutdownTime != nil {
 				require.NotNil(t, updated.Spec.ShutdownTime, "ShutdownTime should be preserved")
 				assert.WithinDuration(t, tt.shutdownTime.Time, updated.Spec.ShutdownTime.Time, time.Second)
+			}
+			
+			// Verify PauseTime is not injected for never-timeout or shutdown-only sandboxes
+			if tt.pauseTime == nil {
+				assert.Nil(t, updated.Spec.PauseTime, "PauseTime should not be injected for non-auto-pause sandboxes")
 			}
 		})
 	}

--- a/pkg/sandbox-gateway/wake/wake_test.go
+++ b/pkg/sandbox-gateway/wake/wake_test.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wake
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/cache/cachetest"
+)
+
+func TestInitWakerAndGetWaker(t *testing.T) {
+	// Reset before test
+	defaultWaker.Store(nil)
+	t.Cleanup(func() { defaultWaker.Store(nil) })
+
+	// Before init, GetWaker returns nil
+	if w := GetWaker(); w != nil {
+		t.Error("GetWaker() should return nil before InitWaker is called")
+	}
+
+	// InitWaker(nil) clears the waker, so GetWaker keeps returning nil
+	InitWaker(nil)
+	if w := GetWaker(); w != nil {
+		t.Error("GetWaker() should return nil after InitWaker(nil)")
+	}
+}
+
+func TestHasWakeAnnotation(t *testing.T) {
+	tests := []struct {
+		name        string
+		sandboxName string
+		sandboxNS   string
+		annotations map[string]string
+		createSbx   bool
+		wakerNil    bool
+		want        bool
+	}{
+		{
+			name:        "annotation present true",
+			sandboxName: "sbx-wake",
+			sandboxNS:   "default",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: agentsv1alpha1.True,
+			},
+			createSbx: true,
+			want:      true,
+		},
+		{
+			name:        "annotation present false",
+			sandboxName: "sbx-no-wake",
+			sandboxNS:   "default",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "false",
+			},
+			createSbx: true,
+			want:      false,
+		},
+		{
+			name:        "annotation absent",
+			sandboxName: "sbx-no-annot",
+			sandboxNS:   "default",
+			annotations: nil,
+			createSbx:   true,
+			want:        false,
+		},
+		{
+			name:        "sandbox not found",
+			sandboxName: "sbx-missing",
+			sandboxNS:   "default",
+			createSbx:   false,
+			want:        false,
+		},
+		{
+			name:     "nil waker returns false",
+			wakerNil: true,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wakerNil {
+				var nilWaker *Waker
+				assert.False(t, nilWaker.HasWakeAnnotation(context.Background(), "default", "sbx"))
+				return
+			}
+
+			var initObjs []ctrl.Object
+			if tt.createSbx {
+				sbx := &agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        tt.sandboxName,
+						Namespace:   tt.sandboxNS,
+						Annotations: tt.annotations,
+					},
+				}
+				initObjs = append(initObjs, sbx)
+			}
+
+			cacheProvider, _, err := cachetest.NewTestCache(t, initObjs...)
+			require.NoError(t, err)
+
+			waker := &Waker{cache: cacheProvider}
+			got := waker.HasWakeAnnotation(context.Background(), tt.sandboxNS, tt.sandboxName)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// newPausedSandbox creates a Sandbox CR in Paused state with Paused condition True.
+func newPausedSandbox(name, namespace string, annotations map[string]string, shutdownTime *metav1.Time) *agentsv1alpha1.Sandbox {
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			UID:         types.UID("uid-" + name),
+			Annotations: annotations,
+			Labels: map[string]string{
+				agentsv1alpha1.LabelSandboxIsClaimed: "true",
+			},
+		},
+		Spec: agentsv1alpha1.SandboxSpec{
+			Paused:       true,
+			ShutdownTime: shutdownTime,
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxPaused,
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(agentsv1alpha1.SandboxConditionPaused),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			PodInfo: agentsv1alpha1.PodInfo{
+				PodIP: "10.0.0.1",
+			},
+		},
+	}
+	return sbx
+}
+
+func TestWake(t *testing.T) {
+	shutdownTime := time.Now().Add(2 * time.Hour)
+	pauseTime := time.Now().Add(1 * time.Hour)
+
+	tests := []struct {
+		name           string
+		sandboxName    string
+		sandboxNS      string
+		annotations    map[string]string
+		shutdownTime   *metav1.Time
+		pauseTime      *metav1.Time
+		defaultTimeout time.Duration
+		skipCreate     bool
+		simulateResume bool
+		expectError    string
+	}{
+		{
+			name:           "sandbox not found returns error",
+			sandboxName:    "nonexistent",
+			sandboxNS:      "default",
+			defaultTimeout: 60 * time.Second,
+			skipCreate:     true,
+			expectError:    "not found",
+		},
+		{
+			name:           "successful wake with default timeout",
+			sandboxName:    "sbx-default",
+			sandboxNS:      "default",
+			annotations:    map[string]string{},
+			shutdownTime:   &metav1.Time{Time: shutdownTime},
+			pauseTime:      &metav1.Time{Time: pauseTime},
+			defaultTimeout: 60 * time.Second,
+			simulateResume: true,
+			expectError:    "",
+		},
+		{
+			name:        "wake with annotation timeout",
+			sandboxName: "sbx-annot",
+			sandboxNS:   "default",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "120",
+			},
+			shutdownTime:   &metav1.Time{Time: shutdownTime},
+			pauseTime:      &metav1.Time{Time: pauseTime},
+			defaultTimeout: 60 * time.Second,
+			simulateResume: true,
+			expectError:    "",
+		},
+		{
+			name:        "invalid annotation falls back to default",
+			sandboxName: "sbx-invalid",
+			sandboxNS:   "default",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "abc",
+			},
+			shutdownTime:   &metav1.Time{Time: shutdownTime},
+			pauseTime:      &metav1.Time{Time: pauseTime},
+			defaultTimeout: 60 * time.Second,
+			simulateResume: true,
+			expectError:    "",
+		},
+		{
+			name:        "negative annotation falls back to default",
+			sandboxName: "sbx-negative",
+			sandboxNS:   "default",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "-5",
+			},
+			shutdownTime:   &metav1.Time{Time: shutdownTime},
+			pauseTime:      &metav1.Time{Time: pauseTime},
+			defaultTimeout: 60 * time.Second,
+			simulateResume: true,
+			expectError:    "",
+		},
+		{
+			name:           "short default timeout still resumes",
+			sandboxName:    "sbx-short-timeout",
+			sandboxNS:      "default",
+			annotations:    map[string]string{},
+			shutdownTime:   &metav1.Time{Time: shutdownTime},
+			pauseTime:      &metav1.Time{Time: pauseTime},
+			defaultTimeout: 30 * time.Second,
+			simulateResume: true,
+			expectError:    "",
+		},
+		{
+			name:           "wake preserves nil ShutdownTime",
+			sandboxName:    "sbx-nil-shutdown",
+			sandboxNS:      "default",
+			annotations:    map[string]string{},
+			shutdownTime:   nil,
+			pauseTime:      nil,
+			defaultTimeout: 30 * time.Second,
+			simulateResume: true,
+			expectError:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.skipCreate {
+				// Test with no sandbox in the cluster
+				cacheProvider, _, err := cachetest.NewTestCache(t)
+				require.NoError(t, err)
+				require.NoError(t, cacheProvider.Run(t.Context()))
+				t.Cleanup(func() { cacheProvider.Stop(t.Context()) })
+
+				waker := &Waker{cache: cacheProvider}
+				ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+				defer cancel()
+				err = waker.Wake(ctx, tt.sandboxNS, tt.sandboxName, tt.defaultTimeout)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+
+			sbx := newPausedSandbox(tt.sandboxName, tt.sandboxNS, tt.annotations, tt.shutdownTime)
+			if tt.pauseTime != nil {
+				sbx.Spec.PauseTime = tt.pauseTime
+			}
+
+			cacheProvider, fc, err := cachetest.NewTestCache(t)
+			require.NoError(t, err)
+			require.NoError(t, cacheProvider.Run(t.Context()))
+			t.Cleanup(func() { cacheProvider.Stop(t.Context()) })
+
+			// Create sandbox with status
+			require.NoError(t, fc.Create(t.Context(), sbx))
+			require.NoError(t, fc.Status().Update(t.Context(), sbx))
+			time.Sleep(10 * time.Millisecond)
+
+			waker := &Waker{cache: cacheProvider}
+
+			if tt.simulateResume {
+				mockMgr := cacheProvider.GetMockManager()
+				mockMgr.AddWaitReconcileKey(sbx)
+
+				modified := sbx.DeepCopy()
+				mergeFrom := ctrl.MergeFrom(sbx)
+				time.AfterFunc(20*time.Millisecond, func() {
+					modified.Status.Phase = agentsv1alpha1.SandboxRunning
+					modified.Status.Conditions = []metav1.Condition{
+						{Type: string(agentsv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Resume"},
+					}
+					_ = fc.Status().Patch(t.Context(), modified, mergeFrom)
+				})
+			}
+
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+
+			err = waker.Wake(ctx, tt.sandboxNS, tt.sandboxName, tt.defaultTimeout)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+			require.NoError(t, err)
+
+			// Verify the sandbox was unpaused
+			var updated agentsv1alpha1.Sandbox
+			require.NoError(t, fc.Get(t.Context(), ctrl.ObjectKey{Namespace: tt.sandboxNS, Name: tt.sandboxName}, &updated))
+			assert.False(t, updated.Spec.Paused, "sandbox should be unpaused after wake")
+
+			// Verify ShutdownTime is preserved
+			if tt.shutdownTime != nil {
+				require.NotNil(t, updated.Spec.ShutdownTime, "ShutdownTime should be preserved")
+				assert.WithinDuration(t, tt.shutdownTime.Time, updated.Spec.ShutdownTime.Time, time.Second)
+			}
+		})
+	}
+}

--- a/pkg/sandbox-gateway/wake/wake_test.go
+++ b/pkg/sandbox-gateway/wake/wake_test.go
@@ -344,7 +344,7 @@ func TestWake(t *testing.T) {
 				require.NotNil(t, updated.Spec.ShutdownTime, "ShutdownTime should be preserved")
 				assert.WithinDuration(t, tt.shutdownTime.Time, updated.Spec.ShutdownTime.Time, time.Second)
 			}
-			
+
 			// Verify PauseTime is not injected for never-timeout or shutdown-only sandboxes
 			if tt.pauseTime == nil {
 				assert.Nil(t, updated.Spec.PauseTime, "PauseTime should not be injected for non-auto-pause sandboxes")

--- a/pkg/sandbox-gateway/wake/wake_test.go
+++ b/pkg/sandbox-gateway/wake/wake_test.go
@@ -174,9 +174,13 @@ func TestWake(t *testing.T) {
 		shutdownTime   *metav1.Time
 		pauseTime      *metav1.Time
 		defaultTimeout time.Duration
-		skipCreate     bool
-		simulateResume bool
-		expectError    string
+		// wantPauseSeconds, when > 0, asserts the fresh PauseTime written by
+		// the wake is now + wantPauseSeconds (i.e. the resume timeout floor
+		// has been applied to the effective value).
+		wantPauseSeconds int
+		skipCreate       bool
+		simulateResume   bool
+		expectError      string
 	}{
 		{
 			name:           "sandbox not found returns error",
@@ -194,8 +198,10 @@ func TestWake(t *testing.T) {
 			shutdownTime:   &metav1.Time{Time: shutdownTime},
 			pauseTime:      &metav1.Time{Time: pauseTime},
 			defaultTimeout: 60 * time.Second,
-			simulateResume: true,
-			expectError:    "",
+			// 60s default is below the resume floor and must be raised.
+			wantPauseSeconds: 300,
+			simulateResume:   true,
+			expectError:      "",
 		},
 		{
 			name:        "wake with annotation timeout",
@@ -204,11 +210,43 @@ func TestWake(t *testing.T) {
 			annotations: map[string]string{
 				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "120",
 			},
-			shutdownTime:   &metav1.Time{Time: shutdownTime},
-			pauseTime:      &metav1.Time{Time: pauseTime},
-			defaultTimeout: 60 * time.Second,
-			simulateResume: true,
-			expectError:    "",
+			shutdownTime: &metav1.Time{Time: shutdownTime},
+			pauseTime:    &metav1.Time{Time: pauseTime},
+			// 120s is below the resume floor and must be raised.
+			defaultTimeout:   60 * time.Second,
+			wantPauseSeconds: 300,
+			simulateResume:   true,
+			expectError:      "",
+		},
+		{
+			name:        "wake annotation below resume floor is raised to floor",
+			sandboxName: "sbx-annot-below-floor",
+			sandboxNS:   "default",
+			annotations: map[string]string{
+				// The create API allows wake timeouts as short as 30s; the
+				// written PauseTime must not expire mid-resume.
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "30",
+			},
+			shutdownTime:     &metav1.Time{Time: shutdownTime},
+			pauseTime:        &metav1.Time{Time: pauseTime},
+			defaultTimeout:   60 * time.Second,
+			wantPauseSeconds: 300,
+			simulateResume:   true,
+			expectError:      "",
+		},
+		{
+			name:        "wake annotation above resume floor unchanged",
+			sandboxName: "sbx-annot-above-floor",
+			sandboxNS:   "default",
+			annotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "600",
+			},
+			shutdownTime:     &metav1.Time{Time: shutdownTime},
+			pauseTime:        &metav1.Time{Time: pauseTime},
+			defaultTimeout:   60 * time.Second,
+			wantPauseSeconds: 600,
+			simulateResume:   true,
+			expectError:      "",
 		},
 		{
 			name:        "invalid annotation falls back to default",
@@ -244,8 +282,11 @@ func TestWake(t *testing.T) {
 			shutdownTime:   &metav1.Time{Time: shutdownTime},
 			pauseTime:      &metav1.Time{Time: pauseTime},
 			defaultTimeout: 30 * time.Second,
-			simulateResume: true,
-			expectError:    "",
+			// The 30s wait deadline is raised to the resume floor before it
+			// is written as the fresh PauseTime.
+			wantPauseSeconds: 300,
+			simulateResume:   true,
+			expectError:      "",
 		},
 		{
 			name:           "wake preserves nil ShutdownTime",
@@ -348,6 +389,14 @@ func TestWake(t *testing.T) {
 			// Verify PauseTime is not injected for never-timeout or shutdown-only sandboxes
 			if tt.pauseTime == nil {
 				assert.Nil(t, updated.Spec.PauseTime, "PauseTime should not be injected for non-auto-pause sandboxes")
+			}
+
+			// Verify the fresh PauseTime carries the floored effective timeout
+			if tt.wantPauseSeconds > 0 {
+				require.NotNil(t, updated.Spec.PauseTime, "PauseTime should be written for auto-pause sandboxes")
+				wantPauseTime := time.Now().Add(time.Duration(tt.wantPauseSeconds) * time.Second)
+				assert.WithinDuration(t, wantPauseTime, updated.Spec.PauseTime.Time, 10*time.Second,
+					"fresh PauseTime must reflect the effective (floored) wake timeout")
 			}
 		})
 	}

--- a/pkg/sandbox-manager/core.go
+++ b/pkg/sandbox-manager/core.go
@@ -99,7 +99,7 @@ func (b *SandboxManagerBuilder) WithSandboxInfra() *SandboxManagerBuilder {
 		if err != nil {
 			return nil, err
 		}
-		cache, err := infracache.NewCacheWithHealth(mgr, health)
+		cache, err := infracache.NewCacheWithHealth(mgr, health, false)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -2477,7 +2477,7 @@ func TestTryClaimSandbox_LockConflict(t *testing.T) {
 				WithClient(fc).
 				WithWaitSimulation().
 				Build()
-			testCache, err := infracache.NewCache(mgr)
+			testCache, err := infracache.NewCache(mgr, false)
 			require.NoError(t, err)
 			mgr.SetWaitHooks(testCache.GetWaitHooks())
 
@@ -3128,7 +3128,7 @@ func TestTryClaimSandbox_ReleasesAdmissionOnRejectedLockWrite(t *testing.T) {
 				mgrBuilder, err := controllers.NewMockManagerBuilder(t)
 				require.NoError(t, err)
 				mgr := mgrBuilder.WithScheme(scheme).WithClient(fc).WithWaitSimulation().Build()
-				testCache, err := infracache.NewCache(mgr)
+				testCache, err := infracache.NewCache(mgr, false)
 				require.NoError(t, err)
 				mgr.SetWaitHooks(testCache.GetWaitHooks())
 

--- a/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
@@ -851,6 +851,7 @@ func TestSandbox_Resume(t *testing.T) {
 		withInitRuntime         bool
 		simulateResumeCompleted bool // use time.AfterFunc to simulate underlying resume completion
 		useShortTimeout         bool // simulate underlying not completing by using short context timeout
+		withEmbeddedTemplate    bool // seed spec.embeddedSandboxTemplate and assert the resume patch preserves it
 	}{
 		{
 			name: "resume paused sandbox - operation completed successfully",
@@ -867,6 +868,29 @@ func TestSandbox_Resume(t *testing.T) {
 			expectedState:           v1alpha1.SandboxStateRunning,
 			expectError:             "",
 			simulateResumeCompleted: true,
+		},
+		{
+			name: "resume paused sandbox preserves embedded template",
+			initSandbox: func(sbx *v1alpha1.Sandbox) {
+				sbx.Status.Phase = v1alpha1.SandboxPaused
+				sbx.Status.Conditions = append(sbx.Status.Conditions, metav1.Condition{
+					Type:   string(v1alpha1.SandboxConditionPaused),
+					Status: metav1.ConditionTrue,
+				})
+				sbx.Spec.Paused = true
+				// The gateway informer cache strips the embedded template
+				// (#724); the resume patch must not erase it on the API
+				// server while unpausing.
+				sbx.Spec.EmbeddedSandboxTemplate = v1alpha1.EmbeddedSandboxTemplate{
+					TemplateRef: &v1alpha1.SandboxTemplateRef{Name: "wake-template"},
+				}
+				state, reason := utils.GetSandboxState(sbx)
+				assert.Equal(t, v1alpha1.SandboxStatePaused, state, reason)
+			},
+			expectedState:           v1alpha1.SandboxStateRunning,
+			expectError:             "",
+			simulateResumeCompleted: true,
+			withEmbeddedTemplate:    true,
 		},
 		{
 			name: "resume paused sandbox - underlying operation not completed",
@@ -1087,6 +1111,11 @@ func TestSandbox_Resume(t *testing.T) {
 			require.NotNil(t, updatedSbx.Spec.PauseTime)
 			assert.WithinDuration(t, shutdownTime, updatedSbx.Spec.ShutdownTime.Time, time.Second)
 			assert.WithinDuration(t, pauseTime, updatedSbx.Spec.PauseTime.Time, time.Second)
+			if tt.withEmbeddedTemplate {
+				require.NotNil(t, updatedSbx.Spec.EmbeddedSandboxTemplate.TemplateRef,
+					"resume patch must not erase the embedded template")
+				assert.Equal(t, "wake-template", updatedSbx.Spec.EmbeddedSandboxTemplate.TemplateRef.Name)
+			}
 		})
 	}
 }
@@ -1616,7 +1645,7 @@ func TestSandbox_ResumeMutatorAtomicity(t *testing.T) {
 			// IsSandboxResumable passes and the mutator runs (released by the
 			// Ready-flip AfterFunc below). Losers (initialPaused=false):
 			// Phase=Running + ConditionReady so Resume() hits the
-			// "sandbox is already resumed" early-return before retryUpdate.
+			// "sandbox is already resumed" early-return before retryPatch.
 			phase := v1alpha1.SandboxPaused
 			conds := []metav1.Condition{
 				{Type: string(v1alpha1.SandboxConditionPaused), Status: metav1.ConditionTrue, Reason: "Paused"},
@@ -1665,16 +1694,16 @@ func TestSandbox_ResumeMutatorAtomicity(t *testing.T) {
 				})
 			}
 
-			// Intercept Update calls to capture the payload that crossed the wire.
-			var updatePayloads []*v1alpha1.Sandbox
+			// Intercept Patch calls to capture the payload that crossed the wire.
+			var patchPayloads []*v1alpha1.Sandbox
 			cacheClient, ok := cache.GetClient().(ctrl.WithWatch)
 			require.True(t, ok)
 			interceptedClient := interceptor.NewClient(cacheClient, interceptor.Funcs{
-				Update: func(ctx context.Context, c ctrl.WithWatch, obj ctrl.Object, opts ...ctrl.UpdateOption) error {
+				Patch: func(ctx context.Context, c ctrl.WithWatch, obj ctrl.Object, patch ctrl.Patch, opts ...ctrl.PatchOption) error {
 					if sbx, ok := obj.(*v1alpha1.Sandbox); ok {
-						updatePayloads = append(updatePayloads, sbx.DeepCopy())
+						patchPayloads = append(patchPayloads, sbx.DeepCopy())
 					}
-					return c.Update(ctx, obj, opts...)
+					return c.Patch(ctx, obj, patch, opts...)
 				},
 			})
 
@@ -1688,12 +1717,12 @@ func TestSandbox_ResumeMutatorAtomicity(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			// Loser case: Resume early-returns; no Update should have happened.
+			// Loser case: Resume early-returns; no Patch should have happened.
 			if !tc.initialPaused {
-				assert.Empty(t, updatePayloads, "loser path must not Update")
+				assert.Empty(t, patchPayloads, "loser path must not Patch")
 			} else {
-				require.Len(t, updatePayloads, 1, "exactly one Update payload expected")
-				payload := updatePayloads[0]
+				require.Len(t, patchPayloads, 1, "exactly one Patch payload expected")
+				payload := patchPayloads[0]
 				assert.False(t, payload.Spec.Paused, "Paused must be false in the payload")
 				assertTimePtrEqual(t, tc.want.pauseTime, payload.Spec.PauseTime, "PauseTime in payload must match expected")
 				assertTimePtrEqual(t, tc.want.shutdownTime, payload.Spec.ShutdownTime, "ShutdownTime in payload must match expected")
@@ -1912,11 +1941,11 @@ func TestSandbox_ResumeFailurePathsLeaveRealTimeout(t *testing.T) {
 				resumeCtx, cancel := context.WithCancel(t.Context())
 				cacheClient, ok := cache.GetClient().(ctrl.WithWatch)
 				require.True(t, ok)
-				var updates atomic.Int32
+				var patches atomic.Int32
 				interceptedClient := interceptor.NewClient(cacheClient, interceptor.Funcs{
-					Update: func(ctx context.Context, c ctrl.WithWatch, obj ctrl.Object, opts ...ctrl.UpdateOption) error {
-						err := c.Update(ctx, obj, opts...)
-						if _, ok := obj.(*v1alpha1.Sandbox); ok && updates.Add(1) == 1 {
+					Patch: func(ctx context.Context, c ctrl.WithWatch, obj ctrl.Object, patch ctrl.Patch, opts ...ctrl.PatchOption) error {
+						err := c.Patch(ctx, obj, patch, opts...)
+						if _, ok := obj.(*v1alpha1.Sandbox); ok && patches.Add(1) == 1 {
 							cancel()
 						}
 						return err
@@ -1958,7 +1987,9 @@ func TestSandbox_ResumeFailurePathsLeaveRealTimeout(t *testing.T) {
 				var updates atomic.Int32
 				interceptedClient := interceptor.NewClient(cacheClient, interceptor.Funcs{
 					Update: func(ctx context.Context, c ctrl.WithWatch, obj ctrl.Object, opts ...ctrl.UpdateOption) error {
-						if _, ok := obj.(*v1alpha1.Sandbox); ok && updates.Add(1) > 1 {
+						// Resume mutates via Patch, so the first intercepted
+						// Update belongs to SaveTimeoutWithPolicy: fail it.
+						if _, ok := obj.(*v1alpha1.Sandbox); ok && updates.Add(1) >= 1 {
 							return injectedErr
 						}
 						return c.Update(ctx, obj, opts...)

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -197,6 +197,80 @@ func (s *Sandbox) retryUpdate(ctx context.Context, modifier ModifierFunc) (bool,
 	return updated, nil
 }
 
+// retryPatch mirrors retryUpdate but persists the mutation with a
+// MergeFromWithOptimisticLock patch instead of a full Update. The patch body
+// only carries the fields the modifier changed plus the resourceVersion
+// precondition, so callers backed by a field-stripping informer cache (the
+// sandbox-gateway cache, see stripSandboxCacheFields) cannot erase stripped
+// fields such as spec.embeddedSandboxTemplate on the API server.
+//
+// Returns the same contract as retryUpdate.
+func (s *Sandbox) retryPatch(ctx context.Context, modifier ModifierFunc) (bool, error) {
+	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(s.Sandbox))
+	objectKey := client.ObjectKeyFromObject(s.Sandbox)
+	updated := false
+	first := true
+	var attemptErr error
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() (err error) {
+		defer func() { attemptErr = err }()
+		if err = ctx.Err(); err != nil {
+			return err
+		}
+		latest := &agentsv1alpha1.Sandbox{}
+		if first {
+			err = s.Cache.GetClient().Get(ctx, objectKey, latest)
+		} else {
+			err = s.Cache.GetAPIReader().Get(ctx, objectKey, latest)
+		}
+		first = false
+		if err != nil {
+			return err
+		}
+
+		copied := latest.DeepCopy()
+		shouldUpdate, err := modifier(copied)
+		if err != nil {
+			return err
+		}
+		if !shouldUpdate {
+			// The informer view may lag behind writes made earlier in the same
+			// operation; never roll the wrapper back to an older object.
+			if expectations.IsResourceVersionNewer(s.Sandbox.ResourceVersion, latest.ResourceVersion) {
+				s.Sandbox = latest
+			}
+			updated = false
+			return nil
+		}
+		// Inject trace context into annotations before patching so the
+		// sandbox-controller can establish parent-child span relationship.
+		copied.Annotations = tracing.InjectTraceContext(ctx, copied.Annotations)
+		patch := client.MergeFromWithOptions(latest, client.MergeFromWithOptimisticLock{})
+		if err = s.Cache.GetClient().Patch(ctx, copied, patch); err != nil {
+			return err
+		}
+		s.Sandbox = copied
+		expectations.ResourceVersionExpectationExpect(copied)
+		updated = true
+		return nil
+	})
+	if err == nil && attemptErr != nil {
+		// retry.OnError rewrites wait.Interrupted errors (context cancellation
+		// included) to the last conflict, which is nil when no conflict
+		// happened; restore the real cause instead of reporting success.
+		err = attemptErr
+	}
+	if err != nil {
+		log.Error(err, "failed to patch sandbox after retries")
+		return false, err
+	}
+	if updated {
+		log.Info("sandbox patched successfully")
+	} else {
+		log.Info("sandbox patch skipped")
+	}
+	return updated, nil
+}
+
 func (s *Sandbox) refreshFromAPIReader(ctx context.Context) error {
 	latest := &agentsv1alpha1.Sandbox{}
 	if err := s.Cache.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(s.Sandbox), latest); err != nil {
@@ -491,7 +565,7 @@ func (s *Sandbox) Resume(ctx context.Context, opts infra.ResumeOptions) (err err
 
 	state, reason := s.GetState()
 	log.Info("try to resume sandbox", "state", state, "reason", reason)
-	resumeUpdated, err := s.retryUpdate(ctx, func(sbx *agentsv1alpha1.Sandbox) (bool, error) {
+	resumeModifier := func(sbx *agentsv1alpha1.Sandbox) (bool, error) {
 		if !sbx.Spec.Paused {
 			// First-writer-wins: the loser must not overwrite the winner's
 			// fresh PauseTime, otherwise the controller would auto-pause.
@@ -502,7 +576,8 @@ func (s *Sandbox) Resume(ctx context.Context, opts infra.ResumeOptions) (err err
 			setTimeout(sbx, *opts.Timeout)
 		}
 		return true, nil
-	})
+	}
+	resumeUpdated, err := s.retryPatch(ctx, resumeModifier)
 	if err != nil {
 		log.Error(err, "failed to update sandbox spec.paused")
 		return err

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
@@ -347,7 +347,7 @@ func TestSandbox_SaveTimeoutWithPolicy_OnConflict(t *testing.T) {
 		WithWaitSimulation().
 		Build()
 
-	testCache, err := infracache.NewCache(mgr)
+	testCache, err := infracache.NewCache(mgr, false)
 	require.NoError(t, err)
 	mgr.SetWaitHooks(testCache.GetWaitHooks())
 

--- a/pkg/sandboxroute/refresh/handler.go
+++ b/pkg/sandboxroute/refresh/handler.go
@@ -71,7 +71,10 @@ func NewHandler(
 		}
 
 		var result sandboxroute.MutationResult
-		if route.State == v1alpha1.SandboxStateDead {
+		// Delete routes for dead and empty (unset) states; retain routes for
+		// every other state, including Paused — wake-on-traffic depends on
+		// Paused routes surviving peer sync.
+		if route.State == v1alpha1.SandboxStateDead || route.State == "" {
 			if route.ResourceVersion == "" {
 				http.Error(w, "invalid route refresh payload", http.StatusBadRequest)
 				return

--- a/pkg/sandboxroute/refresh/handler_test.go
+++ b/pkg/sandboxroute/refresh/handler_test.go
@@ -121,6 +121,29 @@ func TestHandler(t *testing.T) {
 			expectAfterCalls: 1,
 		},
 		{
+			name: "empty state route is deleted",
+			route: &sandboxroute.Route{
+				Namespace:       "ns",
+				Name:            "sandbox",
+				State:           "",
+				ResourceVersion: "2",
+			},
+			deleteResult:     applied,
+			expectStatus:     http.StatusNoContent,
+			expectOperation:  "delete",
+			expectMutations:  1,
+			expectAfterCalls: 1,
+		},
+		{
+			name: "empty state route without resource version is rejected",
+			route: &sandboxroute.Route{
+				Namespace: "ns",
+				Name:      "sandbox",
+				State:     "",
+			},
+			expectStatus: http.StatusBadRequest,
+		},
+		{
 			name:             "running route is upserted",
 			route:            fullRoute(v1alpha1.SandboxStateRunning, "1"),
 			upsertResult:     applied,

--- a/pkg/sandboxroute/route.go
+++ b/pkg/sandboxroute/route.go
@@ -41,13 +41,14 @@ type Route struct {
 	ResourceVersion    string    `json:"resourceVersion"`
 	AccessToken        string    `json:"accessToken,omitempty"`
 	RequireTrafficAuth bool      `json:"requireTrafficAuth,omitempty"`
+	WakeOnTraffic      bool      `json:"wakeOnTraffic,omitempty"`
 }
 
 // String implements fmt.Stringer without exposing the access token.
 func (r Route) String() string {
 	return fmt.Sprintf(
-		"{IP:%s ID:%s Namespace:%s Name:%s UID:%s Owner:%s State:%s ResourceVersion:%s AccessToken:*** RequireTrafficAuth:%t}",
-		r.IP, r.ID, r.Namespace, r.Name, r.UID, r.Owner, r.State, r.ResourceVersion, r.RequireTrafficAuth,
+		"{IP:%s ID:%s Namespace:%s Name:%s UID:%s Owner:%s State:%s ResourceVersion:%s AccessToken:*** RequireTrafficAuth:%t WakeOnTraffic:%t}",
+		r.IP, r.ID, r.Namespace, r.Name, r.UID, r.Owner, r.State, r.ResourceVersion, r.RequireTrafficAuth, r.WakeOnTraffic,
 	)
 }
 
@@ -113,6 +114,7 @@ func RouteFromSandbox(sandbox *agentsv1alpha1.Sandbox) (Route, error) {
 		ResourceVersion:    sandbox.ResourceVersion,
 		AccessToken:        utils.GetAccessToken(sandbox),
 		RequireTrafficAuth: identity.IsAccessTokenRequested(sandbox),
+		WakeOnTraffic:      annotations[agentsv1alpha1.AnnotationWakeOnTraffic] == agentsv1alpha1.True,
 	}
 	if err := route.validate(); err != nil {
 		return Route{}, err

--- a/pkg/sandboxroute/route_test.go
+++ b/pkg/sandboxroute/route_test.go
@@ -129,6 +129,7 @@ func TestRouteFromSandboxDerivation(t *testing.T) {
 		expectID    string
 		expectToken string
 		expectAuth  bool
+		expectWake  bool
 		expectState string
 		expectIP    string
 		expectError string
@@ -172,6 +173,21 @@ func TestRouteFromSandboxDerivation(t *testing.T) {
 			name: "jwt auth non-true value is ignored",
 			sandbox: newSandbox(nil, map[string]string{
 				identity.AnnotationEnableJwtAuth: "True",
+			}),
+			expectID: "ns--name",
+		},
+		{
+			name: "wake-on-traffic requires exact true",
+			sandbox: newSandbox(nil, map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: agentsv1alpha1.True,
+			}),
+			expectID:   "ns--name",
+			expectWake: true,
+		},
+		{
+			name: "wake-on-traffic non-true value is ignored",
+			sandbox: newSandbox(nil, map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: "True",
 			}),
 			expectID: "ns--name",
 		},
@@ -241,6 +257,7 @@ func TestRouteFromSandboxDerivation(t *testing.T) {
 			assert.Equal(t, "owner", route.Owner)
 			assert.Equal(t, tt.expectToken, route.AccessToken)
 			assert.Equal(t, tt.expectAuth, route.RequireTrafficAuth)
+			assert.Equal(t, tt.expectWake, route.WakeOnTraffic)
 		})
 	}
 }

--- a/pkg/servers/e2b/core_test.go
+++ b/pkg/servers/e2b/core_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	utilruntime "github.com/openkruise/agents/pkg/utils/runtime"
 	"github.com/openkruise/agents/pkg/utils/testutils"
+	"github.com/openkruise/agents/pkg/utils/timeout"
 )
 
 var TestServerPort = 9999
@@ -84,11 +85,11 @@ func CreateSandboxWithStatus(t *testing.T, c ctrlclient.Client, sbx *agentsv1alp
 }
 
 func Setup(t *testing.T) (*Controller, ctrlclient.Client, func()) {
-	return SetupWithMinResumeTimeout(t, models.DefaultMinResumeTimeoutSeconds)
+	return SetupWithMinResumeTimeout(t, timeout.DefaultMinResumeTimeoutSeconds)
 }
 
 func SetupWithQuota(t *testing.T, enforcer sandboxmanager.QuotaEnforcer) (*Controller, ctrlclient.Client, func()) {
-	return setupWithMinResumeTimeoutAndQuota(t, models.DefaultMinResumeTimeoutSeconds, enforcer)
+	return setupWithMinResumeTimeoutAndQuota(t, timeout.DefaultMinResumeTimeoutSeconds, enforcer)
 }
 
 func refreshKeyStorageForTest(t *testing.T, controller *Controller) {

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -448,7 +448,11 @@ func (sc *Controller) basicSandboxCreateModifier(ctx context.Context, sbx infra.
 	}
 	if request.AutoResume.Enabled {
 		annotations[agentsv1alpha1.AnnotationWakeOnTraffic] = agentsv1alpha1.True
-		if !request.Extensions.NeverTimeout && request.Timeout > 0 {
+		// The wake timeout only feeds the fresh PauseTime that the gateway
+		// wake path writes for auto-pause sandboxes; shutdown-only
+		// sandboxes never carry a PauseTime, so skip the annotation to
+		// avoid misleading metadata.
+		if request.AutoPause && !request.Extensions.NeverTimeout && request.Timeout > 0 {
 			if _, exists := annotations[agentsv1alpha1.AnnotationWakeTimeoutSeconds]; !exists {
 				annotations[agentsv1alpha1.AnnotationWakeTimeoutSeconds] = strconv.Itoa(request.Timeout)
 			}

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -431,6 +431,12 @@ func (sc *Controller) basicSandboxCreateModifier(ctx context.Context, sbx infra.
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
+	// The wake policy is decided solely by the current request. A claimed CR
+	// may still carry wake annotations from a previous delivery; drop them
+	// before merging the request metadata so stale values never leak into
+	// this delivery (an explicit value in request.Metadata below still wins).
+	delete(annotations, agentsv1alpha1.AnnotationWakeOnTraffic)
+	delete(annotations, agentsv1alpha1.AnnotationWakeTimeoutSeconds)
 	annotations[agentsv1alpha1.AnnotationReservePausedSandboxDuration] = request.Extensions.ReservePausedSandboxDuration
 	for k, v := range request.Metadata {
 		annotations[k] = v
@@ -450,13 +456,19 @@ func (sc *Controller) basicSandboxCreateModifier(ctx context.Context, sbx infra.
 		annotations[agentsv1alpha1.AnnotationWakeOnTraffic] = agentsv1alpha1.True
 		// The wake timeout only feeds the fresh PauseTime that the gateway
 		// wake path writes for auto-pause sandboxes; shutdown-only
-		// sandboxes never carry a PauseTime, so skip the annotation to
+		// sandboxes never carry a PauseTime, so remove the annotation to
 		// avoid misleading metadata.
 		if request.AutoPause && !request.Extensions.NeverTimeout && request.Timeout > 0 {
 			if _, exists := annotations[agentsv1alpha1.AnnotationWakeTimeoutSeconds]; !exists {
 				annotations[agentsv1alpha1.AnnotationWakeTimeoutSeconds] = strconv.Itoa(request.Timeout)
 			}
+		} else {
+			delete(annotations, agentsv1alpha1.AnnotationWakeTimeoutSeconds)
 		}
+	} else {
+		// autoResume disabled: a wake timeout without wake-on-traffic is
+		// meaningless, so drop any explicit metadata override too.
+		delete(annotations, agentsv1alpha1.AnnotationWakeTimeoutSeconds)
 	}
 	sbx.SetAnnotations(annotations)
 

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -444,6 +445,14 @@ func (sc *Controller) basicSandboxCreateModifier(ctx context.Context, sbx infra.
 	}
 	if request.Extensions.ReturnPodIP {
 		annotations[models.ExtensionKeyReturnPodIP] = agentsv1alpha1.True
+	}
+	if request.AutoResume.Enabled {
+		annotations[agentsv1alpha1.AnnotationWakeOnTraffic] = agentsv1alpha1.True
+		if !request.Extensions.NeverTimeout && request.Timeout > 0 {
+			if _, exists := annotations[agentsv1alpha1.AnnotationWakeTimeoutSeconds]; !exists {
+				annotations[agentsv1alpha1.AnnotationWakeTimeoutSeconds] = strconv.Itoa(request.Timeout)
+			}
+		}
 	}
 	sbx.SetAnnotations(annotations)
 

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -832,6 +832,25 @@ func TestParseCreateSandboxRequest(t *testing.T) {
 		assert.Equal(t, "/models", got.Extensions.CSIMount.MountConfigs[1].MountPath)
 	})
 
+	t.Run("autoResume parsed from JSON body", func(t *testing.T) {
+		body := `{
+			"templateID":"t1",
+			"autoResume":{"enabled":true}
+		}`
+		req := httptest.NewRequest(http.MethodPost, "/sandboxes", strings.NewReader(body))
+		got, apiErr := ctrl.parseCreateSandboxRequest(req)
+		require.Nil(t, apiErr)
+		assert.True(t, got.AutoResume.Enabled)
+	})
+
+	t.Run("autoResume absent defaults to disabled", func(t *testing.T) {
+		body := `{"templateID":"t1"}`
+		req := httptest.NewRequest(http.MethodPost, "/sandboxes", strings.NewReader(body))
+		got, apiErr := ctrl.parseCreateSandboxRequest(req)
+		require.Nil(t, apiErr)
+		assert.False(t, got.AutoResume.Enabled)
+	})
+
 	t.Run("volumeMounts with empty name", func(t *testing.T) {
 		body := `{
 			"templateID":"t1",
@@ -938,6 +957,138 @@ func TestParseCreateSandboxRequest(t *testing.T) {
 		require.Len(t, got.VolumeMounts, 1)
 		assert.Equal(t, "volume-pv", got.VolumeMounts[0].Name)
 	})
+}
+
+func TestBasicSandboxCreateModifier(t *testing.T) {
+	tests := []struct {
+		name                string
+		request             models.NewSandboxRequest
+		initialAnnotations  map[string]string
+		initialLabels       map[string]string
+		maxTimeout          int
+		expectAnnotations   map[string]string
+		expectNoAnnotations []string
+		expectLabels        map[string]string
+	}{
+		{
+			name: "metadata propagated to annotations",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    300,
+				Metadata:   map[string]string{"user-key": "user-val"},
+			},
+			maxTimeout:        3600,
+			expectAnnotations: map[string]string{"user-key": "user-val"},
+		},
+		{
+			name: "returnPodIP extension sets annotation",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    300,
+				Extensions: models.NewSandboxRequestExtension{ReturnPodIP: true},
+			},
+			maxTimeout: 3600,
+			expectAnnotations: map[string]string{
+				models.ExtensionKeyReturnPodIP: agentsv1alpha1.True,
+			},
+		},
+		{
+			name: "labels propagated from extensions",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    300,
+				Extensions: models.NewSandboxRequestExtension{
+					Labels: map[string]string{"env": "test"},
+				},
+			},
+			maxTimeout:   3600,
+			expectLabels: map[string]string{"env": "test"},
+		},
+		{
+			name: "autoResume enabled sets wake annotations",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    300,
+				AutoResume: models.SandboxAutoResumeConfig{Enabled: true},
+			},
+			maxTimeout: 3600,
+			expectAnnotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic:      agentsv1alpha1.True,
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "300",
+			},
+		},
+		{
+			name: "autoResume enabled preserves explicit wake timeout annotation",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    300,
+				Metadata: map[string]string{
+					agentsv1alpha1.AnnotationWakeTimeoutSeconds: "180",
+				},
+				AutoResume: models.SandboxAutoResumeConfig{Enabled: true},
+			},
+			maxTimeout: 3600,
+			expectAnnotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic:      agentsv1alpha1.True,
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "180",
+			},
+		},
+		{
+			name: "autoResume disabled does not set wake-on-traffic annotation",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    300,
+				AutoResume: models.SandboxAutoResumeConfig{Enabled: false},
+			},
+			maxTimeout:          3600,
+			expectNoAnnotations: []string{agentsv1alpha1.AnnotationWakeOnTraffic},
+		},
+		{
+			name: "autoResume absent does not set wake-on-traffic annotation",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    300,
+			},
+			maxTimeout:          3600,
+			expectNoAnnotations: []string{agentsv1alpha1.AnnotationWakeOnTraffic},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSbx := &sandboxcr.Sandbox{
+				Sandbox: &agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-sandbox",
+						Namespace:   "default",
+						Annotations: tt.initialAnnotations,
+						Labels:      tt.initialLabels,
+					},
+				},
+			}
+
+			c := &Controller{maxTimeout: tt.maxTimeout}
+			c.basicSandboxCreateModifier(context.Background(), mockSbx, tt.request)
+
+			annotations := mockSbx.GetAnnotations()
+			for k, v := range tt.expectAnnotations {
+				got, ok := annotations[k]
+				assert.True(t, ok, "expected annotation %q to exist", k)
+				assert.Equal(t, v, got, "annotation %q value mismatch", k)
+			}
+			for _, k := range tt.expectNoAnnotations {
+				_, ok := annotations[k]
+				assert.False(t, ok, "expected annotation %q to NOT exist", k)
+			}
+
+			labels := mockSbx.GetLabels()
+			for k, v := range tt.expectLabels {
+				got, ok := labels[k]
+				assert.True(t, ok, "expected label %q to exist", k)
+				assert.Equal(t, v, got, "label %q value mismatch", k)
+			}
+		})
+	}
 }
 
 func TestMapInfraErrorToApiError(t *testing.T) {

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -1036,6 +1036,27 @@ func TestBasicSandboxCreateModifier(t *testing.T) {
 			},
 		},
 		{
+			// A recycled CR can still carry the wake timeout of delivery A;
+			// delivery B's request decides the policy, so the stale value is
+			// replaced by the current request timeout.
+			name: "autoResume enabled overwrites stale inherited wake timeout",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    300,
+				AutoPause:  true,
+				AutoResume: models.SandboxAutoResumeConfig{Enabled: true},
+			},
+			initialAnnotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic:      agentsv1alpha1.True,
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "999",
+			},
+			maxTimeout: 3600,
+			expectAnnotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic:      agentsv1alpha1.True,
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "300",
+			},
+		},
+		{
 			// Shutdown-only lifecycle: the wake timeout only feeds the
 			// fresh PauseTime of auto-pause sandboxes, so the annotation
 			// would be misleading metadata.
@@ -1045,6 +1066,9 @@ func TestBasicSandboxCreateModifier(t *testing.T) {
 				Timeout:    300,
 				AutoPause:  false,
 				AutoResume: models.SandboxAutoResumeConfig{Enabled: true},
+			},
+			initialAnnotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "999",
 			},
 			maxTimeout: 3600,
 			expectAnnotations: map[string]string{
@@ -1061,6 +1085,27 @@ func TestBasicSandboxCreateModifier(t *testing.T) {
 			},
 			maxTimeout:          3600,
 			expectNoAnnotations: []string{agentsv1alpha1.AnnotationWakeOnTraffic},
+		},
+		{
+			// Delivery A enabled autoResume; the CR was recycled and
+			// claimed by delivery B without autoResume. Both inherited
+			// wake annotations must be dropped so B cannot be woken by
+			// traffic.
+			name: "autoResume disabled clears inherited wake annotations",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    300,
+				AutoResume: models.SandboxAutoResumeConfig{Enabled: false},
+			},
+			initialAnnotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic:      agentsv1alpha1.True,
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "300",
+			},
+			maxTimeout: 3600,
+			expectNoAnnotations: []string{
+				agentsv1alpha1.AnnotationWakeOnTraffic,
+				agentsv1alpha1.AnnotationWakeTimeoutSeconds,
+			},
 		},
 		{
 			name: "autoResume absent does not set wake-on-traffic annotation",

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -1009,6 +1009,7 @@ func TestBasicSandboxCreateModifier(t *testing.T) {
 			request: models.NewSandboxRequest{
 				TemplateID: "t1",
 				Timeout:    300,
+				AutoPause:  true,
 				AutoResume: models.SandboxAutoResumeConfig{Enabled: true},
 			},
 			maxTimeout: 3600,
@@ -1022,6 +1023,7 @@ func TestBasicSandboxCreateModifier(t *testing.T) {
 			request: models.NewSandboxRequest{
 				TemplateID: "t1",
 				Timeout:    300,
+				AutoPause:  true,
 				Metadata: map[string]string{
 					agentsv1alpha1.AnnotationWakeTimeoutSeconds: "180",
 				},
@@ -1032,6 +1034,23 @@ func TestBasicSandboxCreateModifier(t *testing.T) {
 				agentsv1alpha1.AnnotationWakeOnTraffic:      agentsv1alpha1.True,
 				agentsv1alpha1.AnnotationWakeTimeoutSeconds: "180",
 			},
+		},
+		{
+			// Shutdown-only lifecycle: the wake timeout only feeds the
+			// fresh PauseTime of auto-pause sandboxes, so the annotation
+			// would be misleading metadata.
+			name: "autoResume enabled without auto-pause skips wake timeout annotation",
+			request: models.NewSandboxRequest{
+				TemplateID: "t1",
+				Timeout:    300,
+				AutoPause:  false,
+				AutoResume: models.SandboxAutoResumeConfig{Enabled: true},
+			},
+			maxTimeout: 3600,
+			expectAnnotations: map[string]string{
+				agentsv1alpha1.AnnotationWakeOnTraffic: agentsv1alpha1.True,
+			},
+			expectNoAnnotations: []string{agentsv1alpha1.AnnotationWakeTimeoutSeconds},
 		},
 		{
 			name: "autoResume disabled does not set wake-on-traffic annotation",

--- a/pkg/servers/e2b/models/consts.go
+++ b/pkg/servers/e2b/models/consts.go
@@ -20,10 +20,6 @@ const (
 	DefaultMaxTimeout        = 2592000 // 30 days
 	DefaultMinTimeoutSeconds = 30
 	DefaultTimeoutSeconds    = 300
-	// DefaultMinResumeTimeoutSeconds floors Connect/Resume requests that
-	// trigger Resume on a Paused sandbox, so the placeholder cannot expire
-	// mid-Resume. Tune via --e2b-min-resume-timeout.
-	DefaultMinResumeTimeoutSeconds = 300
 
 	MaxListLimit = 100
 	MinListLimit = 1

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -58,16 +58,25 @@ type TrafficAccessToken struct {
 	TrafficAccessTokenExpiration string `json:"trafficAccessTokenExpiration"`
 }
 
+// SandboxAutoResumeConfig mirrors the E2B API's autoResume field.
+// When Enabled is true, the sandbox is annotated with
+// agents.kruise.io/wake-on-traffic so the sandbox-gateway will auto-resume
+// it on incoming traffic after it is paused.
+type SandboxAutoResumeConfig struct {
+	Enabled bool `json:"enabled"`
+}
+
 // NewSandboxRequest represents a request to create a new sandbox
 type NewSandboxRequest struct {
-	TemplateID          string                `json:"templateID"`
-	Timeout             int                   `json:"timeout,omitempty"`
-	AutoPause           bool                  `json:"autoPause,omitempty"`
-	AllowInternetAccess *bool                 `json:"allow_internet_access,omitempty"`
-	Metadata            map[string]string     `json:"metadata,omitempty"`
-	EnvVars             EnvVars               `json:"envVars,omitempty"`
-	VolumeMounts        []VolumeMount         `json:"volumeMounts,omitempty"`
-	Network             *SandboxNetworkConfig `json:"network,omitempty"`
+	TemplateID          string                  `json:"templateID"`
+	Timeout             int                     `json:"timeout,omitempty"`
+	AutoPause           bool                    `json:"autoPause,omitempty"`
+	AutoResume          SandboxAutoResumeConfig `json:"autoResume,omitempty"`
+	AllowInternetAccess *bool                   `json:"allow_internet_access,omitempty"`
+	Metadata            map[string]string       `json:"metadata,omitempty"`
+	EnvVars             EnvVars                 `json:"envVars,omitempty"`
+	VolumeMounts        []VolumeMount           `json:"volumeMounts,omitempty"`
+	Network             *SandboxNetworkConfig   `json:"network,omitempty"`
 
 	Extensions NewSandboxRequestExtension `json:"-"`
 

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -198,6 +198,7 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 	if apiErr := sc.updateConnectTimeout(ctx, sbx, effectiveTimeout, state, autoPause, currentEndAt); apiErr != nil {
 		return web.ApiResponse[struct{}]{}, withSandboxResourceContext(apiErr, sbx)
 	}
+
 	return web.ApiResponse[struct{}]{
 		Code: http.StatusNoContent,
 	}, nil

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -210,14 +210,17 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 // hibernated mid-Resume. The floor is skipped for never-timeout sandboxes
 // (hasDeadline == false) since they carry no deadline.
 func (sc *Controller) getEffectivePauseTimeSeconds(log klog.Logger, requested int, paused, hasDeadline bool) int {
-	if !paused || !hasDeadline || requested >= sc.minResumeTimeoutValue {
+	if !paused || !hasDeadline {
 		return requested
 	}
-	log.Info("connect-on-paused timeout floor applied",
-		"requestedSeconds", requested,
-		"effectiveSeconds", sc.minResumeTimeoutValue,
-		"reason", "request shorter than --e2b-min-resume-timeout")
-	return sc.minResumeTimeoutValue
+	effective := timeout.ApplyResumeTimeoutFloor(requested, sc.minResumeTimeoutValue)
+	if effective != requested {
+		log.Info("connect-on-paused timeout floor applied",
+			"requestedSeconds", requested,
+			"effectiveSeconds", effective,
+			"reason", "request shorter than --e2b-min-resume-timeout")
+	}
+	return effective
 }
 
 // computeTimeoutOptions computes timeout options from resolved parameters.

--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -39,13 +39,17 @@ import (
 )
 
 func (sc *Controller) registerRoutes() {
-	sc.mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+	healthHandler := func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprintf(w, "OK")
 		if err != nil {
 			klog.ErrorS(err, "Failed to write health check response")
 		}
-	})
+	}
+	sc.mux.HandleFunc("GET /health", healthHandler)
+	// Also register under the /kruise/api prefix so requests routed through
+	// the sandbox-gateway (which forwards /kruise/api/* to the manager) work.
+	sc.mux.HandleFunc("GET "+adapters.CustomPrefix+"/api/health", healthHandler)
 
 	// Prometheus metrics endpoint for exporting metrics
 	sc.mux.Handle("GET /metrics", promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{}))

--- a/pkg/utils/timeout/timeout.go
+++ b/pkg/utils/timeout/timeout.go
@@ -22,6 +22,23 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 )
 
+// DefaultMinResumeTimeoutSeconds floors the timeout carried by a Resume of a
+// paused sandbox (E2B Connect/Resume and gateway wake-on-traffic), so the
+// freshly written deadline cannot expire while the sandbox is still resuming.
+// The E2B floor is tunable via --e2b-min-resume-timeout.
+const DefaultMinResumeTimeoutSeconds = 300
+
+// ApplyResumeTimeoutFloor raises requested to at least floor, so a short
+// timeout cannot expire while the sandbox is still resuming and trigger a
+// re-pause mid-resume. A floor <= 0 disables the floor and requested is
+// returned unchanged.
+func ApplyResumeTimeoutFloor(requested, floor int) int {
+	if floor <= 0 || requested >= floor {
+		return requested
+	}
+	return floor
+}
+
 func GetTimeoutFromSandbox(sbx *agentsv1alpha1.Sandbox) Options {
 	opts := Options{}
 	if sbx.Spec.ShutdownTime != nil {

--- a/pkg/utils/timeout/timeout_test.go
+++ b/pkg/utils/timeout/timeout_test.go
@@ -339,3 +339,50 @@ func TestTimeEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyResumeTimeoutFloor(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested int
+		floor     int
+		want      int
+	}{
+		{
+			name:      "below floor is raised",
+			requested: 30,
+			floor:     DefaultMinResumeTimeoutSeconds,
+			want:      DefaultMinResumeTimeoutSeconds,
+		},
+		{
+			name:      "equal to floor unchanged",
+			requested: DefaultMinResumeTimeoutSeconds,
+			floor:     DefaultMinResumeTimeoutSeconds,
+			want:      DefaultMinResumeTimeoutSeconds,
+		},
+		{
+			name:      "above floor unchanged",
+			requested: 600,
+			floor:     DefaultMinResumeTimeoutSeconds,
+			want:      600,
+		},
+		{
+			name:      "zero floor disables",
+			requested: 30,
+			floor:     0,
+			want:      30,
+		},
+		{
+			name:      "negative floor disables",
+			requested: 30,
+			floor:     -1,
+			want:      30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ApplyResumeTimeoutFloor(tt.requested, tt.floor)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/test/e2b/test_wake_on_traffic.py
+++ b/test/e2b/test_wake_on_traffic.py
@@ -1,0 +1,203 @@
+"""E2E test: wake a paused sandbox by sending traffic through the gateway."""
+import json
+import subprocess
+import time
+from importlib.metadata import version as _pkg_version
+
+import pytest
+import requests
+from e2b_code_interpreter import Sandbox, SandboxState
+
+GATEWAY_URL = "http://localhost:80"
+# Health-check path routed to manager_cluster by Envoy (prefix: /kruise/api).
+# GET /health is the manager's dedicated health endpoint (returns 200 OK).
+# A 200 here confirms the port-forward and Envoy are both alive.
+_HEALTH_PATH = "/kruise/api/health"
+
+# Annotation keys used by the wake-on-traffic feature.
+_ANN_WAKE_ON_TRAFFIC = "agents.kruise.io/wake-on-traffic"
+_ANN_WAKE_TIMEOUT_SECONDS = "agents.kruise.io/wake-timeout-seconds"
+
+# e2b-code-interpreter 2.4.x predates the `lifecycle={"on_timeout": "pause"}`
+# parameter, so auto-pause cannot be requested through that SDK.
+_E2B_CODE_INTERPRETER_VERSION = _pkg_version("e2b-code-interpreter")
+_SDK_LACKS_AUTO_PAUSE = _E2B_CODE_INTERPRETER_VERSION.startswith("2.4.")
+
+
+def _gateway_health_check():
+    """Return True if the gateway port-forward is alive."""
+    try:
+        r = requests.get(f"{GATEWAY_URL}{_HEALTH_PATH}", timeout=10)
+        ok = r.status_code == 200
+        print(f"gateway health-check: status={r.status_code} ok={ok}")
+        return ok
+    except Exception as e:
+        print(f"gateway health-check failed: {e}")
+        return False
+
+
+def _split_sandbox_id(sandbox_id: str) -> tuple[str | None, str]:
+    """Split a sandbox ID into namespace and resource name."""
+    if "--" not in sandbox_id:
+        return None, sandbox_id
+    namespace, name = sandbox_id.split("--", 1)
+    return namespace, name
+
+
+def _get_sandbox_annotations(sandbox_id: str) -> dict:
+    """Fetch the annotations of a Sandbox CR via kubectl."""
+    namespace, name = _split_sandbox_id(sandbox_id)
+    cmd = ["kubectl", "get", "sandbox", name, "-o", "json"]
+    if namespace:
+        cmd.extend(["-n", namespace])
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    cr = json.loads(result.stdout)
+    return cr.get("metadata", {}).get("annotations", {})
+
+
+def _request_gateway_until_forwarded(headers: dict, timeout_sec: int = 120) -> requests.Response:
+    """Send requests to the gateway until we get a non-502/503 response.
+
+    The wake-on-traffic filter may return 502/503 while the sandbox is still
+    resuming. We poll with a short interval to avoid flaky tests.
+    """
+    deadline = time.time() + timeout_sec
+    last_resp = None
+    attempt = 0
+    while time.time() < deadline:
+        attempt += 1
+        try:
+            resp = requests.get(
+                f"{GATEWAY_URL}/",
+                headers=headers,
+                timeout=30,
+            )
+            last_resp = resp
+            print(f"gateway attempt {attempt}: status={resp.status_code}")
+            if resp.status_code not in (502, 503):
+                return resp
+        except Exception as e:
+            print(f"gateway attempt {attempt}: error={e}")
+        time.sleep(2)
+    return last_resp
+
+
+@pytest.mark.skipif(_SDK_LACKS_AUTO_PAUSE, reason="SDK lacks lifecycle on_timeout pause")
+def test_wake_on_traffic(sandbox_context):
+    """Traffic to a paused sandbox with wake-on-traffic should resume it."""
+    # Step 1: Create sandbox with auto-pause and auto-resume enabled.
+    # auto_resume=True causes the API to set the wake-on-traffic annotation
+    # automatically at sandbox creation time (no kubectl annotate needed).
+    # Use a longer timeout (120s) to give enough time for the auto-pause wait
+    # and the wake test to complete before ShutdownTime triggers deletion.
+    sbx: Sandbox = sandbox_context.add(Sandbox.create(
+        template="code-interpreter",
+        timeout=120,
+        lifecycle={"on_timeout": "pause", "auto_resume": True},
+        metadata={"test_case": "test_wake_on_traffic"},
+        headers={"x-request-id": sandbox_context.request_id},
+    ))
+    sandbox_id = sbx.sandbox_id
+    print(f"sandbox-id: {sandbox_id}")
+    assert sbx.get_info().state == SandboxState.RUNNING
+
+    # Step 2: Verify wake annotations were set by the API.
+    annotations = _get_sandbox_annotations(sandbox_id)
+    assert annotations.get(_ANN_WAKE_ON_TRAFFIC) == "true", (
+        f"autoResume=true should set wake-on-traffic annotation, got: {annotations}"
+    )
+    wake_timeout_ann = annotations.get(_ANN_WAKE_TIMEOUT_SECONDS)
+    assert wake_timeout_ann == "120", (
+        f"autoResume=true should set wake-timeout-seconds annotation, got: {annotations}"
+    )
+    print(
+        "wake annotations verified: "
+        f"wake-on-traffic=true, wake-timeout-seconds={wake_timeout_ann}"
+    )
+
+    # Step 3: Wait for auto-pause.
+    # The sandbox timeout is 120s, but the E2B SDK's auto-pause is triggered
+    # by the server-side timeout handler. The server may use a shorter internal
+    # pause deadline. Poll until the sandbox reports PAUSED state.
+    pause_deadline = time.time() + 120 + 120
+    paused = False
+    while time.time() < pause_deadline:
+        info = sbx.get_info()
+        if info.state == SandboxState.PAUSED:
+            paused = True
+            print(f"sandbox auto-paused: {sandbox_id} state={info.state}")
+            break
+        time.sleep(2)
+    assert paused, f"sandbox {sandbox_id} did not auto-pause within deadline"
+
+    # Step 4: Verify gateway connectivity before sending wake traffic.
+    assert _gateway_health_check(), (
+        "Gateway port-forward is not alive before wake request. "
+        "The port-forward may have dropped during the auto-pause wait."
+    )
+
+    # Step 5: Send traffic through the gateway (triggers wake).
+    # The wake-on-traffic annotation was set by the API (autoResume=true),
+    # so the gateway registry already has WakeOnTraffic=true.
+    #
+    # The access token is required by the agent-runtime sidecar inside
+    # the pod (not the gateway filter). Even when gateway auth is disabled,
+    # the pod's envd still validates the token. The SDK returns it directly
+    # from the create response, so no kubectl lookup is needed.
+    access_token = sbx._envd_access_token or ""
+    headers = {
+        "e2b-sandbox-id": sandbox_id,
+        "e2b-sandbox-port": "49983",
+    }
+    if access_token:
+        headers["X-Access-Token"] = access_token
+
+    print(f"sending wake traffic to {GATEWAY_URL} for {sandbox_id}")
+    resp = _request_gateway_until_forwarded(headers, timeout_sec=120)
+    assert resp is not None, "gateway did not respond within timeout"
+    print(f"wake response: status={resp.status_code} body={resp.text[:200]!r}")
+    print(f"wake response headers: {dict(resp.headers)}")
+
+    # Step 6: Assert wake succeeded (not 502/503)
+    assert resp.status_code != 502, (
+        f"Gateway 502: sandbox {sandbox_id} not found or not running after wake"
+    )
+    assert resp.status_code != 503, (
+        f"Gateway 503: sandbox {sandbox_id} wake failed or timed out"
+    )
+
+    # Step 7: Verify sandbox is Running (poll with retry for controller
+    # reconciliation — the gateway wake triggers an async controller
+    # reconcile to update Status.Phase from Paused to Running).
+    running_deadline = time.time() + 60
+    running = False
+    last_state = None
+    while time.time() < running_deadline:
+        info = sbx.get_info()
+        last_state = info.state
+        if info.state == SandboxState.RUNNING:
+            running = True
+            break
+        print(f"waiting for running state, current: {info.state}")
+        time.sleep(2)
+    assert running, (
+        f"sandbox should be RUNNING after wake; got {last_state}"
+    )
+    print(f"wake-on-traffic succeeded: {sandbox_id} is running")
+
+    # Step 8: Verify wake-on-traffic annotation persists after wake.
+    # The Resume operation should preserve the wake annotations (they are
+    # part of the sandbox metadata, not stripped by Resume).
+    post_wake_annotations = _get_sandbox_annotations(sandbox_id)
+    assert post_wake_annotations.get(_ANN_WAKE_ON_TRAFFIC) == "true", (
+        f"wake-on-traffic annotation should persist after wake, got: {post_wake_annotations}"
+    )
+    assert post_wake_annotations.get(_ANN_WAKE_TIMEOUT_SECONDS) == wake_timeout_ann, (
+        f"wake-timeout-seconds annotation should persist after wake, got: {post_wake_annotations}"
+    )
+    print(f"post-wake annotations verified: {post_wake_annotations}")

--- a/test/e2b/test_wake_on_traffic.py
+++ b/test/e2b/test_wake_on_traffic.py
@@ -58,31 +58,37 @@ def _get_sandbox_annotations(sbx: Sandbox) -> dict:
     return cr.get("metadata", {}).get("annotations", {})
 
 
-def _request_gateway_until_forwarded(headers: dict, timeout_sec: int = 120) -> requests.Response:
-    """Send requests to the gateway until we get a non-502/503 response.
+# Response bodies of every local reply the gateway filter can send instead of
+# forwarding the request upstream. A response carrying any of these bodies was
+# produced by the gateway itself, not by the sandbox, so it cannot prove the
+# pending wake request was continued.
+_GATEWAY_LOCAL_REPLY_BODIES = (
+    "sandbox gateway is not ready",
+    "sandbox not found:",
+    "unauthorized: invalid or missing access token",
+    "forbidden:",
+    "service unavailable: traffic access token verifier is not ready",
+    "healthy sandbox not found:",
+    "wake failed",
+    "sandbox wake failed",
+)
 
-    The wake-on-traffic filter may return 502/503 while the sandbox is still
-    resuming. We poll with a short interval to avoid flaky tests.
+
+def _send_single_wake_request(headers: dict, timeout_sec: int = 180) -> requests.Response:
+    """Send exactly one request through the gateway and return its response.
+
+    The wake-on-traffic filter holds this very request (api.Running) while
+    the sandbox resumes and continues it once the sandbox is Ready, so the
+    response proves both that the wake happened and that the original
+    request was forwarded upstream. The client timeout must cover the full
+    wake budget.
+
+    Deliberately no retry: a retried request can succeed once the sandbox
+    is Running even if the original pending request was never continued,
+    which would hide a broken wake-completion path. Retries belong in the
+    pre-wake synchronization steps only.
     """
-    deadline = time.time() + timeout_sec
-    last_resp = None
-    attempt = 0
-    while time.time() < deadline:
-        attempt += 1
-        try:
-            resp = requests.get(
-                f"{GATEWAY_URL}/",
-                headers=headers,
-                timeout=30,
-            )
-            last_resp = resp
-            print(f"gateway attempt {attempt}: status={resp.status_code}")
-            if resp.status_code not in (502, 503):
-                return resp
-        except Exception as e:
-            print(f"gateway attempt {attempt}: error={e}")
-        time.sleep(2)
-    return last_resp
+    return requests.get(f"{GATEWAY_URL}/", headers=headers, timeout=timeout_sec)
 
 
 @pytest.mark.skipif(_SDK_LACKS_AUTO_PAUSE, reason="SDK lacks lifecycle on_timeout pause")
@@ -139,7 +145,7 @@ def test_wake_on_traffic(sandbox_context):
         "The port-forward may have dropped during the auto-pause wait."
     )
 
-    # Step 5: Send traffic through the gateway (triggers wake).
+    # Step 5: Send a single request through the gateway (triggers wake).
     # The wake-on-traffic annotation was set by the API (autoResume=true),
     # so the gateway registry already has WakeOnTraffic=true.
     #
@@ -156,17 +162,24 @@ def test_wake_on_traffic(sandbox_context):
         headers["X-Access-Token"] = access_token
 
     print(f"sending wake traffic to {GATEWAY_URL} for {sandbox_id}")
-    resp = _request_gateway_until_forwarded(headers, timeout_sec=120)
-    assert resp is not None, "gateway did not respond within timeout"
+    resp = _send_single_wake_request(headers, timeout_sec=180)
     print(f"wake response: status={resp.status_code} body={resp.text[:200]!r}")
     print(f"wake response headers: {dict(resp.headers)}")
 
-    # Step 6: Assert wake succeeded (not 502/503)
-    assert resp.status_code != 502, (
-        f"Gateway 502: sandbox {sandbox_id} not found or not running after wake"
+    # Step 6: Assert the single pending request was continued to the
+    # sandbox's envd upstream. Any gateway local reply (wake failure,
+    # auth rejection, missing route) means the original request was
+    # answered by the filter instead of being forwarded, which fails the
+    # test regardless of whether a later request would have succeeded.
+    # (Gateway auth is disabled in this setup, so a 401 cannot come from
+    # the gateway filter here.)
+    body_start = resp.text.lstrip()[:120]
+    assert not any(body_start.startswith(marker) for marker in _GATEWAY_LOCAL_REPLY_BODIES), (
+        f"gateway answered the wake request locally instead of forwarding it "
+        f"upstream: status={resp.status_code} body={resp.text[:200]!r}"
     )
-    assert resp.status_code != 503, (
-        f"Gateway 503: sandbox {sandbox_id} wake failed or timed out"
+    assert resp.status_code != 401, (
+        f"envd rejected the access token: status=401 body={resp.text[:200]!r}"
     )
 
     # Step 7: Verify sandbox is Running (poll with retry for controller

--- a/test/e2b/test_wake_on_traffic.py
+++ b/test/e2b/test_wake_on_traffic.py
@@ -8,6 +8,8 @@ import pytest
 import requests
 from e2b_code_interpreter import Sandbox, SandboxState
 
+from utils import resolve_sandbox_cr
+
 GATEWAY_URL = "http://localhost:80"
 # Health-check path routed to manager_cluster by Envoy (prefix: /kruise/api).
 # GET /health is the manager's dedicated health endpoint (returns 200 OK).
@@ -36,22 +38,18 @@ def _gateway_health_check():
         return False
 
 
-def _split_sandbox_id(sandbox_id: str) -> tuple[str | None, str]:
-    """Split a sandbox ID into namespace and resource name."""
-    if "--" not in sandbox_id:
-        return None, sandbox_id
-    namespace, name = sandbox_id.split("--", 1)
-    return namespace, name
+def _get_sandbox_annotations(sbx: Sandbox) -> dict:
+    """Fetch the annotations of a Sandbox CR via kubectl.
 
-
-def _get_sandbox_annotations(sandbox_id: str) -> dict:
-    """Fetch the annotations of a Sandbox CR via kubectl."""
-    namespace, name = _split_sandbox_id(sandbox_id)
-    cmd = ["kubectl", "get", "sandbox", name, "-o", "json"]
-    if namespace:
-        cmd.extend(["-n", namespace])
+    The E2B sandbox ID is not necessarily the CR name: sandboxes claimed
+    from a pre-warmed pool keep their original name and carry the ID in the
+    agents.kruise.io/sandbox-id label. Resolve the CR through the shared
+    resolver instead of treating the ID as a name.
+    """
+    namespace, name = resolve_sandbox_cr(sbx.sandbox_id, getattr(sbx, "metadata", None))
+    assert namespace and name, f"could not resolve Sandbox CR for id {sbx.sandbox_id}"
     result = subprocess.run(
-        cmd,
+        ["kubectl", "get", "sandbox", name, "-n", namespace, "-o", "json"],
         capture_output=True,
         text=True,
         check=True,
@@ -107,7 +105,7 @@ def test_wake_on_traffic(sandbox_context):
     assert sbx.get_info().state == SandboxState.RUNNING
 
     # Step 2: Verify wake annotations were set by the API.
-    annotations = _get_sandbox_annotations(sandbox_id)
+    annotations = _get_sandbox_annotations(sbx)
     assert annotations.get(_ANN_WAKE_ON_TRAFFIC) == "true", (
         f"autoResume=true should set wake-on-traffic annotation, got: {annotations}"
     )
@@ -193,7 +191,7 @@ def test_wake_on_traffic(sandbox_context):
     # Step 8: Verify wake-on-traffic annotation persists after wake.
     # The Resume operation should preserve the wake annotations (they are
     # part of the sandbox metadata, not stripped by Resume).
-    post_wake_annotations = _get_sandbox_annotations(sandbox_id)
+    post_wake_annotations = _get_sandbox_annotations(sbx)
     assert post_wake_annotations.get(_ANN_WAKE_ON_TRAFFIC) == "true", (
         f"wake-on-traffic annotation should persist after wake, got: {post_wake_annotations}"
     )

--- a/test/e2b/test_wake_on_traffic.py
+++ b/test/e2b/test_wake_on_traffic.py
@@ -38,8 +38,8 @@ def _gateway_health_check():
         return False
 
 
-def _get_sandbox_annotations(sbx: Sandbox) -> dict:
-    """Fetch the annotations of a Sandbox CR via kubectl.
+def _get_sandbox_cr(sbx: Sandbox) -> dict:
+    """Fetch a Sandbox CR via kubectl.
 
     The E2B sandbox ID is not necessarily the CR name: sandboxes claimed
     from a pre-warmed pool keep their original name and carry the ID in the
@@ -54,8 +54,41 @@ def _get_sandbox_annotations(sbx: Sandbox) -> dict:
         text=True,
         check=True,
     )
-    cr = json.loads(result.stdout)
-    return cr.get("metadata", {}).get("annotations", {})
+    return json.loads(result.stdout)
+
+
+def _get_sandbox_annotations(sbx: Sandbox) -> dict:
+    """Fetch the annotations of a Sandbox CR via kubectl."""
+    return _get_sandbox_cr(sbx).get("metadata", {}).get("annotations", {})
+
+
+def _wait_sandbox_fully_paused(sbx: Sandbox, budget_sec: int = 120):
+    """Wait until the CR has fully completed the pause transition.
+
+    get_info() reports paused as soon as spec.paused is set, while
+    status.phase may still be Running. Resume rejects that intermediate
+    state ("sandbox is not resumable, reason: SandboxIsPausing"), so the
+    single wake request may only be sent after the controller has finished
+    pausing: status.phase == Paused and the SandboxPaused condition is
+    True. Polling is allowed here because this is pre-wake synchronization,
+    not the wake request itself.
+    """
+    deadline = time.time() + budget_sec
+    while time.time() < deadline:
+        cr = _get_sandbox_cr(sbx)
+        phase = cr.get("status", {}).get("phase")
+        conditions = cr.get("status", {}).get("conditions", [])
+        paused_cond = next(
+            (c for c in conditions if c.get("type") == "SandboxPaused"), None
+        )
+        if phase == "Paused" and paused_cond and paused_cond.get("status") == "True":
+            print(f"sandbox fully paused: phase={phase}")
+            return
+        print(f"waiting for pause transition to complete, phase={phase}")
+        time.sleep(2)
+    raise AssertionError(
+        f"sandbox {sbx.sandbox_id} did not finish pausing within {budget_sec}s"
+    )
 
 
 # Response bodies of every local reply the gateway filter can send instead of
@@ -138,6 +171,14 @@ def test_wake_on_traffic(sandbox_context):
             break
         time.sleep(2)
     assert paused, f"sandbox {sandbox_id} did not auto-pause within deadline"
+
+    # Step 3.5: Wait for the pause transition to fully complete. get_info()
+    # flips to PAUSED as soon as spec.paused is set (phase may still be
+    # Running); a wake request in that window is rejected with
+    # SandboxIsPausing. Since step 5 sends exactly one request, it must only
+    # go out after status.phase is Paused and the SandboxPaused condition
+    # is True.
+    _wait_sandbox_fully_paused(sbx)
 
     # Step 4: Verify gateway connectivity before sending wake traffic.
     assert _gateway_health_check(), (


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR implements **wake-on-traffic** for paused sandboxes in the sandbox-gateway. When a paused sandbox receives incoming traffic, the gateway automatically resumes it and forwards the suspended request once the sandbox is running again. Design: `docs/proposals/20260627-wake-on-traffic-via-spec-patch.md`.

**Key changes:**

1. **Wake-on-traffic in filter** (`pkg/sandbox-gateway/filter/filter.go`): When a paused sandbox with wake-on-traffic enabled receives traffic, the filter launches wake in a goroutine with a detached context whose deadline it derives from the filter config, and returns `api.Running` to suspend Envoy request processing. `wakeAndContinue` calls `Continue(api.Continue)` on success or a generic `SendLocalReply(503)` on failure (error detail is logged server-side only, never echoed to callers). A mutex-protected completion state machine prevents double-reply when the async goroutine and `Destroy` race. Wake eligibility is encapsulated in `shouldWakeSandbox()`, which first enforces a **UID fence**: the route's sandbox UID must match the informer's sandbox UID, failing closed on a missing object or mismatch, so a stale route authenticated against a deleted sandbox can never wake or reach a same-name recreated sandbox. The normal Running path and the async wake completion path share `applyUpstreamOverrides()`, so the request that triggered the wake gets identical `envoy.lb.original_dst`, runtime mTLS metadata, and route-cache handling as a request that arrived on a Running sandbox.

2. **New `wake` package** (`pkg/sandbox-gateway/wake/`): `Waker.Wake()` delegates to the sandbox-manager infra `sandboxcr.Sandbox.Resume()` and then syncs the route locally and to peer gateways. The caller owns the wait deadline; `defaultWakeTimeout` is only the fallback timeout used when the sandbox carries no `wake-timeout-seconds` annotation, and `Wake` rejects a non-positive value explicitly. The wake path mirrors the E2B timeout-mode logic: only auto-pause sandboxes get a fresh `PauseTime`, and their `ShutdownTime` is reset to `now + ForeverReservePausedSandboxDuration` (100y) so a retained stale/soon-to-expire ShutdownTime cannot auto-delete a sandbox that was just woken by traffic — the next pause recomputes ShutdownTime from the paused-retention policy. Never-timeout and shutdown-only sandboxes keep their semantics. Dedup comes from Resume's first-writer-wins retry plus refcounted `NewSandboxResumeTask`, so no singleflight is needed.

3. **Resume persists via optimistic merge patch** (`pkg/sandbox-manager/infra/sandboxcr/sandbox.go`): All `Resume` operations now persist via `retryPatch` using `MergeFromWithOptimisticLock` instead of a full Update. The gateway informer cache strips `ManagedFields` and `spec.embeddedSandboxTemplate` (see #724), so a full Update of the cached object would have erased the embedded template on the API server; the patch body carries only the fields Resume changes plus the resourceVersion precondition.

4. **Shared resume timeout floor** (`pkg/utils/timeout/timeout.go`): `ApplyResumeTimeoutFloor` + `DefaultMinResumeTimeoutSeconds` (300s) floor the timeout carried by a Resume of a paused sandbox so the fresh deadline cannot expire mid-resume and re-pause the sandbox. The E2B Connect/Resume handlers reuse it with their tunable `--e2b-min-resume-timeout` value (behavior unchanged), and the gateway wake path applies the same floor to the `wake-timeout-seconds` value (the create API allows values as short as 30s).

5. **autoResume API support** (`pkg/servers/e2b/models/sandbox.go`, `pkg/servers/e2b/create.go`): `"autoResume": {"enabled": true}` in the E2B create request stamps `agents.kruise.io/wake-on-traffic=true` at creation time (the E2B SDK maps `lifecycle={"auto_resume": True}` to this field). The `wake-timeout-seconds` annotation is only stamped when the request also configures auto-pause — for shutdown-only lifecycles the gateway wake path never uses it, so it would be misleading metadata. Create also deletes any inherited wake annotations before merging template metadata, and both wake annotations are added to `AnnotationsClearedOnRecycle`, so every delivery's wake policy is decided solely by the current request — nothing leaks from a previous delivery on a recycled CR.

6. **New annotations** (`api/v1alpha1/annotations.go`): `agents.kruise.io/wake-on-traffic` and `agents.kruise.io/wake-timeout-seconds`.

7. **Route propagation** (`pkg/sandboxroute/`, `pkg/sandbox-gateway/server/server.go`, `pkg/proxy/routes.go`): `Route` gains `WakeOnTraffic`, derived from the annotation in `RouteFromSandbox`; the route's existing `UID` field is what the filter's UID fence compares against the informer object. `handleRefresh` retains routes for all states except `dead` and empty string so the filter has full visibility for wake decisions. `SyncRouteWithPeers` becomes a package-level function so the gateway Waker can sync routes without constructing a full `proxy.Server`.

8. **Gateway cache sandbox-only mode** (`pkg/cache/`): `NewCache`/`SetupCacheControllersWithManager`/`AddIndexesToCache` take a `sandboxOnly` flag; when true only Sandbox-related controllers and indexes are registered (Checkpoint, PVC, and SandboxSet are skipped), reducing the gateway's memory usage and API server load.

9. **Configuration** (`pkg/sandbox-gateway/filter/config.go`, `config/sandbox-gateway/configmap.yaml`): filter config fields `enable-wake-on-traffic` (bool) and `wake-timeout-seconds` (int, default 60). Wake configuration is **listener-level only**: per-route overrides are not supported and this is documented on both fields and in `Merge` (a per-route config can neither disable wake nor unintentionally reset the listener timeout).

10. **E2B health route** (`pkg/servers/e2b/routes.go`): `GET /health` is also registered under the `/kruise/api` prefix so health checks forwarded through the sandbox-gateway work.

11. **New E2E test** (`test/e2b/test_wake_on_traffic.py`): creates a sandbox with `lifecycle={"on_timeout": "pause", "auto_resume": True}`, pauses it, and wakes it with **exactly one request** whose client timeout covers the full wake budget — the filter holds that very request while the sandbox resumes and continues it when Ready, so the response proves both the wake and the completion path. The response is asserted to not be any gateway local reply (fingerprinted by the filter's local-reply bodies) and not an envd 401, ruling out success from unrelated retries. The sandbox CR is resolved via the `agents.kruise.io/sandbox-id` label so pool-claimed sandboxes work. Wired into `hack/run-e2b-e2e-test.sh`.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run unit tests:
   ```bash
   go test ./pkg/sandbox-gateway/... ./pkg/cache/... ./pkg/servers/e2b/... ./pkg/utils/timeout/... ./pkg/sandbox-manager/infra/sandboxcr/...
   ```
2. Run E2E test:
   ```bash
   pytest test/e2b/test_wake_on_traffic.py
   ```
3. Manual verification:
   - Create a sandbox with `lifecycle={"on_timeout": "pause", "auto_resume": True}` (SDK) or `"autoResume": {"enabled": true}` (raw API)
   - Verify the sandbox is annotated with `agents.kruise.io/wake-on-traffic=true`
   - Pause it via `POST /sandboxes/{id}/pause`
   - Send traffic to the paused sandbox
   - Verify the sandbox is automatically resumed and the request is forwarded

### Ⅳ. Special notes for reviews

- **Async wake**: `DecodeHeaders` returns `api.Running` when wake is triggered, launching `wakeAndContinue` in a goroutine with a detached context whose deadline is the sole wake deadline (derived from `wake-timeout-seconds` filter config). On completion it calls `Continue(api.Continue)` or `SendLocalReply`; `Destroy()` cancels the in-flight wake. A mutex-protected completion state machine prevents double-reply races. Wake failure replies stay generic — Kubernetes API error strings are logged server-side, not returned to callers.
- **UID fence**: `shouldWakeSandbox` checks `Waker.SandboxUIDMatches` before any wake decision; a route whose recorded sandbox UID does not match the informer object (or a missing object / empty UID) fails closed. This blocks the attack where a stale route, authenticated against a deleted sandbox, wakes or accesses a same-name recreated sandbox.
- **No singleflight**: dedup is handled by Resume's first-writer-wins `retryPatch` and refcounted wait via `NewSandboxResumeTask`, avoiding the footgun where a canceled caller context would cut short a shared Resume for all coalesced callers.
- **Optimistic patch vs gateway cache stripping**: since #724 strips `spec.embeddedSandboxTemplate` from the gateway informer cache, Resume persists via `MergeFromWithOptimisticLock` patch; a full Update would have erased the template. First-writer-wins, conflict retry, trace injection, and resourceVersion expectations are preserved.
- **Resume timeout floor**: the gateway wake path reuses the same floor (default 300s) as E2B Connect/Resume so a short `wake-timeout-seconds` (create API minimum is 30s) cannot expire mid-resume and trigger a controller re-pause.
- **Timeout-mode preservation during wake**: only auto-pause sandboxes receive a fresh `PauseTime`; never-timeout and shutdown-only sandboxes are resumed without injecting one. Auto-pause wake additionally resets `ShutdownTime` to the forever retention horizon (100y) so a retained ShutdownTime cannot delete a just-woken sandbox; the next pause recomputes it per the paused-retention policy.
- **Wake annotation lifecycle**: wake-on-traffic can be enabled via the E2B create API (`autoResume.enabled`) or manually via `kubectl annotate`; `wake-timeout-seconds` is only stamped by the create API for auto-pause sandboxes. Create strips inherited wake annotations before merging template metadata, and recycle clears both annotations (`AnnotationsClearedOnRecycle`), so a recycled CR never carries the previous delivery's wake policy. The E2E test verifies both annotations persist across the wake.
- **Listener-level config**: wake config is not supported at the per-route level (`typed_per_filter_config`); `Merge` only lets an explicit true / positive value override the listener value. This is documented in `config.go` rather than fixed, matching deployments that only render `plugin_config`.
- **handleRefresh**: only `dead` and empty-state routes are deleted from the registry; all other states are retained for full filter visibility.

### Ⅴ. Test coverage

Measured with `go test -cover` on the final diff:

| Package | Coverage |
|---------|----------|
| `pkg/sandbox-gateway/filter` | 88.8% |
| `pkg/sandbox-gateway/wake` | 77.8% |
| `pkg/servers/e2b` | 88.5% |
| `pkg/proxy` | 89.7% |
