### PR TITLE
fix(sandbox-metrics): fix stale condition metrics and add _time metrics for abnormal states

### DIFF
--- a/pkg/controller/sandbox/metrics.go
+++ b/pkg/controller/sandbox/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sandbox
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -343,6 +344,17 @@ var observedReuseDurations sync.Map
 // deletionStartTimes tracks the deletion start time per sandbox for duration calculation.
 var deletionStartTimes sync.Map
 
+// abnormalStartTimes tracks the first time a sandbox entered an abnormal state.
+// Key format: "namespace/name/type". The timestamp is set only on the normal→abnormal
+// transition and cleared on abnormal→normal, so the _time metric stays stable across
+// repeated reconciles while the sandbox remains abnormal.
+var abnormalStartTimes sync.Map
+
+// runtimeContainerAbnormalStartTimes tracks the first time a runtime container became
+// abnormal. Key format: "namespace/name/container". Same stable-timestamp pattern as
+// abnormalStartTimes.
+var runtimeContainerAbnormalStartTimes sync.Map
+
 // sandboxLabels is the opt-in metric that exposes sandbox labels as Prometheus labels,
 // controlled via --metric-labels-allowlist flag, following the kube_pod_labels pattern.
 var sandboxLabels *prometheus.GaugeVec
@@ -623,21 +635,8 @@ func recordSandboxMetrics(sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod) {
 		}
 	}
 
-	abnormalTime := float64(time.Now().Unix())
-	if pauseAbnormal {
-		sandboxStatusAbnormal.WithLabelValues(namespace, name, "pause_incomplete").Set(1)
-		sandboxStatusAbnormalTime.WithLabelValues(namespace, name, "pause_incomplete").Set(abnormalTime)
-	} else {
-		sandboxStatusAbnormal.DeleteLabelValues(namespace, name, "pause_incomplete")
-		sandboxStatusAbnormalTime.DeleteLabelValues(namespace, name, "pause_incomplete")
-	}
-	if resumeAbnormal {
-		sandboxStatusAbnormal.WithLabelValues(namespace, name, "resume_incomplete").Set(1)
-		sandboxStatusAbnormalTime.WithLabelValues(namespace, name, "resume_incomplete").Set(abnormalTime)
-	} else {
-		sandboxStatusAbnormal.DeleteLabelValues(namespace, name, "resume_incomplete")
-		sandboxStatusAbnormalTime.DeleteLabelValues(namespace, name, "resume_incomplete")
-	}
+	setAbnormalTimeMetric(namespace, name, "pause_incomplete", pauseAbnormal)
+	setAbnormalTimeMetric(namespace, name, "resume_incomplete", resumeAbnormal)
 
 	// sandbox_labels: opt-in metric controlled via --metric-labels-allowlist
 	if sandboxLabels != nil {
@@ -699,6 +698,44 @@ func DeleteSandboxMetrics(namespace, name string) {
 	observedCreationFailure.Delete(key)
 	reuseStartTimes.Delete(key)
 	observedReuseDurations.Delete(key)
+
+	// Clean up abnormal start-time tracking.
+	// Use prefix matching to catch all types/containers for this sandbox.
+	abnormalStartTimes.Range(func(k, _ any) bool {
+		if s, ok := k.(string); ok && strings.HasPrefix(s, key+"/") {
+			abnormalStartTimes.Delete(k)
+		}
+		return true
+	})
+	runtimeContainerAbnormalStartTimes.Range(func(k, _ any) bool {
+		if s, ok := k.(string); ok && strings.HasPrefix(s, key+"/") {
+			runtimeContainerAbnormalStartTimes.Delete(k)
+		}
+		return true
+	})
+}
+
+// setAbnormalTimeMetric manages the abnormal gauge and its _time companion.
+// On the normal→abnormal transition it stores the current timestamp in
+// abnormalStartTimes and sets the _time metric to that value. While the state
+// remains abnormal across subsequent reconciles, the timestamp is NOT refreshed.
+// On the abnormal→normal transition it deletes both the metric series and the
+// stored start time.
+func setAbnormalTimeMetric(namespace, name, abnormalType string, abnormal bool) {
+	key := namespace + "/" + name + "/" + abnormalType
+	if abnormal {
+		// Only set the timestamp on the first transition into abnormal.
+		if _, exists := abnormalStartTimes.Load(key); !exists {
+			now := float64(time.Now().Unix())
+			abnormalStartTimes.Store(key, now)
+			sandboxStatusAbnormalTime.WithLabelValues(namespace, name, abnormalType).Set(now)
+		}
+		sandboxStatusAbnormal.WithLabelValues(namespace, name, abnormalType).Set(1)
+	} else {
+		abnormalStartTimes.Delete(key)
+		sandboxStatusAbnormal.DeleteLabelValues(namespace, name, abnormalType)
+		sandboxStatusAbnormalTime.DeleteLabelValues(namespace, name, abnormalType)
+	}
 }
 
 func recordRuntimeContainerAbnormal(namespace, name string, pod *corev1.Pod) {
@@ -710,10 +747,17 @@ func recordRuntimeContainerAbnormal(namespace, name string, pod *corev1.Pod) {
 		if !sidecarutils.RuntimeContainerNames.Has(cs.Name) {
 			continue
 		}
+		containerKey := namespace + "/" + name + "/" + cs.Name
 		if cs.RestartCount > 0 && !cs.Ready {
+			// Only set the timestamp on the first transition into abnormal.
+			if _, exists := runtimeContainerAbnormalStartTimes.Load(containerKey); !exists {
+				now := float64(time.Now().Unix())
+				runtimeContainerAbnormalStartTimes.Store(containerKey, now)
+				sandboxRuntimeContainerAbnormalTime.WithLabelValues(namespace, name, cs.Name).Set(now)
+			}
 			sandboxRuntimeContainerAbnormal.WithLabelValues(namespace, name, cs.Name).Set(1)
-			sandboxRuntimeContainerAbnormalTime.WithLabelValues(namespace, name, cs.Name).Set(float64(time.Now().Unix()))
 		} else {
+			runtimeContainerAbnormalStartTimes.Delete(containerKey)
 			sandboxRuntimeContainerAbnormal.WithLabelValues(namespace, name, cs.Name).Set(0)
 			sandboxRuntimeContainerAbnormalTime.DeleteLabelValues(namespace, name, cs.Name)
 		}

--- a/pkg/controller/sandbox/metrics.go
+++ b/pkg/controller/sandbox/metrics.go
@@ -252,6 +252,24 @@ var (
 		[]string{"namespace", "name", "type"},
 	)
 
+	// sandboxStatusAbnormalTime records the Unix timestamp when the sandbox entered the abnormal state.
+	sandboxStatusAbnormalTime = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sandbox_status_abnormal_time",
+			Help: "Unix timestamp when the sandbox entered an abnormal state",
+		},
+		[]string{"namespace", "name", "type"},
+	)
+
+	// sandboxRuntimeContainerAbnormalTime records the Unix timestamp when a runtime container became abnormal.
+	sandboxRuntimeContainerAbnormalTime = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sandbox_runtime_container_abnormal_time",
+			Help: "Unix timestamp when a sandbox runtime container became abnormal",
+		},
+		[]string{"namespace", "name", "container"},
+	)
+
 	// sandboxReuseTotal tracks the total number of sandbox reuse operations.
 	sandboxReuseTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -355,7 +373,9 @@ func init() {
 		sandboxResumeTotal,
 		sandboxDeletionDuration,
 		sandboxRuntimeContainerAbnormal,
+		sandboxRuntimeContainerAbnormalTime,
 		sandboxStatusAbnormal,
+		sandboxStatusAbnormalTime,
 		sandboxReuseTotal,
 		sandboxReuseDuration,
 	)
