### PR TITLE
fix(commit): skip provider deletion for commits without CommitID and reject deleting pods

### DIFF
--- a/pkg/controller/commit/commit_controller.go
+++ b/pkg/controller/commit/commit_controller.go
@@ -213,6 +213,17 @@ func (r *CommitReconciler) handleCommitDelete(ctx context.Context, args *core.En
 	log := log.FromContext(ctx)
 	commit := args.Commit
 	log.V(3).Info("handleCommitDelete", "commit", klog.KObj(commit), "commitID", commit.Status.CommitID, "uid", commit.UID)
+
+	// If commit never reached Running (no CommitID), just remove finalizer without
+	// calling the provider to delete a non-existent remote resource.
+	if commit.Status.CommitID == "" {
+		log.Info("Commit has no commitID, just remove finalizer", "commit", klog.KObj(commit))
+		if _, err := utils.PatchFinalizer(ctx, r.Client, commit, utils.RemoveFinalizerOpType, agentsv1alpha1.CommitFinalizer); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
 	requeueAfter, err := control.EnsureCommitDeleted(ctx, args)
 	if err != nil {
 		log.Error(err, "handleCommitDelete failed", "commit", klog.KObj(commit))
@@ -223,11 +234,11 @@ func (r *CommitReconciler) handleCommitDelete(ctx context.Context, args *core.En
 
 func (r *CommitReconciler) handleCommitPending(ctx context.Context, args *core.EnsureFuncArgs, control core.CommitControl) (ctrl.Result, error) {
 	commit := args.Commit
-	if args.Pod == nil {
+	if args.Pod == nil || !args.Pod.DeletionTimestamp.IsZero() {
 		now := metav1.Now()
 		args.NewStatus.Phase = agentsv1alpha1.CommitPhaseFailed
 		args.NewStatus.CompletionTime = &now
-		r.Recorder.Eventf(commit, corev1.EventTypeWarning, "PodNotFound", "Target pod %s not found", commit.Spec.PodName)
+		r.Recorder.Eventf(commit, corev1.EventTypeWarning, "PodNotFound", "Target pod %s not found or deleting", commit.Spec.PodName)
 		return ctrl.Result{}, r.updateCommitStatus(ctx, *args.NewStatus, commit)
 	}
 	return r.ensureAndApply(ctx, args, control.EnsureCommitRunning)

--- a/pkg/controller/commit/commit_controller_test.go
+++ b/pkg/controller/commit/commit_controller_test.go
@@ -159,6 +159,57 @@ func TestReconcile_CommitPhasePending_PodNotFound(t *testing.T) {
 	}
 }
 
+func TestReconcile_CommitPhasePending_PodDeleting(t *testing.T) {
+	now := metav1.Now()
+	commit := newCommit("test-commit", "default", agentsv1alpha1.CommitPhasePending)
+	commit.Finalizers = []string{agentsv1alpha1.CommitFinalizer}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-pod",
+			Namespace:         "default",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"test-finalizer"},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	r, mock := newTestReconciler(commit, pod)
+
+	_, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-commit", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.runningCalled {
+		t.Error("EnsureCommitRunning should not be called when pod is deleting")
+	}
+
+	updated := &agentsv1alpha1.Commit{}
+	_ = r.Get(context.TODO(), client.ObjectKey{Name: "test-commit", Namespace: "default"}, updated)
+	if updated.Status.Phase != agentsv1alpha1.CommitPhaseFailed {
+		t.Errorf("expected Failed phase, got %s", updated.Status.Phase)
+	}
+}
+
+func TestReconcile_CommitDeleting_NoCommitID(t *testing.T) {
+	now := metav1.Now()
+	commit := newCommit("test-commit", "default", agentsv1alpha1.CommitPhaseRunning)
+	// CommitID is empty — commit never reached Running via provider
+	commit.DeletionTimestamp = &now
+	commit.Finalizers = []string{agentsv1alpha1.CommitFinalizer}
+	r, mock := newTestReconciler(commit)
+
+	_, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-commit", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.deletedCalled {
+		t.Error("EnsureCommitDeleted should NOT be called when CommitID is empty")
+	}
+}
+
 func TestReconcile_CommitPhasePending_PodExists(t *testing.T) {
 	commit := newCommit("test-commit", "default", agentsv1alpha1.CommitPhasePending)
 	commit.Finalizers = []string{agentsv1alpha1.CommitFinalizer}
@@ -204,6 +255,7 @@ func TestReconcile_CommitPhaseRunning(t *testing.T) {
 func TestReconcile_CommitDeleting(t *testing.T) {
 	now := metav1.Now()
 	commit := newCommit("test-commit", "default", agentsv1alpha1.CommitPhaseRunning)
+	commit.Status.CommitID = "cm-test-123"
 	commit.DeletionTimestamp = &now
 	commit.Finalizers = []string{agentsv1alpha1.CommitFinalizer}
 	r, mock := newTestReconciler(commit)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Two defensive improvements to the Commit controller reconcile loop:

1. **handleCommitDelete**: If `CommitID` is empty (commit never reached Running phase), directly remove the finalizer without calling the provider's `EnsureCommitDeleted`. This avoids sending a delete request with an empty resource ID to providers that may reject or error on it.

2. **handleCommitPending**: Also reject pods that are being deleted (`DeletionTimestamp` is set), in addition to the existing nil check. Starting a commit on a pod that is about to disappear will inevitably fail, so we fail fast with a clear event.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run unit tests:
   ```bash
   go test ./pkg/controller/commit/ -v -count=1
   ```
2. `TestReconcile_CommitDeleting` verifies the provider is called when CommitID is set.
3. `TestReconcile_CommitPhasePending_PodNotFound` already covers the pod-nil path.

### Ⅳ. Special notes for reviews

- The existing `TestReconcile_CommitDeleting` test needed `CommitID` to be set on the test fixture, since the new short-circuit skips provider calls when CommitID is empty.
- The `DeletionTimestamp` check uses `!IsZero()` which is the idiomatic way to detect a set deletion timestamp.
