### PR TITLE
refactor: rename sandbox reuse concept to recycle

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -232,9 +232,9 @@ type SandboxStatus struct {
 	// +optional
 	UpdateRevision string `json:"updateRevision,omitempty"`
 
-	// ReuseCount records the number of times this sandbox has been reused.
+	// RecycledCount records the number of times this sandbox has been recycled.
 	// +optional
-	ReuseCount int32 `json:"reuseCount,omitempty"`
+	RecycledCount int32 `json:"recycledCount,omitempty"`
 }
 
 // SandboxPhase is a label for the condition of a pod at the current time.
@@ -262,8 +262,8 @@ const (
 	// SandboxFailed means that all containers in the pod have terminated, and at least one container has
 	// terminated in a failure (exited with a non-zero exit code or was stopped by the system).
 	SandboxFailed SandboxPhase = "Failed"
-	// SandboxReusing means the sandbox is being cleaned up and preparing to return to pool.
-	SandboxReusing SandboxPhase = "Reusing"
+	// SandboxRecycling means the sandbox is being recycled and preparing to return to pool.
+	SandboxRecycling SandboxPhase = "Recycling"
 	// SandboxTerminating means sandbox will perform cleanup after deletion.
 	SandboxTerminating SandboxPhase = "Terminating"
 )
