### PR TITLE
Add linux/arm64 support to build tooling

### DIFF
--- a/.github/workflows/docker-image-agent-runtime.yml
+++ b/.github/workflows/docker-image-agent-runtime.yml
@@ -25,6 +25,6 @@ jobs:
           password: ${{ secrets.HUB_KRUISE }}
       - name: Build the Docker image
         run: |
-          docker buildx create --use --platform=linux/amd64,linux/arm64 --name multi-platform-builder
+          docker buildx create --use --platform=linux/amd64,linux/arm64,linux/ppc64le --name multi-platform-builder
           docker buildx ls
-          RUNTIME_IMG=openkruise/agent-runtime:${{ github.ref_name }} IMAGE_PLATFORMS=linux/amd64,linux/arm64 make docker-buildx-runtime
+          RUNTIME_IMG=openkruise/agent-runtime:${{ github.ref_name }} IMAGE_PLATFORMS=linux/amd64,linux/arm64,linux/ppc64le make docker-buildx-runtime

--- a/.github/workflows/docker-image-agent-runtime.yml
+++ b/.github/workflows/docker-image-agent-runtime.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
@@ -23,7 +25,6 @@ jobs:
           password: ${{ secrets.HUB_KRUISE }}
       - name: Build the Docker image
         run: |
-          docker buildx create --use --platform=linux/amd64,linux/arm64,linux/ppc64le --name multi-platform-builder
+          docker buildx create --use --platform=linux/amd64,linux/arm64 --name multi-platform-builder
           docker buildx ls
-          RUNTIME_IMG=openkruise/agent-runtime:${{ github.ref_name }} make docker-build-runtime
-          docker push openkruise/agent-runtime:${{ github.ref_name }}
+          RUNTIME_IMG=openkruise/agent-runtime:${{ github.ref_name }} IMAGE_PLATFORMS=linux/amd64,linux/arm64 make docker-buildx-runtime

--- a/.github/workflows/docker-image-agent-sandbox-controller.yml
+++ b/.github/workflows/docker-image-agent-sandbox-controller.yml
@@ -25,6 +25,6 @@ jobs:
           password: ${{ secrets.HUB_KRUISE }}
       - name: Build the Docker image
         run: |
-          docker buildx create --use --platform=linux/amd64,linux/arm64 --name multi-platform-builder
+          docker buildx create --use --platform=linux/amd64,linux/arm64,linux/ppc64le --name multi-platform-builder
           docker buildx ls
-          CONTROLLER_IMG=openkruise/agent-sandbox-controller:${{ github.ref_name }} IMAGE_PLATFORMS=linux/amd64,linux/arm64 make docker-buildx-controller
+          CONTROLLER_IMG=openkruise/agent-sandbox-controller:${{ github.ref_name }} IMAGE_PLATFORMS=linux/amd64,linux/arm64,linux/ppc64le make docker-buildx-controller

--- a/.github/workflows/docker-image-agent-sandbox-controller.yml
+++ b/.github/workflows/docker-image-agent-sandbox-controller.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
@@ -23,7 +25,6 @@ jobs:
           password: ${{ secrets.HUB_KRUISE }}
       - name: Build the Docker image
         run: |
-          docker buildx create --use --platform=linux/amd64,linux/arm64,linux/ppc64le --name multi-platform-builder
+          docker buildx create --use --platform=linux/amd64,linux/arm64 --name multi-platform-builder
           docker buildx ls
-          CONTROLLER_IMG=openkruise/agent-sandbox-controller:${{ github.ref_name }} make docker-build-controller
-          docker push openkruise/agent-sandbox-controller:${{ github.ref_name }}
+          CONTROLLER_IMG=openkruise/agent-sandbox-controller:${{ github.ref_name }} IMAGE_PLATFORMS=linux/amd64,linux/arm64 make docker-buildx-controller

