### PR TITLE
fix(security): mask AccessToken in Route log output and debug endpoint

### DIFF
--- a/pkg/sandbox-manager/debug.go
+++ b/pkg/sandbox-manager/debug.go
@@ -27,8 +27,14 @@ type DebugInfo struct {
 }
 
 func (m *SandboxManager) GetDebugInfo() DebugInfo {
+	routes := m.proxy.ListRoutes()
+	// Mask AccessToken to prevent credential leakage via the debug endpoint.
+	// Always set to "***" to avoid revealing which sandboxes have tokens configured.
+	for i := range routes {
+		routes[i].AccessToken = "***"
+	}
 	info := DebugInfo{
-		Routes: m.proxy.ListRoutes(),
+		Routes: routes,
 		Peers:  m.proxy.ListPeers(),
 		Pools:  m.infra.LoadDebugInfo(),
 	}

--- a/pkg/sandbox-manager/debug_test.go
+++ b/pkg/sandbox-manager/debug_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandbox_manager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openkruise/agents/pkg/proxy"
+)
+
+func TestSandboxManager_DebugMaskAccessToken(t *testing.T) {
+	manager, _ := setupTestManager(t)
+
+	tests := []struct {
+		name        string
+		routes      []proxy.Route
+		expectCount int
+	}{
+		{
+			name:        "no routes returns empty list",
+			routes:      nil,
+			expectCount: 0,
+		},
+		{
+			name: "routes with access token are masked",
+			routes: []proxy.Route{
+				{ID: "default--sbx1", IP: "10.0.0.1", State: "running", ResourceVersion: "1", AccessToken: "secret-token-1"},
+				{ID: "default--sbx2", IP: "10.0.0.2", State: "running", ResourceVersion: "2", AccessToken: ""},
+			},
+			expectCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup routes
+			for _, route := range tt.routes {
+				manager.proxy.SetRoute(t.Context(), route)
+			}
+
+			info := manager.GetDebugInfo()
+			assert.Len(t, info.Routes, tt.expectCount)
+
+			// Verify all AccessTokens are masked to "***"
+			for _, route := range info.Routes {
+				assert.Equal(t, "***", route.AccessToken, "AccessToken should be masked for route %s", route.ID)
+			}
+		})
+	}
+}

--- a/pkg/utils/proxyutils/route.go
+++ b/pkg/utils/proxyutils/route.go
@@ -17,6 +17,8 @@ limitations under the License.
 package proxyutils
 
 import (
+	"fmt"
+
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/utils"
 	"k8s.io/apimachinery/pkg/types"
@@ -48,4 +50,11 @@ type Route struct {
 	State           string    `json:"state"`
 	ResourceVersion string    `json:"resourceVersion"`
 	AccessToken     string    `json:"accessToken,omitempty"`
+}
+
+// String implements fmt.Stringer to prevent AccessToken from being leaked in logs.
+// Always prints "***" to avoid revealing whether a token is configured.
+func (r Route) String() string {
+	return fmt.Sprintf("{IP:%s ID:%s UID:%s Owner:%s State:%s ResourceVersion:%s AccessToken:***}",
+		r.IP, r.ID, r.UID, r.Owner, r.State, r.ResourceVersion)
 }

--- a/pkg/utils/proxyutils/route_test.go
+++ b/pkg/utils/proxyutils/route_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxyutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+)
+
+func TestRouteString(t *testing.T) {
+	tests := []struct {
+		name             string
+		route            Route
+		expectContains   []string
+		expectNotContain []string
+	}{
+		{
+			name: "route with access token masks token value",
+			route: Route{
+				IP:              "10.0.0.1",
+				ID:              "default--my-sandbox",
+				UID:             "uid-123",
+				Owner:           "user1",
+				State:           v1alpha1.SandboxStateRunning,
+				ResourceVersion: "100",
+				AccessToken:     "super-secret-token",
+			},
+			expectContains:   []string{"10.0.0.1", "default--my-sandbox", "uid-123", "user1", "running", "100", "AccessToken:***"},
+			expectNotContain: []string{"super-secret-token"},
+		},
+		{
+			name: "route without access token still prints masked placeholder",
+			route: Route{
+				IP:              "10.0.0.2",
+				ID:              "default--no-token",
+				UID:             "uid-456",
+				Owner:           "",
+				State:           v1alpha1.SandboxStateCreating,
+				ResourceVersion: "50",
+				AccessToken:     "",
+			},
+			expectContains:   []string{"10.0.0.2", "default--no-token", "uid-456", "creating", "50", "AccessToken:***"},
+			expectNotContain: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.route.String()
+			for _, s := range tt.expectContains {
+				assert.Contains(t, result, s)
+			}
+			for _, s := range tt.expectNotContain {
+				assert.NotContains(t, result, s)
+			}
+		})
+	}
+}

--- a/test/e2b/test_gateway.py
+++ b/test/e2b/test_gateway.py
@@ -13,9 +13,15 @@ logger = logging.getLogger(__name__)
 
 def get_sandbox_access_token(sandbox_id: str) -> str:
     """Retrieve the runtime-access-token annotation from a Sandbox CR via kubectl."""
-    name = sandbox_id.split("--")[1] if "--" in sandbox_id else sandbox_id
+    if "--" in sandbox_id:
+        parts = sandbox_id.split("--")
+        namespace = parts[0]
+        name = parts[1]
+    else:
+        namespace = "default"
+        name = sandbox_id
     result = subprocess.run(
-        ["kubectl", "get", "sandbox", name, "-o", "json"],
+        ["kubectl", "get", "sandbox", name, "-n", namespace, "-o", "json"],
         capture_output=True,
         text=True,
         check=True,


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Prevents `Route.AccessToken` from being leaked through logs and the `/debug` HTTP endpoint.

**Changes:**

1. **Route.String() masking** (`pkg/utils/proxyutils/route.go`): Implements `fmt.Stringer` on `Route` struct, always printing `AccessToken:***` regardless of whether the field is empty — preventing attackers from inferring token configuration status via log side-channel.

2. **Debug endpoint masking** (`pkg/sandbox-manager/debug.go`): `GetDebugInfo()` now unconditionally masks `AccessToken` to `"***"` for all routes before returning the JSON response, closing a privilege escalation vector where any valid API Key holder could extract all sandbox tokens.

3. **Unit tests**: Added `route_test.go` and `debug_test.go` covering both token-present and token-absent scenarios.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run unit tests:
   ```bash
   go test ./pkg/utils/proxyutils/ -run TestRouteString -v
   go test ./pkg/sandbox-manager/ -run TestSandboxManager_DebugMaskAccessToken -v
   ```
2. Verify log output: `SetRoute` logs should display `AccessToken:***` (visible in test output).
3. Verify debug endpoint: `GET /debug` response should show `"accessToken":"***"` for all routes.

### Ⅳ. Special notes for reviews

- `Route` is a value type stored in `sync.Map`; `ListRoutes()` returns copies, so masking in `GetDebugInfo()` does not affect the actual routing data or peer synchronization.
- The `json:"accessToken,omitempty"` tag remains unchanged — peer sync (`SyncRouteWithPeers`) intentionally transmits the real token for gateway authentication. This is internal cluster communication and is by design.
- The `String()` method uses a constant mask (no conditional on empty) to prevent timing/side-channel inference.

---

### Appendix: Incidental Changes

- Fix namespace parsing in E2B gateway test helper (`test/e2b/test_gateway.py`): correctly extract namespace from `namespace--name` format sandbox IDs and pass `-n` flag to `kubectl get sandbox`.