@@ -310,8 +310,8 @@ const (
 	// after resume/recreate/upgrade).
 	RuntimeInitialized SandboxConditionType = "RuntimeInitialized"
 
-	// SandboxConditionReusing tracks reuse progress.
-	SandboxConditionReusing SandboxConditionType = "Reusing"
+	// SandboxConditionRecycling tracks recycling progress.
+	SandboxConditionRecycling SandboxConditionType = "Recycling"
 )
 
 const (
@@ -354,13 +354,13 @@ const (
 	SandboxConditionRuntimeInitReasonSucceeded = "Succeeded"
 	SandboxConditionRuntimeInitReasonFailed    = "Failed"
 
-	// SandboxConditionReusing Reason
-	SandboxReusingReasonStarted   = "ReuseStarted"
-	SandboxReusingReasonCompleted = "ReuseCompleted"
-	SandboxReusingReasonSucceeded = "ReuseSucceeded"
-	SandboxReusingReasonFailed    = "ReuseFailed"
-	SandboxReusingReasonTimeout   = "ReuseTimeout"
-	SandboxReusingReasonRejected  = "ReuseRejected"
+	// SandboxConditionRecycling Reason
+	SandboxRecyclingReasonStarted   = "RecyclingStarted"
+	SandboxRecyclingReasonCompleted = "RecyclingCompleted"
+	SandboxRecyclingReasonSucceeded = "RecyclingSucceeded"
+	SandboxRecyclingReasonFailed    = "RecyclingFailed"
+	SandboxRecyclingReasonTimeout   = "RecyclingTimeout"
+	SandboxRecyclingReasonRejected  = "RecyclingRejected"
 )
 
 // +genclient
@@ -373,7 +373,7 @@ const (
 // +kubebuilder:printcolumn:name="Claimed",type="string",JSONPath=".metadata.labels.agents\\.kruise\\.io/sandbox-claimed"
 // +kubebuilder:printcolumn:name="shutdown_time",type="string",JSONPath=".spec.shutdownTime"
 // +kubebuilder:printcolumn:name="pause_time",type="string",JSONPath=".spec.pauseTime"
-// +kubebuilder:printcolumn:name="ReuseCount",type="integer",JSONPath=".status.reuseCount"
+// +kubebuilder:printcolumn:name="RecycledCount",type="integer",JSONPath=".status.recycledCount"
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.message"
 
 // Sandbox is the Schema for the sandboxes API

--- a/api/v1alpha1/sandboxset_types.go
+++ b/api/v1alpha1/sandboxset_types.go
@@ -25,7 +25,7 @@ const (
 	InternalPrefix = "agents.kruise.io/"
 
 	// LabelSandboxPool identifies which SandboxSet generated the sandbox.
-	// Used by the reuse flow to find the origin SandboxSet.
+	// Used by the recycle flow to find the origin SandboxSet.
 	LabelSandboxPool = InternalPrefix + "sandbox-pool"
 	// LabelSandboxTemplate identifies which template generated the sandbox
 	LabelSandboxTemplate = InternalPrefix + "sandbox-template"
@@ -45,37 +45,37 @@ const (
 	AnnotationSandboxID          = InternalPrefix + "sandbox-id"
 	AnnotationMemberlistURL      = InternalPrefix + "memberlist-url"
 
-	// AnnotationReuseEnabled marks a sandbox as supporting reuse.
-	AnnotationReuseEnabled = InternalPrefix + "reuse-enabled"
-	// AnnotationReuse triggers the sandbox reuse flow. Removed by the controller after successful reuse.
-	AnnotationReuse = InternalPrefix + "reuse"
-	// AnnotationReuseRetainOnFailure controls how long the sandbox is retained after reuse failure.
+	// AnnotationCleanupEnabled marks a sandbox as supporting recycle.
+	AnnotationCleanupEnabled = InternalPrefix + "cleanup-enabled"
+	// AnnotationCleanup triggers the sandbox recycle flow. Removed by the controller after successful recycle.
+	AnnotationCleanup = InternalPrefix + "cleanup"
+	// AnnotationCleanupRetainOnFailure controls how long the sandbox is retained after recycle failure.
 	// Accepts a Go duration string (e.g., "5m") — the sandbox is retained for that duration and then
-	// deleted via ShutdownTime. By default (unset), the sandbox is deleted immediately after reuse failure.
+	// deleted via ShutdownTime. By default (unset), the sandbox is deleted immediately after recycle failure.
 	// If the value is invalid, the sandbox is also deleted immediately with a warning log.
-	AnnotationReuseRetainOnFailure = InternalPrefix + "reuse-retain-on-failure"
+	AnnotationCleanupRetainOnFailure = InternalPrefix + "cleanup-retain-on-failure"
 	// AnnotationUpdatedMetadataInClaim stores the keys of labels/annotations added or modified
-	// during the claim flow (JSON format, keys only). Used by the reuse flow to reset metadata.
+	// during the claim flow (JSON format, keys only). Used by the recycle flow to reset metadata.
 	AnnotationUpdatedMetadataInClaim = InternalPrefix + "updated-metadata-in-claim"
 )
 
-// AnnotationsClearedOnReuse lists all annotation keys that are removed from a
-// sandbox when it is successfully reused and returned to the pool. When adding
-// a new annotation that should be cleared during reuse, append it here to avoid
-// missing the cleanup in resetMetadataForPool.
+// AnnotationsClearedOnRecycle lists all annotation keys that are removed from a
+// sandbox when it is successfully recycled and returned to the pool. When adding
+// a new annotation that should be cleared during recycle, append it here to avoid
+// missing the recycle in resetMetadataForPool.
 //
 // Note: AnnotationUpdatedMetadataInClaim is handled separately because it is
 // consumed before deletion to determine user-specified metadata keys.
 // Annotations from other packages (e.g. identity.AgentKeyTokenRefreshStatus)
 // are handled individually in resetMetadataForPool.
-var AnnotationsClearedOnReuse = []string{
+var AnnotationsClearedOnRecycle = []string{
 	AnnotationClaimTime,
 	AnnotationLock,
 	AnnotationOwner,
 	AnnotationInitRuntimeRequest,
 	AnnotationRuntimeAccessToken,
-	AnnotationReuse,
-	AnnotationReuseRetainOnFailure,
+	AnnotationCleanup,
+	AnnotationCleanupRetainOnFailure,
 	AnnotationCSIVolumeConfig,
 	SandboxAnnotationPriority,
 	AnnotationEnvdAccessToken,
@@ -89,12 +89,12 @@ var AnnotationsClearedOnReuse = []string{
 // new internal key that should survive sandbox creation, add it here to avoid
 // accidental deletion in clearAndInitInnerKeys.
 var InternalKeysPreservedOnCreation = map[string]struct{}{
-	AnnotationReuseEnabled:         {},
-	AnnotationReuseRetainOnFailure: {},
+	AnnotationCleanupEnabled:         {},
+	AnnotationCleanupRetainOnFailure: {},
 }
 
 // UpdatedMetadataInClaim records the keys of labels/annotations added or modified during claim.
-// Used by the reuse flow to determine which metadata to reset.
+// Used by the recycle flow to determine which metadata to reset.
 type UpdatedMetadataInClaim struct {
 	Labels      []string `json:"labels,omitempty"`
 	Annotations []string `json:"annotations,omitempty"`

--- a/config/crd/bases/agents.kruise.io_sandboxes.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxes.yaml
@@ -32,8 +32,8 @@ spec:
     - jsonPath: .spec.pauseTime
       name: pause_time
       type: string
-    - jsonPath: .status.reuseCount
-      name: ReuseCount
+    - jsonPath: .status.recycledCount
+      name: RecycledCount
       type: integer
     - jsonPath: .status.message
       name: Message
@@ -202,6 +202,11 @@ spec:
           status:
             description: status defines the observed state of Sandbox
             properties:
+              recycledCount:
+                description: RecycledCount records the number of times this sandbox
+                  has been recycled.
+                format: int32
+                type: integer
               conditions:
                 description: |-
                   conditions represent the current state of the Sandbox resource.
@@ -305,11 +310,6 @@ spec:
                     description: PodUID is pod uid.
                     type: string
                 type: object
-              reuseCount:
-                description: ReuseCount records the number of times this sandbox has
-                  been reused.
-                format: int32
-                type: integer
               sandboxIp:
                 description: SandboxIp is the ip address allocated to the sandbox.
                 type: string

--- a/pkg/controller/sandbox/core/checkpoint_test.go
+++ b/pkg/controller/sandbox/core/checkpoint_test.go
@@ -279,7 +279,7 @@ func TestListCheckpointsForSandbox(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "test-sandbox-abc",
 						Namespace:         "default",
-						CreationTimestamp:  metav1.Now(),
+						CreationTimestamp: metav1.Now(),
 						OwnerReferences:   []metav1.OwnerReference{ownerRef},
 						Labels: map[string]string{
 							agentsv1alpha1.CheckpointLabelSandboxName: "test-sandbox",
@@ -304,7 +304,7 @@ func TestListCheckpointsForSandbox(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "test-sandbox-old",
 						Namespace:         "default",
-						CreationTimestamp:  metav1.NewTime(metav1.Now().Add(-10 * 60 * 1e9)),
+						CreationTimestamp: metav1.NewTime(metav1.Now().Add(-10 * 60 * 1e9)),
 						OwnerReferences:   []metav1.OwnerReference{ownerRef},
 						Labels: map[string]string{
 							agentsv1alpha1.CheckpointLabelSandboxName: "test-sandbox",
@@ -316,7 +316,7 @@ func TestListCheckpointsForSandbox(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "test-sandbox-new",
 						Namespace:         "default",
-						CreationTimestamp:  metav1.Now(),
+						CreationTimestamp: metav1.Now(),
 						OwnerReferences:   []metav1.OwnerReference{ownerRef},
 						Labels: map[string]string{
 							agentsv1alpha1.CheckpointLabelSandboxName: "test-sandbox",
@@ -514,9 +514,9 @@ func TestAssumePodCheckpointed(t *testing.T) {
 			expectReason: agentsv1alpha1.SandboxPausedReasonImageChanged,
 		},
 		{
-			name:         "image changed retry from ImageChanged reason",
-			enableGate:   true,
-			condReason:   agentsv1alpha1.SandboxPausedReasonImageChanged,
+			name:       "image changed retry from ImageChanged reason",
+			enableGate: true,
+			condReason: agentsv1alpha1.SandboxPausedReasonImageChanged,
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default", UID: "pod-uid-001"},
 				Spec: corev1.PodSpec{

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -68,7 +68,7 @@ type commonControl struct {
 	podControl           *PodControl
 	lifecycleHookFunc    LifecycleHookFunc
 	initializer          SandboxInitializer
-	reuseControl         *SandboxReuseControl
+	recycleControl       *SandboxRecycleControl
 }
 
 func NewCommonControl(args SandboxControlArgs) SandboxControl {
@@ -86,13 +86,13 @@ func NewCommonControl(args SandboxControlArgs) SandboxControl {
 			storageRegistry: storages.NewStorageProvider(),
 			recorder:        args.Recorder,
 		},
-		reuseControl: NewSandboxReuseControl(args.Client, args.Recorder, args.ReuseConfig),
+		recycleControl: NewSandboxRecycleControl(args.Client, args.Recorder, args.RecycleConfig),
 	}
 	return control
 }
 
-func (r *commonControl) EnsureSandboxReused(ctx context.Context, args EnsureFuncArgs) (time.Duration, error) {
-	return r.reuseControl.ensureSandboxReused(ctx, args)
+func (r *commonControl) EnsureSandboxRecycled(ctx context.Context, args EnsureFuncArgs) (time.Duration, error) {
+	return r.recycleControl.ensureSandboxRecycled(ctx, args)
 }
 
 func (r *commonControl) EnsureSandboxRunning(ctx context.Context, args EnsureFuncArgs) (time.Duration, error) {

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -576,8 +576,8 @@ func TestCommonControl_EnsureSandboxUpdated_InitializePath(t *testing.T) {
 			expectError: "runtime init failed",
 		},
 		{
-			name: "pod ready, init failed, retries initialize and succeeds",
-			pod:  readyPod,
+			name:        "pod ready, init failed, retries initialize and succeeds",
+			pod:         readyPod,
 			initializer: &mockSandboxInitializer{},
 			conditions: []metav1.Condition{
 				{
@@ -3294,4 +3294,3 @@ func TestCommonControl_performRecreateUpgrade_InitializerPath(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/controller/sandbox/core/interface.go
+++ b/pkg/controller/sandbox/core/interface.go
@@ -95,7 +95,7 @@ type FailedReason interface {
 
 // SandboxRecycleConfig groups all recycle-related configuration for the sandbox controller.
 type SandboxRecycleConfig struct {
-	Recycler              SandboxRecycler
+	Recycler             SandboxRecycler
 	Timeout              time.Duration
 	GracePeriod          time.Duration
 	FailureShutdownGrace time.Duration

--- a/pkg/controller/sandbox/core/interface.go
+++ b/pkg/controller/sandbox/core/interface.go
@@ -58,19 +58,19 @@ type SandboxControl interface {
 	// EnsureSandboxUpgraded handle sandbox with status phase = Upgrading
 	EnsureSandboxUpgraded(ctx context.Context, args EnsureFuncArgs) error
 
-	// EnsureSandboxReused handle sandbox with status phase = Reusing
-	EnsureSandboxReused(ctx context.Context, args EnsureFuncArgs) (time.Duration, error)
+	// EnsureSandboxRecycled handle sandbox with status phase = Recycling
+	EnsureSandboxRecycled(ctx context.Context, args EnsureFuncArgs) (time.Duration, error)
 
 	// EnsureSandboxTerminated handle sandbox with status phase = Terminating
 	EnsureSandboxTerminated(ctx context.Context, args EnsureFuncArgs) error
 }
 
-// SandboxReuser handles the cleanup of user and container data inside a sandbox.
+// SandboxRecycler handles the recycle of user and container data inside a sandbox.
 // Implementations should wrap transient errors (API timeouts, network issues) with
 // RetriableError so the caller can distinguish them from permanent failures.
-type SandboxReuser interface {
-	Reuse(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod) error
-	IsReuseComplete(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod) (complete bool, err error)
+type SandboxRecycler interface {
+	Recycle(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod) error
+	IsRecycleComplete(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod) (complete bool, err error)
 }
 
 // RetriableError wraps a transient error that the caller should retry.
@@ -87,20 +87,20 @@ func IsRetriable(err error) bool {
 }
 
 // FailedReason allows a permanent error to specify a condition reason other
-// than the default SandboxReusingReasonFailed. handleReuseFailed checks for
+// than the default SandboxRecyclingReasonFailed. handleRecycleFailed checks for
 // this interface to set the correct condition reason.
 type FailedReason interface {
 	Reason() string
 }
 
-// SandboxReuseConfig groups all reuse-related configuration for the sandbox controller.
-type SandboxReuseConfig struct {
-	Reuser               SandboxReuser
+// SandboxRecycleConfig groups all recycle-related configuration for the sandbox controller.
+type SandboxRecycleConfig struct {
+	Recycler              SandboxRecycler
 	Timeout              time.Duration
 	GracePeriod          time.Duration
 	FailureShutdownGrace time.Duration
 	// CSIResetSignalDir is the directory inside the sandbox where a reset signal
-	// file is written before reuse when the sandbox carries CSI mounts, so that a
+	// file is written before recycle when the sandbox carries CSI mounts, so that a
 	// stopping csi-sidecar can detect it during prestop/SIGTERM and unmount stale
 	// volumes. Empty disables the behavior.
 	CSIResetSignalDir string
@@ -116,7 +116,7 @@ type SandboxControlArgs struct {
 	RateLimiter       *RateLimiter
 	CheckpointControl *CheckpointControl
 	PodControl        *PodControl
-	ReuseConfig       SandboxReuseConfig
+	RecycleConfig     SandboxRecycleConfig
 }
 
 func NewSandboxControl(args SandboxControlArgs) map[string]SandboxControl {

--- a/pkg/controller/sandbox/core/recycle.go
+++ b/pkg/controller/sandbox/core/recycle.go
@@ -41,7 +41,7 @@ const (
 	// csiResetSignalWriteTimeout bounds a single write attempt of the reset signal file.
 	csiResetSignalWriteTimeout = 3 * time.Second
 	// csiResetSignalMaxRetries is the number of write attempts for the reset signal
-	// file before giving up. Transient runtime unavailability right at reuse start
+	// file before giving up. Transient runtime unavailability right at recycle start
 	// is common, so a few inline retries smooth over it.
 	csiResetSignalMaxRetries = 3
 )
@@ -54,91 +54,91 @@ var csiResetSignalRetryInterval = 1 * time.Second
 // so tests can stub the runtime file write without a live sandbox.
 var writeRuntimeFileFunc = agentsruntime.WriteFileWithRuntime
 
-// TODO for CRR based reuser
-type noopSandboxReuser struct{}
+// TODO for CRR based recycler
+type noopSandboxRecycler struct{}
 
-func (n *noopSandboxReuser) Reuse(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *corev1.Pod) error {
+func (n *noopSandboxRecycler) Recycle(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *corev1.Pod) error {
 	return nil
 }
 
-func (n *noopSandboxReuser) IsReuseComplete(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *corev1.Pod) (bool, error) {
+func (n *noopSandboxRecycler) IsRecycleComplete(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *corev1.Pod) (bool, error) {
 	return true, nil
 }
 
-// SandboxReuseControl handles the sandbox reuse lifecycle (Reusing phase).
+// SandboxRecycleControl handles the sandbox recycle lifecycle (Recycling phase).
 // It is designed to be used by any SandboxControl implementation
-// (e.g. commonControl, acsControl) to share the reuse logic.
-type SandboxReuseControl struct {
+// (e.g. commonControl, acsControl) to share the recycle logic.
+type SandboxRecycleControl struct {
 	client   client.Client
 	recorder record.EventRecorder
-	config   SandboxReuseConfig
+	config   SandboxRecycleConfig
 }
 
 const defaultFailureShutdownGrace = 5 * time.Minute
 
-func NewSandboxReuseControl(c client.Client, recorder record.EventRecorder, config SandboxReuseConfig) *SandboxReuseControl {
-	if config.Reuser == nil {
-		config.Reuser = &noopSandboxReuser{}
+func NewSandboxRecycleControl(c client.Client, recorder record.EventRecorder, config SandboxRecycleConfig) *SandboxRecycleControl {
+	if config.Recycler == nil {
+		config.Recycler = &noopSandboxRecycler{}
 	}
 	if config.FailureShutdownGrace == 0 {
 		config.FailureShutdownGrace = defaultFailureShutdownGrace
 	}
-	return &SandboxReuseControl{
+	return &SandboxRecycleControl{
 		client:   c,
 		recorder: recorder,
 		config:   config,
 	}
 }
 
-// ensureSandboxReused is the entry point for the reuse lifecycle. It delegates
-// the core logic to doReuse and unifies error handling: retriable errors are
+// ensureSandboxRecycled is the entry point for the recycle lifecycle. It delegates
+// the core logic to doRecycle and unifies error handling: retriable errors are
 // returned directly so the controller retries; permanent failures are
-// delegated to handleReuseFailed.
-func (r *SandboxReuseControl) ensureSandboxReused(ctx context.Context, args EnsureFuncArgs) (time.Duration, error) {
-	requeue, err := r.doReuse(ctx, args)
+// delegated to handleRecycleFailed.
+func (r *SandboxRecycleControl) ensureSandboxRecycled(ctx context.Context, args EnsureFuncArgs) (time.Duration, error) {
+	requeue, err := r.doRecycle(ctx, args)
 	if err == nil {
 		return requeue, nil
 	}
 	if IsRetriable(err) {
 		return 0, err
 	}
-	return r.handleReuseFailed(ctx, args.Box, args.NewStatus, err)
+	return r.handleRecycleFailed(ctx, args.Box, args.NewStatus, err)
 }
 
-// doReuse contains the core reuse state-machine logic. Every error is returned
+// doRecycle contains the core recycle state-machine logic. Every error is returned
 // directly — either as a RetriableError (transient, caller should retry) or a
-// plain error (permanent). The caller (ensureSandboxReused) is responsible for
+// plain error (permanent). The caller (ensureSandboxRecycled) is responsible for
 // classifying and acting on the error.
-func (r *SandboxReuseControl) doReuse(ctx context.Context, args EnsureFuncArgs) (time.Duration, error) {
+func (r *SandboxRecycleControl) doRecycle(ctx context.Context, args EnsureFuncArgs) (time.Duration, error) {
 	box, newStatus := args.Box, args.NewStatus
 
-	sbs, err := r.validateReusePreconditions(ctx, args)
+	sbs, err := r.validateRecyclePreconditions(ctx, args)
 	if err != nil {
 		return 0, err
 	}
 
-	reuseCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReusing))
-	if reuseCond == nil {
-		reuseCond = &metav1.Condition{
-			Type:               string(agentsv1alpha1.SandboxConditionReusing),
+	recycleCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionRecycling))
+	if recycleCond == nil {
+		recycleCond = &metav1.Condition{
+			Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 			Status:             metav1.ConditionFalse,
-			Reason:             agentsv1alpha1.SandboxReusingReasonStarted,
+			Reason:             agentsv1alpha1.SandboxRecyclingReasonStarted,
 			LastTransitionTime: metav1.Now(),
 		}
-		utils.SetSandboxCondition(newStatus, *reuseCond)
-		r.recorder.Event(box, corev1.EventTypeNormal, agentsv1alpha1.SandboxReusingReasonStarted,
-			fmt.Sprintf("Reuse started for sandbox %s", box.Name))
-		klog.InfoS("Reuse started", "sandbox", klog.KObj(box))
+		utils.SetSandboxCondition(newStatus, *recycleCond)
+		r.recorder.Event(box, corev1.EventTypeNormal, agentsv1alpha1.SandboxRecyclingReasonStarted,
+			fmt.Sprintf("Recycling started for sandbox %s", box.Name))
+		klog.InfoS("Recycling started", "sandbox", klog.KObj(box))
 
 		// Signal the csi-sidecar to unmount stale CSI volumes when it stops
-		// (prestop/SIGTERM) before handing the sandbox back for reuse. Must run
-		// while the runtime is still reachable, i.e. before the reuser resets the
+		// (prestop/SIGTERM) before handing the sandbox back for recycle. Must run
+		// while the runtime is still reachable, i.e. before the recycler resets the
 		// sandbox.
 		if err := r.ensureCSIResetSignal(ctx, box); err != nil {
 			return 0, err
 		}
 
-		if err := r.config.Reuser.Reuse(ctx, box, args.Pod); err != nil {
+		if err := r.config.Recycler.Recycle(ctx, box, args.Pod); err != nil {
 			return 0, err
 		}
 		return 0, nil
@@ -146,17 +146,17 @@ func (r *SandboxReuseControl) doReuse(ctx context.Context, args EnsureFuncArgs) 
 
 	var requeue time.Duration
 
-	switch reuseCond.Reason {
-	case agentsv1alpha1.SandboxReusingReasonStarted:
-		requeue, err = r.handleReuseInProgress(ctx, args, reuseCond)
-		if err != nil || reuseCond.Reason != agentsv1alpha1.SandboxReusingReasonCompleted {
+	switch recycleCond.Reason {
+	case agentsv1alpha1.SandboxRecyclingReasonStarted:
+		requeue, err = r.handleRecycleInProgress(ctx, args, recycleCond)
+		if err != nil || recycleCond.Reason != agentsv1alpha1.SandboxRecyclingReasonCompleted {
 			return requeue, err
 		}
-		// Reuse just transitioned to Completed; fall through to grace period
+		// Recycle just transitioned to Completed; fall through to grace period
 		// handling to avoid wasting a reconcile cycle (especially when GracePeriod == 0).
 		fallthrough
-	case agentsv1alpha1.SandboxReusingReasonCompleted:
-		requeue, err = r.handleReuseGracePeriod(ctx, args, reuseCond, sbs)
+	case agentsv1alpha1.SandboxRecyclingReasonCompleted:
+		requeue, err = r.handleRecycleGracePeriod(ctx, args, recycleCond, sbs)
 	default:
 		// no action needed for terminal states (Succeeded, Failed, Timeout)
 	}
@@ -171,11 +171,11 @@ func (r *SandboxReuseControl) doReuse(ctx context.Context, args EnsureFuncArgs) 
 //
 // It is a no-op when the sandbox carries no CSI mount annotation. When the sandbox
 // does carry CSI mounts but the reset directory is not configured, it fails the
-// reuse rather than silently returning stale mounts to the pool. The write goes
+// recycle rather than silently returning stale mounts to the pool. The write goes
 // through the agent-runtime files API, so it only depends on the runtime sidecar
 // being reachable, not on any binary inside the sandbox. Transient failures are
 // retried a few times inline.
-func (r *SandboxReuseControl) ensureCSIResetSignal(ctx context.Context, box *agentsv1alpha1.Sandbox) error {
+func (r *SandboxRecycleControl) ensureCSIResetSignal(ctx context.Context, box *agentsv1alpha1.Sandbox) error {
 	if box.Annotations[agentsv1alpha1.AnnotationCSIVolumeConfig] == "" {
 		return nil
 	}
@@ -197,7 +197,7 @@ func (r *SandboxReuseControl) ensureCSIResetSignal(ctx context.Context, box *age
 			Timeout:     csiResetSignalWriteTimeout,
 		})
 		if lastErr == nil {
-			klog.InfoS("Wrote CSI reset signal for reuse", "sandbox", klog.KObj(box), "file", resetFile, "attempt", attempt)
+			klog.InfoS("Wrote CSI reset signal for recycle", "sandbox", klog.KObj(box), "file", resetFile, "attempt", attempt)
 			return nil
 		}
 		if attempt < csiResetSignalMaxRetries {
@@ -213,11 +213,11 @@ func (r *SandboxReuseControl) ensureCSIResetSignal(ctx context.Context, box *age
 	return fmt.Errorf("failed to write csi reset signal to %s after %d attempts: %w", resetFile, csiResetSignalMaxRetries, lastErr)
 }
 
-// validateReusePreconditions performs all pre-condition checks before the
-// reuse state machine begins: pool label, SandboxSet existence, template-hash
+// validateRecyclePreconditions performs all pre-condition checks before the
+// recycle state machine begins: pool label, SandboxSet existence, template-hash
 // currency, and Pod health. It returns the SandboxSet (needed by later stages)
 // and an error if any check fails.
-func (r *SandboxReuseControl) validateReusePreconditions(ctx context.Context, args EnsureFuncArgs) (*agentsv1alpha1.SandboxSet, error) {
+func (r *SandboxRecycleControl) validateRecyclePreconditions(ctx context.Context, args EnsureFuncArgs) (*agentsv1alpha1.SandboxSet, error) {
 	box := args.Box
 
 	poolName := box.Labels[agentsv1alpha1.LabelSandboxPool]
@@ -234,91 +234,91 @@ func (r *SandboxReuseControl) validateReusePreconditions(ctx context.Context, ar
 
 	// If the sandbox's template-hash does not match the SandboxSet's
 	// updateRevision, the template has been updated since the sandbox was
-	// created. There is no point continuing the reuse — the sandbox is
+	// created. There is no point continuing the recycle — the sandbox is
 	// outdated and should not be returned to the pool.
 	// When the SandboxSet's updateRevision is empty (not yet reconciled),
 	// the check is skipped to avoid false failures during initial setup.
 	if sbs.Status.UpdateRevision != "" &&
 		box.Labels[agentsv1alpha1.LabelTemplateHash] != sbs.Status.UpdateRevision {
-		return nil, fmt.Errorf("sandbox template-hash %q does not match SandboxSet %s updateRevision %q, sandbox is outdated and cannot be reused",
+		return nil, fmt.Errorf("sandbox template-hash %q does not match SandboxSet %s updateRevision %q, sandbox is outdated and cannot be recycled",
 			box.Labels[agentsv1alpha1.LabelTemplateHash], sbs.Name, sbs.Status.UpdateRevision)
 	}
 
-	// A nil Pod during reuse is an abnormal state — the sandbox should always
+	// A nil Pod during recycle is an abnormal state — the sandbox should always
 	// have a running Pod. Fail immediately rather than waiting indefinitely.
 	if args.Pod == nil {
-		return nil, fmt.Errorf("pod not found during reuse")
+		return nil, fmt.Errorf("pod not found during recycle")
 	}
 
 	// If the Pod has already entered a terminal phase (Succeeded/Failed), the
-	// runtime can never complete the reset. Fail the reuse immediately instead
+	// runtime can never complete the reset. Fail the recycle immediately instead
 	// of waiting until the timeout fires.
 	if args.Pod.Status.Phase == corev1.PodSucceeded || args.Pod.Status.Phase == corev1.PodFailed {
-		return nil, fmt.Errorf("pod entered terminal phase %s during reuse", args.Pod.Status.Phase)
+		return nil, fmt.Errorf("pod entered terminal phase %s during recycle", args.Pod.Status.Phase)
 	}
 
 	return sbs, nil
 }
 
-func (r *SandboxReuseControl) handleReuseInProgress(ctx context.Context, args EnsureFuncArgs, reuseCond *metav1.Condition) (time.Duration, error) {
+func (r *SandboxRecycleControl) handleRecycleInProgress(ctx context.Context, args EnsureFuncArgs, recycleCond *metav1.Condition) (time.Duration, error) {
 	box, newStatus := args.Box, args.NewStatus
 
 	var remaining time.Duration
 	if r.config.Timeout > 0 {
-		elapsed := time.Since(reuseCond.LastTransitionTime.Time)
+		elapsed := time.Since(recycleCond.LastTransitionTime.Time)
 		if elapsed > r.config.Timeout {
-			return 0, &reuseTimeoutError{timeout: r.config.Timeout}
+			return 0, &recycleTimeoutError{timeout: r.config.Timeout}
 		}
 		remaining = r.config.Timeout - elapsed
 	}
 
-	complete, err := r.config.Reuser.IsReuseComplete(ctx, box, args.Pod)
+	complete, err := r.config.Recycler.IsRecycleComplete(ctx, box, args.Pod)
 	if err != nil {
 		return 0, err
 	}
 	if !complete {
-		klog.InfoS("Reuse cleanup not yet complete, waiting", "sandbox", klog.KObj(box))
+		klog.InfoS("Recycling not yet complete, waiting", "sandbox", klog.KObj(box))
 		// Return a requeue duration to guarantee the controller re-reconciles
 		// even if no external events arrive (e.g. runtime not responding).
 		// This ensures the timeout check is eventually executed.
-		return r.reusePollingInterval(remaining), nil
+		return r.recyclePollingInterval(remaining), nil
 	}
 	// Check whether the Pod is Ready before transitioning to the Completed phase.
-	// The reuser reports cleanup completion, but the Pod may still be restarting
+	// The recycler reports recycle completion, but the Pod may still be restarting
 	// after reset. We wait for Pod Ready to ensure the sandbox is truly available.
 	readyCond := utils.GetPodCondition(&args.Pod.Status, corev1.PodReady)
 	if readyCond == nil || readyCond.Status != corev1.ConditionTrue {
-		klog.InfoS("Reuse cleanup complete but pod not ready, waiting", "sandbox", klog.KObj(box))
-		return r.reusePollingInterval(remaining), nil
+		klog.InfoS("Recycling complete but pod not ready, waiting", "sandbox", klog.KObj(box))
+		return r.recyclePollingInterval(remaining), nil
 	}
-	reuseCond.Reason = agentsv1alpha1.SandboxReusingReasonCompleted
-	reuseCond.LastTransitionTime = metav1.Now()
-	reuseCond.Message = ""
-	utils.SetSandboxCondition(newStatus, *reuseCond)
-	klog.InfoS("Reuse cleanup completed, entering grace period", "sandbox", klog.KObj(box))
+	recycleCond.Reason = agentsv1alpha1.SandboxRecyclingReasonCompleted
+	recycleCond.LastTransitionTime = metav1.Now()
+	recycleCond.Message = ""
+	utils.SetSandboxCondition(newStatus, *recycleCond)
+	klog.InfoS("Recycling completed, entering grace period", "sandbox", klog.KObj(box))
 	return r.config.GracePeriod, nil
 }
 
-// reusePollingInterval returns the requeue duration when waiting for reuse to
+// recyclePollingInterval returns the requeue duration when waiting for recycle to
 // complete. If a timeout is configured, it returns the remaining time so the
 // timeout fires on time. Otherwise it returns a default polling interval.
-const defaultReusePollingInterval = 5 * time.Second
+const defaultRecyclePollingInterval = 5 * time.Second
 
-func (r *SandboxReuseControl) reusePollingInterval(remaining time.Duration) time.Duration {
+func (r *SandboxRecycleControl) recyclePollingInterval(remaining time.Duration) time.Duration {
 	if remaining > 0 {
-		if remaining < defaultReusePollingInterval {
+		if remaining < defaultRecyclePollingInterval {
 			return remaining
 		}
-		return defaultReusePollingInterval
+		return defaultRecyclePollingInterval
 	}
 	// No timeout configured; poll periodically anyway to avoid stalling.
-	return defaultReusePollingInterval
+	return defaultRecyclePollingInterval
 }
 
-func (r *SandboxReuseControl) handleReuseGracePeriod(ctx context.Context, args EnsureFuncArgs, reuseCond *metav1.Condition, sbs *agentsv1alpha1.SandboxSet) (time.Duration, error) {
+func (r *SandboxRecycleControl) handleRecycleGracePeriod(ctx context.Context, args EnsureFuncArgs, recycleCond *metav1.Condition, sbs *agentsv1alpha1.SandboxSet) (time.Duration, error) {
 	box, newStatus := args.Box, args.NewStatus
 
-	elapsed := time.Since(reuseCond.LastTransitionTime.Time)
+	elapsed := time.Since(recycleCond.LastTransitionTime.Time)
 	if elapsed < r.config.GracePeriod {
 		return r.config.GracePeriod - elapsed, nil
 	}
@@ -327,40 +327,40 @@ func (r *SandboxReuseControl) handleReuseGracePeriod(ctx context.Context, args E
 		return 0, &RetriableError{Err: err}
 	}
 
-	newStatus.ReuseCount++
+	newStatus.RecycledCount++
 	newStatus.Phase = agentsv1alpha1.SandboxRunning
-	reuseCond.Reason = agentsv1alpha1.SandboxReusingReasonSucceeded
-	reuseCond.Status = metav1.ConditionTrue
-	reuseCond.LastTransitionTime = metav1.Now()
-	utils.SetSandboxCondition(newStatus, *reuseCond)
+	recycleCond.Reason = agentsv1alpha1.SandboxRecyclingReasonSucceeded
+	recycleCond.Status = metav1.ConditionTrue
+	recycleCond.LastTransitionTime = metav1.Now()
+	utils.SetSandboxCondition(newStatus, *recycleCond)
 	utils.SetSandboxCondition(newStatus, metav1.Condition{
 		Type:               string(agentsv1alpha1.SandboxConditionReady),
 		Status:             metav1.ConditionTrue,
 		Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
 		LastTransitionTime: metav1.Now(),
 	})
-	r.recorder.Event(box, corev1.EventTypeNormal, agentsv1alpha1.SandboxReusingReasonSucceeded,
-		fmt.Sprintf("Reuse succeeded, sandbox returned to pool (reuseCount: %d)", newStatus.ReuseCount))
-	klog.InfoS("Sandbox returned to pool", "sandbox", klog.KObj(box), "reuseCount", newStatus.ReuseCount)
+	r.recorder.Event(box, corev1.EventTypeNormal, agentsv1alpha1.SandboxRecyclingReasonSucceeded,
+		fmt.Sprintf("Recycling succeeded, sandbox returned to pool (recycledCount: %d)", newStatus.RecycledCount))
+	klog.InfoS("Sandbox returned to pool", "sandbox", klog.KObj(box), "recycledCount", newStatus.RecycledCount)
 	return 0, nil
 }
 
-// reuseTimeoutError is a permanent error that carries the SandboxReusingReasonTimeout
-// condition reason so handleReuseFailed can distinguish it from other failures.
-type reuseTimeoutError struct {
+// recycleTimeoutError is a permanent error that carries the SandboxRecyclingReasonTimeout
+// condition reason so handleRecycleFailed can distinguish it from other failures.
+type recycleTimeoutError struct {
 	timeout time.Duration
 }
 
-func (e *reuseTimeoutError) Error() string {
-	return fmt.Sprintf("reuse timed out after %s", e.timeout)
+func (e *recycleTimeoutError) Error() string {
+	return fmt.Sprintf("recycle timed out after %s", e.timeout)
 }
 
-func (e *reuseTimeoutError) Reason() string {
-	return agentsv1alpha1.SandboxReusingReasonTimeout
+func (e *recycleTimeoutError) Reason() string {
+	return agentsv1alpha1.SandboxRecyclingReasonTimeout
 }
 
-func (r *SandboxReuseControl) handleReuseFailed(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus, err error) (time.Duration, error) {
-	reason := agentsv1alpha1.SandboxReusingReasonFailed
+func (r *SandboxRecycleControl) handleRecycleFailed(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus, err error) (time.Duration, error) {
+	reason := agentsv1alpha1.SandboxRecyclingReasonFailed
 	var fr FailedReason
 	if errors.As(err, &fr) {
 		reason = fr.Reason()
@@ -368,37 +368,37 @@ func (r *SandboxReuseControl) handleReuseFailed(ctx context.Context, box *agents
 	msg := err.Error()
 	r.recorder.Event(box, corev1.EventTypeWarning, reason, msg)
 	utils.SetSandboxCondition(newStatus, metav1.Condition{
-		Type:               string(agentsv1alpha1.SandboxConditionReusing),
+		Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 		Status:             metav1.ConditionFalse,
 		Reason:             reason,
 		Message:            msg,
 		LastTransitionTime: metav1.Now(),
 	})
-	// Parse reuse-retain-on-failure annotation (duration string, e.g. "5m"):
+	// Parse cleanup-retain-on-failure annotation (duration string, e.g. "5m"):
 	//   - not set: delete the sandbox immediately.
 	//   - valid duration: set ShutdownTime = now + duration, let checkTimers handle deletion.
 	//   - invalid: log a warning and delete the sandbox immediately.
-	retainStr := box.Annotations[agentsv1alpha1.AnnotationReuseRetainOnFailure]
+	retainStr := box.Annotations[agentsv1alpha1.AnnotationCleanupRetainOnFailure]
 	if retainStr == "" {
-		klog.InfoS("Reuse failed, deleting sandbox immediately", "sandbox", klog.KObj(box), "reason", msg)
+		klog.InfoS("Recycling failed, deleting sandbox immediately", "sandbox", klog.KObj(box), "reason", msg)
 		return 0, r.client.Delete(ctx, box)
 	}
 	retainDuration, parseErr := time.ParseDuration(retainStr)
 	if parseErr != nil || retainDuration <= 0 {
-		klog.InfoS("Reuse failed, invalid reuse-retain-on-failure value, deleting sandbox", "sandbox", klog.KObj(box), "value", retainStr, "reason", msg)
+		klog.InfoS("Recycling failed, invalid cleanup-retain-on-failure value, deleting sandbox", "sandbox", klog.KObj(box), "value", retainStr, "reason", msg)
 		return 0, r.client.Delete(ctx, box)
 	}
 	shutdownAt := metav1.NewTime(time.Now().Add(retainDuration))
 	patch := client.MergeFrom(box.DeepCopy())
 	box.Spec.ShutdownTime = &shutdownAt
 	if err := r.client.Patch(ctx, box, patch); err != nil {
-		return 0, fmt.Errorf("failed to set shutdownTime on reuse failure: %w", err)
+		return 0, fmt.Errorf("failed to set shutdownTime on recycle failure: %w", err)
 	}
-	klog.InfoS("Reuse failed, scheduled shutdown", "sandbox", klog.KObj(box), "shutdownTime", shutdownAt.Time, "retainDuration", retainDuration, "reason", msg)
+	klog.InfoS("Recycling failed, scheduled shutdown", "sandbox", klog.KObj(box), "shutdownTime", shutdownAt.Time, "retainDuration", retainDuration, "reason", msg)
 	return retainDuration, nil
 }
 
-func (r *SandboxReuseControl) resetMetadataForPool(ctx context.Context, box *agentsv1alpha1.Sandbox, sbs *agentsv1alpha1.SandboxSet) error {
+func (r *SandboxRecycleControl) resetMetadataForPool(ctx context.Context, box *agentsv1alpha1.Sandbox, sbs *agentsv1alpha1.SandboxSet) error {
 	patch := client.MergeFrom(box.DeepCopy())
 
 	// Part 1: Reset fixed claim metadata
@@ -409,10 +409,10 @@ func (r *SandboxReuseControl) resetMetadataForPool(ctx context.Context, box *age
 	}
 	box.Labels[agentsv1alpha1.LabelSandboxIsClaimed] = agentsv1alpha1.False
 	delete(box.Labels, agentsv1alpha1.LabelSandboxClaimName)
-	for _, ann := range agentsv1alpha1.AnnotationsClearedOnReuse {
+	for _, ann := range agentsv1alpha1.AnnotationsClearedOnRecycle {
 		delete(box.Annotations, ann)
 	}
-	// Annotations from other packages not included in AnnotationsClearedOnReuse:
+	// Annotations from other packages not included in AnnotationsClearedOnRecycle:
 	delete(box.Annotations, identity.AgentKeyTokenRefreshStatus)
 
 	// Part 2: Delete user-specified metadata keys

--- a/pkg/controller/sandbox/core/recycle_test.go
+++ b/pkg/controller/sandbox/core/recycle_test.go
@@ -42,25 +42,25 @@ import (
 	agentsruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
-type mockSandboxReuser struct {
-	reuseErr      error
+type mockSandboxRecycler struct {
+	recycleErr    error
 	completeVal   bool
 	completeErr   error
-	reuseCalled   bool
+	recycleCalled bool
 	completeCalls int
 }
 
-func (m *mockSandboxReuser) Reuse(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *corev1.Pod) error {
-	m.reuseCalled = true
-	return m.reuseErr
+func (m *mockSandboxRecycler) Recycle(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *corev1.Pod) error {
+	m.recycleCalled = true
+	return m.recycleErr
 }
 
-func (m *mockSandboxReuser) IsReuseComplete(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *corev1.Pod) (bool, error) {
+func (m *mockSandboxRecycler) IsRecycleComplete(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *corev1.Pod) (bool, error) {
 	m.completeCalls++
 	return m.completeVal, m.completeErr
 }
 
-func newTestReuseControl(t *testing.T, objs []client.Object, reuser SandboxReuser, reuseTimeout, gracePeriod time.Duration) (*SandboxReuseControl, client.Client) {
+func newTestRecycleControl(t *testing.T, objs []client.Object, recycler SandboxRecycler, recycleTimeout, gracePeriod time.Duration) (*SandboxRecycleControl, client.Client) {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
@@ -70,15 +70,15 @@ func newTestReuseControl(t *testing.T, objs []client.Object, reuser SandboxReuse
 		WithObjects(objs...).
 		WithStatusSubresource(&agentsv1alpha1.Sandbox{}).
 		Build()
-	control := NewSandboxReuseControl(fakeClient, record.NewFakeRecorder(10), SandboxReuseConfig{
-		Reuser:      reuser,
-		Timeout:     reuseTimeout,
+	control := NewSandboxRecycleControl(fakeClient, record.NewFakeRecorder(10), SandboxRecycleConfig{
+		Recycler:     recycler,
+		Timeout:     recycleTimeout,
 		GracePeriod: gracePeriod,
 	})
 	return control, fakeClient
 }
 
-func TestEnsureSandboxReused(t *testing.T) {
+func TestEnsureSandboxRecycled(t *testing.T) {
 	readyPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default"},
 		Status: corev1.PodStatus{
@@ -90,9 +90,9 @@ func TestEnsureSandboxReused(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		reuser             *mockSandboxReuser
-		reuseTimeout       time.Duration
-		reuseGracePeriod   time.Duration
+		recycler           *mockSandboxRecycler
+		recycleTimeout     time.Duration
+		recycleGracePeriod time.Duration
 		box                *agentsv1alpha1.Sandbox
 		pod                *corev1.Pod
 		newStatus          *agentsv1alpha1.SandboxStatus
@@ -102,31 +102,31 @@ func TestEnsureSandboxReused(t *testing.T) {
 		expectError        string
 		expectPhase        agentsv1alpha1.SandboxPhase
 		expectRequeue      bool
-		expectReuseCount   int32
+		expectRecycledCount int32
 		expectCondReason   string
 		expectShutdownTime bool
 		expectDeleted      bool
 		expectCSIWrite     bool
 	}{
 		{
-			name:             "missing sandbox-pool label - reuse failed",
-			reuser:           &mockSandboxReuser{},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			name:               "missing sandbox-pool label - recycle failed",
+			recycler:           &mockSandboxRecycler{},
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
 					Namespace: "default",
 				},
 			},
-			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxReusing},
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRecycling},
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonFailed,
 		},
 		{
-			name:             "sandboxset not found - reuse failed",
-			reuser:           &mockSandboxReuser{},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			name:               "sandboxset not found - recycle failed",
+			recycler:           &mockSandboxRecycler{},
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -136,14 +136,14 @@ func TestEnsureSandboxReused(t *testing.T) {
 					},
 				},
 			},
-			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxReusing},
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRecycling},
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonFailed,
 		},
 		{
-			name:             "first entry - reuse started with noop reuser",
-			reuser:           &mockSandboxReuser{},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			name:               "first entry - recycle started with noop recycler",
+			recycler:           &mockSandboxRecycler{},
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -152,8 +152,8 @@ func TestEnsureSandboxReused(t *testing.T) {
 						agentsv1alpha1.LabelSandboxPool: "test-pool",
 					},
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse:        "true",
-						agentsv1alpha1.AnnotationReuseEnabled: "true",
+						agentsv1alpha1.AnnotationCleanup:        "true",
+						agentsv1alpha1.AnnotationCleanupEnabled: "true",
 					},
 				},
 			},
@@ -166,14 +166,14 @@ func TestEnsureSandboxReused(t *testing.T) {
 				},
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
-			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxReusing},
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonStarted,
+			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRecycling},
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonStarted,
 		},
 		{
-			name:             "first entry - csi mounts with reset-signal-dir configured - signal written, reuse started",
-			reuser:           &mockSandboxReuser{},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			name:               "first entry - csi mounts with reset-signal-dir configured - signal written, recycle started",
+			recycler:           &mockSandboxRecycler{},
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -182,8 +182,8 @@ func TestEnsureSandboxReused(t *testing.T) {
 						agentsv1alpha1.LabelSandboxPool: "test-pool",
 					},
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse:           "true",
-						agentsv1alpha1.AnnotationReuseEnabled:    "true",
+						agentsv1alpha1.AnnotationCleanup:         "true",
+						agentsv1alpha1.AnnotationCleanupEnabled:  "true",
 						agentsv1alpha1.AnnotationCSIVolumeConfig: `[{"mountPath":"/data"}]`,
 					},
 				},
@@ -197,16 +197,16 @@ func TestEnsureSandboxReused(t *testing.T) {
 				},
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
-			newStatus:         &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxReusing},
+			newStatus:         &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRecycling},
 			csiResetSignalDir: "/var/run/csi-reset",
 			expectCSIWrite:    true,
-			expectCondReason:  agentsv1alpha1.SandboxReusingReasonStarted,
+			expectCondReason:  agentsv1alpha1.SandboxRecyclingReasonStarted,
 		},
 		{
-			name:             "first entry - csi mounts but reset-signal-dir not configured - reuse failed and deleted",
-			reuser:           &mockSandboxReuser{},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			name:               "first entry - csi mounts but reset-signal-dir not configured - recycle failed and deleted",
+			recycler:           &mockSandboxRecycler{},
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -215,8 +215,8 @@ func TestEnsureSandboxReused(t *testing.T) {
 						agentsv1alpha1.LabelSandboxPool: "test-pool",
 					},
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse:           "true",
-						agentsv1alpha1.AnnotationReuseEnabled:    "true",
+						agentsv1alpha1.AnnotationCleanup:         "true",
+						agentsv1alpha1.AnnotationCleanupEnabled:  "true",
 						agentsv1alpha1.AnnotationCSIVolumeConfig: `[{"mountPath":"/data"}]`,
 					},
 				},
@@ -230,18 +230,18 @@ func TestEnsureSandboxReused(t *testing.T) {
 				},
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
-			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxReusing},
+			newStatus:         &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRecycling},
 			csiResetSignalDir: "",
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
-			expectDeleted:    true,
+			expectCondReason:  agentsv1alpha1.SandboxRecyclingReasonFailed,
+			expectDeleted:     true,
 		},
 		{
-			name: "reuse in progress - not complete, requeues for polling",
-			reuser: &mockSandboxReuser{
+			name: "recycle in progress - not complete, requeues for polling",
+			recycler: &mockSandboxRecycler{
 				completeVal: false,
 			},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -261,26 +261,26 @@ func TestEnsureSandboxReused(t *testing.T) {
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
-						Reason:             agentsv1alpha1.SandboxReusingReasonStarted,
+						Reason:             agentsv1alpha1.SandboxRecyclingReasonStarted,
 						LastTransitionTime: metav1.Now(),
 					},
 				},
 			},
 			expectRequeue:    true,
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonStarted,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonStarted,
 		},
 		{
-			name: "reuse in progress - complete, pod ready, enters grace period",
-			reuser: &mockSandboxReuser{
+			name: "recycle in progress - complete, pod ready, enters grace period",
+			recycler: &mockSandboxRecycler{
 				completeVal: true,
 			},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -289,7 +289,7 @@ func TestEnsureSandboxReused(t *testing.T) {
 						agentsv1alpha1.LabelSandboxPool: "test-pool",
 					},
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse: "true",
+						agentsv1alpha1.AnnotationCleanup: "true",
 					},
 				},
 			},
@@ -311,26 +311,26 @@ func TestEnsureSandboxReused(t *testing.T) {
 				},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
-						Reason:             agentsv1alpha1.SandboxReusingReasonStarted,
+						Reason:             agentsv1alpha1.SandboxRecyclingReasonStarted,
 						LastTransitionTime: metav1.Now(),
 					},
 				},
 			},
 			expectRequeue:    true,
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonCompleted,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonCompleted,
 		},
 		{
-			name: "reuse in progress - complete but pod not ready, requeues for polling",
-			reuser: &mockSandboxReuser{
+			name: "recycle in progress - complete but pod not ready, requeues for polling",
+			recycler: &mockSandboxRecycler{
 				completeVal: true,
 			},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -356,26 +356,26 @@ func TestEnsureSandboxReused(t *testing.T) {
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
-						Reason:             agentsv1alpha1.SandboxReusingReasonStarted,
+						Reason:             agentsv1alpha1.SandboxRecyclingReasonStarted,
 						LastTransitionTime: metav1.Now(),
 					},
 				},
 			},
 			expectRequeue:    true,
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonStarted,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonStarted,
 		},
 		{
-			name: "pod is nil - reuse failed",
-			reuser: &mockSandboxReuser{
+			name: "pod is nil - recycle failed",
+			recycler: &mockSandboxRecycler{
 				completeVal: true,
 			},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -393,25 +393,25 @@ func TestEnsureSandboxReused(t *testing.T) {
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
-						Reason:             agentsv1alpha1.SandboxReusingReasonStarted,
+						Reason:             agentsv1alpha1.SandboxRecyclingReasonStarted,
 						LastTransitionTime: metav1.Now(),
 					},
 				},
 			},
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonFailed,
 		},
 		{
-			name: "pod in Succeeded phase - reuse failed immediately",
-			reuser: &mockSandboxReuser{
+			name: "pod in Succeeded phase - recycle failed immediately",
+			recycler: &mockSandboxRecycler{
 				completeVal: true,
 			},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -433,25 +433,25 @@ func TestEnsureSandboxReused(t *testing.T) {
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
-						Reason:             agentsv1alpha1.SandboxReusingReasonStarted,
+						Reason:             agentsv1alpha1.SandboxRecyclingReasonStarted,
 						LastTransitionTime: metav1.Now(),
 					},
 				},
 			},
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonFailed,
 		},
 		{
-			name: "pod in Failed phase - reuse failed immediately",
-			reuser: &mockSandboxReuser{
+			name: "pod in Failed phase - recycle failed immediately",
+			recycler: &mockSandboxRecycler{
 				completeVal: true,
 			},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -473,22 +473,22 @@ func TestEnsureSandboxReused(t *testing.T) {
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
-						Reason:             agentsv1alpha1.SandboxReusingReasonStarted,
+						Reason:             agentsv1alpha1.SandboxRecyclingReasonStarted,
 						LastTransitionTime: metav1.Now(),
 					},
 				},
 			},
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonFailed,
 		},
 		{
-			name:             "grace period elapsed - returns to pool",
-			reuser:           &mockSandboxReuser{},
-			reuseGracePeriod: 1 * time.Second,
+			name:               "grace period elapsed - returns to pool",
+			recycler:           &mockSandboxRecycler{},
+			recycleGracePeriod: 1 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -510,27 +510,27 @@ func TestEnsureSandboxReused(t *testing.T) {
 				},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
-						Reason:             agentsv1alpha1.SandboxReusingReasonCompleted,
+						Reason:             agentsv1alpha1.SandboxRecyclingReasonCompleted,
 						LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Second)),
 					},
 				},
 			},
-			expectPhase:      agentsv1alpha1.SandboxRunning,
-			expectReuseCount: 1,
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonSucceeded,
+			expectPhase:        agentsv1alpha1.SandboxRunning,
+			expectRecycledCount: 1,
+			expectCondReason:   agentsv1alpha1.SandboxRecyclingReasonSucceeded,
 		},
 		{
-			name: "reuse timeout - condition reason Timeout",
-			reuser: &mockSandboxReuser{
+			name: "recycle timeout - condition reason Timeout",
+			recycler: &mockSandboxRecycler{
 				completeVal: false,
 			},
-			reuseTimeout:     1 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			recycleTimeout:     1 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -550,25 +550,25 @@ func TestEnsureSandboxReused(t *testing.T) {
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
-						Reason:             agentsv1alpha1.SandboxReusingReasonStarted,
+						Reason:             agentsv1alpha1.SandboxRecyclingReasonStarted,
 						LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Second)),
 					},
 				},
 			},
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonTimeout,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonTimeout,
 		},
 		{
-			name: "reuse failed - IsReuseComplete returns error",
-			reuser: &mockSandboxReuser{
+			name: "recycle failed - IsRecycleComplete returns error",
+			recycler: &mockSandboxRecycler{
 				completeErr: assert.AnError,
 			},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -588,25 +588,25 @@ func TestEnsureSandboxReused(t *testing.T) {
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
-						Reason:             agentsv1alpha1.SandboxReusingReasonStarted,
+						Reason:             agentsv1alpha1.SandboxRecyclingReasonStarted,
 						LastTransitionTime: metav1.Now(),
 					},
 				},
 			},
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonFailed,
 		},
 		{
-			name: "reuse in progress - IsReuseComplete returns retriable error - retried",
-			reuser: &mockSandboxReuser{
+			name: "recycle in progress - IsRecycleComplete returns retriable error - retried",
+			recycler: &mockSandboxRecycler{
 				completeErr: &RetriableError{Err: assert.AnError},
 			},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -626,26 +626,26 @@ func TestEnsureSandboxReused(t *testing.T) {
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
-						Reason:             agentsv1alpha1.SandboxReusingReasonStarted,
+						Reason:             agentsv1alpha1.SandboxRecyclingReasonStarted,
 						LastTransitionTime: metav1.Now(),
 					},
 				},
 			},
 			expectError:      "assert.AnError general error for testing",
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonStarted,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonStarted,
 		},
 		{
-			name: "reuse failed with valid retain-on-failure duration - ShutdownTime set",
-			reuser: &mockSandboxReuser{
+			name: "recycle failed with valid retain-on-failure duration - ShutdownTime set",
+			recycler: &mockSandboxRecycler{
 				completeErr: assert.AnError,
 			},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -654,7 +654,7 @@ func TestEnsureSandboxReused(t *testing.T) {
 						agentsv1alpha1.LabelSandboxPool: "test-pool",
 					},
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuseRetainOnFailure: "5m",
+						agentsv1alpha1.AnnotationCleanupRetainOnFailure: "5m",
 					},
 				},
 			},
@@ -668,27 +668,27 @@ func TestEnsureSandboxReused(t *testing.T) {
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
-						Reason:             agentsv1alpha1.SandboxReusingReasonStarted,
+						Reason:             agentsv1alpha1.SandboxRecyclingReasonStarted,
 						LastTransitionTime: metav1.Now(),
 					},
 				},
 			},
 			expectRequeue:      true,
-			expectCondReason:   agentsv1alpha1.SandboxReusingReasonFailed,
+			expectCondReason:   agentsv1alpha1.SandboxRecyclingReasonFailed,
 			expectShutdownTime: true,
 		},
 		{
-			name: "reuse failed with invalid retain-on-failure value - sandbox deleted",
-			reuser: &mockSandboxReuser{
+			name: "recycle failed with invalid retain-on-failure value - sandbox deleted",
+			recycler: &mockSandboxRecycler{
 				completeErr: assert.AnError,
 			},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -697,7 +697,7 @@ func TestEnsureSandboxReused(t *testing.T) {
 						agentsv1alpha1.LabelSandboxPool: "test-pool",
 					},
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuseRetainOnFailure: "not-a-duration",
+						agentsv1alpha1.AnnotationCleanupRetainOnFailure: "not-a-duration",
 					},
 				},
 			},
@@ -711,26 +711,26 @@ func TestEnsureSandboxReused(t *testing.T) {
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
-						Reason:             agentsv1alpha1.SandboxReusingReasonStarted,
+						Reason:             agentsv1alpha1.SandboxRecyclingReasonStarted,
 						LastTransitionTime: metav1.Now(),
 					},
 				},
 			},
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonFailed,
 			expectDeleted:    true,
 		},
 		{
-			name: "reuse failed with negative retain-on-failure duration - sandbox deleted",
-			reuser: &mockSandboxReuser{
+			name: "recycle failed with negative retain-on-failure duration - sandbox deleted",
+			recycler: &mockSandboxRecycler{
 				completeErr: assert.AnError,
 			},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -739,7 +739,7 @@ func TestEnsureSandboxReused(t *testing.T) {
 						agentsv1alpha1.LabelSandboxPool: "test-pool",
 					},
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuseRetainOnFailure: "-5m",
+						agentsv1alpha1.AnnotationCleanupRetainOnFailure: "-5m",
 					},
 				},
 			},
@@ -753,26 +753,26 @@ func TestEnsureSandboxReused(t *testing.T) {
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
-						Reason:             agentsv1alpha1.SandboxReusingReasonStarted,
+						Reason:             agentsv1alpha1.SandboxRecyclingReasonStarted,
 						LastTransitionTime: metav1.Now(),
 					},
 				},
 			},
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonFailed,
 			expectDeleted:    true,
 		},
 		{
 			name: "fallthrough with GracePeriod == 0 - immediately succeeds",
-			reuser: &mockSandboxReuser{
+			recycler: &mockSandboxRecycler{
 				completeVal: true,
 			},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 0,
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 0,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -792,27 +792,27 @@ func TestEnsureSandboxReused(t *testing.T) {
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
-						Reason:             agentsv1alpha1.SandboxReusingReasonStarted,
+						Reason:             agentsv1alpha1.SandboxRecyclingReasonStarted,
 						LastTransitionTime: metav1.Now(),
 					},
 				},
 			},
-			expectPhase:      agentsv1alpha1.SandboxRunning,
-			expectReuseCount: 1,
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonSucceeded,
+			expectPhase:        agentsv1alpha1.SandboxRunning,
+			expectRecycledCount: 1,
+			expectCondReason:   agentsv1alpha1.SandboxRecyclingReasonSucceeded,
 		},
 		{
-			name: "first entry - Reuse returns non-retriable error - reuse failed",
-			reuser: &mockSandboxReuser{
-				reuseErr: assert.AnError,
+			name: "first entry - Recycle returns non-retriable error - recycle failed",
+			recycler: &mockSandboxRecycler{
+				recycleErr: assert.AnError,
 			},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -821,8 +821,8 @@ func TestEnsureSandboxReused(t *testing.T) {
 						agentsv1alpha1.LabelSandboxPool: "test-pool",
 					},
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse:        "true",
-						agentsv1alpha1.AnnotationReuseEnabled: "true",
+						agentsv1alpha1.AnnotationCleanup:        "true",
+						agentsv1alpha1.AnnotationCleanupEnabled: "true",
 					},
 				},
 			},
@@ -835,17 +835,17 @@ func TestEnsureSandboxReused(t *testing.T) {
 				},
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
-			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxReusing},
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRecycling},
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonFailed,
 			expectDeleted:    true,
 		},
 		{
-			name: "first entry - Reuse returns retriable error - retried",
-			reuser: &mockSandboxReuser{
-				reuseErr: &RetriableError{Err: assert.AnError},
+			name: "first entry - Recycle returns retriable error - retried",
+			recycler: &mockSandboxRecycler{
+				recycleErr: &RetriableError{Err: assert.AnError},
 			},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -854,8 +854,8 @@ func TestEnsureSandboxReused(t *testing.T) {
 						agentsv1alpha1.LabelSandboxPool: "test-pool",
 					},
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse:        "true",
-						agentsv1alpha1.AnnotationReuseEnabled: "true",
+						agentsv1alpha1.AnnotationCleanup:        "true",
+						agentsv1alpha1.AnnotationCleanupEnabled: "true",
 					},
 				},
 			},
@@ -868,15 +868,15 @@ func TestEnsureSandboxReused(t *testing.T) {
 				},
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
-			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxReusing},
+			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRecycling},
 			expectError:      "assert.AnError general error for testing",
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonStarted,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonStarted,
 		},
 		{
-			name:             "unknown condition reason - no-op",
-			reuser:           &mockSandboxReuser{},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			name:               "unknown condition reason - no-op",
+			recycler:           &mockSandboxRecycler{},
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -896,10 +896,10 @@ func TestEnsureSandboxReused(t *testing.T) {
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
 						Reason:             "UnknownReason",
 						LastTransitionTime: metav1.Now(),
@@ -908,9 +908,9 @@ func TestEnsureSandboxReused(t *testing.T) {
 			},
 		},
 		{
-			name:             "grace period not yet elapsed - returns remaining time",
-			reuser:           &mockSandboxReuser{},
-			reuseGracePeriod: 10 * time.Second,
+			name:               "grace period not yet elapsed - returns remaining time",
+			recycler:           &mockSandboxRecycler{},
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -930,24 +930,24 @@ func TestEnsureSandboxReused(t *testing.T) {
 				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
 			},
 			newStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxReusing,
+				Phase: agentsv1alpha1.SandboxRecycling,
 				Conditions: []metav1.Condition{
 					{
-						Type:               string(agentsv1alpha1.SandboxConditionReusing),
+						Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 						Status:             metav1.ConditionFalse,
-						Reason:             agentsv1alpha1.SandboxReusingReasonCompleted,
+						Reason:             agentsv1alpha1.SandboxRecyclingReasonCompleted,
 						LastTransitionTime: metav1.Now(),
 					},
 				},
 			},
 			expectRequeue:    true,
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonCompleted,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonCompleted,
 		},
 		{
-			name:             "template-hash mismatch - reuse failed immediately",
-			reuser:           &mockSandboxReuser{},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			name:               "template-hash mismatch - recycle failed immediately",
+			recycler:           &mockSandboxRecycler{},
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -957,8 +957,8 @@ func TestEnsureSandboxReused(t *testing.T) {
 						agentsv1alpha1.LabelTemplateHash: "old-hash",
 					},
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse:        "true",
-						agentsv1alpha1.AnnotationReuseEnabled: "true",
+						agentsv1alpha1.AnnotationCleanup:        "true",
+						agentsv1alpha1.AnnotationCleanupEnabled: "true",
 					},
 				},
 			},
@@ -974,15 +974,15 @@ func TestEnsureSandboxReused(t *testing.T) {
 					UpdateRevision: "new-hash",
 				},
 			},
-			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxReusing},
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRecycling},
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonFailed,
 			expectDeleted:    true,
 		},
 		{
-			name:             "template-hash match - reuse proceeds normally",
-			reuser:           &mockSandboxReuser{},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			name:               "template-hash match - recycle proceeds normally",
+			recycler:           &mockSandboxRecycler{},
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -992,8 +992,8 @@ func TestEnsureSandboxReused(t *testing.T) {
 						agentsv1alpha1.LabelTemplateHash: "matching-hash",
 					},
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse:        "true",
-						agentsv1alpha1.AnnotationReuseEnabled: "true",
+						agentsv1alpha1.AnnotationCleanup:        "true",
+						agentsv1alpha1.AnnotationCleanupEnabled: "true",
 					},
 				},
 			},
