### PR TITLE
feat(sandbox-manager): propagate identity annotations to checkpoint

### DIFF
--- a/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils.go
@@ -17,13 +17,55 @@ limitations under the License.
 package sandboxcr
 
 import (
+	"strings"
+
 	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/identity"
 )
 
-// necessaryAnnotationKeys defines the list of annotation keys that need to be
-// preserved when converting between Sandbox and SandboxTemplate.
+// necessaryAnnotationKeys defines the exact annotation keys that need to be
+// preserved when converting between Sandbox and Checkpoint.
 var necessaryAnnotationKeys = []string{
 	v1alpha1.AnnotationCSIVolumeConfig,
+}
+
+// necessaryAnnotationKeyPrefixes defines annotation key prefixes whose matching
+// keys need to be preserved when converting between Sandbox and Checkpoint.
+// All security-related annotations (identity provider integration) share the
+// SecurityMetadataPrefix and must travel together with the checkpoint.
+var necessaryAnnotationKeyPrefixes = []string{
+	identity.SecurityMetadataPrefix,
+}
+
+// shouldPreserveAnnotation reports whether the given annotation key should be
+// preserved, either because it exactly matches one of necessaryAnnotationKeys
+// or because it carries one of necessaryAnnotationKeyPrefixes.
+func shouldPreserveAnnotation(key string) bool {
+	for _, k := range necessaryAnnotationKeys {
+		if key == k {
+			return true
+		}
+	}
+	for _, prefix := range necessaryAnnotationKeyPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// copyPreservedAnnotations copies every preserved annotation with a non-empty
+// value from src into dst, allocating dst when it is nil, and returns dst.
+func copyPreservedAnnotations(src, dst map[string]string) map[string]string {
+	if dst == nil {
+		dst = make(map[string]string, len(necessaryAnnotationKeys))
+	}
+	for key, val := range src {
+		if val != "" && shouldPreserveAnnotation(key) {
+			dst[key] = val
+		}
+	}
+	return dst
 }
 
 func PropagateAnnotationsToCheckpoint(sbx *v1alpha1.Sandbox, cp *v1alpha1.Checkpoint) {
@@ -31,16 +73,7 @@ func PropagateAnnotationsToCheckpoint(sbx *v1alpha1.Sandbox, cp *v1alpha1.Checkp
 	if sbxAnnotations == nil {
 		return
 	}
-	cpAnnotations := cp.GetAnnotations()
-	if cpAnnotations == nil {
-		cpAnnotations = make(map[string]string, len(necessaryAnnotationKeys))
-	}
-	for _, key := range necessaryAnnotationKeys {
-		if val, ok := sbxAnnotations[key]; ok && val != "" {
-			cpAnnotations[key] = val
-		}
-	}
-	cp.SetAnnotations(cpAnnotations)
+	cp.SetAnnotations(copyPreservedAnnotations(sbxAnnotations, cp.GetAnnotations()))
 }
 
 // RestoreAnnotationsFromCheckpoint copies necessary annotations from a Checkpoint back to a Sandbox.
@@ -51,14 +84,5 @@ func RestoreAnnotationsFromCheckpoint(cp *v1alpha1.Checkpoint, sbx *v1alpha1.San
 	if cpAnnotations == nil {
 		return
 	}
-	sbxAnnotations := sbx.GetAnnotations()
-	if sbxAnnotations == nil {
-		sbxAnnotations = make(map[string]string, len(necessaryAnnotationKeys))
-	}
-	for _, key := range necessaryAnnotationKeys {
-		if val, ok := cpAnnotations[key]; ok && val != "" {
-			sbxAnnotations[key] = val
-		}
-	}
-	sbx.SetAnnotations(sbxAnnotations)
+	sbx.SetAnnotations(copyPreservedAnnotations(cpAnnotations, sbx.GetAnnotations()))
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils_test.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/identity"
 )
 
 func TestPropagateAnnotationsToCheckpoint(t *testing.T) {
@@ -128,6 +129,51 @@ func TestPropagateAnnotationsToCheckpoint(t *testing.T) {
 			},
 			expectedAnnotation: map[string]string{
 				"existing-key": "existing-value",
+			},
+		},
+		{
+			name: "sandbox has security-prefixed annotations - propagated to checkpoint",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						identity.AnnotationAgentName:        "my-agent",
+						identity.AgentKeyTokenRefreshStatus: `{"accessTokenExpiration":"2026-01-01T00:00:00Z"}`,
+						"some-other-key":                    "should-not-propagate",
+					},
+				},
+			},
+			cp: &v1alpha1.Checkpoint{},
+			expectedAnnotation: map[string]string{
+				identity.AnnotationAgentName:        "my-agent",
+				identity.AgentKeyTokenRefreshStatus: `{"accessTokenExpiration":"2026-01-01T00:00:00Z"}`,
+			},
+		},
+		{
+			name: "security-prefixed annotation with empty value - not propagated",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						identity.AnnotationAgentName: "",
+					},
+				},
+			},
+			cp:                 &v1alpha1.Checkpoint{},
+			expectedAnnotation: map[string]string{},
+		},
+		{
+			name: "sandbox has both necessary and security-prefixed annotations - both propagated",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						csiKey:                       `[{"driver":"nfs"}]`,
+						identity.AnnotationAgentName: "my-agent",
+					},
+				},
+			},
+			cp: &v1alpha1.Checkpoint{},
+			expectedAnnotation: map[string]string{
+				csiKey:                       `[{"driver":"nfs"}]`,
+				identity.AnnotationAgentName: "my-agent",
 			},
 		},
 	}
