### PR TITLE
fix(sandboxclaim): avoid claim identity collisions

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -367,6 +367,23 @@ func listObjectWithUserAndNamespace[T ctrlclient.ObjectList](ctx context.Context
 	return client.List(ctx, list, listOpts...)
 }
 
+func listSandboxesWithOptions(ctx context.Context, client ctrlclient.Client, list *agentsv1alpha1.SandboxList, opts ListSandboxesOptions, listOpts ...ctrlclient.ListOption) error {
+	if opts.Namespace != "" {
+		listOpts = append(listOpts, ctrlclient.InNamespace(opts.Namespace))
+	}
+	matchingFields := ctrlclient.MatchingFields{}
+	if opts.User != "" {
+		matchingFields[IndexUser] = opts.User
+	}
+	if opts.ClaimName != "" {
+		matchingFields[IndexSandboxClaimName] = opts.ClaimName
+	}
+	if len(matchingFields) > 0 {
+		listOpts = append(listOpts, matchingFields)
+	}
+	return client.List(ctx, list, listOpts...)
+}
+
 func (c *Cache) ListSandboxSets(ctx context.Context, opts ListSandboxSetsOptions) ([]*agentsv1alpha1.SandboxSet, error) {
 	resultVal, err, _ := c.indexGetGroup.Do("sandboxsets:"+opts.Namespace, func() (any, error) {
 		list := &agentsv1alpha1.SandboxSetList{}
@@ -387,7 +404,7 @@ func (c *Cache) ListSandboxSets(ctx context.Context, opts ListSandboxSetsOptions
 
 func (c *Cache) ListSandboxes(ctx context.Context, opts ListSandboxesOptions) ([]*agentsv1alpha1.Sandbox, error) {
 	list := &agentsv1alpha1.SandboxList{}
-	if err := listObjectWithUserAndNamespace(ctx, c.client, list, opts.User, opts.Namespace); err != nil {
+	if err := listSandboxesWithOptions(ctx, c.client, list, opts); err != nil {
 		return nil, err
 	}
 	result := make([]*agentsv1alpha1.Sandbox, 0, len(list.Items))
@@ -402,7 +419,7 @@ func (c *Cache) ListSandboxes(ctx context.Context, opts ListSandboxesOptions) ([
 
 func (c *Cache) CountActiveSandboxes(ctx context.Context, opts ListSandboxesOptions) (int32, error) {
 	list := &agentsv1alpha1.SandboxList{}
-	if err := listObjectWithUserAndNamespace(ctx, c.client, list, opts.User, opts.Namespace); err != nil {
+	if err := listSandboxesWithOptions(ctx, c.client, list, opts); err != nil {
 		return 0, err
 	}
 	var cnt int32

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -166,10 +166,12 @@ func TestClaimedSandboxIndexUsesOneResolvedKey(t *testing.T) {
 		},
 		{
 			name: "unclaimed sandbox yields no key",
-			sandbox: &agentsv1alpha1.Sandbox{ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "pooled",
-			}},
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "pooled",
+				},
+			},
 		},
 	}
 
@@ -184,6 +186,58 @@ func TestClaimedSandboxIndexUsesOneResolvedKey(t *testing.T) {
 			}
 			require.NotNil(t, extract)
 			assert.Equal(t, tt.expectKeys, extract(tt.sandbox))
+		})
+	}
+}
+
+func TestCache_IndexSandboxClaimName(t *testing.T) {
+	var extract func(ctrlclient.Object) []string
+	for _, idx := range cache.GetIndexFuncs() {
+		if idx.FieldName == cache.IndexSandboxClaimName {
+			extract = idx.Extract
+			break
+		}
+	}
+	require.NotNil(t, extract)
+
+	tests := []struct {
+		name       string
+		obj        ctrlclient.Object
+		expectKeys []string
+	}{
+		{
+			name:       "non sandbox object returns no index keys",
+			obj:        &corev1.ConfigMap{},
+			expectKeys: nil,
+		},
+		{
+			name: "sandbox without claim name returns no index keys",
+			obj: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unclaimed-sandbox",
+					Namespace: "default",
+				},
+			},
+			expectKeys: nil,
+		},
+		{
+			name: "sandbox with claim name returns claim name index key",
+			obj: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "claimed-sandbox",
+					Namespace: "default",
+					Labels: map[string]string{
+						agentsv1alpha1.LabelSandboxClaimName: "test-claim",
+					},
+				},
+			},
+			expectKeys: []string{"test-claim"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectKeys, extract(tt.obj))
 		})
 	}
 }
