### PR TITLE
Signal csi-sidecar to unmount stale CSI volumes before sandbox reuse

### DIFF
--- a/.github/workflows/e2e-1.32.yaml
+++ b/.github/workflows/e2e-1.32.yaml
@@ -41,14 +41,21 @@ jobs:
           export IMAGE="agent-sandbox-controller:latest"
           docker build -f dockerfiles/agent-sandbox-controller.Dockerfile  --pull --no-cache . -t $IMAGE
           kind load docker-image --name=${KIND_CLUSTER_NAME} $IMAGE || { echo >&2 "kind not installed or error loading image: $IMAGE"; exit 1; }
+          # Build and load agent-runtime so the reuse E2E can exercise the real
+          # agent-runtime files API, which the controller uses to write the CSI
+          # reset signal before returning a sandbox to the pool.
+          make docker-build-runtime
+          kind load docker-image --name=${KIND_CLUSTER_NAME} agent-runtime:latest || { echo >&2 "kind not installed or error loading image: agent-runtime:latest"; exit 1; }
       - name: Install Kruise Agents
         run: |
           CONTROLLER_IMG=agent-sandbox-controller:latest make deploy-agent-sandbox-controller
           # Enable SandboxPauseCheckpoint feature gate only for this E2E workflow
           # so the pause/resume tests exercise the Checkpoint CR code path.
+          # Enable the CSI reset-signal write path so the reuse E2E can verify
+          # the controller writes the signal through the agent-runtime files API.
           kubectl -n sandbox-system patch deployment sandbox-controller-manager \
             --type=json \
-            -p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--feature-gates=SandboxPauseCheckpoint=true"}]'
+            -p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--feature-gates=SandboxPauseCheckpoint=true"},{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--csi-reset-signal-dir=/tmp"}]'
           # Wait for the rolling update triggered by the patch to complete before
           # running wait-agent-sandbox-controller.sh, which only checks pod readiness
           # and can falsely pass by seeing the OLD (pre-patch) pod.

--- a/pkg/controller/sandbox/core/interface.go
+++ b/pkg/controller/sandbox/core/interface.go
@@ -101,8 +101,8 @@ type SandboxReuseConfig struct {
 	FailureShutdownGrace time.Duration
 	// CSIResetSignalDir is the directory inside the sandbox where a reset signal
 	// file is written before reuse when the sandbox carries CSI mounts, so that a
-	// restarting csi-sidecar can detect it and unmount stale volumes. Empty
-	// disables the behavior.
+	// stopping csi-sidecar can detect it during prestop/SIGTERM and unmount stale
+	// volumes. Empty disables the behavior.
 	CSIResetSignalDir string
 	// CSIResetSignalFileName is the name of the reset signal file written into
 	// CSIResetSignalDir.

--- a/pkg/controller/sandbox/core/interface.go
+++ b/pkg/controller/sandbox/core/interface.go
@@ -99,6 +99,14 @@ type SandboxReuseConfig struct {
 	Timeout              time.Duration
 	GracePeriod          time.Duration
 	FailureShutdownGrace time.Duration
+	// CSIResetSignalDir is the directory inside the sandbox where a reset signal
+	// file is written before reuse when the sandbox carries CSI mounts, so that a
+	// restarting csi-sidecar can detect it and unmount stale volumes. Empty
+	// disables the behavior.
+	CSIResetSignalDir string
+	// CSIResetSignalFileName is the name of the reset signal file written into
+	// CSIResetSignalDir.
+	CSIResetSignalFileName string
 }
 
 type SandboxControlArgs struct {

--- a/pkg/controller/sandbox/core/reuse.go
+++ b/pkg/controller/sandbox/core/reuse.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -33,7 +34,25 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/utils"
+	agentsruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
+
+const (
+	// csiResetSignalWriteTimeout bounds a single write attempt of the reset signal file.
+	csiResetSignalWriteTimeout = 3 * time.Second
+	// csiResetSignalMaxRetries is the number of write attempts for the reset signal
+	// file before giving up. Transient runtime unavailability right at reuse start
+	// is common, so a few inline retries smooth over it.
+	csiResetSignalMaxRetries = 3
+)
+
+// csiResetSignalRetryInterval is the backoff between reset signal write attempts.
+// It is a var rather than a const so tests can shorten it.
+var csiResetSignalRetryInterval = 1 * time.Second
+
+// writeRuntimeFileFunc is a package-level seam over agentsruntime.WriteFileWithRuntime
+// so tests can stub the runtime file write without a live sandbox.
+var writeRuntimeFileFunc = agentsruntime.WriteFileWithRuntime
 
 // TODO for CRR based reuser
 type noopSandboxReuser struct{}
@@ -111,6 +130,13 @@ func (r *SandboxReuseControl) doReuse(ctx context.Context, args EnsureFuncArgs) 
 			fmt.Sprintf("Reuse started for sandbox %s", box.Name))
 		klog.InfoS("Reuse started", "sandbox", klog.KObj(box))
 
+		// Signal the csi-sidecar to unmount stale CSI volumes on its next restart
+		// before handing the sandbox back for reuse. Must run while the runtime is
+		// still reachable, i.e. before the reuser resets the sandbox.
+		if err := r.ensureCSIResetSignal(ctx, box); err != nil {
+			return 0, err
+		}
+
 		if err := r.config.Reuser.Reuse(ctx, box, args.Pod); err != nil {
 			return 0, err
 		}
@@ -135,6 +161,54 @@ func (r *SandboxReuseControl) doReuse(ctx context.Context, args EnsureFuncArgs) 
 	}
 
 	return requeue, err