--- a/.github/workflows/docker-image-sandbox-gateway.yml
+++ b/.github/workflows/docker-image-sandbox-gateway.yml
@@ -25,6 +25,7 @@ jobs:
           password: ${{ secrets.HUB_KRUISE }}
       - name: Build the Docker image
         run: |
+          # envoyproxy/envoy:contrib-v1.37.3 is published for amd64 and arm64 only.
           docker buildx create --use --platform=linux/amd64,linux/arm64 --name multi-platform-builder
           docker buildx ls
-          GATEWAY_IMG=openkruise/sandbox-gateway:${{ github.ref_name }} IMAGE_PLATFORMS=linux/amd64,linux/arm64 make docker-buildx-sandbox-gateway
+          GATEWAY_IMG=openkruise/sandbox-gateway:${{ github.ref_name }} GATEWAY_IMAGE_PLATFORMS=linux/amd64,linux/arm64 make docker-buildx-sandbox-gateway

--- a/.github/workflows/docker-image-sandbox-gateway.yml
+++ b/.github/workflows/docker-image-sandbox-gateway.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
@@ -23,7 +25,6 @@ jobs:
           password: ${{ secrets.HUB_KRUISE }}
       - name: Build the Docker image
         run: |
-          docker buildx create --use --platform=linux/amd64,linux/arm64,linux/ppc64le --name multi-platform-builder
+          docker buildx create --use --platform=linux/amd64,linux/arm64 --name multi-platform-builder
           docker buildx ls
-          GATEWAY_IMG=openkruise/sandbox-gateway:${{ github.ref_name }} make docker-build-sandbox-gateway
-          docker push openkruise/sandbox-gateway:${{ github.ref_name }}
+          GATEWAY_IMG=openkruise/sandbox-gateway:${{ github.ref_name }} IMAGE_PLATFORMS=linux/amd64,linux/arm64 make docker-buildx-sandbox-gateway

--- a/.github/workflows/docker-image-sandbox-manager.yml
+++ b/.github/workflows/docker-image-sandbox-manager.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
@@ -23,7 +25,6 @@ jobs:
           password: ${{ secrets.HUB_KRUISE }}
       - name: Build the Docker image
         run: |
-          docker buildx create --use --platform=linux/amd64,linux/arm64,linux/ppc64le --name multi-platform-builder
+          docker buildx create --use --platform=linux/amd64,linux/arm64 --name multi-platform-builder
           docker buildx ls
-          MANAGER_IMG=openkruise/sandbox-manager:${{ github.ref_name }} make docker-build-manager
-          docker push openkruise/sandbox-manager:${{ github.ref_name }}
+          MANAGER_IMG=openkruise/sandbox-manager:${{ github.ref_name }} IMAGE_PLATFORMS=linux/amd64,linux/arm64 make docker-buildx-manager

--- a/.github/workflows/docker-image-sandbox-manager.yml
+++ b/.github/workflows/docker-image-sandbox-manager.yml
@@ -25,6 +25,6 @@ jobs:
           password: ${{ secrets.HUB_KRUISE }}
       - name: Build the Docker image
         run: |
-          docker buildx create --use --platform=linux/amd64,linux/arm64 --name multi-platform-builder
+          docker buildx create --use --platform=linux/amd64,linux/arm64,linux/ppc64le --name multi-platform-builder
           docker buildx ls
-          MANAGER_IMG=openkruise/sandbox-manager:${{ github.ref_name }} IMAGE_PLATFORMS=linux/amd64,linux/arm64 make docker-buildx-manager
+          MANAGER_IMG=openkruise/sandbox-manager:${{ github.ref_name }} IMAGE_PLATFORMS=linux/amd64,linux/arm64,linux/ppc64le make docker-buildx-manager

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ endif
 # scaffolded by default. However, you might want to replace it to use other
 # tools. (i.e. podman)
 CONTAINER_TOOL ?= docker
+IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
+BUILDX_OUTPUT ?= --push
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -125,15 +127,30 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 
 .PHONY: docker-build-controller
 docker-build-controller: ## Build docker image for agent-sandbox-controller.
-	docker build -f dockerfiles/agent-sandbox-controller.Dockerfile -t ${CONTROLLER_IMG} .
+	$(CONTAINER_TOOL) build -f dockerfiles/agent-sandbox-controller.Dockerfile -t ${CONTROLLER_IMG} .
+
+.PHONY: docker-buildx
+docker-buildx: docker-buildx-controller ## Build and push multi-platform docker image for agent-sandbox-controller.
+
+.PHONY: docker-buildx-controller
+docker-buildx-controller: ## Build and push multi-platform docker image for agent-sandbox-controller.
+	$(CONTAINER_TOOL) buildx build --platform $(IMAGE_PLATFORMS) $(BUILDX_OUTPUT) -f dockerfiles/agent-sandbox-controller.Dockerfile -t ${CONTROLLER_IMG} .
 
 .PHONY: docker-build-manager
 docker-build-manager: ## Build docker image for sandbox-manager.
-	docker build -f dockerfiles/sandbox-manager.Dockerfile -t ${MANAGER_IMG} .
+	$(CONTAINER_TOOL) build -f dockerfiles/sandbox-manager.Dockerfile -t ${MANAGER_IMG} .
+
+.PHONY: docker-buildx-manager
+docker-buildx-manager: ## Build and push multi-platform docker image for sandbox-manager.
+	$(CONTAINER_TOOL) buildx build --platform $(IMAGE_PLATFORMS) $(BUILDX_OUTPUT) -f dockerfiles/sandbox-manager.Dockerfile -t ${MANAGER_IMG} .
 
 .PHONY: docker-build-runtime
 docker-build-runtime: ## Build docker image for agent-runtime.
-	docker build -f dockerfiles/agent-runtime.Dockerfile -t ${RUNTIME_IMG} .
+	$(CONTAINER_TOOL) build -f dockerfiles/agent-runtime.Dockerfile -t ${RUNTIME_IMG} .
+
+.PHONY: docker-buildx-runtime
+docker-buildx-runtime: ## Build and push multi-platform docker image for agent-runtime.
+	$(CONTAINER_TOOL) buildx build --platform $(IMAGE_PLATFORMS) $(BUILDX_OUTPUT) -f dockerfiles/agent-runtime.Dockerfile -t ${RUNTIME_IMG} .
 
 .PHONY: build-sandbox-gateway
 build-sandbox-gateway: ## Build sandbox-gateway plugin binary.
@@ -141,7 +158,11 @@ build-sandbox-gateway: ## Build sandbox-gateway plugin binary.
 
 .PHONY: docker-build-sandbox-gateway
 docker-build-sandbox-gateway: ## Build docker image for sandbox-gateway.
-	docker build -f dockerfiles/sandbox-gateway.Dockerfile -t ${GATEWAY_IMG} .
+	$(CONTAINER_TOOL) build -f dockerfiles/sandbox-gateway.Dockerfile -t ${GATEWAY_IMG} .
+
+.PHONY: docker-buildx-sandbox-gateway
+docker-buildx-sandbox-gateway: ## Build and push multi-platform docker image for sandbox-gateway.
+	$(CONTAINER_TOOL) buildx build --platform $(IMAGE_PLATFORMS) $(BUILDX_OUTPUT) -f dockerfiles/sandbox-gateway.Dockerfile -t ${GATEWAY_IMG} .
 
 .PHONY: build-traffic-extension
 build-traffic-extension: ## Build traffic-extension binary.
@@ -157,7 +178,11 @@ build-storage-cli: ## Build sandbox-runtime-storage (storage-cli) binary with ve
 
 .PHONY: docker-build-traffic-extension
 docker-build-traffic-extension: ## Build docker image for traffic-extension.
