### PR TITLE
fix(ci): retry E2B Build Image steps on runner resource failures

### DIFF
--- a/.github/workflows/e2e-e2b-2.24.0.yaml
+++ b/.github/workflows/e2e-e2b-2.24.0.yaml
@@ -94,28 +94,53 @@ jobs:
             docker save ${INPLACE_UPDATE_IMG} -o /tmp/docker-images/inplace-update.tar
             echo "Cached inplace-update image"
           fi
+      # Retry transient GitHub runner resource failures (OOM / disk pressure) during image builds.
       - name: Build image
-        run: |
-          make docker-build-manager
-          make docker-build-controller
-          make docker-build-runtime
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${CONTROLLER_IMG} || { echo >&2 "kind not installed or error loading image: ${CONTROLLER_IMG}"; exit 1; }
-          docker rmi ${CONTROLLER_IMG}
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMG} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMG}"; exit 1; }
-          docker rmi ${MANAGER_IMG}
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${RUNTIME_IMG} || { echo >&2 "kind not installed or error loading image: ${RUNTIME_IMG}"; exit 1; }
-          docker rmi ${RUNTIME_IMG}
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${CODE_INTERPRETER_IMG} || { echo >&2 "kind not installed or error loading image: ${CODE_INTERPRETER_IMG}"; exit 1; }
-          docker rmi ${CODE_INTERPRETER_IMG}
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${INPLACE_UPDATE_IMG} || { echo >&2 "kind not installed or error loading image: ${INPLACE_UPDATE_IMG}"; exit 1; }
-          docker rmi ${INPLACE_UPDATE_IMG}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          retry_wait_seconds: 60
+          retry_on: error
+          shell: bash
+          on_retry_command: |
+            echo "Build image failed; pruning Docker state before retry..."
+            docker builder prune -af || true
+            docker system prune -f || true
+            df -h || true
+          command: |
+            make docker-build-manager
+            make docker-build-controller
+            make docker-build-runtime
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${CONTROLLER_IMG} || { echo >&2 "kind not installed or error loading image: ${CONTROLLER_IMG}"; exit 1; }
+            docker rmi ${CONTROLLER_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMG} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMG}"; exit 1; }
+            docker rmi ${MANAGER_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${RUNTIME_IMG} || { echo >&2 "kind not installed or error loading image: ${RUNTIME_IMG}"; exit 1; }
+            docker rmi ${RUNTIME_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${CODE_INTERPRETER_IMG} || { echo >&2 "kind not installed or error loading image: ${CODE_INTERPRETER_IMG}"; exit 1; }
+            docker rmi ${CODE_INTERPRETER_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${INPLACE_UPDATE_IMG} || { echo >&2 "kind not installed or error loading image: ${INPLACE_UPDATE_IMG}"; exit 1; }
+            docker rmi ${INPLACE_UPDATE_IMG}
 
       - name: Build sandbox-gateway image
         if: matrix.with_gateway
-        run: |
-          make docker-build-sandbox-gateway
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${GATEWAY_IMG} || { echo >&2 "kind not installed or error loading image: ${GATEWAY_IMG}"; exit 1; }
-          docker rmi ${GATEWAY_IMG}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 60
+          retry_on: error
+          shell: bash
+          on_retry_command: |
+            echo "Build sandbox-gateway image failed; pruning Docker state before retry..."
+            docker builder prune -af || true
+            docker system prune -f || true
+            df -h || true
+          command: |
+            make docker-build-sandbox-gateway
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${GATEWAY_IMG} || { echo >&2 "kind not installed or error loading image: ${GATEWAY_IMG}"; exit 1; }
+            docker rmi ${GATEWAY_IMG}
 
       - name: Install Kruise Agents
         run: |

--- a/.github/workflows/e2e-e2b-2.8.1.yaml
+++ b/.github/workflows/e2e-e2b-2.8.1.yaml
@@ -84,28 +84,53 @@ jobs:
             docker save ${INPLACE_UPDATE_IMG} -o /tmp/docker-images/inplace-update.tar
             echo "Cached inplace-update image"
           fi
+      # Retry transient GitHub runner resource failures (OOM / disk pressure) during image builds.
       - name: Build image
-        run: |
-          make docker-build-manager
-          make docker-build-controller
-          make docker-build-runtime
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${CONTROLLER_IMG} || { echo >&2 "kind not installed or error loading image: ${CONTROLLER_IMG}"; exit 1; }
-          docker rmi ${CONTROLLER_IMG}
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMG} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMG}"; exit 1; }
-          docker rmi ${MANAGER_IMG}
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${RUNTIME_IMG} || { echo >&2 "kind not installed or error loading image: ${RUNTIME_IMG}"; exit 1; }
-          docker rmi ${RUNTIME_IMG}
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${CODE_INTERPRETER_IMG} || { echo >&2 "kind not installed or error loading image: ${CODE_INTERPRETER_IMG}"; exit 1; }
-          docker rmi ${CODE_INTERPRETER_IMG}
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${INPLACE_UPDATE_IMG} || { echo >&2 "kind not installed or error loading image: ${INPLACE_UPDATE_IMG}"; exit 1; }
-          docker rmi ${INPLACE_UPDATE_IMG}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          retry_wait_seconds: 60
+          retry_on: error
+          shell: bash
+          on_retry_command: |
+            echo "Build image failed; pruning Docker state before retry..."
+            docker builder prune -af || true
+            docker system prune -f || true
+            df -h || true
+          command: |
+            make docker-build-manager
+            make docker-build-controller
+            make docker-build-runtime
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${CONTROLLER_IMG} || { echo >&2 "kind not installed or error loading image: ${CONTROLLER_IMG}"; exit 1; }
+            docker rmi ${CONTROLLER_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMG} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMG}"; exit 1; }
+            docker rmi ${MANAGER_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${RUNTIME_IMG} || { echo >&2 "kind not installed or error loading image: ${RUNTIME_IMG}"; exit 1; }
+            docker rmi ${RUNTIME_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${CODE_INTERPRETER_IMG} || { echo >&2 "kind not installed or error loading image: ${CODE_INTERPRETER_IMG}"; exit 1; }
+            docker rmi ${CODE_INTERPRETER_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${INPLACE_UPDATE_IMG} || { echo >&2 "kind not installed or error loading image: ${INPLACE_UPDATE_IMG}"; exit 1; }
+            docker rmi ${INPLACE_UPDATE_IMG}
 
       - name: Build sandbox-gateway image
         if: matrix.with_gateway
-        run: |
-          make docker-build-sandbox-gateway
-          kind load docker-image --name=${KIND_CLUSTER_NAME} ${GATEWAY_IMG} || { echo >&2 "kind not installed or error loading image: ${GATEWAY_IMG}"; exit 1; }
-          docker rmi ${GATEWAY_IMG}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 60
+          retry_on: error
+          shell: bash
+          on_retry_command: |
+            echo "Build sandbox-gateway image failed; pruning Docker state before retry..."
+            docker builder prune -af || true
+            docker system prune -f || true
+            df -h || true
+          command: |
+            make docker-build-sandbox-gateway
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${GATEWAY_IMG} || { echo >&2 "kind not installed or error loading image: ${GATEWAY_IMG}"; exit 1; }
+            docker rmi ${GATEWAY_IMG}
 
       - name: Install Kruise Agents
         run: |

--- a/.github/workflows/e2e-e2b-latest.yaml
+++ b/.github/workflows/e2e-e2b-latest.yaml
@@ -113,28 +113,53 @@ jobs:
             echo "Cached inplace-update image"
           fi
 
+      # Retry transient GitHub runner resource failures (OOM / disk pressure) during image builds.
       - name: Build image
-        run: |
-           make docker-build-manager
-           make docker-build-controller
-           make docker-build-runtime
-           kind load docker-image --name=${KIND_CLUSTER_NAME} ${CONTROLLER_IMG} || { echo >&2 "kind not installed or error loading image: ${CONTROLLER_IMG}"; exit 1; }
-           docker rmi ${CONTROLLER_IMG}
-           kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMG} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMG}"; exit 1; }
-           docker rmi ${MANAGER_IMG}
-           kind load docker-image --name=${KIND_CLUSTER_NAME} ${RUNTIME_IMG} || { echo >&2 "kind not installed or error loading image: ${RUNTIME_IMG}"; exit 1; }
-           docker rmi ${RUNTIME_IMG}
-           kind load docker-image --name=${KIND_CLUSTER_NAME} ${CODE_INTERPRETER_IMG} || { echo >&2 "kind not installed or error loading image: ${CODE_INTERPRETER_IMG}"; exit 1; }
-           docker rmi ${CODE_INTERPRETER_IMG}
-           kind load docker-image --name=${KIND_CLUSTER_NAME} ${INPLACE_UPDATE_IMG} || { echo >&2 "kind not installed or error loading image: ${INPLACE_UPDATE_IMG}"; exit 1; }
-           docker rmi ${INPLACE_UPDATE_IMG}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          retry_wait_seconds: 60
+          retry_on: error
+          shell: bash
+          on_retry_command: |
+            echo "Build image failed; pruning Docker state before retry..."
+            docker builder prune -af || true
+            docker system prune -f || true
+            df -h || true
+          command: |
+            make docker-build-manager
+            make docker-build-controller
+            make docker-build-runtime
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${CONTROLLER_IMG} || { echo >&2 "kind not installed or error loading image: ${CONTROLLER_IMG}"; exit 1; }
+            docker rmi ${CONTROLLER_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMG} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMG}"; exit 1; }
+            docker rmi ${MANAGER_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${RUNTIME_IMG} || { echo >&2 "kind not installed or error loading image: ${RUNTIME_IMG}"; exit 1; }
+            docker rmi ${RUNTIME_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${CODE_INTERPRETER_IMG} || { echo >&2 "kind not installed or error loading image: ${CODE_INTERPRETER_IMG}"; exit 1; }
+            docker rmi ${CODE_INTERPRETER_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${INPLACE_UPDATE_IMG} || { echo >&2 "kind not installed or error loading image: ${INPLACE_UPDATE_IMG}"; exit 1; }
+            docker rmi ${INPLACE_UPDATE_IMG}
 
       - name: Build sandbox-gateway image
         if: matrix.with_gateway
-        run: |
-           make docker-build-sandbox-gateway
-           kind load docker-image --name=${KIND_CLUSTER_NAME} ${GATEWAY_IMG} || { echo >&2 "kind not installed or error loading image: ${GATEWAY_IMG}"; exit 1; }
-           docker rmi ${GATEWAY_IMG}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 60
+          retry_on: error
+          shell: bash
+          on_retry_command: |
+            echo "Build sandbox-gateway image failed; pruning Docker state before retry..."
+            docker builder prune -af || true
+            docker system prune -f || true
+            df -h || true
+          command: |
+            make docker-build-sandbox-gateway
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${GATEWAY_IMG} || { echo >&2 "kind not installed or error loading image: ${GATEWAY_IMG}"; exit 1; }
+            docker rmi ${GATEWAY_IMG}
 
       - name: Install Kruise Agents
         run: |

--- a/.github/workflows/e2e-e2b-mysql-latest.yaml
+++ b/.github/workflows/e2e-e2b-mysql-latest.yaml
@@ -100,28 +100,53 @@ jobs:
           fi
 
       # Flow: build/load images → MySQL → schema → deploy agents with MySQL key storage (no post-deploy patch) → E2E
+      # Retry transient GitHub runner resource failures (OOM / disk pressure) during image builds.
       - name: Build and load container images
-        run: |
-           make docker-build-manager
-           make docker-build-controller
-           make docker-build-runtime
-           kind load docker-image --name=${KIND_CLUSTER_NAME} ${CONTROLLER_IMG} || { echo >&2 "kind not installed or error loading image: ${CONTROLLER_IMG}"; exit 1; }
-           docker rmi ${CONTROLLER_IMG}
-           kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMG} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMG}"; exit 1; }
-           docker rmi ${MANAGER_IMG}
-           kind load docker-image --name=${KIND_CLUSTER_NAME} ${RUNTIME_IMG} || { echo >&2 "kind not installed or error loading image: ${RUNTIME_IMG}"; exit 1; }
-           docker rmi ${RUNTIME_IMG}
-           kind load docker-image --name=${KIND_CLUSTER_NAME} ${CODE_INTERPRETER_IMG} || { echo >&2 "kind not installed or error loading image: ${CODE_INTERPRETER_IMG}"; exit 1; }
-           docker rmi ${CODE_INTERPRETER_IMG}
-           kind load docker-image --name=${KIND_CLUSTER_NAME} ${INPLACE_UPDATE_IMG} || { echo >&2 "kind not installed or error loading image: ${INPLACE_UPDATE_IMG}"; exit 1; }
-           docker rmi ${INPLACE_UPDATE_IMG}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          retry_wait_seconds: 60
+          retry_on: error
+          shell: bash
+          on_retry_command: |
+            echo "Build and load container images failed; pruning Docker state before retry..."
+            docker builder prune -af || true
+            docker system prune -f || true
+            df -h || true
+          command: |
+            make docker-build-manager
+            make docker-build-controller
+            make docker-build-runtime
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${CONTROLLER_IMG} || { echo >&2 "kind not installed or error loading image: ${CONTROLLER_IMG}"; exit 1; }
+            docker rmi ${CONTROLLER_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMG} || { echo >&2 "kind not installed or error loading image: ${MANAGER_IMG}"; exit 1; }
+            docker rmi ${MANAGER_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${RUNTIME_IMG} || { echo >&2 "kind not installed or error loading image: ${RUNTIME_IMG}"; exit 1; }
+            docker rmi ${RUNTIME_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${CODE_INTERPRETER_IMG} || { echo >&2 "kind not installed or error loading image: ${CODE_INTERPRETER_IMG}"; exit 1; }
+            docker rmi ${CODE_INTERPRETER_IMG}
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${INPLACE_UPDATE_IMG} || { echo >&2 "kind not installed or error loading image: ${INPLACE_UPDATE_IMG}"; exit 1; }
+            docker rmi ${INPLACE_UPDATE_IMG}
 
       - name: Build sandbox-gateway image
         if: matrix.with_gateway
-        run: |
-           make docker-build-sandbox-gateway
-           kind load docker-image --name=${KIND_CLUSTER_NAME} ${GATEWAY_IMG} || { echo >&2 "kind not installed or error loading image: ${GATEWAY_IMG}"; exit 1; }
-           docker rmi ${GATEWAY_IMG}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 60
+          retry_on: error
+          shell: bash
+          on_retry_command: |
+            echo "Build sandbox-gateway image failed; pruning Docker state before retry..."
+            docker builder prune -af || true
+            docker system prune -f || true
+            df -h || true
+          command: |
+            make docker-build-sandbox-gateway
+            kind load docker-image --name=${KIND_CLUSTER_NAME} ${GATEWAY_IMG} || { echo >&2 "kind not installed or error loading image: ${GATEWAY_IMG}"; exit 1; }
+            docker rmi ${GATEWAY_IMG}
 
       - name: Deploy MySQL in Kind cluster
         env:


### PR DESCRIPTION
## Summary

E2B E2E workflows sometimes fail in the **Build Image** stage due to transient GitHub-hosted runner resource pressure (OOM / disk). This change makes those image build/load steps retryable instead of failing the whole job on the first flake.

## Changes

Updated all four E2B E2E workflows:

- `e2e-e2b-latest.yaml`
- `e2e-e2b-2.8.1.yaml`
- `e2e-e2b-2.24.0.yaml`
- `e2e-e2b-mysql-latest.yaml`

For both **Build image** / **Build and load container images** and **Build sandbox-gateway image**:

- Wrap the step with `nick-fields/retry@v4.0.0` (SHA-pinned)
- `max_attempts: 3`
- `retry_wait_seconds: 60`
- On retry: prune Docker builder/system state and print `df -h` for diagnostics

Build/test logic itself is unchanged; only failure handling around image builds is added.

## Why step-level retry

Re-running only the flaky build step is faster than restarting Kind setup / image cache restore, and matches the reported failure mode.