@@ -728,6 +782,143 @@ func TestCache_CountActiveSandboxes(t *testing.T) {
 	cnt, err := c.CountActiveSandboxes(t.Context(), cache.ListSandboxesOptions{User: "user-1"})
 	require.NoError(t, err)
 	assert.Equal(t, listActive, cnt, "CountActiveSandboxes should match ListSandboxes active count")
+}
+
+func TestCache_CountActiveSandboxesWithClaimIdentity(t *testing.T) {
+	const (
+		namespace = "default"
+		claimName = "recreated-claim"
+		newUID    = "new-claim-uid"
+		oldUID    = "old-claim-uid"
+	)
+
+	runningStatus := agentsv1alpha1.SandboxStatus{
+		Phase: agentsv1alpha1.SandboxRunning,
+		Conditions: []metav1.Condition{
+			{Type: string(agentsv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue},
+		},
+	}
+	sandboxes := []ctrlclient.Object{
+		&agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "matching-sandbox",
+				Namespace: namespace,
+				Annotations: map[string]string{
+					agentsv1alpha1.AnnotationOwner: newUID,
+				},
+				Labels: map[string]string{
+					agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.True,
+					agentsv1alpha1.LabelSandboxClaimName: claimName,
+				},
+			},
+			Status: runningStatus,
+		},
+		&agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "old-uid-sandbox",
+				Namespace: namespace,
+				Annotations: map[string]string{
+					agentsv1alpha1.AnnotationOwner: oldUID,
+				},
+				Labels: map[string]string{
+					agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.True,
+					agentsv1alpha1.LabelSandboxClaimName: claimName,
+				},
+			},
+			Status: runningStatus,
+		},
+		&agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "other-claim-sandbox",
+				Namespace: namespace,
+				Annotations: map[string]string{
+					agentsv1alpha1.AnnotationOwner: newUID,
+				},
+				Labels: map[string]string{
+					agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.True,
+					agentsv1alpha1.LabelSandboxClaimName: "other-claim",
+				},
+			},
+			Status: runningStatus,
+		},
+		&agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dead-matching-sandbox",
+				Namespace: namespace,
+				Annotations: map[string]string{
+					agentsv1alpha1.AnnotationOwner: newUID,
+				},
+				Labels: map[string]string{
+					agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.True,
+					agentsv1alpha1.LabelSandboxClaimName: claimName,
+				},
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				Finalizers:        []string{"agents.kruise.io/sandbox"},
+			},
+			Status: runningStatus,
+		},
+	}
+	c, _, err := cachetest.NewTestCache(t, sandboxes...)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		opts        cache.ListSandboxesOptions
+		expectCount int32
+	}{
+		{
+			name: "claim name and uid count only the matching active sandbox",
+			opts: cache.ListSandboxesOptions{
+				Namespace: namespace,
+				User:      newUID,
+				ClaimName: claimName,
+			},
+			expectCount: 1,
+		},
+		{
+			name: "same claim name with old uid is isolated",
+			opts: cache.ListSandboxesOptions{
+				Namespace: namespace,
+				User:      oldUID,
+				ClaimName: claimName,
+			},
+			expectCount: 1,
+		},
+		{
+			name: "same uid with another claim name is isolated",
+			opts: cache.ListSandboxesOptions{
+				Namespace: namespace,
+				User:      newUID,
+				ClaimName: "other-claim",
+			},
+			expectCount: 1,
+		},
+		{
+			name: "unknown uid with same claim name counts zero",
+			opts: cache.ListSandboxesOptions{
+				Namespace: namespace,
+				User:      "missing-uid",
+				ClaimName: claimName,
+			},
+			expectCount: 0,
+		},
+		{
+			name: "claim name alone excludes dead sandboxes",
+			opts: cache.ListSandboxesOptions{
+				Namespace: namespace,
+				ClaimName: claimName,
+			},
+			expectCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cnt, err := c.CountActiveSandboxes(t.Context(), tt.opts)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectCount, cnt)
+		})
+	}
 }
 
 func TestCache_ListCheckpointsWithOptions_UserScoped(t *testing.T) {

--- a/pkg/cache/index.go
+++ b/pkg/cache/index.go
@@ -35,6 +35,7 @@ import (
 var (
 	IndexSandboxPool            = "sandboxPool"
 	IndexClaimedSandboxID       = "sandboxID"
+	IndexSandboxClaimName       = "sandboxClaimName"
 	IndexUser                   = "user"
 	IndexTemplateID             = "templateID"
 	IndexCheckpointID           = "checkpointID"
@@ -108,6 +109,20 @@ func GetIndexFuncs() []IndexFunc {
 				}
 				if user := sbx.GetAnnotations()[agentsv1alpha1.AnnotationOwner]; user != "" {
 					return []string{user}
+				}
+				return nil
+			},
+		},
+		{
+			Obj:       &agentsv1alpha1.Sandbox{},
+			FieldName: IndexSandboxClaimName,
+			Extract: func(obj client.Object) []string {
+				sbx, ok := obj.(*agentsv1alpha1.Sandbox)
+				if !ok {
+					return nil
+				}
+				if claimName := sbx.GetLabels()[agentsv1alpha1.LabelSandboxClaimName]; claimName != "" {
+					return []string{claimName}
 				}
 				return nil
 			},

--- a/pkg/cache/interface.go
+++ b/pkg/cache/interface.go
@@ -46,13 +46,13 @@ type Provider interface {
 
 	ListSandboxSets(ctx context.Context, opts ListSandboxSetsOptions) ([]*agentsv1alpha1.SandboxSet, error)
 
-	// ListSandboxes returns Sandbox CRD objects filtered by namespace and optional owner,
-	// excluding reserved-failed sandboxes kept for debugging.
+	// ListSandboxes returns Sandbox CRD objects filtered by namespace, optional owner,
+	// and optional claim name, excluding reserved-failed sandboxes kept for debugging.
 	// Ownership is determined by the AnnotationOwner annotation on the Sandbox resource when User is set.
 	ListSandboxes(ctx context.Context, opts ListSandboxesOptions) ([]*agentsv1alpha1.Sandbox, error)
 
-	// CountActiveSandboxes counts active (non-dead and not reserved-failed) sandboxes
-	// filtered by namespace and optional owner. Faster than ListSandboxes when only the count is needed.
+	// CountActiveSandboxes counts active (non-dead and not reserved-failed) sandboxes filtered by namespace
+	// and optional owner or claim name. Faster than ListSandboxes when only the count is needed.
 	CountActiveSandboxes(ctx context.Context, opts ListSandboxesOptions) (int32, error)
 
 	// ListLiveSandboxesByOwner returns quota-live sandboxes for the given owner
@@ -150,6 +150,7 @@ type ListSandboxSetsOptions struct {
 type ListSandboxesOptions struct {
 	Namespace string
 	User      string
+	ClaimName string
 }
 
 type ListCheckpointsOptions struct {

--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -322,11 +322,12 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 			if labels == nil {
 				labels = make(map[string]string)
 			}
-			labels[agentsv1alpha1.LabelSandboxClaimName] = claim.Name
 
 			for k, v := range claim.Spec.Labels {
 				labels[k] = v
 			}
+			// The claim name label is internal bookkeeping and must not be overwritten by user labels.
+			labels[agentsv1alpha1.LabelSandboxClaimName] = claim.Name
 			sbx.SetLabels(labels)
 
 			// propagate labels to podtemplate
@@ -496,5 +497,6 @@ func (c *commonControl) countClaimedSandboxes(ctx context.Context, claim *agents
 	return c.cache.CountActiveSandboxes(ctx, cache.ListSandboxesOptions{
 		User:      string(claim.UID),
 		Namespace: claim.Namespace,
+		ClaimName: claim.Name,
 	})
 }

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -411,7 +411,7 @@ func TestCommonControl_EnsureClaimClaiming(t *testing.T) {
 							Labels: map[string]string{
 								agentsv1alpha1.LabelSandboxTemplate:  "test-template",
 								agentsv1alpha1.LabelSandboxIsClaimed: "true",
-								agentsv1alpha1.LabelSandboxClaimName: "test-claim-3",
+								agentsv1alpha1.LabelSandboxClaimName: "test-claim-4",
 							},
 						},
 						Status: agentsv1alpha1.SandboxStatus{
@@ -434,7 +434,7 @@ func TestCommonControl_EnsureClaimClaiming(t *testing.T) {
 							Labels: map[string]string{
 								agentsv1alpha1.LabelSandboxTemplate:  "test-template",
 								agentsv1alpha1.LabelSandboxIsClaimed: "true",
-								agentsv1alpha1.LabelSandboxClaimName: "test-claim-3",
+								agentsv1alpha1.LabelSandboxClaimName: "test-claim-4",
 							},
 						},
 						Status: agentsv1alpha1.SandboxStatus{
@@ -504,6 +504,147 @@ func TestCommonControl_EnsureClaimClaiming(t *testing.T) {
 			if tt.checkStatus != nil && !tt.expectError {
 				tt.checkStatus(t, tt.newStatus)
 			}
+		})
+	}
+}
+
+func TestCommonControl_countClaimedSandboxesWithClaimIdentity(t *testing.T) {
+	const (
+		namespace = "default"
+		claimName = "recreated-claim"
+		newUID    = "new-claim-uid"
+		oldUID    = "old-claim-uid"
+	)
+
+	runningStatus := agentsv1alpha1.SandboxStatus{
+		Phase: agentsv1alpha1.SandboxRunning,
+		Conditions: []metav1.Condition{
+			{Type: string(agentsv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		claim       *agentsv1alpha1.SandboxClaim
+		sandboxes   []client.Object
+		expectCount int32
+		expectError string
+	}{
+		{
+			name: "recreated claim with same name ignores old uid sandboxes",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      claimName,
+					Namespace: namespace,
+					UID:       newUID,
+				},
+			},
+			sandboxes: []client.Object{
+				&agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "old-uid-sandbox",
+						Namespace: namespace,
+						Annotations: map[string]string{
+							agentsv1alpha1.AnnotationOwner: oldUID,
+						},
+						Labels: map[string]string{
+							agentsv1alpha1.LabelSandboxIsClaimed: "true",
+							agentsv1alpha1.LabelSandboxClaimName: claimName,
+						},
+					},
+					Status: runningStatus,
+				},
+			},
+			expectCount: 0,
+		},
+		{
+			name: "claim name and uid count only matching active sandboxes",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      claimName,
+					Namespace: namespace,
+					UID:       newUID,
+				},
+			},
+			sandboxes: []client.Object{
+				&agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "matching-sandbox",
+						Namespace: namespace,
+						Annotations: map[string]string{
+							agentsv1alpha1.AnnotationOwner: newUID,
+						},
+						Labels: map[string]string{
+							agentsv1alpha1.LabelSandboxIsClaimed: "true",
+							agentsv1alpha1.LabelSandboxClaimName: claimName,
+						},
+					},
+					Status: runningStatus,
+				},
+				&agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "old-uid-sandbox",
+						Namespace: namespace,
+						Annotations: map[string]string{
+							agentsv1alpha1.AnnotationOwner: oldUID,
+						},
+						Labels: map[string]string{
+							agentsv1alpha1.LabelSandboxIsClaimed: "true",
+							agentsv1alpha1.LabelSandboxClaimName: claimName,
+						},
+					},
+					Status: runningStatus,
+				},
+				&agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "other-claim-sandbox",
+						Namespace: namespace,
+						Annotations: map[string]string{
+							agentsv1alpha1.AnnotationOwner: newUID,
+						},
+						Labels: map[string]string{
+							agentsv1alpha1.LabelSandboxIsClaimed: "true",
+							agentsv1alpha1.LabelSandboxClaimName: "other-claim",
+						},
+					},
+					Status: runningStatus,
+				},
+				&agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dead-matching-sandbox",
+						Namespace: namespace,
+						Annotations: map[string]string{
+							agentsv1alpha1.AnnotationOwner: newUID,
+						},
+						Labels: map[string]string{
+							agentsv1alpha1.LabelSandboxIsClaimed: "true",
+							agentsv1alpha1.LabelSandboxClaimName: claimName,
+						},
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+						Finalizers:        []string{"agents.kruise.io/sandbox"},
+					},
+					Status: runningStatus,
+				},
+			},
+			expectCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initObjs := append([]client.Object{tt.claim}, tt.sandboxes...)
+			cache, fakeClient, err := cachetest.NewTestCache(t, initObjs...)
+			require.NoError(t, err)
+
+			control := NewCommonControl(fakeClient, record.NewFakeRecorder(10), cache).(*commonControl)
+			count, err := control.countClaimedSandboxes(t.Context(), tt.claim)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectCount, count)
 		})
 	}
 }
