### PR TITLE
refactor(identity): consume security metadata from sandbox annotations

### DIFF
--- a/pkg/identity/sandbox_token_helper.go
+++ b/pkg/identity/sandbox_token_helper.go
@@ -31,37 +31,47 @@ import (
 // identity provider issuance path.
 //
 // The opt-in signal is the presence of a non-empty
-// "security.agents.kruise.io/agent-name" label on the sandbox: setting this
-// label expresses the user's intent to bind the sandbox to a logical agent
-// identity, which is the precondition for the identity provider to mint a
-// security token. A nil sandbox, a sandbox without Labels, or one whose value
-// for that key is empty all collapse to "not requested", letting callers
+// "security.agents.kruise.io/agent-name" annotation on the sandbox: setting
+// this annotation expresses the user's intent to bind the sandbox to a logical
+// agent identity, which is the precondition for the identity provider to mint a
+// security token. A nil sandbox, a sandbox without Annotations, or one whose
+// value for that key is empty all collapse to "not requested", letting callers
 // short-circuit the issuance path without paying any provider cost.
 //
-// The check is intentionally label-only and value-presence-only: it does NOT
-// validate the label value against any naming convention, since the identity
+// The check is intentionally annotation-only and value-presence-only: it does
+// NOT validate the value against any naming convention, since the identity
 // provider is the authoritative source of truth for agent-name semantics.
 func IsIdentityProviderRequested(sbx *agentsv1alpha1.Sandbox) bool {
 	if sbx == nil {
 		return false
 	}
-	return sbx.GetLabels()[LabelAgentName] != ""
+	return sbx.GetAnnotations()[AnnotationAgentName] != ""
 }
 
-// ExtractSecurityMetadata returns a map containing only the sandbox labels
+// ExtractSecurityMetadata returns a map containing only the sandbox annotations
 // whose keys are prefixed with SecurityMetadataPrefix. Providers that want to
-// include security labels in token issuance requests should call this helper
+// include security metadata in token issuance requests should call this helper
 // instead of re-implementing the prefix filter.
 //
 // A nil sandbox results in a nil map. The returned map is never nil when the
-// sandbox is non-nil, even if no matching labels exist, so providers can safely
-// iterate over it.
+// sandbox is non-nil, even if no matching annotations exist, so providers can
+// safely iterate over it.
 func ExtractSecurityMetadata(sbx *agentsv1alpha1.Sandbox) map[string]string {
 	if sbx == nil {
 		return nil
 	}
+	return ExtractSecurityMetadataFromMap(sbx.GetAnnotations())
+}
+
+// ExtractSecurityMetadataFromMap returns a new map containing only the entries
+// of in whose keys are prefixed with SecurityMetadataPrefix. It is the single
+// source of truth for the security-prefix filter, shared by the
+// Sandbox-annotations path (ExtractSecurityMetadata) and caller-supplied inputs
+// such as the E2B API request. The returned map is never nil, so callers can
+// safely iterate over it even when no entry matches.
+func ExtractSecurityMetadataFromMap(in map[string]string) map[string]string {
 	metadata := make(map[string]string)
-	for k, v := range sbx.GetLabels() {
+	for k, v := range in {
 		if strings.HasPrefix(k, SecurityMetadataPrefix) {
 			metadata[k] = v
 		}
@@ -74,7 +84,7 @@ func ExtractSecurityMetadata(sbx *agentsv1alpha1.Sandbox) map[string]string {
 //
 // It builds a TokenRequest of type TokenTypeAgent, forwarding the sandbox and
 // claim objects verbatim to the provider. Metadata extraction is intentionally
-// left to the provider: implementations that need security labels can call
+// left to the provider: implementations that need security metadata can call
 // ExtractSecurityMetadata(sbx), and those that need storage-auth or other
 // annotations can read them directly from sbx.GetAnnotations().
 //

--- a/pkg/identity/sandbox_token_helper_test.go
+++ b/pkg/identity/sandbox_token_helper_test.go
@@ -116,8 +116,8 @@ func TestIssueSandboxToken_Success(t *testing.T) {
 }
 
 // TestExtractSecurityMetadata verifies the prefix filter used to collect
-// security-prefixed labels into a metadata map. Providers call this helper when
-// they want to include security labels in token issuance requests.
+// security-prefixed annotations into a metadata map. Providers call this helper
+// when they want to include security metadata in token issuance requests.
 func TestExtractSecurityMetadata(t *testing.T) {
 	const tenantKey = SecurityMetadataPrefix + "tenant"
 	const projectKey = SecurityMetadataPrefix + "project"
@@ -134,19 +134,19 @@ func TestExtractSecurityMetadata(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "sandbox without labels returns empty map",
+			name: "sandbox without annotations returns empty map",
 			sbx: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{Name: "sbx", Namespace: "ns"},
 			},
 			want: map[string]string{},
 		},
 		{
-			name: "only security-prefixed labels are collected",
+			name: "only security-prefixed annotations are collected",
 			sbx: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sbx",
 					Namespace: "ns",
-					Labels: map[string]string{
+					Annotations: map[string]string{
 						tenantKey:  "t1",
 						projectKey: "p1",
 						"app":      "demo",
@@ -164,7 +164,7 @@ func TestExtractSecurityMetadata(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sbx",
 					Namespace: "ns",
-					Labels: map[string]string{
+					Annotations: map[string]string{
 						"agents.kruise.io/team":          "infra",
 						"security-fake.agents.kruise.io": "no",
 						"x-security.agents.kruise.io/y":  "no",
@@ -183,6 +183,55 @@ func TestExtractSecurityMetadata(t *testing.T) {
 				return
 			}
 			require.NotNil(t, got)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestExtractSecurityMetadataFromMap verifies the prefix filter that backs both
+// ExtractSecurityMetadata and the caller-supplied E2B input path. The returned
+// map must be non-nil even when no entry matches, and must contain only
+// security-prefixed keys.
+func TestExtractSecurityMetadataFromMap(t *testing.T) {
+	const agentKey = SecurityMetadataPrefix + "agent-name"
+	const tenantKey = SecurityMetadataPrefix + "tenant"
+
+	tests := []struct {
+		name string
+		in   map[string]string
+		want map[string]string
+	}{
+		{
+			name: "nil map returns empty map",
+			in:   nil,
+			want: map[string]string{},
+		},
+		{
+			name: "only security-prefixed keys are collected",
+			in: map[string]string{
+				agentKey:  "agent-a",
+				tenantKey: "t1",
+				"app":     "demo",
+			},
+			want: map[string]string{
+				agentKey:  "agent-a",
+				tenantKey: "t1",
+			},
+		},
+		{
+			name: "near-miss keys are rejected",
+			in: map[string]string{
+				"agents.kruise.io/team":         "infra",
+				"x-security.agents.kruise.io/y": "no",
+			},
+			want: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractSecurityMetadataFromMap(tt.in)
+			require.NotNil(t, got, "returned map must never be nil")
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -445,9 +494,9 @@ func TestPropagateSandboxToken(t *testing.T) {
 
 // TestIsIdentityProviderRequested verifies the opt-in predicate that gates the
 // identity provider issuance path. The contract is: a sandbox opts in iff its
-// Labels carry a non-empty value under LabelAgentName; every other shape
-// (nil sandbox, missing Labels map, absent key, empty value, near-miss key)
-// must collapse to false so callers can safely short-circuit.
+// Annotations carry a non-empty value under AnnotationAgentName; every other
+// shape (nil sandbox, missing Annotations map, absent key, empty value,
+// near-miss key) must collapse to false so callers can safely short-circuit.
 func TestIsIdentityProviderRequested(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -462,48 +511,48 @@ func TestIsIdentityProviderRequested(t *testing.T) {
 			reason: "a nil sandbox must never trigger the provider path",
 		},
 		{
-			name: "sandbox without Labels map returns false",
+			name: "sandbox without Annotations map returns false",
 			sbx: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{Name: "sbx", Namespace: "ns"},
 			},
 			want:   false,
-			reason: "GetLabels() on a sandbox without ObjectMeta.Labels yields a nil map; lookup must be false",
+			reason: "GetAnnotations() on a sandbox without ObjectMeta.Annotations yields a nil map; lookup must be false",
 		},
 		{
-			name: "empty Labels map returns false",
+			name: "empty Annotations map returns false",
 			sbx: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "sbx",
-					Namespace: "ns",
-					Labels:    map[string]string{},
+					Name:        "sbx",
+					Namespace:   "ns",
+					Annotations: map[string]string{},
 				},
 			},
 			want:   false,
 			reason: "an explicitly empty map carries no opt-in signal",
 		},
 		{
-			name: "agent-name label absent returns false",
+			name: "agent-name annotation absent returns false",
 			sbx: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sbx",
 					Namespace: "ns",
-					Labels: map[string]string{
+					Annotations: map[string]string{
 						"app":                             "demo",
 						SecurityMetadataPrefix + "tenant": "t1",
 					},
 				},
 			},
 			want:   false,
-			reason: "other security-prefixed labels must not opt the sandbox into the provider path",
+			reason: "other security-prefixed annotations must not opt the sandbox into the provider path",
 		},
 		{
-			name: "agent-name label present but empty returns false",
+			name: "agent-name annotation present but empty returns false",
 			sbx: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sbx",
 					Namespace: "ns",
-					Labels: map[string]string{
-						LabelAgentName: "",
+					Annotations: map[string]string{
+						AnnotationAgentName: "",
 					},
 				},
 			},
@@ -516,7 +565,7 @@ func TestIsIdentityProviderRequested(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sbx",
 					Namespace: "ns",
-					Labels: map[string]string{
+					Annotations: map[string]string{
 						SecurityMetadataPrefix + "agent-name-suffix": "foo",
 						"agent-name": "bar",
 					},
@@ -526,13 +575,13 @@ func TestIsIdentityProviderRequested(t *testing.T) {
 			reason: "the predicate matches the FQ key exactly; near-miss keys must not trigger the path",
 		},
 		{
-			name: "agent-name label present with value returns true",
+			name: "agent-name annotation present with value returns true",
 			sbx: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sbx",
 					Namespace: "ns",
-					Labels: map[string]string{
-						LabelAgentName: "my-agent",
+					Annotations: map[string]string{
+						AnnotationAgentName: "my-agent",
 					},
 				},
 			},
@@ -540,20 +589,20 @@ func TestIsIdentityProviderRequested(t *testing.T) {
 			reason: "the canonical opt-in: a non-empty agent-name value",
 		},
 		{
-			name: "agent-name label coexisting with unrelated labels returns true",
+			name: "agent-name annotation coexisting with unrelated annotations returns true",
 			sbx: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sbx",
 					Namespace: "ns",
-					Labels: map[string]string{
-						LabelAgentName:                    "agent-x",
+					Annotations: map[string]string{
+						AnnotationAgentName:               "agent-x",
 						SecurityMetadataPrefix + "tenant": "t1",
 						"app":                             "demo",
 					},
 				},
 			},
 			want:   true,
-			reason: "presence of other labels must not interfere with the opt-in decision",
+			reason: "presence of other annotations must not interfere with the opt-in decision",
 		},
 	}
 

--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -30,15 +30,17 @@ const (
 )
 
 const (
-	// SecurityMetadataPrefix is the prefix for all security-related label/annotations.
+	// SecurityMetadataPrefix is the prefix for all security-related annotations.
 	SecurityMetadataPrefix = "security.agents.kruise.io/"
 	// AgentKeyTokenRefreshStatus is the Sandbox Annotation Key,
 	// used to store the JSON serialized result of TokenRefreshStatus.
 	AgentKeyTokenRefreshStatus = SecurityMetadataPrefix + "token-status"
-	// LabelAgentName is the sandbox Label Key whose presence opts the sandbox
-	// into the identity provider issuance path. Its value carries the logical
-	// agent name that the identity provider uses to mint the security token.
-	LabelAgentName = SecurityMetadataPrefix + "agent-name"
+	// AnnotationAgentName is the sandbox Annotation Key whose presence opts the
+	// sandbox into the identity provider issuance path. Its value carries the
+	// logical agent name that the identity provider uses to mint the security
+	// token. An annotation is used instead of a label so the value is free of
+	// the 63-char / DNS-label constraints and can express richer content.
+	AnnotationAgentName = SecurityMetadataPrefix + "agent-name"
 )
 
 // TokenRequest represents a request to issue an identity-aware access token.

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -40,7 +40,6 @@ import (
 	infracache "github.com/openkruise/agents/pkg/cache"
 	cacheutils "github.com/openkruise/agents/pkg/cache/utils"
 	"github.com/openkruise/agents/pkg/controller/sandboxset"
-	"github.com/openkruise/agents/pkg/features"
 	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
@@ -48,7 +47,6 @@ import (
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
-	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 	"github.com/openkruise/agents/pkg/utils/runtime"
 	timeoututils "github.com/openkruise/agents/pkg/utils/timeout"
 )
@@ -357,9 +355,9 @@ func runClaimPostProcesses(ctx context.Context, sbx *Sandbox, lockType infra.Loc
 }
 
 // processSecurityToken issues and propagates a sandbox security token when the
-// identity provider feature gate and sandbox annotations request it.
+// sandbox annotations opt into the identity provider path.
 func processSecurityToken(ctx context.Context, opts infra.ClaimSandboxOptions, sbx *Sandbox, cache infracache.Provider, metrics *infra.ClaimMetrics) error {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.SecurityIdentityProviderGate) || !identity.IsIdentityProviderRequested(sbx.Sandbox) {
+	if !identity.IsIdentityProviderRequested(sbx.Sandbox) {
 		return nil
 	}
 

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -4623,14 +4623,14 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 			},
 		},
 		{
-			// Verifies the second clause of the gate at claim.go:236 — when the
+			// Verifies the IsIdentityProviderRequested opt-in gate — when the
 			// sandbox does NOT carry the security.agents.kruise.io/agent-name
-			// label, the entire identity provider branch must be skipped: neither
+			// annotation, the entire identity provider branch must be skipped: neither
 			// IssueToken nor PropagateSecurityToken may run, no TokenRefreshStatus
 			// annotation may be persisted, and metrics.SecurityToken must remain
 			// zero. This is the dedicated opt-in regression test for the
 			// IsIdentityProviderRequested predicate.
-			name: "skips security token issuance when agent-name label is absent",
+			name: "skips security token issuance when agent-name annotation is absent",
 			options: infra.ClaimSandboxOptions{
 				User:     user,
 				Template: existTemplate,
@@ -4639,16 +4639,16 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				},
 			},
 			preModifier: func(sbx *v1alpha1.Sandbox) {
-				// Strip the opt-in label so IsIdentityProviderRequested returns false.
-				delete(sbx.Labels, identity.LabelAgentName)
+				// Strip the opt-in annotation so IsIdentityProviderRequested returns false.
+				delete(sbx.Annotations, identity.AnnotationAgentName)
 			},
 			mockProvider: &mockIdentityProvider{
 				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim, req identity.TokenRequest) (*identity.TokenResponse, error) {
-					t.Fatalf("IssueToken must not be called when agent-name label is absent")
+					t.Fatalf("IssueToken must not be called when agent-name annotation is absent")
 					return nil, nil
 				},
 				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
-					t.Fatalf("PropagateSecurityToken must not be called when agent-name label is absent")
+					t.Fatalf("PropagateSecurityToken must not be called when agent-name annotation is absent")
 					return nil
 				},
 			},
@@ -4686,13 +4686,13 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 					Labels: map[string]string{
 						v1alpha1.LabelSandboxTemplate:        existTemplate,
 						agentsv1alpha1.LabelSandboxIsClaimed: "false",
-						// Opt the sandbox into the identity provider issuance path;
-						// the dedicated "absent" sub-test strips this label via preModifier.
-						identity.LabelAgentName: "test-agent",
 					},
 					CreationTimestamp: metav1.Now(),
 					Annotations: map[string]string{
 						v1alpha1.AnnotationRuntimeURL: server.URL,
+						// Opt the sandbox into the identity provider issuance path;
+						// the dedicated "absent" sub-test strips this annotation via preModifier.
+						identity.AnnotationAgentName: "test-agent",
 					},
 					OwnerReferences: GetSbsOwnerReference(),
 				},


### PR DESCRIPTION
The identity-provider opt-in gate and security-metadata extraction used to read from sbx.Labels. However E2B security metadata (the security.agents.kruise.io/* entries in request.Metadata) is written onto the sandbox annotations by basicSandboxCreateModifier, so the provider never saw it - a silent data-flow break.

Switch the consumer side to annotations to close the gap:
- IsIdentityProviderRequested now reads sbx.GetAnnotations()[AnnotationAgentName]
- ExtractSecurityMetadata now filters sbx.GetAnnotations()
- rename constant LabelAgentName -> AnnotationAgentName (value unchanged: security.agents.kruise.io/agent-name)

This unifies the security metadata source with storage-auth / token-status (already annotation-based), removes the 63-char / DNS-label constraints so richer values can be expressed, and aligns naturally with the request.Metadata -> annotations mapping (no create.go / claim.go changes needed). No label selector depends on agent-name (securitytokenrefresh is gated by the token-status annotation), so the switch is behavior-preserving.

Tests updated to place the opt-in key and security entries under annotations. go build and the identity / sandbox-manager / securitytokenrefresh package tests pass.

Note: the constant rename LabelAgentName -> AnnotationAgentName must be synced in the enterprise (inner) branch.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

