### PR TITLE
feat(controller): lazy sandbox finalizer — add on pause, remove on resume

### DIFF
--- a/docs/proposals/20260702-sandbox-otel-distributed-tracing-en.md
+++ b/docs/proposals/20260702-sandbox-otel-distributed-tracing-en.md
@@ -574,11 +574,11 @@ following early return paths:
 3. ✅ Terminal state (Failed/Succeeded) → return (no Span needed)
 4. ✅ Empty template (after termination handling) → return (no Span needed)
 
-Specifically, the placement is after `addSandboxFinalizerAndHash` and before `calculateStatus`:
+Specifically, the placement is after `addSandboxHashAnnotation` and before `calculateStatus`:
 
 ```go
 // sandbox_controller.go Reconcile():
-box, err = r.addSandboxFinalizerAndHash(ctx, box)
+box, err = r.addSandboxHashAnnotation(ctx, box)
 if err != nil { return reconcile.Result{}, err }
 
 // --- Tracing: create Reconcile Span ---

--- a/docs/specs/2026-07-02-sandbox-otel-tracing-design-en.md
+++ b/docs/specs/2026-07-02-sandbox-otel-tracing-design-en.md
@@ -184,7 +184,7 @@ In `pkg/controller/sandbox/sandbox_controller.go`'s `Reconcile` method:
 func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (crl ctrl.Result, err error) {
     // ... existing early return paths (Sandbox not found, expectation, terminal state, etc.) ...
 
-    box, err = r.addSandboxFinalizerAndHash(ctx, box)
+    box, err = r.addSandboxHashAnnotation(ctx, box)
     if err != nil { return reconcile.Result{}, err }
 
     // --- Tracing: create Reconcile Span ---

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/distribution/reference"
 
@@ -201,6 +202,14 @@ func (r *commonControl) EnsureSandboxPaused(ctx context.Context, args EnsureFunc
 	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
 	cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
 	if cond == nil {
+		// Add finalizer on first entry into paused state to ensure
+		// controller-mediated cleanup if the sandbox is deleted while paused.
+		if !controllerutil.ContainsFinalizer(box, SandboxFinalizer) {
+			if _, err := utils.PatchFinalizer(ctx, r.Client, box, utils.AddFinalizerOpType, SandboxFinalizer); err != nil {
+				return fmt.Errorf("failed to add finalizer for paused sandbox: %w", err)
+			}
+			klog.InfoS("Add finalizer for paused sandbox", "sandbox", klog.KObj(box))
+		}
 		cond = &metav1.Condition{
 			Type:               string(agentsv1alpha1.SandboxConditionPaused),
 			Status:             metav1.ConditionFalse,
@@ -274,6 +283,19 @@ func (r *commonControl) EnsureSandboxResumed(ctx context.Context, args EnsureFun
 
 	// when pod is running, transition sandbox from resuming to running
 	if pod.Status.Phase == corev1.PodRunning && isContainersConsistent(pod, box) {
+		// Best-effort removal of the finalizer added during pause. Now that
+		// the pod is running again, the finalizer is no longer needed.
+		// A leftover finalizer does not block the resume path — it will be
+		// cleaned up when the sandbox is eventually paused again or
+		// terminated — so we only log the error and proceed with the phase
+		// transition instead of failing the resume.
+		if controllerutil.ContainsFinalizer(box, SandboxFinalizer) {
+			if _, err := utils.PatchFinalizer(ctx, r.Client, box, utils.RemoveFinalizerOpType, SandboxFinalizer); err != nil {
+				klog.ErrorS(err, "failed to remove finalizer after resume, proceeding anyway", "sandbox", klog.KObj(box))
+			} else {
+				klog.InfoS("Remove finalizer after resume", "sandbox", klog.KObj(box))
+			}
+		}
 		newStatus.Phase = agentsv1alpha1.SandboxRunning
 		newStatus.NodeName = pod.Spec.NodeName
 		newStatus.SandboxIp = pod.Status.PodIP
@@ -362,12 +384,14 @@ func (r *commonControl) EnsureSandboxTerminated(ctx context.Context, args Ensure
 	pod, box, _ := args.Pod, args.Box, args.NewStatus
 	var err error
 	if pod == nil {
-		_, err = utils.PatchFinalizer(ctx, r.Client, box, utils.RemoveFinalizerOpType, SandboxFinalizer)
-		if err != nil {
-			klog.ErrorS(err, "update sandbox finalizer failed", "sandbox", klog.KObj(box))
-			return err
+		if controllerutil.ContainsFinalizer(box, SandboxFinalizer) {
+			_, err = utils.PatchFinalizer(ctx, r.Client, box, utils.RemoveFinalizerOpType, SandboxFinalizer)
+			if err != nil {
+				klog.ErrorS(err, "update sandbox finalizer failed", "sandbox", klog.KObj(box))
+				return err
+			}
+			klog.InfoS("remove sandbox finalizer success", "sandbox", klog.KObj(box))
 		}
-		klog.InfoS("remove sandbox finalizer success", "sandbox", klog.KObj(box))
 		return nil
 	} else if !pod.DeletionTimestamp.IsZero() {
 		klog.InfoS("Pod is deleting, and wait a moment", "sandbox", klog.KObj(box))

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
@@ -2561,6 +2562,117 @@ func TestCommonControl_EnsureSandboxResumed_RemovesFinalizer(t *testing.T) {
 	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: box.Name, Namespace: box.Namespace}, updatedBox)
 	assert.NoError(t, err)
 	assert.NotContains(t, updatedBox.Finalizers, SandboxFinalizer)
+}
+
+func TestCommonControl_EnsureSandboxPaused_FinalizerPatchError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	box := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+		},
+	}
+	newStatus := &agentsv1alpha1.SandboxStatus{
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(agentsv1alpha1.SandboxConditionReady),
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(box).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				return fmt.Errorf("simulated patch error")
+			},
+		}).
+		Build()
+
+	control := &commonControl{
+		Client:               fakeClient,
+		recorder:             record.NewFakeRecorder(10),
+		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
+		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+		checkpointControl:    NewCheckpointControl(fakeClient, record.NewFakeRecorder(10)),
+	}
+
+	err := control.EnsureSandboxPaused(context.TODO(), EnsureFuncArgs{Pod: nil, Box: box, NewStatus: newStatus})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to add finalizer for paused sandbox")
+	// Paused condition should NOT be set because the function returned early on error
+	assert.Nil(t, utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused)))
+}
+
+func TestCommonControl_EnsureSandboxResumed_FinalizerPatchError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{NodeName: "node1"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: "10.0.0.1",
+		},
+	}
+	box := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-sandbox",
+			Namespace:  "default",
+			Finalizers: []string{SandboxFinalizer},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(box, pod).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				return fmt.Errorf("simulated patch error")
+			},
+		}).
+		Build()
+
+	control := &commonControl{
+		Client:               fakeClient,
+		recorder:             record.NewFakeRecorder(10),
+		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
+		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+		checkpointControl:    NewCheckpointControl(fakeClient, record.NewFakeRecorder(10)),
+	}
+
+	now := metav1.Now()
+	newStatus := &agentsv1alpha1.SandboxStatus{
+		Phase: agentsv1alpha1.SandboxResuming,
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(agentsv1alpha1.SandboxConditionResumed),
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: now,
+				Reason:             agentsv1alpha1.SandboxResumeReasonCreatePod,
+			},
+		},
+	}
+
+	err := control.EnsureSandboxResumed(context.TODO(), EnsureFuncArgs{Pod: pod, Box: box, NewStatus: newStatus})
+
+	// Finalizer removal failure should not block the resume path.
+	assert.NoError(t, err)
+	// Phase should have transitioned to Running despite the finalizer patch error.
+	assert.Equal(t, agentsv1alpha1.SandboxRunning, newStatus.Phase)
 }
 
 func TestCommonControl_EnsureSandboxTerminated_PodNotExist_NoFinalizer(t *testing.T) {

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/identity"
@@ -784,11 +785,65 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 			podExists: true,
 			wantErr:   false,
 		},
+		{
+			name: "re-pause after resume, finalizer already present, no Paused condition",
+			args: EnsureFuncArgs{
+				Pod: nil,
+				Box: &agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "test-sandbox",
+						Namespace:  "default",
+						Finalizers: []string{SandboxFinalizer},
+					},
+				},
+				NewStatus: &agentsv1alpha1.SandboxStatus{
+					// No Paused condition — simulates state after resume
+					// where calculateStatus removed the Paused condition.
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(agentsv1alpha1.SandboxConditionReady),
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.Now(),
+							Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
+						},
+					},
+				},
+			},
+			podExists: false,
+			wantErr:   false,
+		},
+		{
+			name: "re-reconcile during pausing, finalizer already present, Paused condition exists",
+			args: EnsureFuncArgs{
+				Pod: nil,
+				Box: &agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "test-sandbox",
+						Namespace:  "default",
+						Finalizers: []string{SandboxFinalizer},
+					},
+				},
+				NewStatus: &agentsv1alpha1.SandboxStatus{
+					// Paused condition exists with Status=False — pausing in progress.
+					// The cond != nil branch should NOT attempt to add the finalizer.
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(agentsv1alpha1.SandboxConditionPaused),
+							Status:             metav1.ConditionFalse,
+							Reason:             agentsv1alpha1.SandboxPausedReasonPausing,
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			podExists: false,
+			wantErr:   false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			objects := []client.Object{}
+			objects := []client.Object{tt.args.Box}
 			if tt.args.Pod != nil {
 				objects = append(objects, tt.args.Pod)
 			}
@@ -800,12 +855,24 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fc, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
 				syncStatusFromPod:    defaultSyncStatusFromPod,
+				checkpointControl:    NewCheckpointControl(fc, record.NewFakeRecorder(10)),
 			}
 
 			err := control.EnsureSandboxPaused(context.TODO(), tt.args)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("EnsureSandboxPaused() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+
+			// Verify finalizer was added (first entry into paused state has no Paused condition)
+			if !tt.wantErr {
+				updatedBox := &agentsv1alpha1.Sandbox{}
+				if getErr := fc.Get(context.TODO(), types.NamespacedName{Name: tt.args.Box.Name, Namespace: tt.args.Box.Namespace}, updatedBox); getErr != nil {
+					t.Fatalf("Failed to get updated sandbox: %v", getErr)
+				}
+				if !controllerutil.ContainsFinalizer(updatedBox, SandboxFinalizer) {
+					t.Errorf("Expected finalizer %q to be added to sandbox", SandboxFinalizer)
+				}
 			}
 
 			// Verify pod was deleted if it existed initially
@@ -2434,6 +2501,66 @@ func TestCommonControl_EnsureSandboxResumed_LegacyBackfill(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCommonControl_EnsureSandboxResumed_RemovesFinalizer(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{NodeName: "node1"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: "10.0.0.1",
+		},
+	}
+
+	box := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-sandbox",
+			Namespace:  "default",
+			Finalizers: []string{SandboxFinalizer},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(box, pod).Build()
+	control := &commonControl{
+		Client:               fakeClient,
+		recorder:             record.NewFakeRecorder(10),
+		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
+		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+		checkpointControl:    NewCheckpointControl(fakeClient, record.NewFakeRecorder(10)),
+	}
+
+	now := metav1.Now()
+	newStatus := &agentsv1alpha1.SandboxStatus{
+		Phase: agentsv1alpha1.SandboxResuming,
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(agentsv1alpha1.SandboxConditionResumed),
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: now,
+				Reason:             agentsv1alpha1.SandboxResumeReasonCreatePod,
+			},
+		},
+	}
+
+	err := control.EnsureSandboxResumed(context.TODO(), EnsureFuncArgs{Pod: pod, Box: box, NewStatus: newStatus})
+	assert.NoError(t, err)
+
+	// Phase should transition to Running
+	assert.Equal(t, agentsv1alpha1.SandboxRunning, newStatus.Phase)
+
+	// Finalizer should be removed from the persisted sandbox
+	updatedBox := &agentsv1alpha1.Sandbox{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: box.Name, Namespace: box.Namespace}, updatedBox)
+	assert.NoError(t, err)
+	assert.NotContains(t, updatedBox.Finalizers, SandboxFinalizer)
 }
 
 func TestCommonControl_EnsureSandboxTerminated_PodNotExist_NoFinalizer(t *testing.T) {

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -34,7 +34,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -278,8 +277,8 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 		return ctrl.Result{}, nil
 	}
 
-	// add finalizer
-	if box, err = r.addSandboxFinalizerAndHash(ctx, box); err != nil {
+	// add hash annotation for in-place update detection
+	if box, err = r.addSandboxHashAnnotation(ctx, box); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -355,24 +354,23 @@ func pauseTimeReached(pauseTime *metav1.Time, now metav1.Time) bool {
 	return pauseTime != nil && !pauseTime.After(now.Time)
 }
 
-func (r *SandboxReconciler) addSandboxFinalizerAndHash(ctx context.Context, box *agentsv1alpha1.Sandbox) (*agentsv1alpha1.Sandbox, error) {
-	if !box.DeletionTimestamp.IsZero() || controllerutil.ContainsFinalizer(box, core.SandboxFinalizer) {
+func (r *SandboxReconciler) addSandboxHashAnnotation(ctx context.Context, box *agentsv1alpha1.Sandbox) (*agentsv1alpha1.Sandbox, error) {
+	if !box.DeletionTimestamp.IsZero() || box.Annotations[agentsv1alpha1.SandboxHashImmutablePart] != "" {
 		return box, nil
 	}
 
 	originObj := box.DeepCopy()
 	patch := client.MergeFrom(box)
-	controllerutil.AddFinalizer(originObj, core.SandboxFinalizer)
 	if originObj.Annotations == nil {
 		originObj.Annotations = make(map[string]string)
 	}
 	_, hashImmutablePart := core.HashSandbox(box)
 	originObj.Annotations[agentsv1alpha1.SandboxHashImmutablePart] = hashImmutablePart
 	if err := client.IgnoreNotFound(r.Patch(ctx, originObj, patch)); err != nil {
-		klog.ErrorS(err, "failed to patch sandbox finalizer and hash", "sandbox", klog.KObj(box))
-		return nil, fmt.Errorf("failed to patch finalizer: %w", err)
+		klog.ErrorS(err, "failed to patch sandbox hash annotation", "sandbox", klog.KObj(box))
+		return nil, fmt.Errorf("failed to patch hash annotation: %w", err)
 	}
-	klog.InfoS("patch sandbox hash annotations and finalizer success", "sandbox", klog.KObj(box))
+	klog.InfoS("patch sandbox hash annotation success", "sandbox", klog.KObj(box))
 	return originObj, nil
 }
 

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -3466,7 +3466,7 @@ func TestCalculateStatus(t *testing.T) {
 	}
 }
 
-func TestSandboxReconciler_AddSandboxFinalizerAndHash(t *testing.T) {
+func TestSandboxReconciler_AddSandboxHashAnnotation(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = agentsv1alpha1.AddToScheme(scheme)
@@ -3475,13 +3475,12 @@ func TestSandboxReconciler_AddSandboxFinalizerAndHash(t *testing.T) {
 		name                 string
 		sandbox              *agentsv1alpha1.Sandbox
 		expectErr            bool
-		expectFinalizerAdded bool
 		expectHashAnnotation bool
 		expectPatchCalled    bool
 		checkResult          func(t *testing.T, result *agentsv1alpha1.Sandbox, original *agentsv1alpha1.Sandbox)
 	}{
 		{
-			name: "sandbox without finalizer and hash - should add both",
+			name: "sandbox without hash annotation - should add hash annotation",
 			sandbox: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox",
@@ -3503,23 +3502,11 @@ func TestSandboxReconciler_AddSandboxFinalizerAndHash(t *testing.T) {
 				},
 			},
 			expectErr:            false,
-			expectFinalizerAdded: true,
 			expectHashAnnotation: true,
 			expectPatchCalled:    true,
 			checkResult: func(t *testing.T, result *agentsv1alpha1.Sandbox, original *agentsv1alpha1.Sandbox) {
 				if result == nil {
 					t.Fatalf("Result sandbox should not be nil")
-				}
-				// Check finalizer
-				hasFinalizerInResult := false
-				for _, f := range result.Finalizers {
-					if f == core.SandboxFinalizer {
-						hasFinalizerInResult = true
-						break
-					}
-				}
-				if !hasFinalizerInResult {
-					t.Errorf("Finalizer should be added to result sandbox")
 				}
 				// Check hash annotation
 				if result.Annotations == nil {
@@ -3531,12 +3518,14 @@ func TestSandboxReconciler_AddSandboxFinalizerAndHash(t *testing.T) {
 			},
 		},
 		{
-			name: "sandbox with existing finalizer - should return without patching",
+			name: "sandbox with existing hash annotation - should return without patching",
 			sandbox: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-sandbox-with-finalizer",
-					Namespace:  "default",
-					Finalizers: []string{core.SandboxFinalizer},
+					Name:      "test-sandbox-with-hash",
+					Namespace: "default",
+					Annotations: map[string]string{
+						agentsv1alpha1.SandboxHashImmutablePart: "existing-hash",
+					},
 				},
 				Spec: agentsv1alpha1.SandboxSpec{
 					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
@@ -3549,7 +3538,6 @@ func TestSandboxReconciler_AddSandboxFinalizerAndHash(t *testing.T) {
 				},
 			},
 			expectErr:            false,
-			expectFinalizerAdded: false,
 			expectHashAnnotation: false,
 			expectPatchCalled:    false,
 			checkResult: func(t *testing.T, result *agentsv1alpha1.Sandbox, original *agentsv1alpha1.Sandbox) {
@@ -3582,7 +3570,6 @@ func TestSandboxReconciler_AddSandboxFinalizerAndHash(t *testing.T) {
 				},
 			},
 			expectErr:            false,
-			expectFinalizerAdded: false,
 			expectHashAnnotation: false,
 			expectPatchCalled:    false,
 			checkResult: func(t *testing.T, result *agentsv1alpha1.Sandbox, original *agentsv1alpha1.Sandbox) {
@@ -3614,7 +3601,6 @@ func TestSandboxReconciler_AddSandboxFinalizerAndHash(t *testing.T) {
 				},
 			},
 			expectErr:            false,
-			expectFinalizerAdded: true,
 			expectHashAnnotation: true,
 			expectPatchCalled:    true,
 			checkResult: func(t *testing.T, result *agentsv1alpha1.Sandbox, original *agentsv1alpha1.Sandbox) {
@@ -3652,7 +3638,6 @@ func TestSandboxReconciler_AddSandboxFinalizerAndHash(t *testing.T) {
 				},
 			},
 			expectErr:            false,
-			expectFinalizerAdded: true,
 			expectHashAnnotation: true,
 			expectPatchCalled:    true,
 			checkResult: func(t *testing.T, result *agentsv1alpha1.Sandbox, original *agentsv1alpha1.Sandbox) {
@@ -3685,7 +3670,7 @@ func TestSandboxReconciler_AddSandboxFinalizerAndHash(t *testing.T) {
 			ctx := context.Background()
 
 			// Call the method
-			result, err := reconciler.addSandboxFinalizerAndHash(ctx, tt.sandbox)
+			result, err := reconciler.addSandboxHashAnnotation(ctx, tt.sandbox)
 
 			// Check error expectation
 			if tt.expectErr && err == nil {
@@ -3709,20 +3694,6 @@ func TestSandboxReconciler_AddSandboxFinalizerAndHash(t *testing.T) {
 				}, updatedSandbox)
 				if err != nil {
 					t.Fatalf("Failed to get updated sandbox: %v", err)
-				}
-
-				// Verify finalizer in persisted object
-				if tt.expectFinalizerAdded {
-					hasFinalizer := false
-					for _, f := range updatedSandbox.Finalizers {
-						if f == core.SandboxFinalizer {
-							hasFinalizer = true
-							break
-						}
-					}
-					if !hasFinalizer {
-						t.Errorf("Finalizer should be added to persisted sandbox")
-					}
 				}
 
 				// Verify hash annotation in persisted object
@@ -3871,6 +3842,7 @@ func TestReconcile_SandboxLifecycle_ClearSpecThenDelete(t *testing.T) {
 		}),
 		checkpointControl: core.NewCheckpointControl(fakeClient, fakeRecorder),
 		rateLimiter:       rl,
+		metricsCleanup:    &fakeEnqueuer{},
 	}
 
 	req := ctrl.Request{
@@ -3880,8 +3852,8 @@ func TestReconcile_SandboxLifecycle_ClearSpecThenDelete(t *testing.T) {
 		},
 	}
 
-	// Step 1: Create a Sandbox with Template, trigger reconcile, verify finalizer is added
-	t.Run("step1_create_sandbox_and_add_finalizer", func(t *testing.T) {
+	// Step 1: Create a Sandbox with Template, trigger reconcile, verify hash annotation is added
+	t.Run("step1_create_sandbox_and_add_hash_annotation", func(t *testing.T) {
 		sandbox := &agentsv1alpha1.Sandbox{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       sbxName,
@@ -3911,20 +3883,13 @@ func TestReconcile_SandboxLifecycle_ClearSpecThenDelete(t *testing.T) {
 			t.Errorf("Expected no requeue, got requeue = %v", result.Requeue)
 		}
 
-		// Verify finalizer was added
+		// Verify hash annotation was added (finalizer is no longer added by default)
 		updatedSandbox := &agentsv1alpha1.Sandbox{}
 		if err := fakeClient.Get(ctx, req.NamespacedName, updatedSandbox); err != nil {
 			t.Fatalf("Failed to get sandbox: %v", err)
 		}
-		hasFinalizer := false
-		for _, f := range updatedSandbox.Finalizers {
-			if f == core.SandboxFinalizer {
-				hasFinalizer = true
-				break
-			}
-		}
-		if !hasFinalizer {
-			t.Errorf("Expected finalizer %s to be added", core.SandboxFinalizer)
+		if updatedSandbox.Annotations[agentsv1alpha1.SandboxHashImmutablePart] == "" {
+			t.Errorf("Expected hash annotation %s to be added", agentsv1alpha1.SandboxHashImmutablePart)
 		}
 	})
 
@@ -3990,11 +3955,7 @@ func TestReconcile_SandboxLifecycle_ClearSpecThenDelete(t *testing.T) {
 			if updatedSandbox.DeletionTimestamp.IsZero() {
 				t.Errorf("Expected DeletionTimestamp to be set")
 			}
-			for _, f := range updatedSandbox.Finalizers {
-				if f == core.SandboxFinalizer {
-					t.Errorf("Expected finalizer to be removed, but it still exists")
-				}
-			}
+			assert.NotContains(t, updatedSandbox.Finalizers, core.SandboxFinalizer)
 		} else {
 			// If sandbox is not found, it means finalizer was removed and sandbox was garbage collected - this is expected behavior
 			if !apierrors.IsNotFound(err) {
@@ -5124,7 +5085,7 @@ func TestEnsureVolumeClaimTemplates_CreateAlreadyExists(t *testing.T) {
 	}
 }
 
-func TestAddSandboxFinalizerAndHash_PatchError(t *testing.T) {
+func TestAddSandboxHashAnnotation_PatchError(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = agentsv1alpha1.AddToScheme(scheme)
@@ -5160,7 +5121,7 @@ func TestAddSandboxFinalizerAndHash_PatchError(t *testing.T) {
 		Scheme: scheme,
 	}
 
-	result, err := reconciler.addSandboxFinalizerAndHash(context.Background(), sandbox)
+	result, err := reconciler.addSandboxHashAnnotation(context.Background(), sandbox)
 	if err == nil {
 		t.Error("Expected error from Patch, got nil")
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The sandbox controller no longer adds the `agents.kruise.io/sandbox` finalizer to every sandbox by default during reconciliation. Instead:

- **Finalizer is added** only when a sandbox first enters the Paused (hibernation) state (`EnsureSandboxPaused` with `cond == nil`)
- **Finalizer is removed** when the sandbox successfully resumes to Running (`EnsureSandboxResumed` when pod is `Running`)
- **Hash annotation** (for in-place update detection) is decoupled from the finalizer and continues to be applied early in the reconcile loop as before

Running sandboxes do not need a controller-mediated finalizer because their pods are cleaned up via Kubernetes owner-reference garbage collection. The finalizer is only meaningful for paused sandboxes where the pod has already been deleted and the controller must manage lifecycle transitions.

Key changes:
- Renamed `addSandboxFinalizerAndHash` → `addSandboxHashAnnotation`, removed finalizer-adding logic
- Added finalizer patch in `EnsureSandboxPaused` (idempotent via `PatchFinalizer`)
- Added finalizer removal in `EnsureSandboxResumed` (idempotent, retries on failure)
- `EnsureSandboxTerminated` remains unchanged — its `PatchFinalizer(RemoveFinalizerOpType)` is already idempotent

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run unit tests:
   ```bash
   go test -mod=mod ./pkg/controller/sandbox/... -run 'TestSandboxReconciler_AddSandboxHashAnnotation|TestAddSandboxHashAnnotation_PatchError|TestReconcile_SandboxLifecycle_ClearSpecThenDelete|TestCommonControl_EnsureSandboxPaused|TestCommonControl_EnsureSandboxResumed_RemovesFinalizer' -count=1 -v
   ```
2. Verify that a newly created Running sandbox does **not** have the finalizer
3. Verify that a paused sandbox **does** have the finalizer
4. Verify that a resumed sandbox has the finalizer **removed**
5. Verify that a sandbox deleted while paused is properly cleaned up (finalizer ensures controller-mediated termination)

### Ⅳ. Special notes for reviews

- **Multi-cycle safety**: The Paused condition is removed by `calculateStatus` during the resume transition (`utils.RemoveSandboxCondition`), so on re-pause, `cond == nil` again and the finalizer is correctly re-added. Test cases cover this scenario.
- **Idempotency**: `PatchFinalizer` checks `ContainsFinalizer` before making API calls, so add/remove are both idempotent. If the finalizer patch fails, the function returns error without advancing state, so the next reconcile retries.
- **Backward compatibility**: Sandboxes created under the old behavior that already have the finalizer will continue to work — `EnsureSandboxTerminated` removes it idempotently. Sandboxes currently paused with the finalizer will have it removed on resume.
- **Metrics cleanup**: When a Running sandbox (no finalizer) is deleted, the controller receives NotFound, cleans up expectations, and enqueues metrics cleanup via `r.metricsCleanup.Enqueue()`. Pod cleanup is handled by K8s GC via owner references.

---

### Appendix: Incidental Changes

The following changes are side modifications not directly related to the main purpose of this PR:

- Updated stale references to `addSandboxFinalizerAndHash` → `addSandboxHashAnnotation` in documentation (`docs/specs/2026-07-02-sandbox-otel-tracing-design-en.md`, `docs/proposals/20260702-sandbox-otel-distributed-tracing-en.md`)