@@ -1009,14 +1009,14 @@ func TestEnsureSandboxReused(t *testing.T) {
 					UpdateRevision: "matching-hash",
 				},
 			},
-			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxReusing},
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonStarted,
+			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRecycling},
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonStarted,
 		},
 		{
-			name:             "updateRevision empty - hash check skipped, reuse proceeds",
-			reuser:           &mockSandboxReuser{},
-			reuseTimeout:     60 * time.Second,
-			reuseGracePeriod: 10 * time.Second,
+			name:               "updateRevision empty - hash check skipped, recycle proceeds",
+			recycler:           &mockSandboxRecycler{},
+			recycleTimeout:     60 * time.Second,
+			recycleGracePeriod: 10 * time.Second,
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -1026,8 +1026,8 @@ func TestEnsureSandboxReused(t *testing.T) {
 						agentsv1alpha1.LabelTemplateHash: "some-hash",
 					},
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse:        "true",
-						agentsv1alpha1.AnnotationReuseEnabled: "true",
+						agentsv1alpha1.AnnotationCleanup:        "true",
+						agentsv1alpha1.AnnotationCleanupEnabled: "true",
 					},
 				},
 			},
@@ -1043,8 +1043,8 @@ func TestEnsureSandboxReused(t *testing.T) {
 					UpdateRevision: "",
 				},
 			},
