### PR TITLE
Normalize invalid gateway server ports to the default port

### DIFF
--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -55,6 +55,13 @@ func getMemberlistBindPort() int {
 	return config.DefaultMemberlistBindPort
 }
 
+func normalizePort(port int, defaultPort int) int {
+	if port <= 0 {
+		return defaultPort
+	}
+	return port
+}
+
 // Server handles peer-to-peer communication for route synchronization
 type Server struct {
 	httpServer         *http.Server
@@ -66,11 +73,8 @@ type Server struct {
 
 // NewServer creates a new peer server
 func NewServer(client client.Client, port int) *Server {
-	if port == 0 {
-		port = proxy.SystemPort
-	}
 	return &Server{
-		port:               port,
+		port:               normalizePort(port, proxy.SystemPort),
 		client:             client,
 		memberlistBindPort: getMemberlistBindPort(),
 	}
@@ -82,7 +86,7 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc(proxy.RefreshAPI, s.handleRefresh)
 
 	s.httpServer = &http.Server{
-		Addr:              fmt.Sprintf(":%d", s.port),
+		Addr:              fmt.Sprintf(":%d", normalizePort(s.port, proxy.SystemPort)),
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}

--- a/pkg/sandbox-gateway/server/server_test.go
+++ b/pkg/sandbox-gateway/server/server_test.go
@@ -104,6 +104,12 @@ func TestNewServer(t *testing.T) {
 			wantBindPort: config.DefaultMemberlistBindPort,
 		},
 		{
+			name:         "with negative port uses default",
+			port:         -1,
+			wantPort:     proxy.SystemPort,
+			wantBindPort: config.DefaultMemberlistBindPort,
+		},
+		{
 			name:         "with custom memberlist port from env",
 			port:         8080,
 			wantPort:     8080,


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

This PR fixes a bug in the sandbox gateway server where negative or non-positive port values were accepted instead of falling back to the default system port.

The change normalizes the configured port during server creation and startup so invalid values no longer cause bind/listen issues later. It also adds regression tests covering zero and negative port handling.

## Ⅱ. Does this pull request fix one issue?

fixes #<issue-number>

## Ⅲ. Describe how to verify it

Run the following test:

```bash
go test -v ./pkg/sandbox-gateway/server -count=1
```

This verifies the new regression tests and the existing gateway server behavior.

## Ⅳ. Special notes for reviews

- The change is intentionally small and focused on port normalization.
- It keeps the behavior consistent with the existing memberlist port handling, which already falls back to the default when the configured value is invalid.
