### PR TITLE
fix(ci): add free-disk-space step to e2e-e2b-mysql-latest workflow

### DIFF
--- a/.github/workflows/e2e-e2b-mysql-latest.yaml
+++ b/.github/workflows/e2e-e2b-mysql-latest.yaml
@@ -55,6 +55,16 @@ jobs:
           config: ./test/kind-conf.yaml
           version: ${{ env.KIND_VERSION }}
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+
       - name: Cache Docker images
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Adds the `jlumbroso/free-disk-space` step to the `e2e-e2b-mysql-latest` workflow, matching what `e2e-e2b-latest` and `e2e-e2b-2.24.0` already include. The step removes pre-installed toolchains (dotnet, haskell, android) from the GitHub Actions runner before building Docker images, freeing ~10GB of disk space.

### Ⅱ. Does this pull request fix one issue?

NONE

The `e2e-e2b-mysql-latest` workflow's "with sandbox-gateway" matrix variant failed with `System.IO.IOException: No space left on device` (run [#29259033051](https://github.com/openkruise/agents/actions/runs/29259033051/job/86847007101)). The runner ran out of disk because the MySQL variant builds 5 Docker images (controller, manager, runtime, code-interpreter, inplace-update) plus the gateway image, without the disk-space cleanup step that the other E2E workflows already have.

### Ⅲ. Describe how to verify it

1. Confirm the new "Free disk space" step appears after "Setup Kind Cluster" and before "Cache Docker images" — identical to the pattern in `e2e-e2b-latest.yaml`.
2. Re-run the `E2E for E2B SDK - latest (MySQL Key Storage)` workflow and verify the "with sandbox-gateway" variant no longer fails with disk exhaustion.

### Ⅳ. Special notes for reviews

- The added step is a verbatim copy of the same step in `e2e-e2b-latest.yaml` (lines 72-80) and `e2e-e2b-2.24.0.yaml` (lines 54-62).
- Other E2E workflows also missing this step (`e2e-e2b-2.8.1`, `e2e-1.32`, `e2e-okactl`, `e2e-upgrade-1.32`) are lower risk since they only run `with_gateway: false`, but could benefit from the same fix in a follow-up.
