### PR TITLE
feat(sandbox-manager): issue security token in sandbox clone

### DIFF
--- a/pkg/controller/securitytokenrefresh/core/refresher.go
+++ b/pkg/controller/securitytokenrefresh/core/refresher.go
@@ -68,7 +68,7 @@ func NewDefaultRefresher(c client.Client) Refresher {
 func (r *defaultRefresher) Refresh(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (*identity.TokenResponse, error) {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
 
-	tokenResp, _, err := identity.IssueSandboxToken(ctx, sbx, nil)
+	tokenResp, err := identity.IssueSandboxToken(ctx, sbx)
 	if err != nil {
 		return nil, fmt.Errorf("issue token: %w", err)
 	}

--- a/pkg/controller/securitytokenrefresh/core/refresher_test.go
+++ b/pkg/controller/securitytokenrefresh/core/refresher_test.go
@@ -44,7 +44,7 @@ type stubIdentityProvider struct {
 	issueCalls     int
 }
 
-func (s *stubIdentityProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *agentsv1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
+func (s *stubIdentityProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox) (*identity.TokenResponse, error) {
 	s.issueCalls++
 	if s.issueErr != nil {
 		return nil, s.issueErr

--- a/pkg/identity/common_provider.go
+++ b/pkg/identity/common_provider.go
@@ -36,7 +36,7 @@ func NewDefaultIdentityProvider() IdentityProvider {
 	return &defaultTokenProvider{}
 }
 
-func (u *defaultTokenProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *agentsv1alpha1.SandboxClaim) (*TokenResponse, error) {
+func (u *defaultTokenProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox) (*TokenResponse, error) {
 	return &TokenResponse{
 		RequestID:             uuid.NewString(),
 		AccessToken:           uuid.NewString(),

--- a/pkg/identity/common_provider_test.go
+++ b/pkg/identity/common_provider_test.go
@@ -42,14 +42,14 @@ func TestDefaultTokenProvider_IssueToken(t *testing.T) {
 	provider := NewDefaultIdentityProvider()
 	ctx := context.Background()
 
-	resp, err := provider.IssueToken(ctx, nil, nil)
+	resp, err := provider.IssueToken(ctx, nil)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.NotEmpty(t, resp.RequestID, "RequestID should be a non-empty string")
 	assert.NotEmpty(t, resp.AccessToken, "AccessToken should be a non-empty string")
 
 	// Two calls should produce different tokens.
-	resp2, err := provider.IssueToken(ctx, nil, nil)
+	resp2, err := provider.IssueToken(ctx, nil)
 	require.NoError(t, err)
 	assert.NotEqual(t, resp.AccessToken, resp2.AccessToken, "each call should produce a unique token")
 }

--- a/pkg/identity/default_provider.go
+++ b/pkg/identity/default_provider.go
@@ -47,8 +47,8 @@ func RegisterProvider(p IdentityProvider) {
 }
 
 // IssueToken delegates to the registered provider to generate an access token.
-func IssueToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, claim *agentsv1alpha1.SandboxClaim) (*TokenResponse, error) {
-	return provider.IssueToken(ctx, sbx, claim)
+func IssueToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (*TokenResponse, error) {
+	return provider.IssueToken(ctx, sbx)
 }
 
 // PropagateSecurityToken delegates to the registered provider to execute

--- a/pkg/identity/interface.go
+++ b/pkg/identity/interface.go
@@ -37,8 +37,6 @@ type IdentityProvider interface {
 	// IssueToken generates an access token for the given sandbox.
 	// The sbx parameter carries the sandbox workload metadata; it may be nil in
 	// future principal-token paths, so implementations must guard against nil.
-	// The claim parameter is the SandboxClaim that triggered the issuance when
-	// called from the SandboxClaim controller, and nil for refresh or E2B paths.
 	//
 	// Implementations own the composition of the concrete wire request: they
 	// derive the SandboxInfo projection and any security metadata directly from
@@ -46,7 +44,7 @@ type IdentityProvider interface {
 	// pre-built TokenRequest. This keeps the community baseline free of
 	// enterprise-only request-shaping policy while letting each provider assemble
 	// exactly the atomic request its backend expects.
-	IssueToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, claim *agentsv1alpha1.SandboxClaim) (*TokenResponse, error)
+	IssueToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (*TokenResponse, error)
 
 	// PropagateSecurityToken executes post-token processing after a token is issued,
 	// such as writing credentials into the sandbox runtime.

--- a/pkg/identity/sandbox_token_helper.go
+++ b/pkg/identity/sandbox_token_helper.go
@@ -82,33 +82,29 @@ func ExtractSecurityMetadataFromMap(in map[string]string) map[string]string {
 // IssueSandboxToken issues a security token for the given sandbox using the
 // registered identity provider.
 //
-// It forwards the sandbox and claim objects verbatim to the provider. The
-// provider owns the composition of the concrete wire request (SandboxInfo
-// projection, security metadata, token type): it derives everything it needs
-// directly from the sandbox object. The community baseline therefore carries no
+// It forwards the sandbox object verbatim to the provider. The provider owns
+// the composition of the concrete wire request (SandboxInfo projection,
+// security metadata, token type): it derives everything it needs directly from
+// the sandbox object. The community baseline therefore carries no
 // request-shaping policy here, and enterprise providers assemble exactly the
 // atomic request their backend expects.
-//
-// The claim parameter may be nil for non-CRD issuance paths (e.g. token refresh
-// or the E2B API). IdentityProvider implementations must handle a nil claim
-// gracefully.
 //
 // The function is intentionally side-effect free: it does NOT mutate the
 // sandbox object or persist the response. Callers are responsible for
 // persisting the returned TokenResponse into the appropriate place
 // (e.g. ClaimSandboxOptions, sandbox annotations, or runtime credentials).
-func IssueSandboxToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, claim *agentsv1alpha1.SandboxClaim) (*TokenResponse, time.Duration, error) {
+func IssueSandboxToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (*TokenResponse, error) {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx), "action", "IssueSandboxToken")
 	start := time.Now()
 
-	tokenResp, err := IssueToken(ctx, sbx, claim)
+	tokenResp, err := IssueToken(ctx, sbx)
 	cost := time.Since(start)
 	if err != nil {
 		log.Error(err, "failed to issue sandbox security token", "cost", cost)
-		return nil, cost, fmt.Errorf("failed to issue security token: %w", err)
+		return nil, fmt.Errorf("failed to issue security token: %w", err)
 	}
 	log.Info("sandbox security token issued", "cost", cost)
-	return tokenResp, cost, nil
+	return tokenResp, nil
 }
 
 // PropagateSandboxToken propagates the freshly issued security token to the

--- a/pkg/identity/sandbox_token_helper_test.go
+++ b/pkg/identity/sandbox_token_helper_test.go
@@ -34,17 +34,15 @@ import (
 // TokenResponse / error. Only the IssueToken path is exercised by
 // IssueSandboxToken; PropagateSecurityToken is implemented as a no-op.
 type fakeIdentityProvider struct {
-	gotSbx   *agentsv1alpha1.Sandbox
-	gotClaim *agentsv1alpha1.SandboxClaim
-	called   int
+	gotSbx *agentsv1alpha1.Sandbox
+	called int
 
 	resp *TokenResponse
 	err  error
 }
 
-func (f *fakeIdentityProvider) IssueToken(_ context.Context, sbx *agentsv1alpha1.Sandbox, claim *agentsv1alpha1.SandboxClaim) (*TokenResponse, error) {
+func (f *fakeIdentityProvider) IssueToken(_ context.Context, sbx *agentsv1alpha1.Sandbox) (*TokenResponse, error) {
 	f.gotSbx = sbx
-	f.gotClaim = claim
 	f.called++
 	return f.resp, f.err
 }
@@ -63,9 +61,9 @@ func withFakeProvider(t *testing.T, fake *fakeIdentityProvider) {
 }
 
 // TestIssueSandboxToken_Success exercises the happy path: the helper must
-// forward the sandbox and claim to the provider unchanged and return the
-// provider's response together with a non-negative cost and a nil error.
-// Building the TokenRequest is left entirely to the provider.
+// forward the sandbox to the provider unchanged and return the provider's
+// response together with a nil error. Building the TokenRequest is left
+// entirely to the provider.
 func TestIssueSandboxToken_Success(t *testing.T) {
 	wantResp := &TokenResponse{
 		RequestID:             "req-1",
@@ -84,11 +82,10 @@ func TestIssueSandboxToken_Success(t *testing.T) {
 		},
 	}
 
-	gotResp, cost, err := IssueSandboxToken(context.Background(), sbx, nil)
+	gotResp, err := IssueSandboxToken(context.Background(), sbx)
 	require.NoError(t, err)
 	require.NotNil(t, gotResp)
 	assert.Same(t, wantResp, gotResp, "response must be returned as-is from the provider")
-	assert.GreaterOrEqual(t, int64(cost), int64(0), "cost should be non-negative")
 	assert.Equal(t, 1, fake.called, "underlying provider must be called exactly once")
 	assert.Same(t, sbx, fake.gotSbx, "sandbox pointer must be forwarded unchanged to the provider")
 }
@@ -215,56 +212,6 @@ func TestExtractSecurityMetadataFromMap(t *testing.T) {
 	}
 }
 
-// TestIssueSandboxToken_ClaimPassedThrough verifies that a non-nil SandboxClaim
-// is forwarded verbatim to the registered IdentityProvider, while nil claims
-// (e.g. refresh or E2B paths) are also forwarded as nil.
-func TestIssueSandboxToken_ClaimPassedThrough(t *testing.T) {
-	claim := &agentsv1alpha1.SandboxClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "claim-a",
-			Namespace: "ns-a",
-			UID:       types.UID("claim-uid-a"),
-		},
-	}
-
-	tests := []struct {
-		name     string
-		claim    *agentsv1alpha1.SandboxClaim
-		wantSame *agentsv1alpha1.SandboxClaim
-	}{
-		{
-			name:     "claim is forwarded to provider",
-			claim:    claim,
-			wantSame: claim,
-		},
-		{
-			name:     "nil claim is forwarded as nil",
-			claim:    nil,
-			wantSame: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fake := &fakeIdentityProvider{resp: &TokenResponse{AccessToken: "tok"}}
-			withFakeProvider(t, fake)
-
-			sbx := &agentsv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "sbx-claim",
-					Namespace: "ns-a",
-					UID:       types.UID("uid-claim"),
-				},
-			}
-
-			_, _, err := IssueSandboxToken(context.Background(), sbx, tt.claim)
-			require.NoError(t, err)
-			assert.Same(t, sbx, fake.gotSbx, "sandbox pointer must be forwarded unchanged")
-			assert.Same(t, tt.wantSame, fake.gotClaim, "claim pointer must be forwarded unchanged")
-		})
-	}
-}
-
 // annotationReadingProvider is an IdentityProvider that extracts a specific
 // annotation from the sandbox and records it so tests can verify the sandbox
 // object forwarded to the provider is complete and readable.
@@ -273,7 +220,7 @@ type annotationReadingProvider struct {
 	gotValue       string
 }
 
-func (p *annotationReadingProvider) IssueToken(_ context.Context, sbx *agentsv1alpha1.Sandbox, _ *agentsv1alpha1.SandboxClaim) (*TokenResponse, error) {
+func (p *annotationReadingProvider) IssueToken(_ context.Context, sbx *agentsv1alpha1.Sandbox) (*TokenResponse, error) {
 	p.gotValue = sbx.GetAnnotations()[p.storageAuthKey]
 	return &TokenResponse{AccessToken: "tok"}, nil
 }
@@ -309,7 +256,7 @@ func TestIssueSandboxToken_ProviderCanReadSandboxAnnotations(t *testing.T) {
 		},
 	}
 
-	_, _, err := IssueSandboxToken(context.Background(), sbx, nil)
+	_, err := IssueSandboxToken(context.Background(), sbx)
 	require.NoError(t, err)
 	assert.Equal(t, `[{"credentialProviderName":"my-provider"}]`, reader.gotValue,
 		"provider must be able to read annotations directly from the forwarded sandbox")
@@ -331,10 +278,9 @@ func TestIssueSandboxToken_ProviderError(t *testing.T) {
 		},
 	}
 
-	gotResp, cost, err := IssueSandboxToken(context.Background(), sbx, nil)
+	gotResp, err := IssueSandboxToken(context.Background(), sbx)
 	require.Error(t, err)
 	assert.Nil(t, gotResp, "response must be nil on error to prevent persisting a zero-value token")
-	assert.GreaterOrEqual(t, int64(cost), int64(0), "cost must still be reported even on failure for metric accounting")
 
 	// Wrap message must remain stable; downstream code matches against this prefix.
 	assert.Contains(t, err.Error(), "failed to issue security token")
@@ -360,7 +306,7 @@ func TestIssueSandboxToken_DefaultProviderIntegration(t *testing.T) {
 		},
 	}
 
-	resp, _, err := IssueSandboxToken(context.Background(), sbx, nil)
+	resp, err := IssueSandboxToken(context.Background(), sbx)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.NotEmpty(t, resp.AccessToken, "default provider must mint a non-empty access token")
@@ -384,7 +330,7 @@ type propagatingFakeProvider struct {
 	err error
 }
 
-func (p *propagatingFakeProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *agentsv1alpha1.SandboxClaim) (*TokenResponse, error) {
+func (p *propagatingFakeProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox) (*TokenResponse, error) {
 	p.issueCalls++
 	return nil, nil
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -332,11 +332,13 @@ func runClaimPostProcesses(ctx context.Context, sbx *Sandbox, lockType infra.Loc
 	// receives the token first, and any downstream storage authentication
 	// decisions made by the provider can rely on the sandbox annotations already
 	// injected by modifyPickedSandbox.
-	// processSecurityToken already returns a descriptive retriableError; return
-	// it directly so the retry classification via errors.As(claimErr, &retriableError{})
-	// is preserved rather than being flattened into a terminal error.
-	if err := processSecurityToken(ctx, opts, sbx, cache, metrics); err != nil {
-		return err
+	if identity.IsIdentityProviderRequested(sbx.Sandbox) {
+		var err error
+		metrics.SecurityToken, err = processSecurityToken(ctx, sbx, cache)
+		if err != nil {
+			return retriableError{Message: fmt.Sprintf("failed to process security token: %s", err)}
+		}
+		metrics.Total += metrics.SecurityToken
 	}
 
 	if opts.CSIMount != nil {
@@ -354,37 +356,36 @@ func runClaimPostProcesses(ctx context.Context, sbx *Sandbox, lockType infra.Loc
 	return nil
 }
 
-// processSecurityToken issues and propagates a sandbox security token when the
-// sandbox annotations opt into the identity provider path.
-func processSecurityToken(ctx context.Context, opts infra.ClaimSandboxOptions, sbx *Sandbox, cache infracache.Provider, metrics *infra.ClaimMetrics) error {
-	if !identity.IsIdentityProviderRequested(sbx.Sandbox) {
-		return nil
-	}
-
+// processSecurityToken issues and propagates a sandbox security token.
+// It persists the token refresh status via recordSecurityTokenRefreshStatus
+// and propagates the token to the runtime.
+// Returns the total duration of the function execution so callers can record metrics.
+// Callers are responsible for gating on identity.IsIdentityProviderRequested before
+// calling this function.
+func processSecurityToken(ctx context.Context, sbx *Sandbox, cache infracache.Provider) (time.Duration, error) {
+	start := time.Now()
 	log := klog.FromContext(ctx)
-	opts.SecurityToken = &infra.SecurityTokenOptions{}
 	log.Info("starting to issue security token via identity provider")
-	var err error
-	metrics.SecurityToken, err = issueSecurityToken(ctx, sbx, opts.Claim, opts.SecurityToken)
+
+	securityToken, err := identity.IssueSandboxToken(ctx, sbx.Sandbox)
 	if err != nil {
 		log.Error(err, "failed to issue security token")
-		return retriableError{Message: fmt.Sprintf("security token issuance failed: %s", err)}
+		return time.Since(start), err
 	}
-	metrics.Total += metrics.SecurityToken
 
 	// At this point modifyPickedSandbox has already persisted the locking patch,
 	// so additional annotation mutations on sbx.Sandbox would only live in memory.
-	// Patch via the apiserver here to persist the refresh status, and keep
+	// Patch via the apiserver here to persist the refresh status and keep
 	// sbx.Sandbox in sync with the patched object.
-	if err = recordSecurityTokenRefreshStatus(ctx, cache.GetClient(), sbx, opts); err != nil {
+	if err := recordSecurityTokenRefreshStatus(ctx, cache.GetClient(), sbx, securityToken); err != nil {
 		log.Error(err, "failed to modify picked sandbox for security token status")
-		return retriableError{Message: fmt.Sprintf("failed to modify picked sandbox for security token status: %s", err)}
+		return time.Since(start), err
 	}
 
-	if err = identity.PropagateSandboxToken(ctx, sbx.Sandbox, &opts.SecurityToken.TokenResponse); err != nil {
-		return retriableError{Message: fmt.Sprintf("security token propagation failed: %s", err)}
+	if err := identity.PropagateSandboxToken(ctx, sbx.Sandbox, securityToken); err != nil {
+		return time.Since(start), err
 	}
-	return nil
+	return time.Since(start), nil
 }
 
 // clearFailedSandbox cleans up (or reserves) a failed sandbox according to
@@ -631,19 +632,6 @@ func pickFromCandidates(ctx context.Context, candidates []*v1alpha1.Sandbox, pic
 	return nil, errors.New("all candidates are picked")
 }
 
-// issueSecurityToken issues a security token for the given sandbox via
-// identity.IssueSandboxToken and writes the full issued token response into
-// the sandbox's SecurityToken option for downstream consumption (annotation
-// recording and runtime propagation).
-func issueSecurityToken(ctx context.Context, sbx *Sandbox, claim *v1alpha1.SandboxClaim, opts *infra.SecurityTokenOptions) (time.Duration, error) {
-	tokenResp, cost, err := identity.IssueSandboxToken(ctx, sbx.Sandbox, claim)
-	if err != nil {
-		return cost, err
-	}
-	opts.TokenResponse = *tokenResp
-	return cost, nil
-}
-
 var FilteredAnnotationsOnCreation []string
 
 func newSandboxFromSandboxSet(ctx context.Context, opts infra.ClaimSandboxOptions, cache infracache.Provider) (*Sandbox, infra.LockType, error) {
@@ -749,11 +737,11 @@ func modifyPickedSandbox(sbx *Sandbox, lockType infra.LockType, opts infra.Claim
 //
 // On success, the local sbx.Sandbox is replaced with the patched object so subsequent in-memory
 // reads observe the new annotation.
-func recordSecurityTokenRefreshStatus(ctx context.Context, c client.Client, sbx *Sandbox, opts infra.ClaimSandboxOptions) error {
-	if opts.SecurityToken == nil {
+func recordSecurityTokenRefreshStatus(ctx context.Context, c client.Client, sbx *Sandbox, securityToken *identity.TokenResponse) error {
+	if securityToken == nil {
 		return nil
 	}
-	raw, err := identity.EncodeTokenRefreshStatus(identity.BuildTokenRefreshStatus(&opts.SecurityToken.TokenResponse))
+	raw, err := identity.EncodeTokenRefreshStatus(identity.BuildTokenRefreshStatus(securityToken))
 	if err != nil {
 		return fmt.Errorf("failed to marshal token refresh expiration status: %w", err)
 	}

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -2367,19 +2367,15 @@ func TestModifyPickedSandbox_CSIMount(t *testing.T) {
 func TestRecordSecurityTokenRefreshStatus(t *testing.T) {
 	tests := []struct {
 		name             string
-		opts             infra.ClaimSandboxOptions
+		securityToken    *identity.TokenResponse
 		expectedAnnos    map[string]string
 		notExpectedAnnos []string
 	}{
 		{
 			name: "with security token and expiration",
-			opts: infra.ClaimSandboxOptions{
-				SecurityToken: &infra.SecurityTokenOptions{
-					TokenResponse: identity.TokenResponse{
-						AccessToken:           "security-access-token",
-						AccessTokenExpiration: "2026-12-31T23:59:59Z",
-					},
-				},
+			securityToken: &identity.TokenResponse{
+				AccessToken:           "security-access-token",
+				AccessTokenExpiration: "2026-12-31T23:59:59Z",
 			},
 			expectedAnnos: map[string]string{
 				identity.AgentKeyTokenRefreshStatus: `{"accessTokenExpiration":"2026-12-31T23:59:59Z"}`,
@@ -2387,12 +2383,8 @@ func TestRecordSecurityTokenRefreshStatus(t *testing.T) {
 		},
 		{
 			name: "with security token without expiration",
-			opts: infra.ClaimSandboxOptions{
-				SecurityToken: &infra.SecurityTokenOptions{
-					TokenResponse: identity.TokenResponse{
-						AccessToken: "at-456",
-					},
-				},
+			securityToken: &identity.TokenResponse{
+				AccessToken: "at-456",
 			},
 			expectedAnnos: map[string]string{
 				// AccessTokenExpiration is omitempty, so empty value produces "{}"
@@ -2400,10 +2392,8 @@ func TestRecordSecurityTokenRefreshStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "without security token",
-			opts: infra.ClaimSandboxOptions{
-				SecurityToken: nil,
-			},
+			name:          "without security token",
+			securityToken: nil,
 			notExpectedAnnos: []string{
 				identity.AgentKeyTokenRefreshStatus,
 			},
@@ -2428,7 +2418,7 @@ func TestRecordSecurityTokenRefreshStatus(t *testing.T) {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sbx.Sandbox.DeepCopy()).Build()
 
-			err := recordSecurityTokenRefreshStatus(t.Context(), fakeClient, sbx, tt.opts)
+			err := recordSecurityTokenRefreshStatus(t.Context(), fakeClient, sbx, tt.securityToken)
 			require.NoError(t, err)
 
 			annotations := sbx.GetAnnotations()
@@ -2469,19 +2459,15 @@ func TestRecordSecurityTokenRefreshStatus_NilAnnotations(t *testing.T) {
 	tests := []struct {
 		name          string
 		initialAnnos  map[string]string
-		opts          infra.ClaimSandboxOptions
+		securityToken *identity.TokenResponse
 		expectedValue string
 	}{
 		{
 			name:         "nil annotations map is created",
 			initialAnnos: nil,
-			opts: infra.ClaimSandboxOptions{
-				SecurityToken: &infra.SecurityTokenOptions{
-					TokenResponse: identity.TokenResponse{
-						AccessToken:           "token-1",
-						AccessTokenExpiration: "2026-06-01T00:00:00Z",
-					},
-				},
+			securityToken: &identity.TokenResponse{
+				AccessToken:           "token-1",
+				AccessTokenExpiration: "2026-06-01T00:00:00Z",
 			},
 			expectedValue: `{"accessTokenExpiration":"2026-06-01T00:00:00Z"}`,
 		},
@@ -2490,22 +2476,16 @@ func TestRecordSecurityTokenRefreshStatus_NilAnnotations(t *testing.T) {
 			initialAnnos: map[string]string{
 				"existing-key": "existing-value",
 			},
-			opts: infra.ClaimSandboxOptions{
-				SecurityToken: &infra.SecurityTokenOptions{
-					TokenResponse: identity.TokenResponse{
-						AccessToken:           "token-2",
-						AccessTokenExpiration: "2026-07-01T00:00:00Z",
-					},
-				},
+			securityToken: &identity.TokenResponse{
+				AccessToken:           "token-2",
+				AccessTokenExpiration: "2026-07-01T00:00:00Z",
 			},
 			expectedValue: `{"accessTokenExpiration":"2026-07-01T00:00:00Z"}`,
 		},
 		{
-			name:         "nil security token is no-op with nil annotations",
-			initialAnnos: nil,
-			opts: infra.ClaimSandboxOptions{
-				SecurityToken: nil,
-			},
+			name:          "nil security token is no-op with nil annotations",
+			initialAnnos:  nil,
+			securityToken: nil,
 			expectedValue: "",
 		},
 	}
@@ -2528,7 +2508,7 @@ func TestRecordSecurityTokenRefreshStatus_NilAnnotations(t *testing.T) {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sbx.Sandbox.DeepCopy()).Build()
 
-			err := recordSecurityTokenRefreshStatus(t.Context(), fakeClient, sbx, tt.opts)
+			err := recordSecurityTokenRefreshStatus(t.Context(), fakeClient, sbx, tt.securityToken)
 			require.NoError(t, err)
 
 			annotations := sbx.GetAnnotations()
@@ -2623,16 +2603,12 @@ func TestRecordSecurityTokenRefreshStatus_PatchErrors(t *testing.T) {
 			}
 			fakeClient := builder.Build()
 
-			opts := infra.ClaimSandboxOptions{
-				SecurityToken: &infra.SecurityTokenOptions{
-					TokenResponse: identity.TokenResponse{
-						AccessToken:           "at-err",
-						AccessTokenExpiration: "2027-01-01T00:00:00Z",
-					},
-				},
+			securityToken := &identity.TokenResponse{
+				AccessToken:           "at-err",
+				AccessTokenExpiration: "2027-01-01T00:00:00Z",
 			}
 
-			err := recordSecurityTokenRefreshStatus(t.Context(), fakeClient, sbx, opts)
+			err := recordSecurityTokenRefreshStatus(t.Context(), fakeClient, sbx, securityToken)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectErrSubstring)
 
@@ -2675,16 +2651,12 @@ func TestRecordSecurityTokenRefreshStatus_Overwrite(t *testing.T) {
 	originalSbxRef := sbx.Sandbox
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sbx.Sandbox.DeepCopy()).Build()
 
-	opts := infra.ClaimSandboxOptions{
-		SecurityToken: &infra.SecurityTokenOptions{
-			TokenResponse: identity.TokenResponse{
-				AccessToken:           "at-new",
-				AccessTokenExpiration: "2027-06-01T00:00:00Z",
-			},
-		},
+	securityToken := &identity.TokenResponse{
+		AccessToken:           "at-new",
+		AccessTokenExpiration: "2027-06-01T00:00:00Z",
 	}
 
-	err := recordSecurityTokenRefreshStatus(t.Context(), fakeClient, sbx, opts)
+	err := recordSecurityTokenRefreshStatus(t.Context(), fakeClient, sbx, securityToken)
 	require.NoError(t, err)
 
 	// Annotation is overwritten with the newly issued status.
@@ -4464,13 +4436,13 @@ func TestNewSandboxFromSandboxSet_TemplateRef(t *testing.T) {
 
 // mockIdentityProvider is a configurable mock for testing TryClaimSandbox security token flows.
 type mockIdentityProvider struct {
-	issueTokenFunc func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error)
+	issueTokenFunc func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error)
 	propagateFunc  func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error
 }
 
-func (m *mockIdentityProvider) IssueToken(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
+func (m *mockIdentityProvider) IssueToken(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
 	if m.issueTokenFunc != nil {
-		return m.issueTokenFunc(ctx, sbx, claim)
+		return m.issueTokenFunc(ctx, sbx)
 	}
 	return &identity.TokenResponse{AccessToken: uuid.NewString()}, nil
 }
@@ -4511,12 +4483,9 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				InitRuntime: &config.InitRuntimeOptions{
 					AccessToken: "original-uuid-token",
 				},
-				SecurityToken: &infra.SecurityTokenOptions{
-					TokenResponse: identity.TokenResponse{AccessToken: "placeholder"},
-				},
 			},
 			mockProvider: &mockIdentityProvider{
-				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
 					return &identity.TokenResponse{AccessToken: "secure-token-123"}, nil
 				},
 				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
@@ -4544,12 +4513,9 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				InitRuntime: &config.InitRuntimeOptions{
 					AccessToken: "original-uuid-token",
 				},
-				SecurityToken: &infra.SecurityTokenOptions{
-					TokenResponse: identity.TokenResponse{AccessToken: "placeholder"},
-				},
 			},
 			mockProvider: &mockIdentityProvider{
-				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
 					return nil, fmt.Errorf("identity provider unavailable")
 				},
 				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
@@ -4557,7 +4523,7 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 					return nil
 				},
 			},
-			expectError: "security token issuance failed",
+			expectError: "failed to issue security token",
 		},
 		{
 			name: "propagate security token failure returns retriable error",
@@ -4567,19 +4533,16 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				InitRuntime: &config.InitRuntimeOptions{
 					AccessToken: "original-uuid-token",
 				},
-				SecurityToken: &infra.SecurityTokenOptions{
-					TokenResponse: identity.TokenResponse{AccessToken: "placeholder"},
-				},
 			},
 			mockProvider: &mockIdentityProvider{
-				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
 					return &identity.TokenResponse{AccessToken: "secure-token-456"}, nil
 				},
 				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
 					return fmt.Errorf("propagation failed")
 				},
 			},
-			expectError: "security token propagation failed",
+			expectError: "propagation failed",
 		},
 		{
 			name: "security token is issued even when access token is not UUID",
@@ -4591,7 +4554,7 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				},
 			},
 			mockProvider: &mockIdentityProvider{
-				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
 					return &identity.TokenResponse{AccessToken: "issued-token"}, nil
 				},
 			},
@@ -4610,7 +4573,7 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				Template: existTemplate,
 			},
 			mockProvider: &mockIdentityProvider{
-				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
 					return &identity.TokenResponse{AccessToken: "issued-token"}, nil
 				},
 			},
@@ -4643,7 +4606,7 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				delete(sbx.Annotations, identity.AnnotationAgentName)
 			},
 			mockProvider: &mockIdentityProvider{
-				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, claim *v1alpha1.SandboxClaim) (*identity.TokenResponse, error) {
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
 					t.Fatalf("IssueToken must not be called when agent-name annotation is absent")
 					return nil, nil
 				},

--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/openkruise/agents/api/v1alpha1"
 	infracache "github.com/openkruise/agents/pkg/cache"
+	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
@@ -162,7 +163,21 @@ func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache inf
 		return
 	}
 
-	// Step 6: csi mount
+	// Step 6: process security token
+	// Issue and propagate the identity-provider security token before performing
+	// CSI mounts, mirroring the claim flow ordering.
+	if identity.IsIdentityProviderRequested(sbx.Sandbox) {
+		metrics.SecurityToken, err = processSecurityToken(ctx, sbx, cache)
+		if err != nil {
+			if !wait.Interrupted(err) {
+				err = retriableError{Message: fmt.Sprintf("security token processing failed: %s", err)}
+			}
+			return
+		}
+		metrics.Total += metrics.SecurityToken
+	}
+
+	// Step 7: csi mount
 	// If opts.CSIMount is not provided from request, try to resolve mount options from sandbox annotation.
 	if opts.CSIMount == nil {
 		var resolveErr error

--- a/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
@@ -36,16 +36,17 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/openkruise/agents/pkg/utils/runtime"
-
 	"github.com/openkruise/agents/api/v1alpha1"
 	infracache "github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/cache/cachetest"
+	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
+	"github.com/openkruise/agents/pkg/utils/runtime"
 	utestutils "github.com/openkruise/agents/pkg/utils/testutils"
 	testutils "github.com/openkruise/agents/test/utils"
 )
@@ -2150,4 +2151,217 @@ func TestCloneSandboxAdmissionUsesPersistedLockString(t *testing.T) {
 	require.NotNil(t, sbx)
 	require.NotEmpty(t, acquired)
 	assert.Equal(t, acquired, sbx.GetAnnotations()[v1alpha1.AnnotationLock])
+}
+
+//goland:noinspection GoDeprecation
+func TestCloneSandbox_SecurityToken(t *testing.T) {
+	utestutils.InitLogOutput()
+
+	// Enable SecurityIdentityProviderGate for all sub-tests
+	require.NoError(t, utilfeature.DefaultMutableFeatureGate.Set("SecurityIdentityProvider=true"))
+	t.Cleanup(func() {
+		require.NoError(t, utilfeature.DefaultMutableFeatureGate.Set("SecurityIdentityProvider=false"))
+	})
+
+	checkpointID := "clone-sec-token-cp"
+	user := "test-user"
+
+	tests := []struct {
+		name         string
+		mockProvider *mockIdentityProvider
+		addAgentName bool
+		expectError  string
+		postCheck    func(t *testing.T, sbx infra.Sandbox, metrics infra.CloneMetrics)
+	}{
+		{
+			name: "issue security token success and propagate",
+			mockProvider: &mockIdentityProvider{
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
+					return &identity.TokenResponse{AccessToken: "clone-secure-token-123"}, nil
+				},
+				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
+					return nil
+				},
+			},
+			addAgentName: true,
+			postCheck: func(t *testing.T, sbx infra.Sandbox, metrics infra.CloneMetrics) {
+				annotations := sbx.GetAnnotations()
+				// SecurityToken metrics should be recorded
+				assert.Greater(t, metrics.SecurityToken, time.Duration(0))
+				// TokenRefreshStatus annotation should be set
+				raw := annotations[identity.AgentKeyTokenRefreshStatus]
+				assert.NotEmpty(t, raw)
+				var decoded identity.TokenRefreshStatus
+				require.NoError(t, json.Unmarshal([]byte(raw), &decoded))
+			},
+		},
+		{
+			name: "issue security token failure returns retriable error",
+			mockProvider: &mockIdentityProvider{
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
+					return nil, fmt.Errorf("identity provider unavailable")
+				},
+				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
+					t.Fatalf("PropagateSecurityToken must not be called when IssueToken fails")
+					return nil
+				},
+			},
+			addAgentName: true,
+			expectError:  "failed to issue security token",
+		},
+		{
+			name: "propagate security token failure returns retriable error",
+			mockProvider: &mockIdentityProvider{
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
+					return &identity.TokenResponse{AccessToken: "clone-secure-token-456"}, nil
+				},
+				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
+					return fmt.Errorf("propagation failed")
+				},
+			},
+			addAgentName: true,
+			expectError:  "propagation failed",
+		},
+		{
+			name: "skips security token issuance when agent-name annotation is absent",
+			mockProvider: &mockIdentityProvider{
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
+					t.Fatalf("IssueToken must not be called when agent-name annotation is absent")
+					return nil, nil
+				},
+				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
+					t.Fatalf("PropagateSecurityToken must not be called when agent-name annotation is absent")
+					return nil
+				},
+			},
+			addAgentName: false,
+			postCheck: func(t *testing.T, sbx infra.Sandbox, metrics infra.CloneMetrics) {
+				annotations := sbx.GetAnnotations()
+				assert.Empty(t, annotations[identity.AgentKeyTokenRefreshStatus],
+					"TokenRefreshStatus annotation must NOT be written when the provider branch is skipped")
+				assert.Equal(t, time.Duration(0), metrics.SecurityToken,
+					"SecurityToken metric must remain zero when the provider branch is skipped")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup runtime server for InitRuntime
+			server := testutils.NewTestRuntimeServer(testutils.TestRuntimeServerOptions{
+				RunCommandResult:      runtime.RunCommandResult{PID: 1, Exited: true},
+				RunCommandImmediately: true,
+			})
+			defer server.Close()
+
+			// Save and restore the registered provider
+			identity.RegisterProvider(tt.mockProvider)
+			t.Cleanup(func() { identity.RegisterProvider(identity.NewDefaultIdentityProvider()) })
+
+			cache, fc, err := cachetest.NewTestCache(t)
+			require.NoError(t, err)
+			require.NoError(t, cache.Run(t.Context()))
+			defer cache.Stop(t.Context())
+
+			// Create SandboxTemplate with same name as checkpoint
+			sbt := &v1alpha1.SandboxTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      checkpointID,
+					Namespace: "default",
+				},
+				Spec: v1alpha1.SandboxTemplateSpec{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "main", Image: "test-image"},
+							},
+						},
+					},
+				},
+			}
+			require.NoError(t, fc.Create(t.Context(), sbt))
+
+			// Create Checkpoint
+			cp := &v1alpha1.Checkpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      checkpointID,
+					Namespace: "default",
+					Labels: map[string]string{
+						v1alpha1.LabelSandboxTemplate: checkpointID,
+					},
+				},
+				Status: v1alpha1.CheckpointStatus{
+					CheckpointId: checkpointID,
+				},
+			}
+			require.NoError(t, fc.Create(t.Context(), cp))
+			require.Eventually(t, func() bool {
+				_, err := cache.GetCheckpoint(t.Context(), infracache.GetCheckpointOptions{CheckpointID: checkpointID})
+				return err == nil
+			}, time.Second, 10*time.Millisecond)
+
+			// Decorator: DefaultCreateSandbox - set sandbox ready after creation and
+			// optionally add the agent-name annotation to opt into the identity provider path.
+			origCreateSandbox := DefaultCreateSandbox
+			DefaultCreateSandbox = func(ctx context.Context, sbx *v1alpha1.Sandbox, c client.Client) (*v1alpha1.Sandbox, error) {
+				if sbx.Annotations == nil {
+					sbx.Annotations = map[string]string{}
+				}
+				sbx.Annotations[v1alpha1.AnnotationRuntimeURL] = server.URL
+				if tt.addAgentName {
+					sbx.Annotations[identity.AnnotationAgentName] = "test-agent"
+				}
+				created, err := origCreateSandbox(ctx, sbx, c)
+				if err != nil {
+					return nil, err
+				}
+				// Update Sandbox status to Ready
+				created.Status = v1alpha1.SandboxStatus{
+					Phase:              v1alpha1.SandboxRunning,
+					ObservedGeneration: created.Generation,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1alpha1.SandboxConditionReady),
+							Status: metav1.ConditionTrue,
+							Reason: v1alpha1.SandboxReadyReasonPodReady,
+						},
+					},
+					PodInfo: v1alpha1.PodInfo{
+						PodIP: "1.2.3.4",
+					},
+				}
+				if err = c.Status().Update(ctx, created); err != nil {
+					return nil, err
+				}
+				return created, nil
+			}
+			t.Cleanup(func() { DefaultCreateSandbox = origCreateSandbox })
+
+			opts := infra.CloneSandboxOptions{
+				User:             user,
+				CheckPointID:     checkpointID,
+				WaitReadyTimeout: 30 * time.Second,
+				CloneTimeout:     500 * time.Millisecond,
+			}
+
+			ctx, cancel := context.WithTimeout(t.Context(), opts.CloneTimeout)
+			defer cancel()
+
+			sbx, metrics, cloneErr := CloneSandbox(ctx, opts, cache)
+
+			if tt.expectError != "" {
+				require.Error(t, cloneErr)
+				assert.Contains(t, cloneErr.Error(), tt.expectError)
+				var retryErr retriableError
+				assert.True(t, errors.As(cloneErr, &retryErr), "error should be a retriableError")
+			} else {
+				require.NoError(t, cloneErr)
+				require.NotNil(t, sbx)
+			}
+
+			if tt.postCheck != nil {
+				tt.postCheck(t, sbx, metrics)
+			}
+		})
+	}
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -166,6 +166,7 @@ func (i *Infra) ClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions
 		metrics.PickAndLock += tryMetrics.PickAndLock
 		metrics.WaitReady += tryMetrics.WaitReady
 		metrics.InitRuntime += tryMetrics.InitRuntime
