### PR TITLE
feat(sandbox): emit event and set condition on pod creation failure

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -320,6 +320,7 @@ const (
 	SandboxReadyReasonInplaceUpdating      = "InplaceUpdating"
 	SandboxReadyReasonUpgrading            = "Upgrading"
 	SandboxReadyReasonStartContainerFailed = "StartContainerFailed"
+	SandboxReadyReasonPodCreateFailed      = "PodCreateFailed"
 
 	// SandboxConditionInplaceUpdate Reason
 	SandboxInplaceUpdateReasonInplaceUpdating = "InplaceUpdating"

--- a/pkg/controller/sandbox/core/pod_control.go
+++ b/pkg/controller/sandbox/core/pod_control.go
@@ -104,6 +104,18 @@ func (c *PodControl) CreatePod(ctx context.Context, args CreatePodArgs) (*corev1
 		ScaleExpectation.ObserveScale(GetControllerKey(box), expectations.Create, box.Name)
 		if !errors.IsAlreadyExists(err) {
 			klog.ErrorS(err, "create pod failed", "sandbox", klog.KObj(box))
+			// Emit Warning Event and set Ready condition to reflect the failure
+			// so that users can diagnose the root cause (e.g., invalid PVC, quota
+			// exceeded, etc.) without digging through controller logs.
+			c.recorder.Event(box, corev1.EventTypeWarning, agentsv1alpha1.SandboxReadyReasonPodCreateFailed,
+				fmt.Sprintf("Failed to create pod: %v", err))
+			utils.SetSandboxCondition(args.NewStatus, metav1.Condition{
+				Type:               string(agentsv1alpha1.SandboxConditionReady),
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: metav1.Now(),
+				Reason:             agentsv1alpha1.SandboxReadyReasonPodCreateFailed,
+				Message:            utils.TruncateConditionMessage(err.Error()),
+			})
 			return nil, err
 		}
 	}

--- a/pkg/controller/sandbox/core/pod_control_test.go
+++ b/pkg/controller/sandbox/core/pod_control_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/utils"
+)
+
+// simplePodGenFunc is a minimal PodGenerateFunc for testing that returns a
+// basic pod without requiring a full sandbox template.
+func simplePodGenFunc(_ context.Context, args PodGenerateArgs) (*corev1.Pod, error) {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      args.Box.Name,
+			Namespace: args.Box.Namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "main", Image: "nginx:latest"},
+			},
+		},
+	}, nil
+}
+
+func TestCreatePod(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	baseBox := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+		},
+	}
+
+	tests := []struct {
+		name          string
+		createErr     error // error returned by the fake client Create; nil means success
+		newStatus     *agentsv1alpha1.SandboxStatus
+		expectError   string
+		expectPod     bool   // whether a non-nil pod should be returned
+		expectEvent   bool   // whether a Warning event should be emitted
+		expectCond    bool   // whether a Ready=False condition should be set
+		expectReason  string // expected condition reason
+		expectMessage string // expected substring in condition message and event
+	}{
+		{
+			name:        "create succeeds - no event, no condition",
+			createErr:   nil,
+			newStatus:   &agentsv1alpha1.SandboxStatus{},
+			expectError: "",
+			expectPod:   true,
+			expectEvent: false,
+			expectCond:  false,
+		},
+		{
+			name:          "create fails with generic error - emits event and sets condition",
+			createErr:     fmt.Errorf("pvc test-pvc is invalid"),
+			newStatus:     &agentsv1alpha1.SandboxStatus{},
+			expectError:   "pvc test-pvc is invalid",
+			expectPod:     false,
+			expectEvent:   true,
+			expectCond:    true,
+			expectReason:  agentsv1alpha1.SandboxReadyReasonPodCreateFailed,
+			expectMessage: "pvc test-pvc is invalid",
+		},
+		{
+			name:        "create fails with AlreadyExists - no event, no condition, returns pod",
+			createErr:   apierrors.NewAlreadyExists(schema.GroupResource{Resource: "pods"}, "test-sandbox"),
+			newStatus:   &agentsv1alpha1.SandboxStatus{},
+			expectError: "",
+			expectPod:   true,
+			expectEvent: false,
+			expectCond:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fc client.Client
+			if tt.createErr != nil {
+				fc = fake.NewClientBuilder().WithScheme(scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+							return tt.createErr
+						},
+					}).Build()
+			} else {
+				fc = fake.NewClientBuilder().WithScheme(scheme).Build()
+			}
+
+			recorder := record.NewFakeRecorder(10)
+			podControl := NewPodControl(fc, recorder, simplePodGenFunc)
+
+			box := baseBox.DeepCopy()
+			args := CreatePodArgs{
+				Box:       box,
+				NewStatus: tt.newStatus,
+			}
+
+			pod, err := podControl.CreatePod(context.TODO(), args)
+
+			// Error assertion
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Pod assertion
+			if tt.expectPod {
+				assert.NotNil(t, pod)
+			} else {
+				assert.Nil(t, pod)
+			}
+
+			// Event assertion
+			if tt.expectEvent {
+				select {
+				case event := <-recorder.Events:
+					assert.Contains(t, event, "PodCreateFailed")
+					if tt.expectMessage != "" {
+						assert.Contains(t, event, tt.expectMessage)
+					}
+				default:
+					t.Error("expected a Warning event to be recorded")
+				}
+			} else {
+				select {
+				case <-recorder.Events:
+					t.Error("did not expect any event to be recorded")
+				default:
+					// expected - no event
+				}
+			}
+
+			// Condition assertion
+			if tt.expectCond {
+				require.NotNil(t, tt.newStatus, "NewStatus should not be nil when expecting condition")
+				cond := utils.GetSandboxCondition(tt.newStatus, string(agentsv1alpha1.SandboxConditionReady))
+				require.NotNil(t, cond, "expected Ready condition to be set")
+				assert.Equal(t, metav1.ConditionFalse, cond.Status)
+				assert.Equal(t, tt.expectReason, cond.Reason)
+				if tt.expectMessage != "" {
+					assert.Contains(t, cond.Message, tt.expectMessage)
+				}
+			} else {
+				cond := utils.GetSandboxCondition(tt.newStatus, string(agentsv1alpha1.SandboxConditionReady))
+				assert.Nil(t, cond, "did not expect Ready condition to be set")
+			}
+		})
+	}
+}