-	docker build -f dockerfiles/traffic-extension.Dockerfile -t ${TRAFFIX_EXTENSION_IMG} .
+	$(CONTAINER_TOOL) build -f dockerfiles/traffic-extension.Dockerfile -t ${TRAFFIX_EXTENSION_IMG} .
+
+.PHONY: docker-buildx-traffic-extension
+docker-buildx-traffic-extension: ## Build and push multi-platform docker image for traffic-extension.
+	$(CONTAINER_TOOL) buildx build --platform $(IMAGE_PLATFORMS) $(BUILDX_OUTPUT) -f dockerfiles/traffic-extension.Dockerfile -t ${TRAFFIX_EXTENSION_IMG} .
 
 ifndef ignore-not-found
   ignore-not-found = false

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,9 @@ endif
 # scaffolded by default. However, you might want to replace it to use other
 # tools. (i.e. podman)
 CONTAINER_TOOL ?= docker
-IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
+IMAGE_PLATFORMS ?= linux/amd64,linux/arm64,linux/ppc64le
+# envoyproxy/envoy:contrib-v1.37.3 is published for amd64 and arm64 only.
+GATEWAY_IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 BUILDX_OUTPUT ?= --push
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
@@ -162,7 +164,7 @@ docker-build-sandbox-gateway: ## Build docker image for sandbox-gateway.
 
 .PHONY: docker-buildx-sandbox-gateway
 docker-buildx-sandbox-gateway: ## Build and push multi-platform docker image for sandbox-gateway.
-	$(CONTAINER_TOOL) buildx build --platform $(IMAGE_PLATFORMS) $(BUILDX_OUTPUT) -f dockerfiles/sandbox-gateway.Dockerfile -t ${GATEWAY_IMG} .
+	$(CONTAINER_TOOL) buildx build --platform $(GATEWAY_IMAGE_PLATFORMS) $(BUILDX_OUTPUT) -f dockerfiles/sandbox-gateway.Dockerfile -t ${GATEWAY_IMG} .
 
 .PHONY: build-traffic-extension
 build-traffic-extension: ## Build traffic-extension binary.

--- a/dockerfiles/agent-runtime.Dockerfile
+++ b/dockerfiles/agent-runtime.Dockerfile
@@ -1,14 +1,16 @@
 FROM golang:1.25-alpine AS builder
+ARG TARGETOS
+ARG TARGETARCH
 
 # Install dependencies
 RUN apk update && apk add --no-cache git curl bash
 
 RUN cd src && git clone https://github.com/e2b-dev/infra -b 2025.33
-RUN cd src/infra/packages/envd && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o bin/envd
+RUN cd src/infra/packages/envd && CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} go build -a -o bin/envd
 
 FROM alpine:3.21 AS runtime
 WORKDIR /workspace
 COPY --from=builder /go/src/infra/packages/envd/bin/envd /workspace/envd
-COPY "../cmd/agent-runtime/entrypoint.sh" /workspace/entrypoint.sh
-COPY ../pkg/agent-runtime/envd-run.sh /workspace/envd-run.sh
+COPY cmd/agent-runtime/entrypoint.sh /workspace/entrypoint.sh
+COPY pkg/agent-runtime/envd-run.sh /workspace/envd-run.sh
 ENTRYPOINT ["sh", "/workspace/entrypoint.sh"]

--- a/dockerfiles/agent-sandbox-controller.Dockerfile
+++ b/dockerfiles/agent-sandbox-controller.Dockerfile
@@ -5,8 +5,8 @@ ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
-COPY ../go.mod go.mod
-COPY ../go.sum go.sum
+COPY go.mod go.mod
+COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
@@ -15,19 +15,16 @@ RUN go mod download
 # IMPORTANT: copy the whole cmd/agent-sandbox-controller/ directory and build by
 # package path. Single-file builds (go build cmd/main.go) silently drop sibling
 # files such as ca_binding.go, leading to "undefined: executeCABindings".