-			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxReusing},
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonStarted,
+			newStatus:        &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRecycling},
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonStarted,
 		},
 	}
 
@@ -1070,11 +1070,11 @@ func TestEnsureSandboxReused(t *testing.T) {
 			if tt.sbs != nil {
 				objs = append(objs, tt.sbs)
 			}
-			control, fakeClient := newTestReuseControl(t, objs, tt.reuser, tt.reuseTimeout, tt.reuseGracePeriod)
+			control, fakeClient := newTestRecycleControl(t, objs, tt.recycler, tt.recycleTimeout, tt.recycleGracePeriod)
 			control.config.CSIResetSignalDir = tt.csiResetSignalDir
 
 			args := EnsureFuncArgs{Pod: tt.pod, Box: tt.box, NewStatus: tt.newStatus}
-			requeue, err := control.ensureSandboxReused(context.TODO(), args)
+			requeue, err := control.ensureSandboxRecycled(context.TODO(), args)
 
 			if tt.expectCSIWrite {
 				assert.Positive(t, csiWriteCalls, "expected CSI reset signal to be written")
@@ -1091,7 +1091,7 @@ func TestEnsureSandboxReused(t *testing.T) {
 				assert.Greater(t, requeue, time.Duration(0))
 			}
 
-			cond := utils.GetSandboxCondition(tt.newStatus, string(agentsv1alpha1.SandboxConditionReusing))
+			cond := utils.GetSandboxCondition(tt.newStatus, string(agentsv1alpha1.SandboxConditionRecycling))
 			if tt.expectCondReason != "" {
 				require.NotNil(t, cond)
 				assert.Equal(t, tt.expectCondReason, cond.Reason)
@@ -1101,8 +1101,8 @@ func TestEnsureSandboxReused(t *testing.T) {
 				assert.Equal(t, tt.expectPhase, tt.newStatus.Phase)
 			}
 
-			if tt.expectReuseCount > 0 {
-				assert.Equal(t, tt.expectReuseCount, tt.newStatus.ReuseCount)
+			if tt.expectRecycledCount > 0 {
+				assert.Equal(t, tt.expectRecycledCount, tt.newStatus.RecycledCount)
 			}
 
 			if tt.expectShutdownTime {
@@ -1128,7 +1128,7 @@ func TestResetForPool(t *testing.T) {
 		expectAnnotations map[string]string
 	}{
 		{
-			name: "no updated metadata - clears spec times, restores ownerRef, removes reuse annotation",
+			name: "no updated metadata - clears spec times, restores ownerRef, removes recycle annotation",
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -1137,7 +1137,7 @@ func TestResetForPool(t *testing.T) {
 						agentsv1alpha1.LabelSandboxPool: "test-pool",
 					},
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse: "true",
+						agentsv1alpha1.AnnotationCleanup: "true",
 					},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
@@ -1167,20 +1167,20 @@ func TestResetForPool(t *testing.T) {
 						"user-label":                         "user-value",
 					},
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse:                "true",
-						agentsv1alpha1.AnnotationReuseRetainOnFailure: "true",
-						agentsv1alpha1.AnnotationLock:                 "some-lock",
-						agentsv1alpha1.AnnotationOwner:                "some-user",
-						agentsv1alpha1.AnnotationClaimTime:            "2026-06-17T00:00:00Z",
-						agentsv1alpha1.AnnotationInitRuntimeRequest:   "{}",
-						agentsv1alpha1.AnnotationRuntimeAccessToken:   "token",
-						agentsv1alpha1.AnnotationCSIVolumeConfig:      `{"mountOptionList":[]}`,
-						agentsv1alpha1.SandboxAnnotationPriority:      "100",
-						identity.AgentKeyTokenRefreshStatus:           `{"accessTokenExpiration":"2026-06-18T00:00:00Z"}`,
-						agentsv1alpha1.AnnotationEnvdAccessToken:      "legacy-envd-token",
-						agentsv1alpha1.AnnotationEnvdURL:              "http://legacy-envd.example.com",
-						agentsv1alpha1.AnnotationRuntimeURL:           "http://runtime.example.com",
-						"user-anno":                                   "user-value",
+						agentsv1alpha1.AnnotationCleanup:                "true",
+						agentsv1alpha1.AnnotationCleanupRetainOnFailure: "true",
+						agentsv1alpha1.AnnotationLock:                   "some-lock",
+						agentsv1alpha1.AnnotationOwner:                  "some-user",
+						agentsv1alpha1.AnnotationClaimTime:              "2026-06-17T00:00:00Z",
+						agentsv1alpha1.AnnotationInitRuntimeRequest:     "{}",
+						agentsv1alpha1.AnnotationRuntimeAccessToken:     "token",
+						agentsv1alpha1.AnnotationCSIVolumeConfig:        `{"mountOptionList":[]}`,
+						agentsv1alpha1.SandboxAnnotationPriority:        "100",
+						identity.AgentKeyTokenRefreshStatus:             `{"accessTokenExpiration":"2026-06-18T00:00:00Z"}`,
+						agentsv1alpha1.AnnotationEnvdAccessToken:        "legacy-envd-token",
+						agentsv1alpha1.AnnotationEnvdURL:                "http://legacy-envd.example.com",
+						agentsv1alpha1.AnnotationRuntimeURL:             "http://runtime.example.com",
+						"user-anno":                                     "user-value",
 						agentsv1alpha1.AnnotationUpdatedMetadataInClaim: mustMarshal(agentsv1alpha1.UpdatedMetadataInClaim{
 							Labels:      []string{"user-label"},
 							Annotations: []string{"user-anno"},
@@ -1237,7 +1237,7 @@ func TestResetForPool(t *testing.T) {
 			if tt.sbs != nil {
 				objs = append(objs, tt.sbs)
 			}
-			control, fakeClient := newTestReuseControl(t, objs, nil, 0, 0)
+			control, fakeClient := newTestRecycleControl(t, objs, nil, 0, 0)
 
 			err := control.resetMetadataForPool(context.TODO(), tt.box, tt.sbs)
 
@@ -1258,8 +1258,8 @@ func TestResetForPool(t *testing.T) {
 			assert.Equal(t, tt.sbs.Name, updated.OwnerReferences[0].Name)
 			assert.Equal(t, agentsv1alpha1.False, updated.Labels[agentsv1alpha1.LabelSandboxIsClaimed])
 			assert.Empty(t, updated.Labels[agentsv1alpha1.LabelSandboxClaimName])
-			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationReuse])
-			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationReuseRetainOnFailure])
+			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationCleanup])
+			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationCleanupRetainOnFailure])
 			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationLock])
 			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationOwner])
 			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationClaimTime])
@@ -1295,7 +1295,7 @@ func TestResetForPool_PatchError(t *testing.T) {
 				agentsv1alpha1.LabelSandboxPool: "test-pool",
 			},
 			Annotations: map[string]string{
-				agentsv1alpha1.AnnotationReuse: "true",
+				agentsv1alpha1.AnnotationCleanup: "true",
 			},
 		},
 	}
@@ -1316,7 +1316,7 @@ func TestResetForPool_PatchError(t *testing.T) {
 			},
 		}).Build()
 
-	control := NewSandboxReuseControl(fakeClient, record.NewFakeRecorder(10), SandboxReuseConfig{})
+	control := NewSandboxRecycleControl(fakeClient, record.NewFakeRecorder(10), SandboxRecycleConfig{})
 
 	err := control.resetMetadataForPool(context.TODO(), box, sbs)
 
@@ -1325,18 +1325,18 @@ func TestResetForPool_PatchError(t *testing.T) {
 	assert.Contains(t, err.Error(), "patch denied")
 }
 