+}
+
+// ensureCSIResetSignal writes an empty reset signal file into the sandbox's
+// configured CSI reset directory so that a restarting csi-sidecar can detect it
+// and unmount stale CSI volumes before the sandbox is returned to the pool.
+//
+// It is a no-op when the sandbox carries no CSI mount annotation. When the sandbox
+// does carry CSI mounts but the reset directory is not configured, it fails the
+// reuse rather than silently returning stale mounts to the pool. The write goes
+// through the agent-runtime files API, so it only depends on the runtime sidecar
+// being reachable, not on any binary inside the sandbox. Transient failures are
+// retried a few times inline.
+func (r *SandboxReuseControl) ensureCSIResetSignal(ctx context.Context, box *agentsv1alpha1.Sandbox) error {
+	if box.Annotations[agentsv1alpha1.AnnotationCSIVolumeConfig] == "" {
+		return nil
+	}
+	if r.config.CSIResetSignalDir == "" {
+		return fmt.Errorf("sandbox carries CSI mounts but csi-reset-signal-dir is not configured")
+	}
+
+	resetFile := path.Join(r.config.CSIResetSignalDir, r.config.CSIResetSignalFileName)
+	var lastErr error
+	for attempt := 1; attempt <= csiResetSignalMaxRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		_, lastErr = writeRuntimeFileFunc(ctx, agentsruntime.WriteFileArgs{
+			Sbx:         box,
+			FilePath:    resetFile,
+			Content:     []byte{},
+			Permissions: 0644,
+			Timeout:     csiResetSignalWriteTimeout,
+		})
+		if lastErr == nil {
+			klog.InfoS("Wrote CSI reset signal for reuse", "sandbox", klog.KObj(box), "file", resetFile, "attempt", attempt)
+			return nil
+		}
+		klog.InfoS("Failed to write CSI reset signal, will retry", "sandbox", klog.KObj(box),
+			"file", resetFile, "attempt", attempt, "error", lastErr)
+		if attempt < csiResetSignalMaxRetries {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(csiResetSignalRetryInterval):
+			}
+		}
+	}
+	return fmt.Errorf("failed to write csi reset signal to %s after %d attempts: %w", resetFile, csiResetSignalMaxRetries, lastErr)
 }
 
 // validateReusePreconditions performs all pre-condition checks before the

--- a/pkg/controller/sandbox/core/reuse.go
+++ b/pkg/controller/sandbox/core/reuse.go
@@ -130,9 +130,10 @@ func (r *SandboxReuseControl) doReuse(ctx context.Context, args EnsureFuncArgs) 
 			fmt.Sprintf("Reuse started for sandbox %s", box.Name))
 		klog.InfoS("Reuse started", "sandbox", klog.KObj(box))
 
-		// Signal the csi-sidecar to unmount stale CSI volumes on its next restart
-		// before handing the sandbox back for reuse. Must run while the runtime is
-		// still reachable, i.e. before the reuser resets the sandbox.
+		// Signal the csi-sidecar to unmount stale CSI volumes when it stops
+		// (prestop/SIGTERM) before handing the sandbox back for reuse. Must run
+		// while the runtime is still reachable, i.e. before the reuser resets the
+		// sandbox.
 		if err := r.ensureCSIResetSignal(ctx, box); err != nil {
 			return 0, err
 		}
