### PR TITLE
fix(e2b): poll is_running after kill to avoid async deletion race

### DIFF
--- a/test/e2b/test_sandbox.py
+++ b/test/e2b/test_sandbox.py
@@ -573,7 +573,19 @@ def test_is_running(sandbox_context, config):
     assert sbx.is_running()  # Returns True
 
     sbx.kill()
-    assert not sbx.is_running()  # Returns False
+    # kill() sends a DELETE request that returns immediately, but the
+    # underlying pod deletion is asynchronous — the gateway's informer
+    # cache may still serve the route for a few hundred milliseconds.
+    # Poll until is_running() returns False.
+    max_wait = 30
+    interval = 1
+    deadline = time.time() + max_wait
+    while time.time() < deadline:
+        if not sbx.is_running():
+            break
+        time.sleep(interval)
+    assert not sbx.is_running(), \
+        f"Sandbox was still running {max_wait}s after kill()"
 
 
 zero_time = datetime(1, 1, 1, 0, 0, tzinfo=tzutc())


### PR DESCRIPTION
## What changed

`test_is_running` in `test/e2b/test_sandbox.py` called `sbx.kill()` and immediately asserted `not sbx.is_running()`. Because `kill()` sends a DELETE request that returns 204 **immediately** while the underlying pod deletion is asynchronous, `is_running()` could still return `True` for a few hundred milliseconds — the gateway informer cache had not yet received the deletion update and the pod was still alive.

This race caused an intermittent CI failure:

```
FAILED test/e2b/test_sandbox.py::test_is_running - assert not True
 +  where True = is_running()
```

Observed in CI run [#29330433277](https://github.com/openkruise/agents/actions/runs/29330433277) on PR #586.

## Fix

Replace the immediate assertion with a polling loop (30s timeout, 1s interval) that waits for `is_running()` to return `False`, consistent with the retry patterns already used in `test/e2b/utils.py` (`connect_sandbox`, `run_code_sandbox`).

## Why this is a flake, not a regression

| Evidence | Details |
|----------|---------|
| Same commit, different matrix | `sandbox (with sandbox-gateway)` (auth enabled) **passed** the same test |
| Previous commits | `test_is_running` passed for 4 prior commits on the feature branch |
| Master branch | `e2e-e2b-latest` workflow has 3 failures in the last 10 runs on master, all with different tests |
| No code change | The failing CI run only added unit tests in `filter_test.go` — zero production code changes |

## Testing

- [x] Code follows project style
- [ ] CI will validate the fix

```release-note
Fix intermittent `test_is_running` E2E failure by polling `is_running()` after `kill()` instead of asserting immediately.
```