@@ -1802,6 +1943,79 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 				assert.Nil(t, opts.Modifier)
 			}
 			if !tt.expectError && tt.validate != nil {
+				tt.validate(t, opts)
+			}
+		})
+	}
+}
+
+func TestCommonControl_buildClaimOptionsProtectsClaimNameLabel(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+	fakeRecorder := record.NewFakeRecorder(10)
+	control := NewCommonControl(fakeClient, fakeRecorder, nil).(*commonControl)
+
+	tests := []struct {
+		name        string
+		claim       *agentsv1alpha1.SandboxClaim
+		sandboxSet  *agentsv1alpha1.SandboxSet
+		expectError string
+		validate    func(t *testing.T, opts infra.ClaimSandboxOptions)
+	}{
+		{
+			name: "user-provided claim name label cannot override internal claim name",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim",
+					Namespace: "default",
+					UID:       "test-uid-override",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "test-template",
+					Labels: map[string]string{
+						"team":                               "platform",
+						agentsv1alpha1.LabelSandboxClaimName: "user-claim-name",
+					},
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-template",
+					Namespace: "default",
+				},
+			},
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				require.NotNil(t, opts.Modifier)
+				mockSandbox := &sandboxcr.Sandbox{
+					Sandbox: &agentsv1alpha1.Sandbox{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-sandbox",
+							Namespace: "default",
+						},
+					},
+				}
+				opts.Modifier(mockSandbox)
+
+				assert.Equal(t, "test-claim", mockSandbox.Labels[agentsv1alpha1.LabelSandboxClaimName])
+				assert.Equal(t, "platform", mockSandbox.Labels["team"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, err := control.buildClaimOptions(t.Context(), tt.claim, tt.sandboxSet)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+			require.NoError(t, err)
+			if tt.validate != nil {
 				tt.validate(t, opts)
 			}
 		})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR fixes SandboxClaim claimed-sandbox counting so a claim is identified by both internal claim-name bookkeeping and the claim UID.