@@ -164,8 +165,9 @@ func (r *SandboxReuseControl) doReuse(ctx context.Context, args EnsureFuncArgs) 
 }
 
 // ensureCSIResetSignal writes an empty reset signal file into the sandbox's
-// configured CSI reset directory so that a restarting csi-sidecar can detect it
-// and unmount stale CSI volumes before the sandbox is returned to the pool.
+// configured CSI reset directory so that a stopping csi-sidecar can detect it
+// during prestop/SIGTERM and unmount stale CSI volumes before the sandbox is
+// returned to the pool.
 //
 // It is a no-op when the sandbox carries no CSI mount annotation. When the sandbox
 // does carry CSI mounts but the reset directory is not configured, it fails the
@@ -198,9 +200,9 @@ func (r *SandboxReuseControl) ensureCSIResetSignal(ctx context.Context, box *age
 			klog.InfoS("Wrote CSI reset signal for reuse", "sandbox", klog.KObj(box), "file", resetFile, "attempt", attempt)
 			return nil
 		}
-		klog.InfoS("Failed to write CSI reset signal, will retry", "sandbox", klog.KObj(box),
-			"file", resetFile, "attempt", attempt, "error", lastErr)
 		if attempt < csiResetSignalMaxRetries {
+			klog.InfoS("Failed to write CSI reset signal, will retry", "sandbox", klog.KObj(box),
+				"file", resetFile, "attempt", attempt, "error", lastErr)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()

--- a/pkg/controller/sandbox/core/reuse_test.go
+++ b/pkg/controller/sandbox/core/reuse_test.go
@@ -39,6 +39,7 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/utils"
+	agentsruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 type mockSandboxReuser struct {
@@ -96,6 +97,8 @@ func TestEnsureSandboxReused(t *testing.T) {
 		pod                *corev1.Pod
 		newStatus          *agentsv1alpha1.SandboxStatus
 		sbs                *agentsv1alpha1.SandboxSet
+		csiResetSignalDir  string
+		csiWriteErr        error
 		expectError        string
 		expectPhase        agentsv1alpha1.SandboxPhase
 		expectRequeue      bool
@@ -103,6 +106,7 @@ func TestEnsureSandboxReused(t *testing.T) {
 		expectCondReason   string
 		expectShutdownTime bool
 		expectDeleted      bool
+		expectCSIWrite     bool
 	}{
 		{
 			name:             "missing sandbox-pool label - reuse failed",
@@ -164,6 +168,72 @@ func TestEnsureSandboxReused(t *testing.T) {
 			},
 			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxReusing},
 			expectCondReason: agentsv1alpha1.SandboxReusingReasonStarted,
+		},
+		{
+			name:             "first entry - csi mounts with reset-signal-dir configured - signal written, reuse started",
+			reuser:           &mockSandboxReuser{},
+			reuseTimeout:     60 * time.Second,
+			reuseGracePeriod: 10 * time.Second,
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+					Labels: map[string]string{
+						agentsv1alpha1.LabelSandboxPool: "test-pool",
+					},
+					Annotations: map[string]string{
+						agentsv1alpha1.AnnotationReuse:           "true",
+						agentsv1alpha1.AnnotationReuseEnabled:    "true",
+						agentsv1alpha1.AnnotationCSIVolumeConfig: `[{"mountPath":"/data"}]`,
+					},
+				},
+			},
+			pod: readyPod,
+			sbs: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pool",
+					Namespace: "default",
+					UID:       types.UID("test-uid"),
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
+			},
+			newStatus:         &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxReusing},
+			csiResetSignalDir: "/var/run/csi-reset",
+			expectCSIWrite:    true,
+			expectCondReason:  agentsv1alpha1.SandboxReusingReasonStarted,
+		},
+		{
+			name:             "first entry - csi mounts but reset-signal-dir not configured - reuse failed and deleted",
+			reuser:           &mockSandboxReuser{},
+			reuseTimeout:     60 * time.Second,
+			reuseGracePeriod: 10 * time.Second,
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+					Labels: map[string]string{
+						agentsv1alpha1.LabelSandboxPool: "test-pool",
+					},
+					Annotations: map[string]string{
+						agentsv1alpha1.AnnotationReuse:           "true",
+						agentsv1alpha1.AnnotationReuseEnabled:    "true",
+						agentsv1alpha1.AnnotationCSIVolumeConfig: `[{"mountPath":"/data"}]`,
+					},
+				},
+			},
+			pod: readyPod,
+			sbs: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pool",
+					Namespace: "default",
+					UID:       types.UID("test-uid"),
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
+			},
+			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxReusing},
+			csiResetSignalDir: "",
+			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			expectDeleted:    true,
 		},
 		{
 			name: "reuse in progress - not complete, requeues for polling",
@@ -980,14 +1050,35 @@ func TestEnsureSandboxReused(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			origWrite := writeRuntimeFileFunc
+			origInterval := csiResetSignalRetryInterval
+			t.Cleanup(func() {
+				writeRuntimeFileFunc = origWrite
+				csiResetSignalRetryInterval = origInterval
+			})
+			csiResetSignalRetryInterval = time.Millisecond
+			var csiWriteCalls int
+			writeRuntimeFileFunc = func(_ context.Context, _ agentsruntime.WriteFileArgs) (agentsruntime.WriteFileResult, error) {
+				csiWriteCalls++
+				if tt.csiWriteErr != nil {
+					return agentsruntime.WriteFileResult{}, tt.csiWriteErr
+				}
+				return agentsruntime.WriteFileResult{StatusCode: 200}, nil
+			}
+
 			objs := []client.Object{tt.box}
 			if tt.sbs != nil {
 				objs = append(objs, tt.sbs)
 			}
 			control, fakeClient := newTestReuseControl(t, objs, tt.reuser, tt.reuseTimeout, tt.reuseGracePeriod)
+			control.config.CSIResetSignalDir = tt.csiResetSignalDir
 
 			args := EnsureFuncArgs{Pod: tt.pod, Box: tt.box, NewStatus: tt.newStatus}
 			requeue, err := control.ensureSandboxReused(context.TODO(), args)
+
+			if tt.expectCSIWrite {
+				assert.Positive(t, csiWriteCalls, "expected CSI reset signal to be written")
+			}
 
 			if tt.expectError != "" {
 				require.Error(t, err)
@@ -1936,6 +2027,139 @@ func TestReusePollingInterval(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, control.reusePollingInterval(tt.remaining))
+		})
+	}
+}
+
+func TestEnsureCSIResetSignal(t *testing.T) {
+	origWrite := writeRuntimeFileFunc
+	origInterval := csiResetSignalRetryInterval
+	t.Cleanup(func() {
+		writeRuntimeFileFunc = origWrite
+		csiResetSignalRetryInterval = origInterval
+	})
+	csiResetSignalRetryInterval = time.Millisecond
+
+	sandboxWithCSI := func() *agentsv1alpha1.Sandbox {
+		return &agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sandbox",
+				Namespace: "default",
+				Annotations: map[string]string{
+					agentsv1alpha1.AnnotationCSIVolumeConfig: `[{"mountPath":"/data"}]`,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		dir          string
+		fileName     string
+		box          *agentsv1alpha1.Sandbox
+		cancelCtx    bool
+		failTimes    int // number of leading write attempts that fail before succeeding
+		writeErr     error
+		wantCalls    int
+		wantFilePath string
+		expectError  string
+	}{
+		{
+			name:        "csi mounts but no reset dir configured fails",
+			dir:         "",
+			box:         sandboxWithCSI(),
+			wantCalls:   0,
+			expectError: "csi-reset-signal-dir is not configured",
+		},
+		{
+			name: "no csi annotation skips write",
+			dir:  "/var/run/csi-reset",
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default"},
+			},
+			wantCalls: 0,
+		},
+		{
+			name:         "success on first attempt",
+			dir:          "/var/run/csi-reset",
+			fileName:     "reset",
+			box:          sandboxWithCSI(),
+			wantCalls:    1,
+			wantFilePath: "/var/run/csi-reset/reset",
+		},
+		{
+			name:         "custom file name is used",
+			dir:          "/var/run/csi-reset",
+			fileName:     "unmount",
+			box:          sandboxWithCSI(),
+			wantCalls:    1,
+			wantFilePath: "/var/run/csi-reset/unmount",
+		},
+		{
+			name:         "success after retries",
+			dir:          "/var/run/csi-reset",
+			fileName:     "reset",
+			box:          sandboxWithCSI(),
+			failTimes:    2,
+			writeErr:     fmt.Errorf("runtime unavailable"),
+			wantCalls:    3,
+			wantFilePath: "/var/run/csi-reset/reset",
+		},
+		{
+			name:        "failure after exhausting retries",
+			dir:         "/var/run/csi-reset",
+			box:         sandboxWithCSI(),
+			failTimes:   csiResetSignalMaxRetries,
+			writeErr:    fmt.Errorf("runtime unavailable"),
+			wantCalls:   csiResetSignalMaxRetries,
+			expectError: "runtime unavailable",
+		},
+		{
+			name:        "canceled context returns before writing",
+			dir:         "/var/run/csi-reset",
+			box:         sandboxWithCSI(),
+			cancelCtx:   true,
+			wantCalls:   0,
+			expectError: "context canceled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls int
+			var gotPath string
+			var gotContent []byte
+			writeRuntimeFileFunc = func(_ context.Context, args agentsruntime.WriteFileArgs) (agentsruntime.WriteFileResult, error) {
+				calls++
+				gotPath = args.FilePath
+				gotContent = args.Content
+				if calls <= tt.failTimes {
+					return agentsruntime.WriteFileResult{}, tt.writeErr
+				}
+				return agentsruntime.WriteFileResult{StatusCode: 200}, nil
+			}
+
+			ctx := context.Background()
+			if tt.cancelCtx {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+
+			control := &SandboxReuseControl{config: SandboxReuseConfig{CSIResetSignalDir: tt.dir, CSIResetSignalFileName: tt.fileName}}
+			err := control.ensureCSIResetSignal(ctx, tt.box)
+
+			assert.Equal(t, tt.wantCalls, calls)
+			if tt.wantFilePath != "" {
+				assert.Equal(t, tt.wantFilePath, gotPath)
+				assert.Empty(t, gotContent, "reset signal file must be an empty marker")
+			}
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			}
 		})
 	}
 }

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -53,6 +53,11 @@ func init() {
 	flag.DurationVar(&reuseTimeout, "reuse-timeout", reuseTimeout, "Timeout for sandbox reuse cleanup operations.")
 	flag.DurationVar(&reuseGracePeriod, "reuse-grace-period", reuseGracePeriod, "Grace period after reuse cleanup before sandbox returns to pool.")
 	flag.DurationVar(&reuseFailureShutdownGrace, "reuse-failure-shutdown-grace", reuseFailureShutdownGrace, "Grace period before shutting down a sandbox after reuse failure.")
+	flag.StringVar(&csiResetSignalDir, "csi-reset-signal-dir", csiResetSignalDir,
+		"Directory inside the sandbox where a reset signal file is written before reuse when the sandbox carries CSI mounts, "+
+			"so a restarting csi-sidecar can unmount stale volumes. Empty disables the behavior.")
+	flag.StringVar(&csiResetSignalFileName, "csi-reset-signal-file", csiResetSignalFileName,
+		"Name of the reset signal file written into --csi-reset-signal-dir before reuse.")
 }
 
 var (
@@ -61,6 +66,8 @@ var (
 	reuseTimeout              = 60 * time.Second
 	reuseGracePeriod          = 10 * time.Second
 	reuseFailureShutdownGrace = 5 * time.Minute
+	csiResetSignalDir         = ""
+	csiResetSignalFileName    = "reset"
 )
 
 // Enqueuer is the contract the Sandbox controller depends on for async
@@ -93,9 +100,11 @@ func Add(mgr manager.Manager, metricsCleanup Enqueuer) error {
 			CheckpointControl: checkpointControl,
 			PodControl:        podControl,
 			ReuseConfig: core.SandboxReuseConfig{
-				Timeout:              reuseTimeout,
-				GracePeriod:          reuseGracePeriod,
-				FailureShutdownGrace: reuseFailureShutdownGrace,
+				Timeout:                reuseTimeout,
+				GracePeriod:            reuseGracePeriod,
+				FailureShutdownGrace:   reuseFailureShutdownGrace,
+				CSIResetSignalDir:      csiResetSignalDir,
+				CSIResetSignalFileName: csiResetSignalFileName,
 			},
 		}),
 		rateLimiter:    rateLimiter,

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -55,7 +55,7 @@ func init() {
 	flag.DurationVar(&reuseFailureShutdownGrace, "reuse-failure-shutdown-grace", reuseFailureShutdownGrace, "Grace period before shutting down a sandbox after reuse failure.")
 	flag.StringVar(&csiResetSignalDir, "csi-reset-signal-dir", csiResetSignalDir,
 		"Directory inside the sandbox where a reset signal file is written before reuse when the sandbox carries CSI mounts, "+
-			"so a restarting csi-sidecar can unmount stale volumes. Empty disables the behavior.")
+			"so a stopping csi-sidecar can unmount stale volumes during prestop/SIGTERM. Empty disables the behavior.")
 	flag.StringVar(&csiResetSignalFileName, "csi-reset-signal-file", csiResetSignalFileName,
 		"Name of the reset signal file written into --csi-reset-signal-dir before reuse.")
 }

