### PR TITLE
refactor(identity): drop req param from IssueToken so providers build their own request

### DIFF
--- a/pkg/controller/securitytokenrefresh/core/refresher_test.go
+++ b/pkg/controller/securitytokenrefresh/core/refresher_test.go
@@ -44,7 +44,7 @@ type stubIdentityProvider struct {
 	issueCalls     int
 }
 
-func (s *stubIdentityProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *agentsv1alpha1.SandboxClaim, _ identity.TokenRequest) (*identity.TokenResponse, error) {
+func (s *stubIdentityProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *agentsv1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
 	s.issueCalls++
 	if s.issueErr != nil {
 		return nil, s.issueErr

--- a/pkg/identity/common_provider.go
+++ b/pkg/identity/common_provider.go
@@ -36,7 +36,7 @@ func NewDefaultIdentityProvider() IdentityProvider {
 	return &defaultTokenProvider{}
 }
 
-func (u *defaultTokenProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *agentsv1alpha1.SandboxClaim, _ TokenRequest) (*TokenResponse, error) {
+func (u *defaultTokenProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *agentsv1alpha1.SandboxClaim) (*TokenResponse, error) {
 	return &TokenResponse{
 		RequestID:             uuid.NewString(),
 		AccessToken:           uuid.NewString(),

--- a/pkg/identity/common_provider_test.go
+++ b/pkg/identity/common_provider_test.go
@@ -42,14 +42,14 @@ func TestDefaultTokenProvider_IssueToken(t *testing.T) {
 	provider := NewDefaultIdentityProvider()
 	ctx := context.Background()
 
-	resp, err := provider.IssueToken(ctx, nil, nil, TokenRequest{TokenType: TokenTypeAgent})
+	resp, err := provider.IssueToken(ctx, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.NotEmpty(t, resp.RequestID, "RequestID should be a non-empty string")
 	assert.NotEmpty(t, resp.AccessToken, "AccessToken should be a non-empty string")
 
 	// Two calls should produce different tokens.
-	resp2, err := provider.IssueToken(ctx, nil, nil, TokenRequest{TokenType: TokenTypeAgent})
+	resp2, err := provider.IssueToken(ctx, nil, nil)
 	require.NoError(t, err)
 	assert.NotEqual(t, resp.AccessToken, resp2.AccessToken, "each call should produce a unique token")
 }

--- a/pkg/identity/default_provider.go
+++ b/pkg/identity/default_provider.go
@@ -47,8 +47,8 @@ func RegisterProvider(p IdentityProvider) {
 }
 
 // IssueToken delegates to the registered provider to generate an access token.
-func IssueToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, claim *agentsv1alpha1.SandboxClaim, req TokenRequest) (*TokenResponse, error) {
-	return provider.IssueToken(ctx, sbx, claim, req)
+func IssueToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, claim *agentsv1alpha1.SandboxClaim) (*TokenResponse, error) {
+	return provider.IssueToken(ctx, sbx, claim)
 }
 
 // PropagateSecurityToken delegates to the registered provider to execute

--- a/pkg/identity/interface.go
+++ b/pkg/identity/interface.go
@@ -34,15 +34,19 @@ import (
 //     directly (no silent degradation to UUID).
 //   - PropagateSecurityToken: executes registered propagators (e.g., write credential files).
 type IdentityProvider interface {
-	// IssueToken generates an access token for the given token request.
+	// IssueToken generates an access token for the given sandbox.
 	// The sbx parameter carries the sandbox workload metadata; it may be nil in
 	// future principal-token paths, so implementations must guard against nil.
 	// The claim parameter is the SandboxClaim that triggered the issuance when
 	// called from the SandboxClaim controller, and nil for refresh or E2B paths.
-	// Implementations that need extra context (e.g. storage-auth annotations)
-	// should read it directly from sbx.GetAnnotations() rather than relying on
-	// caller-side metadata hooks.
-	IssueToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, claim *agentsv1alpha1.SandboxClaim, req TokenRequest) (*TokenResponse, error)
+	//
+	// Implementations own the composition of the concrete wire request: they
+	// derive the SandboxInfo projection and any security metadata directly from
+	// sbx (e.g. sbx.GetAnnotations() for storage-auth) rather than receiving a
+	// pre-built TokenRequest. This keeps the community baseline free of
+	// enterprise-only request-shaping policy while letting each provider assemble
+	// exactly the atomic request its backend expects.
+	IssueToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, claim *agentsv1alpha1.SandboxClaim) (*TokenResponse, error)
 
 	// PropagateSecurityToken executes post-token processing after a token is issued,
 	// such as writing credentials into the sandbox runtime.

--- a/pkg/identity/sandbox_token_helper.go
+++ b/pkg/identity/sandbox_token_helper.go
@@ -82,11 +82,12 @@ func ExtractSecurityMetadataFromMap(in map[string]string) map[string]string {
 // IssueSandboxToken issues a security token for the given sandbox using the
 // registered identity provider.
 //
-// It builds a TokenRequest of type TokenTypeAgent, forwarding the sandbox and
-// claim objects verbatim to the provider. Metadata extraction is intentionally
-// left to the provider: implementations that need security metadata can call
-// ExtractSecurityMetadata(sbx), and those that need storage-auth or other
-// annotations can read them directly from sbx.GetAnnotations().
+// It forwards the sandbox and claim objects verbatim to the provider. The
+// provider owns the composition of the concrete wire request (SandboxInfo
+// projection, security metadata, token type): it derives everything it needs
+// directly from the sandbox object. The community baseline therefore carries no
+// request-shaping policy here, and enterprise providers assemble exactly the
+// atomic request their backend expects.
 //
 // The claim parameter may be nil for non-CRD issuance paths (e.g. token refresh
 // or the E2B API). IdentityProvider implementations must handle a nil claim
@@ -100,16 +101,7 @@ func IssueSandboxToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, claim *
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx), "action", "IssueSandboxToken")
 	start := time.Now()
 
-	tokenResp, err := IssueToken(ctx, sbx, claim, TokenRequest{
-		TokenType: TokenTypeAgent,
-		Sandbox: &SandboxInfo{
-			PodName:      sbx.Name,
-			PodNamespace: sbx.Namespace,
-			SandboxID:    fmt.Sprintf("%s/%s/%s", sbx.Namespace, sbx.Name, sbx.UID),
-			SandboxName:  sbx.Name,
-			SandboxUID:   string(sbx.UID),
-		},
-	})
+	tokenResp, err := IssueToken(ctx, sbx, claim)
 	cost := time.Since(start)
 	if err != nil {
 		log.Error(err, "failed to issue sandbox security token", "cost", cost)

--- a/pkg/identity/sandbox_token_helper_test.go
+++ b/pkg/identity/sandbox_token_helper_test.go
@@ -34,7 +34,6 @@ import (
 // TokenResponse / error. Only the IssueToken path is exercised by
 // IssueSandboxToken; PropagateSecurityToken is implemented as a no-op.
 type fakeIdentityProvider struct {
-	gotReq   TokenRequest
 	gotSbx   *agentsv1alpha1.Sandbox
 	gotClaim *agentsv1alpha1.SandboxClaim
 	called   int
@@ -43,8 +42,7 @@ type fakeIdentityProvider struct {
 	err  error
 }
 
-func (f *fakeIdentityProvider) IssueToken(_ context.Context, sbx *agentsv1alpha1.Sandbox, claim *agentsv1alpha1.SandboxClaim, req TokenRequest) (*TokenResponse, error) {
-	f.gotReq = req
+func (f *fakeIdentityProvider) IssueToken(_ context.Context, sbx *agentsv1alpha1.Sandbox, claim *agentsv1alpha1.SandboxClaim) (*TokenResponse, error) {
 	f.gotSbx = sbx
 	f.gotClaim = claim
 	f.called++
@@ -65,9 +63,9 @@ func withFakeProvider(t *testing.T, fake *fakeIdentityProvider) {
 }
 
 // TestIssueSandboxToken_Success exercises the happy path: the helper must
-// project the sandbox identity into the TokenRequest.Sandbox field and return
-// the provider's response unchanged together with a non-negative cost and a
-// nil error. Metadata extraction is left to the provider.
+// forward the sandbox and claim to the provider unchanged and return the
+// provider's response together with a non-negative cost and a nil error.
+// Building the TokenRequest is left entirely to the provider.
 func TestIssueSandboxToken_Success(t *testing.T) {
 	wantResp := &TokenResponse{
 		RequestID:             "req-1",
@@ -83,12 +81,6 @@ func TestIssueSandboxToken_Success(t *testing.T) {
 			Name:      "sbx-a",
 			Namespace: "ns-a",
 			UID:       types.UID("uid-a"),
-			Labels: map[string]string{
-				SecurityMetadataPrefix + "tenant":  "t1",
-				SecurityMetadataPrefix + "project": "p1",
-				"app":                              "demo",        // non-security label, must be filtered out
-				"kubernetes.io/managed-by":         "sandbox-mgr", // non-security label, must be filtered out
-			},
 		},
 	}
 
@@ -98,21 +90,7 @@ func TestIssueSandboxToken_Success(t *testing.T) {
 	assert.Same(t, wantResp, gotResp, "response must be returned as-is from the provider")
 	assert.GreaterOrEqual(t, int64(cost), int64(0), "cost should be non-negative")
 	assert.Equal(t, 1, fake.called, "underlying provider must be called exactly once")
-
-	// Verify the TokenRequest projection.
-	gotReq := fake.gotReq
-	assert.Equal(t, TokenTypeAgent, gotReq.TokenType, "TokenType must be Agent for sandbox issuance")
-	require.NotNil(t, gotReq.Sandbox)
-	assert.Equal(t, "sbx-a", gotReq.Sandbox.PodName)
-	assert.Equal(t, "ns-a", gotReq.Sandbox.PodNamespace)
-	assert.Equal(t, "ns-a/sbx-a/uid-a", gotReq.Sandbox.SandboxID,
-		"SandboxID must follow the canonical namespace/name/uid layout")
-	assert.Equal(t, "sbx-a", gotReq.Sandbox.SandboxName)
-	assert.Equal(t, "uid-a", gotReq.Sandbox.SandboxUID)
-
-	// Metadata is intentionally left empty by the helper; providers decide what
-	// to include by reading sbx/claim directly or calling ExtractSecurityMetadata.
-	assert.Nil(t, gotReq.Metadata, "helper must not pre-populate Metadata")
+	assert.Same(t, sbx, fake.gotSbx, "sandbox pointer must be forwarded unchanged to the provider")
 }
 
 // TestExtractSecurityMetadata verifies the prefix filter used to collect
@@ -295,7 +273,7 @@ type annotationReadingProvider struct {
 	gotValue       string
 }
 
-func (p *annotationReadingProvider) IssueToken(_ context.Context, sbx *agentsv1alpha1.Sandbox, _ *agentsv1alpha1.SandboxClaim, _ TokenRequest) (*TokenResponse, error) {
+func (p *annotationReadingProvider) IssueToken(_ context.Context, sbx *agentsv1alpha1.Sandbox, _ *agentsv1alpha1.SandboxClaim) (*TokenResponse, error) {
 	p.gotValue = sbx.GetAnnotations()[p.storageAuthKey]
 	return &TokenResponse{AccessToken: "tok"}, nil
 }
@@ -406,7 +384,7 @@ type propagatingFakeProvider struct {
 	err error
 }
 
-func (p *propagatingFakeProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *agentsv1alpha1.SandboxClaim, _ TokenRequest) (*TokenResponse, error) {
+func (p *propagatingFakeProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *agentsv1alpha1.SandboxClaim) (*TokenResponse, error) {
 	p.issueCalls++
 	return nil, nil
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -4464,13 +4464,13 @@ func TestNewSandboxFromSandboxSet_TemplateRef(t *testing.T) {
 
 // mockIdentityProvider is a configurable mock for testing TryClaimSandbox security token flows.
 type mockIdentityProvider struct {
-	issueTokenFunc func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim, req identity.TokenRequest) (*identity.TokenResponse, error)
+	issueTokenFunc func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error)
 	propagateFunc  func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error
 }
 
-func (m *mockIdentityProvider) IssueToken(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim, req identity.TokenRequest) (*identity.TokenResponse, error) {
+func (m *mockIdentityProvider) IssueToken(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
 	if m.issueTokenFunc != nil {
-		return m.issueTokenFunc(ctx, sbx, claim, req)
+		return m.issueTokenFunc(ctx, sbx, claim)
 	}
 	return &identity.TokenResponse{AccessToken: uuid.NewString()}, nil
 }
@@ -4516,7 +4516,7 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				},
 			},
 			mockProvider: &mockIdentityProvider{
-				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim, req identity.TokenRequest) (*identity.TokenResponse, error) {
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
 					return &identity.TokenResponse{AccessToken: "secure-token-123"}, nil
 				},
 				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
@@ -4549,7 +4549,7 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				},
 			},
 			mockProvider: &mockIdentityProvider{
-				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim, req identity.TokenRequest) (*identity.TokenResponse, error) {
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
 					return nil, fmt.Errorf("identity provider unavailable")
 				},
 				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
@@ -4572,7 +4572,7 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				},
 			},
 			mockProvider: &mockIdentityProvider{
-				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim, req identity.TokenRequest) (*identity.TokenResponse, error) {
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
 					return &identity.TokenResponse{AccessToken: "secure-token-456"}, nil
 				},
 				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
@@ -4591,7 +4591,7 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				},
 			},
 			mockProvider: &mockIdentityProvider{
-				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim, req identity.TokenRequest) (*identity.TokenResponse, error) {
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
 					return &identity.TokenResponse{AccessToken: "issued-token"}, nil
 				},
 			},
@@ -4610,7 +4610,7 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				Template: existTemplate,
 			},
 			mockProvider: &mockIdentityProvider{
-				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim, req identity.TokenRequest) (*identity.TokenResponse, error) {
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
 					return &identity.TokenResponse{AccessToken: "issued-token"}, nil
 				},
 			},
@@ -4643,7 +4643,7 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				delete(sbx.Annotations, identity.AnnotationAgentName)
 			},
 			mockProvider: &mockIdentityProvider{
-				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim, req identity.TokenRequest) (*identity.TokenResponse, error) {
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
 					t.Fatalf("IssueToken must not be called when agent-name annotation is absent")
 					return nil, nil
 				},


### PR DESCRIPTION
… their own request

The IdentityProvider.IssueToken signature no longer takes a pre-built TokenRequest. Each provider derives the SandboxInfo projection and security metadata directly from the Sandbox object and assembles the atomic request its backend needs. Security metadata is now sourced from annotations.

Also adapts the mock/stub providers in the affected tests to the new signature.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

