### PR TITLE
fix:TrafficPolicy Add Validation

### DIFF
--- a/api/v1alpha1/trafficpolicy_types.go
+++ b/api/v1alpha1/trafficpolicy_types.go
@@ -59,6 +59,8 @@ type TrafficPolicyWorkloadRef struct {
 	// +kubebuilder:validation:MaxLength=63
 	Namespace string `json:"namespace"`
 	// Selector is a label selector that matches the target pods.
+	//
+	// +kubebuilder:validation:MaxProperties=10
 	Selector map[string]string `json:"selector"`
 }
 
@@ -71,6 +73,7 @@ type TrafficPolicyPeer struct {
 	//
 	// +optional
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=43
 	CIDR string `json:"cidr,omitempty"`
 	// FQDN is a fully qualified domain name to match (e.g. "api.example.com").
 	//
@@ -126,17 +129,20 @@ type TrafficPolicyRule struct {
 	//
 	// +optional
 	// +listType=atomic
+	// +kubebuilder:validation:MaxItems=20
 	From []TrafficPolicyPeer `json:"from,omitempty"`
 	// To lists destination peers. Multiple entries are ORed.
 	//
 	// +optional
 	// +listType=atomic
+	// +kubebuilder:validation:MaxItems=20
 	To []TrafficPolicyPeer `json:"to,omitempty"`
 	// Ports restricts this rule to specific L4 protocol/port combinations.
 	// Multiple entries are ORed. If empty, the rule matches all ports.
 	//
 	// +optional
 	// +listType=atomic
+	// +kubebuilder:validation:MaxItems=20
 	Ports []TrafficPolicyPort `json:"ports,omitempty"`
 }
 
@@ -148,6 +154,7 @@ type TrafficPolicyDirection struct {
 	//
 	// +optional
 	// +listType=atomic
+	// +kubebuilder:validation:MaxItems=50
 	Rules []TrafficPolicyRule `json:"rules,omitempty"`
 }
 
@@ -198,6 +205,7 @@ type TrafficPolicyStatus struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=type
+	// +kubebuilder:validation:MaxItems=20
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/config/crd/bases/agents.kruise.io_globaltrafficpolicies.yaml
+++ b/config/crd/bases/agents.kruise.io_globaltrafficpolicies.yaml
@@ -80,6 +80,7 @@ spec:
                               cidr:
                                 description: CIDR is an IP address range in CIDR notation
                                   (e.g. "10.0.0.0/8").
+                                maxLength: 43
                                 minLength: 1
                                 type: string
                               fqdn:
@@ -122,6 +123,7 @@ spec:
                                       type: string
                                     description: Selector is a label selector that
                                       matches the target pods.
+                                    maxProperties: 10
                                     type: object
                                 required:
                                 - namespace
@@ -133,6 +135,7 @@ spec:
                                 must be set
                               rule: '[has(self.cidr), has(self.fqdn), has(self.service),
                                 has(self.workload)].filter(x, x).size() == 1'
+                          maxItems: 20
                           type: array
                           x-kubernetes-list-type: atomic
                         ports:
@@ -174,6 +177,7 @@ spec:
                               rule: '!has(self.endPort) || has(self.port)'
                             - message: endPort must be greater than or equal to port
                               rule: '!has(self.endPort) || self.endPort >= self.port'
+                          maxItems: 20
                           type: array
                           x-kubernetes-list-type: atomic
                         to:
@@ -187,6 +191,7 @@ spec:
                               cidr:
                                 description: CIDR is an IP address range in CIDR notation
                                   (e.g. "10.0.0.0/8").
+                                maxLength: 43
                                 minLength: 1
                                 type: string
                               fqdn:
@@ -229,6 +234,7 @@ spec:
                                       type: string
                                     description: Selector is a label selector that
                                       matches the target pods.
+                                    maxProperties: 10
                                     type: object
                                 required:
                                 - namespace
@@ -240,11 +246,13 @@ spec:
                                 must be set
                               rule: '[has(self.cidr), has(self.fqdn), has(self.service),
                                 has(self.workload)].filter(x, x).size() == 1'
+                          maxItems: 20
                           type: array
                           x-kubernetes-list-type: atomic
                       required:
                       - action
                       type: object
+                    maxItems: 50
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
@@ -279,6 +287,7 @@ spec:
                               cidr:
                                 description: CIDR is an IP address range in CIDR notation
                                   (e.g. "10.0.0.0/8").
+                                maxLength: 43
                                 minLength: 1
                                 type: string
                               fqdn:
@@ -321,6 +330,7 @@ spec:
                                       type: string
                                     description: Selector is a label selector that
                                       matches the target pods.
+                                    maxProperties: 10
                                     type: object
                                 required:
                                 - namespace
@@ -332,6 +342,7 @@ spec:
                                 must be set
                               rule: '[has(self.cidr), has(self.fqdn), has(self.service),
                                 has(self.workload)].filter(x, x).size() == 1'
+                          maxItems: 20
                           type: array
                           x-kubernetes-list-type: atomic
                         ports:
@@ -373,6 +384,7 @@ spec:
                               rule: '!has(self.endPort) || has(self.port)'
                             - message: endPort must be greater than or equal to port
                               rule: '!has(self.endPort) || self.endPort >= self.port'
+                          maxItems: 20
                           type: array
                           x-kubernetes-list-type: atomic
                         to:
@@ -386,6 +398,7 @@ spec:
                               cidr:
                                 description: CIDR is an IP address range in CIDR notation
                                   (e.g. "10.0.0.0/8").