-func TestNoopSandboxReuser(t *testing.T) {
-	reuser := &noopSandboxReuser{}
+func TestNoopSandboxRecycler(t *testing.T) {
+	recycler := &noopSandboxRecycler{}
 
-	err := reuser.Reuse(context.TODO(), &agentsv1alpha1.Sandbox{}, &corev1.Pod{})
+	err := recycler.Recycle(context.TODO(), &agentsv1alpha1.Sandbox{}, &corev1.Pod{})
 	assert.NoError(t, err)
 
-	complete, err := reuser.IsReuseComplete(context.TODO(), &agentsv1alpha1.Sandbox{}, &corev1.Pod{})
+	complete, err := recycler.IsRecycleComplete(context.TODO(), &agentsv1alpha1.Sandbox{}, &corev1.Pod{})
 	assert.NoError(t, err)
 	assert.True(t, complete)
 }
 
-// annotationResetRequest is the annotation key used by MockSandboxReuser to
+// annotationResetRequest is the annotation key used by MockSandboxRecycler to
 // write reset requests on Pods.
 const annotationResetRequest = "agents.kruise.io/reset-request"
 
@@ -1354,21 +1354,21 @@ type ResetResult struct {
 	Error      string `json:"error,omitempty"`
 }
 
-// MockSandboxReuser is a mock SandboxReuser implementation that writes a
+// MockSandboxRecycler is a mock SandboxRecycler implementation that writes a
 // reset-request annotation on the sandbox's Pod and polls a PodCondition for
 // completion. It is intended for testing and E2E scenarios where a real
 // agent-runtime is not available.
-type MockSandboxReuser struct {
+type MockSandboxRecycler struct {
 	client client.Client
 }
 
-func NewMockSandboxReuser(c client.Client) SandboxReuser {
-	return &MockSandboxReuser{client: c}
+func NewMockSandboxRecycler(c client.Client) SandboxRecycler {
+	return &MockSandboxRecycler{client: c}
 }
 
-func (r *MockSandboxReuser) Reuse(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod) error {
+func (r *MockSandboxRecycler) Recycle(ctx context.Context, sandbox *agentsv1alpha1.Sandbox, pod *corev1.Pod) error {
 	request := ResetRequest{
-		ResetID:     fmt.Sprintf("%d", sandbox.Status.ReuseCount+1),
+		ResetID:     fmt.Sprintf("%d", sandbox.Status.RecycledCount+1),
 		RequestTime: time.Now().UTC().Format(time.RFC3339),
 	}
 	raw, err := json.Marshal(request)
@@ -1387,7 +1387,7 @@ func (r *MockSandboxReuser) Reuse(ctx context.Context, sandbox *agentsv1alpha1.S
 	return nil
 }
 
-func (r *MockSandboxReuser) IsReuseComplete(_ context.Context, _ *agentsv1alpha1.Sandbox, pod *corev1.Pod) (bool, error) {
+func (r *MockSandboxRecycler) IsRecycleComplete(_ context.Context, _ *agentsv1alpha1.Sandbox, pod *corev1.Pod) (bool, error) {
 	cond := utils.GetPodCondition(&pod.Status, PodConditionResetComplete)
 	if cond == nil {
 		return false, nil
@@ -1427,7 +1427,7 @@ func newFakeClient(objs ...client.Object) client.Client {
 		Build()
 }
 
-func TestMockSandboxReuser_Reuse(t *testing.T) {
+func TestMockSandboxRecycler_Recycle(t *testing.T) {
 	tests := []struct {
 		name        string
 		sandbox     *agentsv1alpha1.Sandbox
@@ -1438,7 +1438,7 @@ func TestMockSandboxReuser_Reuse(t *testing.T) {
 			name: "patches pod with reset-request annotation",
 			sandbox: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{Name: "sbx-1", Namespace: "default"},
-				Status:     agentsv1alpha1.SandboxStatus{ReuseCount: 2},
+				Status:     agentsv1alpha1.SandboxStatus{RecycledCount: 2},
 			},
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "sbx-1", Namespace: "default"},
@@ -1449,9 +1449,9 @@ func TestMockSandboxReuser_Reuse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			objs := []client.Object{tt.pod}
-			reuser := NewMockSandboxReuser(newFakeClient(objs...))
+			recycler := NewMockSandboxRecycler(newFakeClient(objs...))
 
-			err := reuser.Reuse(context.TODO(), tt.sandbox, tt.pod)
+			err := recycler.Recycle(context.TODO(), tt.sandbox, tt.pod)
 
 			if tt.expectError != "" {
 				require.Error(t, err)
@@ -1461,8 +1461,8 @@ func TestMockSandboxReuser_Reuse(t *testing.T) {
 			require.NoError(t, err)
 
 			updated := &corev1.Pod{}
-			reuserImpl := reuser.(*MockSandboxReuser)
-			err = reuserImpl.client.Get(context.TODO(), client.ObjectKeyFromObject(tt.sandbox), updated)
+			recyclerImpl := recycler.(*MockSandboxRecycler)
+			err = recyclerImpl.client.Get(context.TODO(), client.ObjectKeyFromObject(tt.sandbox), updated)
 			require.NoError(t, err)
 
 			raw := updated.Annotations[annotationResetRequest]
@@ -1476,7 +1476,7 @@ func TestMockSandboxReuser_Reuse(t *testing.T) {
 	}
 }
 
-func TestMockSandboxReuser_IsReuseComplete(t *testing.T) {
+func TestMockSandboxRecycler_IsRecycleComplete(t *testing.T) {
 	resetRequest := mustMarshal(ResetRequest{ResetID: "5", RequestTime: "2026-06-11T10:00:00Z"})
 
 	tests := []struct {
@@ -1648,9 +1648,9 @@ func TestMockSandboxReuser_IsReuseComplete(t *testing.T) {
 			sandbox := &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{Name: "sbx-1", Namespace: "default"},
 			}
-			reuser := NewMockSandboxReuser(newFakeClient())
+			recycler := NewMockSandboxRecycler(newFakeClient())
 
-			complete, err := reuser.IsReuseComplete(context.TODO(), sandbox, tt.pod)
+			complete, err := recycler.IsRecycleComplete(context.TODO(), sandbox, tt.pod)
 
 			if tt.expectError != "" {
 				require.Error(t, err)
@@ -1672,36 +1672,36 @@ func mustMarshal(v any) string {
 	return string(data)
 }
 
-func TestNewSandboxReuseControl(t *testing.T) {
-	t.Run("nil reuser defaults to noopSandboxReuser", func(t *testing.T) {
-		control := NewSandboxReuseControl(newFakeClient(), record.NewFakeRecorder(10), SandboxReuseConfig{})
-		require.NotNil(t, control.config.Reuser)
-		complete, err := control.config.Reuser.IsReuseComplete(context.TODO(), nil, nil)
+func TestNewSandboxRecycleControl(t *testing.T) {
+	t.Run("nil recycler defaults to noopSandboxRecycler", func(t *testing.T) {
+		control := NewSandboxRecycleControl(newFakeClient(), record.NewFakeRecorder(10), SandboxRecycleConfig{})
+		require.NotNil(t, control.config.Recycler)
+		complete, err := control.config.Recycler.IsRecycleComplete(context.TODO(), nil, nil)
 		assert.NoError(t, err)
 		assert.True(t, complete)
 	})
 
 	t.Run("zero FailureShutdownGrace defaults to 5m", func(t *testing.T) {
-		control := NewSandboxReuseControl(newFakeClient(), record.NewFakeRecorder(10), SandboxReuseConfig{})
+		control := NewSandboxRecycleControl(newFakeClient(), record.NewFakeRecorder(10), SandboxRecycleConfig{})
 		assert.Equal(t, defaultFailureShutdownGrace, control.config.FailureShutdownGrace)
 	})
 
 	t.Run("explicit values are preserved", func(t *testing.T) {
-		reuser := &mockSandboxReuser{}
-		control := NewSandboxReuseControl(newFakeClient(), record.NewFakeRecorder(10), SandboxReuseConfig{
-			Reuser:               reuser,
+		recycler := &mockSandboxRecycler{}
+		control := NewSandboxRecycleControl(newFakeClient(), record.NewFakeRecorder(10), SandboxRecycleConfig{
+			Recycler:              recycler,
 			Timeout:              30 * time.Second,
 			GracePeriod:          5 * time.Second,
 			FailureShutdownGrace: 10 * time.Second,
 		})
-		assert.Equal(t, reuser, control.config.Reuser)
+		assert.Equal(t, recycler, control.config.Recycler)
 		assert.Equal(t, 30*time.Second, control.config.Timeout)
 		assert.Equal(t, 5*time.Second, control.config.GracePeriod)
 		assert.Equal(t, 10*time.Second, control.config.FailureShutdownGrace)
 	})
 }
 
-func TestHandleReuseFailed(t *testing.T) {
+func TestHandleRecycleFailed(t *testing.T) {
 	tests := []struct {
 		name               string
 		box                *agentsv1alpha1.Sandbox
@@ -1723,7 +1723,7 @@ func TestHandleReuseFailed(t *testing.T) {
 			},
 			err:              fmt.Errorf("some failure"),
 			expectDeleted:    true,
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonFailed,
 		},
 		{
 			name: "annotation valid duration - ShutdownTime set",
@@ -1732,14 +1732,14 @@ func TestHandleReuseFailed(t *testing.T) {
 					Name:      "test-sandbox",
 					Namespace: "default",
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuseRetainOnFailure: "5m",
+						agentsv1alpha1.AnnotationCleanupRetainOnFailure: "5m",
 					},
 				},
 			},
 			err:                fmt.Errorf("some failure"),
 			expectRequeue:      5 * time.Minute,
 			expectShutdownTime: true,
-			expectCondReason:   agentsv1alpha1.SandboxReusingReasonFailed,
+			expectCondReason:   agentsv1alpha1.SandboxRecyclingReasonFailed,
 		},
 		{
 			name: "annotation invalid string - delete immediately",
@@ -1748,13 +1748,13 @@ func TestHandleReuseFailed(t *testing.T) {
 					Name:      "test-sandbox",
 					Namespace: "default",
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuseRetainOnFailure: "not-a-duration",
+						agentsv1alpha1.AnnotationCleanupRetainOnFailure: "not-a-duration",
 					},
 				},
 			},
 			err:              fmt.Errorf("some failure"),
 			expectDeleted:    true,
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonFailed,
 		},
 		{
 			name: "annotation negative duration - delete immediately",
@@ -1763,13 +1763,13 @@ func TestHandleReuseFailed(t *testing.T) {
 					Name:      "test-sandbox",
 					Namespace: "default",
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuseRetainOnFailure: "-5m",
+						agentsv1alpha1.AnnotationCleanupRetainOnFailure: "-5m",
 					},
 				},
 			},
 			err:              fmt.Errorf("some failure"),
 			expectDeleted:    true,
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonFailed,
 		},
 		{
 			name: "annotation zero duration - delete immediately",
@@ -1778,13 +1778,13 @@ func TestHandleReuseFailed(t *testing.T) {
 					Name:      "test-sandbox",
 					Namespace: "default",
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuseRetainOnFailure: "0s",
+						agentsv1alpha1.AnnotationCleanupRetainOnFailure: "0s",
 					},
 				},
 			},
 			err:              fmt.Errorf("some failure"),
 			expectDeleted:    true,
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonFailed,
 		},
 		{
 			name: "timeout error - reason Timeout, sandbox deleted",
@@ -1794,9 +1794,9 @@ func TestHandleReuseFailed(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			err:              &reuseTimeoutError{timeout: 30 * time.Second},
+			err:              &recycleTimeoutError{timeout: 30 * time.Second},
 			expectDeleted:    true,
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonTimeout,
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonTimeout,
 		},
 		{
 			name: "patch fails - error returned",
@@ -1805,14 +1805,14 @@ func TestHandleReuseFailed(t *testing.T) {
 					Name:      "test-sandbox",
 					Namespace: "default",
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuseRetainOnFailure: "5m",
+						agentsv1alpha1.AnnotationCleanupRetainOnFailure: "5m",
 					},
 				},
 			},
 			err:              fmt.Errorf("some failure"),
 			patchFails:       true,
-			expectError:      "failed to set shutdownTime on reuse failure",
-			expectCondReason: agentsv1alpha1.SandboxReusingReasonFailed,
+			expectError:      "failed to set shutdownTime on recycle failure",
+			expectCondReason: agentsv1alpha1.SandboxRecyclingReasonFailed,
 		},
 	}
 
@@ -1836,12 +1836,12 @@ func TestHandleReuseFailed(t *testing.T) {
 				fakeClient = newFakeClient(objs...)
 			}
 
-			control := NewSandboxReuseControl(fakeClient, record.NewFakeRecorder(10), SandboxReuseConfig{
-				Reuser: &noopSandboxReuser{},
+			control := NewSandboxRecycleControl(fakeClient, record.NewFakeRecorder(10), SandboxRecycleConfig{
+				Recycler: &noopSandboxRecycler{},
 			})
 
 			newStatus := &agentsv1alpha1.SandboxStatus{}
-			requeue, err := control.handleReuseFailed(context.TODO(), tt.box, newStatus, tt.err)
+			requeue, err := control.handleRecycleFailed(context.TODO(), tt.box, newStatus, tt.err)
 
 			if tt.expectError != "" {
 				require.Error(t, err)
@@ -1852,7 +1852,7 @@ func TestHandleReuseFailed(t *testing.T) {
 
 			assert.Equal(t, tt.expectRequeue, requeue)
 
-			cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReusing))
+			cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionRecycling))
 			require.NotNil(t, cond)
 			assert.Equal(t, tt.expectCondReason, cond.Reason)
 
@@ -1868,7 +1868,7 @@ func TestHandleReuseFailed(t *testing.T) {
 	}
 }
 
-func TestHandleReuseGracePeriod_ResetError(t *testing.T) {
+func TestHandleRecycleGracePeriod_ResetError(t *testing.T) {
 	box := &agentsv1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-sandbox",
@@ -1889,19 +1889,19 @@ func TestHandleReuseGracePeriod_ResetError(t *testing.T) {
 		},
 	}
 
-	control, _ := newTestReuseControl(t, []client.Object{box, sbs}, nil, 0, 1*time.Second)
+	control, _ := newTestRecycleControl(t, []client.Object{box, sbs}, nil, 0, 1*time.Second)
 
-	reuseCond := &metav1.Condition{
-		Type:               string(agentsv1alpha1.SandboxConditionReusing),
+	recycleCond := &metav1.Condition{
+		Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 		Status:             metav1.ConditionFalse,
-		Reason:             agentsv1alpha1.SandboxReusingReasonCompleted,
+		Reason:             agentsv1alpha1.SandboxRecyclingReasonCompleted,
 		LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Second)),
 	}
-	newStatus := &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxReusing}
-	utils.SetSandboxCondition(newStatus, *reuseCond)
+	newStatus := &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRecycling}
+	utils.SetSandboxCondition(newStatus, *recycleCond)
 
 	args := EnsureFuncArgs{Box: box, NewStatus: newStatus}
-	requeue, err := control.handleReuseGracePeriod(context.TODO(), args, reuseCond, sbs)
+	requeue, err := control.handleRecycleGracePeriod(context.TODO(), args, recycleCond, sbs)
 
 	require.Error(t, err)
 	assert.True(t, IsRetriable(err))
@@ -1909,7 +1909,7 @@ func TestHandleReuseGracePeriod_ResetError(t *testing.T) {
 	assert.Equal(t, time.Duration(0), requeue)
 }
 
-func TestDoReuse_SandboxSetGetError(t *testing.T) {
+func TestDoRecycle_SandboxSetGetError(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = agentsv1alpha1.AddToScheme(scheme)
@@ -1936,17 +1936,17 @@ func TestDoReuse_SandboxSetGetError(t *testing.T) {
 			},
 		}).Build()
 
-	control := NewSandboxReuseControl(fakeClient, record.NewFakeRecorder(10), SandboxReuseConfig{
-		Reuser: &noopSandboxReuser{},
+	control := NewSandboxRecycleControl(fakeClient, record.NewFakeRecorder(10), SandboxRecycleConfig{
+		Recycler: &noopSandboxRecycler{},
 	})
 
 	args := EnsureFuncArgs{
 		Box:       box,
 		Pod:       &corev1.Pod{},
-		NewStatus: &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxReusing},
+		NewStatus: &agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxRecycling},
 	}
 
-	requeue, err := control.doReuse(context.TODO(), args)
+	requeue, err := control.doRecycle(context.TODO(), args)
 
 	require.Error(t, err)
 	assert.True(t, IsRetriable(err))
@@ -1954,7 +1954,7 @@ func TestDoReuse_SandboxSetGetError(t *testing.T) {
 	assert.Equal(t, time.Duration(0), requeue)
 }
 
-func TestMockSandboxReuser_Reuse_PatchError(t *testing.T) {
+func TestMockSandboxRecycler_Recycle_PatchError(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = agentsv1alpha1.AddToScheme(scheme)
@@ -1972,61 +1972,61 @@ func TestMockSandboxReuser_Reuse_PatchError(t *testing.T) {
 			},
 		}).Build()
 
-	reuser := NewMockSandboxReuser(fakeClient)
+	recycler := NewMockSandboxRecycler(fakeClient)
 	sandbox := &agentsv1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{Name: "sbx-1", Namespace: "default"},
 	}
 
-	err := reuser.Reuse(context.TODO(), sandbox, pod)
+	err := recycler.Recycle(context.TODO(), sandbox, pod)
 
 	require.Error(t, err)
 	assert.True(t, IsRetriable(err))
 	assert.Contains(t, err.Error(), "failed to patch pod with reset request")
 }
 
-func TestReuseTimeoutError(t *testing.T) {
-	e := &reuseTimeoutError{timeout: 30 * time.Second}
+func TestRecycleTimeoutError(t *testing.T) {
+	e := &recycleTimeoutError{timeout: 30 * time.Second}
 	assert.Contains(t, e.Error(), "30s")
-	assert.Equal(t, agentsv1alpha1.SandboxReusingReasonTimeout, e.Reason())
+	assert.Equal(t, agentsv1alpha1.SandboxRecyclingReasonTimeout, e.Reason())
 }
 
-func TestReusePollingInterval(t *testing.T) {
-	control := &SandboxReuseControl{}
+func TestRecyclePollingInterval(t *testing.T) {
+	control := &SandboxRecycleControl{}
 
 	tests := []struct {
-		name     string
+		name      string
 		remaining time.Duration
-		expected time.Duration
+		expected  time.Duration
 	}{
 		{
-			name:     "remaining greater than default interval returns default",
+			name:      "remaining greater than default interval returns default",
 			remaining: 60 * time.Second,
-			expected: defaultReusePollingInterval,
+			expected:  defaultRecyclePollingInterval,
 		},
 		{
-			name:     "remaining less than default interval returns remaining",
+			name:      "remaining less than default interval returns remaining",
 			remaining: 2 * time.Second,
-			expected: 2 * time.Second,
+			expected:  2 * time.Second,
 		},
 		{
-			name:     "remaining zero returns default (no timeout configured)",
+			name:      "remaining zero returns default (no timeout configured)",
 			remaining: 0,
-			expected: defaultReusePollingInterval,
+			expected:  defaultRecyclePollingInterval,
 		},
 		{
-			name:     "remaining negative returns default (no timeout configured)",
+			name:      "remaining negative returns default (no timeout configured)",
 			remaining: -1 * time.Second,
-			expected: defaultReusePollingInterval,
+			expected:  defaultRecyclePollingInterval,
 		},
 		{
-			name:     "remaining exactly default interval returns default",
-			remaining: defaultReusePollingInterval,
-			expected: defaultReusePollingInterval,
+			name:      "remaining exactly default interval returns default",
+			remaining: defaultRecyclePollingInterval,
+			expected:  defaultRecyclePollingInterval,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, control.reusePollingInterval(tt.remaining))
+			assert.Equal(t, tt.expected, control.recyclePollingInterval(tt.remaining))
 		})
 	}
 }
@@ -2146,7 +2146,7 @@ func TestEnsureCSIResetSignal(t *testing.T) {
 				cancel()
 			}
 
-			control := &SandboxReuseControl{config: SandboxReuseConfig{CSIResetSignalDir: tt.dir, CSIResetSignalFileName: tt.fileName}}
+			control := &SandboxRecycleControl{config: SandboxRecycleConfig{CSIResetSignalDir: tt.dir, CSIResetSignalFileName: tt.fileName}}
 			err := control.ensureCSIResetSignal(ctx, tt.box)
 
 			assert.Equal(t, tt.wantCalls, calls)

--- a/pkg/controller/sandbox/core/recycle_test.go
+++ b/pkg/controller/sandbox/core/recycle_test.go
@@ -71,7 +71,7 @@ func newTestRecycleControl(t *testing.T, objs []client.Object, recycler SandboxR
 		WithStatusSubresource(&agentsv1alpha1.Sandbox{}).
 		Build()
 	control := NewSandboxRecycleControl(fakeClient, record.NewFakeRecorder(10), SandboxRecycleConfig{
-		Recycler:     recycler,
+		Recycler:    recycler,
 		Timeout:     recycleTimeout,
 		GracePeriod: gracePeriod,
 	})
@@ -89,24 +89,24 @@ func TestEnsureSandboxRecycled(t *testing.T) {
 	}
 
 	tests := []struct {
-		name               string
-		recycler           *mockSandboxRecycler
-		recycleTimeout     time.Duration
-		recycleGracePeriod time.Duration
-		box                *agentsv1alpha1.Sandbox
-		pod                *corev1.Pod
-		newStatus          *agentsv1alpha1.SandboxStatus
-		sbs                *agentsv1alpha1.SandboxSet
-		csiResetSignalDir  string
-		csiWriteErr        error
-		expectError        string
-		expectPhase        agentsv1alpha1.SandboxPhase
-		expectRequeue      bool
+		name                string
+		recycler            *mockSandboxRecycler
+		recycleTimeout      time.Duration
+		recycleGracePeriod  time.Duration
+		box                 *agentsv1alpha1.Sandbox
+		pod                 *corev1.Pod
+		newStatus           *agentsv1alpha1.SandboxStatus
+		sbs                 *agentsv1alpha1.SandboxSet
+		csiResetSignalDir   string
+		csiWriteErr         error
+		expectError         string
+		expectPhase         agentsv1alpha1.SandboxPhase
+		expectRequeue       bool
 		expectRecycledCount int32
-		expectCondReason   string
-		expectShutdownTime bool
-		expectDeleted      bool
-		expectCSIWrite     bool
+		expectCondReason    string
+		expectShutdownTime  bool
+		expectDeleted       bool
+		expectCSIWrite      bool
 	}{
 		{
 			name:               "missing sandbox-pool label - recycle failed",
@@ -520,9 +520,9 @@ func TestEnsureSandboxRecycled(t *testing.T) {
 					},
 				},
 			},
-			expectPhase:        agentsv1alpha1.SandboxRunning,
+			expectPhase:         agentsv1alpha1.SandboxRunning,
 			expectRecycledCount: 1,
-			expectCondReason:   agentsv1alpha1.SandboxRecyclingReasonSucceeded,
+			expectCondReason:    agentsv1alpha1.SandboxRecyclingReasonSucceeded,
 		},
 		{
 			name: "recycle timeout - condition reason Timeout",
@@ -802,9 +802,9 @@ func TestEnsureSandboxRecycled(t *testing.T) {
 					},
 				},
 			},
-			expectPhase:        agentsv1alpha1.SandboxRunning,
+			expectPhase:         agentsv1alpha1.SandboxRunning,
 			expectRecycledCount: 1,
-			expectCondReason:   agentsv1alpha1.SandboxRecyclingReasonSucceeded,
+			expectCondReason:    agentsv1alpha1.SandboxRecyclingReasonSucceeded,
 		},
 		{
 			name: "first entry - Recycle returns non-retriable error - recycle failed",
@@ -1689,7 +1689,7 @@ func TestNewSandboxRecycleControl(t *testing.T) {
 	t.Run("explicit values are preserved", func(t *testing.T) {
 		recycler := &mockSandboxRecycler{}
 		control := NewSandboxRecycleControl(newFakeClient(), record.NewFakeRecorder(10), SandboxRecycleConfig{
-			Recycler:              recycler,
+			Recycler:             recycler,
 			Timeout:              30 * time.Second,
 			GracePeriod:          5 * time.Second,
 			FailureShutdownGrace: 10 * time.Second,

--- a/pkg/controller/sandbox/core/sandbox_initializer.go
+++ b/pkg/controller/sandbox/core/sandbox_initializer.go
@@ -118,7 +118,7 @@ func Initialize(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *age
 			})
 		}
 
-		// Reuse ProcessCSIMounts for concurrent mount execution
+		// Cleanup ProcessCSIMounts for concurrent mount execution
 		duration, mountErr := utilruntime.ProcessCSIMounts(ctx, sbxForInit, config.CSIMountOptions{
 			MountOptionList: mountOptionList,
 		})

--- a/pkg/controller/sandbox/metrics.go
+++ b/pkg/controller/sandbox/metrics.go
@@ -270,23 +270,23 @@ var (
 		[]string{"namespace", "name", "container"},
 	)
 
-	// sandboxReuseTotal tracks the total number of sandbox reuse operations.
-	sandboxReuseTotal = prometheus.NewCounterVec(
+	// sandboxRecycleTotal tracks the total number of sandbox recycle operations.
+	sandboxRecycleTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name:        "sandbox_reuse_total",
-			Help:        "Total number of sandbox reuse operations",
+			Name:        "sandbox_recycle_total",
+			Help:        "Total number of sandbox recycle operations",
 			ConstLabels: prometheus.Labels{"source": "k8s"},
 		},
 		[]string{"namespace", "result"},
 	)
 
-	// sandboxReuseDuration tracks the duration of sandbox reuse operations.
-	// Reuse includes cleanup, pod-ready wait, and a configurable grace period, so
+	// sandboxRecycleDuration tracks the duration of sandbox recycle operations.
+	// Recycle includes the recycle step, pod-ready wait, and a configurable grace period, so
 	// buckets extend higher than other lifecycle histograms.
-	sandboxReuseDuration = prometheus.NewHistogramVec(
+	sandboxRecycleDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:        "sandbox_reuse_duration_seconds",
-			Help:        "Duration of sandbox reuse operations from start to success in seconds",
+			Name:        "sandbox_recycle_duration_seconds",
+			Help:        "Duration of sandbox recycle operations from start to success in seconds",
 			ConstLabels: prometheus.Labels{"source": "k8s"},
 			Buckets:     prometheus.ExponentialBuckets(0.1, 2, 13), // 100ms -> ~409s (~7min)
 		},
@@ -300,7 +300,7 @@ var (
 		agentsv1alpha1.SandboxPaused,
 		agentsv1alpha1.SandboxResuming,
 		agentsv1alpha1.SandboxUpgrading,
-		agentsv1alpha1.SandboxReusing,
+		agentsv1alpha1.SandboxRecycling,
 		agentsv1alpha1.SandboxSucceeded,
 		agentsv1alpha1.SandboxFailed,
 		agentsv1alpha1.SandboxTerminating,
@@ -343,11 +343,11 @@ var observedResumeDurations sync.Map
 // observedCreationFailure tracks which sandboxes have had their creation failure counted.
 var observedCreationFailure sync.Map
 
-// reuseStartTimes tracks the start time of reuse operations
-var reuseStartTimes sync.Map
+// recycleStartTimes tracks the start time of recycle operations
+var recycleStartTimes sync.Map
 
-// observedReuseDurations tracks which sandboxes have had their reuse duration observed
-var observedReuseDurations sync.Map
+// observedRecycleDurations tracks which sandboxes have had their recycle duration observed
+var observedRecycleDurations sync.Map
 
 // deletionStartTimes tracks the deletion start time per sandbox for duration calculation.
 var deletionStartTimes sync.Map
@@ -396,8 +396,8 @@ func init() {
 		sandboxRuntimeContainerAbnormalTime,
 		sandboxStatusAbnormal,
 		sandboxStatusAbnormalTime,
-		sandboxReuseTotal,
-		sandboxReuseDuration,
+		sandboxRecycleTotal,
+		sandboxRecycleDuration,
 	)
 }
 
@@ -554,27 +554,27 @@ func recordSandboxConditionMetrics(sandbox *agentsv1alpha1.Sandbox, namespace, n
 				sandboxResumeDuration.WithLabelValues(namespace),
 				sandboxResumeTotal.WithLabelValues(namespace, "success"))
 
-		case agentsv1alpha1.SandboxConditionReusing:
+		case agentsv1alpha1.SandboxConditionRecycling:
 			key := namespace + "/" + name
-			if condition.Status == metav1.ConditionFalse && condition.Reason == agentsv1alpha1.SandboxReusingReasonStarted {
-				reuseStartTimes.Store(key, condition.LastTransitionTime.Time)
-				observedReuseDurations.Delete(key)
-			} else if condition.Status == metav1.ConditionTrue && condition.Reason == agentsv1alpha1.SandboxReusingReasonSucceeded {
-				if startTime, ok := reuseStartTimes.Load(key); ok {
-					if _, observed := observedReuseDurations.LoadOrStore(key, true); !observed {
+			if condition.Status == metav1.ConditionFalse && condition.Reason == agentsv1alpha1.SandboxRecyclingReasonStarted {
+				recycleStartTimes.Store(key, condition.LastTransitionTime.Time)
+				observedRecycleDurations.Delete(key)
+			} else if condition.Status == metav1.ConditionTrue && condition.Reason == agentsv1alpha1.SandboxRecyclingReasonSucceeded {
+				if startTime, ok := recycleStartTimes.Load(key); ok {
+					if _, observed := observedRecycleDurations.LoadOrStore(key, true); !observed {
 						duration := condition.LastTransitionTime.Sub(startTime.(time.Time))
-						sandboxReuseDuration.WithLabelValues(namespace).Observe(duration.Seconds())
-						sandboxReuseTotal.WithLabelValues(namespace, "success").Inc()
+						sandboxRecycleDuration.WithLabelValues(namespace).Observe(duration.Seconds())
+						sandboxRecycleTotal.WithLabelValues(namespace, "success").Inc()
 					}
 				}
 			} else if condition.Status == metav1.ConditionFalse &&
-				(condition.Reason == agentsv1alpha1.SandboxReusingReasonFailed || condition.Reason == agentsv1alpha1.SandboxReusingReasonTimeout) {
-				if _, observed := observedReuseDurations.LoadOrStore(key, true); !observed {
+				(condition.Reason == agentsv1alpha1.SandboxRecyclingReasonFailed || condition.Reason == agentsv1alpha1.SandboxRecyclingReasonTimeout) {
+				if _, observed := observedRecycleDurations.LoadOrStore(key, true); !observed {
 					result := "failed"
-					if condition.Reason == agentsv1alpha1.SandboxReusingReasonTimeout {
+					if condition.Reason == agentsv1alpha1.SandboxRecyclingReasonTimeout {
 						result = "timeout"
 					}
-					sandboxReuseTotal.WithLabelValues(namespace, result).Inc()
+					sandboxRecycleTotal.WithLabelValues(namespace, result).Inc()
 				}
 			}
 		}
@@ -704,8 +704,8 @@ func DeleteSandboxMetrics(namespace, name string) {
 	resumeStartTimes.Delete(key)
 	observedResumeDurations.Delete(key)
 	observedCreationFailure.Delete(key)
-	reuseStartTimes.Delete(key)
-	observedReuseDurations.Delete(key)
+	recycleStartTimes.Delete(key)
+	observedRecycleDurations.Delete(key)
 
 	// Clean up abnormal start-time tracking with O(1) direct deletes.
 	// The set of possible types and container names is fixed and small,

--- a/pkg/controller/sandbox/metrics_test.go
+++ b/pkg/controller/sandbox/metrics_test.go
@@ -2358,12 +2358,12 @@ func TestStaleUnpausedMetricReset(t *testing.T) {
 func TestSandboxStatusAbnormalTime(t *testing.T) {
 	now := metav1.NewTime(time.Now())
 	tests := []struct {
-		name             string
-		abnormalPhase    agentsv1alpha1.SandboxPhase
-		abnormalConds    []metav1.Condition
-		abnormalType     string
-		normalPhase      agentsv1alpha1.SandboxPhase
-		normalConds      []metav1.Condition
+		name          string
+		abnormalPhase agentsv1alpha1.SandboxPhase
+		abnormalConds []metav1.Condition
+		abnormalType  string
+		normalPhase   agentsv1alpha1.SandboxPhase
+		normalConds   []metav1.Condition
 	}{
 		{
 			name:          "resume_incomplete",
@@ -2385,9 +2385,9 @@ func TestSandboxStatusAbnormalTime(t *testing.T) {
 			name:          "pause_incomplete",
 			abnormalPhase: agentsv1alpha1.SandboxPaused,
 			abnormalConds: nil, // No Paused condition → abnormal
-			abnormalType: "pause_incomplete",
-			normalPhase:  agentsv1alpha1.SandboxRunning,
-			normalConds:  nil,
+			abnormalType:  "pause_incomplete",
+			normalPhase:   agentsv1alpha1.SandboxRunning,
+			normalConds:   nil,
 		},
 	}
 

--- a/pkg/controller/sandbox/pod_event_handler_test.go
+++ b/pkg/controller/sandbox/pod_event_handler_test.go
@@ -1119,15 +1119,15 @@ func TestIsContainerStatusImageEqual(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "single container - images match",
-			old:  []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:1.0"}},
-			new:  []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:1.0"}},
+			name:     "single container - images match",
+			old:      []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:1.0"}},
+			new:      []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:1.0"}},
 			expected: true,
 		},
 		{
-			name: "single container - images differ",
-			old:  []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:1.0"}},
-			new:  []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:2.0"}},
+			name:     "single container - images differ",
+			old:      []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:1.0"}},
+			new:      []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:2.0"}},
 			expected: false,
 		},
 		{
@@ -1176,9 +1176,9 @@ func TestIsContainerStatusImageEqual(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "same count but different names",
-			old:  []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:1.0"}},
-			new:  []corev1.ContainerStatus{{Name: "init-b", Image: "busybox:1.0"}},
+			name:     "same count but different names",
+			old:      []corev1.ContainerStatus{{Name: "init-a", Image: "busybox:1.0"}},
+			new:      []corev1.ContainerStatus{{Name: "init-b", Image: "busybox:1.0"}},
 			expected: false,
 		},
 	}

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -50,24 +50,24 @@ import (
 
 func init() {
 	flag.IntVar(&concurrentReconciles, "sandbox-workers", concurrentReconciles, "Max concurrent reconciles for Sandbox controller.")
-	flag.DurationVar(&reuseTimeout, "reuse-timeout", reuseTimeout, "Timeout for sandbox reuse cleanup operations.")
-	flag.DurationVar(&reuseGracePeriod, "reuse-grace-period", reuseGracePeriod, "Grace period after reuse cleanup before sandbox returns to pool.")
-	flag.DurationVar(&reuseFailureShutdownGrace, "reuse-failure-shutdown-grace", reuseFailureShutdownGrace, "Grace period before shutting down a sandbox after reuse failure.")
+	flag.DurationVar(&recycleTimeout, "recycle-timeout", recycleTimeout, "Timeout for sandbox recycle operations.")
+	flag.DurationVar(&recycleGracePeriod, "recycle-grace-period", recycleGracePeriod, "Grace period after recycle before sandbox returns to pool.")
+	flag.DurationVar(&recycleFailureShutdownGrace, "recycle-failure-shutdown-grace", recycleFailureShutdownGrace, "Grace period before shutting down a sandbox after recycle failure.")
 	flag.StringVar(&csiResetSignalDir, "csi-reset-signal-dir", csiResetSignalDir,
-		"Directory inside the sandbox where a reset signal file is written before reuse when the sandbox carries CSI mounts, "+
+		"Directory inside the sandbox where a reset signal file is written before recycle when the sandbox carries CSI mounts, "+
 			"so a stopping csi-sidecar can unmount stale volumes during prestop/SIGTERM. Empty disables the behavior.")
 	flag.StringVar(&csiResetSignalFileName, "csi-reset-signal-file", csiResetSignalFileName,
-		"Name of the reset signal file written into --csi-reset-signal-dir before reuse.")
+		"Name of the reset signal file written into --csi-reset-signal-dir before recycle.")
 }
 
 var (
-	concurrentReconciles      = 500
-	sandboxControllerKind     = agentsv1alpha1.GroupVersion.WithKind("Sandbox")
-	reuseTimeout              = 60 * time.Second
-	reuseGracePeriod          = 10 * time.Second
-	reuseFailureShutdownGrace = 5 * time.Minute
-	csiResetSignalDir         = ""
-	csiResetSignalFileName    = "reset"
+	concurrentReconciles        = 500
+	sandboxControllerKind       = agentsv1alpha1.GroupVersion.WithKind("Sandbox")
+	recycleTimeout              = 60 * time.Second
+	recycleGracePeriod          = 10 * time.Second
+	recycleFailureShutdownGrace = 5 * time.Minute
+	csiResetSignalDir           = ""
+	csiResetSignalFileName      = "reset"
 )
 
 // Enqueuer is the contract the Sandbox controller depends on for async
@@ -99,10 +99,10 @@ func Add(mgr manager.Manager, metricsCleanup Enqueuer) error {
 			RateLimiter:       rateLimiter,
 			CheckpointControl: checkpointControl,
 			PodControl:        podControl,
-			ReuseConfig: core.SandboxReuseConfig{
-				Timeout:                reuseTimeout,
-				GracePeriod:            reuseGracePeriod,
-				FailureShutdownGrace:   reuseFailureShutdownGrace,
+			RecycleConfig: core.SandboxRecycleConfig{
+				Timeout:                recycleTimeout,
+				GracePeriod:            recycleGracePeriod,
+				FailureShutdownGrace:   recycleFailureShutdownGrace,
 				CSIResetSignalDir:      csiResetSignalDir,
 				CSIResetSignalFileName: csiResetSignalFileName,
 			},
@@ -278,8 +278,8 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 		err = r.getControl(args.Pod).EnsureSandboxResumed(ctx, args)
 	case agentsv1alpha1.SandboxUpgrading:
 		err = r.getControl(args.Pod).EnsureSandboxUpgraded(ctx, args)
-	case agentsv1alpha1.SandboxReusing:
-		requeueAfter, err = r.getControl(args.Pod).EnsureSandboxReused(ctx, args)
+	case agentsv1alpha1.SandboxRecycling:
+		requeueAfter, err = r.getControl(args.Pod).EnsureSandboxRecycled(ctx, args)
 	default:
 		klog.InfoS("sandbox status phase is invalid", "sandbox", klog.KObj(box), "phase", box.Status.Phase)
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
@@ -372,24 +372,24 @@ func (r *SandboxReconciler) calculateStatus(ctx context.Context, args core.Ensur
 			return newStatus, true
 		}
 	case agentsv1alpha1.SandboxRunning:
-		// Reuse trigger takes priority over Pod terminal detection.
-		// If reuse is requested, always enter Reusing regardless of Pod state —
-		// doReuse's terminal phase check properly handles dead Pods via
-		// handleReuseFailed (which deletes the sandbox and cleans up metadata).
+		// Recycle trigger takes priority over Pod terminal detection.
+		// If recycle is requested, always enter Recycling regardless of Pod state —
+		// doRecycle's terminal phase check properly handles dead Pods via
+		// handleRecycleFailed (which deletes the sandbox and cleans up metadata).
 		// This prevents the sandbox from getting stuck in Failed with dirty
 		// claim metadata when the Pod dies between claim-release and the next reconcile.
-		if isReuseTriggered(box) {
+		if isRecycleTriggered(box) {
 			if hasPVCVolumes(box) {
-				r.rejectReuse(box, newStatus, "reuse is not supported for sandboxes with persistent volume claims")
+				r.rejectRecycle(box, newStatus, "recycle is not supported for sandboxes with persistent volume claims")
 			} else {
-				klog.InfoS("Detected reuse trigger", "sandbox", klog.KObj(box))
-				newStatus.Phase = agentsv1alpha1.SandboxReusing
-				utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReusing))
+				klog.InfoS("Detected recycle trigger", "sandbox", klog.KObj(box))
+				newStatus.Phase = agentsv1alpha1.SandboxRecycling
+				utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionRecycling))
 				break
 			}
 		}
 
-		// Pod terminal detection (only when reuse is NOT triggered)
+		// Pod terminal detection (only when recycle is NOT triggered)
 		if pod == nil || !pod.DeletionTimestamp.IsZero() {
 			newStatus.Phase = agentsv1alpha1.SandboxFailed
 			newStatus.Message = "Pod Not Found"
@@ -417,9 +417,9 @@ func (r *SandboxReconciler) calculateStatus(ctx context.Context, args core.Ensur
 		}
 
 	case agentsv1alpha1.SandboxPaused:
-		// Paused state does not support reuse; reject immediately.
-		if isReuseTriggered(box) {
-			r.rejectReuse(box, newStatus, "reuse is not supported in Paused state")
+		// Paused state does not support recycle; reject immediately.
+		if isRecycleTriggered(box) {
+			r.rejectRecycle(box, newStatus, "recycle is not supported in Paused state")
 		}
 
 		cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
@@ -439,9 +439,9 @@ func (r *SandboxReconciler) calculateStatus(ctx context.Context, args core.Ensur
 			klog.InfoS("sandbox pause not completed, cannot enter resume state temporarily", "sandbox", klog.KObj(box))
 		}
 
-	case agentsv1alpha1.SandboxReusing:
-		// Reuse lifecycle (progress checking, grace period, success/failure
-		// transitions) is handled entirely by EnsureSandboxReused.
+	case agentsv1alpha1.SandboxRecycling:
+		// Recycle lifecycle (progress checking, grace period, success/failure
+		// transitions) is handled entirely by EnsureSandboxRecycled.
 
 	case agentsv1alpha1.SandboxUpgrading:
 		// This indicates the podTemplate has changed again during an ongoing upgrade.
@@ -465,11 +465,11 @@ func (r *SandboxReconciler) calculateStatus(ctx context.Context, args core.Ensur
 	return newStatus, false
 }
 
-// isReuseTriggered returns true when the reuse annotation and the reuse-enabled
+// isRecycleTriggered returns true when the recycle annotation and the recycle-enabled
 // annotation are both set to "true" on the sandbox.
-func isReuseTriggered(box *agentsv1alpha1.Sandbox) bool {
-	return box.Annotations[agentsv1alpha1.AnnotationReuse] == "true" &&
-		box.Annotations[agentsv1alpha1.AnnotationReuseEnabled] == "true"
+func isRecycleTriggered(box *agentsv1alpha1.Sandbox) bool {
+	return box.Annotations[agentsv1alpha1.AnnotationCleanup] == "true" &&
+		box.Annotations[agentsv1alpha1.AnnotationCleanupEnabled] == "true"
 }
 
 // hasPVCVolumes returns true if the sandbox has VolumeClaimTemplates or its pod
@@ -488,30 +488,30 @@ func hasPVCVolumes(box *agentsv1alpha1.Sandbox) bool {
 	return false
 }
 
-// rejectReuse sets a Reusing condition with reason ReuseRejected and records a
+// rejectRecycle sets a Recycling condition with reason RecycleRejected and records a
 // Warning event. The sandbox stays in its current phase (Running or Paused).
 // The msg parameter provides the specific rejection reason.
-func (r *SandboxReconciler) rejectReuse(box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus, msg string) {
-	// Avoid duplicate events if the condition is already set to ReuseRejected
+func (r *SandboxReconciler) rejectRecycle(box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus, msg string) {
+	// Avoid duplicate events if the condition is already set to RecycleRejected
 	// with the same message.
-	if existing := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReusing)); existing != nil &&
-		existing.Reason == agentsv1alpha1.SandboxReusingReasonRejected && existing.Message == msg {
+	if existing := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionRecycling)); existing != nil &&
+		existing.Reason == agentsv1alpha1.SandboxRecyclingReasonRejected && existing.Message == msg {
 		return
 	}
 
 	utils.SetSandboxCondition(newStatus, metav1.Condition{
-		Type:               string(agentsv1alpha1.SandboxConditionReusing),
+		Type:               string(agentsv1alpha1.SandboxConditionRecycling),
 		Status:             metav1.ConditionFalse,
-		Reason:             agentsv1alpha1.SandboxReusingReasonRejected,
+		Reason:             agentsv1alpha1.SandboxRecyclingReasonRejected,
 		Message:            msg,
 		LastTransitionTime: metav1.Now(),
 	})
 
 	if r.recorder != nil {
-		r.recorder.Event(box, corev1.EventTypeWarning, agentsv1alpha1.SandboxReusingReasonRejected, msg)
+		r.recorder.Event(box, corev1.EventTypeWarning, agentsv1alpha1.SandboxRecyclingReasonRejected, msg)
 	}
 
-	klog.InfoS("Reuse rejected", "sandbox", klog.KObj(box), "reason", msg)
+	klog.InfoS("Recycling rejected", "sandbox", klog.KObj(box), "reason", msg)
 }
 
 func determineUpgradeResumeReason(
@@ -622,15 +622,15 @@ func (r *SandboxReconciler) ensureVolumeClaimTemplates(ctx context.Context, box 
 }
 
 func (r *SandboxReconciler) checkTimers(ctx context.Context, box *agentsv1alpha1.Sandbox) (ctrl.Result, bool, error) {
-	// Skip timers during reuse unless the reuse has reached a terminal
+	// Skip timers during recycle unless the recycle has reached a terminal
 	// failure state (Failed/Timeout). Only then can ShutdownTime set by
-	// handleReuseFailed be processed. Using != avoids needing to update
+	// handleRecycleFailed be processed. Using != avoids needing to update
 	// this check when new in-progress reasons are added in the future.
-	if box.Status.Phase == agentsv1alpha1.SandboxReusing {
-		reuseCond := utils.GetSandboxCondition(&box.Status, string(agentsv1alpha1.SandboxConditionReusing))
-		if reuseCond == nil ||
-			(reuseCond.Reason != agentsv1alpha1.SandboxReusingReasonFailed &&
-				reuseCond.Reason != agentsv1alpha1.SandboxReusingReasonTimeout) {
+	if box.Status.Phase == agentsv1alpha1.SandboxRecycling {
+		recycleCond := utils.GetSandboxCondition(&box.Status, string(agentsv1alpha1.SandboxConditionRecycling))
+		if recycleCond == nil ||
+			(recycleCond.Reason != agentsv1alpha1.SandboxRecyclingReasonFailed &&
+				recycleCond.Reason != agentsv1alpha1.SandboxRecyclingReasonTimeout) {
 			return ctrl.Result{}, false, nil
 		}
 	}

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -2033,7 +2033,7 @@ func TestCalculateStatus(t *testing.T) {
 			expectedShouldReq: true,
 		},
 		{
-			name: "running phase with reuse annotations should transition to reusing",
+			name: "running phase with cleanup annotations should transition to cleaning",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -2047,8 +2047,8 @@ func TestCalculateStatus(t *testing.T) {
 					Namespace:  "default",
 					Generation: 1,
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse:        "true",
-						agentsv1alpha1.AnnotationReuseEnabled: "true",
+						agentsv1alpha1.AnnotationCleanup:        "true",
+						agentsv1alpha1.AnnotationCleanupEnabled: "true",
 					},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
@@ -2064,11 +2064,11 @@ func TestCalculateStatus(t *testing.T) {
 			initStatus: &agentsv1alpha1.SandboxStatus{
 				Phase: agentsv1alpha1.SandboxRunning,
 			},
-			expectedPhase:     agentsv1alpha1.SandboxReusing,
+			expectedPhase:     agentsv1alpha1.SandboxRecycling,
 			expectedShouldReq: false,
 		},
 		{
-			name: "running phase with only reuse annotation (no reuse-enabled) should not transition",
+			name: "running phase with only cleanup annotation (no cleanup-enabled) should not transition",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -2082,7 +2082,7 @@ func TestCalculateStatus(t *testing.T) {
 					Namespace:  "default",
 					Generation: 1,
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse: "true",
+						agentsv1alpha1.AnnotationCleanup: "true",
 					},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
@@ -2102,7 +2102,7 @@ func TestCalculateStatus(t *testing.T) {
 			expectedShouldReq: false,
 		},
 		{
-			name: "running phase with reuse annotations and VolumeClaimTemplates should reject and stay running",
+			name: "running phase with cleanup annotations and VolumeClaimTemplates should reject and stay running",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -2116,8 +2116,8 @@ func TestCalculateStatus(t *testing.T) {
 					Namespace:  "default",
 					Generation: 1,
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse:        "true",
-						agentsv1alpha1.AnnotationReuseEnabled: "true",
+						agentsv1alpha1.AnnotationCleanup:        "true",
+						agentsv1alpha1.AnnotationCleanupEnabled: "true",
 					},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
@@ -2139,15 +2139,15 @@ func TestCalculateStatus(t *testing.T) {
 			expectedPhase:     agentsv1alpha1.SandboxRunning,
 			expectedShouldReq: false,
 			checkConditions: func(t *testing.T, status *agentsv1alpha1.SandboxStatus) {
-				cond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionReusing))
-				require.NotNil(t, cond, "Reusing condition should be set")
+				cond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionRecycling))
+				require.NotNil(t, cond, "Cleaning condition should be set")
 				assert.Equal(t, metav1.ConditionFalse, cond.Status)
-				assert.Equal(t, agentsv1alpha1.SandboxReusingReasonRejected, cond.Reason)
+				assert.Equal(t, agentsv1alpha1.SandboxRecyclingReasonRejected, cond.Reason)
 				assert.Contains(t, cond.Message, "persistent volume claims")
 			},
 		},
 		{
-			name: "running phase with reuse annotations and PVC in pod template volumes should reject and stay running",
+			name: "running phase with cleanup annotations and PVC in pod template volumes should reject and stay running",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -2161,8 +2161,8 @@ func TestCalculateStatus(t *testing.T) {
 					Namespace:  "default",
 					Generation: 1,
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse:        "true",
-						agentsv1alpha1.AnnotationReuseEnabled: "true",
+						agentsv1alpha1.AnnotationCleanup:        "true",
+						agentsv1alpha1.AnnotationCleanupEnabled: "true",
 					},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
@@ -2191,14 +2191,14 @@ func TestCalculateStatus(t *testing.T) {
 			expectedPhase:     agentsv1alpha1.SandboxRunning,
 			expectedShouldReq: false,
 			checkConditions: func(t *testing.T, status *agentsv1alpha1.SandboxStatus) {
-				cond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionReusing))
-				require.NotNil(t, cond, "Reusing condition should be set")
+				cond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionRecycling))
+				require.NotNil(t, cond, "Cleaning condition should be set")
 				assert.Equal(t, metav1.ConditionFalse, cond.Status)
-				assert.Equal(t, agentsv1alpha1.SandboxReusingReasonRejected, cond.Reason)
+				assert.Equal(t, agentsv1alpha1.SandboxRecyclingReasonRejected, cond.Reason)
 			},
 		},
 		{
-			name: "paused phase with reuse annotations should reject and stay paused",
+			name: "paused phase with cleanup annotations should reject and stay paused",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -2212,8 +2212,8 @@ func TestCalculateStatus(t *testing.T) {
 					Namespace:  "default",
 					Generation: 1,
 					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationReuse:        "true",
-						agentsv1alpha1.AnnotationReuseEnabled: "true",
+						agentsv1alpha1.AnnotationCleanup:        "true",
+						agentsv1alpha1.AnnotationCleanupEnabled: "true",
 					},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
@@ -2239,10 +2239,10 @@ func TestCalculateStatus(t *testing.T) {
 			expectedPhase:     agentsv1alpha1.SandboxPaused,
 			expectedShouldReq: false,
 			checkConditions: func(t *testing.T, status *agentsv1alpha1.SandboxStatus) {
-				cond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionReusing))
-				require.NotNil(t, cond, "Reusing condition should be set")
+				cond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionRecycling))
+				require.NotNil(t, cond, "Cleaning condition should be set")
 				assert.Equal(t, metav1.ConditionFalse, cond.Status)
-				assert.Equal(t, agentsv1alpha1.SandboxReusingReasonRejected, cond.Reason)
+				assert.Equal(t, agentsv1alpha1.SandboxRecyclingReasonRejected, cond.Reason)
 				assert.Contains(t, cond.Message, "Paused state")
 			},
 		},
@@ -4514,7 +4514,7 @@ func TestHasPVCVolumes(t *testing.T) {
 	}
 }
 
-func TestRejectReuse(t *testing.T) {
+func TestRejectCleanup(t *testing.T) {
 	box := &agentsv1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-sandbox",
@@ -4527,18 +4527,18 @@ func TestRejectReuse(t *testing.T) {
 		r := &SandboxReconciler{recorder: recorder}
 		status := &agentsv1alpha1.SandboxStatus{}
 
-		r.rejectReuse(box, status, "test reason")
+		r.rejectRecycle(box, status, "test reason")
 
-		cond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionReusing))
+		cond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionRecycling))
 		require.NotNil(t, cond)
 		assert.Equal(t, metav1.ConditionFalse, cond.Status)
-		assert.Equal(t, agentsv1alpha1.SandboxReusingReasonRejected, cond.Reason)
+		assert.Equal(t, agentsv1alpha1.SandboxRecyclingReasonRejected, cond.Reason)
 		assert.Equal(t, "test reason", cond.Message)
 
 		// Verify event was recorded
 		select {
 		case event := <-recorder.Events:
-			assert.Contains(t, event, agentsv1alpha1.SandboxReusingReasonRejected)
+			assert.Contains(t, event, agentsv1alpha1.SandboxRecyclingReasonRejected)
 			assert.Contains(t, event, "test reason")
 		default:
 			t.Error("expected event to be recorded")
@@ -4550,12 +4550,12 @@ func TestRejectReuse(t *testing.T) {
 		status := &agentsv1alpha1.SandboxStatus{}
 
 		assert.NotPanics(t, func() {
-			r.rejectReuse(box, status, "test reason")
+			r.rejectRecycle(box, status, "test reason")
 		})
 
-		cond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionReusing))
+		cond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionRecycling))
 		require.NotNil(t, cond)
-		assert.Equal(t, agentsv1alpha1.SandboxReusingReasonRejected, cond.Reason)
+		assert.Equal(t, agentsv1alpha1.SandboxRecyclingReasonRejected, cond.Reason)
 	})
 
 	t.Run("deduplication - same reason and message skips update", func(t *testing.T) {
@@ -4564,10 +4564,10 @@ func TestRejectReuse(t *testing.T) {
 		status := &agentsv1alpha1.SandboxStatus{}
 
 		// First call sets the condition and records an event
-		r.rejectReuse(box, status, "test reason")
+		r.rejectRecycle(box, status, "test reason")
 
 		// Second call with same reason+message should be a no-op
-		r.rejectReuse(box, status, "test reason")
+		r.rejectRecycle(box, status, "test reason")
 
 		// Only one event should have been recorded
 		select {
@@ -4589,10 +4589,10 @@ func TestRejectReuse(t *testing.T) {
 		r := &SandboxReconciler{recorder: recorder}
 		status := &agentsv1alpha1.SandboxStatus{}
 
-		r.rejectReuse(box, status, "reason A")
-		r.rejectReuse(box, status, "reason B")
+		r.rejectRecycle(box, status, "reason A")
+		r.rejectRecycle(box, status, "reason B")
 
-		cond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionReusing))
+		cond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionRecycling))
 		require.NotNil(t, cond)
 		assert.Equal(t, "reason B", cond.Message)
 

--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -291,7 +291,7 @@ func (r *Reconciler) scaleDown(ctx context.Context, count int, sbs *agentsv1alph
 	}
 
 	// Phase 2: Delete updated revision sandboxes if more needed.
-	// Priority: Pending > Reused (reuseCount desc) > Running-NotReady > Available fresh.
+	// Priority: Pending > Recycled (recycledCount desc) > Running-NotReady > Available fresh.
 	slices.SortFunc(updatedCandidates, compareScaleDownPriority)
 	updatedToDelete := updatedCandidates[:min(remaining, len(updatedCandidates))]
 	successes, err = utils.DoItSlowlyWithInputs(updatedToDelete, initialBatchSize, deleteFunc)
@@ -315,8 +315,8 @@ func scaleDownPriority(sbx *agentsv1alpha1.Sandbox) int {
 	if !ready {
 		return 2 // Running but not Ready
 	}
-	if sbx.Status.ReuseCount > 0 {
-		return 1 // Reused
+	if sbx.Status.RecycledCount > 0 {
+		return 1 // Recycled
 	}
 	return 3 // Available fresh
 }
@@ -326,10 +326,10 @@ func compareScaleDownPriority(a, b *agentsv1alpha1.Sandbox) int {
 	if pa != pb {
 		return pa - pb
 	}
-	if pa == 1 && a.Status.ReuseCount != b.Status.ReuseCount {
-		return int(b.Status.ReuseCount) - int(a.Status.ReuseCount)
+	if pa == 1 && a.Status.RecycledCount != b.Status.RecycledCount {
+		return int(b.Status.RecycledCount) - int(a.Status.RecycledCount)
 	}
-	// Within the same category (and same reuseCount for Reused),
+	// Within the same category (and same recycledCount for Recycled),
 	// prefer to delete older sandboxes first.
 	return a.CreationTimestamp.Time.Compare(b.CreationTimestamp.Time)
 }

--- a/pkg/controller/sandboxset/sandboxset_controller_test.go
+++ b/pkg/controller/sandboxset/sandboxset_controller_test.go
@@ -313,14 +313,14 @@ func TestReconcile_DeleteDead(t *testing.T) {
 			}
 			assert.NoError(t, k8sClient.Create(ctx, sbs))
 			newStatus, err := reconciler.initNewStatus(ctx, sbs)
-		
+
 			assert.NoError(t, err)
 			sbs.Status = *newStatus.status
 			CreateSandboxes(t, tt.request, sbs, k8sClient)
-		
+
 			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(sbs)})
 			assert.NoError(t, err)
-		
+
 			if tt.checkFunc != nil {
 				tt.checkFunc(t, k8sClient, sbs)
 			}
@@ -728,7 +728,7 @@ func TestReconcile_ScaleDown(t *testing.T) {
 	}
 }
 
-func TestReconcile_ScaleDown_ReusedFirst(t *testing.T) {
+func TestReconcile_ScaleDown_RecycledFirst(t *testing.T) {
 	utestutils.InitLogOutput()
 	ctx := context.Background()
 	k8sClient := NewClient()
@@ -749,7 +749,7 @@ func TestReconcile_ScaleDown_ReusedFirst(t *testing.T) {
 	require.NoError(t, err)
 
 	ownerRef := []metav1.OwnerReference{*metav1.NewControllerRef(sbs, v1alpha1.SandboxSetControllerKind)}
-	makeAvailable := func(name string, reuseCount int32) *v1alpha1.Sandbox {
+	makeAvailable := func(name string, recycledCount int32) *v1alpha1.Sandbox {
 		sbx := getBaseSandbox(0, name, hash)
 		sbx.Name = name
 		sbx.Status.Phase = v1alpha1.SandboxRunning
@@ -757,15 +757,15 @@ func TestReconcile_ScaleDown_ReusedFirst(t *testing.T) {
 		sbx.Status.Conditions = []metav1.Condition{
 			{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue},
 		}
-		sbx.Status.ReuseCount = reuseCount
+		sbx.Status.RecycledCount = recycledCount
 		sbx.OwnerReferences = ownerRef
 		return sbx
 	}
 
 	fresh := makeAvailable("fresh-0", 0)
-	reused := makeAvailable("reused-1", 2)
+	recycled := makeAvailable("recycled-1", 2)
 	CreateSandboxWithStatus(t, k8sClient, fresh)
-	CreateSandboxWithStatus(t, k8sClient, reused)
+	CreateSandboxWithStatus(t, k8sClient, recycled)
 
 	scaleUpExpectation.DeleteExpectations(GetControllerKey(sbs))
 	scaleDownExpectation.DeleteExpectations(GetControllerKey(sbs))
@@ -775,7 +775,7 @@ func TestReconcile_ScaleDown_ReusedFirst(t *testing.T) {
 	sandboxes := &v1alpha1.SandboxList{}
 	assert.NoError(t, k8sClient.List(ctx, sandboxes))
 	require.Len(t, sandboxes.Items, 1)
-	assert.Equal(t, "fresh-0", sandboxes.Items[0].Name, "reused sandbox should be deleted first, fresh one kept")
+	assert.Equal(t, "fresh-0", sandboxes.Items[0].Name, "recycled sandbox should be deleted first, fresh one kept")
 }
 
 func TestReconcile_ScaleDown_Priority(t *testing.T) {
@@ -806,17 +806,17 @@ func TestReconcile_ScaleDown_Priority(t *testing.T) {
 	pending.OwnerReferences = ownerRef
 	CreateSandboxWithStatus(t, k8sClient, pending)
 
-	// Priority 1: Reused (Available with reuseCount > 0)
-	reused := getBaseSandbox(0, "reused-", hash)
-	reused.Name = "reused-0"
-	reused.Status.Phase = v1alpha1.SandboxRunning
-	reused.Status.PodInfo.PodIP = "1.2.3.4"
-	reused.Status.Conditions = []metav1.Condition{
+	// Priority 1: Recycled (Available with recycledCount > 0)
+	recycled := getBaseSandbox(0, "recycled-", hash)
+	recycled.Name = "recycled-0"
+	recycled.Status.Phase = v1alpha1.SandboxRunning
+	recycled.Status.PodInfo.PodIP = "1.2.3.4"
+	recycled.Status.Conditions = []metav1.Condition{
 		{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue},
 	}
-	reused.Status.ReuseCount = 2
-	reused.OwnerReferences = ownerRef
-	CreateSandboxWithStatus(t, k8sClient, reused)
+	recycled.Status.RecycledCount = 2
+	recycled.OwnerReferences = ownerRef
+	CreateSandboxWithStatus(t, k8sClient, recycled)
 
 	// Priority 2: Running but not Ready
 	notReady := getBaseSandbox(0, "notready-", hash)
@@ -837,7 +837,7 @@ func TestReconcile_ScaleDown_Priority(t *testing.T) {
 	fresh.Status.Conditions = []metav1.Condition{
 		{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue},
 	}
-	fresh.Status.ReuseCount = 0
+	fresh.Status.RecycledCount = 0
 	fresh.OwnerReferences = ownerRef
 	CreateSandboxWithStatus(t, k8sClient, fresh)
 
@@ -849,19 +849,19 @@ func TestReconcile_ScaleDown_Priority(t *testing.T) {
 	sandboxes := &v1alpha1.SandboxList{}
 	assert.NoError(t, k8sClient.List(ctx, sandboxes))
 	require.Len(t, sandboxes.Items, 1)
-	assert.Equal(t, "fresh-0", sandboxes.Items[0].Name, "pending, reused, and not-ready should be deleted; fresh available kept")
+	assert.Equal(t, "fresh-0", sandboxes.Items[0].Name, "pending, recycled, and not-ready should be deleted; fresh available kept")
 }
 
 func TestCompareScaleDownPriority(t *testing.T) {
-	makeSandbox := func(phase v1alpha1.SandboxPhase, ready bool, reuseCount int32) *v1alpha1.Sandbox {
+	makeSandbox := func(phase v1alpha1.SandboxPhase, ready bool, recycledCount int32) *v1alpha1.Sandbox {
 		readyStatus := metav1.ConditionFalse
 		if ready {
 			readyStatus = metav1.ConditionTrue
 		}
 		return &v1alpha1.Sandbox{
 			Status: v1alpha1.SandboxStatus{
-				Phase:      phase,
-				ReuseCount: reuseCount,
+				Phase:        phase,
+				RecycledCount: recycledCount,
 				Conditions: []metav1.Condition{
 					{Type: string(v1alpha1.SandboxConditionReady), Status: readyStatus},
 				},
@@ -875,13 +875,13 @@ func TestCompareScaleDownPriority(t *testing.T) {
 		wantSign int // -1: a first, 0: equal, 1: b first
 	}{
 		{
-			name:     "pending before reused",
+			name:     "pending before recycled",
 			a:        makeSandbox(v1alpha1.SandboxPending, false, 0),
 			b:        makeSandbox(v1alpha1.SandboxRunning, true, 3),
 			wantSign: -1,
 		},
 		{
-			name:     "reused before running-not-ready",
+			name:     "recycled before running-not-ready",
 			a:        makeSandbox(v1alpha1.SandboxRunning, true, 1),
 			b:        makeSandbox(v1alpha1.SandboxRunning, false, 0),
 			wantSign: -1,
@@ -893,13 +893,13 @@ func TestCompareScaleDownPriority(t *testing.T) {
 			wantSign: -1,
 		},
 		{
-			name:     "higher reuseCount first among reused",
+			name:     "higher recycledCount first among recycled",
 			a:        makeSandbox(v1alpha1.SandboxRunning, true, 5),
 			b:        makeSandbox(v1alpha1.SandboxRunning, true, 2),
 			wantSign: -1,
 		},
 		{
-			name:     "equal reuseCount among reused",
+			name:     "equal recycledCount among recycled",
 			a:        makeSandbox(v1alpha1.SandboxRunning, true, 3),
 			b:        makeSandbox(v1alpha1.SandboxRunning, true, 3),
 			wantSign: 0,

--- a/pkg/controller/sandboxset/utils_test.go
+++ b/pkg/controller/sandboxset/utils_test.go
@@ -613,20 +613,20 @@ func TestClearAndInitInnerKeys(t *testing.T) {
 		{
 			name: "internal keys are deleted except preserved ones",
 			input: map[string]string{
-				agentsv1alpha1.InternalPrefix + "reuse-enabled":         "true",
-				agentsv1alpha1.InternalPrefix + "reuse-retain-on-failure": "5m",
-				agentsv1alpha1.InternalPrefix + "cleanup-candidate":        "true",
-				agentsv1alpha1.InternalPrefix + "sandbox-pool":             "test-pool",
+				agentsv1alpha1.InternalPrefix + "cleanup-enabled":           "true",
+				agentsv1alpha1.InternalPrefix + "cleanup-retain-on-failure": "5m",
+				agentsv1alpha1.InternalPrefix + "cleanup-candidate":         "true",
+				agentsv1alpha1.InternalPrefix + "sandbox-pool":              "test-pool",
 			},
 			expected: map[string]string{
-				agentsv1alpha1.InternalPrefix + "reuse-enabled":         "true",
-				agentsv1alpha1.InternalPrefix + "reuse-retain-on-failure": "5m",
+				agentsv1alpha1.InternalPrefix + "cleanup-enabled":           "true",
+				agentsv1alpha1.InternalPrefix + "cleanup-retain-on-failure": "5m",
 			},
 		},
 		{
 			name: "non-internal keys are preserved",
 			input: map[string]string{
-				"app":                       "my-app",
+				"app":                                "my-app",
 				"agents.kruise.io/cleanup-candidate": "true",
 			},
 			expected: map[string]string{
@@ -636,13 +636,13 @@ func TestClearAndInitInnerKeys(t *testing.T) {
 		{
 			name: "mix of internal, preserved, and non-internal keys",
 			input: map[string]string{
-				"app":                                           "my-app",
-				agentsv1alpha1.InternalPrefix + "reuse-enabled":  "true",
+				"app": "my-app",
+				agentsv1alpha1.InternalPrefix + "cleanup-enabled":   "true",
 				agentsv1alpha1.InternalPrefix + "cleanup-candidate": "true",
 			},
 			expected: map[string]string{
-				"app":                                      "my-app",
-				agentsv1alpha1.InternalPrefix + "reuse-enabled": "true",
+				"app": "my-app",
+				agentsv1alpha1.InternalPrefix + "cleanup-enabled": "true",
 			},
 		},
 	}

--- a/pkg/sandbox-manager/api.go
+++ b/pkg/sandbox-manager/api.go
@@ -280,19 +280,19 @@ func (m *SandboxManager) deleteRouteAndSync(ctx context.Context, sbx infra.Sandb
 }
 
 // DeleteSandbox deletes a sandbox and syncs route with peers.
-// If the sandbox is reuse-enabled and in Running phase, it triggers reuse instead of deletion.
+// If the sandbox is cleanup-enabled and in Running phase, it triggers cleanup instead of deletion.
 func (m *SandboxManager) DeleteSandbox(ctx context.Context, sbx infra.Sandbox) error {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
 
-	if sbx.IsReuseEnabled() && sbx.Phase() == string(v1alpha1.SandboxRunning) {
-		log.Info("sandbox is reuse-enabled, triggering reuse instead of deletion")
+	if sbx.IsRecycleEnabled() && sbx.Phase() == string(v1alpha1.SandboxRunning) {
+		log.Info("sandbox is recycle-enabled, triggering recycle instead of deletion")
 		start := time.Now()
-		if err := sbx.TriggerReuse(ctx); err != nil {
-			log.Error(err, "failed to trigger reuse, falling back to delete")
-			sandboxReuseResponses.WithLabelValues(sbx.GetNamespace(), "failure").Inc()
+		if err := sbx.TriggerRecycle(ctx); err != nil {
+			log.Error(err, "failed to trigger recycle, falling back to delete")
+			sandboxRecycleResponses.WithLabelValues(sbx.GetNamespace(), "failure").Inc()
 		} else {
-			sandboxReuseResponses.WithLabelValues(sbx.GetNamespace(), "success").Inc()
-			sandboxReuseDuration.WithLabelValues(sbx.GetNamespace()).Observe(time.Since(start).Seconds())
+			sandboxRecycleResponses.WithLabelValues(sbx.GetNamespace(), "success").Inc()
+			sandboxRecycleDuration.WithLabelValues(sbx.GetNamespace()).Observe(time.Since(start).Seconds())
 			m.deleteRouteAndSync(ctx, sbx)
 			return nil
 		}

--- a/pkg/sandbox-manager/infra/interface.go
+++ b/pkg/sandbox-manager/infra/interface.go
@@ -183,8 +183,8 @@ type Sandbox interface {
 	GetTimeout() timeout.Options
 	GetClaimTime() (time.Time, error)
 	Kill(ctx context.Context) error                                                                     // Delete the Sandbox resource
-	TriggerReuse(ctx context.Context) error                                                             // Trigger sandbox reuse flow instead of deletion
-	IsReuseEnabled() bool                                                                               // Whether the sandbox supports reuse
+	TriggerRecycle(ctx context.Context) error                                                           // Trigger sandbox recycle flow instead of deletion
+	IsRecycleEnabled() bool                                                                             // Whether the sandbox supports recycle
 	Phase() string                                                                                      // Get the current sandbox phase
 	InplaceRefresh(ctx context.Context, deepcopy bool) error                                            // Update the Sandbox resource object to the latest
 	Request(ctx context.Context, method, path string, port int, body io.Reader) (*http.Response, error) // Make a request to the Sandbox

--- a/pkg/sandbox-manager/infra/interface_test.go
+++ b/pkg/sandbox-manager/infra/interface_test.go
@@ -180,8 +180,8 @@ func (m *mockSandboxForLabels) GetClaimTime() (time.Time, error) {
 	return time.Time{}, nil
 }
 func (m *mockSandboxForLabels) Kill(context.Context) error             { return nil }
-func (m *mockSandboxForLabels) TriggerReuse(context.Context) error     { return nil }
-func (m *mockSandboxForLabels) IsReuseEnabled() bool                   { return false }
+func (m *mockSandboxForLabels) TriggerRecycle(context.Context) error     { return nil }
+func (m *mockSandboxForLabels) IsRecycleEnabled() bool                   { return false }
 func (m *mockSandboxForLabels) Phase() string                          { return "" }
 func (m *mockSandboxForLabels) InplaceRefresh(context.Context, bool) error {
 	return nil

--- a/pkg/sandbox-manager/infra/interface_test.go
+++ b/pkg/sandbox-manager/infra/interface_test.go
@@ -164,14 +164,14 @@ func (m *mockSandboxForLabels) Pause(context.Context, PauseOptions) error { retu
 func (m *mockSandboxForLabels) Resume(context.Context, ResumeOptions) error {
 	return nil
 }
-func (m *mockSandboxForLabels) GetSandboxID() string             { return "" }
-func (m *mockSandboxForLabels) GetRoute() proxy.Route            { return proxy.Route{} }
-func (m *mockSandboxForLabels) GetState() (string, string)       { return "", "" }
-func (m *mockSandboxForLabels) GetTemplate() string              { return "" }
-func (m *mockSandboxForLabels) GetResource() SandboxResource     { return SandboxResource{} }
-func (m *mockSandboxForLabels) SetImage(string)                  {}
-func (m *mockSandboxForLabels) GetImage() string                 { return "" }
-func (m *mockSandboxForLabels) SetTimeout(timeout.Options)       {}
+func (m *mockSandboxForLabels) GetSandboxID() string         { return "" }
+func (m *mockSandboxForLabels) GetRoute() proxy.Route        { return proxy.Route{} }
+func (m *mockSandboxForLabels) GetState() (string, string)   { return "", "" }
+func (m *mockSandboxForLabels) GetTemplate() string          { return "" }
+func (m *mockSandboxForLabels) GetResource() SandboxResource { return SandboxResource{} }
+func (m *mockSandboxForLabels) SetImage(string)              {}
+func (m *mockSandboxForLabels) GetImage() string             { return "" }
+func (m *mockSandboxForLabels) SetTimeout(timeout.Options)   {}
 func (m *mockSandboxForLabels) SaveTimeoutWithPolicy(context.Context, timeout.Options, timeout.UpdatePolicy) (TimeoutUpdateResult, error) {
 	return TimeoutUpdateResult{}, nil
 }
@@ -179,10 +179,10 @@ func (m *mockSandboxForLabels) GetTimeout() timeout.Options { return timeout.Opt
 func (m *mockSandboxForLabels) GetClaimTime() (time.Time, error) {
 	return time.Time{}, nil
 }
-func (m *mockSandboxForLabels) Kill(context.Context) error             { return nil }
-func (m *mockSandboxForLabels) TriggerRecycle(context.Context) error     { return nil }
-func (m *mockSandboxForLabels) IsRecycleEnabled() bool                   { return false }
-func (m *mockSandboxForLabels) Phase() string                          { return "" }
+func (m *mockSandboxForLabels) Kill(context.Context) error           { return nil }
+func (m *mockSandboxForLabels) TriggerRecycle(context.Context) error { return nil }
+func (m *mockSandboxForLabels) IsRecycleEnabled() bool               { return false }
+func (m *mockSandboxForLabels) Phase() string                        { return "" }
 func (m *mockSandboxForLabels) InplaceRefresh(context.Context, bool) error {
 	return nil
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
@@ -258,7 +258,7 @@ func TestInfra_GetSandbox(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 			defer cancel()
 			result, err := infraInstance.GetSandbox(ctx, infra.GetSandboxOptions{
-				SandboxID:      tt.sandboxID,
+				SandboxID: tt.sandboxID,
 			})
 			if tt.expectError {
 				assert.Error(t, err)
@@ -290,8 +290,8 @@ func TestInfra_GetClaimedSandboxWithOptions_NamespaceScoped(t *testing.T) {
 	sandboxID := utils.GetSandboxID(sbx)
 
 	got, err := infraInstance.GetSandbox(t.Context(), infra.GetSandboxOptions{
-		Namespace:      "team-a",
-		SandboxID:      sandboxID,
+		Namespace: "team-a",
+		SandboxID: sandboxID,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "team-a", got.GetNamespace())
@@ -300,8 +300,8 @@ func TestInfra_GetClaimedSandboxWithOptions_NamespaceScoped(t *testing.T) {
 	getCtx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 	defer cancel()
 	_, err = infraInstance.GetSandbox(getCtx, infra.GetSandboxOptions{
-		Namespace:      "team-b",
-		SandboxID:      sandboxID,
+		Namespace: "team-b",
+		SandboxID: sandboxID,
 	})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
@@ -356,8 +356,8 @@ func TestInfra_GetClaimedSandbox_CacheMiss_WaitsUntilCacheHit(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 			defer cancel()
 			got, err := infraInstance.GetSandbox(ctx, infra.GetSandboxOptions{
-				Namespace:      "team-a",
-				SandboxID:      id,
+				Namespace: "team-a",
+				SandboxID: id,
 			})
 
 			require.NoError(t, err)
@@ -410,8 +410,8 @@ func TestInfra_GetClaimedSandbox_SharedContextError_RetriesWhileContextLive(t *t
 			ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 			defer cancel()
 			got, err := infraInstance.GetSandbox(ctx, infra.GetSandboxOptions{
-				Namespace:      "team-a",
-				SandboxID:      id,
+				Namespace: "team-a",
+				SandboxID: id,
 			})
 
 			if tt.expectError != "" {
@@ -460,8 +460,8 @@ func TestInfra_GetClaimedSandbox_CacheMiss_ReturnsContextError(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 75*time.Millisecond)
 			defer cancel()
 			got, err := infraInstance.GetSandbox(ctx, infra.GetSandboxOptions{
-				Namespace:      "team-a",
-				SandboxID:      id,
+				Namespace: "team-a",
+				SandboxID: id,
 			})
 
 			require.Error(t, err)
@@ -492,8 +492,8 @@ func TestInfra_GetClaimedSandbox_RouteRVNewerThanCache_FallsBackToAPIReader(t *t
 	})
 
 	got, err := infraInstance.GetSandbox(t.Context(), infra.GetSandboxOptions{
-		Namespace:      "team-a",
-		SandboxID:      id,
+		Namespace: "team-a",
+		SandboxID: id,
 	})
 
 	require.NoError(t, err)
@@ -526,8 +526,8 @@ func TestInfra_GetClaimedSandbox_CacheRVEqualsRouteRV_NoFallback(t *testing.T) {
 	})
 
 	got, err := infraInstance.GetSandbox(t.Context(), infra.GetSandboxOptions{
-		Namespace:      "team-a",
-		SandboxID:      id,
+		Namespace: "team-a",
+		SandboxID: id,
 	})
 
 	require.NoError(t, err)
@@ -577,8 +577,8 @@ func TestInfra_GetClaimedSandbox_StaleCacheFallback_APIReaderRequiresClaimedLabe
 			ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 			defer cancel()
 			got, err := infraInstance.GetSandbox(ctx, infra.GetSandboxOptions{
-				Namespace:      "team-a",
-				SandboxID:      id,
+				Namespace: "team-a",
+				SandboxID: id,
 			})
 
 			require.Error(t, err)
@@ -607,8 +607,8 @@ func TestInfra_GetClaimedSandbox_StaleCacheFallback_APIReaderNotFound_WrapsCache
 	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 	defer cancel()
 	got, err := infraInstance.GetSandbox(ctx, infra.GetSandboxOptions{
-		Namespace:      "team-a",
-		SandboxID:      id,
+		Namespace: "team-a",
+		SandboxID: id,
 	})
 
 	require.Error(t, err)

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -105,7 +105,7 @@ func (s *Sandbox) refreshFunc() runtime.RefreshFunc {
 }
 
 // retryUpdate loads the latest sandbox from informer first, applies modifier, and retries on conflict.
-// Conflict retries refresh from APIReader to avoid reusing stale informer data.
+// Conflict retries refresh from APIReader to avoid cleaning stale informer data.
 //
 // Returns:
 //   - updated: true if a real Update was issued and the sandbox was written back; false if no update was needed.
@@ -174,17 +174,17 @@ func (s *Sandbox) Kill(ctx context.Context) error {
 	return DefaultDeleteSandbox(ctx, s.Sandbox, s.Cache.GetClient())
 }
 
-func (s *Sandbox) TriggerReuse(ctx context.Context) error {
+func (s *Sandbox) TriggerRecycle(ctx context.Context) error {
 	patch := client.MergeFrom(s.Sandbox.DeepCopy())
 	if s.Sandbox.Annotations == nil {
 		s.Sandbox.Annotations = make(map[string]string, 1)
 	}
-	s.Sandbox.Annotations[agentsv1alpha1.AnnotationReuse] = "true"
+	s.Sandbox.Annotations[agentsv1alpha1.AnnotationCleanup] = "true"
 	return s.Cache.GetClient().Patch(ctx, s.Sandbox, patch)
 }
 
-func (s *Sandbox) IsReuseEnabled() bool {
-	return s.Sandbox.Annotations[agentsv1alpha1.AnnotationReuseEnabled] == "true"
+func (s *Sandbox) IsRecycleEnabled() bool {
+	return s.Sandbox.Annotations[agentsv1alpha1.AnnotationCleanupEnabled] == "true"
 }
 
 func (s *Sandbox) Phase() string {

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
@@ -1200,7 +1200,7 @@ func TestSandbox_CSIMount(t *testing.T) {
 	}
 }
 
-func TestSandbox_TriggerReuse(t *testing.T) {
+func TestSandbox_TriggerRecycle(t *testing.T) {
 	tests := []struct {
 		name               string
 		initialAnnotations map[string]string
@@ -1252,18 +1252,18 @@ func TestSandbox_TriggerReuse(t *testing.T) {
 			}
 			s := AsSandbox(sbx, provider)
 
-			err := s.TriggerReuse(t.Context())
+			err := s.TriggerRecycle(t.Context())
 			if tt.expectError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectError)
 			} else {
 				require.NoError(t, err)
 				// Verify annotation is set on the in-memory object
-				assert.Equal(t, "true", s.Sandbox.Annotations[v1alpha1.AnnotationReuse])
+				assert.Equal(t, "true", s.Sandbox.Annotations[v1alpha1.AnnotationCleanup])
 				// Verify annotation is persisted to the fake client
 				var stored v1alpha1.Sandbox
 				require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: sbx.Namespace, Name: sbx.Name}, &stored))
-				assert.Equal(t, "true", stored.Annotations[v1alpha1.AnnotationReuse])
+				assert.Equal(t, "true", stored.Annotations[v1alpha1.AnnotationCleanup])
 				// Verify existing annotations are preserved
 				for k, v := range tt.initialAnnotations {
 					assert.Equal(t, v, stored.Annotations[k])

--- a/pkg/sandbox-manager/infra/types.go
+++ b/pkg/sandbox-manager/infra/types.go
@@ -79,7 +79,7 @@ type ClaimSandboxOptions struct {
 	SpeculateCreatingDuration time.Duration `json:"speculateCreatingDuration"`
 	// UserMetadataKeys records the keys of user-specified labels/annotations
 	// added during claim (from SandboxClaim.Spec or E2B request). Used by the
-	// reuse flow to clean up user metadata when returning the sandbox to the pool.
+	// cleanup flow to clean up user metadata when returning the sandbox to the pool.
 	UserMetadataKeys *v1alpha1.UpdatedMetadataInClaim `json:"-"`
 }
 

--- a/pkg/sandbox-manager/metrics.go
+++ b/pkg/sandbox-manager/metrics.go
@@ -85,21 +85,21 @@ var (
 		[]string{"namespace"},
 	)
 
-	// sandboxReuseResponses tracks total reuse requests and their results
-	sandboxReuseResponses = prometheus.NewCounterVec(
+	// sandboxRecycleResponses tracks total recycle requests and their results
+	sandboxRecycleResponses = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name:        "sandbox_reuse_responses",
-			Help:        "Total number of sandbox reuse requests and their results",
+			Name:        "sandbox_recycle_responses",
+			Help:        "Total number of sandbox recycle requests and their results",
 			ConstLabels: prometheus.Labels{"source": "e2b"},
 		},
 		[]string{"namespace", "result"},
 	)
 
-	// sandboxReuseDuration tracks the time of sandbox reuse trigger operations
-	sandboxReuseDuration = prometheus.NewHistogramVec(
+	// sandboxRecycleDuration tracks the time of sandbox recycle trigger operations
+	sandboxRecycleDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:        "sandbox_reuse_duration_seconds",
-			Help:        "Duration of sandbox reuse trigger operations in seconds",
+			Name:        "sandbox_recycle_duration_seconds",
+			Help:        "Duration of sandbox recycle trigger operations in seconds",
 			ConstLabels: prometheus.Labels{"source": "e2b"},
 			Buckets:     prometheus.ExponentialBuckets(0.02, 2, 12), // 20ms -> ~41s
 		},
@@ -202,13 +202,13 @@ func init() {
 	metrics.Registry.MustRegister(sandboxClaimCreationResponses,
 		sandboxPauseDuration, sandboxPauseResponses,
 		sandboxResumeDuration, sandboxResumeResponses,
-		sandboxDeleteResponses, sandboxReuseResponses,
+		sandboxDeleteResponses, sandboxRecycleResponses,
 		// Claim
 		sandboxClaimDuration, sandboxClaimTotal, sandboxClaimRetries,
 		// Clone
 		sandboxCloneDuration, sandboxCloneTotal,
-		// Delete & Reuse duration
-		sandboxDeleteDuration, sandboxReuseDuration,
+		// Delete & Recycle duration
+		sandboxDeleteDuration, sandboxRecycleDuration,
 		// Route sync
 		sandboxRouteSyncDuration, sandboxRouteSyncTotal,
 	)

--- a/test/e2e/sandbox_recycle_test.go
+++ b/test/e2e/sandbox_recycle_test.go
@@ -32,7 +32,7 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 )
 
-var _ = Describe("Sandbox Reuse", func() {
+var _ = Describe("Sandbox Recycle", func() {
 	var (
 		ctx        = context.Background()
 		namespace  string
@@ -43,7 +43,7 @@ var _ = Describe("Sandbox Reuse", func() {
 		namespace = createNamespace(ctx)
 		sandboxSet = &agentsv1alpha1.SandboxSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("reuse-pool-%d", time.Now().UnixNano()),
+				Name:      fmt.Sprintf("recycle-pool-%d", time.Now().UnixNano()),
 				Namespace: namespace,
 			},
 			Spec: agentsv1alpha1.SandboxSetSpec{
@@ -112,16 +112,16 @@ var _ = Describe("Sandbox Reuse", func() {
 		}, time.Second*10, time.Second).Should(Succeed())
 	}
 
-	// triggerReuse patches the sandbox to trigger reuse.
-	triggerReuse := func(sbx *agentsv1alpha1.Sandbox) {
+	// triggerRecycle patches the sandbox to trigger recycle.
+	triggerRecycle := func(sbx *agentsv1alpha1.Sandbox) {
 		Eventually(func() error {
 			latest := &agentsv1alpha1.Sandbox{}
 			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), latest); err != nil {
 				return err
 			}
 			patch := client.MergeFrom(latest.DeepCopy())
-			latest.Annotations[agentsv1alpha1.AnnotationReuseEnabled] = "true"
-			latest.Annotations[agentsv1alpha1.AnnotationReuse] = "true"
+			latest.Annotations[agentsv1alpha1.AnnotationCleanupEnabled] = "true"
+			latest.Annotations[agentsv1alpha1.AnnotationCleanup] = "true"
 			return k8sClient.Patch(ctx, latest, patch)
 		}, time.Second*10, time.Second).Should(Succeed())
 	}
@@ -147,20 +147,20 @@ var _ = Describe("Sandbox Reuse", func() {
 		return k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), &agentsv1alpha1.Sandbox{}) != nil
 	}
 
-	// triggerReuseAndFail triggers reuse while removing the pool label in a
-	// single atomic patch, so doReuse fails immediately with "no sandbox-pool
-	// label". This avoids any race with the noopSandboxReuser completing
-	// the reuse before we can inject a failure.
+	// triggerRecycleAndFail triggers recycle while removing the pool label in a
+	// single atomic patch, so doRecycle fails immediately with "no sandbox-pool
+	// label". This avoids any race with the noopSandboxRecycler completing
+	// the recycle before we can inject a failure.
 	//
 	// When the sandbox has no retain-on-failure annotation, the controller
-	// sets the ReuseFailed condition and deletes the sandbox in the same
+	// sets the RecycleFailed condition and deletes the sandbox in the same
 	// reconcile cycle. The condition is only observable for a few milliseconds
 	// before the sandbox is gone. To handle this race, we treat a deleted
-	// sandbox as equivalent to observing the ReuseFailed condition — both
-	// indicate the reuse failed. Tests that set a valid retain duration will
+	// sandbox as equivalent to observing the RecycleFailed condition — both
+	// indicate the recycle failed. Tests that set a valid retain duration will
 	// still see the condition because the sandbox is retained.
-	triggerReuseAndFail := func(target *agentsv1alpha1.Sandbox) {
-		By("Triggering reuse with pool label removed to force failure")
+	triggerRecycleAndFail := func(target *agentsv1alpha1.Sandbox) {
+		By("Triggering recycle with pool label removed to force failure")
 		Eventually(func() error {
 			latest := &agentsv1alpha1.Sandbox{}
 			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(target), latest); err != nil {
@@ -171,30 +171,30 @@ var _ = Describe("Sandbox Reuse", func() {
 			if latest.Annotations == nil {
 				latest.Annotations = map[string]string{}
 			}
-			latest.Annotations[agentsv1alpha1.AnnotationReuseEnabled] = "true"
-			latest.Annotations[agentsv1alpha1.AnnotationReuse] = "true"
+			latest.Annotations[agentsv1alpha1.AnnotationCleanupEnabled] = "true"
+			latest.Annotations[agentsv1alpha1.AnnotationCleanup] = "true"
 			return k8sClient.Patch(ctx, latest, patch)
 		}, time.Second*10, time.Second).Should(Succeed())
 
-		By("Waiting for reuse condition to show failure")
+		By("Waiting for recycle condition to show failure")
 		Eventually(func() string {
 			latest := &agentsv1alpha1.Sandbox{}
 			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(target), latest); err != nil {
-				// Sandbox already deleted — reuse failed and was cleaned up
+				// Sandbox already deleted — recycle failed and was recycled up
 				// in the same reconcile cycle before we could observe the
-				// transient ReuseFailed condition.
-				return agentsv1alpha1.SandboxReusingReasonFailed
+				// transient RecycleFailed condition.
+				return agentsv1alpha1.SandboxRecyclingReasonFailed
 			}
 			for _, c := range latest.Status.Conditions {
-				if c.Type == string(agentsv1alpha1.SandboxConditionReusing) {
+				if c.Type == string(agentsv1alpha1.SandboxConditionRecycling) {
 					return c.Reason
 				}
 			}
 			return ""
-		}, time.Second*30, time.Second).Should(Equal(agentsv1alpha1.SandboxReusingReasonFailed))
+		}, time.Second*30, time.Second).Should(Equal(agentsv1alpha1.SandboxRecyclingReasonFailed))
 	}
 
-	Context("Successful reuse", func() {
+	Context("Successful recycle", func() {
 		It("should return sandbox to pool with metadata matching baseline sandbox", func() {
 			sandboxes := listPoolSandboxes()
 			Expect(sandboxes).To(HaveLen(2))
@@ -205,14 +205,14 @@ var _ = Describe("Sandbox Reuse", func() {
 			By("Simulating a claim on the target sandbox")
 			simulateClaim(target)
 
-			By("Triggering reuse on the target sandbox")
-			triggerReuse(target)
+			By("Triggering recycle on the target sandbox")
+			triggerRecycle(target)
 
-			By("Waiting for sandbox to enter Reusing phase")
+			By("Waiting for sandbox to enter Recycling phase")
 			Eventually(func() agentsv1alpha1.SandboxPhase {
 				_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(target), target)
 				return target.Status.Phase
-			}, time.Minute, time.Second).Should(Equal(agentsv1alpha1.SandboxReusing))
+			}, time.Minute, time.Second).Should(Equal(agentsv1alpha1.SandboxRecycling))
 
 			By("Waiting for sandbox to return to Running phase")
 			Eventually(func() agentsv1alpha1.SandboxPhase {
@@ -224,10 +224,10 @@ var _ = Describe("Sandbox Reuse", func() {
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(baseline), baseline)).To(Succeed())
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(target), target)).To(Succeed())
 
-			By("Verifying ReuseCount is incremented")
-			Expect(target.Status.ReuseCount).To(Equal(int32(1)))
+			By("Verifying RecycledCount is incremented")
+			Expect(target.Status.RecycledCount).To(Equal(int32(1)))
 
-			By("Verifying target labels match baseline (except ReuseCount in status)")
+			By("Verifying target labels match baseline (except RecycledCount in status)")
 			Expect(target.Labels[agentsv1alpha1.LabelSandboxIsClaimed]).To(Equal(baseline.Labels[agentsv1alpha1.LabelSandboxIsClaimed]))
 			Expect(target.Labels[agentsv1alpha1.LabelSandboxIsClaimed]).To(Equal("false"))
 			Expect(target.Labels[agentsv1alpha1.LabelSandboxPool]).To(Equal(baseline.Labels[agentsv1alpha1.LabelSandboxPool]))
@@ -238,8 +238,8 @@ var _ = Describe("Sandbox Reuse", func() {
 			Expect(target.Annotations).NotTo(HaveKey(agentsv1alpha1.AnnotationLock))
 			Expect(target.Annotations).NotTo(HaveKey(agentsv1alpha1.AnnotationOwner))
 			Expect(target.Annotations).NotTo(HaveKey(agentsv1alpha1.AnnotationClaimTime))
-			Expect(target.Annotations).NotTo(HaveKey(agentsv1alpha1.AnnotationReuse))
-			Expect(target.Annotations).NotTo(HaveKey(agentsv1alpha1.AnnotationReuseRetainOnFailure))
+			Expect(target.Annotations).NotTo(HaveKey(agentsv1alpha1.AnnotationCleanup))
+			Expect(target.Annotations).NotTo(HaveKey(agentsv1alpha1.AnnotationCleanupRetainOnFailure))
 			Expect(target.Annotations).NotTo(HaveKey(agentsv1alpha1.AnnotationInitRuntimeRequest))
 			Expect(target.Annotations).NotTo(HaveKey(agentsv1alpha1.AnnotationRuntimeAccessToken))
 			Expect(target.Annotations).NotTo(HaveKey(agentsv1alpha1.AnnotationUpdatedMetadataInClaim))
@@ -256,14 +256,14 @@ var _ = Describe("Sandbox Reuse", func() {
 		})
 	})
 
-	Context("Reuse failure", func() {
+	Context("Recycling failure", func() {
 		It("should delete sandbox immediately when reset fails without retain annotation", func() {
 			sandboxes := listPoolSandboxes()
 			Expect(sandboxes).To(HaveLen(2))
 			target := &sandboxes[0]
 
-			By("Triggering reuse without any retain-on-failure annotation")
-			triggerReuseAndFail(target)
+			By("Triggering recycle without any retain-on-failure annotation")
+			triggerRecycleAndFail(target)
 
 			By("Verifying sandbox is deleted immediately")
 			Eventually(func() bool {
@@ -277,9 +277,9 @@ var _ = Describe("Sandbox Reuse", func() {
 			target := &sandboxes[0]
 
 			By("Setting invalid retain-on-failure annotation")
-			setAnnotation(target, agentsv1alpha1.AnnotationReuseRetainOnFailure, "not-a-duration")
+			setAnnotation(target, agentsv1alpha1.AnnotationCleanupRetainOnFailure, "not-a-duration")
 
-			triggerReuseAndFail(target)
+			triggerRecycleAndFail(target)
 
 			By("Verifying sandbox is deleted immediately")
 			Eventually(func() bool {
@@ -293,9 +293,9 @@ var _ = Describe("Sandbox Reuse", func() {
 			target := &sandboxes[0]
 
 			By("Setting valid retain-on-failure annotation")
-			setAnnotation(target, agentsv1alpha1.AnnotationReuseRetainOnFailure, "5m")
+			setAnnotation(target, agentsv1alpha1.AnnotationCleanupRetainOnFailure, "5m")
 
-			triggerReuseAndFail(target)
+			triggerRecycleAndFail(target)
 
 			By("Verifying ShutdownTime is set")
 			Eventually(func() bool {
@@ -313,9 +313,9 @@ var _ = Describe("Sandbox Reuse", func() {
 			target := &sandboxes[0]
 
 			By("Setting short retain-on-failure annotation")
-			setAnnotation(target, agentsv1alpha1.AnnotationReuseRetainOnFailure, "10s")
+			setAnnotation(target, agentsv1alpha1.AnnotationCleanupRetainOnFailure, "10s")
 
-			triggerReuseAndFail(target)
+			triggerRecycleAndFail(target)
 
 			By("Waiting for ShutdownTime to be set")
 			Eventually(func() bool {
@@ -329,7 +329,7 @@ var _ = Describe("Sandbox Reuse", func() {
 			}, time.Second*60, time.Second).Should(BeTrue())
 		})
 
-		It("should fail reuse when template-hash does not match SandboxSet updateRevision", func() {
+		It("should fail recycle when template-hash does not match SandboxSet updateRevision", func() {
 			sandboxes := listPoolSandboxes()
 			Expect(sandboxes).To(HaveLen(2))
 			target := &sandboxes[0]
@@ -370,8 +370,8 @@ var _ = Describe("Sandbox Reuse", func() {
 				return sandboxSet.Status.UpdateRevision != "" && sandboxSet.Status.UpdateRevision != originalHash
 			}, time.Minute, time.Second).Should(BeTrue())
 
-			By("Triggering reuse on the target sandbox with outdated template-hash")
-			triggerReuse(target)
+			By("Triggering recycle on the target sandbox with outdated template-hash")
+			triggerRecycle(target)
 
 			By("Verifying sandbox is deleted due to template-hash mismatch")
 			Eventually(func() bool {
@@ -382,12 +382,12 @@ var _ = Describe("Sandbox Reuse", func() {
 })
 
 // This suite covers the CSI reset-signal write that runs before a sandbox is
-// returned to the pool. Unlike the reuse suite above (which uses the noop reuser
+// returned to the pool. Unlike the recycle suite above (which uses the noop recycler
 // and a bare nginx pod), it needs a pod running the real agent-runtime (envd)
 // sidecar, because the controller writes the reset signal through the
 // agent-runtime files API. It requires the controller to be started with
 // --csi-reset-signal-dir and the agent-runtime image to be available in-cluster.
-var _ = Describe("Sandbox Reuse CSI Reset Signal", func() {
+var _ = Describe("Sandbox Recycle CSI Reset Signal", func() {
 	var (
 		ctx        = context.Background()
 		namespace  string
@@ -399,7 +399,7 @@ var _ = Describe("Sandbox Reuse CSI Reset Signal", func() {
 		alwaysRestart := corev1.ContainerRestartPolicyAlways
 		sandboxSet = &agentsv1alpha1.SandboxSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("reuse-csi-pool-%d", time.Now().UnixNano()),
+				Name:      fmt.Sprintf("recycle-csi-pool-%d", time.Now().UnixNano()),
 				Namespace: namespace,
 			},
 			Spec: agentsv1alpha1.SandboxSetSpec{
@@ -473,7 +473,7 @@ var _ = Describe("Sandbox Reuse CSI Reset Signal", func() {
 		Expect(list.Items).To(HaveLen(1))
 		target := &list.Items[0]
 
-		By("Marking the sandbox as carrying a CSI mount and triggering reuse")
+		By("Marking the sandbox as carrying a CSI mount and triggering recycle")
 		Eventually(func() error {
 			latest := &agentsv1alpha1.Sandbox{}
 			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(target), latest); err != nil {
@@ -484,21 +484,21 @@ var _ = Describe("Sandbox Reuse CSI Reset Signal", func() {
 				latest.Annotations = map[string]string{}
 			}
 			latest.Annotations[agentsv1alpha1.AnnotationCSIVolumeConfig] = `[{"mountPath":"/data"}]`
-			latest.Annotations[agentsv1alpha1.AnnotationReuseEnabled] = "true"
-			latest.Annotations[agentsv1alpha1.AnnotationReuse] = "true"
+			latest.Annotations[agentsv1alpha1.AnnotationCleanupEnabled] = "true"
+			latest.Annotations[agentsv1alpha1.AnnotationCleanup] = "true"
 			return k8sClient.Patch(ctx, latest, patch)
 		}, time.Second*10, time.Second).Should(Succeed())
 
-		// Reuse only succeeds if the controller wrote the reset-signal file into
+		// Recycle only succeeds if the controller wrote the reset-signal file into
 		// the sandbox through the agent-runtime files API. A failed write is a
-		// permanent reuse failure that deletes the sandbox, so observing a
-		// successful reuse (sandbox back in the pool with ReuseCount incremented)
+		// permanent recycle failure that deletes the sandbox, so observing a
+		// successful recycle (sandbox back in the pool with RecycledCount incremented)
 		// proves the write link works end to end.
-		By("Waiting for the sandbox to return to Running with ReuseCount incremented")
+		By("Waiting for the sandbox to return to Running with RecycledCount incremented")
 		Eventually(func(g Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(target), target)).To(Succeed())
 			g.Expect(target.Status.Phase).To(Equal(agentsv1alpha1.SandboxRunning))
-			g.Expect(target.Status.ReuseCount).To(Equal(int32(1)))
+			g.Expect(target.Status.RecycledCount).To(Equal(int32(1)))
 		}, time.Minute*2, time.Second).Should(Succeed())
 	})
 })

--- a/test/e2e/sandboxclaim_test.go
+++ b/test/e2e/sandboxclaim_test.go
@@ -1539,7 +1539,7 @@ var _ = Describe("SandboxClaim", func() {
 		})
 	})
 
-	Context("Cleanup and deletion", func() {
+	Context("Recycling and deletion", func() {
 		var (
 			sandboxSet   *agentsv1alpha1.SandboxSet
 			sandboxClaim *agentsv1alpha1.SandboxClaim
@@ -2357,7 +2357,7 @@ var _ = Describe("SandboxClaim", func() {
 				Expect(sandbox.Annotations).To(HaveKeyWithValue("git-sha", "abc123"))
 			})
 
-			It("should not reuse sandboxes from previous claim with same name", func() {
+			It("should not cleanup sandboxes from previous claim with same name", func() {
 				By("Creating a SandboxClaim and waiting for completion")
 				firstClaimName := fmt.Sprintf("test-claim-recreate-%d", time.Now().UnixNano())
 				sandboxClaim = &agentsv1alpha1.SandboxClaim{
@@ -2484,7 +2484,7 @@ var _ = Describe("SandboxClaim", func() {
 				// No overlap between first and second claim sandboxes
 				for _, newName := range secondClaimSandboxNames {
 					Expect(firstClaimSandboxNames).NotTo(ContainElement(newName),
-						"Second claim should NOT reuse sandboxes from first claim")
+						"Second claim should NOT cleanup sandboxes from first claim")
 				}
 
 				By("Verifying both sets of sandboxes exist simultaneously")


### PR DESCRIPTION
## Summary
- Rename the sandbox "reuse" concept to "cleanup" across API types, controllers, sandbox-manager, metrics, and tests for clearer semantics.
- API changes: `ReuseCount` → `CleanupCount`, `SandboxReusing` phase → `SandboxCleanup`, `SandboxConditionReusing` → `SandboxConditionCleanup`, and the corresponding condition reasons.
- Annotation keys renamed: `reuse-enabled` → `cleanup-enabled`, `reuse` → `cleanup`, `reuse-retain-on-failure` → `cleanup-retain-on-failure`; `AnnotationsClearedOnReuse` → `AnnotationsClearedOnCleanup`.
- Regenerated CRD manifests and renamed related source/test files (`reuse.go` → `cleanup.go`, `sandbox_reuse_test.go` → `sandbox_cleanup_test.go`).

## Test plan
- [ ] `go test ./pkg/controller/sandbox/... ./pkg/controller/sandboxset/... ./pkg/sandbox-manager/...`
- [ ] `make manifests` produces no further diff