@@ -275,6 +321,21 @@ func TestRestoreAnnotationsFromCheckpoint(t *testing.T) {
 				csiKey: `[{"pvName":"pv-1","mountPath":"/data"}]`,
 			},
 		},
+		{
+			name: "checkpoint has security-prefixed annotations - restored to sandbox",
+			cp: &v1alpha1.Checkpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						identity.AnnotationAgentName: "my-agent",
+						"some-other-key":             "should-not-restore",
+					},
+				},
+			},
+			sbx: &v1alpha1.Sandbox{},
+			expectedAnnotation: map[string]string{
+				identity.AnnotationAgentName: "my-agent",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -295,6 +356,116 @@ func TestRestoreAnnotationsFromCheckpoint(t *testing.T) {
 					assert.Empty(t, sbxAnnotations[key], "annotation %s should not be set", key)
 				}
 			}
+		})
+	}
+}
+
+func TestShouldPreserveAnnotation(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		expected bool
+	}{
+		{
+			name:     "exact necessary key - preserved",
+			key:      v1alpha1.AnnotationCSIVolumeConfig,
+			expected: true,
+		},
+		{
+			name:     "security prefix agent-name key - preserved",
+			key:      identity.AnnotationAgentName,
+			expected: true,
+		},
+		{
+			name:     "security prefix token-status key - preserved",
+			key:      identity.AgentKeyTokenRefreshStatus,
+			expected: true,
+		},
+		{
+			name:     "key equals security prefix exactly - preserved",
+			key:      identity.SecurityMetadataPrefix,
+			expected: true,
+		},
+		{
+			name:     "arbitrary key under security prefix - preserved",
+			key:      identity.SecurityMetadataPrefix + "future-key",
+			expected: true,
+		},
+		{
+			name:     "unrelated key - not preserved",
+			key:      "some-other-key",
+			expected: false,
+		},
+		{
+			name:     "empty key - not preserved",
+			key:      "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, shouldPreserveAnnotation(tt.key))
+		})
+	}
+}
+
+func TestCopyPreservedAnnotations(t *testing.T) {
+	csiKey := v1alpha1.AnnotationCSIVolumeConfig
+
+	tests := []struct {
+		name     string
+		src      map[string]string
+		dst      map[string]string
+		expected map[string]string
+	}{
+		{
+			name: "nil dst allocated and preserved keys copied",
+			src: map[string]string{
+				csiKey:                       `[{"driver":"nfs"}]`,
+				identity.AnnotationAgentName: "my-agent",
+				"some-other-key":             "ignored",
+			},
+			dst: nil,
+			expected: map[string]string{
+				csiKey:                       `[{"driver":"nfs"}]`,
+				identity.AnnotationAgentName: "my-agent",
+			},
+		},
+		{
+			name: "empty value preserved key not copied",
+			src: map[string]string{
+				csiKey:                       "",
+				identity.AnnotationAgentName: "",
+			},
+			dst:      nil,
+			expected: map[string]string{},
+		},
+		{
+			name: "existing dst entries retained and merged",
+			src: map[string]string{
+				identity.AnnotationAgentName: "my-agent",
+			},
+			dst: map[string]string{
+				"existing-key": "existing-value",
+			},
+			expected: map[string]string{
+				"existing-key":               "existing-value",
+				identity.AnnotationAgentName: "my-agent",
+			},
+		},
+		{
+			name:     "empty src leaves dst unchanged",
+			src:      map[string]string{},
+			dst:      map[string]string{"existing-key": "existing-value"},
+			expected: map[string]string{"existing-key": "existing-value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := copyPreservedAnnotations(tt.src, tt.dst)
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Generalize checkpoint annotation propagation to support both exact keys
and key prefixes. Introduce necessaryAnnotationKeyPrefixes alongside the
existing necessaryAnnotationKeys, and add identity.SecurityMetadataPrefix
so all security-related annotations (e.g. agent-name, token-status) travel
with the checkpoint for identity provider integration.

Extract shared helpers shouldPreserveAnnotation and copyPreservedAnnotations,
reused symmetrically by PropagateAnnotationsToCheckpoint and
RestoreAnnotationsFromCheckpoint to keep both directions consistent.

Add table-driven unit tests covering exact/prefix matching, empty-value
filtering, nil-map allocation and merge behavior.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