--- a/test/e2e/sandbox_test.go
+++ b/test/e2e/sandbox_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -476,6 +477,76 @@ var _ = Describe("Sandbox", func() {
 
 			// Clean up the failing sandbox
 			_ = k8sClient.Delete(ctx, failingSandbox)
+		})
+	})
+
+	Context("pod creation failure", func() {
+		It("should emit warning event and set Ready condition when pod creation fails", func() {
+			By("Creating a ResourceQuota that prevents pod creation")
+			quota := &corev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prevent-pods",
+					Namespace: namespace,
+				},
+				Spec: corev1.ResourceQuotaSpec{
+					Hard: corev1.ResourceList{
+						corev1.ResourcePods: resource.MustParse("0"),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, quota)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, quota)
+			}()
+
+			By("Creating a new Sandbox")
+			Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
+
+			By("Verifying sandbox reaches Pending phase")
+			Eventually(func() agentsv1alpha1.SandboxPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      sandbox.Name,
+					Namespace: sandbox.Namespace,
+				}, sandbox)
+				return sandbox.Status.Phase
+			}, time.Second*30, time.Millisecond*500).Should(Equal(agentsv1alpha1.SandboxPending))
+
+			By("Verifying sandbox stays in Pending phase (pod creation fails)")
+			Consistently(func() agentsv1alpha1.SandboxPhase {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      sandbox.Name,
+					Namespace: sandbox.Namespace,
+				}, sandbox)
+				return sandbox.Status.Phase
+			}, time.Second*10, time.Second*2).Should(Equal(agentsv1alpha1.SandboxPending))
+
+			By("Verifying Ready condition is set to False with PodCreateFailed reason")
+			Eventually(func(g Gomega) {
+				_ = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      sandbox.Name,
+					Namespace: sandbox.Namespace,
+				}, sandbox)
+				cond := utils.GetSandboxCondition(&sandbox.Status, string(agentsv1alpha1.SandboxConditionReady))
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(Equal(agentsv1alpha1.SandboxReadyReasonPodCreateFailed))
+			}, time.Second*30, time.Millisecond*500).Should(Succeed())
+
+			By("Verifying a warning event is emitted")
+			Eventually(func(g Gomega) {
+				events, err := clientset.CoreV1().Events(sandbox.Namespace).List(ctx, metav1.ListOptions{
+					FieldSelector: fmt.Sprintf("involvedObject.name=%s", sandbox.Name),
+				})
+				g.Expect(err).To(Succeed())
+				found := false
+				for _, event := range events.Items {
+					if event.Reason == "PodCreateFailed" && event.Type == corev1.EventTypeWarning {
+						found = true
+						break
+					}
+				}
+				g.Expect(found).To(BeTrue(), "expected a Warning event with reason PodCreateFailed")
+			}, time.Second*30, time.Millisecond*500).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

When sandbox pod creation fails (excluding AlreadyExists), the controller now:
- Emits a Warning Event with reason `PodCreateFailed` on the Sandbox object
- Sets the `Ready` condition to `False` with reason `PodCreateFailed` and the error message

This allows users to diagnose the root cause (e.g., invalid PVC, quota exceeded) directly from `kubectl describe sandbox` and `kubectl get events` without digging through controller logs.

Changes:
- Add `SandboxReadyReasonPodCreateFailed` constant in `api/v1alpha1/sandbox_types.go`
- Modify `CreatePod` in `pod_control.go` to emit Event + Condition on non-AlreadyExists errors
- Add unit tests in `pod_control_test.go` covering success, generic error, and AlreadyExists cases
- Add E2E test in `sandbox_test.go` verifying Event + Condition when pod creation is blocked by ResourceQuota

### Ⅱ. Does this pull request fix one issue?
NONE

### Ⅲ. Describe how to verify it
1. Run unit tests: `go test -mod=mod -run TestCreatePod -v ./pkg/controller/sandbox/core/`
2. E2E test: creates a ResourceQuota with `pods: "0"` to block pod creation, then verifies:
   - Sandbox stays in Pending phase
   - Ready condition = False with reason PodCreateFailed
   - Warning event with reason PodCreateFailed is emitted

### Ⅳ. Special notes for reviews
- The `AlreadyExists` error path is intentionally excluded — it means the pod already exists and is handled separately (returns the existing pod)
- All callers of `CreatePod` pass a non-nil `NewStatus` (traced back to `box.Status.DeepCopy()` in the reconciler), so no nil check is needed before calling `utils.SetSandboxCondition`