+		metrics.SecurityToken += tryMetrics.SecurityToken
 		metrics.CSIMount += tryMetrics.CSIMount
 		metrics.LockType = tryMetrics.LockType
 		metrics.MergePickSandboxFailures(tryMetrics.PickSandboxFailures)

--- a/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
@@ -1247,7 +1247,7 @@ func TestInfra_CloneSandboxDoesNotRetryCreateFailure(t *testing.T) {
 
 func assertCloneMetricsTotalConsistent(t *testing.T, metrics infra.CloneMetrics) {
 	t.Helper()
-	expectedTotal := metrics.Wait + metrics.GetTemplate + metrics.CreateSandbox + metrics.WaitReady + metrics.InitRuntime + metrics.CSIMount
+	expectedTotal := metrics.Wait + metrics.GetTemplate + metrics.CreateSandbox + metrics.WaitReady + metrics.InitRuntime + metrics.SecurityToken + metrics.CSIMount
 	assert.Equal(t, expectedTotal, metrics.Total)
 }
 

--- a/pkg/sandbox-manager/infra/types.go
+++ b/pkg/sandbox-manager/infra/types.go
@@ -25,20 +25,9 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/openkruise/agents/api/v1alpha1"
-	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/utils/timeout"
 )
-
-// SecurityTokenOptions wraps the issued security token response for downstream
-// consumers in the claim pipeline. It lives here (rather than in
-// pkg/sandbox-manager/config) to avoid an import cycle:
-// pkg/identity -> pkg/utils/runtime -> pkg/sandbox-manager/config -> pkg/identity.
-// pkg/sandbox-manager/infra is allowed to depend on pkg/identity because it is
-// not transitively imported by pkg/identity.
-type SecurityTokenOptions struct {
-	identity.TokenResponse
-}
 
 type SaveTimeoutOptions struct {
 	Timeout          timeout.Options
@@ -81,8 +70,6 @@ type ClaimSandboxOptions struct {
 	InitRuntime *config.InitRuntimeOptions `json:"initRuntime"`
 	// Set CSIMount to non-nil value to mount a CSI volume
 	CSIMount *config.CSIMountOptions `json:"CSIMount"`
-	// Set SecurityToken value in runtime
-	SecurityToken *SecurityTokenOptions `json:"securityToken"`
 	// Max ClaimTimeout duration
 	ClaimTimeout time.Duration `json:"claimTimeout"`
 	// Max WaitReadyTimeout duration
@@ -218,6 +205,7 @@ type CloneMetrics struct {
 	CreateSandbox time.Duration
 	WaitReady     time.Duration
 	InitRuntime   time.Duration
+	SecurityToken time.Duration
 	CSIMount      time.Duration
 	Total         time.Duration
 	LastError     error
@@ -228,8 +216,8 @@ func (m *CloneMetrics) String() string {
 	if m.LastError != nil {
 		lastErrStr = sanitizeErrorMessage(m.LastError)
 	}
-	return fmt.Sprintf("CloneMetrics{Retries: %d, Wait: %v, GetTemplate: %v, CreateSandbox: %v, WaitReady: %v, InitRuntime: %v, CSIMount: %v, Total: %v, LastError: %v}",
-		m.Retries, m.Wait, m.GetTemplate, m.CreateSandbox, m.WaitReady, m.InitRuntime, m.CSIMount, m.Total, lastErrStr)
+	return fmt.Sprintf("CloneMetrics{Retries: %d, Wait: %v, GetTemplate: %v, CreateSandbox: %v, WaitReady: %v, InitRuntime: %v, SecurityToken: %v, CSIMount: %v, Total: %v, LastError: %v}",
+		m.Retries, m.Wait, m.GetTemplate, m.CreateSandbox, m.WaitReady, m.InitRuntime, m.SecurityToken, m.CSIMount, m.Total, lastErrStr)
 }
 
 // Merge accumulates per-attempt durations from src into m. Retries and
@@ -241,6 +229,7 @@ func (m *CloneMetrics) Merge(src CloneMetrics) {
 	m.CreateSandbox += src.CreateSandbox
 	m.WaitReady += src.WaitReady
 	m.InitRuntime += src.InitRuntime
+	m.SecurityToken += src.SecurityToken
 	m.CSIMount += src.CSIMount
 	m.Total += src.Total
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Extend the `CloneSandbox` flow with identity-provider security-token processing (new Step 6, between re-init runtime and CSI mount), mirroring the existing claim flow ordering.

As part of sharing the logic between claim and clone, `processSecurityToken` and its helpers were refactored for cleaner ownership and simpler signatures:

- **The `infra.SecurityTokenOptions` wrapper type is removed.** `processSecurityToken` and `recordSecurityTokenRefreshStatus` both accept `*identity.TokenResponse` directly.
- **The `issueSecurityToken` helper is removed.** `processSecurityToken` now calls `identity.IssueSandboxToken` directly, eliminating the one-line wrapper.
- **`identity.IssueSandboxToken` signature simplified:** the unused `time.Duration` second return value is dropped. The helper still measures and logs the cost internally for observability but no longer exposes it to callers. New signature: `IssueSandboxToken(ctx, sbx) (*TokenResponse, error)`.
- **`processSecurityToken`** is refactored to take only `(ctx, sbx, cache)`. The token response is a local variable from `identity.IssueSandboxToken`. It measures the total function execution time via `time.Since(start)` and returns the duration for metrics.
- **The `IsIdentityProviderRequested` opt-in gate** is moved from inside `processSecurityToken` to both callers (`runClaimPostProcesses` and `CloneSandbox`).
- **Error wrapping with `retriableError`** is moved from `processSecurityToken` to the callers, which wrap with descriptive messages (`"failed to process security token"` in claim, `"security token processing failed"` in clone).
- **The `SandboxClaim` parameter** is removed from the `IdentityProvider.IssueToken` interface and all implementations/callers, since no provider consumed it.
- **Dead fields removed**: `ClaimSandboxOptions.SecurityToken` and `CloneSandboxOptions.SecurityToken` were never read (callers allocated and immediately passed them to `processSecurityToken`, which allocated its own). Both are removed.

`CloneMetrics` gains a `SecurityToken` field (with `String`/`Merge` updates). Callers assign the first return value of `processSecurityToken` directly to `metrics.SecurityToken`.

A pre-existing metrics-accumulation bug in the `ClaimSandbox` retry loop is also fixed: the loop now accumulates `metrics.SecurityToken += tryMetrics.SecurityToken` across attempts (previously missing).

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how to verify it

1. `go build ./...`
2. `go test ./pkg/identity/... ./pkg/sandbox-manager/infra/sandboxcr/... ./pkg/controller/securitytokenrefresh/...` — all pass
3. New `TestCloneSandbox_SecurityToken` covers: success path, issuance failure (retriable), propagation failure (retriable), and the opt-out skip path (agent-name annotation absent → neither `IssueToken` nor `PropagateSecurityToken` is called)
4. Existing claim-path security-token tests continue to pass with the refactored signatures

### Ⅳ. Special notes for reviews

- **`IdentityProvider.IssueToken` signature change (breaking for out-of-tree providers):** `IssueToken(ctx, sbx, claim)` → `IssueToken(ctx, sbx)`. The `claim` parameter was unused by every in-tree provider and the refresher path; removing it tightens the contract. External providers (if any) must drop the second parameter.
- **`IssueSandboxToken` signature change (breaking for external callers):** `(*TokenResponse, time.Duration, error)` → `(*TokenResponse, error)`. The duration was discarded (`_`) at every call site. Cost is still logged internally.
- **`infra.SecurityTokenOptions` type removed:** claim/clone flows now use `*identity.TokenResponse` directly. Any external caller constructing `infra.SecurityTokenOptions{}` must switch to `identity.TokenResponse{}`.
- **`processSecurityToken` return change:** now `(time.Duration, error)` where the duration is the total function execution time (issue + record + propagate). Callers assign the first return value directly to `metrics.SecurityToken`.
- **`issueSecurityToken` helper removed:** the caller (`processSecurityToken`) now invokes `identity.IssueSandboxToken` directly.
- **Gate moved to callers:** the `identity.IsIdentityProviderRequested(sbx.Sandbox)` check is performed in `runClaimPostProcesses` (`claim.go`) and `CloneSandbox` (`clone.go`) before calling `processSecurityToken`.
- **Error wrapping moved to callers:** `processSecurityToken` returns raw errors from its sub-calls; callers wrap with `retriableError` and descriptive messages.
- **Metrics bug fix in `ClaimSandbox` retry loop:** `metrics.SecurityToken += tryMetrics.SecurityToken` is now accumulated in `infra.go`, consistent with all other per-field metrics.
- **Interface simplification propagation:** `IssueSandboxToken` (helper) callers — the `securitytokenrefresh` controller, the `sandboxcr` infra layer, and all test stubs — are updated accordingly. The obsolete `TestIssueSandboxToken_ClaimPassedThrough` test is removed.

---

### Appendix: Incidental Changes

The following changes are side modifications not directly related to the main purpose of this PR:

- gofmt import ordering fix in `pkg/sandbox-manager/infra/sandboxcr/clone_test.go` (folded `utilfeature` and `runtime` imports into the main `github.com/openkruise/agents/...` group in alphabetical order)