@@ -459,6 +479,14 @@ func findCondition(conditions []metav1.Condition, condType string) *metav1.Condi
 }
 
 func recordSandboxConditionMetrics(sandbox *agentsv1alpha1.Sandbox, namespace, name string) {
+	// Reset all condition-based "un" metrics to 0 before processing conditions.
+	// This ensures that when a condition is absent from the conditions slice
+	// (e.g., SandboxConditionResumed is removed during pause), stale metric
+	// values from a previous reconcile are cleared.
+	sandboxStatusInplaceUpdating.WithLabelValues(namespace, name).Set(0)
+	sandboxStatusUnpaused.WithLabelValues(namespace, name).Set(0)
+	sandboxStatusUnresumed.WithLabelValues(namespace, name).Set(0)
+
 	for _, condition := range sandbox.Status.Conditions {
 		switch agentsv1alpha1.SandboxConditionType(condition.Type) {
 		case agentsv1alpha1.SandboxConditionReady:
@@ -595,15 +623,20 @@ func recordSandboxMetrics(sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod) {
 		}
 	}
 
+	abnormalTime := float64(time.Now().Unix())
 	if pauseAbnormal {
 		sandboxStatusAbnormal.WithLabelValues(namespace, name, "pause_incomplete").Set(1)
+		sandboxStatusAbnormalTime.WithLabelValues(namespace, name, "pause_incomplete").Set(abnormalTime)
 	} else {
 		sandboxStatusAbnormal.DeleteLabelValues(namespace, name, "pause_incomplete")
+		sandboxStatusAbnormalTime.DeleteLabelValues(namespace, name, "pause_incomplete")
 	}
 	if resumeAbnormal {
 		sandboxStatusAbnormal.WithLabelValues(namespace, name, "resume_incomplete").Set(1)
+		sandboxStatusAbnormalTime.WithLabelValues(namespace, name, "resume_incomplete").Set(abnormalTime)
 	} else {
 		sandboxStatusAbnormal.DeleteLabelValues(namespace, name, "resume_incomplete")
+		sandboxStatusAbnormalTime.DeleteLabelValues(namespace, name, "resume_incomplete")
 	}
 
 	// sandbox_labels: opt-in metric controlled via --metric-labels-allowlist
@@ -648,7 +681,9 @@ func DeleteSandboxMetrics(namespace, name string) {
 	// Counter metrics at namespace level are not deleted per-sandbox
 
 	sandboxStatusAbnormal.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "name": name})
+	sandboxStatusAbnormalTime.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "name": name})
 	sandboxRuntimeContainerAbnormal.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "name": name})
+	sandboxRuntimeContainerAbnormalTime.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "name": name})
 
 	if sandboxLabels != nil {
 		sandboxLabels.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "name": name})
@@ -677,8 +712,10 @@ func recordRuntimeContainerAbnormal(namespace, name string, pod *corev1.Pod) {
 		}
 		if cs.RestartCount > 0 && !cs.Ready {
 			sandboxRuntimeContainerAbnormal.WithLabelValues(namespace, name, cs.Name).Set(1)
+			sandboxRuntimeContainerAbnormalTime.WithLabelValues(namespace, name, cs.Name).Set(float64(time.Now().Unix()))
 		} else {
 			sandboxRuntimeContainerAbnormal.WithLabelValues(namespace, name, cs.Name).Set(0)
+			sandboxRuntimeContainerAbnormalTime.DeleteLabelValues(namespace, name, cs.Name)
 		}
 	}
 }

--- a/pkg/controller/sandbox/metrics.go
+++ b/pkg/controller/sandbox/metrics.go
@@ -17,7 +17,6 @@ limitations under the License.
 package sandbox
 
 import (
-	"strings"
 	"sync"
 	"time"
 
@@ -306,6 +305,10 @@ var (
 		agentsv1alpha1.SandboxFailed,
 		agentsv1alpha1.SandboxTerminating,
 	}
+
+	// abnormalTypes enumerates all possible sandbox_status_abnormal type label values.
+	// Used for O(1) cleanup in DeleteSandboxMetrics instead of O(N) Range scan.
+	abnormalTypes = []string{"pause_incomplete", "resume_incomplete"}
 )
 
 // observedCreationToReady tracks which sandboxes have had their creation-to-ready
@@ -699,20 +702,15 @@ func DeleteSandboxMetrics(namespace, name string) {
 	reuseStartTimes.Delete(key)
 	observedReuseDurations.Delete(key)
 
-	// Clean up abnormal start-time tracking.
-	// Use prefix matching to catch all types/containers for this sandbox.
-	abnormalStartTimes.Range(func(k, _ any) bool {
-		if s, ok := k.(string); ok && strings.HasPrefix(s, key+"/") {
-			abnormalStartTimes.Delete(k)
-		}
-		return true
-	})
-	runtimeContainerAbnormalStartTimes.Range(func(k, _ any) bool {
-		if s, ok := k.(string); ok && strings.HasPrefix(s, key+"/") {
-			runtimeContainerAbnormalStartTimes.Delete(k)
-		}
-		return true
-	})
+	// Clean up abnormal start-time tracking with O(1) direct deletes.
+	// The set of possible types and container names is fixed and small,
+	// so we avoid an O(N) Range scan across all sandboxes' entries.
+	for _, t := range abnormalTypes {
+		abnormalStartTimes.Delete(key + "/" + t)
+	}
+	for _, c := range sidecarutils.RuntimeContainerNames.List() {
+		runtimeContainerAbnormalStartTimes.Delete(key + "/" + c)
+	}
 }
 
 // setAbnormalTimeMetric manages the abnormal gauge and its _time companion.