--- a/test/e2e/sandbox_reuse_test.go
+++ b/test/e2e/sandbox_reuse_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
@@ -377,5 +378,127 @@ var _ = Describe("Sandbox Reuse", func() {
 				return isSandboxDeleted(target)
 			}, time.Second*30, time.Second).Should(BeTrue())
 		})
+	})
+})
+
+// This suite covers the CSI reset-signal write that runs before a sandbox is
+// returned to the pool. Unlike the reuse suite above (which uses the noop reuser
+// and a bare nginx pod), it needs a pod running the real agent-runtime (envd)
+// sidecar, because the controller writes the reset signal through the
+// agent-runtime files API. It requires the controller to be started with
+// --csi-reset-signal-dir and the agent-runtime image to be available in-cluster.
+var _ = Describe("Sandbox Reuse CSI Reset Signal", func() {
+	var (
+		ctx        = context.Background()
+		namespace  string
+		sandboxSet *agentsv1alpha1.SandboxSet
+	)
+
+	BeforeEach(func() {
+		namespace = createNamespace(ctx)
+		alwaysRestart := corev1.ContainerRestartPolicyAlways
+		sandboxSet = &agentsv1alpha1.SandboxSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("reuse-csi-pool-%d", time.Now().UnixNano()),
+				Namespace: namespace,
+			},
+			Spec: agentsv1alpha1.SandboxSetSpec{
+				Replicas: 1,
+				EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name:            "runtime",
+									Image:           "agent-runtime:latest",
+									ImagePullPolicy: corev1.PullIfNotPresent,
+									Command:         []string{"sh", "/workspace/entrypoint.sh"},
+									VolumeMounts:    []corev1.VolumeMount{{Name: "envd-volume", MountPath: "/mnt/envd"}},
+									Env:             []corev1.EnvVar{{Name: "ENVD_DIR", Value: "/mnt/envd"}},
+									RestartPolicy:   &alwaysRestart,
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Name:         "sandbox",
+									Image:        "centos:7",
+									Command:      []string{"/bin/bash", "-c", "sleep infinity"},
+									Env:          []corev1.EnvVar{{Name: "ENVD_DIR", Value: "/mnt/envd"}},
+									VolumeMounts: []corev1.VolumeMount{{Name: "envd-volume", MountPath: "/mnt/envd"}},
+									StartupProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(49983)},
+										},
+										FailureThreshold:    20,
+										InitialDelaySeconds: 3,
+										PeriodSeconds:       1,
+										SuccessThreshold:    1,
+										TimeoutSeconds:      1,
+									},
+									Lifecycle: &corev1.Lifecycle{
+										PostStart: &corev1.LifecycleHandler{
+											Exec: &corev1.ExecAction{Command: []string{"sh", "/mnt/envd/envd-run.sh"}},
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{Name: "envd-volume", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+							},
+							RestartPolicy: corev1.RestartPolicyNever,
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, sandboxSet)).To(Succeed())
+
+		By("Waiting for the runtime-backed sandbox to be Running")
+		Eventually(func() int32 {
+			_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(sandboxSet), sandboxSet)
+			return sandboxSet.Status.AvailableReplicas
+		}, time.Minute*3, time.Second).Should(Equal(int32(1)))
+	})
+
+	AfterEach(func() {
+		if sandboxSet != nil {
+			_ = k8sClient.Delete(ctx, sandboxSet)
+		}
+	})
+
+	It("should write the reset signal through agent-runtime and return the sandbox to the pool", func() {
+		list := &agentsv1alpha1.SandboxList{}
+		Expect(k8sClient.List(ctx, list, client.InNamespace(namespace),
+			client.MatchingLabels{agentsv1alpha1.LabelSandboxPool: sandboxSet.Name})).To(Succeed())
+		Expect(list.Items).To(HaveLen(1))
+		target := &list.Items[0]
+
+		By("Marking the sandbox as carrying a CSI mount and triggering reuse")
+		Eventually(func() error {
+			latest := &agentsv1alpha1.Sandbox{}
+			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(target), latest); err != nil {
+				return err
+			}
+			patch := client.MergeFrom(latest.DeepCopy())
+			if latest.Annotations == nil {
+				latest.Annotations = map[string]string{}
+			}
+			latest.Annotations[agentsv1alpha1.AnnotationCSIVolumeConfig] = `[{"mountPath":"/data"}]`
+			latest.Annotations[agentsv1alpha1.AnnotationReuseEnabled] = "true"
+			latest.Annotations[agentsv1alpha1.AnnotationReuse] = "true"
+			return k8sClient.Patch(ctx, latest, patch)
+		}, time.Second*10, time.Second).Should(Succeed())
+
+		// Reuse only succeeds if the controller wrote the reset-signal file into
+		// the sandbox through the agent-runtime files API. A failed write is a
+		// permanent reuse failure that deletes the sandbox, so observing a
+		// successful reuse (sandbox back in the pool with ReuseCount incremented)
+		// proves the write link works end to end.
+		By("Waiting for the sandbox to return to Running with ReuseCount incremented")
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(target), target)).To(Succeed())
+			g.Expect(target.Status.Phase).To(Equal(agentsv1alpha1.SandboxRunning))
+			g.Expect(target.Status.ReuseCount).To(Equal(int32(1)))
+		}, time.Minute*2, time.Second).Should(Succeed())
 	})
 })

