### PR TITLE
fix(sandbox-gateway): improve port validation and normalization logic

### DIFF
--- a/pkg/sandbox-gateway/filter/config.go
+++ b/pkg/sandbox-gateway/filter/config.go
@@ -92,7 +92,7 @@ func (c *Config) GetSandboxPortHeader() string {
 // GetDefaultPort returns the default port as an integer
 func (c *Config) GetDefaultPort() int {
 	if c.DefaultPort != "" {
-		if p, err := strconv.Atoi(c.DefaultPort); err == nil {
+		if p, err := strconv.Atoi(c.DefaultPort); err == nil && p > 0 && p <= 65535 {
 			return p
 		}
 	}

--- a/pkg/sandbox-gateway/filter/config_test.go
+++ b/pkg/sandbox-gateway/filter/config_test.go
@@ -148,6 +148,57 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
+func TestGetDefaultPort(t *testing.T) {
+	tests := []struct {
+		name        string
+		defaultPort string
+		want        int
+	}{
+		{
+			name:        "valid port",
+			defaultPort: "8080",
+			want:        8080,
+		},
+		{
+			name:        "empty port falls back to default",
+			defaultPort: "",
+			want:        49983,
+		},
+		{
+			name:        "invalid port falls back to default",
+			defaultPort: "invalid",
+			want:        49983,
+		},
+		{
+			name:        "zero port falls back to default",
+			defaultPort: "0",
+			want:        49983,
+		},
+		{
+			name:        "negative port falls back to default",
+			defaultPort: "-1",
+			want:        49983,
+		},
+		{
+			name:        "above max port falls back to default",
+			defaultPort: "70000",
+			want:        49983,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				DefaultPort: tt.defaultPort,
+			}
+			got := cfg.GetDefaultPort()
+			if got != tt.want {
+				t.Errorf("GetDefaultPort() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestConfigParserParse(t *testing.T) {
 	parser := &ConfigParser{}
 

--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -48,15 +48,15 @@ const (
 // Returns the default port if not set or invalid
 func getMemberlistBindPort() int {
 	if val := os.Getenv(EnvMemberlistBindPort); val != "" {
-		if port, err := strconv.Atoi(val); err == nil && port > 0 {
-			return port
+		if port, err := strconv.Atoi(val); err == nil {
+			return normalizePort(port, config.DefaultMemberlistBindPort)
 		}
 	}
 	return config.DefaultMemberlistBindPort
 }
 
 func normalizePort(port int, defaultPort int) int {
-	if port <= 0 {
+	if port <= 0 || port > 65535 {
 		return defaultPort
 	}
 	return port

--- a/pkg/sandbox-gateway/server/server_test.go
+++ b/pkg/sandbox-gateway/server/server_test.go
@@ -116,6 +116,19 @@ func TestNewServer(t *testing.T) {
 			envPort:      "9000",
 			wantBindPort: 9000,
 		},
+		{
+			name:         "with port above max uses default",
+			port:         70000,
+			wantPort:     proxy.SystemPort,
+			wantBindPort: config.DefaultMemberlistBindPort,
+		},
+		{
+			name:         "with env port above max uses default",
+			port:         8080,
+			wantPort:     8080,
+			envPort:      "70000",
+			wantBindPort: config.DefaultMemberlistBindPort,
+		},
 	}
 
 	for _, tt := range tests {
@@ -321,7 +334,7 @@ func TestGetMemberlistBindPort_EdgeCases(t *testing.T) {
 		{
 			name:     "very large number",
 			envValue: "999999",
-			want:     999999,
+			want:     config.DefaultMemberlistBindPort,
 		},
 		{
 			name:     "port 1 is valid",


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR improves TCP port validation and normalization logic within the `sandbox-gateway` component. 
Specifically, it ensures that port values are within the valid TCP range (`1` to `65535` inclusive):
- **Server**: In `pkg/sandbox-gateway/server/server.go`, `normalizePort` and `getMemberlistBindPort` now reject ports larger than `65535` and fall back to the default memberlist bind port.
- **Filter**: In `pkg/sandbox-gateway/filter/config.go`, `GetDefaultPort` now enforces the range check (`1 <= port <= 65535`) on the configured default port.

This prevents the gateway server and filter from crashing or failing silently at runtime due to out-of-bounds TCP ports.

### Ⅱ. Does this pull request fix one issue?
NONE

### Ⅲ. Describe how to verify it
Unit tests in both the `server` and `filter` packages have been added and updated to cover these validation checks:
1. **Server Tests**: Ran `go test -v ./pkg/sandbox-gateway/server/...` to verify fallback behavior for negative ports, zero port, and ports above `65535` (e.g. `70000`).
2. **Filter Tests**: Added a new test suite `TestGetDefaultPort` in `pkg/sandbox-gateway/filter/config_test.go` and ran `go test -v ./pkg/sandbox-gateway/filter/...` to verify config parsing validation.

### Ⅳ. Special notes for reviews
- Commits have been signed off (`git commit -s`).
- Tests are passing successfully with 100% coverage on the new/modified validation paths.
