### PR TITLE
feat(controller): add k8s lifecycle events

### DIFF
--- a/pkg/controller/sandbox/core/checkpoint.go
+++ b/pkg/controller/sandbox/core/checkpoint.go
@@ -43,6 +43,11 @@ type CheckpointControl struct {
 	recorder record.EventRecorder
 }
 
+const (
+	EventCheckpointStarted   = "CheckpointStarted"
+	EventCheckpointSucceeded = "CheckpointSucceeded"
+)
+
 // NewCheckpointControl creates a new CheckpointControl.
 func NewCheckpointControl(cli client.Client, recorder record.EventRecorder) *CheckpointControl {
 	return &CheckpointControl{Client: cli, recorder: recorder}
@@ -111,6 +116,7 @@ func (c *CheckpointControl) AssumePodCheckpointed(ctx context.Context, pod *core
 		cond.Reason = agentsv1alpha1.SandboxPausedReasonCheckpointSucceeded
 		cond.Message = ""
 		utils.SetSandboxCondition(newStatus, *cond)
+		c.recordCheckpointEvent(box, corev1.EventTypeNormal, EventCheckpointSucceeded, "Checkpoint %s succeeded", cp.Name)
 		return false
 	case agentsv1alpha1.CheckpointFailed:
 		cond.Reason = agentsv1alpha1.SandboxPausedReasonCheckpointFailed
@@ -196,8 +202,16 @@ func (c *CheckpointControl) createCheckpoint(ctx context.Context, box *agentsv1a
 		ScaleExpectation.ObserveScale(GetControllerKey(box), expectations.Create, cpName)
 		return fmt.Errorf("failed to create checkpoint CR: %w", err)
 	}
+	c.recordCheckpointEvent(box, corev1.EventTypeNormal, EventCheckpointStarted, "Checkpoint %s created, waiting for completion", cpName)
 	klog.InfoS("Created checkpoint CR", "sandbox", klog.KObj(box), "checkpoint", cpName)
 	return nil
+}
+
+func (c *CheckpointControl) recordCheckpointEvent(box *agentsv1alpha1.Sandbox, eventType, reason, messageFmt string, args ...any) {
+	if c.recorder == nil {
+		return
+	}
+	c.recorder.Eventf(box, eventType, reason, messageFmt, args...)
 }
 
 // validateContainerImages compares each user container's Image in the live Pod

--- a/pkg/controller/sandbox/core/checkpoint_test.go
+++ b/pkg/controller/sandbox/core/checkpoint_test.go
@@ -396,6 +396,11 @@ func TestListCheckpointsForSandbox(t *testing.T) {
 }
 
 func newCheckpointTestControl(objs ...client.Object) (*CheckpointControl, client.Client) {
+	ctrl, cli, _ := newCheckpointTestControlWithRecorder(objs...)
+	return ctrl, cli
+}
+
+func newCheckpointTestControlWithRecorder(objs ...client.Object) (*CheckpointControl, client.Client, *record.FakeRecorder) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = agentsv1alpha1.AddToScheme(scheme)
@@ -407,7 +412,7 @@ func newCheckpointTestControl(objs ...client.Object) (*CheckpointControl, client
 	}
 	cli := builder.Build()
 	recorder := record.NewFakeRecorder(10)
-	return NewCheckpointControl(cli, recorder), cli
+	return NewCheckpointControl(cli, recorder), cli, recorder
 }
 
 func newCheckpointTestSandbox() *agentsv1alpha1.Sandbox {
@@ -725,7 +730,7 @@ func TestCleanup(t *testing.T) {
 func TestCreateCheckpoint(t *testing.T) {
 	enableCheckpointGate(t)
 	box := newCheckpointTestSandbox()
-	ctrl, cli := newCheckpointTestControl()
+	ctrl, cli, recorder := newCheckpointTestControlWithRecorder()
 
 	err := ctrl.createCheckpoint(context.TODO(), box)
 	assert.NoError(t, err)
@@ -742,6 +747,55 @@ func TestCreateCheckpoint(t *testing.T) {
 	assert.Equal(t, agentsv1alpha1.CheckpointTypePodInfo, cp.Labels[agentsv1alpha1.CheckpointLabelType])
 	assert.Len(t, cp.OwnerReferences, 1)
 	assert.Equal(t, box.Name, cp.OwnerReferences[0].Name)
+	assertCheckpointRecorderEvent(t, recorder, corev1.EventTypeNormal+" "+EventCheckpointStarted, "created, waiting for completion")
+}
+
+func TestAssumePodCheckpointedRecordsCheckpointSuccessEvent(t *testing.T) {
+	tests := []struct {
+		name           string
+		checkpoint     *agentsv1alpha1.Checkpoint
+		expectPrefix   string
+		expectContains string
+	}{
+		{
+			name:           "checkpoint succeeded records normal event",
+			checkpoint:     newCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded),
+			expectPrefix:   corev1.EventTypeNormal + " " + EventCheckpointSucceeded,
+			expectContains: "Checkpoint test-sandbox-cp1 succeeded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enableCheckpointGate(t)
+			box := newCheckpointTestSandbox()
+			ctrl, _, recorder := newCheckpointTestControlWithRecorder(tt.checkpoint)
+			newStatus := &agentsv1alpha1.SandboxStatus{}
+			cond := &metav1.Condition{
+				Type:               string(agentsv1alpha1.SandboxConditionPaused),
+				Status:             metav1.ConditionFalse,
+				Reason:             agentsv1alpha1.SandboxPausedReasonCheckpointCreating,
+				LastTransitionTime: metav1.Now(),
+			}
+
+			wait := ctrl.AssumePodCheckpointed(context.TODO(), newCheckpointTestPod(), box, newStatus, cond)
+
+			assert.False(t, wait)
+			assert.Equal(t, agentsv1alpha1.SandboxPausedReasonCheckpointSucceeded, cond.Reason)
+			assertCheckpointRecorderEvent(t, recorder, tt.expectPrefix, tt.expectContains)
+		})
+	}
+}
+
+func assertCheckpointRecorderEvent(t *testing.T, recorder *record.FakeRecorder, expectPrefix, expectContains string) {
+	t.Helper()
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, expectPrefix)
+		assert.Contains(t, event, expectContains)
+	default:
+		t.Fatalf("expected event %q, got none", expectPrefix)
+	}
 }
 
 func TestAssumePodCheckpointed_ListError(t *testing.T) {

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -72,6 +72,33 @@ var (
 	csiResetSignalFileName      = "reset"
 )
 
+const (
+	eventReasonSandboxTerminating = "SandboxTerminating"
+)
+
+type sandboxPhaseTransition struct {
+	oldPhase agentsv1alpha1.SandboxPhase
+	newPhase agentsv1alpha1.SandboxPhase
+}
+
+var sandboxPhaseTransitionMessages = map[sandboxPhaseTransition]string{
+	{oldPhase: "", newPhase: agentsv1alpha1.SandboxPending}:                              "Start sandbox",
+	{oldPhase: agentsv1alpha1.SandboxPending, newPhase: agentsv1alpha1.SandboxRunning}:   "Sandbox started",
+	{oldPhase: agentsv1alpha1.SandboxRunning, newPhase: agentsv1alpha1.SandboxPaused}:    "Pause sandbox",
+	{oldPhase: agentsv1alpha1.SandboxPaused, newPhase: agentsv1alpha1.SandboxResuming}:   "Resume sandbox",
+	{oldPhase: agentsv1alpha1.SandboxPaused, newPhase: agentsv1alpha1.SandboxRunning}:    "Resume sandbox",
+	{oldPhase: agentsv1alpha1.SandboxResuming, newPhase: agentsv1alpha1.SandboxRunning}:  "Sandbox resumed",
+	{oldPhase: agentsv1alpha1.SandboxRunning, newPhase: agentsv1alpha1.SandboxUpgrading}: "Upgrade sandbox",
+	{oldPhase: agentsv1alpha1.SandboxUpgrading, newPhase: agentsv1alpha1.SandboxRunning}: "Sandbox upgraded",
+	{oldPhase: agentsv1alpha1.SandboxRunning, newPhase: agentsv1alpha1.SandboxRecycling}: "Recycle sandbox",
+	{oldPhase: agentsv1alpha1.SandboxRecycling, newPhase: agentsv1alpha1.SandboxRunning}: "Sandbox recycled",
+}
+
+var sandboxPhaseTargetMessages = map[agentsv1alpha1.SandboxPhase]string{
+	agentsv1alpha1.SandboxSucceeded: "Sandbox succeeded",
+	agentsv1alpha1.SandboxFailed:    "Sandbox failed",
+}
+
 // Enqueuer is the contract the Sandbox controller depends on for async
 // metric cleanup. sandboxmetricsgc.Reconciler satisfies it.
 type Enqueuer interface {
@@ -303,8 +330,15 @@ func (r *SandboxReconciler) EnsureSandboxPaused(ctx context.Context, args core.E
 }
 
 func (r *SandboxReconciler) handleTerminating(ctx context.Context, args core.EnsureFuncArgs) (ctrl.Result, error) {
-	pod, _, _ := args.Pod, args.Box, args.NewStatus
-	return ctrl.Result{}, r.getControl(pod).EnsureSandboxTerminated(ctx, args)
+	pod, box, _ := args.Pod, args.Box, args.NewStatus
+	recordTerminatingEvent := pod != nil && pod.DeletionTimestamp.IsZero()
+	if err := r.getControl(pod).EnsureSandboxTerminated(ctx, args); err != nil {
+		return ctrl.Result{}, err
+	}
+	if recordTerminatingEvent {
+		r.recordSandboxTerminatingEvent(box)
+	}
+	return ctrl.Result{}, nil
 }
 
 func isSandboxCompletedPhase(phase agentsv1alpha1.SandboxPhase) bool {
@@ -340,6 +374,7 @@ func (r *SandboxReconciler) updateSandboxStatus(ctx context.Context, newStatus a
 	if reflect.DeepEqual(box.Status, newStatus) {
 		return nil
 	}
+	oldPhase := box.Status.Phase
 
 	by, _ := json.Marshal(newStatus)
 	patchStatus := fmt.Sprintf(`{"status":%s}`, string(by))
@@ -352,9 +387,58 @@ func (r *SandboxReconciler) updateSandboxStatus(ctx context.Context, newStatus a
 	core.ResourceVersionExpectations.Expect(rcvObject)
 	klog.InfoS("update sandbox status success", "sandbox", klog.KObj(box), "status", utils.DumpJson(newStatus))
 	box.Status = newStatus
+	r.recordSandboxPhaseEvent(box, oldPhase, newStatus)
 	// Update metrics after status change (pod=nil: container metrics already recorded in Reconcile)
 	recordSandboxMetrics(box, nil)
 	return nil
+}
+
+func (r *SandboxReconciler) recordSandboxPhaseEvent(box *agentsv1alpha1.Sandbox, oldPhase agentsv1alpha1.SandboxPhase, newStatus agentsv1alpha1.SandboxStatus) {
+	if r.recorder == nil || oldPhase == newStatus.Phase || newStatus.Phase == "" {
+		return
+	}
+
+	eventType := corev1.EventTypeNormal
+	if newStatus.Phase == agentsv1alpha1.SandboxFailed {
+		eventType = corev1.EventTypeWarning
+	}
+	message := sandboxPhaseEventMessage(oldPhase, newStatus.Phase)
+	if newStatus.Message != "" {
+		message = fmt.Sprintf("%s: %s", message, newStatus.Message)
+	}
+	r.recorder.Event(box, eventType, sandboxPhaseEventReason(newStatus.Phase), message)
+}
+
+func (r *SandboxReconciler) recordSandboxTerminatingEvent(box *agentsv1alpha1.Sandbox) {
+	if r.recorder == nil || box == nil || box.DeletionTimestamp.IsZero() {
+		return
+	}
+	r.recorder.Eventf(box, corev1.EventTypeNormal, eventReasonSandboxTerminating,
+		"Sandbox deletion is in progress from phase %s", phaseForEvent(box.Status.Phase))
+}
+
+func sandboxPhaseEventMessage(oldPhase, newPhase agentsv1alpha1.SandboxPhase) string {
+	if message, ok := sandboxPhaseTransitionMessages[sandboxPhaseTransition{oldPhase: oldPhase, newPhase: newPhase}]; ok {
+		return message
+	}
+	if message, ok := sandboxPhaseTargetMessages[newPhase]; ok {
+		return message
+	}
+	return fmt.Sprintf("Sandbox phase changed from %s to %s", phaseForEvent(oldPhase), newPhase)
+}
+
+func sandboxPhaseEventReason(phase agentsv1alpha1.SandboxPhase) string {
+	if phase == "" {
+		return "SandboxPhaseChanged"
+	}
+	return "Sandbox" + string(phase)
+}
+
+func phaseForEvent(phase agentsv1alpha1.SandboxPhase) string {
+	if phase == "" {
+		return "<empty>"
+	}
+	return string(phase)
 }
 
 func (r *SandboxReconciler) calculateStatus(ctx context.Context, args core.EnsureFuncArgs) (*agentsv1alpha1.SandboxStatus, bool) {

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -862,6 +862,403 @@ func TestSandboxReconciler_updateSandboxStatus(t *testing.T) {
 	}
 }
 
+func TestSandboxReconciler_updateSandboxStatusRecordsPhaseEvent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	tests := []struct {
+		name           string
+		oldStatus      agentsv1alpha1.SandboxStatus
+		newStatus      agentsv1alpha1.SandboxStatus
+		expectEvent    bool
+		expectPrefix   string
+		expectContains string
+	}{
+		{
+			name:      "records start message for initial pending phase",
+			oldStatus: agentsv1alpha1.SandboxStatus{},
+			newStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPending,
+			},
+			expectEvent:    true,
+			expectPrefix:   corev1.EventTypeNormal + " SandboxPending",
+			expectContains: "Start sandbox",
+		},
+		{
+			name: "records started message when pending sandbox becomes running",
+			oldStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPending,
+			},
+			newStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxRunning,
+			},
+			expectEvent:    true,
+			expectPrefix:   corev1.EventTypeNormal + " SandboxRunning",
+			expectContains: "Sandbox started",
+		},
+		{
+			name: "records resume message when paused sandbox becomes resuming",
+			oldStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPaused,
+			},
+			newStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxResuming,
+			},
+			expectEvent:    true,
+			expectPrefix:   corev1.EventTypeNormal + " SandboxResuming",
+			expectContains: "Resume sandbox",
+		},
+		{
+			name: "records resume message when paused sandbox becomes running",
+			oldStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPaused,
+			},
+			newStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxRunning,
+			},
+			expectEvent:    true,
+			expectPrefix:   corev1.EventTypeNormal + " SandboxRunning",
+			expectContains: "Resume sandbox",
+		},
+		{
+			name: "records resume message when resuming sandbox becomes running",
+			oldStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxResuming,
+			},
+			newStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxRunning,
+			},
+			expectEvent:    true,
+			expectPrefix:   corev1.EventTypeNormal + " SandboxRunning",
+			expectContains: "Sandbox resumed",
+		},
+		{
+			name: "records pause message when running sandbox becomes paused",
+			oldStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxRunning,
+			},
+			newStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPaused,
+			},
+			expectEvent:    true,
+			expectPrefix:   corev1.EventTypeNormal + " SandboxPaused",
+			expectContains: "Pause sandbox",
+		},
+		{
+			name: "records upgrade message when running sandbox becomes upgrading",
+			oldStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxRunning,
+			},
+			newStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxUpgrading,
+			},
+			expectEvent:    true,
+			expectPrefix:   corev1.EventTypeNormal + " SandboxUpgrading",
+			expectContains: "Upgrade sandbox",
+		},
+		{
+			name: "records upgraded message when upgrading sandbox becomes running",
+			oldStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxUpgrading,
+			},
+			newStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxRunning,
+			},
+			expectEvent:    true,
+			expectPrefix:   corev1.EventTypeNormal + " SandboxRunning",
+			expectContains: "Sandbox upgraded",
+		},
+		{
+			name: "records recycle message when running sandbox becomes recycling",
+			oldStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxRunning,
+			},
+			newStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxRecycling,
+			},
+			expectEvent:    true,
+			expectPrefix:   corev1.EventTypeNormal + " SandboxRecycling",
+			expectContains: "Recycle sandbox",
+		},
+		{
+			name: "records recycled message when recycling sandbox becomes running",
+			oldStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxRecycling,
+			},
+			newStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxRunning,
+			},
+			expectEvent:    true,
+			expectPrefix:   corev1.EventTypeNormal + " SandboxRunning",
+			expectContains: "Sandbox recycled",
+		},
+		{
+			name: "records warning event when phase changes to failed",
+			oldStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxRunning,
+			},
+			newStatus: agentsv1alpha1.SandboxStatus{
+				Phase:   agentsv1alpha1.SandboxFailed,
+				Message: "Pod status phase is Failed",
+			},
+			expectEvent:    true,
+			expectPrefix:   corev1.EventTypeWarning + " SandboxFailed",
+			expectContains: "Sandbox failed: Pod status phase is Failed",
+		},
+		{
+			name: "records succeeded message when phase changes to succeeded",
+			oldStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxRunning,
+			},
+			newStatus: agentsv1alpha1.SandboxStatus{
+				Phase:   agentsv1alpha1.SandboxSucceeded,
+				Message: "Pod status phase is Succeeded",
+			},
+			expectEvent:    true,
+			expectPrefix:   corev1.EventTypeNormal + " SandboxSucceeded",
+			expectContains: "Sandbox succeeded: Pod status phase is Succeeded",
+		},
+		{
+			name: "records generic message for unknown transition",
+			oldStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPhase("CustomOldPhase"),
+			},
+			newStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPhase("CustomNewPhase"),
+			},
+			expectEvent:    true,
+			expectPrefix:   corev1.EventTypeNormal + " SandboxCustomNewPhase",
+			expectContains: "Sandbox phase changed from CustomOldPhase to CustomNewPhase",
+		},
+		{
+			name: "does not record event when only message changes",
+			oldStatus: agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxRunning,
+			},
+			newStatus: agentsv1alpha1.SandboxStatus{
+				Phase:   agentsv1alpha1.SandboxRunning,
+				Message: "still running",
+			},
+			expectEvent: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := record.NewFakeRecorder(10)
+			sandbox := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+				},
+				Status: tt.oldStatus,
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&agentsv1alpha1.Sandbox{}).
+				WithObjects(sandbox).
+				Build()
+			reconciler := &SandboxReconciler{
+				Client:   fakeClient,
+				Scheme:   scheme,
+				recorder: recorder,
+			}
+
+			err := reconciler.updateSandboxStatus(context.Background(), tt.newStatus, sandbox)
+			assert.NoError(t, err)
+			if tt.expectEvent {
+				assertSandboxRecorderEvent(t, recorder, tt.expectPrefix, tt.expectContains)
+			} else {
+				assertNoSandboxRecorderEvent(t, recorder)
+			}
+		})
+	}
+}
+
+func TestSandboxReconciler_recordSandboxTerminatingEvent(t *testing.T) {
+	tests := []struct {
+		name           string
+		recorder       *record.FakeRecorder
+		deleting       bool
+		expectEvent    bool
+		expectContains string
+	}{
+		{
+			name:           "records terminating event for deleting sandbox",
+			recorder:       record.NewFakeRecorder(10),
+			deleting:       true,
+			expectEvent:    true,
+			expectContains: "Sandbox deletion is in progress from phase Running",
+		},
+		{
+			name:        "does not record event without deletion timestamp",
+			recorder:    record.NewFakeRecorder(10),
+			deleting:    false,
+			expectEvent: false,
+		},
+		{
+			name:        "nil recorder is ignored",
+			recorder:    nil,
+			deleting:    true,
+			expectEvent: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sandbox := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+				},
+			}
+			if tt.deleting {
+				now := metav1.Now()
+				sandbox.DeletionTimestamp = &now
+			}
+			var eventRecorder record.EventRecorder
+			if tt.recorder != nil {
+				eventRecorder = tt.recorder
+			}
+			reconciler := &SandboxReconciler{recorder: eventRecorder}
+
+			reconciler.recordSandboxTerminatingEvent(sandbox)
+
+			if tt.expectEvent {
+				assertSandboxRecorderEvent(t, tt.recorder, corev1.EventTypeNormal+" "+eventReasonSandboxTerminating, tt.expectContains)
+			} else if tt.recorder != nil {
+				assertNoSandboxRecorderEvent(t, tt.recorder)
+			}
+		})
+	}
+}
+
+func TestSandboxReconciler_handleTerminatingRecordsEventOnlyWhenDeletingPod(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	now := metav1.Now()
+	tests := []struct {
+		name                   string
+		pod                    *corev1.Pod
+		expectEvent            bool
+		expectFinalizerRemoved bool
+	}{
+		{
+			name: "records event when active pod is deleted",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+				},
+			},
+			expectEvent: true,
+		},
+		{
+			name: "does not record event when pod is already deleting",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-sandbox",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{"fake-finalizer"},
+				},
+			},
+			expectEvent: false,
+		},
+		{
+			name:                   "does not record event when removing finalizer after pod is gone",
+			pod:                    nil,
+			expectEvent:            false,
+			expectFinalizerRemoved: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deletionTime := metav1.Now()
+			sandbox := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-sandbox",
+					Namespace:         "default",
+					DeletionTimestamp: &deletionTime,
+					Finalizers:        []string{core.SandboxFinalizer},
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+				},
+			}
+
+			objects := []client.Object{sandbox}
+			if tt.pod != nil {
+				objects = append(objects, tt.pod)
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+			recorder := record.NewFakeRecorder(10)
+			reconciler := &SandboxReconciler{
+				Client:   fakeClient,
+				Scheme:   scheme,
+				recorder: recorder,
+				controls: core.NewSandboxControl(core.SandboxControlArgs{
+					Client:   fakeClient,
+					Recorder: recorder,
+				}),
+			}
+
+			_, err := reconciler.handleTerminating(context.Background(), core.EnsureFuncArgs{
+				Pod:       tt.pod,
+				Box:       sandbox,
+				NewStatus: sandbox.Status.DeepCopy(),
+			})
+			assert.NoError(t, err)
+
+			if tt.expectEvent {
+				assertSandboxRecorderEvent(t, recorder, corev1.EventTypeNormal+" "+eventReasonSandboxTerminating, "Sandbox deletion is in progress from phase Running")
+			} else {
+				assertNoSandboxRecorderEvent(t, recorder)
+			}
+
+			if tt.expectFinalizerRemoved {
+				updatedSandbox := &agentsv1alpha1.Sandbox{}
+				err := fakeClient.Get(context.Background(), types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}, updatedSandbox)
+				if apierrors.IsNotFound(err) {
+					return
+				}
+				assert.NoError(t, err)
+				assert.NotContains(t, updatedSandbox.Finalizers, core.SandboxFinalizer)
+			}
+		})
+	}
+}
+
+func assertSandboxRecorderEvent(t *testing.T, recorder *record.FakeRecorder, expectPrefix, expectContains string) {
+	t.Helper()
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, expectPrefix)
+		assert.Contains(t, event, expectContains)
+	default:
+		t.Fatalf("expected event %q, got none", expectPrefix)
+	}
+}
+
+func assertNoSandboxRecorderEvent(t *testing.T, recorder *record.FakeRecorder) {
+	t.Helper()
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected event: %s", event)
+	default:
+	}
+}
+
 func TestSandboxReconciler_updateSandboxStatusNoChange(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)

