### PR TITLE
test: fix flaky TestSandboxManager_DebugMaskAccessToken

### DIFF
--- a/pkg/sandbox-manager/debug_test.go
+++ b/pkg/sandbox-manager/debug_test.go
@@ -22,10 +22,13 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openkruise/agents/pkg/proxy"
+	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 )
 
 func TestSandboxManager_DebugMaskAccessToken(t *testing.T) {
-	manager, _ := setupTestManager(t)
+	// Disable route reconciliation to prevent the background reconciler from
+	// deleting test routes as orphaned between SetRoute and GetDebugInfo.
+	manager, _ := setupTestManager(t, config.SandboxManagerOptions{DisableRouteReconciliation: true})
 
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Problem

`TestSandboxManager_DebugMaskAccessToken` is flaky — it fails intermittently with:

```
Error: "[{IP:10.0.0.2 ID:default--sbx2 ...}]" should have 2 item(s), but has 1
```

## Root Cause

`setupTestManager` calls `InfraBuilder.Build()`, which starts a background route reconciler goroutine (`go i.startRouteReconciler(...)`). This reconciler periodically deletes routes that have no corresponding Sandbox CR as "orphaned".

In the test, routes `sbx1` and `sbx2` are set via `SetRoute` without backing Sandbox CRs. When the reconciler runs between `SetRoute` and `GetDebugInfo()`, it deletes `sbx1`, causing the assertion to see 1 route instead of 2.

## Fix

Pass `DisableRouteReconciliation: true` to `setupTestManager`, which skips the route reconciler goroutine entirely. The test only validates debug token masking behavior and does not need route reconciliation.

## Verification

- `go test -run TestSandboxManager_DebugMaskAccessToken -count=100 ./pkg/sandbox-manager/` — 100/100 PASS
- `go test -race -run TestSandboxManager_DebugMaskAccessToken -count=20 ./pkg/sandbox-manager/` — PASS
- Full `pkg/sandbox-manager` test suite — PASS
