### PR TITLE
fix(e2b): return 404 for dead sandboxes in DescribeSandbox to avoid SDK ValueError

### DIFF
--- a/pkg/servers/e2b/services.go
+++ b/pkg/servers/e2b/services.go
@@ -43,7 +43,11 @@ func (sc *Controller) DescribeSandbox(r *http.Request) (web.ApiResponse[*models.
 	log := klog.FromContext(r.Context())
 	log.Info("describe sandbox", "id", id)
 
-	sbx, err := sc.getSandboxOfUser(r.Context(), id, claimedSandboxStates)
+	// Use liveSandboxStates so that dead sandboxes return 404 (NotFound).
+	// The E2B SDK's SandboxState enum does not include "dead", so returning it
+	// would cause a ValueError on the client side. A dead sandbox is effectively
+	// unusable, so treating it as not-found from the API perspective is correct.
+	sbx, err := sc.getSandboxOfUser(r.Context(), id, liveSandboxStates)
 	if err != nil {
 		log.Error(err, "failed to get sandbox", "id", id)
 		return web.ApiResponse[*models.Sandbox]{}, err

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -2256,10 +2256,12 @@ func TestDescribeSandboxDeadClaimedSandbox(t *testing.T) {
 		"sandboxID": sandboxID,
 	}, user))
 
-	require.Nil(t, apiErr)
-	require.NotNil(t, describeResp.Body)
-	assert.Equal(t, sandboxID, describeResp.Body.SandboxID)
-	assert.Equal(t, v1alpha1.SandboxStateDead, describeResp.Body.State)
+	// A dead sandbox should be treated as not found from the E2B API perspective,
+	// because the E2B SDK cannot parse the "dead" state. Returning 404 allows
+	// clients to detect sandbox removal via SandboxNotFoundException.
+	assert.Nil(t, describeResp.Body)
+	require.NotNil(t, apiErr)
+	assert.Equal(t, http.StatusNotFound, apiErr.Code)
 }
 
 func TestDescribeSandboxReservedFailedSandboxReturnsNotFound(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The E2B Python SDK's `SandboxState` enum only includes `running` and `paused` (verified across all published versions 1.11.1–2.31.0). When `DescribeSandbox` (the `get_info` API) returned a sandbox in the `dead` state, the SDK crashed with:

```
ValueError: 'dead' is not a valid SandboxState
```

This commonly happens in upgrade/snapshot-restore flows: after `kill()`, the sandbox enters the `dead` state before the CR is fully removed. Polling `get_info()` to detect sandbox removal would crash instead of raising `SandboxNotFoundException`.

**Fix:** Changed `DescribeSandbox` to use `liveSandboxStates` (running + paused) instead of `claimedSandboxStates` (running + paused + dead). Dead sandboxes now return 404 NotFound, which the SDK translates to `SandboxNotFoundException`.

`DeleteSandbox` and `PauseSandbox` still use `claimedSandboxStates` with dead included, so dead sandboxes can still be killed or cleaned up via the API.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run unit tests: `go test ./pkg/servers/e2b/ -run TestDescribeSandbox -v`
2. Run the full e2b test suite: `go test ./pkg/servers/e2b/ -count=1`
3. Verify `TestDescribeSandboxDeadClaimedSandbox` now expects 404 (not 200 with `dead` state)
4. Verify `TestDeleteSandboxDeadClaimedSandbox` still passes (dead sandboxes can still be deleted)

### Ⅳ. Special notes for reviews

- The `dead` state is a Kruise Agents internal concept (`SandboxStateDead = "dead"` in `api/v1alpha1/sandboxset_types.go`) that the E2B SDK was never designed to handle.
- All E2B SDK versions (1.11.1 through 2.31.0) use `SandboxState(d.pop("state"))` — a bare enum constructor with no error handling. No version can parse `"dead"`.
- `DeleteSandbox` handler already gracefully handles the not-found case (returns 204), so removing dead from describe does not break kill semantics.
- `TestDescribeSandboxDeadClaimedSandbox` was updated from expecting `200 + state=dead` to expecting `404 NotFound`.