--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
@@ -51,6 +51,10 @@ var (
 	ResourceVersionExpectations = expectations.NewResourceVersionExpectation()
 )
 
+const (
+	eventReasonSandboxUpdateOpsPhaseChanged = "SandboxUpdateOpsPhaseChanged"
+)
+
 func init() {
 	flag.IntVar(&concurrentReconciles, "sandboxupdateops-workers", concurrentReconciles, "Max concurrent workers for SandboxUpdateOps controller.")
 }
@@ -415,6 +419,8 @@ func (r *Reconciler) updateStatus(ctx context.Context, ops *agentsv1alpha1.Sandb
 	if reflect.DeepEqual(ops.Status, *newStatus) {
 		return nil
 	}
+	oldPhase := ops.Status.Phase
+
 	by, _ := json.Marshal(newStatus)
 	patchStatus := fmt.Sprintf(`{"status":%s}`, string(by))
 	rcvObject := &agentsv1alpha1.SandboxUpdateOps{
@@ -426,6 +432,29 @@ func (r *Reconciler) updateStatus(ctx context.Context, ops *agentsv1alpha1.Sandb
 		klog.ErrorS(err, "Failed to update SandboxUpdateOps status", "ops", klog.KObj(ops), "patch", patchStatus)
 	} else {
 		klog.InfoS("Successfully updated SandboxUpdateOps status", "ops", klog.KObj(ops), "patch", patchStatus)
+		r.recordPhaseEvent(ops, oldPhase, newStatus)
 	}
 	return err
+}
+
+func (r *Reconciler) recordPhaseEvent(ops *agentsv1alpha1.SandboxUpdateOps, oldPhase agentsv1alpha1.SandboxUpdateOpsPhase, newStatus *agentsv1alpha1.SandboxUpdateOpsStatus) {
+	if r.Recorder == nil || oldPhase == newStatus.Phase || newStatus.Phase == "" {
+		return
+	}
+
+	eventType := v1.EventTypeNormal
+	if newStatus.Phase == agentsv1alpha1.SandboxUpdateOpsFailed {
+		eventType = v1.EventTypeWarning
+	}
+	r.Recorder.Eventf(ops, eventType, eventReasonSandboxUpdateOpsPhaseChanged,
+		"SandboxUpdateOps phase changed from %s to %s: total=%d, updated=%d, updating=%d, failed=%d",
+		updateOpsPhaseForEvent(oldPhase), newStatus.Phase, newStatus.Replicas,
+		newStatus.UpdatedReplicas, newStatus.UpdatingReplicas, newStatus.FailedReplicas)
+}
+
+func updateOpsPhaseForEvent(phase agentsv1alpha1.SandboxUpdateOpsPhase) string {
+	if phase == "" {
+		return "<empty>"
+	}
+	return string(phase)
 }

--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
@@ -828,9 +828,9 @@ func TestClassifySandbox_OtherOpsLabel(t *testing.T) {
 		Status: agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRunning},
 	}
 	tests := []struct {
-		name           string
-		otherOpsPhase  agentsv1alpha1.SandboxUpdateOpsPhase
-		expected       sandboxUpdateState
+		name          string
+		otherOpsPhase agentsv1alpha1.SandboxUpdateOpsPhase
+		expected      sandboxUpdateState
 	}{
 		{
 			name:          "other ops Pending -> noNeedUpdate",
@@ -1656,4 +1656,95 @@ func TestUpdateStatus_NoChange(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, ops.Status.Phase, updatedOps.Status.Phase)
 	assert.Equal(t, ops.Status.Replicas, updatedOps.Status.Replicas)
+}
+
+func TestUpdateStatus_RecordsPhaseEvent(t *testing.T) {
+	tests := []struct {
+		name           string
+		oldPhase       agentsv1alpha1.SandboxUpdateOpsPhase
+		newPhase       agentsv1alpha1.SandboxUpdateOpsPhase
+		expectEvent    bool
+		expectPrefix   string
+		expectContains string
+	}{
+		{
+			name:           "records normal event when phase changes to updating",
+			oldPhase:       agentsv1alpha1.SandboxUpdateOpsPending,
+			newPhase:       agentsv1alpha1.SandboxUpdateOpsUpdating,
+			expectEvent:    true,
+			expectPrefix:   corev1.EventTypeNormal + " " + eventReasonSandboxUpdateOpsPhaseChanged,
+			expectContains: "phase changed from Pending to Updating",
+		},
+		{
+			name:           "records warning event when phase changes to failed",
+			oldPhase:       agentsv1alpha1.SandboxUpdateOpsUpdating,
+			newPhase:       agentsv1alpha1.SandboxUpdateOpsFailed,
+			expectEvent:    true,
+			expectPrefix:   corev1.EventTypeWarning + " " + eventReasonSandboxUpdateOpsPhaseChanged,
+			expectContains: "failed=1",
+		},
+		{
+			name:        "does not record event when phase does not change",
+			oldPhase:    agentsv1alpha1.SandboxUpdateOpsUpdating,
+			newPhase:    agentsv1alpha1.SandboxUpdateOpsUpdating,
+			expectEvent: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := newSandboxUpdateOps("test-ops", "default", tt.oldPhase, false, nil)
+			ops.Status.Replicas = 3
+			ops.Status.UpdatedReplicas = 1
+			ops.Status.UpdatingReplicas = 2
+			recorder := record.NewFakeRecorder(10)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithStatusSubresource(&agentsv1alpha1.SandboxUpdateOps{}).
+				WithRuntimeObjects(ops).
+				Build()
+			r := &Reconciler{
+				Client:   fakeClient,
+				Scheme:   testScheme,
+				Recorder: recorder,
+			}
+			newStatus := ops.Status.DeepCopy()
+			newStatus.Phase = tt.newPhase
+			if tt.newPhase == agentsv1alpha1.SandboxUpdateOpsFailed {
+				newStatus.FailedReplicas = 1
+				newStatus.UpdatingReplicas = 0
+			} else {
+				newStatus.UpdatedReplicas = 2
+			}
+
+			err := r.updateStatus(context.Background(), ops, newStatus)
+
+			assert.NoError(t, err)
+			if tt.expectEvent {
+				assertUpdateOpsRecorderEvent(t, recorder, tt.expectPrefix, tt.expectContains)
+			} else {
+				assertNoUpdateOpsRecorderEvent(t, recorder)
+			}
+		})
+	}
+}
+
+func assertUpdateOpsRecorderEvent(t *testing.T, recorder *record.FakeRecorder, expectPrefix, expectContains string) {
+	t.Helper()
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, expectPrefix)
+		assert.Contains(t, event, expectContains)
+	default:
+		t.Fatalf("expected event %q, got none", expectPrefix)
+	}
+}
+
+func assertNoUpdateOpsRecorderEvent(t *testing.T, recorder *record.FakeRecorder) {
+	t.Helper()
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected event: %s", event)
+	default:
+	}
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds Kubernetes events for key lifecycle transitions in core controllers.

* Emits Sandbox phase events after successful status updates, so events are recorded only when `status.phase` actually changes.
* Records Sandbox deletion progress with a `SandboxTerminating` event, without changing the existing `status.phase` semantics.
* Adds normal events for Checkpoint start and success, while keeping existing warning events for failure paths.
* Adds SandboxUpdateOps phase summary events with total / updated / updating / failed replica counts.
* Adds focused unit tests for the new event recording behavior.

### Ⅱ. Does this pull request fix one issue?

Refs #593

This PR covers the main lifecycle event gaps for Sandbox, Checkpoint, and SandboxUpdateOps. It intentionally does not change Sandbox `Terminating` status semantics, and it does not expand SandboxSet per-sandbox event volume in this first pass.

### Ⅲ. Describe how to verify it

```bash
go test ./pkg/controller/...
```

### Ⅳ. Special notes for reviews
The event emission is placed after successful status updates where possible, to avoid recording lifecycle events for failed status patches or repeated reconcile attempts.
For Sandbox deletion, this PR only emits a SandboxTerminating event when deletion is in progress. It does not set status.phase=Terminating, because the existing deletion path performs finalizer cleanup directly and does not currently persist that phase.