### PR TITLE
feat(identity): defer security token refresh until sandbox is Ready

### DIFF
--- a/pkg/controller/securitytokenrefresh/predicate.go
+++ b/pkg/controller/securitytokenrefresh/predicate.go
@@ -17,12 +17,14 @@ limitations under the License.
 package securitytokenrefresh
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/identity"
+	"github.com/openkruise/agents/pkg/utils"
 )
 
 // needsRefreshPredicate filters Sandbox events down to the subset that this controller
@@ -46,6 +48,15 @@ func needsRefreshPredicate() predicate.Predicate {
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			if !isRefreshTarget(e.ObjectNew) {
 				return false
+			}
+			// Re-enqueue when a serving runtime appears (no runtime -> serving
+			// runtime). While there is no serving runtime the reconciler defers
+			// refresh, so we must re-evaluate promptly on that edge rather than
+			// depend on the resume flow's annotation rewrite to wake us up; this
+			// keeps the refresh controller self-sufficient and guarantees an
+			// overdue token is refreshed as soon as a serving runtime exists.
+			if !hasServingRuntime(e.ObjectOld) && hasServingRuntime(e.ObjectNew) {
+				return true
 			}
 			oldRaw := tokenStatusAnnotation(e.ObjectOld)
 			newRaw := tokenStatusAnnotation(e.ObjectNew)
@@ -87,6 +98,45 @@ func isRefreshTarget(obj client.Object) bool {
 		return true
 	}
 	return status != nil && status.AccessTokenExpiration != ""
+}
+
+// hasServingRuntime reports whether the sandbox currently has a live runtime
+// pod that has finished initialization and can therefore receive a propagated
+// token. It is deliberately token-INDEPENDENT: it looks only at the sandbox
+// Phase and the RuntimeInitialized condition, never at readiness.
+//
+// This independence is the whole point. The aggregate SandboxConditionReady
+// tracks the Pod's PodReady, which is the AND of every container's readiness
+// probe including the business container. When the business container consumes
+// our security token, its readiness probe can fail once the token expires;
+// gating refresh on Ready would then close a deadlock loop:
+//
+//	expired token -> business container not ready -> Pod not ready ->
+//	Sandbox not Ready -> refresh deferred -> token never refreshed.
+//
+// Neither Phase nor RuntimeInitialized can be pulled down by token expiry, so
+// gating on them lets the refresh always fire while a serving runtime exists,
+// breaking the loop.
+//
+// A serving runtime requires BOTH:
+//   - Phase == Running: a bound pod whose containers have started. This excludes
+//     Paused (pod deleted), Resuming, Pending/creating and recreate-Upgrading,
+//     where there is no reachable runtime and a propagate would fail.
+//   - RuntimeInitialized == True: the agent-runtime sidecar finished
+//     (re-)initialization and can accept a token. Resume resets this to False,
+//     so a resuming pod is correctly excluded until its runtime is re-inited.
+//
+// A non-Sandbox object (which never reaches this controller) reports false.
+func hasServingRuntime(obj client.Object) bool {
+	box, ok := obj.(*agentsv1alpha1.Sandbox)
+	if !ok {
+		return false
+	}
+	if box.Status.Phase != agentsv1alpha1.SandboxRunning {
+		return false
+	}
+	cond := utils.GetSandboxCondition(&box.Status, string(agentsv1alpha1.RuntimeInitialized))
+	return cond != nil && cond.Status == metav1.ConditionTrue
 }
 
 // tokenStatusAnnotation returns the raw value of the token-status annotation,