--- a/test/e2e/sandbox_reuse_test.go
+++ b/test/e2e/sandbox_reuse_test.go
@@ -421,7 +421,7 @@ var _ = Describe("Sandbox Reuse CSI Reset Signal", func() {
 							Containers: []corev1.Container{
 								{
 									Name:         "sandbox",
-									Image:        "centos:7",
+									Image:        "ubuntu:24.04",
 									Command:      []string{"/bin/bash", "-c", "sleep infinity"},
 									Env:          []corev1.EnvVar{{Name: "ENVD_DIR", Value: "/mnt/envd"}},
 									VolumeMounts: []corev1.VolumeMount{{Name: "envd-volume", MountPath: "/mnt/envd"}},
@@ -437,7 +437,7 @@ var _ = Describe("Sandbox Reuse CSI Reset Signal", func() {
 									},
 									Lifecycle: &corev1.Lifecycle{
 										PostStart: &corev1.LifecycleHandler{
-											Exec: &corev1.ExecAction{Command: []string{"sh", "/mnt/envd/envd-run.sh"}},
+											Exec: &corev1.ExecAction{Command: []string{"bash", "/mnt/envd/envd-run.sh"}},
 										},
 									},
 								},


### PR DESCRIPTION
## Summary

Before a sandbox is returned to the pool for reuse, if it carries CSI mounts, the controller now writes an empty reset-signal file into a configurable directory through the agent-runtime files API. A stopping csi-sidecar can detect this file during prestop/SIGTERM and unmount stale CSI volumes before the sandbox is handed back for reuse.

- Add `ensureCSIResetSignal` in the reuse state machine: no-op when the sandbox carries no CSI annotation; hard-fail the reuse when CSI mounts are present but `--csi-reset-signal-dir` is unconfigured; otherwise write the signal file (with a few inline retries) while the runtime is still reachable, before the reuser resets the sandbox.
- Add `--csi-reset-signal-dir` / `--csi-reset-signal-file` controller flags wired into `SandboxReuseConfig`.

## Tests

- Unit tests: cover `ensureCSIResetSignal` (no dir, no CSI annotation, success, custom file name, retry, exhausted retries, canceled context) plus two `doReuse` integration cases exercising the CSI wiring and error propagation through the full state machine.
- E2E: new `Sandbox Reuse CSI Reset Signal` case runs a pool backed by the real agent-runtime (envd) sidecar and verifies a CSI-annotated sandbox reuses successfully — proving the reset-signal write link works end to end. The `E2E-1.32` workflow now builds/loads `agent-runtime` and starts the controller with `--csi-reset-signal-dir`.

## Test plan

- [ ] `go test ./pkg/controller/sandbox/core/...`
- [ ] E2E-1.32 workflow green (new reuse CSI case)