--- a/pkg/controller/sandbox/metrics.go
+++ b/pkg/controller/sandbox/metrics.go
@@ -309,6 +309,11 @@ var (
 	// abnormalTypes enumerates all possible sandbox_status_abnormal type label values.
 	// Used for O(1) cleanup in DeleteSandboxMetrics instead of O(N) Range scan.
 	abnormalTypes = []string{"pause_incomplete", "resume_incomplete"}
+
+	// runtimeContainerNamesList is the pre-computed sorted list of runtime container
+	// names, used for O(1) cleanup in DeleteSandboxMetrics. Pre-computed to avoid
+	// allocating a new slice on every DeleteSandboxMetrics call.
+	runtimeContainerNamesList = sidecarutils.RuntimeContainerNames.List()
 )
 
 // observedCreationToReady tracks which sandboxes have had their creation-to-ready
@@ -708,7 +713,7 @@ func DeleteSandboxMetrics(namespace, name string) {
 	for _, t := range abnormalTypes {
 		abnormalStartTimes.Delete(key + "/" + t)
 	}
-	for _, c := range sidecarutils.RuntimeContainerNames.List() {
+	for _, c := range runtimeContainerNamesList {
 		runtimeContainerAbnormalStartTimes.Delete(key + "/" + c)
 	}
 }

--- a/pkg/controller/sandbox/metrics_test.go
+++ b/pkg/controller/sandbox/metrics_test.go
@@ -2525,12 +2525,45 @@ func TestSandboxRuntimeContainerAbnormalTime(t *testing.T) {
 // cleans up sandbox_status_abnormal_time and sandbox_runtime_container_abnormal_time.
 func TestDeleteSandboxMetrics_ClearsAbnormalTimeMetrics(t *testing.T) {
 	ns, name := "default", "cleanup-abnormal-time-sandbox"
+	now := metav1.NewTime(time.Now())
 
-	// Set up abnormal metrics
-	sandboxStatusAbnormal.WithLabelValues(ns, name, "pause_incomplete").Set(1)
-	sandboxStatusAbnormalTime.WithLabelValues(ns, name, "pause_incomplete").Set(float64(time.Now().Unix()))
-	sandboxRuntimeContainerAbnormal.WithLabelValues(ns, name, "agent-runtime").Set(1)
-	sandboxRuntimeContainerAbnormalTime.WithLabelValues(ns, name, "agent-runtime").Set(float64(time.Now().Unix()))
+	// Populate abnormal state through the real recording functions so that both
+	// the Prometheus gauges AND the sync.Map start-time trackers are populated.
+	// Directly setting gauges would leave the sync.Maps empty, causing the Range
+	// cleanup in DeleteSandboxMetrics to be uncovered.
+	sandbox := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: ns,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxPaused,
+			Conditions: []metav1.Condition{{
+				Type:               string(agentsv1alpha1.SandboxConditionPaused),
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: now,
+			}},
+		},
+	}
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{Name: "agent-runtime", Ready: false, RestartCount: 2},
+			},
+		},
+	}
+
+	recordSandboxMetrics(sandbox, pod)
+
+	// Verify sync.Map entries were populated
+	statusKey := ns + "/" + name + "/pause_incomplete"
+	if _, ok := abnormalStartTimes.Load(statusKey); !ok {
+		t.Fatalf("precondition: abnormalStartTimes should have entry for %s", statusKey)
+	}
+	containerKey := ns + "/" + name + "/agent-runtime"
+	if _, ok := runtimeContainerAbnormalStartTimes.Load(containerKey); !ok {
+		t.Fatalf("precondition: runtimeContainerAbnormalStartTimes should have entry for %s", containerKey)
+	}
 
 	DeleteSandboxMetrics(ns, name)
 
@@ -2543,6 +2576,14 @@ func TestDeleteSandboxMetrics_ClearsAbnormalTimeMetrics(t *testing.T) {
 	runtimeTimeVal := testutil.ToFloat64(sandboxRuntimeContainerAbnormalTime.WithLabelValues(ns, name, "agent-runtime"))
 	if runtimeTimeVal != 0 {
 		t.Errorf("sandbox_runtime_container_abnormal_time after delete = %v, want 0", runtimeTimeVal)
+	}
+
+	// Verify sync.Map entries were cleaned up
+	if _, ok := abnormalStartTimes.Load(statusKey); ok {
+		t.Errorf("abnormalStartTimes should not have entry for %s after delete", statusKey)
+	}
+	if _, ok := runtimeContainerAbnormalStartTimes.Load(containerKey); ok {
+		t.Errorf("runtimeContainerAbnormalStartTimes should not have entry for %s after delete", containerKey)
 	}
 }
 

