### PR TITLE
fix(clone): honor request CSI mount config over checkpoint annotation

### DIFF
--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -296,6 +296,14 @@ func prepareSandboxFromCheckpoint(ctx context.Context, opts infra.CloneSandboxOp
 	}
 	// e.g., copy csi mount config from checkpoint to sandbox obj
 	RestoreAnnotationsFromCheckpoint(cp, sbx.Sandbox)
+	// When the clone request explicitly provides CSI mount configs, they take
+	// precedence over the csi-volume-config restored from the checkpoint. This
+	// keeps the persisted annotation consistent with the mount performed in the
+	// csi-mount step, so later re-mounts (resume / in-place update / pod
+	// recreation) reuse the user-provided config instead of the checkpoint one.
+	if opts.CSIMount != nil && opts.CSIMount.MountOptionListRaw != "" {
+		sbx.Annotations[v1alpha1.AnnotationCSIVolumeConfig] = opts.CSIMount.MountOptionListRaw
+	}
 	DefaultPostProcessClonedSandbox(sbx.Sandbox)
 	return sbx, initRuntimeOpts, nil
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
@@ -380,6 +380,84 @@ func TestNewSandboxFromTemplate_StampsCloneLockString(t *testing.T) {
 	assert.Equal(t, "lock-1", sbx.Annotations[v1alpha1.AnnotationLock])
 }
 
+// TestPrepareSandboxFromCheckpoint_CSIMountConfigPrecedence verifies that a
+// request-supplied CSI mount config (opts.CSIMount.MountOptionListRaw) overrides
+// the csi-volume-config annotation restored from the checkpoint, while an absent
+// or empty request config leaves the checkpoint-restored annotation untouched.
+func TestPrepareSandboxFromCheckpoint_CSIMountConfigPrecedence(t *testing.T) {
+	const (
+		checkpointCSIConfig = `[{"pvName":"oss-pv","mountPath":"/oss-data/sub3","subPath":"read-write-01"}]`
+		userCSIConfig       = `[{"pvName":"oss-pv","mountPath":"/oss-data/sub3","subPath":"read-write-01","attributes":{"credentialProviderName":"oss-rw"}}]`
+	)
+
+	tmpl := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "cp-1", Namespace: "default"},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "test-image"}},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name              string
+		csiMount          *config.CSIMountOptions
+		checkpointCSIAnno string
+		expectCSIAnno     string
+	}{
+		{
+			name:              "user-provided csi mount config overrides checkpoint",
+			csiMount:          &config.CSIMountOptions{MountOptionListRaw: userCSIConfig},
+			checkpointCSIAnno: checkpointCSIConfig,
+			expectCSIAnno:     userCSIConfig,
+		},
+		{
+			name:              "no user csi mount config keeps checkpoint",
+			csiMount:          nil,
+			checkpointCSIAnno: checkpointCSIConfig,
+			expectCSIAnno:     checkpointCSIConfig,
+		},
+		{
+			name:              "empty user raw keeps checkpoint",
+			csiMount:          &config.CSIMountOptions{MountOptionListRaw: ""},
+			checkpointCSIAnno: checkpointCSIConfig,
+			expectCSIAnno:     checkpointCSIConfig,
+		},
+		{
+			name:              "user-provided csi mount config with no checkpoint annotation",
+			csiMount:          &config.CSIMountOptions{MountOptionListRaw: userCSIConfig},
+			checkpointCSIAnno: "",
+			expectCSIAnno:     userCSIConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cp := &v1alpha1.Checkpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: "cp-1", Namespace: "default"},
+			}
+			if tt.checkpointCSIAnno != "" {
+				cp.Annotations = map[string]string{
+					v1alpha1.AnnotationCSIVolumeConfig: tt.checkpointCSIAnno,
+				}
+			}
+
+			opts := infra.CloneSandboxOptions{
+				User:         "test-user",
+				CheckPointID: "cp-1",
+				CSIMount:     tt.csiMount,
+			}
+
+			sbx, _, err := prepareSandboxFromCheckpoint(t.Context(), opts, tmpl, cp, nil)
+			require.NoError(t, err)
+			require.NotNil(t, sbx)
+			assert.Equal(t, tt.expectCSIAnno, sbx.GetAnnotations()[v1alpha1.AnnotationCSIVolumeConfig])
+		})
+	}
+}
+
 func TestFindCheckpointAndTemplateById_NamespaceScoped(t *testing.T) {
 	objects := []client.Object{
 		&v1alpha1.SandboxTemplate{

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -278,9 +278,22 @@ func (sc *Controller) createSandboxWithClone(ctx context.Context, request models
 				Driver:     driverName,
 				RequestRaw: csiReqConfigRaw,
 			})
-			infraOpts.CSIMount = &config.CSIMountOptions{
-				MountOptionList: csiMountOptions,
+		}
+		// Persist the user-provided CSI mount config as raw JSON. During clone this
+		// lets the request-supplied csi mount config take precedence over the
+		// csi-volume-config restored from the checkpoint (see
+		// prepareSandboxFromCheckpoint), keeping the persisted annotation consistent
+		// with the mount actually performed so later re-mounts reuse the same config.
+		csiMountConfigRaw, err := json.Marshal(request.Extensions.CSIMount.MountConfigs)
+		if err != nil {
+			return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
+				Code:    http.StatusInternalServerError,
+				Message: fmt.Sprintf("failed to marshal csi mount config: %s", err.Error()),
 			}
+		}
+		infraOpts.CSIMount = &config.CSIMountOptions{
+			MountOptionList:    csiMountOptions,
+			MountOptionListRaw: string(csiMountConfigRaw),
 		}
 	}
 


### PR DESCRIPTION
During clone, the csi-volume-config annotation restored from the checkpoint could shadow a request-supplied CSI mount config. For agent-identity OSS mounts this dropped the credentialProviderName attribute, so sandboxCredProviderName was never injected and ossfs rejected the mount.

Persist the request-supplied config as raw JSON in createSandboxWithClone and override the checkpoint-restored csi-volume-config annotation with it in prepareSandboxFromCheckpoint when present. Behavior is unchanged when the request carries no CSI mount config.

Add table-driven coverage in TestPrepareSandboxFromCheckpoint_CSIMountConfigPrecedence.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