The previous flow could become unstable because `agents.kruise.io/claim-name` is an internal label but user-provided `spec.labels` could override it, while claimed-sandbox recovery did not narrow the cache query by claim name. This could make recreated same-name claims or later reconciliations report incorrect `ClaimedReplicas`.

Key changes:

1. Add a claim-name sandbox cache index and extend `ListSandboxesOptions` with `ClaimName`.
2. Apply claim-name filtering together with the existing claim UID owner filter in `ListSandboxes` and `CountActiveSandboxes`.
3. Pass `ClaimName: claim.Name` from SandboxClaim claimed-sandbox recovery.
4. Preserve the internal `agents.kruise.io/claim-name` label after applying user labels so `spec.labels` cannot override it.
5. Add regression tests for recreated same-name claims, combined claim-name/UID filtering, dead sandbox exclusion, and user-provided claim-name label overrides.

### Ⅱ. Does this pull request fix one issue?

Fixes #311

### Ⅲ. Describe how to verify it

```bash
go test -count=1 ./pkg/cache/... ./pkg/controller/sandboxclaim/core/...
git diff --check
```

### Ⅳ. Special notes for reviews

- No CRD/API changes are introduced, so `make generate` and `make manifests` are not required.
- The new claim-name index is registered through `GetIndexFuncs`, keeping production cache and test cache index definitions consistent.
