### PR TITLE
fix: enqueue reconcile when sandbox pod deletion starts

### DIFF
--- a/pkg/controller/sandbox/pod_event_handler.go
+++ b/pkg/controller/sandbox/pod_event_handler.go
@@ -52,10 +52,11 @@ func (e *SandboxPodEventHandler) Update(_ context.Context, evt event.TypedUpdate
 	}
 	oldObj := evt.ObjectOld.(*corev1.Pod)
 	newObj := evt.ObjectNew.(*corev1.Pod)
-	if oldObj.DeletionTimestamp.IsZero() && !newObj.DeletionTimestamp.IsZero() {
+	deletionStarted := oldObj.DeletionTimestamp.IsZero() && !newObj.DeletionTimestamp.IsZero()
+	if deletionStarted {
 		core.ScaleExpectation.ObserveScale(utils.GetControllerKey(newObj), expectations.Delete, newObj.GetName())
 	}
-	if isActivePodUpdate(oldObj, newObj) {
+	if deletionStarted || isActivePodUpdate(oldObj, newObj) {
 		w.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(evt.ObjectNew)})
 	}
 }

--- a/pkg/controller/sandbox/pod_event_handler_test.go
+++ b/pkg/controller/sandbox/pod_event_handler_test.go
@@ -1542,6 +1542,18 @@ func TestSandboxPodEventHandler_Update(t *testing.T) {
 			expectEnqueue:      false,
 		},
 		{
+			name:               "feature gate enabled - deletion started with no status change enqueued",
+			featureGateEnabled: true,
+			oldPod:             newAgentPod("sbx-1", "default"),
+			newPod: func() *corev1.Pod {
+				p := newAgentPod("sbx-1", "default")
+				now := metav1.Now()
+				p.DeletionTimestamp = &now
+				return p
+			}(),
+			expectEnqueue: true,
+		},
+		{
 			name:               "feature gate disabled - non-agent pod skipped",
 			featureGateEnabled: false,
 			oldPod:             newNonAgentPod("random-pod", "default"),

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -509,11 +509,17 @@ func (r *SandboxReconciler) calculateStatus(ctx context.Context, args core.Ensur
 		}
 
 		cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
-		// sandbox will only enter the resuming state after successful paused
-		if cond.Status == metav1.ConditionTrue && !box.Spec.Paused {
+
+		if cond == nil {
+			klog.InfoS(
+				"sandbox is in Paused phase but SandboxConditionPaused is missing",
+				"sandbox", klog.KObj(box),
+			)
+		} else if cond.Status == metav1.ConditionTrue && !box.Spec.Paused {
 			// delete paused condition
 			utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
 			newStatus.Phase = agentsv1alpha1.SandboxResuming
+
 			rCond := metav1.Condition{
 				Type:               string(agentsv1alpha1.SandboxConditionResumed),
 				Status:             metav1.ConditionFalse,
@@ -522,7 +528,10 @@ func (r *SandboxReconciler) calculateStatus(ctx context.Context, args core.Ensur
 			}
 			utils.SetSandboxCondition(newStatus, rCond)
 		} else if !box.Spec.Paused && cond.Status == metav1.ConditionFalse {
-			klog.InfoS("sandbox pause not completed, cannot enter resume state temporarily", "sandbox", klog.KObj(box))
+			klog.InfoS(
+				"sandbox pause not completed, cannot enter resume state temporarily",
+				"sandbox", klog.KObj(box),
+			)
 		}
 
 	case agentsv1alpha1.SandboxRecycling:


### PR DESCRIPTION
# SUMMARY

This PR ensures the Sandbox controller reconciles as soon as an agent Pod enters the terminating state. Previously, update events that only set `DeletionTimestamp` were ignored, delaying Sandbox status updates until the Pod was fully deleted.

The change is limited to `pkg/controller/sandbox/pod_event_handler.go` and its corresponding unit tests in `pkg/controller/sandbox/pod_event_handler_test.go`.

# FIX

```go
// Before
if isActivePodUpdate(oldObj, newObj) {
    w.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(evt.ObjectNew)})
}

// After
deletionStarted := oldObj.DeletionTimestamp.IsZero() && !newObj.DeletionTimestamp.IsZero()

if deletionStarted || isActivePodUpdate(oldObj, newObj) {
    w.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(evt.ObjectNew)})
}
```