--- a/pkg/controller/sandbox/metrics_test.go
+++ b/pkg/controller/sandbox/metrics_test.go
@@ -2354,123 +2354,98 @@ func TestStaleUnpausedMetricReset(t *testing.T) {
 
 // TestSandboxStatusAbnormalTime verifies that sandbox_status_abnormal_time is set when
 // the sandbox enters an abnormal state and deleted when it returns to normal.
+// It is parameterized by abnormal type (resume_incomplete / pause_incomplete).
 func TestSandboxStatusAbnormalTime(t *testing.T) {
-	ns := "default"
-	name := "abnormal-time-sandbox"
 	now := metav1.NewTime(time.Now())
-
-	// Step 1: Record with an abnormal state (Phase=Resuming, SandboxResumed=False)
-	sandboxAbnormal := &agentsv1alpha1.Sandbox{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name, Namespace: ns,
-			CreationTimestamp: metav1.NewTime(time.Now()),
+	tests := []struct {
+		name             string
+		abnormalPhase    agentsv1alpha1.SandboxPhase
+		abnormalConds    []metav1.Condition
+		abnormalType     string
+		normalPhase      agentsv1alpha1.SandboxPhase
+		normalConds      []metav1.Condition
+	}{
+		{
+			name:          "resume_incomplete",
+			abnormalPhase: agentsv1alpha1.SandboxResuming,
+			abnormalConds: []metav1.Condition{{
+				Type:               string(agentsv1alpha1.SandboxConditionResumed),
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: now,
+			}},
+			abnormalType: "resume_incomplete",
+			normalPhase:  agentsv1alpha1.SandboxRunning,
+			normalConds: []metav1.Condition{{
+				Type:               string(agentsv1alpha1.SandboxConditionResumed),
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: now,
+			}},
 		},
-		Status: agentsv1alpha1.SandboxStatus{
-			Phase: agentsv1alpha1.SandboxResuming,
-			Conditions: []metav1.Condition{
-				{
-					Type:               string(agentsv1alpha1.SandboxConditionResumed),
-					Status:             metav1.ConditionFalse,
-					LastTransitionTime: now,
+		{
+			name:          "pause_incomplete",
+			abnormalPhase: agentsv1alpha1.SandboxPaused,
+			abnormalConds: nil, // No Paused condition → abnormal
+			abnormalType: "pause_incomplete",
+			normalPhase:  agentsv1alpha1.SandboxRunning,
+			normalConds:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := "default"
+			name := tt.name + "-abnormal-time-sandbox"
+
+			// Step 1: Record with an abnormal state
+			sandboxAbnormal := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name, Namespace: ns,
+					CreationTimestamp: metav1.NewTime(time.Now()),
 				},
-			},
-		},
-	}
-	recordSandboxMetrics(sandboxAbnormal, nil)
-
-	// Abnormal metric should be 1 and time metric should be set (>0)
-	abnormalVal := testutil.ToFloat64(sandboxStatusAbnormal.WithLabelValues(ns, name, "resume_incomplete"))
-	if abnormalVal != 1 {
-		t.Fatalf("sandbox_status_abnormal{type=resume_incomplete} = %v, want 1", abnormalVal)
-	}
-
-	timeVal := testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, "resume_incomplete"))
-	if timeVal <= 0 {
-		t.Errorf("sandbox_status_abnormal_time{type=resume_incomplete} = %v, want > 0", timeVal)
-	}
-
-	// Step 2: Record with a normal state (Phase=Running, SandboxResumed=True)
-	sandboxNormal := &agentsv1alpha1.Sandbox{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name, Namespace: ns,
-			CreationTimestamp: metav1.NewTime(time.Now()),
-		},
-		Status: agentsv1alpha1.SandboxStatus{
-			Phase: agentsv1alpha1.SandboxRunning,
-			Conditions: []metav1.Condition{
-				{
-					Type:               string(agentsv1alpha1.SandboxConditionResumed),
-					Status:             metav1.ConditionTrue,
-					LastTransitionTime: now,
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase:      tt.abnormalPhase,
+					Conditions: tt.abnormalConds,
 				},
-			},
-		},
-	}
-	recordSandboxMetrics(sandboxNormal, nil)
-	defer DeleteSandboxMetrics(ns, name)
+			}
+			recordSandboxMetrics(sandboxAbnormal, nil)
 
-	// Abnormal metric should be deleted (returns 0 from a new series)
-	abnormalVal = testutil.ToFloat64(sandboxStatusAbnormal.WithLabelValues(ns, name, "resume_incomplete"))
-	if abnormalVal != 0 {
-		t.Errorf("sandbox_status_abnormal{type=resume_incomplete} = %v, want 0 after recovery", abnormalVal)
-	}
+			// Abnormal metric should be 1 and time metric should be set (>0)
+			abnormalVal := testutil.ToFloat64(sandboxStatusAbnormal.WithLabelValues(ns, name, tt.abnormalType))
+			if abnormalVal != 1 {
+				t.Fatalf("sandbox_status_abnormal{type=%s} = %v, want 1", tt.abnormalType, abnormalVal)
+			}
 
-	// Time metric should also be deleted (returns 0 from a new series)
-	timeVal = testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, "resume_incomplete"))
-	if timeVal != 0 {
-		t.Errorf("sandbox_status_abnormal_time{type=resume_incomplete} = %v, want 0 after recovery", timeVal)
-	}
-}
+			timeVal := testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, tt.abnormalType))
+			if timeVal <= 0 {
+				t.Errorf("sandbox_status_abnormal_time{type=%s} = %v, want > 0", tt.abnormalType, timeVal)
+			}
 
-// TestSandboxStatusAbnormalTime_PauseIncomplete verifies the pause_incomplete abnormal time metric.
-func TestSandboxStatusAbnormalTime_PauseIncomplete(t *testing.T) {
-	ns := "default"
-	name := "pause-abnormal-time-sandbox"
+			// Step 2: Record with a normal state
+			sandboxNormal := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name, Namespace: ns,
+					CreationTimestamp: metav1.NewTime(time.Now()),
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase:      tt.normalPhase,
+					Conditions: tt.normalConds,
+				},
+			}
+			recordSandboxMetrics(sandboxNormal, nil)
+			defer DeleteSandboxMetrics(ns, name)
 
-	// Phase=Paused but SandboxPaused condition is absent → abnormal
-	sandboxAbnormal := &agentsv1alpha1.Sandbox{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name, Namespace: ns,
-			CreationTimestamp: metav1.NewTime(time.Now()),
-		},
-		Status: agentsv1alpha1.SandboxStatus{
-			Phase:      agentsv1alpha1.SandboxPaused,
-			Conditions: nil, // No Paused condition → abnormal
-		},
-	}
-	recordSandboxMetrics(sandboxAbnormal, nil)
+			// Abnormal metric should be deleted (returns 0 from a new series)
+			abnormalVal = testutil.ToFloat64(sandboxStatusAbnormal.WithLabelValues(ns, name, tt.abnormalType))
+			if abnormalVal != 0 {
+				t.Errorf("sandbox_status_abnormal{type=%s} = %v, want 0 after recovery", tt.abnormalType, abnormalVal)
+			}
 
-	abnormalVal := testutil.ToFloat64(sandboxStatusAbnormal.WithLabelValues(ns, name, "pause_incomplete"))
-	if abnormalVal != 1 {
-		t.Fatalf("sandbox_status_abnormal{type=pause_incomplete} = %v, want 1", abnormalVal)
-	}
-
-	timeVal := testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, "pause_incomplete"))
-	if timeVal <= 0 {
-		t.Errorf("sandbox_status_abnormal_time{type=pause_incomplete} = %v, want > 0", timeVal)
-	}
-
-	// Now transition to normal (Phase=Running)
-	sandboxNormal := &agentsv1alpha1.Sandbox{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name, Namespace: ns,
-			CreationTimestamp: metav1.NewTime(time.Now()),
-		},
-		Status: agentsv1alpha1.SandboxStatus{
-			Phase: agentsv1alpha1.SandboxRunning,
-		},
-	}
-	recordSandboxMetrics(sandboxNormal, nil)
-	defer DeleteSandboxMetrics(ns, name)
-
-	abnormalVal = testutil.ToFloat64(sandboxStatusAbnormal.WithLabelValues(ns, name, "pause_incomplete"))
-	if abnormalVal != 0 {
-		t.Errorf("sandbox_status_abnormal{type=pause_incomplete} = %v, want 0 after recovery", abnormalVal)
-	}
-
-	timeVal = testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, "pause_incomplete"))
-	if timeVal != 0 {
-		t.Errorf("sandbox_status_abnormal_time{type=pause_incomplete} = %v, want 0 after recovery", timeVal)
+			// Time metric should also be deleted (returns 0 from a new series)
+			timeVal = testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, tt.abnormalType))
+			if timeVal != 0 {
+				t.Errorf("sandbox_status_abnormal_time{type=%s} = %v, want 0 after recovery", tt.abnormalType, timeVal)
+			}
+		})
 	}
 }
 