--- a/pkg/controller/securitytokenrefresh/predicate_test.go
+++ b/pkg/controller/securitytokenrefresh/predicate_test.go
@@ -134,6 +134,18 @@ func TestNeedsRefreshPredicate(t *testing.T) {
 	unrelatedUpdate := newSandbox("a", true, sampleStatus, false)
 	unrelatedUpdate.Spec.Paused = true // a non-annotation mutation
 
+	// notServing/serving pair share the same (unchanged) annotation so only the
+	// serving-runtime transition can drive the predicate decision. A serving
+	// runtime requires BOTH Phase==Running and RuntimeInitialized==True; the gate
+	// is intentionally token-independent (never the aggregate Ready condition).
+	notServing := newSandbox("a", true, sampleStatus, false)
+	serving := newSandbox("a", true, sampleStatus, false)
+	serving.Status.Phase = agentsv1alpha1.SandboxRunning
+	serving.Status.Conditions = []metav1.Condition{{
+		Type:   string(agentsv1alpha1.RuntimeInitialized),
+		Status: metav1.ConditionTrue,
+	}}
+
 	p := needsRefreshPredicate()
 
 	t.Run("create on refresh target", func(t *testing.T) {
@@ -156,6 +168,12 @@ func TestNeedsRefreshPredicate(t *testing.T) {
 	})
 	t.Run("update onto deleting sandbox", func(t *testing.T) {
 		assert.False(t, p.Update(event.UpdateEvent{ObjectOld: target, ObjectNew: deleting}))
+	})
+	t.Run("gain serving runtime (none -> serving) with unchanged annotation re-enqueues", func(t *testing.T) {
+		assert.True(t, p.Update(event.UpdateEvent{ObjectOld: notServing, ObjectNew: serving}))
+	})
+	t.Run("lose serving runtime (serving -> none) with unchanged annotation is dropped", func(t *testing.T) {
+		assert.False(t, p.Update(event.UpdateEvent{ObjectOld: serving, ObjectNew: notServing}))
 	})
 }
 

--- a/pkg/controller/securitytokenrefresh/token_refresh_controller.go
+++ b/pkg/controller/securitytokenrefresh/token_refresh_controller.go
@@ -94,7 +94,7 @@ func init() {
 }
 
 var (
-	concurrentReconciles = 10
+	concurrentReconciles = 500
 	refreshLeadTime      = defaultRefreshLeadTime
 	jitterRatio          = defaultJitterRatio
 	refreshRetryAfter    = defaultRefreshRetryAfter
@@ -218,6 +218,29 @@ func (r *SecurityTokenRefreshReconciler) Reconcile(ctx context.Context, req ctrl
 	// reconciler picks it up the sandbox might have been released or deleted.
 	if !isRefreshTarget(box) {
 		klog.V(5).InfoS("sandbox is not a refresh target, skip", "sandbox", klog.KObj(box))
+		return reconcile.Result{}, nil
+	}
+
+	// Only refresh the token of a sandbox whose runtime is actually serving. When
+	// there is no serving runtime pod (paused, resuming, pending, recreate-upgrading,
+	// ...) there is nothing to receive a refreshed token, so a refresh here would
+	// fail at the propagate step and spin the workqueue with TokenRefreshFailed
+	// noise while burning identity-provider issuance calls. An expired token is
+	// harmless with no serving runtime because nothing is consuming it, so we defer
+	// all refresh work until a serving runtime exists again: the
+	// no-runtime->serving predicate transition re-enqueues the sandbox (and the
+	// resume/recreate flow additionally rewrites the token-status annotation via
+	// reinitSecurityToken), so the schedule re-arms itself without any timing
+	// requeue here. We deliberately emit no event, since a sandbox with no serving
+	// runtime generating zero token traffic is exactly the intended behaviour.
+	//
+	// Crucially the gate is token-INDEPENDENT (Phase + RuntimeInitialized, never
+	// the aggregate Ready condition): a business container that consumes our token
+	// can fail its readiness probe once the token expires, and gating on Ready
+	// would then deadlock (expired token -> not Ready -> refresh deferred -> token
+	// never refreshed). See hasServingRuntime for the full rationale.
+	if !hasServingRuntime(box) {
+		klog.V(5).InfoS("sandbox has no serving runtime, defer security token refresh until it is serving", "sandbox", klog.KObj(box))
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/securitytokenrefresh/token_refresh_controller_test.go
+++ b/pkg/controller/securitytokenrefresh/token_refresh_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -134,7 +135,12 @@ func TestReconcile(t *testing.T) {
 		// claimed toggles the LabelSandboxIsClaimed=true label.
 		claimed       bool
 		objectMissing bool
-		refresher     *fakeRefresher
+		// notServing leaves Phase/RuntimeInitialized unset so the sandbox is treated
+		// as having no serving runtime; by default cases set Phase=Running and
+		// RuntimeInitialized=True so the timing branches run. The gate is
+		// token-independent (never the aggregate Ready condition).
+		notServing bool
+		refresher  *fakeRefresher
 		// expected outcomes
 		expectErr        string
 		expectRequeueMin time.Duration
@@ -318,6 +324,22 @@ func TestReconcile(t *testing.T) {
 			expectCalls:      1,
 			expectEvent:      "TokenRefreshed",
 		},
+		{
+			// A sandbox with no serving runtime (e.g. paused/resuming) has no pod
+			// to receive the token, so the reconciler must defer the refresh
+			// entirely: no refresher call, no requeue and no event, even though the
+			// token is already inside the lead window. The refresh is picked up
+			// again on the no-runtime->serving predicate transition (and the resume
+			// flow's annotation rewrite).
+			name:                      "sandbox with no serving runtime defers refresh even when due",
+			status:                    `{"accessTokenExpiration":"` + expireNow + `"}`,
+			claimed:                   true,
+			notServing:                true,
+			refresher:                 &fakeRefresher{},
+			expectErr:                 "",
+			expectCalls:               0,
+			expectAnnotationUnchanged: true,
+		},
 	}
 
 	cleanup := withFlags(defaultRefreshLeadTime, 0, defaultRefreshRetryAfter)
@@ -329,6 +351,13 @@ func TestReconcile(t *testing.T) {
 			if !tt.objectMissing {
 				sbx = newSandbox(sandboxName, tt.claimed, tt.status, false)
 				sbx.Namespace = sandboxNs
+				if !tt.notServing {
+					sbx.Status.Phase = agentsv1alpha1.SandboxRunning
+					sbx.Status.Conditions = []metav1.Condition{{
+						Type:   string(agentsv1alpha1.RuntimeInitialized),
+						Status: metav1.ConditionTrue,
+					}}
+				}
 			}
 			r, rec, c := newReconciler(t, tt.refresher, now, sbx)
 


### PR DESCRIPTION
Gate token refresh on sandbox readiness: while a sandbox is not Ready (paused, resuming, pending, upgrading) there is no serving runtime pod to receive a refreshed token, so refreshing would fail at the propagate step and spin the workqueue while burning issuance calls. The reconciler now defers all refresh work until the sandbox is Ready, and the predicate re-enqueues on the notReady->Ready transition so the schedule re-arms itself without a timing requeue.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