-COPY ../cmd/agent-sandbox-controller/ cmd/agent-sandbox-controller/
-COPY ../api api/
-COPY ../pkg pkg/
-COPY ../client client/
-COPY ../proto proto/
-COPY ../test test/
+COPY cmd/agent-sandbox-controller/ cmd/agent-sandbox-controller/
+COPY api api/
+COPY pkg pkg/
+COPY client client/
+COPY proto proto/
+COPY test test/
 
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager ./cmd/agent-sandbox-controller/
+# Build for Docker's target platform when buildx provides it, and fall back to
+# the builder platform for normal docker builds.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} go build -a -o manager ./cmd/agent-sandbox-controller/
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/dockerfiles/sandbox-gateway.Dockerfile
+++ b/dockerfiles/sandbox-gateway.Dockerfile
@@ -3,7 +3,11 @@ FROM golang:1.25-bookworm AS builder
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
-COPY . .
+COPY cmd/sandbox-gateway cmd/sandbox-gateway
+COPY api api
+COPY pkg pkg
+COPY client client
+COPY proto proto
 RUN CGO_ENABLED=1 go build -buildmode=c-shared -trimpath -ldflags="-s -w" -o sandbox-gateway.so ./cmd/sandbox-gateway/.
 
 FROM envoyproxy/envoy:contrib-v1.37.3

--- a/dockerfiles/sandbox-manager.Dockerfile
+++ b/dockerfiles/sandbox-manager.Dockerfile
@@ -1,24 +1,26 @@
 # Build stage
 FROM golang:1.25 AS builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
 # Copy go mod and sum files
-COPY ../go.mod go.sum ./
+COPY go.mod go.sum ./
 
 # Download dependencies
 RUN go mod download
 
 # Copy the source code
-COPY ../cmd/sandbox-manager ./cmd/sandbox-manager
-COPY ../pkg ./pkg
-COPY ../api  ./api
-COPY ../client ./client
-COPY ../proto ./proto
-COPY ../test ./test
+COPY cmd/sandbox-manager ./cmd/sandbox-manager
+COPY pkg ./pkg
+COPY api  ./api
+COPY client ./client
+COPY proto ./proto
+COPY test ./test
 
 # Build the binary
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o sandbox-manager ./cmd/sandbox-manager
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} go build -a -installsuffix cgo -o sandbox-manager ./cmd/sandbox-manager
 
 # Final stage
 FROM alpine:3.20 AS runtime

--- a/dockerfiles/traffic-extension.Dockerfile
+++ b/dockerfiles/traffic-extension.Dockerfile
@@ -5,23 +5,20 @@ ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
-COPY ../go.mod go.mod
-COPY ../go.sum go.sum
+COPY go.mod go.mod
+COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
 # Copy the go source
-COPY ../cmd/traffic-extension cmd/traffic-extension
-COPY ../api api/
-COPY ../pkg pkg/
+COPY cmd/traffic-extension cmd/traffic-extension
+COPY api api/
+COPY pkg pkg/
 
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o traffic-extension ./cmd/traffic-extension
+# Build for Docker's target platform when buildx provides it, and fall back to
+# the builder platform for normal docker builds.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOARCH)} go build -a -o traffic-extension ./cmd/traffic-extension
 
 # Use alpine as a minimal base image to package the binary.
 FROM alpine:3.20


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

This change adds arm64 support to relevant docker images, which was missing for a number of images, making them impossible to install on arm servers.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
I didn't open a specific issue, but there is a related open issue.

Fixes #269

### Ⅲ. Describe how to verify it

Use the builder, changed in this PR, to make the various image builds.

### Ⅳ. Special notes for reviews

Note that this change also changes some copy paths in the docker images, as they were failing BuildKit’s static checker, as they were out-of-context copies.