@@ -2478,6 +2453,7 @@ func TestSandboxStatusAbnormalTime_PauseIncomplete(t *testing.T) {
 // is set when a runtime container is abnormal and deleted when it becomes healthy.
 func TestSandboxRuntimeContainerAbnormalTime(t *testing.T) {
 	ns, name := "default", "container-abnormal-time-sandbox"
+	defer DeleteSandboxMetrics(ns, name)
 
 	// Step 1: Record with an abnormal container (RestartCount > 0 and not Ready)
 	podAbnormal := &corev1.Pod{
@@ -2681,6 +2657,7 @@ func TestAbnormalTimeMetricStableAcrossReconciles(t *testing.T) {
 // while the container remains in the same abnormal state.
 func TestRuntimeContainerAbnormalTimeStableAcrossReconciles(t *testing.T) {
 	ns, name := "default", "stable-container-abnormal-time-sandbox"
+	defer DeleteSandboxMetrics(ns, name)
 
 	pod := &corev1.Pod{
 		Status: corev1.PodStatus{

--- a/pkg/controller/sandbox/metrics_test.go
+++ b/pkg/controller/sandbox/metrics_test.go
@@ -2219,3 +2219,329 @@ func TestDeleteSandboxMetrics_ClearsRuntimeContainerAbnormal(t *testing.T) {
 		t.Errorf("after delete, csi-sidecar series = %v, want 0", val)
 	}
 }
+
+// TestStaleConditionMetricsReset verifies the bug fix where condition-based "un" metrics
+// (sandbox_status_unresumed, sandbox_status_unpaused, sandbox_status_inplace_updating)
+// are correctly reset to 0 when the corresponding condition is absent from the conditions slice.
+//
+// Bug: When a condition (e.g. SandboxConditionResumed) is removed during lifecycle transitions
+// (e.g. pause), the metric from the previous reconcile persisted with value 1, causing false alerts.
+func TestStaleConditionMetricsReset(t *testing.T) {
+	ns := "default"
+	name := "stale-condition-sandbox"
+	now := metav1.NewTime(time.Now())
+
+	// Step 1: Record metrics with SandboxResumed=False (unresumed=1)
+	sandboxResuming := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: ns,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxResuming,
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(agentsv1alpha1.SandboxConditionResumed),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+	recordSandboxMetrics(sandboxResuming, nil)
+
+	unresumedVal := testutil.ToFloat64(sandboxStatusUnresumed.WithLabelValues(ns, name))
+	if unresumedVal != 1 {
+		t.Fatalf("precondition: sandbox_status_unresumed = %v, want 1 after Resumed=False", unresumedVal)
+	}
+
+	// Step 2: Record metrics again with conditions that NO LONGER include SandboxResumed.
+	// This simulates the scenario where the condition was removed during a lifecycle transition.
+	// The metric should be reset to 0, not persist at 1.
+	sandboxRunning := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: ns,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxRunning,
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(agentsv1alpha1.SandboxConditionReady),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+	recordSandboxMetrics(sandboxRunning, nil)
+	defer DeleteSandboxMetrics(ns, name)
+
+	// The unresumed metric should now be 0 because the SandboxResumed condition is absent.
+	unresumedVal = testutil.ToFloat64(sandboxStatusUnresumed.WithLabelValues(ns, name))
+	if unresumedVal != 0 {
+		t.Errorf("sandbox_status_unresumed = %v, want 0 (condition absent, should be reset)", unresumedVal)
+	}
+
+	// Similarly verify unpaused and inplace_updating are reset
+	unpausedVal := testutil.ToFloat64(sandboxStatusUnpaused.WithLabelValues(ns, name))
+	if unpausedVal != 0 {
+		t.Errorf("sandbox_status_unpaused = %v, want 0 (condition absent, should be reset)", unpausedVal)
+	}
+
+	inplaceVal := testutil.ToFloat64(sandboxStatusInplaceUpdating.WithLabelValues(ns, name))
+	if inplaceVal != 0 {
+		t.Errorf("sandbox_status_inplace_updating = %v, want 0 (condition absent, should be reset)", inplaceVal)
+	}
+}
+
+// TestStaleUnpausedMetricReset verifies the same bug fix for sandbox_status_unpaused.
+// When SandboxPaused condition is removed (e.g. during resume transition), the metric should reset to 0.
+func TestStaleUnpausedMetricReset(t *testing.T) {
+	ns := "default"
+	name := "stale-unpaused-sandbox"
+	now := metav1.NewTime(time.Now())
+
+	// Step 1: Record with SandboxPaused=False (unpaused=1)
+	sandboxPaused := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: ns,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxPaused,
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(agentsv1alpha1.SandboxConditionPaused),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+	recordSandboxMetrics(sandboxPaused, nil)
+
+	unpausedVal := testutil.ToFloat64(sandboxStatusUnpaused.WithLabelValues(ns, name))
+	if unpausedVal != 1 {
+		t.Fatalf("precondition: sandbox_status_unpaused = %v, want 1 after Paused=False", unpausedVal)
+	}
+
+	// Step 2: Record with conditions that no longer include SandboxPaused.
+	sandboxRunning := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: ns,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxRunning,
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(agentsv1alpha1.SandboxConditionReady),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+	recordSandboxMetrics(sandboxRunning, nil)
+	defer DeleteSandboxMetrics(ns, name)
+
+	unpausedVal = testutil.ToFloat64(sandboxStatusUnpaused.WithLabelValues(ns, name))
+	if unpausedVal != 0 {
+		t.Errorf("sandbox_status_unpaused = %v, want 0 (condition absent, should be reset)", unpausedVal)
+	}
+}
+
+// TestSandboxStatusAbnormalTime verifies that sandbox_status_abnormal_time is set when
+// the sandbox enters an abnormal state and deleted when it returns to normal.
+func TestSandboxStatusAbnormalTime(t *testing.T) {
+	ns := "default"
+	name := "abnormal-time-sandbox"
+	now := metav1.NewTime(time.Now())
+
+	// Step 1: Record with an abnormal state (Phase=Resuming, SandboxResumed=False)
+	sandboxAbnormal := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: ns,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxResuming,
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(agentsv1alpha1.SandboxConditionResumed),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+	recordSandboxMetrics(sandboxAbnormal, nil)
+
+	// Abnormal metric should be 1 and time metric should be set (>0)
+	abnormalVal := testutil.ToFloat64(sandboxStatusAbnormal.WithLabelValues(ns, name, "resume_incomplete"))
+	if abnormalVal != 1 {
+		t.Fatalf("sandbox_status_abnormal{type=resume_incomplete} = %v, want 1", abnormalVal)
+	}
+
+	timeVal := testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, "resume_incomplete"))
+	if timeVal <= 0 {
+		t.Errorf("sandbox_status_abnormal_time{type=resume_incomplete} = %v, want > 0", timeVal)
+	}
+
+	// Step 2: Record with a normal state (Phase=Running, SandboxResumed=True)
+	sandboxNormal := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: ns,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxRunning,
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(agentsv1alpha1.SandboxConditionResumed),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+	recordSandboxMetrics(sandboxNormal, nil)
+	defer DeleteSandboxMetrics(ns, name)
+
+	// Abnormal metric should be deleted (returns 0 from a new series)
+	abnormalVal = testutil.ToFloat64(sandboxStatusAbnormal.WithLabelValues(ns, name, "resume_incomplete"))
+	if abnormalVal != 0 {
+		t.Errorf("sandbox_status_abnormal{type=resume_incomplete} = %v, want 0 after recovery", abnormalVal)
+	}
+
+	// Time metric should also be deleted (returns 0 from a new series)
+	timeVal = testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, "resume_incomplete"))
+	if timeVal != 0 {
+		t.Errorf("sandbox_status_abnormal_time{type=resume_incomplete} = %v, want 0 after recovery", timeVal)
+	}
+}
+
+// TestSandboxStatusAbnormalTime_PauseIncomplete verifies the pause_incomplete abnormal time metric.
+func TestSandboxStatusAbnormalTime_PauseIncomplete(t *testing.T) {
+	ns := "default"
+	name := "pause-abnormal-time-sandbox"
+
+	// Phase=Paused but SandboxPaused condition is absent → abnormal
+	sandboxAbnormal := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: ns,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase:      agentsv1alpha1.SandboxPaused,
+			Conditions: nil, // No Paused condition → abnormal
+		},
+	}
+	recordSandboxMetrics(sandboxAbnormal, nil)
+
+	abnormalVal := testutil.ToFloat64(sandboxStatusAbnormal.WithLabelValues(ns, name, "pause_incomplete"))
+	if abnormalVal != 1 {
+		t.Fatalf("sandbox_status_abnormal{type=pause_incomplete} = %v, want 1", abnormalVal)
+	}
+
+	timeVal := testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, "pause_incomplete"))
+	if timeVal <= 0 {
+		t.Errorf("sandbox_status_abnormal_time{type=pause_incomplete} = %v, want > 0", timeVal)
+	}
+
+	// Now transition to normal (Phase=Running)
+	sandboxNormal := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: ns,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxRunning,
+		},
+	}
+	recordSandboxMetrics(sandboxNormal, nil)
+	defer DeleteSandboxMetrics(ns, name)
+
+	abnormalVal = testutil.ToFloat64(sandboxStatusAbnormal.WithLabelValues(ns, name, "pause_incomplete"))
+	if abnormalVal != 0 {
+		t.Errorf("sandbox_status_abnormal{type=pause_incomplete} = %v, want 0 after recovery", abnormalVal)
+	}
+
+	timeVal = testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, "pause_incomplete"))
+	if timeVal != 0 {
+		t.Errorf("sandbox_status_abnormal_time{type=pause_incomplete} = %v, want 0 after recovery", timeVal)
+	}
+}
+
+// TestSandboxRuntimeContainerAbnormalTime verifies that sandbox_runtime_container_abnormal_time
+// is set when a runtime container is abnormal and deleted when it becomes healthy.
+func TestSandboxRuntimeContainerAbnormalTime(t *testing.T) {
+	ns, name := "default", "container-abnormal-time-sandbox"
+
+	// Step 1: Record with an abnormal container (RestartCount > 0 and not Ready)
+	podAbnormal := &corev1.Pod{
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{Name: "agent-runtime", Ready: false, RestartCount: 2},
+			},
+		},
+	}
+	recordRuntimeContainerAbnormal(ns, name, podAbnormal)
+
+	abnormalVal := testutil.ToFloat64(sandboxRuntimeContainerAbnormal.WithLabelValues(ns, name, "agent-runtime"))
+	if abnormalVal != 1 {
+		t.Fatalf("sandbox_runtime_container_abnormal{container=agent-runtime} = %v, want 1", abnormalVal)
+	}
+
+	timeVal := testutil.ToFloat64(sandboxRuntimeContainerAbnormalTime.WithLabelValues(ns, name, "agent-runtime"))
+	if timeVal <= 0 {
+		t.Errorf("sandbox_runtime_container_abnormal_time{container=agent-runtime} = %v, want > 0", timeVal)
+	}
+
+	// Step 2: Container recovers (Ready=true)
+	podHealthy := &corev1.Pod{
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{Name: "agent-runtime", Ready: true, RestartCount: 2},
+			},
+		},
+	}
+	recordRuntimeContainerAbnormal(ns, name, podHealthy)
+
+	abnormalVal = testutil.ToFloat64(sandboxRuntimeContainerAbnormal.WithLabelValues(ns, name, "agent-runtime"))
+	if abnormalVal != 0 {
+		t.Errorf("sandbox_runtime_container_abnormal{container=agent-runtime} = %v, want 0 after recovery", abnormalVal)
+	}
+
+	// Time metric should be deleted (returns 0 from a new series)
+	timeVal = testutil.ToFloat64(sandboxRuntimeContainerAbnormalTime.WithLabelValues(ns, name, "agent-runtime"))
+	if timeVal != 0 {
+		t.Errorf("sandbox_runtime_container_abnormal_time{container=agent-runtime} = %v, want 0 after recovery", timeVal)
+	}
+}
+
+// TestDeleteSandboxMetrics_ClearsAbnormalTimeMetrics verifies that DeleteSandboxMetrics
+// cleans up sandbox_status_abnormal_time and sandbox_runtime_container_abnormal_time.
+func TestDeleteSandboxMetrics_ClearsAbnormalTimeMetrics(t *testing.T) {
+	ns, name := "default", "cleanup-abnormal-time-sandbox"
+
+	// Set up abnormal metrics
+	sandboxStatusAbnormal.WithLabelValues(ns, name, "pause_incomplete").Set(1)
+	sandboxStatusAbnormalTime.WithLabelValues(ns, name, "pause_incomplete").Set(float64(time.Now().Unix()))
+	sandboxRuntimeContainerAbnormal.WithLabelValues(ns, name, "agent-runtime").Set(1)
+	sandboxRuntimeContainerAbnormalTime.WithLabelValues(ns, name, "agent-runtime").Set(float64(time.Now().Unix()))
+
+	DeleteSandboxMetrics(ns, name)
+
+	// All time metrics should be cleaned up (return 0 from new series)
+	statusTimeVal := testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, "pause_incomplete"))
+	if statusTimeVal != 0 {
+		t.Errorf("sandbox_status_abnormal_time after delete = %v, want 0", statusTimeVal)
+	}
+
+	runtimeTimeVal := testutil.ToFloat64(sandboxRuntimeContainerAbnormalTime.WithLabelValues(ns, name, "agent-runtime"))
+	if runtimeTimeVal != 0 {
+		t.Errorf("sandbox_runtime_container_abnormal_time after delete = %v, want 0", runtimeTimeVal)
+	}
+}