+                                maxLength: 43
                                 minLength: 1
                                 type: string
                               fqdn:
@@ -428,6 +441,7 @@ spec:
                                       type: string
                                     description: Selector is a label selector that
                                       matches the target pods.
+                                    maxProperties: 10
                                     type: object
                                 required:
                                 - namespace
@@ -439,11 +453,13 @@ spec:
                                 must be set
                               rule: '[has(self.cidr), has(self.fqdn), has(self.service),
                                 has(self.workload)].filter(x, x).size() == 1'
+                          maxItems: 20
                           type: array
                           x-kubernetes-list-type: atomic
                       required:
                       - action
                       type: object
+                    maxItems: 50
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
@@ -573,6 +589,7 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 20
                 type: array
                 x-kubernetes-list-map-keys:
                 - type

--- a/config/crd/bases/agents.kruise.io_trafficpolicies.yaml
+++ b/config/crd/bases/agents.kruise.io_trafficpolicies.yaml
@@ -81,6 +81,7 @@ spec:
                               cidr:
                                 description: CIDR is an IP address range in CIDR notation
                                   (e.g. "10.0.0.0/8").
+                                maxLength: 43
                                 minLength: 1
                                 type: string
                               fqdn:
@@ -123,6 +124,7 @@ spec:
                                       type: string
                                     description: Selector is a label selector that
                                       matches the target pods.
+                                    maxProperties: 10
                                     type: object
                                 required:
                                 - namespace
@@ -134,6 +136,7 @@ spec:
                                 must be set
                               rule: '[has(self.cidr), has(self.fqdn), has(self.service),
                                 has(self.workload)].filter(x, x).size() == 1'
+                          maxItems: 20
                           type: array
                           x-kubernetes-list-type: atomic
                         ports:
@@ -175,6 +178,7 @@ spec:
                               rule: '!has(self.endPort) || has(self.port)'
                             - message: endPort must be greater than or equal to port
                               rule: '!has(self.endPort) || self.endPort >= self.port'
+                          maxItems: 20
                           type: array
                           x-kubernetes-list-type: atomic
                         to:
@@ -188,6 +192,7 @@ spec:
                               cidr:
                                 description: CIDR is an IP address range in CIDR notation
                                   (e.g. "10.0.0.0/8").
+                                maxLength: 43
                                 minLength: 1
                                 type: string
                               fqdn:
@@ -230,6 +235,7 @@ spec:
                                       type: string
                                     description: Selector is a label selector that
                                       matches the target pods.
+                                    maxProperties: 10
                                     type: object
                                 required:
                                 - namespace
@@ -241,11 +247,13 @@ spec:
                                 must be set
                               rule: '[has(self.cidr), has(self.fqdn), has(self.service),
                                 has(self.workload)].filter(x, x).size() == 1'
+                          maxItems: 20
                           type: array
                           x-kubernetes-list-type: atomic
                       required:
                       - action
                       type: object
+                    maxItems: 50
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
@@ -280,6 +288,7 @@ spec:
                               cidr:
                                 description: CIDR is an IP address range in CIDR notation
                                   (e.g. "10.0.0.0/8").
+                                maxLength: 43
                                 minLength: 1
                                 type: string
                               fqdn:
@@ -322,6 +331,7 @@ spec:
                                       type: string
                                     description: Selector is a label selector that
                                       matches the target pods.
+                                    maxProperties: 10
                                     type: object
                                 required:
                                 - namespace
@@ -333,6 +343,7 @@ spec:
                                 must be set
                               rule: '[has(self.cidr), has(self.fqdn), has(self.service),
                                 has(self.workload)].filter(x, x).size() == 1'
+                          maxItems: 20
                           type: array
                           x-kubernetes-list-type: atomic
                         ports:
@@ -374,6 +385,7 @@ spec:
                               rule: '!has(self.endPort) || has(self.port)'
                             - message: endPort must be greater than or equal to port
                               rule: '!has(self.endPort) || self.endPort >= self.port'
+                          maxItems: 20
                           type: array
                           x-kubernetes-list-type: atomic
                         to:
@@ -387,6 +399,7 @@ spec:
                               cidr:
                                 description: CIDR is an IP address range in CIDR notation
                                   (e.g. "10.0.0.0/8").
+                                maxLength: 43
                                 minLength: 1
                                 type: string
                               fqdn:
@@ -429,6 +442,7 @@ spec:
                                       type: string
                                     description: Selector is a label selector that
                                       matches the target pods.
+                                    maxProperties: 10
                                     type: object
                                 required:
                                 - namespace
@@ -440,11 +454,13 @@ spec:
                                 must be set
                               rule: '[has(self.cidr), has(self.fqdn), has(self.service),
                                 has(self.workload)].filter(x, x).size() == 1'
+                          maxItems: 20
                           type: array
                           x-kubernetes-list-type: atomic
                       required:
                       - action
                       type: object
+                    maxItems: 50
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
@@ -574,6 +590,7 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 20
                 type: array
                 x-kubernetes-list-map-keys:
                 - type


### PR DESCRIPTION
fix problem of openapi schema generation error, e.g. 
```
spec.validation.openAPIV3Schema.properties[spec].properties[ingress].properties[rules].items.properties[to].items.x-kubernetes-validations[0].rule: Forbidden: contributed to estimated rule cost total exceeding cost limit for entire OpenAPIv3 schema
```