--- a/pkg/controller/sandbox/metrics_test.go
+++ b/pkg/controller/sandbox/metrics_test.go
@@ -2545,3 +2545,153 @@ func TestDeleteSandboxMetrics_ClearsAbnormalTimeMetrics(t *testing.T) {
 		t.Errorf("sandbox_runtime_container_abnormal_time after delete = %v, want 0", runtimeTimeVal)
 	}
 }
+
+// TestAbnormalTimeMetricStableAcrossReconciles verifies that sandbox_status_abnormal_time
+// is set only on the first transition into abnormal and does NOT refresh on subsequent
+// reconciles while the sandbox remains in the same abnormal state.
+// This is the critical test for the bug where time() - abnormal_time never exceeded
+// the reconcile interval, making alerts impossible to trigger.
+func TestAbnormalTimeMetricStableAcrossReconciles(t *testing.T) {
+	ns := "default"
+	name := "stable-abnormal-time-sandbox"
+	now := metav1.NewTime(time.Now())
+
+	sandbox := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: ns,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxResuming,
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(agentsv1alpha1.SandboxConditionResumed),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+
+	// First reconcile: should set the time metric
+	recordSandboxMetrics(sandbox, nil)
+	firstTime := testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, "resume_incomplete"))
+	if firstTime <= 0 {
+		t.Fatalf("first reconcile: sandbox_status_abnormal_time = %v, want > 0", firstTime)
+	}
+
+	// Wait a bit so time.Now() would differ if we refreshed
+	time.Sleep(2 * time.Second)
+
+	// Second reconcile with the same abnormal state: time should NOT change
+	recordSandboxMetrics(sandbox, nil)
+	secondTime := testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, "resume_incomplete"))
+	if secondTime != firstTime {
+		t.Errorf("second reconcile: sandbox_status_abnormal_time = %v, want %v (should not refresh)", secondTime, firstTime)
+	}
+
+	// Third reconcile: still the same
+	time.Sleep(1 * time.Second)
+	recordSandboxMetrics(sandbox, nil)
+	thirdTime := testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, "resume_incomplete"))
+	if thirdTime != firstTime {
+		t.Errorf("third reconcile: sandbox_status_abnormal_time = %v, want %v (should not refresh)", thirdTime, firstTime)
+	}
+
+	// Now transition to normal
+	sandbox.Status.Phase = agentsv1alpha1.SandboxRunning
+	sandbox.Status.Conditions = []metav1.Condition{
+		{
+			Type:               string(agentsv1alpha1.SandboxConditionResumed),
+			Status:             metav1.ConditionTrue,
+			LastTransitionTime: metav1.NewTime(time.Now()),
+		},
+	}
+	recordSandboxMetrics(sandbox, nil)
+	defer DeleteSandboxMetrics(ns, name)
+
+	// Time metric should be deleted (returns 0 from new series)
+	normalTime := testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, "resume_incomplete"))
+	if normalTime != 0 {
+		t.Errorf("after recovery: sandbox_status_abnormal_time = %v, want 0 (deleted)", normalTime)
+	}
+
+	// If abnormal again, a NEW timestamp should be set (not the old one)
+	sandbox.Status.Phase = agentsv1alpha1.SandboxResuming
+	sandbox.Status.Conditions = []metav1.Condition{
+		{
+			Type:               string(agentsv1alpha1.SandboxConditionResumed),
+			Status:             metav1.ConditionFalse,
+			LastTransitionTime: metav1.NewTime(time.Now()),
+		},
+	}
+	recordSandboxMetrics(sandbox, nil)
+	reAbnormalTime := testutil.ToFloat64(sandboxStatusAbnormalTime.WithLabelValues(ns, name, "resume_incomplete"))
+	if reAbnormalTime <= 0 {
+		t.Errorf("re-abnormal: sandbox_status_abnormal_time = %v, want > 0", reAbnormalTime)
+	}
+	if reAbnormalTime == firstTime {
+		t.Errorf("re-abnormal: sandbox_status_abnormal_time = %v, should differ from first time %v", reAbnormalTime, firstTime)
+	}
+}
+
+// TestRuntimeContainerAbnormalTimeStableAcrossReconciles verifies that
+// sandbox_runtime_container_abnormal_time does NOT refresh on subsequent reconciles
+// while the container remains in the same abnormal state.
+func TestRuntimeContainerAbnormalTimeStableAcrossReconciles(t *testing.T) {
+	ns, name := "default", "stable-container-abnormal-time-sandbox"
+
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{Name: "agent-runtime", Ready: false, RestartCount: 2},
+			},
+		},
+	}
+
+	// First reconcile: should set the time metric
+	recordRuntimeContainerAbnormal(ns, name, pod)
+	firstTime := testutil.ToFloat64(sandboxRuntimeContainerAbnormalTime.WithLabelValues(ns, name, "agent-runtime"))
+	if firstTime <= 0 {
+		t.Fatalf("first reconcile: sandbox_runtime_container_abnormal_time = %v, want > 0", firstTime)
+	}
+
+	// Wait a bit so time.Now() would differ if we refreshed
+	time.Sleep(2 * time.Second)
+
+	// Second reconcile: time should NOT change
+	recordRuntimeContainerAbnormal(ns, name, pod)
+	secondTime := testutil.ToFloat64(sandboxRuntimeContainerAbnormalTime.WithLabelValues(ns, name, "agent-runtime"))
+	if secondTime != firstTime {
+		t.Errorf("second reconcile: sandbox_runtime_container_abnormal_time = %v, want %v (should not refresh)", secondTime, firstTime)
+	}
+
+	// Third reconcile: still the same
+	time.Sleep(1 * time.Second)
+	recordRuntimeContainerAbnormal(ns, name, pod)
+	thirdTime := testutil.ToFloat64(sandboxRuntimeContainerAbnormalTime.WithLabelValues(ns, name, "agent-runtime"))
+	if thirdTime != firstTime {
+		t.Errorf("third reconcile: sandbox_runtime_container_abnormal_time = %v, want %v (should not refresh)", thirdTime, firstTime)
+	}
+
+	// Now container recovers
+	pod.Status.InitContainerStatuses[0].Ready = true
+	recordRuntimeContainerAbnormal(ns, name, pod)
+
+	// Time metric should be deleted
+	recoveredTime := testutil.ToFloat64(sandboxRuntimeContainerAbnormalTime.WithLabelValues(ns, name, "agent-runtime"))
+	if recoveredTime != 0 {
+		t.Errorf("after recovery: sandbox_runtime_container_abnormal_time = %v, want 0 (deleted)", recoveredTime)
+	}
+
+	// If abnormal again, a NEW timestamp should be set
+	pod.Status.InitContainerStatuses[0].Ready = false
+	recordRuntimeContainerAbnormal(ns, name, pod)
+	reAbnormalTime := testutil.ToFloat64(sandboxRuntimeContainerAbnormalTime.WithLabelValues(ns, name, "agent-runtime"))
+	if reAbnormalTime <= 0 {
+		t.Errorf("re-abnormal: sandbox_runtime_container_abnormal_time = %v, want > 0", reAbnormalTime)
+	}
+	if reAbnormalTime == firstTime {
+		t.Errorf("re-abnormal: sandbox_runtime_container_abnormal_time = %v, should differ from first time %v", reAbnormalTime, firstTime)
+	}
+}

--- a/pkg/controller/sandbox/metrics_test.go
+++ b/pkg/controller/sandbox/metrics_test.go
@@ -2736,3 +2736,47 @@ func TestRuntimeContainerAbnormalTimeStableAcrossReconciles(t *testing.T) {
 		t.Errorf("re-abnormal: sandbox_runtime_container_abnormal_time = %v, should differ from first time %v", reAbnormalTime, firstTime)
 	}
 }
+
+// TestDeleteSandboxMetrics_ClearsAllSyncMapEntries verifies that DeleteSandboxMetrics
+// cleans up ALL abnormalStartTimes and runtimeContainerAbnormalStartTimes entries,
+// not just the ones that were populated during the test.
+func TestDeleteSandboxMetrics_ClearsAllSyncMapEntries(t *testing.T) {
+	ns, name := "default", "syncmap-cleanup-sandbox"
+	key := ns + "/" + name
+
+	// Populate ALL possible abnormal type entries
+	for _, at := range abnormalTypes {
+		abnormalStartTimes.Store(key+"/"+at, float64(time.Now().Unix()))
+	}
+
+	// Populate ALL possible runtime container entries
+	for _, c := range runtimeContainerNamesList {
+		runtimeContainerAbnormalStartTimes.Store(key+"/"+c, float64(time.Now().Unix()))
+	}
+
+	// Verify all entries exist
+	for _, at := range abnormalTypes {
+		if _, ok := abnormalStartTimes.Load(key + "/" + at); !ok {
+			t.Fatalf("precondition: abnormalStartTimes missing entry for type %s", at)
+		}
+	}
+	for _, c := range runtimeContainerNamesList {
+		if _, ok := runtimeContainerAbnormalStartTimes.Load(key + "/" + c); !ok {
+			t.Fatalf("precondition: runtimeContainerAbnormalStartTimes missing entry for container %s", c)
+		}
+	}
+
+	DeleteSandboxMetrics(ns, name)
+
+	// Verify ALL entries are cleaned up
+	for _, at := range abnormalTypes {
+		if _, ok := abnormalStartTimes.Load(key + "/" + at); ok {
+			t.Errorf("abnormalStartTimes should not have entry for type %s after delete", at)
+		}
+	}
+	for _, c := range runtimeContainerNamesList {
+		if _, ok := runtimeContainerAbnormalStartTimes.Load(key + "/" + c); ok {
+			t.Errorf("runtimeContainerAbnormalStartTimes should not have entry for container %s after delete", c)
+		}
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR fixes a bug where stale condition metrics caused false alerts, and adds two new `_time` metrics for abnormal state tracking.

**Bug fix: stale condition metrics**

When a condition (e.g. `SandboxConditionResumed`) is removed from the sandbox's conditions slice during lifecycle transitions (e.g. entering Paused phase removes the Resumed condition), the corresponding "un" metric (`sandbox_status_unresumed`, `sandbox_status_unpaused`, `sandbox_status_inplace_updating`) persisted with its previous value of `1` from an earlier reconcile. This caused false L1 alerts because Prometheus continued to report `sandbox_status_unresumed == 1` even though the sandbox was actually in a healthy Running state with no `SandboxResumed` condition at all.

**Root cause:** The metrics were only set inside the `for _, condition := range sandbox.Status.Conditions` loop. When a condition was absent, the loop never executed the `case` branch for it, so the old gauge value was never cleared.

**Fix:** Reset all three condition-based "un" metrics to `0` at the start of `recordSandboxConditionMetrics`, before iterating the conditions slice. If the condition is present and False, it will be set back to 1 during the loop; if absent, it correctly stays at 0.

**New metrics: `sandbox_status_abnormal_time` and `sandbox_runtime_container_abnormal_time`**

Following the same pattern as `sandbox_status_unresumed_time`, these new gauge metrics record the Unix timestamp when a sandbox (or runtime container) entered an abnormal state. This enables duration-based alerting without relying on the "un" condition metrics:

```yaml
- alert: SandboxAbnormalCountL1
  expr: |
    sum by(namespace) (
      (sandbox_status_abnormal{} == 1)
      and
      (time() - sandbox_status_abnormal_time{} > 600)
    ) > 10
```

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run unit tests:
   ```bash
   go test ./pkg/controller/sandbox/ -v -run "TestStale|TestSandboxStatusAbnormalTime|TestSandboxRuntimeContainerAbnormalTime|TestDeleteSandboxMetrics_ClearsAbnormalTime" -count=1
   ```
2. Run full test suite:
   ```bash
   go test ./pkg/controller/sandbox/ -v -count=1
   ```
3. Verify the bug fix: Create a sandbox that transitions from Resuming (SandboxResumed=False) to Running (SandboxResumed condition removed). The `sandbox_status_unresumed` metric should be `0`, not `1`.

### Ⅳ. Special notes for reviews

- The bug fix is in `recordSandboxConditionMetrics` — 3 lines that reset the "un" gauges to 0 before the conditions loop
- The `_time` metrics follow the exact same pattern as the existing `sandbox_status_unresumed_time` metric
- `DeleteSandboxMetrics` uses `DeletePartialMatch` for the new time metrics (same as the existing abnormal metrics), since the cleanup function only receives namespace+name
- `recordRuntimeContainerAbnormal` deletes the time metric (via `DeleteLabelValues`) when the container is healthy, rather than setting it to 0 — this matches the behavior of `sandbox_status_abnormal_time` which is also deleted (not zeroed) when the abnormal state clears
