### PR TITLE
feat(gateway): add JWT verification and optional Runtime mTLS

### DIFF
--- a/.github/workflows/e2e-e2b-latest.yaml
+++ b/.github/workflows/e2e-e2b-latest.yaml
@@ -40,7 +40,7 @@ jobs:
             with_gateway: true
             e2b_enable_auth: true
             quota_profile: redis
-          - name: with sandbox-gateway, auth disabled
+          - name: with sandbox-gateway, sandbox-manager auth disabled
             with_gateway: true
             e2b_enable_auth: false
             quota_profile: none
@@ -166,7 +166,7 @@ jobs:
           if [ "${{ matrix.e2b_enable_auth }}" = "false" ]; then
             {
               echo ""
-              echo "# Disable E2B auth (appended by e2e-e2b-latest auth-disabled matrix)"
+              echo "# Disable sandbox-manager E2B API auth"
               echo "# Positional path targets --e2b-enable-auth in config/sandbox-manager/deployment.yaml."
               echo "- op: replace"
               echo "  path: /spec/template/spec/containers/0/args/8"
@@ -229,9 +229,6 @@ jobs:
           args=()
           if [ "${{ matrix.with_gateway }}" = "true" ]; then
             args+=(--with-gateway)
-          fi
-          if [ "${{ matrix.with_gateway }}" = "true" ] && [ "${{ matrix.e2b_enable_auth }}" = "true" ]; then
-            args+=(-m "not gateway_routing and not gateway_uuid_auth and not jwt_auth and not runtime_mtls")
           fi
           if [ "${{ matrix.e2b_enable_auth }}" = "false" ]; then
             args+=(--auth-disabled)

--- a/.github/workflows/e2e-e2b-latest.yaml
+++ b/.github/workflows/e2e-e2b-latest.yaml
@@ -38,42 +38,49 @@ jobs:
             with_gateway: false
             runtime_mtls: false
             jwt_auth: false
+            uuid_auth: false
             e2b_enable_auth: true
             quota_profile: redis-clone
-          - name: with sandbox-gateway
+          - name: with sandbox-gateway, UUID auth
             with_gateway: true
             runtime_mtls: false
             jwt_auth: false
+            uuid_auth: true
             e2b_enable_auth: true
             quota_profile: redis
           - name: with sandbox-gateway, auth disabled
             with_gateway: true
             runtime_mtls: false
             jwt_auth: false
+            uuid_auth: false
             e2b_enable_auth: false
             quota_profile: none
           - name: quota redis fault
             with_gateway: false
             runtime_mtls: false
             jwt_auth: false
+            uuid_auth: false
             e2b_enable_auth: true
             quota_profile: redis-fault
           - name: quota no redis
             with_gateway: false
             runtime_mtls: false
             jwt_auth: false
+            uuid_auth: false
             e2b_enable_auth: true
             quota_profile: no-redis
           - name: with sandbox-gateway, Runtime mTLS
             with_gateway: true
             runtime_mtls: true
             jwt_auth: false
+            uuid_auth: false
             e2b_enable_auth: false
             quota_profile: none
           - name: with sandbox-gateway, JWT auth
             with_gateway: true
             runtime_mtls: false
             jwt_auth: true
+            uuid_auth: false
             e2b_enable_auth: false
             quota_profile: none
     name: sandbox (${{ matrix.name }})
@@ -330,6 +337,14 @@ jobs:
           else
             make deploy-sandbox-gateway
           fi
+          if [ "${{ matrix.uuid_auth }}" = "true" ]; then
+            kubectl get configmap envoy-config -n sandbox-system -o json \
+              | jq '.data["envoy.yaml"] |= sub("enable-auth: false"; "enable-auth: true")' \
+              | kubectl replace -f -
+            kubectl rollout restart deployment/sandbox-gateway -n sandbox-system
+            kubectl rollout status deployment/sandbox-gateway \
+              -n sandbox-system --timeout=5m
+          fi
           if [ "${{ matrix.jwt_auth }}" = "true" ]; then
             kubectl get configmap envoy-config -n sandbox-system -o json \
               | jq '.data["envoy.yaml"] |= sub("enable-auth: false"; "enable-auth: true") | .data["envoy.yaml"] |= sub("enable-jwt-auth: false"; "enable-jwt-auth: true")' \
@@ -359,11 +374,14 @@ jobs:
           if [ "${{ matrix.runtime_mtls }}" = "true" ]; then
             export RUNTIME_MTLS_E2E=true
             args+=(-m runtime_mtls)
-          fi
-          if [ "${{ matrix.jwt_auth }}" = "true" ]; then
+          elif [ "${{ matrix.jwt_auth }}" = "true" ]; then
             export TRAFFIC_ACCESS_TOKEN_JWT_E2E=true
             export JWT_E2E_TOKEN_COMMAND="kubectl exec -n sandbox-system deployment/jwt-e2e-oidc-provider -- /jwt-oidc-provider issue"
             args+=(-m jwt_auth)
+          elif [ "${{ matrix.uuid_auth }}" = "true" ]; then
+            args+=(-m "not gateway_routing and not jwt_auth and not runtime_mtls")
+          elif [ "${{ matrix.with_gateway }}" = "true" ]; then
+            args+=(-m "not gateway_uuid_auth and not jwt_auth and not runtime_mtls")
           fi
           if [ "${{ matrix.e2b_enable_auth }}" = "false" ]; then
             args+=(--auth-disabled)

--- a/.github/workflows/e2e-e2b-latest.yaml
+++ b/.github/workflows/e2e-e2b-latest.yaml
@@ -24,8 +24,6 @@ env:
   GATEWAY_IMG: sandbox-gateway:latest
   CODE_INTERPRETER_IMG: registry-ap-southeast-1.ack.aliyuncs.com/acs/code-interpreter:v1.6
   INPLACE_UPDATE_IMG: registry-ap-southeast-1.ack.aliyuncs.com/acs/code-interpreter:v1.6-new
-  RUNTIME_MTLS_SERVER_IMG: runtime-mtls-server:latest
-  JWT_OIDC_PROVIDER_IMG: jwt-oidc-provider:latest
 
 jobs:
   sandbox:
@@ -36,53 +34,24 @@ jobs:
         include:
           - name: without sandbox-gateway
             with_gateway: false
-            runtime_mtls: false
-            jwt_auth: false
-            uuid_auth: false
             e2b_enable_auth: true
             quota_profile: redis-clone
-          - name: with sandbox-gateway, UUID auth
+          - name: with sandbox-gateway
             with_gateway: true
-            runtime_mtls: false
-            jwt_auth: false
-            uuid_auth: true
             e2b_enable_auth: true
             quota_profile: redis
           - name: with sandbox-gateway, auth disabled
             with_gateway: true
-            runtime_mtls: false
-            jwt_auth: false
-            uuid_auth: false
             e2b_enable_auth: false
             quota_profile: none
           - name: quota redis fault
             with_gateway: false
-            runtime_mtls: false
-            jwt_auth: false
-            uuid_auth: false
             e2b_enable_auth: true
             quota_profile: redis-fault
           - name: quota no redis
             with_gateway: false
-            runtime_mtls: false
-            jwt_auth: false
-            uuid_auth: false
             e2b_enable_auth: true
             quota_profile: no-redis
-          - name: with sandbox-gateway, Runtime mTLS
-            with_gateway: true
-            runtime_mtls: true
-            jwt_auth: false
-            uuid_auth: false
-            e2b_enable_auth: false
-            quota_profile: none
-          - name: with sandbox-gateway, JWT auth
-            with_gateway: true
-            runtime_mtls: false
-            jwt_auth: true
-            uuid_auth: false
-            e2b_enable_auth: false
-            quota_profile: none
     name: sandbox (${{ matrix.name }})
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -192,20 +161,6 @@ jobs:
             kind load docker-image --name=${KIND_CLUSTER_NAME} ${GATEWAY_IMG} || { echo >&2 "kind not installed or error loading image: ${GATEWAY_IMG}"; exit 1; }
             docker rmi ${GATEWAY_IMG}
 
-      - name: Build Runtime mTLS test server image
-        if: matrix.runtime_mtls
-        run: |
-           docker build -t ${RUNTIME_MTLS_SERVER_IMG} -f test/e2b/assets/runtime-mtls-server/Dockerfile .
-           kind load docker-image --name=${KIND_CLUSTER_NAME} ${RUNTIME_MTLS_SERVER_IMG}
-           docker rmi ${RUNTIME_MTLS_SERVER_IMG}
-
-      - name: Build JWT OIDC test provider image
-        if: matrix.jwt_auth
-        run: |
-           docker build -t ${JWT_OIDC_PROVIDER_IMG} -f test/e2b/assets/jwt-oidc-provider/Dockerfile .
-           kind load docker-image --name=${KIND_CLUSTER_NAME} ${JWT_OIDC_PROVIDER_IMG}
-           docker rmi ${JWT_OIDC_PROVIDER_IMG}
-
       - name: Install Kruise Agents
         run: |
           if [ "${{ matrix.e2b_enable_auth }}" = "false" ]; then
@@ -256,106 +211,10 @@ jobs:
           cat config/sandbox-manager/configuration_patch.yaml
           make deploy-sandbox-manager
 
-      - name: Configure Runtime mTLS test identity
-        if: matrix.runtime_mtls
-        run: |
-          set -euo pipefail
-          cert_dir="$(mktemp -d)"
-          trap 'rm -rf "$cert_dir"' EXIT
-
-          openssl req -x509 -newkey rsa:2048 -nodes -days 2 \
-            -keyout "$cert_dir/ca.key" -out "$cert_dir/ca.crt" \
-            -subj "/CN=runtime-mtls-e2e-ca"
-
-          openssl req -newkey rsa:2048 -nodes \
-            -keyout "$cert_dir/client.key" -out "$cert_dir/client.csr" \
-            -subj "/CN=sandbox-gateway"
-          printf 'extendedKeyUsage=clientAuth\n' > "$cert_dir/client.ext"
-          openssl x509 -req -days 2 -sha256 \
-            -in "$cert_dir/client.csr" -CA "$cert_dir/ca.crt" -CAkey "$cert_dir/ca.key" -CAcreateserial \
-            -out "$cert_dir/client.crt" -extfile "$cert_dir/client.ext"
-
-          openssl req -newkey rsa:2048 -nodes \
-            -keyout "$cert_dir/server.key" -out "$cert_dir/server.csr" \
-            -subj "/CN=agentruntime.sandbox.agents.kruise.io"
-          printf 'subjectAltName=DNS:*.sandbox.agents.kruise.io\nextendedKeyUsage=serverAuth\n' > "$cert_dir/server.ext"
-          openssl x509 -req -days 2 -sha256 \
-            -in "$cert_dir/server.csr" -CA "$cert_dir/ca.crt" -CAkey "$cert_dir/ca.key" -CAcreateserial \
-            -out "$cert_dir/server.crt" -extfile "$cert_dir/server.ext"
-
-          kubectl create secret generic sandbox-gateway-runtime-mtls-client-cert \
-            -n sandbox-system \
-            --from-file=tls.crt="$cert_dir/client.crt" \
-            --from-file=tls.key="$cert_dir/client.key" \
-            --from-file=ca.crt="$cert_dir/ca.crt"
-          kubectl create secret generic runtime-mtls-server-tls \
-            -n default \
-            --from-file=tls.crt="$cert_dir/server.crt" \
-            --from-file=tls.key="$cert_dir/server.key" \
-            --from-file=ca.crt="$cert_dir/ca.crt"
-
-      - name: Configure JWT OIDC test provider
-        if: matrix.jwt_auth
-        run: |
-          set -euo pipefail
-          identity_dir="$(mktemp -d)"
-          trap 'rm -rf "$identity_dir"' EXIT
-
-          openssl req -x509 -newkey rsa:2048 -nodes -days 2 \
-            -keyout "$identity_dir/ca.key" -out "$identity_dir/ca.crt" \
-            -subj "/CN=jwt-e2e-oidc-ca"
-          openssl req -newkey rsa:2048 -nodes \
-            -keyout "$identity_dir/tls.key" -out "$identity_dir/tls.csr" \
-            -subj "/CN=jwt-e2e-oidc-provider.sandbox-system.svc"
-          printf '%s\n' \
-            'subjectAltName=DNS:jwt-e2e-oidc-provider.sandbox-system.svc,DNS:jwt-e2e-oidc-provider.sandbox-system.svc.cluster.local' \
-            'extendedKeyUsage=serverAuth' > "$identity_dir/tls.ext"
-          openssl x509 -req -days 2 -sha256 \
-            -in "$identity_dir/tls.csr" -CA "$identity_dir/ca.crt" \
-            -CAkey "$identity_dir/ca.key" -CAcreateserial \
-            -out "$identity_dir/tls.crt" -extfile "$identity_dir/tls.ext"
-          openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \
-            -out "$identity_dir/signing.key"
-
-          kubectl create secret generic jwt-e2e-oidc-provider \
-            -n sandbox-system \
-            --from-file=tls.crt="$identity_dir/tls.crt" \
-            --from-file=tls.key="$identity_dir/tls.key" \
-            --from-file=signing.key="$identity_dir/signing.key"
-          kubectl create configmap jwt-e2e-oidc-ca \
-            -n sandbox-system \
-            --from-file=ca.crt="$identity_dir/ca.crt"
-          kubectl apply -f test/e2b/assets/jwt-oidc-provider/provider.yaml
-          kubectl rollout status deployment/jwt-e2e-oidc-provider \
-            -n sandbox-system --timeout=2m
-
       - name: Deploy sandbox-gateway
         if: matrix.with_gateway
         run: |
-          if [ "${{ matrix.runtime_mtls }}" = "true" ]; then
-            make deploy-sandbox-gateway-runtime-mtls
-          else
-            make deploy-sandbox-gateway
-          fi
-          if [ "${{ matrix.uuid_auth }}" = "true" ]; then
-            kubectl get configmap envoy-config -n sandbox-system -o json \
-              | jq '.data["envoy.yaml"] |= sub("enable-auth: false"; "enable-auth: true")' \
-              | kubectl replace -f -
-            kubectl rollout restart deployment/sandbox-gateway -n sandbox-system
-            kubectl rollout status deployment/sandbox-gateway \
-              -n sandbox-system --timeout=5m
-          fi
-          if [ "${{ matrix.jwt_auth }}" = "true" ]; then
-            kubectl get configmap envoy-config -n sandbox-system -o json \
-              | jq '.data["envoy.yaml"] |= sub("enable-auth: false"; "enable-auth: true") | .data["envoy.yaml"] |= sub("enable-jwt-auth: false"; "enable-jwt-auth: true")' \
-              | kubectl replace -f -
-            kubectl set env deployment/sandbox-gateway -n sandbox-system \
-              OIDC_DISCOVERY_URL=https://jwt-e2e-oidc-provider.sandbox-system.svc:8443/.well-known/openid-configuration \
-              OIDC_CA_CONFIGMAP_NAMESPACE=sandbox-system \
-              OIDC_CA_CONFIGMAP_NAME=jwt-e2e-oidc-ca
-            kubectl rollout status deployment/sandbox-gateway \
-              -n sandbox-system --timeout=5m
-          fi
+          make deploy-sandbox-gateway
 
       - name: Run E2E Tests
         run: |
@@ -371,17 +230,8 @@ jobs:
           if [ "${{ matrix.with_gateway }}" = "true" ]; then
             args+=(--with-gateway)
           fi
-          if [ "${{ matrix.runtime_mtls }}" = "true" ]; then
-            export RUNTIME_MTLS_E2E=true
-            args+=(-m runtime_mtls)
-          elif [ "${{ matrix.jwt_auth }}" = "true" ]; then
-            export TRAFFIC_ACCESS_TOKEN_JWT_E2E=true
-            export JWT_E2E_TOKEN_COMMAND="kubectl exec -n sandbox-system deployment/jwt-e2e-oidc-provider -- /jwt-oidc-provider issue"
-            args+=(-m jwt_auth)
-          elif [ "${{ matrix.uuid_auth }}" = "true" ]; then
-            args+=(-m "not gateway_routing and not jwt_auth and not runtime_mtls")
-          elif [ "${{ matrix.with_gateway }}" = "true" ]; then
-            args+=(-m "not gateway_uuid_auth and not jwt_auth and not runtime_mtls")
+          if [ "${{ matrix.with_gateway }}" = "true" ] && [ "${{ matrix.e2b_enable_auth }}" = "true" ]; then
+            args+=(-m "not gateway_routing and not gateway_uuid_auth and not jwt_auth and not runtime_mtls")
           fi
           if [ "${{ matrix.e2b_enable_auth }}" = "false" ]; then
             args+=(--auth-disabled)

--- a/.github/workflows/e2e-e2b-latest.yaml
+++ b/.github/workflows/e2e-e2b-latest.yaml
@@ -25,6 +25,7 @@ env:
   CODE_INTERPRETER_IMG: registry-ap-southeast-1.ack.aliyuncs.com/acs/code-interpreter:v1.6
   INPLACE_UPDATE_IMG: registry-ap-southeast-1.ack.aliyuncs.com/acs/code-interpreter:v1.6-new
   RUNTIME_MTLS_SERVER_IMG: runtime-mtls-server:latest
+  JWT_OIDC_PROVIDER_IMG: jwt-oidc-provider:latest
 
 jobs:
   sandbox:
@@ -36,31 +37,43 @@ jobs:
           - name: without sandbox-gateway
             with_gateway: false
             runtime_mtls: false
+            jwt_auth: false
             e2b_enable_auth: true
             quota_profile: redis-clone
           - name: with sandbox-gateway
             with_gateway: true
             runtime_mtls: false
+            jwt_auth: false
             e2b_enable_auth: true
             quota_profile: redis
           - name: with sandbox-gateway, auth disabled
             with_gateway: true
             runtime_mtls: false
+            jwt_auth: false
             e2b_enable_auth: false
             quota_profile: none
           - name: quota redis fault
             with_gateway: false
             runtime_mtls: false
+            jwt_auth: false
             e2b_enable_auth: true
             quota_profile: redis-fault
           - name: quota no redis
             with_gateway: false
             runtime_mtls: false
+            jwt_auth: false
             e2b_enable_auth: true
             quota_profile: no-redis
           - name: with sandbox-gateway, Runtime mTLS
             with_gateway: true
             runtime_mtls: true
+            jwt_auth: false
+            e2b_enable_auth: false
+            quota_profile: none
+          - name: with sandbox-gateway, JWT auth
+            with_gateway: true
+            runtime_mtls: false
+            jwt_auth: true
             e2b_enable_auth: false
             quota_profile: none
     name: sandbox (${{ matrix.name }})
@@ -179,6 +192,13 @@ jobs:
            kind load docker-image --name=${KIND_CLUSTER_NAME} ${RUNTIME_MTLS_SERVER_IMG}
            docker rmi ${RUNTIME_MTLS_SERVER_IMG}
 
+      - name: Build JWT OIDC test provider image
+        if: matrix.jwt_auth
+        run: |
+           docker build -t ${JWT_OIDC_PROVIDER_IMG} -f test/e2b/assets/jwt-oidc-provider/Dockerfile .
+           kind load docker-image --name=${KIND_CLUSTER_NAME} ${JWT_OIDC_PROVIDER_IMG}
+           docker rmi ${JWT_OIDC_PROVIDER_IMG}
+
       - name: Install Kruise Agents
         run: |
           if [ "${{ matrix.e2b_enable_auth }}" = "false" ]; then
@@ -266,6 +286,42 @@ jobs:
             --from-file=tls.crt="$cert_dir/server.crt" \
             --from-file=tls.key="$cert_dir/server.key" \
             --from-file=ca.crt="$cert_dir/ca.crt"
+
+      - name: Configure JWT OIDC test provider
+        if: matrix.jwt_auth
+        run: |
+          set -euo pipefail
+          identity_dir="$(mktemp -d)"
+          trap 'rm -rf "$identity_dir"' EXIT
+
+          openssl req -x509 -newkey rsa:2048 -nodes -days 2 \
+            -keyout "$identity_dir/ca.key" -out "$identity_dir/ca.crt" \
+            -subj "/CN=jwt-e2e-oidc-ca"
+          openssl req -newkey rsa:2048 -nodes \
+            -keyout "$identity_dir/tls.key" -out "$identity_dir/tls.csr" \
+            -subj "/CN=jwt-e2e-oidc-provider.sandbox-system.svc"
+          printf '%s\n' \
+            'subjectAltName=DNS:jwt-e2e-oidc-provider.sandbox-system.svc,DNS:jwt-e2e-oidc-provider.sandbox-system.svc.cluster.local' \
+            'extendedKeyUsage=serverAuth' > "$identity_dir/tls.ext"
+          openssl x509 -req -days 2 -sha256 \
+            -in "$identity_dir/tls.csr" -CA "$identity_dir/ca.crt" \
+            -CAkey "$identity_dir/ca.key" -CAcreateserial \
+            -out "$identity_dir/tls.crt" -extfile "$identity_dir/tls.ext"
+          openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \
+            -out "$identity_dir/signing.key"
+
+          kubectl create secret generic jwt-e2e-oidc-provider \
+            -n sandbox-system \
+            --from-file=tls.crt="$identity_dir/tls.crt" \
+            --from-file=tls.key="$identity_dir/tls.key" \
+            --from-file=signing.key="$identity_dir/signing.key"
+          kubectl create configmap jwt-e2e-oidc-ca \
+            -n sandbox-system \
+            --from-file=ca.crt="$identity_dir/ca.crt"
+          kubectl apply -f test/e2b/assets/jwt-oidc-provider/provider.yaml
+          kubectl rollout status deployment/jwt-e2e-oidc-provider \
+            -n sandbox-system --timeout=2m
+
       - name: Deploy sandbox-gateway
         if: matrix.with_gateway
         run: |
@@ -273,6 +329,17 @@ jobs:
             make deploy-sandbox-gateway-runtime-mtls
           else
             make deploy-sandbox-gateway
+          fi
+          if [ "${{ matrix.jwt_auth }}" = "true" ]; then
+            kubectl get configmap envoy-config -n sandbox-system -o json \
+              | jq '.data["envoy.yaml"] |= sub("enable-auth: false"; "enable-auth: true") | .data["envoy.yaml"] |= sub("enable-jwt-auth: false"; "enable-jwt-auth: true")' \
+              | kubectl replace -f -
+            kubectl set env deployment/sandbox-gateway -n sandbox-system \
+              OIDC_DISCOVERY_URL=https://jwt-e2e-oidc-provider.sandbox-system.svc:8443/.well-known/openid-configuration \
+              OIDC_CA_CONFIGMAP_NAMESPACE=sandbox-system \
+              OIDC_CA_CONFIGMAP_NAME=jwt-e2e-oidc-ca
+            kubectl rollout status deployment/sandbox-gateway \
+              -n sandbox-system --timeout=5m
           fi
 
       - name: Run E2E Tests
@@ -292,6 +359,11 @@ jobs:
           if [ "${{ matrix.runtime_mtls }}" = "true" ]; then
             export RUNTIME_MTLS_E2E=true
             args+=(-m runtime_mtls)
+          fi
+          if [ "${{ matrix.jwt_auth }}" = "true" ]; then
+            export TRAFFIC_ACCESS_TOKEN_JWT_E2E=true
+            export JWT_E2E_TOKEN_COMMAND="kubectl exec -n sandbox-system deployment/jwt-e2e-oidc-provider -- /jwt-oidc-provider issue"
+            args+=(-m jwt_auth)
           fi
           if [ "${{ matrix.e2b_enable_auth }}" = "false" ]; then
             args+=(--auth-disabled)

--- a/.github/workflows/e2e-e2b-latest.yaml
+++ b/.github/workflows/e2e-e2b-latest.yaml
@@ -24,6 +24,7 @@ env:
   GATEWAY_IMG: sandbox-gateway:latest
   CODE_INTERPRETER_IMG: registry-ap-southeast-1.ack.aliyuncs.com/acs/code-interpreter:v1.6
   INPLACE_UPDATE_IMG: registry-ap-southeast-1.ack.aliyuncs.com/acs/code-interpreter:v1.6-new
+  RUNTIME_MTLS_SERVER_IMG: runtime-mtls-server:latest
 
 jobs:
   sandbox:
@@ -34,24 +35,34 @@ jobs:
         include:
           - name: without sandbox-gateway
             with_gateway: false
+            runtime_mtls: false
             e2b_enable_auth: true
             quota_profile: redis-clone
           - name: with sandbox-gateway
             with_gateway: true
+            runtime_mtls: false
             e2b_enable_auth: true
             quota_profile: redis
           - name: with sandbox-gateway, auth disabled
             with_gateway: true
+            runtime_mtls: false
             e2b_enable_auth: false
             quota_profile: none
           - name: quota redis fault
             with_gateway: false
+            runtime_mtls: false
             e2b_enable_auth: true
             quota_profile: redis-fault
           - name: quota no redis
             with_gateway: false
+            runtime_mtls: false
             e2b_enable_auth: true
             quota_profile: no-redis
+          - name: with sandbox-gateway, Runtime mTLS
+            with_gateway: true
+            runtime_mtls: true
+            e2b_enable_auth: false
+            quota_profile: none
     name: sandbox (${{ matrix.name }})
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -161,6 +172,13 @@ jobs:
             kind load docker-image --name=${KIND_CLUSTER_NAME} ${GATEWAY_IMG} || { echo >&2 "kind not installed or error loading image: ${GATEWAY_IMG}"; exit 1; }
             docker rmi ${GATEWAY_IMG}
 
+      - name: Build Runtime mTLS test server image
+        if: matrix.runtime_mtls
+        run: |
+           docker build -t ${RUNTIME_MTLS_SERVER_IMG} -f test/e2b/assets/runtime-mtls-server/Dockerfile .
+           kind load docker-image --name=${KIND_CLUSTER_NAME} ${RUNTIME_MTLS_SERVER_IMG}
+           docker rmi ${RUNTIME_MTLS_SERVER_IMG}
+
       - name: Install Kruise Agents
         run: |
           if [ "${{ matrix.e2b_enable_auth }}" = "false" ]; then
@@ -211,9 +229,62 @@ jobs:
           cat config/sandbox-manager/configuration_patch.yaml
           make deploy-sandbox-manager
 
+      - name: Configure Runtime mTLS test identity
+        if: matrix.runtime_mtls
+        run: |
+          set -euo pipefail
+          cert_dir="$(mktemp -d)"
+          trap 'rm -rf "$cert_dir"' EXIT
+
+          openssl req -x509 -newkey rsa:2048 -nodes -days 2 \
+            -keyout "$cert_dir/ca.key" -out "$cert_dir/ca.crt" \
+            -subj "/CN=runtime-mtls-e2e-ca"
+
+          openssl req -newkey rsa:2048 -nodes \
+            -keyout "$cert_dir/client.key" -out "$cert_dir/client.csr" \
+            -subj "/CN=sandbox-gateway"
+          printf 'extendedKeyUsage=clientAuth\n' > "$cert_dir/client.ext"
+          openssl x509 -req -days 2 -sha256 \
+            -in "$cert_dir/client.csr" -CA "$cert_dir/ca.crt" -CAkey "$cert_dir/ca.key" -CAcreateserial \
+            -out "$cert_dir/client.crt" -extfile "$cert_dir/client.ext"
+
+          openssl req -newkey rsa:2048 -nodes \
+            -keyout "$cert_dir/server.key" -out "$cert_dir/server.csr" \
+            -subj "/CN=agentruntime.sandbox.agents.kruise.io"
+          printf 'subjectAltName=DNS:*.sandbox.agents.kruise.io\nextendedKeyUsage=serverAuth\n' > "$cert_dir/server.ext"
+          openssl x509 -req -days 2 -sha256 \
+            -in "$cert_dir/server.csr" -CA "$cert_dir/ca.crt" -CAkey "$cert_dir/ca.key" -CAcreateserial \
+            -out "$cert_dir/server.crt" -extfile "$cert_dir/server.ext"
+
+          kubectl create namespace ack-agent-identity
+          kubectl create secret generic ack-agent-identity-sandbox-manager-client-cert \
+            -n ack-agent-identity \
+            --from-file=tls.crt="$cert_dir/client.crt" \
+            --from-file=tls.key="$cert_dir/client.key" \
+            --from-file=ca.crt="$cert_dir/ca.crt"
+          kubectl create secret generic runtime-mtls-server-tls \
+            -n default \
+            --from-file=tls.crt="$cert_dir/server.crt" \
+            --from-file=tls.key="$cert_dir/server.key" \
+            --from-file=ca.crt="$cert_dir/ca.crt"
+          kubectl create role sandbox-gateway-runtime-client-cert-reader \
+            -n ack-agent-identity \
+            --verb=get \
+            --resource=secrets \
+            --resource-name=ack-agent-identity-sandbox-manager-client-cert
+          kubectl create rolebinding sandbox-gateway-runtime-client-cert-reader \
+            -n ack-agent-identity \
+            --role=sandbox-gateway-runtime-client-cert-reader \
+            --serviceaccount=sandbox-system:sandbox-gateway
+
       - name: Deploy sandbox-gateway
         if: matrix.with_gateway
-        run: make deploy-sandbox-gateway
+        run: |
+          if [ "${{ matrix.runtime_mtls }}" = "true" ]; then
+            make deploy-sandbox-gateway-runtime-mtls
+          else
+            make deploy-sandbox-gateway
+          fi
 
       - name: Run E2E Tests
         run: |
@@ -228,6 +299,10 @@ jobs:
           args=()
           if [ "${{ matrix.with_gateway }}" = "true" ]; then
             args+=(--with-gateway)
+          fi
+          if [ "${{ matrix.runtime_mtls }}" = "true" ]; then
+            export RUNTIME_MTLS_E2E=true
+            args+=(-m runtime_mtls)
           fi
           if [ "${{ matrix.e2b_enable_auth }}" = "false" ]; then
             args+=(--auth-disabled)

--- a/.github/workflows/e2e-e2b-latest.yaml
+++ b/.github/workflows/e2e-e2b-latest.yaml
@@ -256,9 +256,8 @@ jobs:
             -in "$cert_dir/server.csr" -CA "$cert_dir/ca.crt" -CAkey "$cert_dir/ca.key" -CAcreateserial \
             -out "$cert_dir/server.crt" -extfile "$cert_dir/server.ext"
 
-          kubectl create namespace ack-agent-identity
-          kubectl create secret generic ack-agent-identity-sandbox-manager-client-cert \
-            -n ack-agent-identity \
+          kubectl create secret generic sandbox-gateway-runtime-mtls-client-cert \
+            -n sandbox-system \
             --from-file=tls.crt="$cert_dir/client.crt" \
             --from-file=tls.key="$cert_dir/client.key" \
             --from-file=ca.crt="$cert_dir/ca.crt"
@@ -267,16 +266,6 @@ jobs:
             --from-file=tls.crt="$cert_dir/server.crt" \
             --from-file=tls.key="$cert_dir/server.key" \
             --from-file=ca.crt="$cert_dir/ca.crt"
-          kubectl create role sandbox-gateway-runtime-client-cert-reader \
-            -n ack-agent-identity \
-            --verb=get \
-            --resource=secrets \
-            --resource-name=ack-agent-identity-sandbox-manager-client-cert
-          kubectl create rolebinding sandbox-gateway-runtime-client-cert-reader \
-            -n ack-agent-identity \
-            --role=sandbox-gateway-runtime-client-cert-reader \
-            --serviceaccount=sandbox-system:sandbox-gateway
-
       - name: Deploy sandbox-gateway
         if: matrix.with_gateway
         run: |

--- a/.github/workflows/e2e-e2b-mysql-latest.yaml
+++ b/.github/workflows/e2e-e2b-mysql-latest.yaml
@@ -223,7 +223,9 @@ jobs:
           export INPLACE_UPDATE_IMAGE="${INPLACE_UPDATE_IMG}"
           export QUOTA_E2E_PROFILE=redis
           if [ "${{ matrix.with_gateway }}" = "true" ]; then
-            bash hack/run-e2b-e2e-test.sh --with-gateway --pytest-extra-args "-s -x"
+            bash hack/run-e2b-e2e-test.sh --with-gateway \
+              -m "not gateway_routing and not gateway_uuid_auth and not jwt_auth and not runtime_mtls" \
+              --pytest-extra-args "-s -x"
           else
             bash hack/run-e2b-e2e-test.sh --pytest-extra-args "-s -x"
           fi

--- a/.github/workflows/e2e-sandbox-gateway-security.yaml
+++ b/.github/workflows/e2e-sandbox-gateway-security.yaml
@@ -1,0 +1,271 @@
+name: E2E for sandbox-gateway security
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  pull_request: { }
+  workflow_dispatch: { }
+
+permissions: read-all
+
+env:
+  GO_VERSION: '1.23'
+  KIND_VERSION: 'v0.22.0'
+  KIND_IMAGE: 'kindest/node:v1.32.0'
+  KIND_CLUSTER_NAME: 'ci-testing'
+  CONTROLLER_IMG: agent-sandbox-controller:latest
+  MANAGER_IMG: sandbox-manager:latest
+  RUNTIME_IMG: agent-runtime:latest
+  GATEWAY_IMG: sandbox-gateway:latest
+  CODE_INTERPRETER_IMG: registry-ap-southeast-1.ack.aliyuncs.com/acs/code-interpreter:v1.6
+  INPLACE_UPDATE_IMG: registry-ap-southeast-1.ack.aliyuncs.com/acs/code-interpreter:v1.6-new
+  RUNTIME_MTLS_SERVER_IMG: runtime-mtls-server:latest
+  JWT_OIDC_PROVIDER_IMG: jwt-oidc-provider:latest
+
+jobs:
+  sandbox-gateway-security:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: UUID auth
+            profile: uuid-auth
+            marker: gateway_uuid_auth
+            test_file: test/e2b/test_gateway_auth.py
+          - name: JWT auth
+            profile: jwt-auth
+            marker: jwt_auth
+            test_file: test/e2b/test_gateway_jwt_auth.py
+          - name: Runtime mTLS
+            profile: runtime-mtls
+            marker: runtime_mtls
+            test_file: test/e2b/test_gateway_runtime_mtls.py
+    name: sandbox-gateway (${{ matrix.name }})
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+      - name: Setup Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Setup Kind Cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          node_image: ${{ env.KIND_IMAGE }}
+          cluster_name: ${{ env.KIND_CLUSTER_NAME }}
+          config: ./test/kind-conf.yaml
+          version: ${{ env.KIND_VERSION }}
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+
+      - name: Cache Docker images
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/docker-images
+          key: ${{ runner.os }}-docker-${{ env.CODE_INTERPRETER_IMG }}
+          restore-keys: |
+            ${{ runner.os }}-docker-
+
+      - name: Load cached external images
+        run: |
+          if [ -f /tmp/docker-images/code-interpreter.tar ]; then
+            echo "Using cached code-interpreter image"
+            docker load -i /tmp/docker-images/code-interpreter.tar
+          else
+            echo "Pulling code-interpreter image: ${CODE_INTERPRETER_IMG}"
+            docker pull ${CODE_INTERPRETER_IMG}
+            mkdir -p /tmp/docker-images
+            docker save ${CODE_INTERPRETER_IMG} -o /tmp/docker-images/code-interpreter.tar
+          fi
+
+      - name: Load cached inplace update image
+        run: |
+          if [ -f /tmp/docker-images/inplace-update.tar ]; then
+            docker load -i /tmp/docker-images/inplace-update.tar
+          else
+            docker build -t ${INPLACE_UPDATE_IMG} -f test/e2b/assets/Dockerfile .
+            mkdir -p /tmp/docker-images
+            docker save ${INPLACE_UPDATE_IMG} -o /tmp/docker-images/inplace-update.tar
+          fi
+
+      - name: Build core images
+        run: |
+          make docker-build-manager
+          make docker-build-controller
+          make docker-build-runtime
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${CONTROLLER_IMG}
+          docker rmi ${CONTROLLER_IMG}
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${MANAGER_IMG}
+          docker rmi ${MANAGER_IMG}
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${RUNTIME_IMG}
+          docker rmi ${RUNTIME_IMG}
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${CODE_INTERPRETER_IMG}
+          docker rmi ${CODE_INTERPRETER_IMG}
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${INPLACE_UPDATE_IMG}
+          docker rmi ${INPLACE_UPDATE_IMG}
+
+      - name: Build sandbox-gateway image
+        run: |
+          make docker-build-sandbox-gateway
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${GATEWAY_IMG}
+          docker rmi ${GATEWAY_IMG}
+
+      - name: Build Runtime mTLS test server image
+        if: matrix.profile == 'runtime-mtls'
+        run: |
+          docker build -t ${RUNTIME_MTLS_SERVER_IMG} -f test/e2b/assets/runtime-mtls-server/Dockerfile .
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${RUNTIME_MTLS_SERVER_IMG}
+          docker rmi ${RUNTIME_MTLS_SERVER_IMG}
+
+      - name: Build JWT OIDC test provider image
+        if: matrix.profile == 'jwt-auth'
+        run: |
+          docker build -t ${JWT_OIDC_PROVIDER_IMG} -f test/e2b/assets/jwt-oidc-provider/Dockerfile .
+          kind load docker-image --name=${KIND_CLUSTER_NAME} ${JWT_OIDC_PROVIDER_IMG}
+          docker rmi ${JWT_OIDC_PROVIDER_IMG}
+
+      - name: Install Kruise Agents
+        run: |
+          {
+            echo ""
+            echo "# Disable manager API auth for focused gateway security tests"
+            echo "- op: replace"
+            echo "  path: /spec/template/spec/containers/0/args/8"
+            echo "  value: --e2b-enable-auth=false"
+          } >> config/sandbox-manager/configuration_patch.yaml
+          make deploy-agent-sandbox-controller
+          kubectl rollout status deployment/sandbox-controller-manager -n sandbox-system --timeout=5m
+          make deploy-sandbox-manager
+
+      - name: Configure Runtime mTLS test identity
+        if: matrix.profile == 'runtime-mtls'
+        run: |
+          set -euo pipefail
+          cert_dir="$(mktemp -d)"
+          trap 'rm -rf "$cert_dir"' EXIT
+
+          openssl req -x509 -newkey rsa:2048 -nodes -days 2 \
+            -keyout "$cert_dir/ca.key" -out "$cert_dir/ca.crt" \
+            -subj "/CN=runtime-mtls-e2e-ca"
+          openssl req -newkey rsa:2048 -nodes \
+            -keyout "$cert_dir/client.key" -out "$cert_dir/client.csr" \
+            -subj "/CN=sandbox-gateway"
+          printf 'extendedKeyUsage=clientAuth\n' > "$cert_dir/client.ext"
+          openssl x509 -req -days 2 -sha256 \
+            -in "$cert_dir/client.csr" -CA "$cert_dir/ca.crt" \
+            -CAkey "$cert_dir/ca.key" -CAcreateserial \
+            -out "$cert_dir/client.crt" -extfile "$cert_dir/client.ext"
+
+          openssl req -newkey rsa:2048 -nodes \
+            -keyout "$cert_dir/server.key" -out "$cert_dir/server.csr" \
+            -subj "/CN=agentruntime.sandbox.agents.kruise.io"
+          printf 'subjectAltName=DNS:*.sandbox.agents.kruise.io\nextendedKeyUsage=serverAuth\n' > "$cert_dir/server.ext"
+          openssl x509 -req -days 2 -sha256 \
+            -in "$cert_dir/server.csr" -CA "$cert_dir/ca.crt" \
+            -CAkey "$cert_dir/ca.key" -CAcreateserial \
+            -out "$cert_dir/server.crt" -extfile "$cert_dir/server.ext"
+
+          kubectl create secret generic sandbox-gateway-runtime-mtls-client-cert \
+            -n sandbox-system \
+            --from-file=tls.crt="$cert_dir/client.crt" \
+            --from-file=tls.key="$cert_dir/client.key" \
+            --from-file=ca.crt="$cert_dir/ca.crt"
+          kubectl create secret generic runtime-mtls-server-tls \
+            -n default \
+            --from-file=tls.crt="$cert_dir/server.crt" \
+            --from-file=tls.key="$cert_dir/server.key" \
+            --from-file=ca.crt="$cert_dir/ca.crt"
+
+      - name: Configure JWT OIDC test provider
+        if: matrix.profile == 'jwt-auth'
+        run: |
+          set -euo pipefail
+          identity_dir="$(mktemp -d)"
+          trap 'rm -rf "$identity_dir"' EXIT
+
+          openssl req -x509 -newkey rsa:2048 -nodes -days 2 \
+            -keyout "$identity_dir/ca.key" -out "$identity_dir/ca.crt" \
+            -subj "/CN=jwt-e2e-oidc-ca"
+          openssl req -newkey rsa:2048 -nodes \
+            -keyout "$identity_dir/tls.key" -out "$identity_dir/tls.csr" \
+            -subj "/CN=jwt-e2e-oidc-provider.sandbox-system.svc"
+          printf '%s\n' \
+            'subjectAltName=DNS:jwt-e2e-oidc-provider.sandbox-system.svc,DNS:jwt-e2e-oidc-provider.sandbox-system.svc.cluster.local' \
+            'extendedKeyUsage=serverAuth' > "$identity_dir/tls.ext"
+          openssl x509 -req -days 2 -sha256 \
+            -in "$identity_dir/tls.csr" -CA "$identity_dir/ca.crt" \
+            -CAkey "$identity_dir/ca.key" -CAcreateserial \
+            -out "$identity_dir/tls.crt" -extfile "$identity_dir/tls.ext"
+          openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \
+            -out "$identity_dir/signing.key"
+
+          kubectl create secret generic jwt-e2e-oidc-provider \
+            -n sandbox-system \
+            --from-file=tls.crt="$identity_dir/tls.crt" \
+            --from-file=tls.key="$identity_dir/tls.key" \
+            --from-file=signing.key="$identity_dir/signing.key"
+          kubectl create configmap jwt-e2e-oidc-ca \
+            -n sandbox-system \
+            --from-file=ca.crt="$identity_dir/ca.crt"
+          kubectl apply -f test/e2b/assets/jwt-oidc-provider/provider.yaml
+          kubectl rollout status deployment/jwt-e2e-oidc-provider \
+            -n sandbox-system --timeout=2m
+
+      - name: Deploy sandbox-gateway
+        run: |
+          if [ "${{ matrix.profile }}" = "runtime-mtls" ]; then
+            make deploy-sandbox-gateway-runtime-mtls
+          else
+            make deploy-sandbox-gateway
+          fi
+          if [ "${{ matrix.profile }}" = "uuid-auth" ]; then
+            kubectl get configmap envoy-config -n sandbox-system -o json \
+              | jq '.data["envoy.yaml"] |= sub("enable-auth: false"; "enable-auth: true")' \
+              | kubectl replace -f -
+            kubectl rollout restart deployment/sandbox-gateway -n sandbox-system
+            kubectl rollout status deployment/sandbox-gateway \
+              -n sandbox-system --timeout=5m
+          fi
+          if [ "${{ matrix.profile }}" = "jwt-auth" ]; then
+            kubectl get configmap envoy-config -n sandbox-system -o json \
+              | jq '.data["envoy.yaml"] |= sub("enable-auth: false"; "enable-auth: true") | .data["envoy.yaml"] |= sub("enable-jwt-auth: false"; "enable-jwt-auth: true")' \
+              | kubectl replace -f -
+            kubectl set env deployment/sandbox-gateway -n sandbox-system \
+              OIDC_DISCOVERY_URL=https://jwt-e2e-oidc-provider.sandbox-system.svc:8443/.well-known/openid-configuration \
+              OIDC_CA_CONFIGMAP_NAMESPACE=sandbox-system \
+              OIDC_CA_CONFIGMAP_NAME=jwt-e2e-oidc-ca
+            kubectl rollout status deployment/sandbox-gateway \
+              -n sandbox-system --timeout=5m
+          fi
+
+      - name: Run focused gateway security test
+        run: |
+          export KUBECONFIG=/home/runner/.kube/config
+          export E2B_DOMAIN=localhost
+          export E2B_API_KEY=e2b_abc123
+          export INPLACE_UPDATE_IMAGE="${INPLACE_UPDATE_IMG}"
+          if [ "${{ matrix.profile }}" = "runtime-mtls" ]; then
+            export RUNTIME_MTLS_E2E=true
+          fi
+          if [ "${{ matrix.profile }}" = "jwt-auth" ]; then
+            export TRAFFIC_ACCESS_TOKEN_JWT_E2E=true
+            export JWT_E2E_TOKEN_COMMAND="kubectl exec -n sandbox-system deployment/jwt-e2e-oidc-provider -- /jwt-oidc-provider issue"
+          fi
+          bash hack/run-e2b-e2e-test.sh \
+            --with-gateway \
+            --auth-disabled \
+            --test-file "${{ matrix.test_file }}" \
+            -m "${{ matrix.marker }}" \
+            --pytest-extra-args "-s -x"

--- a/Makefile
+++ b/Makefile
@@ -165,8 +165,9 @@ docker-pushx-runtime: ## Build and push multi-platform docker image for agent-ru
 	docker buildx build --platform=$(PLATFORMS) -f dockerfiles/agent-runtime.Dockerfile -t ${RUNTIME_IMG} --push .
 
 .PHONY: build-sandbox-gateway
-build-sandbox-gateway: ## Build sandbox-gateway plugin binary.
+build-sandbox-gateway: $(LOCALBIN) ## Build sandbox-gateway plugin binary.
 	CGO_ENABLED=1 go build -buildmode=c-shared -trimpath -ldflags="-s -w" -o $(GATEWAY_SO_FILE) ./cmd/sandbox-gateway/.
+	CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o $(LOCALBIN)/sandbox-gateway-cert-init ./cmd/sandbox-gateway-cert-init/.
 
 .PHONY: docker-build-sandbox-gateway
 docker-build-sandbox-gateway: ## Build docker image for sandbox-gateway.
@@ -228,6 +229,10 @@ deploy-agent-sandbox-controller: kustomize
 deploy-sandbox-gateway: kustomize
 	$(KUSTOMIZE) build config/sandbox-gateway/ | kubectl apply -f -
 
+.PHONY: deploy-sandbox-gateway-runtime-mtls
+deploy-sandbox-gateway-runtime-mtls: kustomize
+	$(KUSTOMIZE) build config/sandbox-gateway-runtime-mtls/ | kubectl apply -f -
+
 .PHONY: undeploy-sandbox-manager
 undeploy-sandbox-manager: kustomize
 	$(KUSTOMIZE) build config/sandbox-manager/ | kubectl delete -f -
@@ -235,6 +240,10 @@ undeploy-sandbox-manager: kustomize
 .PHONY: undeploy-sandbox-gateway
 undeploy-sandbox-gateway: kustomize
 	$(KUSTOMIZE) build config/sandbox-gateway/ | kubectl delete -f -
+
+.PHONY: undeploy-sandbox-gateway-runtime-mtls
+undeploy-sandbox-gateway-runtime-mtls: kustomize
+	$(KUSTOMIZE) build config/sandbox-gateway-runtime-mtls/ | kubectl delete -f -
 
 .PHONY: undeploy-agent-sandbox-controller
 undeploy-agent-sandbox-controller: kustomize

--- a/cmd/sandbox-gateway-cert-init/main.go
+++ b/cmd/sandbox-gateway-cert-init/main.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 	"log"
 
-	"k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openkruise/agents/pkg/sandbox-gateway/runtimecredentials"
 )
@@ -42,9 +44,13 @@ func run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("get in-cluster configuration: %w", err)
 	}
-	client, err := kubernetes.NewForConfig(config)
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return fmt.Errorf("register Kubernetes API types: %w", err)
+	}
+	apiClient, err := client.New(config, client.Options{Scheme: scheme})
 	if err != nil {
 		return fmt.Errorf("create Kubernetes client: %w", err)
 	}
-	return runtimecredentials.Load(ctx, client, opts)
+	return runtimecredentials.Load(ctx, apiClient, opts)
 }

--- a/cmd/sandbox-gateway-cert-init/main.go
+++ b/cmd/sandbox-gateway-cert-init/main.go
@@ -34,6 +34,10 @@ func main() {
 }
 
 func run(ctx context.Context) error {
+	opts, err := runtimecredentials.OptionsFromEnvironment()
+	if err != nil {
+		return err
+	}
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return fmt.Errorf("get in-cluster configuration: %w", err)
@@ -42,5 +46,5 @@ func run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("create Kubernetes client: %w", err)
 	}
-	return runtimecredentials.Load(ctx, client, runtimecredentials.DefaultOptions())
+	return runtimecredentials.Load(ctx, client, opts)
 }

--- a/cmd/sandbox-gateway-cert-init/main.go
+++ b/cmd/sandbox-gateway-cert-init/main.go
@@ -19,11 +19,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openkruise/agents/pkg/sandbox-gateway/runtimecredentials"
@@ -31,7 +31,7 @@ import (
 
 func main() {
 	if err := run(context.Background()); err != nil {
-		log.Fatalf("initialize runtime mTLS credentials: %v", err)
+		klog.Fatalf("initialize runtime mTLS credentials: %v", err)
 	}
 }
 

--- a/cmd/sandbox-gateway-cert-init/main.go
+++ b/cmd/sandbox-gateway-cert-init/main.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/openkruise/agents/pkg/sandbox-gateway/runtimecredentials"
+)
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		log.Fatalf("initialize runtime mTLS credentials: %v", err)
+	}
+}
+
+func run(ctx context.Context) error {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return fmt.Errorf("get in-cluster configuration: %w", err)
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("create Kubernetes client: %w", err)
+	}
+	return runtimecredentials.Load(ctx, client, runtimecredentials.DefaultOptions())
+}

--- a/cmd/sandbox-gateway/main.go
+++ b/cmd/sandbox-gateway/main.go
@@ -32,18 +32,20 @@ import (
 	"github.com/openkruise/agents/pkg/proxy"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/controller"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/filter"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/jwtauth"
 	peerserver "github.com/openkruise/agents/pkg/sandbox-gateway/server"
 )
 
 func init() {
+	jwtAuthManager := jwtauth.NewManager()
 	envoyhttp.RegisterHttpFilterFactoryAndConfigParser(
 		"sandbox-gateway",
 		filter.FilterFactory,
-		&filter.ConfigParser{},
+		filter.NewConfigParser(jwtAuthManager),
 	)
 
 	go func() {
-		if err := controller.StartManager(context.Background()); err != nil {
+		if err := controller.StartManager(context.Background(), jwtAuthManager); err != nil {
 			api.LogErrorf("sandbox controller manager exited with error: %v", err)
 		}
 	}()
@@ -69,7 +71,7 @@ func init() {
 			os.Exit(1)
 		}
 
-		peerServer := peerserver.NewServer(client, proxy.SystemPort)
+		peerServer := peerserver.NewServer(client, proxy.SystemPort, jwtAuthManager.Ready)
 		if err := peerServer.Start(ctx); err != nil {
 			api.LogErrorf("failed to start peer server: %v", err)
 			os.Exit(1)

--- a/config/sandbox-gateway-runtime-mtls/configmap-patch.yaml
+++ b/config/sandbox-gateway-runtime-mtls/configmap-patch.yaml
@@ -3,9 +3,6 @@ kind: ConfigMap
 metadata:
   name: envoy-config
   namespace: sandbox-system
-  labels:
-    app.kubernetes.io/name: sandbox-gateway
-    app.kubernetes.io/managed-by: kustomize
 data:
   envoy.yaml: |
     admin:
@@ -72,13 +69,22 @@ data:
                         - name: backend
                           domains: ["*"]
                           routes:
-                            # The manager route is only required by this repository's E2E setup.
-                            # Production deployments route only sandbox traffic through the gateway.
                             - match:
                                 prefix: "/kruise/api"
                               route:
                                 cluster: manager_cluster
                                 timeout: 600s
+                            - match:
+                                prefix: "/"
+                                dynamic_metadata:
+                                  - filter: agents.kruise.io/sandbox-gateway
+                                    path:
+                                      - key: upstream-mtls
+                                    value:
+                                      bool_match: true
+                              route:
+                                cluster: original_dst_mtls_cluster
+                                timeout: 0s
                             - match:
                                 prefix: "/"
                               route:
@@ -100,7 +106,7 @@ data:
                               default-port: "49983"
                               enable-auth: false
                               enable-jwt-auth: false
-                              enable-runtime-mtls: false
+                              enable-runtime-mtls: true
                               traffic-access-token-header: x-traffic-access-token
                       - name: envoy.filters.http.router
                         typed_config:
@@ -135,6 +141,45 @@ data:
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
       clusters:
+        - name: original_dst_mtls_cluster
+          type: ORIGINAL_DST
+          lb_policy: CLUSTER_PROVIDED
+          per_connection_buffer_limit_bytes: 1048576
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              common_http_protocol_options:
+                max_requests_per_connection: 1
+              explicit_http_config:
+                http_protocol_options: {}
+          connect_timeout: 5s
+          original_dst_lb_config:
+            metadata_key:
+              key: "envoy.lb.original_dst"
+              path:
+                - key: "host"
+          circuit_breakers:
+            thresholds:
+              - priority: DEFAULT
+                max_connections: 80000
+                max_pending_requests: 32768
+                max_requests: 80000
+                max_retries: 5
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              sni: agentruntime.sandbox.agents.kruise.io
+              auto_sni_san_validation: true
+              common_tls_context:
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /var/run/sandbox-gateway/runtime-mtls/tls.crt
+                    private_key:
+                      filename: /var/run/sandbox-gateway/runtime-mtls/tls.key
+                validation_context:
+                  trusted_ca:
+                    filename: /var/run/sandbox-gateway/runtime-mtls/ca.crt
         - name: original_dst_cluster
           type: ORIGINAL_DST
           lb_policy: CLUSTER_PROVIDED

--- a/config/sandbox-gateway-runtime-mtls/deployment-patch.yaml
+++ b/config/sandbox-gateway-runtime-mtls/deployment-patch.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sandbox-gateway
+  namespace: sandbox-system
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: runtime-mtls-cert-init
+          image: sandbox-gateway:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /usr/local/bin/sandbox-gateway-cert-init
+          volumeMounts:
+            - name: runtime-mtls-certs
+              mountPath: /var/run/sandbox-gateway/runtime-mtls
+      containers:
+        - name: sandbox-gateway
+          volumeMounts:
+            - name: runtime-mtls-certs
+              mountPath: /var/run/sandbox-gateway/runtime-mtls
+              readOnly: true
+      volumes:
+        - name: runtime-mtls-certs
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Mi

--- a/config/sandbox-gateway-runtime-mtls/deployment-patch.yaml
+++ b/config/sandbox-gateway-runtime-mtls/deployment-patch.yaml
@@ -12,6 +12,13 @@ spec:
           imagePullPolicy: IfNotPresent
           command:
             - /usr/local/bin/sandbox-gateway-cert-init
+          env:
+            - name: RUNTIME_MTLS_SECRET_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: RUNTIME_MTLS_SECRET_NAME
+              value: sandbox-gateway-runtime-mtls-client-cert
           volumeMounts:
             - name: runtime-mtls-certs
               mountPath: /var/run/sandbox-gateway/runtime-mtls

--- a/config/sandbox-gateway-runtime-mtls/kustomization.yaml
+++ b/config/sandbox-gateway-runtime-mtls/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../sandbox-gateway
+
+patches:
+  - path: deployment-patch.yaml
+  - path: configmap-patch.yaml

--- a/config/sandbox-gateway-runtime-mtls/kustomization.yaml
+++ b/config/sandbox-gateway-runtime-mtls/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - ../sandbox-gateway
+  - rbac.yaml
 
 patches:
   - path: deployment-patch.yaml

--- a/config/sandbox-gateway-runtime-mtls/rbac.yaml
+++ b/config/sandbox-gateway-runtime-mtls/rbac.yaml
@@ -1,23 +1,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: sandbox-gateway-identity-ca-reader
-  namespace: ack-agent-identity
+  name: sandbox-gateway-runtime-mtls-secret-reader
+  namespace: sandbox-system
 rules:
   - apiGroups: [""]
-    resources: ["configmaps"]
-    resourceNames: ["ack-agent-identity-root-ca.crt"]
+    resources: ["secrets"]
+    resourceNames: ["sandbox-gateway-runtime-mtls-client-cert"]
     verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: sandbox-gateway-identity-ca-reader
-  namespace: ack-agent-identity
+  name: sandbox-gateway-runtime-mtls-secret-reader
+  namespace: sandbox-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: sandbox-gateway-identity-ca-reader
+  name: sandbox-gateway-runtime-mtls-secret-reader
 subjects:
   - kind: ServiceAccount
     name: sandbox-gateway

--- a/config/sandbox-gateway/configmap.yaml
+++ b/config/sandbox-gateway/configmap.yaml
@@ -9,6 +9,7 @@ metadata:
 data:
   envoy.yaml: |
     admin:
+      access_log_path: /dev/stdout
       address:
         socket_address:
           address: 127.0.0.1
@@ -16,6 +17,7 @@ data:
     static_resources:
       listeners:
         - name: listener_0
+          per_connection_buffer_limit_bytes: 1048576
           address:
             socket_address:
               address: 0.0.0.0
@@ -26,9 +28,7 @@ data:
                   typed_config:
                     "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                     stat_prefix: ingress_http
-                    stream_idle_timeout: 600s 
-                    upgrade_configs:
-                      - upgrade_type: websocket
+                    stream_idle_timeout: 600s
                     access_log:
                       - name: envoy.access_loggers.file
                         typed_config:
@@ -38,24 +38,42 @@ data:
                             start_time: "%START_TIME%"
                             method: "%REQ(:METHOD)%"
                             path: "%REQ(:PATH)%"
-                            protocol: "%PROTOCOL%"
-                            response_code: "%RESPONSE_CODE%"
-                            response_flags: "%RESPONSE_FLAGS%"
-                            bytes_received: "%BYTES_RECEIVED%"
-                            bytes_sent: "%BYTES_SENT%"
-                            duration_ms: "%DURATION%"
-                            upstream_host: "%UPSTREAM_HOST%"
-                            downstream_remote_address: "%DOWNSTREAM_REMOTE_ADDRESS%"
                             user_agent: "%REQ(USER-AGENT)%"
                             request_id: "%REQ(X-REQUEST-ID)%"
                             authority: "%REQ(:AUTHORITY)%"
+                            protocol: "%PROTOCOL%"
+                            upstream_protocol: "%UPSTREAM_PROTOCOL%"
+                            response_code: "%RESPONSE_CODE%"
+                            response_code_details: "%RESPONSE_CODE_DETAILS%"
+                            response_flags: "%RESPONSE_FLAGS%"
+                            connection_termination_details: "%CONNECTION_TERMINATION_DETAILS%"
+                            duration_ms: "%DURATION%"
+                            request_duration_ms: "%REQUEST_DURATION%"
+                            request_tx_duration_ms: "%REQUEST_TX_DURATION%"
+                            response_duration_ms: "%RESPONSE_DURATION%"
+                            response_tx_duration_ms: "%RESPONSE_TX_DURATION%"
+                            bytes_received: "%BYTES_RECEIVED%"
+                            bytes_sent: "%BYTES_SENT%"
+                            upstream_wire_bytes_sent: "%UPSTREAM_WIRE_BYTES_SENT%"
+                            upstream_wire_bytes_received: "%UPSTREAM_WIRE_BYTES_RECEIVED%"
+                            downstream_wire_bytes_sent: "%DOWNSTREAM_WIRE_BYTES_SENT%"
+                            downstream_wire_bytes_received: "%DOWNSTREAM_WIRE_BYTES_RECEIVED%"
+                            route_name: "%ROUTE_NAME%"
+                            upstream_cluster: "%UPSTREAM_CLUSTER%"
+                            upstream_host: "%UPSTREAM_HOST%"
                             upstream_local_address: "%UPSTREAM_LOCAL_ADDRESS%"
+                            upstream_request_attempt_count: "%UPSTREAM_REQUEST_ATTEMPT_COUNT%"
+                            downstream_local_address: "%DOWNSTREAM_LOCAL_ADDRESS%"
+                            downstream_remote_address: "%DOWNSTREAM_REMOTE_ADDRESS%"
+                            requested_server_name: "%REQUESTED_SERVER_NAME%"
                     route_config:
                       name: local_route
                       virtual_hosts:
                         - name: backend
                           domains: ["*"]
                           routes:
+                            # The manager route is only required by this repository's E2E setup.
+                            # Production deployments route only sandbox traffic through the gateway.
                             - match:
                                 prefix: "/kruise/api"
                               route:
@@ -65,7 +83,7 @@ data:
                                 prefix: "/"
                               route:
                                 cluster: original_dst_cluster
-                                timeout: 600s
+                                timeout: 0s
                     http_filters:
                       - name: envoy.filters.http.golang
                         typed_config:
@@ -76,20 +94,23 @@ data:
                           plugin_config:
                             "@type": type.googleapis.com/xds.type.v3.TypedStruct
                             value:
-                              host-header-name: "Host"
-                              sandbox-header-name: "e2b-sandbox-id"
-                              sandbox-port-header: "e2b-sandbox-port"
+                              host-header-name: Host
+                              sandbox-header-name: e2b-sandbox-id
+                              sandbox-port-header: e2b-sandbox-port
                               default-port: "49983"
                               enable-auth: false
+                              enable-jwt-auth: false
+                              traffic-access-token-header: x-traffic-access-token
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-
-        - name: prometheus_listener
+                    upgrade_configs:
+                      - upgrade_type: websocket
+        - name: listener_prometheus
           address:
             socket_address:
               address: 0.0.0.0
-              port_value: 9090
+              port_value: 9902
           filter_chains:
             - filters:
                 - name: envoy.filters.network.http_connection_manager
@@ -103,34 +124,40 @@ data:
                           domains: ["*"]
                           routes:
                             - match:
-                                prefix: "/stats/prometheus"
+                                path: /metrics
                               route:
-                                cluster: envoy_admin
-                                prefix_rewrite: "/stats/prometheus"
+                                cluster: admin_cluster
+                                prefix_rewrite: /stats/prometheus
+                                timeout: 30s
                     http_filters:
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-
       clusters:
         - name: original_dst_cluster
           type: ORIGINAL_DST
           lb_policy: CLUSTER_PROVIDED
-          common_http_protocol_options:
-            max_requests_per_connection: 1
+          per_connection_buffer_limit_bytes: 1048576
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              common_http_protocol_options:
+                max_requests_per_connection: 1
+              explicit_http_config:
+                http_protocol_options: {}
           connect_timeout: 5s
           original_dst_lb_config:
             metadata_key:
               key: "envoy.lb.original_dst"
               path:
-              - key: "host"
+                - key: "host"
           circuit_breakers:
             thresholds:
-            - priority: DEFAULT
-              max_connections: 32768
-              max_pending_requests: 32768
-              max_requests: 65536
-              max_retries: 5
+              - priority: DEFAULT
+                max_connections: 80000
+                max_pending_requests: 32768
+                max_requests: 80000
+                max_retries: 5
         - name: manager_cluster
           type: STRICT_DNS
           lb_policy: ROUND_ROBIN
@@ -144,12 +171,12 @@ data:
                         socket_address:
                           address: sandbox-manager.sandbox-system.svc.cluster.local
                           port_value: 7788
-        - name: envoy_admin
+        - name: admin_cluster
           type: STATIC
-          lb_policy: ROUND_ROBIN
           connect_timeout: 5s
+          lb_policy: ROUND_ROBIN
           load_assignment:
-            cluster_name: envoy_admin
+            cluster_name: admin_cluster
             endpoints:
               - lb_endpoints:
                   - endpoint:

--- a/config/sandbox-gateway/deployment.yaml
+++ b/config/sandbox-gateway/deployment.yaml
@@ -65,7 +65,10 @@ spec:
               containerPort: 7788
               protocol: TCP
             - name: metrics
-              containerPort: 9090
+              containerPort: 9902
+              protocol: TCP
+            - name: system
+              containerPort: 7789
               protocol: TCP
           livenessProbe:
             tcpSocket:
@@ -75,8 +78,9 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
-            tcpSocket:
-              port: 7788
+            httpGet:
+              path: /readyz
+              port: system
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 3

--- a/config/sandbox-gateway/identity-ca-rbac.yaml
+++ b/config/sandbox-gateway/identity-ca-rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sandbox-gateway-identity-ca-reader
+  namespace: ack-agent-identity
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["ack-agent-identity-root-ca.crt"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sandbox-gateway-identity-ca-reader
+  namespace: ack-agent-identity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sandbox-gateway-identity-ca-reader
+subjects:
+  - kind: ServiceAccount
+    name: sandbox-gateway
+    namespace: sandbox-system

--- a/config/sandbox-gateway/jwt-auth-rbac.yaml
+++ b/config/sandbox-gateway/jwt-auth-rbac.yaml
@@ -1,0 +1,29 @@
+# This sample assumes the OIDC CA ConfigMap is
+# sandbox-system/sandbox-gateway-oidc-ca. For a cross-namespace identity
+# provider, change both metadata.namespace fields to the provider namespace and
+# restrict resourceNames to the configured OIDC_CA_CONFIGMAP_NAME. Keep the
+# RoleBinding subject namespace set to the sandbox-gateway namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sandbox-gateway-oidc-ca-reader
+  namespace: sandbox-system
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["sandbox-gateway-oidc-ca"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sandbox-gateway-oidc-ca-reader
+  namespace: sandbox-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sandbox-gateway-oidc-ca-reader
+subjects:
+  - kind: ServiceAccount
+    name: sandbox-gateway
+    namespace: sandbox-system

--- a/dockerfiles/sandbox-gateway.Dockerfile
+++ b/dockerfiles/sandbox-gateway.Dockerfile
@@ -5,10 +5,12 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=1 go build -buildmode=c-shared -trimpath -ldflags="-s -w" -o sandbox-gateway.so ./cmd/sandbox-gateway/.
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o sandbox-gateway-cert-init ./cmd/sandbox-gateway-cert-init/.
 
 FROM envoyproxy/envoy:contrib-v1.37.3
 
 COPY --from=builder /build/sandbox-gateway.so /etc/envoy/sandbox-gateway.so
+COPY --from=builder /build/sandbox-gateway-cert-init /usr/local/bin/sandbox-gateway-cert-init
 # COPY envoy.yaml /etc/envoy/envoy.yaml
 
 ENTRYPOINT ["envoy", "-c", "/etc/envoy/envoy.yaml"]

--- a/docs/proposals/20260713-traffic-access-token-jwt-verification.md
+++ b/docs/proposals/20260713-traffic-access-token-jwt-verification.md
@@ -1,0 +1,277 @@
+---
+title: TrafficAccessToken JWT Verification via OIDC
+authors:
+  - "@czy"
+reviewers:
+  - "@TBD"
+creation-date: 2026-07-13
+last-updated: 2026-07-15
+status: provisional
+see-also:
+  - "/docs/proposals/20260427-security-identity-provider.md"
+  - "/docs/proposals/20260521-traffic-policy-and-security-profile.md"
+---
+
+# TrafficAccessToken JWT Verification via OIDC
+
+## Summary
+
+This proposal adds offline JWT verification for the `trafficAccessToken` used
+to access a Sandbox through sandbox-gateway. When JWT authentication is enabled,
+each gateway process loads the identity provider CA from Kubernetes, performs
+OIDC discovery, downloads a JWKS snapshot, and verifies every request locally.
+
+The gateway binds signed `sandboxId` and `sandboxUid` claims to the selected
+route, preventing a valid token for one Sandbox from being replayed against
+another or against a replacement Sandbox with the same name. Token issuance
+and delivery to clients remain owned by the identity integration and are not
+changed by this proposal.
+
+The feature is disabled by default through Envoy filter configuration. Existing
+clusters retain their current behavior until both `enable-auth` and
+`enable-jwt-auth` are set to `true`.
+
+## Goals
+
+- Verify JWT signatures using asymmetric public keys obtained through OIDC.
+- Require and validate `exp`, `iat`, `nbf`, `iss`, and non-empty `sub` claims.
+- Bind tokens to the current Sandbox ID and immutable Sandbox UID.
+- Keep the request path offline after verifier initialization.
+- Fail closed while an enabled verifier is unavailable.
+- Preserve existing UUID authentication when JWT authentication is disabled.
+- Keep configuration and dependencies out of sandbox-manager's controller-only
+  feature-gate package.
+
+## Non-Goals
+
+- Audience or subject-policy authorization beyond requiring a non-empty `sub`.
+- Authorization based on arbitrary signed `metadata` claims.
+- Binding Pod name, namespace, or UID. These are not present in the shared
+  gateway route model.
+- Token introspection, revocation, or opaque-token support.
+- Automatic CA or JWKS refresh. A gateway rollout is required after rotation.
+- Returning replacement tokens issued by the security-token refresh controller.
+- Issuing traffic tokens or adding a manager API that returns them to clients.
+- Changing Sandbox claim, clone, or E2B create response behavior.
+- Supporting more than one issuer per gateway process.
+
+## Behavioral Contract
+
+Gateway authentication has three valid modes:
+
+| `enable-auth` | `enable-jwt-auth` | Behavior |
+|---|---|---|
+| `false` | `false` | Authentication disabled. |
+| `true` | `false` | Existing `x-access-token` UUID authentication. |
+| `true` | `true` | JWT authentication using the traffic-token header. UUID validation is bypassed. |
+
+`enable-jwt-auth=true` with `enable-auth=false` is invalid configuration.
+
+JWT mode intentionally replaces, rather than augments, UUID authentication.
+The `x-access-token` header remains untouched and is forwarded transparently.
+This lets applications use that header independently while gateway access is
+authorized by the JWT.
+
+The traffic-token header defaults to `x-traffic-access-token` and is
+configurable. It must be a valid HTTP header name and must differ from
+`x-access-token`. Its value is a compact JWT, not an `Authorization: Bearer`
+value. After successful verification, the gateway removes this header before
+forwarding the request to the Sandbox.
+
+## Token Claims
+
+The initial claim shape is:
+
+```json
+{
+  "exp": 1784102400,
+  "iat": 1784098800,
+  "nbf": 1784098800,
+  "iss": "https://identity.example",
+  "sub": "e2b:controlplane:client",
+  "sandbox": {
+    "sandboxId": "default--sample",
+    "sandboxUid": "89d24507-936c-4a04-a958-b5d6a8277ed5"
+  }
+}
+```
+
+Verification is split into two stages:
+
+1. `pkg/identity/oidc` validates the signature and registered claims.
+2. `pkg/sandbox-gateway/filter` compares `sandbox.sandboxId` and
+   `sandbox.sandboxUid` with `Route.ID` and `Route.UID`.
+
+Required claim behavior:
+
+| Claim | Validation |
+|---|---|
+| `exp` | Present and not expired, allowing configured clock skew. |
+| `iat` | Present and not in the future beyond configured clock skew. |
+| `nbf` | Present and not in the future beyond configured clock skew. |
+| `iss` | Exactly matches the issuer returned by OIDC discovery. |
+| `sub` | Present and non-empty. |
+| `sandbox.sandboxId` | Exactly matches the selected route ID. |
+| `sandbox.sandboxUid` | Exactly matches the selected route UID. |
+
+The verifier parses but does not authorize `aud` or unknown custom claims.
+Signature integrity must not be confused with authorization policy; future
+metadata- or audience-based authorization requires a separate proposal.
+
+## OIDC Initialization
+
+Each sandbox-gateway process performs the following sequence after Envoy accepts
+an enabled filter configuration:
+
+1. Read the CA PEM from a ConfigMap using the controller-runtime API reader.
+2. Create an HTTPS client rooted only in that CA, with TLS 1.2 or newer.
+3. Fetch the configured OIDC discovery document without following redirects.
+4. Read `issuer` and validate that `jwks_uri` is an absolute HTTPS URL.
+5. Fetch and validate the JWKS.
+6. Atomically publish an immutable verifier to filter workers.
+
+Initialization retries with exponential backoff from one second to 30 seconds.
+There are no per-request network calls. Once a verifier is published, it is not
+replaced during the process lifetime.
+
+The JWKS loader rejects:
+
+- Empty sets, duplicate or empty `kid` values, and invalid keys.
+- Symmetric keys and private keys.
+- Keys whose `use` is not signing or whose declared `key_ops` omits `verify`.
+- A JWK algorithm incompatible with its key type.
+
+Supported signature algorithms are RSA PKCS#1, RSA-PSS, ECDSA, and Ed25519
+algorithms supported by `go-jose`. `alg=none` and HMAC algorithms are rejected.
+
+## Configuration
+
+Envoy filter fields:
+
+| Field | Default | Description |
+|---|---|---|
+| `enable-auth` | `false` | Enables gateway authentication. |
+| `enable-jwt-auth` | `false` | Selects JWT instead of UUID authentication. |
+| `traffic-access-token-header` | `x-traffic-access-token` | Header carrying the compact JWT. |
+
+Gateway environment variables:
+
+| Variable | Default |
+|---|---|
+| `OIDC_DISCOVERY_URL` | `https://id-provider.ack-agent-identity.svc:8445/.well-known/openid-configuration` |
+| `OIDC_CA_CONFIGMAP_NAMESPACE` | `ack-agent-identity` |
+| `OIDC_CA_CONFIGMAP_NAME` | `ack-agent-identity-root-ca.crt` |
+| `OIDC_CA_CONFIGMAP_KEY` | `ca.crt` |
+| `OIDC_CLOCK_SKEW` | `1m` |
+
+Invalid local configuration causes Envoy filter configuration to fail rather
+than silently degrading to UUID or unauthenticated access.
+
+JWT mode is process-wide. Per-route filter configurations may inherit or repeat
+the process mode, but cannot enable or disable JWT independently.
+
+## Token Acquisition Boundary
+
+This change begins after a client has obtained a traffic access token. It does
+not prescribe whether that token comes from an identity-provider SDK, a control
+plane, or another trusted service. Sandbox-manager claim/clone processing and
+the E2B create response remain unchanged.
+
+## Readiness And Errors
+
+The gateway system server exposes:
+
+- `GET /healthz`: process liveness.
+- `GET /readyz`: returns success when JWT is disabled or an enabled verifier is
+  published; otherwise returns `503`.
+
+The Deployment readiness probe uses `/readyz` on system port `7789`.
+
+Request failures use these statuses:
+
+| Condition | Status |
+|---|---|
+| Enabled verifier not ready | `503 Service Unavailable` |
+| Missing, malformed, expired, or invalid JWT | `401 Unauthorized` |
+| Sandbox ID or UID mismatch | `401 Unauthorized` |
+
+Error responses do not expose cryptographic details to clients. Detailed
+verification errors remain in structured gateway logs.
+
+## RBAC
+
+The gateway requires `get` access to one CA ConfigMap in the identity-provider
+namespace. `config/sandbox-gateway/identity-ca-rbac.yaml` provides a
+least-privilege namespaced Role and binds it to the sandbox-gateway ServiceAccount.
+
+The file is intentionally not part of the default sandbox-gateway kustomization:
+the optional identity namespace may not exist in installations where JWT is
+disabled, and Kubernetes cannot create a namespaced Role before its namespace.
+Operators enabling JWT authentication must create the identity namespace and
+apply this RBAC file as part of the identity-enabled deployment profile.
+
+## Compatibility And Upgrade
+
+- Authentication remains disabled by default in the shipped ConfigMap.
+- Existing UUID mode has unchanged request and response behavior.
+- Sandbox-manager APIs and Sandbox claim/clone behavior are unchanged.
+- No CRD, generated client, or protobuf changes are required.
+- Enabling JWT requires the CA ConfigMap, identity-provider connectivity during
+  startup, the optional RBAC, and a gateway rollout.
+- CA or signing-key rotation requires a gateway rollout because trust material
+  is intentionally loaded once.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Identity provider unavailable during startup | Retry with capped exponential backoff and keep readiness false. |
+| Unknown key after signing-key rotation | Fail closed and roll gateway pods after publishing the new JWKS. |
+| Algorithm confusion | Allow only asymmetric algorithms and require key/algorithm compatibility. |
+| Cross-Sandbox replay | Bind both Sandbox ID and immutable UID to the selected route. |
+| Traffic token leaks to workloads | Remove the configured token header before forwarding. |
+| Initial token eventually expires | Clients must obtain a replacement through the identity system or recreate the Sandbox; refresh-token delivery is future work. |
+
+## Test Plan
+
+Unit tests cover:
+
+- Environment defaults and validation.
+- CA ConfigMap errors, TLS discovery, JWKS loading, response limits, and
+  immutable key snapshots.
+- Valid and invalid RSA/ECDSA JWTs, unsupported algorithms, signatures, key
+  selection, required claims, issuer, skew, token size, and Sandbox binding.
+- JWT manager startup ordering, retries, atomic publication, readiness,
+  cancellation, idempotency, and concurrent readers.
+- Filter configuration, UUID compatibility, JWT success/failure, unavailable
+  verifier, route mismatch, custom headers, and header removal.
+- Health and readiness handlers.
+
+The opt-in E2E profile (`TRAFFIC_ACCESS_TOKEN_JWT_E2E=true`) covers:
+
+- An external test issuer command minting a token for the created Sandbox ID/UID.
+- A valid JWT succeeding even when `x-access-token` contains an invalid UUID.
+- Missing and malformed JWTs returning `401`.
+- A token issued for Sandbox A being rejected for Sandbox B.
+
+## Alternatives
+
+### Envoy `jwt_authn`
+
+Envoy's native filter can validate JWTs, but the gateway must obtain its CA from
+Kubernetes and bind claims to the dynamically selected Sandbox route. Keeping
+verification in the existing Go filter provides both capabilities in one path.
+
+### Per-Request Introspection
+
+Calling the identity provider for every request would simplify revocation but
+adds latency and creates a traffic-path availability dependency. Offline
+verification is preferred for the initial implementation.
+
+## Implementation History
+
+- [x] 2026-07-13: Initial proposal drafted.
+- [x] 2026-07-15: Finalized the initial ID/UID-only binding and static JWKS scope.
+- [x] 2026-07-15: Added OIDC verifier, asynchronous manager, filter integration,
+  readiness, RBAC, and unit/E2E coverage.
+- [ ] Community review and follow-up design for key/token rotation.

--- a/docs/proposals/20260713-traffic-access-token-jwt-verification.md
+++ b/docs/proposals/20260713-traffic-access-token-jwt-verification.md
@@ -63,14 +63,14 @@ Gateway authentication has three valid modes:
 |---|---|---|
 | `false` | `false` | Authentication disabled. |
 | `true` | `false` | Existing `x-access-token` UUID authentication. |
-| `true` | `true` | JWT authentication using the traffic-token header. UUID validation is bypassed. |
+| `true` | `true` | JWT authentication using the traffic-token header. Gateway-side UUID validation is bypassed. |
 
 `enable-jwt-auth=true` with `enable-auth=false` is invalid configuration.
 
-JWT mode intentionally replaces, rather than augments, UUID authentication.
-The `x-access-token` header remains untouched and is forwarded transparently.
-This lets applications use that header independently while gateway access is
-authorized by the JWT.
+JWT mode replaces UUID authentication only at the gateway layer. It does not
+replace agent-runtime authentication: clients accessing an endpoint that
+requires `x-access-token` must still provide the Sandbox runtime token. The
+gateway leaves that header untouched and forwards it transparently.
 
 The traffic-token header defaults to `x-traffic-access-token` and is
 configurable. It must be a valid HTTP header name and must differ from
@@ -205,7 +205,11 @@ identity-provider namespace. Operators enabling JWT authentication must grant
 that permission to the `sandbox-gateway` ServiceAccount. A namespaced Role
 restricted with `resourceNames` is recommended. The permission is not included
 in the default kustomization because the identity-provider namespace and
-ConfigMap are deployment-specific.
+ConfigMap are deployment-specific. `config/sandbox-gateway/jwt-auth-rbac.yaml`
+provides a ready-to-adapt sample for a same-namespace CA ConfigMap. Operators
+using a cross-namespace identity provider must change the Role and RoleBinding
+namespace and the allowed `resourceNames`, while keeping the RoleBinding subject
+pointed at the sandbox-gateway ServiceAccount.
 
 ## Compatibility And Upgrade
 
@@ -214,7 +218,7 @@ ConfigMap are deployment-specific.
 - Sandbox-manager APIs and Sandbox claim/clone behavior are unchanged.
 - No CRD, generated client, or protobuf changes are required.
 - Enabling JWT requires the CA ConfigMap, identity-provider connectivity during
-  startup, the optional RBAC, and a gateway rollout.
+  startup, the required RBAC, and a gateway rollout.
 - CA or signing-key rotation requires a gateway rollout because trust material
   is intentionally loaded once.
 
@@ -247,7 +251,7 @@ Unit tests cover:
 The JWT E2E profile uses a local HTTPS OIDC discovery/JWKS provider and covers:
 
 - The in-cluster test issuer minting a token for the created Sandbox ID/UID.
-- A valid JWT succeeding even when `x-access-token` contains an invalid UUID.
+- A valid JWT and the Sandbox runtime access token succeeding together.
 - Missing, malformed, and expired JWTs returning `401`.
 - A token issued for Sandbox A being rejected for Sandbox B.
 

--- a/docs/proposals/20260713-traffic-access-token-jwt-verification.md
+++ b/docs/proposals/20260713-traffic-access-token-jwt-verification.md
@@ -5,7 +5,7 @@ authors:
 reviewers:
   - "@TBD"
 creation-date: 2026-07-13
-last-updated: 2026-07-15
+last-updated: 2026-07-21
 status: provisional
 see-also:
   - "/docs/proposals/20260427-security-identity-provider.md"
@@ -19,7 +19,8 @@ see-also:
 This proposal adds offline JWT verification for the `trafficAccessToken` used
 to access a Sandbox through sandbox-gateway. When JWT authentication is enabled,
 each gateway process loads the identity provider CA from Kubernetes, performs
-OIDC discovery, downloads a JWKS snapshot, and verifies every request locally.
+OIDC discovery, downloads a JWKS snapshot, and locally verifies requests for
+Sandbox routes that explicitly require traffic authentication.
 
 The gateway binds signed `sandboxId` and `sandboxUid` claims to the selected
 route, preventing a valid token for one Sandbox from being replayed against
@@ -27,9 +28,10 @@ another or against a replacement Sandbox with the same name. Token issuance
 and delivery to clients remain owned by the identity integration and are not
 changed by this proposal.
 
-The feature is disabled by default through Envoy filter configuration. Existing
-clusters retain their current behavior until both `enable-auth` and
-`enable-jwt-auth` are set to `true`.
+The process-wide JWT capability is disabled by default through Envoy filter
+configuration. A Sandbox opts into JWT enforcement with the
+`security.agents.kruise.io/enable-jwt-auth: "true"` annotation. Existing routes
+without the annotation decode `RequireTrafficAuth` as `false`.
 
 ## Goals
 
@@ -37,7 +39,8 @@ clusters retain their current behavior until both `enable-auth` and
 - Require and validate `exp`, `iat`, `nbf`, `iss`, and non-empty `sub` claims.
 - Bind tokens to the current Sandbox ID and immutable Sandbox UID.
 - Keep the request path offline after verifier initialization.
-- Fail closed while an enabled verifier is unavailable.
+- Fail closed when a route requires JWT authentication but the JWT capability or
+  verifier is unavailable.
 - Preserve existing UUID authentication when JWT authentication is disabled.
 - Keep configuration and dependencies out of sandbox-manager's controller-only
   feature-gate package.
@@ -57,26 +60,33 @@ clusters retain their current behavior until both `enable-auth` and
 
 ## Behavioral Contract
 
-Gateway authentication has three valid modes:
+Gateway authentication has three valid process modes, combined with a
+route-scoped traffic-auth requirement:
 
-| `enable-auth` | `enable-jwt-auth` | Behavior |
-|---|---|---|
-| `false` | `false` | Authentication disabled. |
-| `true` | `false` | Existing `x-access-token` UUID authentication. |
-| `true` | `true` | JWT authentication using the traffic-token header. Gateway-side UUID validation is bypassed. |
+| `enable-auth` | `enable-jwt-auth` | `RequireTrafficAuth=false` | `RequireTrafficAuth=true` |
+|---|---|---|---|
+| `false` | `false` | Authentication disabled. | Fail closed with `503`. |
+| `true` | `false` | Existing `x-access-token` UUID authentication. | Fail closed with `503`; do not fall back to UUID. |
+| `true` | `true` | Skip gateway authentication and remove the traffic-token header. | Verify the JWT using the traffic-token header. |
 
 `enable-jwt-auth=true` with `enable-auth=false` is invalid configuration.
 
-JWT mode replaces UUID authentication only at the gateway layer. It does not
-replace agent-runtime authentication: clients accessing an endpoint that
-requires `x-access-token` must still provide the Sandbox runtime token. The
-gateway leaves that header untouched and forwards it transparently.
+`RequireTrafficAuth` is derived from the Sandbox annotation and propagated in
+the internal Route model. Only the exact lowercase value `"true"` enables it;
+missing or other values map to `false`. Historical Route payloads omit the
+boolean and therefore keep the zero value `false`.
+
+JWT mode replaces UUID authentication only at the gateway layer for protected
+routes. It does not replace agent-runtime authentication: clients accessing an
+endpoint that requires `x-access-token` must still provide the Sandbox runtime
+token. The gateway leaves that header untouched and forwards it transparently.
 
 The traffic-token header defaults to `x-traffic-access-token` and is
 configurable. It must be a valid HTTP header name and must differ from
 `x-access-token`. Its value is a compact JWT, not an `Authorization: Bearer`
-value. After successful verification, the gateway removes this header before
-forwarding the request to the Sandbox.
+value. The gateway removes this header after successful verification and from
+unprotected routes while JWT mode is active, before forwarding the request to
+the Sandbox.
 
 ## Token Claims
 
@@ -151,7 +161,7 @@ Envoy filter fields:
 | Field | Default | Description |
 |---|---|---|
 | `enable-auth` | `false` | Enables gateway authentication. |
-| `enable-jwt-auth` | `false` | Selects JWT instead of UUID authentication. |
+| `enable-jwt-auth` | `false` | Initializes the process-wide JWT capability. Requires `enable-auth`. |
 | `traffic-access-token-header` | `x-traffic-access-token` | Header carrying the compact JWT. |
 
 Gateway environment variables:
@@ -167,8 +177,10 @@ Gateway environment variables:
 Invalid local configuration causes Envoy filter configuration to fail rather
 than silently degrading to UUID or unauthenticated access.
 
-JWT mode is process-wide. Per-route filter configurations may inherit or repeat
-the process mode, but cannot enable or disable JWT independently.
+JWT capability is process-wide and cannot be configured in a per-route Envoy
+filter configuration. Enforcement is route-scoped through the Sandbox
+annotation and the resulting `Route.RequireTrafficAuth` boolean, not through
+per-route Envoy filter fields.
 
 ## Token Acquisition Boundary
 
@@ -191,9 +203,9 @@ Request failures use these statuses:
 
 | Condition | Status |
 |---|---|
-| Enabled verifier not ready | `503 Service Unavailable` |
-| Missing, malformed, expired, or invalid JWT | `401 Unauthorized` |
-| Sandbox ID or UID mismatch | `401 Unauthorized` |
+| JWT-required route but JWT mode or verifier is unavailable | `503 Service Unavailable` |
+| Missing, malformed, expired, or invalid JWT | `403 Forbidden` |
+| Sandbox ID or UID mismatch | `403 Forbidden` |
 
 Error responses do not expose cryptographic details to clients. Detailed
 verification errors remain in structured gateway logs.
@@ -215,6 +227,10 @@ pointed at the sandbox-gateway ServiceAccount.
 
 - Authentication remains disabled by default in the shipped ConfigMap.
 - Existing UUID mode has unchanged request and response behavior.
+- In JWT mode, routes without the opt-in annotation skip gateway UUID and JWT
+  validation. Operators must account for this when migrating from UUID mode.
+- Gateways must be upgraded before operators create annotated routes because old
+  gateway versions ignore `RequireTrafficAuth`.
 - Sandbox-manager APIs and Sandbox claim/clone behavior are unchanged.
 - No CRD, generated client, or protobuf changes are required.
 - Enabling JWT requires the CA ConfigMap, identity-provider connectivity during
@@ -230,7 +246,7 @@ pointed at the sandbox-gateway ServiceAccount.
 | Unknown key after signing-key rotation | Fail closed and roll gateway pods after publishing the new JWKS. |
 | Algorithm confusion | Allow only asymmetric algorithms and require key/algorithm compatibility. |
 | Cross-Sandbox replay | Bind both Sandbox ID and immutable UID to the selected route. |
-| Traffic token leaks to workloads | Remove the configured token header before forwarding. |
+| Traffic token leaks to workloads | Remove the configured token header on successful JWT verification and from unprotected routes while JWT mode is active. |
 | Initial token eventually expires | Clients must obtain a replacement through the identity system or recreate the Sandbox; refresh-token delivery is future work. |
 
 ## Test Plan
@@ -251,8 +267,9 @@ Unit tests cover:
 The JWT E2E profile uses a local HTTPS OIDC discovery/JWKS provider and covers:
 
 - The in-cluster test issuer minting a token for the created Sandbox ID/UID.
+- An unannotated Sandbox route succeeding without a traffic JWT in JWT mode.
 - A valid JWT and the Sandbox runtime access token succeeding together.
-- Missing, malformed, and expired JWTs returning `401`.
+- Missing, malformed, and expired JWTs returning `403`.
 - A token issued for Sandbox A being rejected for Sandbox B.
 
 ## Alternatives

--- a/docs/proposals/20260713-traffic-access-token-jwt-verification.md
+++ b/docs/proposals/20260713-traffic-access-token-jwt-verification.md
@@ -158,9 +158,9 @@ Gateway environment variables:
 
 | Variable | Default |
 |---|---|
-| `OIDC_DISCOVERY_URL` | `https://id-provider.ack-agent-identity.svc:8445/.well-known/openid-configuration` |
-| `OIDC_CA_CONFIGMAP_NAMESPACE` | `ack-agent-identity` |
-| `OIDC_CA_CONFIGMAP_NAME` | `ack-agent-identity-root-ca.crt` |
+| `OIDC_DISCOVERY_URL` | Required when JWT authentication is enabled |
+| `OIDC_CA_CONFIGMAP_NAMESPACE` | Required when JWT authentication is enabled |
+| `OIDC_CA_CONFIGMAP_NAME` | Required when JWT authentication is enabled |
 | `OIDC_CA_CONFIGMAP_KEY` | `ca.crt` |
 | `OIDC_CLOCK_SKEW` | `1m` |
 
@@ -200,15 +200,12 @@ verification errors remain in structured gateway logs.
 
 ## RBAC
 
-The gateway requires `get` access to one CA ConfigMap in the identity-provider
-namespace. `config/sandbox-gateway/identity-ca-rbac.yaml` provides a
-least-privilege namespaced Role and binds it to the sandbox-gateway ServiceAccount.
-
-The file is intentionally not part of the default sandbox-gateway kustomization:
-the optional identity namespace may not exist in installations where JWT is
-disabled, and Kubernetes cannot create a namespaced Role before its namespace.
-Operators enabling JWT authentication must create the identity namespace and
-apply this RBAC file as part of the identity-enabled deployment profile.
+The gateway requires `get` access to the configured CA ConfigMap in the
+identity-provider namespace. Operators enabling JWT authentication must grant
+that permission to the `sandbox-gateway` ServiceAccount. A namespaced Role
+restricted with `resourceNames` is recommended. The permission is not included
+in the default kustomization because the identity-provider namespace and
+ConfigMap are deployment-specific.
 
 ## Compatibility And Upgrade
 

--- a/docs/proposals/20260713-traffic-access-token-jwt-verification.md
+++ b/docs/proposals/20260713-traffic-access-token-jwt-verification.md
@@ -233,7 +233,7 @@ ConfigMap are deployment-specific.
 
 Unit tests cover:
 
-- Environment defaults and validation.
+- Environment configuration, provider-independent defaults, and validation.
 - CA ConfigMap errors, TLS discovery, JWKS loading, response limits, and
   immutable key snapshots.
 - Valid and invalid RSA/ECDSA JWTs, unsupported algorithms, signatures, key
@@ -244,11 +244,11 @@ Unit tests cover:
   verifier, route mismatch, custom headers, and header removal.
 - Health and readiness handlers.
 
-The opt-in E2E profile (`TRAFFIC_ACCESS_TOKEN_JWT_E2E=true`) covers:
+The JWT E2E profile uses a local HTTPS OIDC discovery/JWKS provider and covers:
 
-- An external test issuer command minting a token for the created Sandbox ID/UID.
+- The in-cluster test issuer minting a token for the created Sandbox ID/UID.
 - A valid JWT succeeding even when `x-access-token` contains an invalid UUID.
-- Missing and malformed JWTs returning `401`.
+- Missing, malformed, and expired JWTs returning `401`.
 - A token issued for Sandbox A being rejected for Sandbox B.
 
 ## Alternatives

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/envoyproxy/envoy v1.37.3
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
@@ -26,6 +27,7 @@ require (
 	github.com/spf13/pflag v1.0.9
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.0
+	golang.org/x/net v0.47.0
 	golang.org/x/sync v0.18.0
 	golang.org/x/time v0.11.0
 	google.golang.org/grpc v1.75.1
@@ -117,7 +119,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20250531010427-b6e5de432a8b // indirect
 	golang.org/x/mod v0.29.0 // indirect
-	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/term v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZ
 github.com/gkampitakis/go-diff v1.3.2/go.mod h1:LLgOrpqleQe26cte8s36HTWcTmMEur6OPYerdAAS9tk=
 github.com/gkampitakis/go-snaps v0.5.15 h1:amyJrvM1D33cPHwVrjo9jQxX8g/7E2wYdZ+01KS3zGE=
 github.com/gkampitakis/go-snaps v0.5.15/go.mod h1:HNpx/9GoKisdhw9AFOBT1N7DBs9DiHo/hGheFGBZ+mc=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=

--- a/hack/run-e2b-e2e-test.sh
+++ b/hack/run-e2b-e2e-test.sh
@@ -377,7 +377,7 @@ if [ -z "$installed_e2b_version" ]; then
 fi
 echo "Detected e2b version: $installed_e2b_version"
 if [[ "$AUTH_DISABLED" == "true" ]]; then
-    echo "E2B auth is disabled; skipping API key compatibility conversion"
+    echo "sandbox-manager E2B API auth is disabled; skipping API key compatibility conversion"
     export E2B_API_KEY="${E2B_API_KEY:-e2b_abc123}"
 else
     convert_e2b_api_key_for_sdk_if_needed "$installed_e2b_version"

--- a/hack/run-e2b-e2e-test.sh
+++ b/hack/run-e2b-e2e-test.sh
@@ -26,6 +26,7 @@ REPEAT=""
 PYTEST_KEYWORD_EXPR=""
 PYTEST_MARKER_EXPR=""
 PYTEST_EXTRA_ARGS=""
+TEST_FILES=()
 MANIFEST_GLOBS=()
 RENDERED_DIR=""
 PORT_FORWARD_PID=""
@@ -54,11 +55,12 @@ parse_args() {
             --repeat)         REPEAT="$2";             shift 2 ;;
             -k)               PYTEST_KEYWORD_EXPR="$2"; shift 2 ;;
             -m)               PYTEST_MARKER_EXPR="$2"; shift 2 ;;
+            --test-file)      TEST_FILES+=("$2");      shift 2 ;;
             --pytest-extra-args) PYTEST_EXTRA_ARGS="$2"; shift 2 ;;
             --auth-disabled)  AUTH_DISABLED="true"; shift ;;
             *)
                 echo "Unknown parameter: $1" >&2
-                echo "Usage: $0 [--plugin P] [--e2b-version V] [--sdk-version V] [--with-gateway] [--no-port-forward] [--manifests GLOB]... [--repeat N] [-k EXPR] [-m MARKER_EXPR] [--pytest-extra-args FLAGS]" >&2
+                echo "Usage: $0 [--plugin P] [--e2b-version V] [--sdk-version V] [--with-gateway] [--no-port-forward] [--manifests GLOB]... [--test-file PATH]... [--repeat N] [-k EXPR] [-m MARKER_EXPR] [--pytest-extra-args FLAGS]" >&2
                 exit 1 ;;
         esac
     done
@@ -438,7 +440,11 @@ pytest_args+=(
 if [[ -n "$PYTEST_EXTRA_ARGS" ]]; then pytest_args+=($PYTEST_EXTRA_ARGS); fi
 
 set +e
-pytest "${pytest_args[@]}" "$TEST_DIR"
+pytest_targets=("$TEST_DIR")
+if [[ ${#TEST_FILES[@]} -gt 0 ]]; then
+    pytest_targets=("${TEST_FILES[@]}")
+fi
+pytest "${pytest_args[@]}" "${pytest_targets[@]}"
 retVal=$?
 set -e
 

--- a/hack/run-e2b-e2e-test.sh
+++ b/hack/run-e2b-e2e-test.sh
@@ -34,7 +34,7 @@ PORT_FORWARD_PID=""
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEST_DIR="$PROJECT_ROOT/test/e2b"
-MANAGER_SELECTOR="component=sandbox-manager"
+MANAGER_SELECTOR="app.kubernetes.io/name=sandbox-manager"
 
 E2B_SDK_COMPAT_MIN_VERSION="2.25.0"
 
@@ -412,6 +412,11 @@ if [[ -n "$PYTEST_MARKER_EXPR" ]]; then pytest_args+=(-m "$PYTEST_MARKER_EXPR");
 if [[ "$WITH_GATEWAY" != "true" ]]; then
     pytest_args+=(--ignore="$TEST_DIR/test_gateway.py")
     pytest_args+=(--ignore="$TEST_DIR/test_gateway_auth.py")
+    pytest_args+=(--ignore="$TEST_DIR/test_gateway_jwt_auth.py")
+    pytest_args+=(--ignore="$TEST_DIR/test_gateway_runtime_mtls.py")
+elif [[ -z "$PYTEST_MARKER_EXPR" ]]; then
+    # The default gateway deployment has authentication and Runtime mTLS disabled.
+    pytest_args+=(-m "not gateway_uuid_auth and not jwt_auth and not runtime_mtls")
 fi
 if [[ "$AUTH_DISABLED" == "true" ]]; then pytest_args+=(--ignore="$TEST_DIR/test_apikey.py"); fi
 

--- a/hack/run-e2b-e2e-test.sh
+++ b/hack/run-e2b-e2e-test.sh
@@ -442,7 +442,14 @@ if [[ -n "$PYTEST_EXTRA_ARGS" ]]; then pytest_args+=($PYTEST_EXTRA_ARGS); fi
 set +e
 pytest_targets=("$TEST_DIR")
 if [[ ${#TEST_FILES[@]} -gt 0 ]]; then
-    pytest_targets=("${TEST_FILES[@]}")
+    pytest_targets=()
+    for test_file in "${TEST_FILES[@]}"; do
+        if [[ "$test_file" = /* ]]; then
+            pytest_targets+=("$test_file")
+        else
+            pytest_targets+=("$PROJECT_ROOT/$test_file")
+        fi
+    done
 fi
 pytest "${pytest_args[@]}" "${pytest_targets[@]}"
 retVal=$?

--- a/pkg/identity/oidc/loader_test.go
+++ b/pkg/identity/oidc/loader_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	"context"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testCANamespace = "identity-system"
+	testCAName      = "oidc-ca"
+	testCAKey       = "ca.crt"
+)
+
+type loaderFixture struct {
+	discoveryStatus int
+	discoveryBody   string
+	jwksStatus      int
+	jwksBody        string
+	discoveryCalls  int
+	jwksCalls       int
+}
+
+func TestNewVerifier(t *testing.T) {
+	rsaKey := mustRSAKey(t)
+	publicJWK := jose.JSONWebKey{Key: &rsaKey.PublicKey, KeyID: "rsa", Use: "sig", Algorithm: string(jose.RS256)}
+
+	tests := []struct {
+		name            string
+		configure       func(*loaderFixture, *httptest.Server)
+		configMap       string
+		maxResponseSize int64
+		assertVerifier  bool
+		expectDiscovery int
+		expectJWKS      int
+		expectError     string
+	}{
+		{name: "valid flow and immutable key snapshot", assertVerifier: true, expectDiscovery: 1, expectJWKS: 1},
+		{name: "ConfigMap missing", configMap: "missing", expectError: "get CA ConfigMap"},
+		{name: "CA key missing", configMap: "key-missing", expectError: "does not contain non-empty key"},
+		{name: "CA PEM invalid", configMap: "bad-ca", expectError: "contains no valid PEM certificates"},
+		{name: "discovery non-200", configure: func(f *loaderFixture, _ *httptest.Server) { f.discoveryStatus = http.StatusServiceUnavailable }, expectDiscovery: 1, expectError: "unexpected HTTP status"},
+		{name: "discovery malformed", configure: func(f *loaderFixture, _ *httptest.Server) { f.discoveryBody = "{" }, expectDiscovery: 1, expectError: "decode JSON response"},
+		{name: "discovery missing issuer", configure: func(f *loaderFixture, server *httptest.Server) {
+			f.discoveryBody = fmt.Sprintf(`{"jwks_uri":%q}`, server.URL+"/jwks")
+		}, expectDiscovery: 1, expectError: "empty issuer"},
+		{name: "discovery missing JWKS URI", configure: func(f *loaderFixture, _ *httptest.Server) { f.discoveryBody = `{"issuer":"https://issuer.example"}` }, expectDiscovery: 1, expectError: "invalid jwks_uri"},
+		{name: "discovery HTTP JWKS URI", configure: func(f *loaderFixture, _ *httptest.Server) {
+			f.discoveryBody = `{"issuer":"https://issuer.example","jwks_uri":"http://issuer.example/jwks"}`
+		}, expectDiscovery: 1, expectError: "absolute HTTPS URL"},
+		{name: "JWKS non-200", configure: func(f *loaderFixture, _ *httptest.Server) { f.jwksStatus = http.StatusBadGateway }, expectDiscovery: 1, expectJWKS: 1, expectError: "unexpected HTTP status"},
+		{name: "JWKS malformed", configure: func(f *loaderFixture, _ *httptest.Server) { f.jwksBody = "{" }, expectDiscovery: 1, expectJWKS: 1, expectError: "decode JSON response"},
+		{name: "JWKS bad key", configure: func(f *loaderFixture, _ *httptest.Server) {
+			f.jwksBody = `{"keys":[{"kty":"oct","kid":"shared","k":"eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHg"}]}`
+		}, expectDiscovery: 1, expectJWKS: 1, expectError: "asymmetric public key"},
+		{name: "JWKS key operations do not permit verification", configure: func(f *loaderFixture, _ *httptest.Server) {
+			encoded := mustJSON(t, publicJWK)
+			f.jwksBody = fmt.Sprintf(`{"keys":[%s]}`, strings.TrimSuffix(encoded, "}")+`,"key_ops":["encrypt"]}`)
+		}, expectDiscovery: 1, expectJWKS: 1, expectError: "key_ops does not permit verify"},
+		{name: "JWKS duplicate kid", configure: func(f *loaderFixture, _ *httptest.Server) {
+			f.jwksBody = mustJSON(t, jose.JSONWebKeySet{Keys: []jose.JSONWebKey{publicJWK, publicJWK}})
+		}, expectDiscovery: 1, expectJWKS: 1, expectError: "duplicate kid"},
+		{name: "discovery response too large", configure: func(f *loaderFixture, _ *httptest.Server) { f.discoveryBody = strings.Repeat("x", 256) }, maxResponseSize: 32, expectDiscovery: 1, expectError: "exceeds maximum size"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := &loaderFixture{discoveryStatus: http.StatusOK, jwksStatus: http.StatusOK}
+			server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				switch request.URL.Path {
+				case "/discovery":
+					fixture.discoveryCalls++
+					response.WriteHeader(fixture.discoveryStatus)
+					_, _ = response.Write([]byte(fixture.discoveryBody))
+				case "/jwks":
+					fixture.jwksCalls++
+					response.WriteHeader(fixture.jwksStatus)
+					_, _ = response.Write([]byte(fixture.jwksBody))
+				default:
+					response.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			fixture.discoveryBody = fmt.Sprintf(`{"issuer":"https://issuer.example","jwks_uri":%q}`, server.URL+"/jwks")
+			fixture.jwksBody = mustJSON(t, jose.JSONWebKeySet{Keys: []jose.JSONWebKey{publicJWK}})
+			if tt.configure != nil {
+				tt.configure(fixture, server)
+			}
+
+			reader := loaderReader(t, server, tt.configMap)
+			opts := Options{
+				DiscoveryURL:         server.URL + "/discovery",
+				CAConfigMapNamespace: testCANamespace,
+				CAConfigMapName:      testCAName,
+				CAConfigMapKey:       testCAKey,
+			}
+			if tt.maxResponseSize != 0 {
+				opts.MaxResponseSize = tt.maxResponseSize
+			}
+
+			underTest, err := NewVerifier(context.Background(), reader, opts)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				assert.Nil(t, underTest)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, underTest)
+			}
+			if tt.assertVerifier {
+				now := time.Now().Truncate(time.Second)
+				validJWT := signToken(t, jose.RS256, rsaKey, "rsa", tokenClaims(now, "https://issuer.example"))
+				claims, verifyErr := underTest.Verify(validJWT)
+				require.NoError(t, verifyErr)
+				require.NotNil(t, claims)
+
+				unknownJWT := signToken(t, jose.RS256, rsaKey, "new-key", tokenClaims(now, "https://issuer.example"))
+				_, verifyErr = underTest.Verify(unknownJWT)
+				require.Error(t, verifyErr)
+				assert.Contains(t, verifyErr.Error(), "unknown kid")
+			}
+			assert.Equal(t, tt.expectDiscovery, fixture.discoveryCalls)
+			assert.Equal(t, tt.expectJWKS, fixture.jwksCalls)
+		})
+	}
+}
+
+func TestNewVerifierInvalidArguments(t *testing.T) {
+	tests := []struct {
+		name        string
+		reader      client.Reader
+		opts        Options
+		expectError string
+	}{
+		{name: "nil reader", opts: defaultOptions(), expectError: "must not be nil"},
+		{name: "invalid URL", reader: fake.NewClientBuilder().Build(), opts: Options{DiscoveryURL: "http://issuer.example"}, expectError: "absolute HTTPS URL"},
+		{name: "negative timeout", reader: fake.NewClientBuilder().Build(), opts: Options{HTTPTimeout: -time.Second}, expectError: "HTTP timeout"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			underTest, err := NewVerifier(context.Background(), tt.reader, tt.opts)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+			assert.Nil(t, underTest)
+		})
+	}
+}
+
+func loaderReader(t *testing.T, server *httptest.Server, configMapMode string) client.Reader {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	if configMapMode == "missing" {
+		return builder.Build()
+	}
+
+	caData := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw}))
+	data := map[string]string{testCAKey: caData}
+	switch configMapMode {
+	case "key-missing":
+		data = map[string]string{}
+	case "bad-ca":
+		data[testCAKey] = "not a certificate"
+	}
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testCANamespace, Name: testCAName},
+		Data:       data,
+	}
+	return builder.WithObjects(configMap).Build()
+}
+
+func TestFetchJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		handler     http.Handler
+		context     func() (context.Context, context.CancelFunc)
+		expectError string
+	}{
+		{
+			name: "cancelled context",
+			handler: http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+				_, _ = response.Write([]byte(`{"value":"ok"}`))
+			}),
+			context: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, func() {}
+			},
+			expectError: "send request",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+			ctx, cancel := tt.context()
+			defer cancel()
+			var destination map[string]string
+			err := fetchJSON(ctx, server.Client(), server.URL, 1024, &destination)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+}

--- a/pkg/identity/oidc/loader_test.go
+++ b/pkg/identity/oidc/loader_test.go
@@ -19,7 +19,9 @@ package oidc
 import (
 	"context"
 	"encoding/pem"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -43,12 +45,14 @@ const (
 )
 
 type loaderFixture struct {
-	discoveryStatus int
-	discoveryBody   string
-	jwksStatus      int
-	jwksBody        string
-	discoveryCalls  int
-	jwksCalls       int
+	discoveryStatus   int
+	discoveryBody     string
+	jwksStatus        int
+	jwksBody          string
+	discoveryCalls    int
+	jwksCalls         int
+	discoveryLocation string
+	redirectCalls     int
 }
 
 func TestNewVerifier(t *testing.T) {
@@ -68,8 +72,13 @@ func TestNewVerifier(t *testing.T) {
 		{name: "valid flow and immutable key snapshot", assertVerifier: true, expectDiscovery: 1, expectJWKS: 1},
 		{name: "ConfigMap missing", configMap: "missing", expectError: "get CA ConfigMap"},
 		{name: "CA key missing", configMap: "key-missing", expectError: "does not contain non-empty key"},
+		{name: "CA key empty", configMap: "key-empty", expectError: "does not contain non-empty key"},
 		{name: "CA PEM invalid", configMap: "bad-ca", expectError: "contains no valid PEM certificates"},
 		{name: "discovery non-200", configure: func(f *loaderFixture, _ *httptest.Server) { f.discoveryStatus = http.StatusServiceUnavailable }, expectDiscovery: 1, expectError: "unexpected HTTP status"},
+		{name: "discovery redirect is not followed", configure: func(f *loaderFixture, server *httptest.Server) {
+			f.discoveryStatus = http.StatusFound
+			f.discoveryLocation = server.URL + "/redirected"
+		}, expectDiscovery: 1, expectError: "unexpected HTTP status"},
 		{name: "discovery malformed", configure: func(f *loaderFixture, _ *httptest.Server) { f.discoveryBody = "{" }, expectDiscovery: 1, expectError: "decode JSON response"},
 		{name: "discovery missing issuer", configure: func(f *loaderFixture, server *httptest.Server) {
 			f.discoveryBody = fmt.Sprintf(`{"jwks_uri":%q}`, server.URL+"/jwks")
@@ -100,12 +109,18 @@ func TestNewVerifier(t *testing.T) {
 				switch request.URL.Path {
 				case "/discovery":
 					fixture.discoveryCalls++
+					if fixture.discoveryLocation != "" {
+						response.Header().Set("Location", fixture.discoveryLocation)
+					}
 					response.WriteHeader(fixture.discoveryStatus)
 					_, _ = response.Write([]byte(fixture.discoveryBody))
 				case "/jwks":
 					fixture.jwksCalls++
 					response.WriteHeader(fixture.jwksStatus)
 					_, _ = response.Write([]byte(fixture.jwksBody))
+				case "/redirected":
+					fixture.redirectCalls++
+					response.WriteHeader(http.StatusOK)
 				default:
 					response.WriteHeader(http.StatusNotFound)
 				}
@@ -152,6 +167,7 @@ func TestNewVerifier(t *testing.T) {
 			}
 			assert.Equal(t, tt.expectDiscovery, fixture.discoveryCalls)
 			assert.Equal(t, tt.expectJWKS, fixture.jwksCalls)
+			assert.Zero(t, fixture.redirectCalls)
 		})
 	}
 }
@@ -192,6 +208,8 @@ func loaderReader(t *testing.T, server *httptest.Server, configMapMode string) c
 	switch configMapMode {
 	case "key-missing":
 		data = map[string]string{}
+	case "key-empty":
+		data[testCAKey] = ""
 	case "bad-ca":
 		data[testCAKey] = "not a certificate"
 	}
@@ -200,6 +218,58 @@ func loaderReader(t *testing.T, server *httptest.Server, configMapMode string) c
 		Data:       data,
 	}
 	return builder.WithObjects(configMap).Build()
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+type errorReader struct {
+	err error
+}
+
+func (r errorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func TestFetchJSONFailures(t *testing.T) {
+	tests := []struct {
+		name        string
+		run         func() error
+		expectError string
+	}{
+		{
+			name: "invalid request URL",
+			run: func() error {
+				return fetchJSON(context.Background(), http.DefaultClient, "\x00", 1024, &map[string]string{})
+			},
+			expectError: "create request",
+		},
+		{
+			name: "response body read failure",
+			run: func() error {
+				client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Body:       io.NopCloser(errorReader{err: errors.New("read failed")}),
+					}, nil
+				})}
+				return fetchJSON(context.Background(), client, "https://issuer.example", 1024, &map[string]string{})
+			},
+			expectError: "read response body",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
 }
 
 func TestFetchJSON(t *testing.T) {

--- a/pkg/identity/oidc/loader_test.go
+++ b/pkg/identity/oidc/loader_test.go
@@ -179,9 +179,9 @@ func TestNewVerifierInvalidArguments(t *testing.T) {
 		opts        Options
 		expectError string
 	}{
-		{name: "nil reader", opts: defaultOptions(), expectError: "must not be nil"},
-		{name: "invalid URL", reader: fake.NewClientBuilder().Build(), opts: Options{DiscoveryURL: "http://issuer.example"}, expectError: "absolute HTTPS URL"},
-		{name: "negative timeout", reader: fake.NewClientBuilder().Build(), opts: Options{HTTPTimeout: -time.Second}, expectError: "HTTP timeout"},
+		{name: "nil reader", opts: validOptions(), expectError: "must not be nil"},
+		{name: "invalid URL", reader: fake.NewClientBuilder().Build(), opts: optionsWith(func(opts *Options) { opts.DiscoveryURL = "http://issuer.example" }), expectError: "absolute HTTPS URL"},
+		{name: "negative timeout", reader: fake.NewClientBuilder().Build(), opts: optionsWith(func(opts *Options) { opts.HTTPTimeout = -time.Second }), expectError: "HTTP timeout"},
 	}
 
 	for _, tt := range tests {
@@ -192,6 +192,12 @@ func TestNewVerifierInvalidArguments(t *testing.T) {
 			assert.Nil(t, underTest)
 		})
 	}
+}
+
+func optionsWith(mutate func(*Options)) Options {
+	opts := validOptions()
+	mutate(&opts)
+	return opts
 }
 
 func loaderReader(t *testing.T, server *httptest.Server, configMapMode string) client.Reader {

--- a/pkg/identity/oidc/options.go
+++ b/pkg/identity/oidc/options.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"time"
+)
+
+// Default verifier configuration.
+const (
+	DefaultDiscoveryURL         = "https://id-provider.ack-agent-identity.svc:8445/.well-known/openid-configuration"
+	DefaultCAConfigMapNamespace = "ack-agent-identity"
+	DefaultCAConfigMapName      = "ack-agent-identity-root-ca.crt"
+	DefaultCAConfigMapKey       = "ca.crt"
+	DefaultClockSkew            = time.Minute
+	DefaultHTTPTimeout          = 10 * time.Second
+	DefaultMaxResponseSize      = int64(1 << 20)
+	DefaultMaxTokenSize         = 64 << 10
+)
+
+const (
+	envDiscoveryURL         = "OIDC_DISCOVERY_URL"
+	envCAConfigMapNamespace = "OIDC_CA_CONFIGMAP_NAMESPACE"
+	envCAConfigMapName      = "OIDC_CA_CONFIGMAP_NAME"
+	envCAConfigMapKey       = "OIDC_CA_CONFIGMAP_KEY"
+	envClockSkew            = "OIDC_CLOCK_SKEW"
+)
+
+// Options configures verifier initialization and local token validation.
+type Options struct {
+	DiscoveryURL         string
+	CAConfigMapNamespace string
+	CAConfigMapName      string
+	CAConfigMapKey       string
+	ClockSkew            time.Duration
+	HTTPTimeout          time.Duration
+	MaxResponseSize      int64
+	MaxTokenSize         int
+}
+
+// OptionsFromEnvironment returns default options with supported environment overrides.
+func OptionsFromEnvironment() (Options, error) {
+	opts := defaultOptions()
+	if value := os.Getenv(envDiscoveryURL); value != "" {
+		opts.DiscoveryURL = value
+	}
+	if value := os.Getenv(envCAConfigMapNamespace); value != "" {
+		opts.CAConfigMapNamespace = value
+	}
+	if value := os.Getenv(envCAConfigMapName); value != "" {
+		opts.CAConfigMapName = value
+	}
+	if value := os.Getenv(envCAConfigMapKey); value != "" {
+		opts.CAConfigMapKey = value
+	}
+	if value := os.Getenv(envClockSkew); value != "" {
+		clockSkew, err := time.ParseDuration(value)
+		if err != nil {
+			return Options{}, fmt.Errorf("parse %s: %w", envClockSkew, err)
+		}
+		opts.ClockSkew = clockSkew
+	}
+
+	if err := validateOptions(opts); err != nil {
+		return Options{}, err
+	}
+	return opts, nil
+}
+
+func defaultOptions() Options {
+	return Options{
+		DiscoveryURL:         DefaultDiscoveryURL,
+		CAConfigMapNamespace: DefaultCAConfigMapNamespace,
+		CAConfigMapName:      DefaultCAConfigMapName,
+		CAConfigMapKey:       DefaultCAConfigMapKey,
+		ClockSkew:            DefaultClockSkew,
+		HTTPTimeout:          DefaultHTTPTimeout,
+		MaxResponseSize:      DefaultMaxResponseSize,
+		MaxTokenSize:         DefaultMaxTokenSize,
+	}
+}
+
+func withDefaults(opts Options) Options {
+	defaults := defaultOptions()
+	if opts.DiscoveryURL == "" {
+		opts.DiscoveryURL = defaults.DiscoveryURL
+	}
+	if opts.CAConfigMapNamespace == "" {
+		opts.CAConfigMapNamespace = defaults.CAConfigMapNamespace
+	}
+	if opts.CAConfigMapName == "" {
+		opts.CAConfigMapName = defaults.CAConfigMapName
+	}
+	if opts.CAConfigMapKey == "" {
+		opts.CAConfigMapKey = defaults.CAConfigMapKey
+	}
+	if opts.ClockSkew == 0 {
+		opts.ClockSkew = defaults.ClockSkew
+	}
+	if opts.HTTPTimeout == 0 {
+		opts.HTTPTimeout = defaults.HTTPTimeout
+	}
+	if opts.MaxResponseSize == 0 {
+		opts.MaxResponseSize = defaults.MaxResponseSize
+	}
+	if opts.MaxTokenSize == 0 {
+		opts.MaxTokenSize = defaults.MaxTokenSize
+	}
+	return opts
+}
+
+func validateOptions(opts Options) error {
+	discoveryURL, err := url.Parse(opts.DiscoveryURL)
+	if err != nil || !discoveryURL.IsAbs() || discoveryURL.Scheme != "https" || discoveryURL.Host == "" {
+		return fmt.Errorf("discovery URL must be an absolute HTTPS URL")
+	}
+	if opts.CAConfigMapNamespace == "" {
+		return fmt.Errorf("CA ConfigMap namespace must not be empty")
+	}
+	if opts.CAConfigMapName == "" {
+		return fmt.Errorf("CA ConfigMap name must not be empty")
+	}
+	if opts.CAConfigMapKey == "" {
+		return fmt.Errorf("CA ConfigMap key must not be empty")
+	}
+	if opts.ClockSkew < 0 {
+		return fmt.Errorf("clock skew must not be negative")
+	}
+	if opts.HTTPTimeout <= 0 {
+		return fmt.Errorf("HTTP timeout must be positive")
+	}
+	if opts.MaxResponseSize <= 0 {
+		return fmt.Errorf("maximum response size must be positive")
+	}
+	if opts.MaxTokenSize <= 0 {
+		return fmt.Errorf("maximum token size must be positive")
+	}
+	return nil
+}

--- a/pkg/identity/oidc/options.go
+++ b/pkg/identity/oidc/options.go
@@ -23,16 +23,13 @@ import (
 	"time"
 )
 
-// Default verifier configuration.
+// Default verifier limits and optional configuration.
 const (
-	DefaultDiscoveryURL         = "https://id-provider.ack-agent-identity.svc:8445/.well-known/openid-configuration"
-	DefaultCAConfigMapNamespace = "ack-agent-identity"
-	DefaultCAConfigMapName      = "ack-agent-identity-root-ca.crt"
-	DefaultCAConfigMapKey       = "ca.crt"
-	DefaultClockSkew            = time.Minute
-	DefaultHTTPTimeout          = 10 * time.Second
-	DefaultMaxResponseSize      = int64(1 << 20)
-	DefaultMaxTokenSize         = 64 << 10
+	DefaultCAConfigMapKey  = "ca.crt"
+	DefaultClockSkew       = time.Minute
+	DefaultHTTPTimeout     = 10 * time.Second
+	DefaultMaxResponseSize = int64(1 << 20)
+	DefaultMaxTokenSize    = 64 << 10
 )
 
 const (
@@ -55,18 +52,13 @@ type Options struct {
 	MaxTokenSize         int
 }
 
-// OptionsFromEnvironment returns default options with supported environment overrides.
+// OptionsFromEnvironment returns verifier options from the environment with
+// defaults for provider-independent settings.
 func OptionsFromEnvironment() (Options, error) {
 	opts := defaultOptions()
-	if value := os.Getenv(envDiscoveryURL); value != "" {
-		opts.DiscoveryURL = value
-	}
-	if value := os.Getenv(envCAConfigMapNamespace); value != "" {
-		opts.CAConfigMapNamespace = value
-	}
-	if value := os.Getenv(envCAConfigMapName); value != "" {
-		opts.CAConfigMapName = value
-	}
+	opts.DiscoveryURL = os.Getenv(envDiscoveryURL)
+	opts.CAConfigMapNamespace = os.Getenv(envCAConfigMapNamespace)
+	opts.CAConfigMapName = os.Getenv(envCAConfigMapName)
 	if value := os.Getenv(envCAConfigMapKey); value != "" {
 		opts.CAConfigMapKey = value
 	}
@@ -86,28 +78,16 @@ func OptionsFromEnvironment() (Options, error) {
 
 func defaultOptions() Options {
 	return Options{
-		DiscoveryURL:         DefaultDiscoveryURL,
-		CAConfigMapNamespace: DefaultCAConfigMapNamespace,
-		CAConfigMapName:      DefaultCAConfigMapName,
-		CAConfigMapKey:       DefaultCAConfigMapKey,
-		ClockSkew:            DefaultClockSkew,
-		HTTPTimeout:          DefaultHTTPTimeout,
-		MaxResponseSize:      DefaultMaxResponseSize,
-		MaxTokenSize:         DefaultMaxTokenSize,
+		CAConfigMapKey:  DefaultCAConfigMapKey,
+		ClockSkew:       DefaultClockSkew,
+		HTTPTimeout:     DefaultHTTPTimeout,
+		MaxResponseSize: DefaultMaxResponseSize,
+		MaxTokenSize:    DefaultMaxTokenSize,
 	}
 }
 
 func withDefaults(opts Options) Options {
 	defaults := defaultOptions()
-	if opts.DiscoveryURL == "" {
-		opts.DiscoveryURL = defaults.DiscoveryURL
-	}
-	if opts.CAConfigMapNamespace == "" {
-		opts.CAConfigMapNamespace = defaults.CAConfigMapNamespace
-	}
-	if opts.CAConfigMapName == "" {
-		opts.CAConfigMapName = defaults.CAConfigMapName
-	}
 	if opts.CAConfigMapKey == "" {
 		opts.CAConfigMapKey = defaults.CAConfigMapKey
 	}

--- a/pkg/identity/oidc/options_test.go
+++ b/pkg/identity/oidc/options_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionsFromEnvironment(t *testing.T) {
+	tests := []struct {
+		name        string
+		environment map[string]string
+		assertions  func(*testing.T, Options)
+		expectError string
+	}{
+		{
+			name: "defaults",
+			assertions: func(t *testing.T, opts Options) {
+				assert.Equal(t, DefaultDiscoveryURL, opts.DiscoveryURL)
+				assert.Equal(t, DefaultCAConfigMapNamespace, opts.CAConfigMapNamespace)
+				assert.Equal(t, DefaultCAConfigMapName, opts.CAConfigMapName)
+				assert.Equal(t, DefaultCAConfigMapKey, opts.CAConfigMapKey)
+				assert.Equal(t, DefaultClockSkew, opts.ClockSkew)
+				assert.Equal(t, DefaultHTTPTimeout, opts.HTTPTimeout)
+				assert.Equal(t, DefaultMaxResponseSize, opts.MaxResponseSize)
+				assert.Equal(t, DefaultMaxTokenSize, opts.MaxTokenSize)
+			},
+		},
+		{
+			name: "overrides",
+			environment: map[string]string{
+				envDiscoveryURL:         "https://issuer.example/discovery",
+				envCAConfigMapNamespace: "identity-system",
+				envCAConfigMapName:      "oidc-ca",
+				envCAConfigMapKey:       "root.pem",
+				envClockSkew:            "15s",
+			},
+			assertions: func(t *testing.T, opts Options) {
+				assert.Equal(t, "https://issuer.example/discovery", opts.DiscoveryURL)
+				assert.Equal(t, "identity-system", opts.CAConfigMapNamespace)
+				assert.Equal(t, "oidc-ca", opts.CAConfigMapName)
+				assert.Equal(t, "root.pem", opts.CAConfigMapKey)
+				assert.Equal(t, 15*time.Second, opts.ClockSkew)
+			},
+		},
+		{
+			name: "invalid duration",
+			environment: map[string]string{
+				envClockSkew: "later",
+			},
+			expectError: envClockSkew,
+		},
+		{
+			name: "negative duration",
+			environment: map[string]string{
+				envClockSkew: "-1s",
+			},
+			expectError: "must not be negative",
+		},
+		{
+			name: "HTTP discovery URL",
+			environment: map[string]string{
+				envDiscoveryURL: "http://issuer.example/discovery",
+			},
+			expectError: "absolute HTTPS URL",
+		},
+		{
+			name: "relative discovery URL",
+			environment: map[string]string{
+				envDiscoveryURL: "/discovery",
+			},
+			expectError: "absolute HTTPS URL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, name := range []string{
+				envDiscoveryURL,
+				envCAConfigMapNamespace,
+				envCAConfigMapName,
+				envCAConfigMapKey,
+				envClockSkew,
+			} {
+				t.Setenv(name, "")
+			}
+			for name, value := range tt.environment {
+				t.Setenv(name, value)
+			}
+
+			opts, err := OptionsFromEnvironment()
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+			require.NoError(t, err)
+			if tt.assertions != nil {
+				tt.assertions(t, opts)
+			}
+		})
+	}
+}
+
+func TestValidateOptions(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(*Options)
+		expectError string
+	}{
+		{name: "valid"},
+		{name: "negative clock skew", mutate: func(opts *Options) { opts.ClockSkew = -time.Second }, expectError: "clock skew"},
+		{name: "negative timeout", mutate: func(opts *Options) { opts.HTTPTimeout = -time.Second }, expectError: "HTTP timeout"},
+		{name: "negative response size", mutate: func(opts *Options) { opts.MaxResponseSize = -1 }, expectError: "response size"},
+		{name: "negative token size", mutate: func(opts *Options) { opts.MaxTokenSize = -1 }, expectError: "token size"},
+		{name: "empty namespace", mutate: func(opts *Options) { opts.CAConfigMapNamespace = "" }, expectError: "namespace"},
+		{name: "empty name", mutate: func(opts *Options) { opts.CAConfigMapName = "" }, expectError: "name"},
+		{name: "empty key", mutate: func(opts *Options) { opts.CAConfigMapKey = "" }, expectError: "key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := defaultOptions()
+			if tt.mutate != nil {
+				tt.mutate(&opts)
+			}
+			err := validateOptions(opts)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/identity/oidc/options_test.go
+++ b/pkg/identity/oidc/options_test.go
@@ -32,17 +32,24 @@ func TestOptionsFromEnvironment(t *testing.T) {
 		expectError string
 	}{
 		{
-			name: "defaults",
-			assertions: func(t *testing.T, opts Options) {
-				assert.Equal(t, DefaultDiscoveryURL, opts.DiscoveryURL)
-				assert.Equal(t, DefaultCAConfigMapNamespace, opts.CAConfigMapNamespace)
-				assert.Equal(t, DefaultCAConfigMapName, opts.CAConfigMapName)
-				assert.Equal(t, DefaultCAConfigMapKey, opts.CAConfigMapKey)
-				assert.Equal(t, DefaultClockSkew, opts.ClockSkew)
-				assert.Equal(t, DefaultHTTPTimeout, opts.HTTPTimeout)
-				assert.Equal(t, DefaultMaxResponseSize, opts.MaxResponseSize)
-				assert.Equal(t, DefaultMaxTokenSize, opts.MaxTokenSize)
+			name:        "required provider configuration",
+			expectError: "absolute HTTPS URL",
+		},
+		{
+			name: "required CA ConfigMap namespace",
+			environment: map[string]string{
+				envDiscoveryURL:    "https://issuer.example/discovery",
+				envCAConfigMapName: "oidc-ca",
 			},
+			expectError: "namespace",
+		},
+		{
+			name: "required CA ConfigMap name",
+			environment: map[string]string{
+				envDiscoveryURL:         "https://issuer.example/discovery",
+				envCAConfigMapNamespace: "identity-system",
+			},
+			expectError: "name",
 		},
 		{
 			name: "overrides",
@@ -59,33 +66,46 @@ func TestOptionsFromEnvironment(t *testing.T) {
 				assert.Equal(t, "oidc-ca", opts.CAConfigMapName)
 				assert.Equal(t, "root.pem", opts.CAConfigMapKey)
 				assert.Equal(t, 15*time.Second, opts.ClockSkew)
+				assert.Equal(t, DefaultHTTPTimeout, opts.HTTPTimeout)
+				assert.Equal(t, DefaultMaxResponseSize, opts.MaxResponseSize)
+				assert.Equal(t, DefaultMaxTokenSize, opts.MaxTokenSize)
 			},
 		},
 		{
 			name: "invalid duration",
 			environment: map[string]string{
-				envClockSkew: "later",
+				envDiscoveryURL:         "https://issuer.example/discovery",
+				envCAConfigMapNamespace: "identity-system",
+				envCAConfigMapName:      "oidc-ca",
+				envClockSkew:            "later",
 			},
 			expectError: envClockSkew,
 		},
 		{
 			name: "negative duration",
 			environment: map[string]string{
-				envClockSkew: "-1s",
+				envDiscoveryURL:         "https://issuer.example/discovery",
+				envCAConfigMapNamespace: "identity-system",
+				envCAConfigMapName:      "oidc-ca",
+				envClockSkew:            "-1s",
 			},
 			expectError: "must not be negative",
 		},
 		{
 			name: "HTTP discovery URL",
 			environment: map[string]string{
-				envDiscoveryURL: "http://issuer.example/discovery",
+				envDiscoveryURL:         "http://issuer.example/discovery",
+				envCAConfigMapNamespace: "identity-system",
+				envCAConfigMapName:      "oidc-ca",
 			},
 			expectError: "absolute HTTPS URL",
 		},
 		{
 			name: "relative discovery URL",
 			environment: map[string]string{
-				envDiscoveryURL: "/discovery",
+				envDiscoveryURL:         "/discovery",
+				envCAConfigMapNamespace: "identity-system",
+				envCAConfigMapName:      "oidc-ca",
 			},
 			expectError: "absolute HTTPS URL",
 		},
@@ -127,6 +147,7 @@ func TestValidateOptions(t *testing.T) {
 		expectError string
 	}{
 		{name: "valid"},
+		{name: "empty discovery URL", mutate: func(opts *Options) { opts.DiscoveryURL = "" }, expectError: "absolute HTTPS URL"},
 		{name: "negative clock skew", mutate: func(opts *Options) { opts.ClockSkew = -time.Second }, expectError: "clock skew"},
 		{name: "negative timeout", mutate: func(opts *Options) { opts.HTTPTimeout = -time.Second }, expectError: "HTTP timeout"},
 		{name: "negative response size", mutate: func(opts *Options) { opts.MaxResponseSize = -1 }, expectError: "response size"},
@@ -138,7 +159,7 @@ func TestValidateOptions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			opts := defaultOptions()
+			opts := validOptions()
 			if tt.mutate != nil {
 				tt.mutate(&opts)
 			}
@@ -151,4 +172,12 @@ func TestValidateOptions(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func validOptions() Options {
+	opts := defaultOptions()
+	opts.DiscoveryURL = "https://issuer.example/discovery"
+	opts.CAConfigMapNamespace = "identity-system"
+	opts.CAConfigMapName = "oidc-ca"
+	return opts
 }

--- a/pkg/identity/oidc/verifier.go
+++ b/pkg/identity/oidc/verifier.go
@@ -1,0 +1,330 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var asymmetricSignatureAlgorithms = []jose.SignatureAlgorithm{
+	jose.RS256, jose.RS384, jose.RS512,
+	jose.PS256, jose.PS384, jose.PS512,
+	jose.ES256, jose.ES384, jose.ES512,
+	jose.EdDSA,
+}
+
+// Verifier verifies a traffic access token against a fixed OIDC key snapshot.
+type Verifier interface {
+	Verify(rawJWT string) (*TrafficAccessTokenClaims, error)
+}
+
+// TrafficAccessTokenClaims contains the claims used to authorize sandbox traffic.
+type TrafficAccessTokenClaims struct {
+	jwt.Claims
+	Sandbox SandboxClaims `json:"sandbox"`
+}
+
+// SandboxClaims identifies the sandbox represented by a traffic access token.
+type SandboxClaims struct {
+	SandboxID  string `json:"sandboxId"`
+	SandboxUID string `json:"sandboxUid"`
+}
+
+type verifier struct {
+	issuer       string
+	keys         map[string]jose.JSONWebKey
+	clockSkew    time.Duration
+	maxTokenSize int
+}
+
+type discoveryDocument struct {
+	Issuer  string `json:"issuer"`
+	JWKSURI string `json:"jwks_uri"`
+}
+
+type jwksDocument struct {
+	Keys []json.RawMessage `json:"keys"`
+}
+
+// NewVerifier loads the OIDC provider and returns a verifier backed by an immutable JWKS snapshot.
+func NewVerifier(ctx context.Context, reader client.Reader, opts Options) (Verifier, error) {
+	opts = withDefaults(opts)
+	if err := validateOptions(opts); err != nil {
+		return nil, fmt.Errorf("invalid OIDC options: %w", err)
+	}
+	if reader == nil {
+		return nil, fmt.Errorf("ConfigMap reader must not be nil")
+	}
+
+	configMap := &corev1.ConfigMap{}
+	key := client.ObjectKey{Namespace: opts.CAConfigMapNamespace, Name: opts.CAConfigMapName}
+	if err := reader.Get(ctx, key, configMap); err != nil {
+		return nil, fmt.Errorf("get CA ConfigMap %s/%s: %w", key.Namespace, key.Name, err)
+	}
+	caPEM, ok := configMap.Data[opts.CAConfigMapKey]
+	if !ok || caPEM == "" {
+		return nil, fmt.Errorf("CA ConfigMap %s/%s does not contain non-empty key %q", key.Namespace, key.Name, opts.CAConfigMapKey)
+	}
+	rootCAs := x509.NewCertPool()
+	if !rootCAs.AppendCertsFromPEM([]byte(caPEM)) {
+		return nil, fmt.Errorf("CA ConfigMap %s/%s key %q contains no valid PEM certificates", key.Namespace, key.Name, opts.CAConfigMapKey)
+	}
+
+	httpClient := &http.Client{
+		Timeout: opts.HTTPTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: rootCAs, MinVersion: tls.VersionTLS12},
+		},
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	defer httpClient.CloseIdleConnections()
+
+	discovery := discoveryDocument{}
+	if err := fetchJSON(ctx, httpClient, opts.DiscoveryURL, opts.MaxResponseSize, &discovery); err != nil {
+		return nil, fmt.Errorf("fetch OIDC discovery document: %w", err)
+	}
+	if discovery.Issuer == "" {
+		return nil, fmt.Errorf("OIDC discovery document has an empty issuer")
+	}
+	if err := validateHTTPSURL(discovery.JWKSURI); err != nil {
+		return nil, fmt.Errorf("OIDC discovery document has invalid jwks_uri: %w", err)
+	}
+
+	keySet := jwksDocument{}
+	if err := fetchJSON(ctx, httpClient, discovery.JWKSURI, opts.MaxResponseSize, &keySet); err != nil {
+		return nil, fmt.Errorf("fetch OIDC JWKS: %w", err)
+	}
+	decodedKeys, err := decodeJWKs(keySet.Keys)
+	if err != nil {
+		return nil, fmt.Errorf("decode OIDC JWKS: %w", err)
+	}
+	keys, err := validateKeys(decodedKeys)
+	if err != nil {
+		return nil, fmt.Errorf("validate OIDC JWKS: %w", err)
+	}
+
+	return &verifier{
+		issuer:       discovery.Issuer,
+		keys:         keys,
+		clockSkew:    opts.ClockSkew,
+		maxTokenSize: opts.MaxTokenSize,
+	}, nil
+}
+
+func decodeJWKs(rawKeys []json.RawMessage) ([]jose.JSONWebKey, error) {
+	keys := make([]jose.JSONWebKey, 0, len(rawKeys))
+	for index, rawKey := range rawKeys {
+		metadata := struct {
+			KeyOperations []string `json:"key_ops"`
+		}{}
+		if err := json.Unmarshal(rawKey, &metadata); err != nil {
+			return nil, fmt.Errorf("decode key %d metadata: %w", index, err)
+		}
+		if len(metadata.KeyOperations) > 0 {
+			canVerify := false
+			for _, operation := range metadata.KeyOperations {
+				if operation == "verify" {
+					canVerify = true
+					break
+				}
+			}
+			if !canVerify {
+				return nil, fmt.Errorf("key %d key_ops does not permit verify", index)
+			}
+		}
+
+		key := jose.JSONWebKey{}
+		if err := json.Unmarshal(rawKey, &key); err != nil {
+			return nil, fmt.Errorf("decode key %d: %w", index, err)
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+// Verify validates a token signature and the required traffic access token claims.
+func (v *verifier) Verify(rawJWT string) (*TrafficAccessTokenClaims, error) {
+	if rawJWT == "" {
+		return nil, fmt.Errorf("token must not be empty")
+	}
+	if len(rawJWT) > v.maxTokenSize {
+		return nil, fmt.Errorf("token exceeds maximum size of %d bytes", v.maxTokenSize)
+	}
+
+	token, err := jwt.ParseSigned(rawJWT, asymmetricSignatureAlgorithms)
+	if err != nil {
+		return nil, fmt.Errorf("parse signed token: %w", err)
+	}
+	if len(token.Headers) != 1 {
+		return nil, fmt.Errorf("token must contain exactly one signature")
+	}
+	header := token.Headers[0]
+	if header.KeyID == "" {
+		return nil, fmt.Errorf("token header must contain a kid")
+	}
+	key, ok := v.keys[header.KeyID]
+	if !ok {
+		return nil, fmt.Errorf("token references unknown kid %q", header.KeyID)
+	}
+	if key.Algorithm != "" && key.Algorithm != header.Algorithm {
+		return nil, fmt.Errorf("token algorithm %q does not match JWK algorithm %q", header.Algorithm, key.Algorithm)
+	}
+	if !algorithmSupportsKey(jose.SignatureAlgorithm(header.Algorithm), key.Key) {
+		return nil, fmt.Errorf("token algorithm %q is incompatible with key %q", header.Algorithm, header.KeyID)
+	}
+
+	claims := &TrafficAccessTokenClaims{}
+	if err := token.Claims(key.Key, claims); err != nil {
+		return nil, fmt.Errorf("verify token signature and decode claims: %w", err)
+	}
+	if claims.Expiry == nil {
+		return nil, fmt.Errorf("token is missing exp claim")
+	}
+	if claims.IssuedAt == nil {
+		return nil, fmt.Errorf("token is missing iat claim")
+	}
+	if claims.NotBefore == nil {
+		return nil, fmt.Errorf("token is missing nbf claim")
+	}
+	if claims.Issuer != v.issuer {
+		return nil, fmt.Errorf("token issuer %q does not match expected issuer %q", claims.Issuer, v.issuer)
+	}
+	if claims.Subject == "" {
+		return nil, fmt.Errorf("token is missing sub claim")
+	}
+	if err := claims.Claims.ValidateWithLeeway(jwt.Expected{Issuer: v.issuer, Time: time.Now()}, v.clockSkew); err != nil {
+		return nil, fmt.Errorf("validate token claims: %w", err)
+	}
+	return claims, nil
+}
+
+func fetchJSON(ctx context.Context, httpClient *http.Client, target string, maxSize int64, dest interface{}) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected HTTP status %s", response.Status)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxSize+1))
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+	if int64(len(body)) > maxSize {
+		return fmt.Errorf("response exceeds maximum size of %d bytes", maxSize)
+	}
+	if err := json.Unmarshal(body, dest); err != nil {
+		return fmt.Errorf("decode JSON response: %w", err)
+	}
+	return nil
+}
+
+func validateHTTPSURL(rawURL string) error {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil || !parsedURL.IsAbs() || parsedURL.Scheme != "https" || parsedURL.Host == "" {
+		return fmt.Errorf("must be an absolute HTTPS URL")
+	}
+	return nil
+}
+
+func validateKeys(input []jose.JSONWebKey) (map[string]jose.JSONWebKey, error) {
+	if len(input) == 0 {
+		return nil, fmt.Errorf("key set must contain at least one key")
+	}
+	keys := make(map[string]jose.JSONWebKey, len(input))
+	for index, key := range input {
+		if key.Key == nil {
+			return nil, fmt.Errorf("key %d is invalid", index)
+		}
+		if key.KeyID == "" {
+			return nil, fmt.Errorf("key %d has an empty kid", index)
+		}
+		if key.Use != "" && key.Use != "sig" {
+			return nil, fmt.Errorf("key %q has unsupported use %q", key.KeyID, key.Use)
+		}
+		if !isAsymmetricPublicKey(key.Key) {
+			return nil, fmt.Errorf("key %q must be an asymmetric public key", key.KeyID)
+		}
+		if !key.Valid() {
+			return nil, fmt.Errorf("key %q is invalid", key.KeyID)
+		}
+		if key.Algorithm != "" && !algorithmSupportsKey(jose.SignatureAlgorithm(key.Algorithm), key.Key) {
+			return nil, fmt.Errorf("key %q has incompatible algorithm %q", key.KeyID, key.Algorithm)
+		}
+		if _, exists := keys[key.KeyID]; exists {
+			return nil, fmt.Errorf("duplicate kid %q", key.KeyID)
+		}
+		keys[key.KeyID] = key
+	}
+	return keys, nil
+}
+
+func isAsymmetricPublicKey(key interface{}) bool {
+	switch key.(type) {
+	case *rsa.PublicKey, *ecdsa.PublicKey, ed25519.PublicKey:
+		return true
+	default:
+		return false
+	}
+}
+
+func algorithmSupportsKey(algorithm jose.SignatureAlgorithm, key interface{}) bool {
+	switch typedKey := key.(type) {
+	case *rsa.PublicKey:
+		return algorithm == jose.RS256 || algorithm == jose.RS384 || algorithm == jose.RS512 ||
+			algorithm == jose.PS256 || algorithm == jose.PS384 || algorithm == jose.PS512
+	case *ecdsa.PublicKey:
+		switch typedKey.Curve.Params().BitSize {
+		case 256:
+			return algorithm == jose.ES256
+		case 384:
+			return algorithm == jose.ES384
+		case 521:
+			return algorithm == jose.ES512
+		default:
+			return false
+		}
+	case ed25519.PublicKey:
+		return algorithm == jose.EdDSA
+	default:
+		return false
+	}
+}

--- a/pkg/identity/oidc/verifier.go
+++ b/pkg/identity/oidc/verifier.go
@@ -187,9 +187,6 @@ func (v *verifier) Verify(rawJWT string) (*TrafficAccessTokenClaims, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse signed token: %w", err)
 	}
-	if len(token.Headers) != 1 {
-		return nil, fmt.Errorf("token must contain exactly one signature")
-	}
 	header := token.Headers[0]
 	if header.KeyID == "" {
 		return nil, fmt.Errorf("token header must contain a kid")

--- a/pkg/identity/oidc/verifier_test.go
+++ b/pkg/identity/oidc/verifier_test.go
@@ -1,0 +1,354 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifierVerify(t *testing.T) {
+	rsaKey := mustRSAKey(t)
+	otherRSAKey := mustRSAKey(t)
+	ecdsaKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	now := time.Now().Truncate(time.Second)
+	issuer := "https://issuer.example"
+	validClaims := tokenClaims(now, issuer)
+
+	tests := []struct {
+		name         string
+		rawJWT       func(*testing.T) string
+		maxTokenSize int
+		assertions   func(*testing.T, *TrafficAccessTokenClaims)
+		expectError  string
+	}{
+		{
+			name: "valid RSA token",
+			rawJWT: func(t *testing.T) string {
+				claims := cloneClaims(validClaims)
+				claims["sandbox"] = map[string]interface{}{
+					"sandboxId": "sandbox-1", "sandboxUid": "uid-1", "ignored": "value",
+				}
+				claims["metadata"] = map[string]interface{}{"tenant": "ignored"}
+				claims["pod"] = map[string]interface{}{"name": "ignored"}
+				return signToken(t, jose.RS256, rsaKey, "rsa", claims)
+			},
+			assertions: func(t *testing.T, claims *TrafficAccessTokenClaims) {
+				assert.Equal(t, "sandbox-1", claims.Sandbox.SandboxID)
+				assert.Equal(t, "uid-1", claims.Sandbox.SandboxUID)
+			},
+		},
+		{
+			name: "valid ECDSA token",
+			rawJWT: func(t *testing.T) string {
+				return signToken(t, jose.ES256, ecdsaKey, "ecdsa", validClaims)
+			},
+		},
+		{
+			name: "audience is ignored",
+			rawJWT: func(t *testing.T) string {
+				claims := cloneClaims(validClaims)
+				claims["aud"] = []string{"unrelated-service"}
+				return signToken(t, jose.RS256, rsaKey, "rsa", claims)
+			},
+		},
+		{
+			name: "long lifetime is accepted",
+			rawJWT: func(t *testing.T) string {
+				claims := cloneClaims(validClaims)
+				claims["iat"] = now.Add(-365 * 24 * time.Hour).Unix()
+				claims["nbf"] = now.Add(-365 * 24 * time.Hour).Unix()
+				claims["exp"] = now.Add(365 * 24 * time.Hour).Unix()
+				return signToken(t, jose.RS256, rsaKey, "rsa", claims)
+			},
+		},
+		{
+			name: "clock skew is applied",
+			rawJWT: func(t *testing.T) string {
+				claims := cloneClaims(validClaims)
+				claims["iat"] = now.Add(30 * time.Second).Unix()
+				claims["nbf"] = now.Add(30 * time.Second).Unix()
+				claims["exp"] = now.Add(-30 * time.Second).Unix()
+				return signToken(t, jose.RS256, rsaKey, "rsa", claims)
+			},
+		},
+		{
+			name:        "empty token",
+			rawJWT:      func(*testing.T) string { return "" },
+			expectError: "must not be empty",
+		},
+		{
+			name:        "malformed token",
+			rawJWT:      func(*testing.T) string { return "not-a-jwt" },
+			expectError: "parse signed token",
+		},
+		{
+			name: "none algorithm",
+			rawJWT: func(*testing.T) string {
+				header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","kid":"rsa"}`))
+				payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"subject"}`))
+				return header + "." + payload + "."
+			},
+			expectError: "parse signed token",
+		},
+		{
+			name: "HMAC algorithm",
+			rawJWT: func(t *testing.T) string {
+				return signToken(t, jose.HS256, []byte(strings.Repeat("x", 32)), "rsa", validClaims)
+			},
+			expectError: "parse signed token",
+		},
+		{
+			name: "missing kid",
+			rawJWT: func(t *testing.T) string {
+				return signToken(t, jose.RS256, rsaKey, "", validClaims)
+			},
+			expectError: "must contain a kid",
+		},
+		{
+			name: "unknown kid",
+			rawJWT: func(t *testing.T) string {
+				return signToken(t, jose.RS256, rsaKey, "unknown", validClaims)
+			},
+			expectError: "unknown kid",
+		},
+		{
+			name: "wrong signature",
+			rawJWT: func(t *testing.T) string {
+				return signToken(t, jose.RS256, otherRSAKey, "rsa", validClaims)
+			},
+			expectError: "verify token signature",
+		},
+		{
+			name: "JWK algorithm mismatch",
+			rawJWT: func(t *testing.T) string {
+				return signToken(t, jose.PS256, rsaKey, "rsa", validClaims)
+			},
+			expectError: "does not match JWK algorithm",
+		},
+		{
+			name: "missing exp",
+			rawJWT: func(t *testing.T) string {
+				return signToken(t, jose.RS256, rsaKey, "rsa", withoutClaim(validClaims, "exp"))
+			},
+			expectError: "missing exp",
+		},
+		{
+			name: "missing iat",
+			rawJWT: func(t *testing.T) string {
+				return signToken(t, jose.RS256, rsaKey, "rsa", withoutClaim(validClaims, "iat"))
+			},
+			expectError: "missing iat",
+		},
+		{
+			name: "missing nbf",
+			rawJWT: func(t *testing.T) string {
+				return signToken(t, jose.RS256, rsaKey, "rsa", withoutClaim(validClaims, "nbf"))
+			},
+			expectError: "missing nbf",
+		},
+		{
+			name: "expired",
+			rawJWT: func(t *testing.T) string {
+				claims := cloneClaims(validClaims)
+				claims["exp"] = now.Add(-2 * time.Minute).Unix()
+				return signToken(t, jose.RS256, rsaKey, "rsa", claims)
+			},
+			expectError: "expired",
+		},
+		{
+			name: "issued in future",
+			rawJWT: func(t *testing.T) string {
+				claims := cloneClaims(validClaims)
+				claims["iat"] = now.Add(2 * time.Minute).Unix()
+				return signToken(t, jose.RS256, rsaKey, "rsa", claims)
+			},
+			expectError: "future",
+		},
+		{
+			name: "not valid yet",
+			rawJWT: func(t *testing.T) string {
+				claims := cloneClaims(validClaims)
+				claims["nbf"] = now.Add(2 * time.Minute).Unix()
+				return signToken(t, jose.RS256, rsaKey, "rsa", claims)
+			},
+			expectError: "not valid yet",
+		},
+		{
+			name: "wrong issuer",
+			rawJWT: func(t *testing.T) string {
+				claims := cloneClaims(validClaims)
+				claims["iss"] = "https://other.example"
+				return signToken(t, jose.RS256, rsaKey, "rsa", claims)
+			},
+			expectError: "does not match expected issuer",
+		},
+		{
+			name: "empty subject",
+			rawJWT: func(t *testing.T) string {
+				claims := cloneClaims(validClaims)
+				claims["sub"] = ""
+				return signToken(t, jose.RS256, rsaKey, "rsa", claims)
+			},
+			expectError: "missing sub",
+		},
+		{
+			name: "oversized token",
+			rawJWT: func(t *testing.T) string {
+				return signToken(t, jose.RS256, rsaKey, "rsa", validClaims)
+			},
+			maxTokenSize: 10,
+			expectError:  "exceeds maximum size",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			maxTokenSize := DefaultMaxTokenSize
+			if tt.maxTokenSize != 0 {
+				maxTokenSize = tt.maxTokenSize
+			}
+			underTest := &verifier{
+				issuer: issuer,
+				keys: map[string]jose.JSONWebKey{
+					"rsa": {
+						Key: &rsaKey.PublicKey, KeyID: "rsa", Algorithm: string(jose.RS256), Use: "sig",
+					},
+					"ecdsa": {
+						Key: &ecdsaKey.PublicKey, KeyID: "ecdsa", Algorithm: string(jose.ES256), Use: "sig",
+					},
+				},
+				clockSkew:    time.Minute,
+				maxTokenSize: maxTokenSize,
+			}
+
+			claims, err := underTest.Verify(tt.rawJWT(t))
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, strings.ToLower(err.Error()), strings.ToLower(tt.expectError))
+				assert.Nil(t, claims)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, claims)
+			if tt.assertions != nil {
+				tt.assertions(t, claims)
+			}
+		})
+	}
+}
+
+func TestValidateKeys(t *testing.T) {
+	rsaKey := mustRSAKey(t)
+	ecdsaKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	validRSA := jose.JSONWebKey{Key: &rsaKey.PublicKey, KeyID: "rsa", Use: "sig", Algorithm: string(jose.RS256)}
+
+	tests := []struct {
+		name        string
+		keys        []jose.JSONWebKey
+		expectCount int
+		expectError string
+	}{
+		{name: "RSA and ECDSA public keys", keys: []jose.JSONWebKey{validRSA, {Key: &ecdsaKey.PublicKey, KeyID: "ec"}}, expectCount: 2},
+		{name: "empty set", expectError: "at least one key"},
+		{name: "invalid key", keys: []jose.JSONWebKey{{KeyID: "bad"}}, expectError: "invalid"},
+		{name: "empty kid", keys: []jose.JSONWebKey{{Key: &rsaKey.PublicKey}}, expectError: "empty kid"},
+		{name: "encryption use", keys: []jose.JSONWebKey{{Key: &rsaKey.PublicKey, KeyID: "enc", Use: "enc"}}, expectError: "unsupported use"},
+		{name: "symmetric key", keys: []jose.JSONWebKey{{Key: []byte(strings.Repeat("x", 32)), KeyID: "symmetric"}}, expectError: "asymmetric public key"},
+		{name: "private key", keys: []jose.JSONWebKey{{Key: rsaKey, KeyID: "private"}}, expectError: "asymmetric public key"},
+		{name: "duplicate kid", keys: []jose.JSONWebKey{validRSA, {Key: &ecdsaKey.PublicKey, KeyID: "rsa"}}, expectError: "duplicate kid"},
+		{name: "incompatible JWK algorithm", keys: []jose.JSONWebKey{{Key: &ecdsaKey.PublicKey, KeyID: "ec", Algorithm: string(jose.RS256)}}, expectError: "incompatible algorithm"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keys, err := validateKeys(tt.keys)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, keys, tt.expectCount)
+		})
+	}
+}
+
+func tokenClaims(now time.Time, issuer string) map[string]interface{} {
+	return map[string]interface{}{
+		"iss": issuer,
+		"sub": "subject-1",
+		"iat": now.Add(-time.Minute).Unix(),
+		"nbf": now.Add(-time.Minute).Unix(),
+		"exp": now.Add(time.Hour).Unix(),
+	}
+}
+
+func cloneClaims(input map[string]interface{}) map[string]interface{} {
+	output := make(map[string]interface{}, len(input))
+	for key, value := range input {
+		output[key] = value
+	}
+	return output
+}
+
+func withoutClaim(input map[string]interface{}, name string) map[string]interface{} {
+	output := cloneClaims(input)
+	delete(output, name)
+	return output
+}
+
+func signToken(t *testing.T, algorithm jose.SignatureAlgorithm, key interface{}, keyID string, claims map[string]interface{}) string {
+	t.Helper()
+	options := &jose.SignerOptions{}
+	if keyID != "" {
+		options.WithHeader("kid", keyID)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: algorithm, Key: key}, options)
+	require.NoError(t, err)
+	rawJWT, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return rawJWT
+}
+
+func mustRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return key
+}
+
+func mustJSON(t *testing.T, value interface{}) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(data)
+}

--- a/pkg/identity/oidc/verifier_test.go
+++ b/pkg/identity/oidc/verifier_test.go
@@ -18,6 +18,7 @@ package oidc
 
 import (
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -69,6 +70,12 @@ func TestVerifierVerify(t *testing.T) {
 			name: "valid ECDSA token",
 			rawJWT: func(t *testing.T) string {
 				return signToken(t, jose.ES256, ecdsaKey, "ecdsa", validClaims)
+			},
+		},
+		{
+			name: "valid RSA token without JWK algorithm",
+			rawJWT: func(t *testing.T) string {
+				return signToken(t, jose.RS256, rsaKey, "rsa-no-alg", validClaims)
 			},
 		},
 		{
@@ -152,6 +159,22 @@ func TestVerifierVerify(t *testing.T) {
 				return signToken(t, jose.PS256, rsaKey, "rsa", validClaims)
 			},
 			expectError: "does not match JWK algorithm",
+		},
+		{
+			name: "key type incompatible with algorithm",
+			rawJWT: func(t *testing.T) string {
+				return signToken(t, jose.ES256, ecdsaKey, "rsa-no-alg", validClaims)
+			},
+			expectError: "incompatible with key",
+		},
+		{
+			name: "invalid claim type",
+			rawJWT: func(t *testing.T) string {
+				claims := cloneClaims(validClaims)
+				claims["exp"] = "invalid"
+				return signToken(t, jose.RS256, rsaKey, "rsa", claims)
+			},
+			expectError: "decode claims",
 		},
 		{
 			name: "missing exp",
@@ -244,6 +267,9 @@ func TestVerifierVerify(t *testing.T) {
 					"ecdsa": {
 						Key: &ecdsaKey.PublicKey, KeyID: "ecdsa", Algorithm: string(jose.ES256), Use: "sig",
 					},
+					"rsa-no-alg": {
+						Key: &rsaKey.PublicKey, KeyID: "rsa-no-alg", Use: "sig",
+					},
 				},
 				clockSkew:    time.Minute,
 				maxTokenSize: maxTokenSize,
@@ -265,9 +291,41 @@ func TestVerifierVerify(t *testing.T) {
 	}
 }
 
+func TestDecodeJWKs(t *testing.T) {
+	rsaKey := mustRSAKey(t)
+	publicJWK := jose.JSONWebKey{Key: &rsaKey.PublicKey, KeyID: "rsa", Use: "sig", Algorithm: string(jose.RS256)}
+	withVerifyOperation := json.RawMessage(strings.TrimSuffix(mustJSON(t, publicJWK), "}") + `,"key_ops":["sign","verify"]}`)
+
+	tests := []struct {
+		name        string
+		rawKeys     []json.RawMessage
+		expectCount int
+		expectError string
+	}{
+		{name: "verify operation permitted", rawKeys: []json.RawMessage{withVerifyOperation}, expectCount: 1},
+		{name: "malformed metadata", rawKeys: []json.RawMessage{json.RawMessage(`{`)}, expectError: "decode key 0 metadata"},
+		{name: "invalid JWK", rawKeys: []json.RawMessage{json.RawMessage(`{"kty":"unsupported","kid":"bad"}`)}, expectError: "decode key 0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keys, err := decodeJWKs(tt.rawKeys)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, keys, tt.expectCount)
+		})
+	}
+}
+
 func TestValidateKeys(t *testing.T) {
 	rsaKey := mustRSAKey(t)
 	ecdsaKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	ed25519PublicKey, _, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)
 	validRSA := jose.JSONWebKey{Key: &rsaKey.PublicKey, KeyID: "rsa", Use: "sig", Algorithm: string(jose.RS256)}
 
@@ -278,8 +336,10 @@ func TestValidateKeys(t *testing.T) {
 		expectError string
 	}{
 		{name: "RSA and ECDSA public keys", keys: []jose.JSONWebKey{validRSA, {Key: &ecdsaKey.PublicKey, KeyID: "ec"}}, expectCount: 2},
+		{name: "Ed25519 public key", keys: []jose.JSONWebKey{{Key: ed25519PublicKey, KeyID: "ed25519", Use: "sig", Algorithm: string(jose.EdDSA)}}, expectCount: 1},
 		{name: "empty set", expectError: "at least one key"},
 		{name: "invalid key", keys: []jose.JSONWebKey{{KeyID: "bad"}}, expectError: "invalid"},
+		{name: "invalid RSA parameters", keys: []jose.JSONWebKey{{Key: &rsa.PublicKey{}, KeyID: "invalid-rsa"}}, expectError: "invalid"},
 		{name: "empty kid", keys: []jose.JSONWebKey{{Key: &rsaKey.PublicKey}}, expectError: "empty kid"},
 		{name: "encryption use", keys: []jose.JSONWebKey{{Key: &rsaKey.PublicKey, KeyID: "enc", Use: "enc"}}, expectError: "unsupported use"},
 		{name: "symmetric key", keys: []jose.JSONWebKey{{Key: []byte(strings.Repeat("x", 32)), KeyID: "symmetric"}}, expectError: "asymmetric public key"},
@@ -298,6 +358,44 @@ func TestValidateKeys(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Len(t, keys, tt.expectCount)
+		})
+	}
+}
+
+func TestAlgorithmSupportsKey(t *testing.T) {
+	rsaKey := mustRSAKey(t)
+	p384Key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+	p521Key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	require.NoError(t, err)
+	ed25519PublicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		algorithm jose.SignatureAlgorithm
+		key       interface{}
+		expected  bool
+	}{
+		{name: "RSA RS384", algorithm: jose.RS384, key: &rsaKey.PublicKey, expected: true},
+		{name: "RSA RS512", algorithm: jose.RS512, key: &rsaKey.PublicKey, expected: true},
+		{name: "RSA PS256", algorithm: jose.PS256, key: &rsaKey.PublicKey, expected: true},
+		{name: "RSA PS384", algorithm: jose.PS384, key: &rsaKey.PublicKey, expected: true},
+		{name: "RSA PS512", algorithm: jose.PS512, key: &rsaKey.PublicKey, expected: true},
+		{name: "RSA rejects ECDSA", algorithm: jose.ES256, key: &rsaKey.PublicKey},
+		{name: "P-384 accepts ES384", algorithm: jose.ES384, key: &p384Key.PublicKey, expected: true},
+		{name: "P-384 rejects ES256", algorithm: jose.ES256, key: &p384Key.PublicKey},
+		{name: "P-521 accepts ES512", algorithm: jose.ES512, key: &p521Key.PublicKey, expected: true},
+		{name: "P-521 rejects ES384", algorithm: jose.ES384, key: &p521Key.PublicKey},
+		{name: "unsupported ECDSA curve", algorithm: jose.ES256, key: &ecdsa.PublicKey{Curve: elliptic.P224()}},
+		{name: "Ed25519 accepts EdDSA", algorithm: jose.EdDSA, key: ed25519PublicKey, expected: true},
+		{name: "Ed25519 rejects RSA", algorithm: jose.RS256, key: ed25519PublicKey},
+		{name: "unsupported key type", algorithm: jose.HS256, key: []byte("symmetric")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, algorithmSupportsKey(tt.algorithm, tt.key))
 		})
 	}
 }

--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -141,11 +141,12 @@ func TestHandleRefresh_OverwritesExistingRoute(t *testing.T) {
 
 func TestServer_handleRefresh(t *testing.T) {
 	tests := []struct {
-		name           string
-		body           string
-		expectedCode   int
-		expectDeleted  bool
-		expectRouteSet bool
+		name              string
+		body              string
+		expectedCode      int
+		expectDeleted     bool
+		expectRouteSet    bool
+		expectTrafficAuth bool
 	}{
 		{
 			name:         "invalid json body",
@@ -164,15 +165,17 @@ func TestServer_handleRefresh(t *testing.T) {
 			expectDeleted: true,
 		},
 		{
-			name: "running state should set route",
+			name: "running state should set route with traffic auth",
 			body: mustMarshal(Route{
-				ID:              "sandbox-2",
-				IP:              "10.0.0.2",
-				State:           v1alpha1.SandboxStateRunning,
-				ResourceVersion: "1",
+				ID:                 "sandbox-2",
+				IP:                 "10.0.0.2",
+				State:              v1alpha1.SandboxStateRunning,
+				ResourceVersion:    "1",
+				RequireTrafficAuth: true,
 			}),
-			expectedCode:   http.StatusNoContent,
-			expectRouteSet: true,
+			expectedCode:      http.StatusNoContent,
+			expectRouteSet:    true,
+			expectTrafficAuth: true,
 		},
 		{
 			name: "available state should set route",
@@ -222,13 +225,16 @@ func TestServer_handleRefresh(t *testing.T) {
 			// Verify route set
 			if tt.expectRouteSet {
 				var routeID string
-				if tt.name == "running state should set route" {
+				if tt.name == "running state should set route with traffic auth" {
 					routeID = "sandbox-2"
 				} else if tt.name == "available state should set route" {
 					routeID = "sandbox-3"
 				}
-				_, loaded := s.routes.Load(routeID)
+				rawRoute, loaded := s.routes.Load(routeID)
 				assert.True(t, loaded, "route should be set")
+				if loaded {
+					assert.Equal(t, tt.expectTrafficAuth, rawRoute.(Route).RequireTrafficAuth)
+				}
 			}
 		})
 	}

--- a/pkg/sandbox-gateway/controller/gateway_controller.go
+++ b/pkg/sandbox-gateway/controller/gateway_controller.go
@@ -21,13 +21,16 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/jwtauth"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
 	proxyutils "github.com/openkruise/agents/pkg/utils/proxyutils"
 )
@@ -64,10 +67,11 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return ctrl.Result{}, nil
 }
 
-func StartManager(ctx context.Context) error {
+func StartManager(ctx context.Context, jwtAuthManager *jwtauth.Manager) error {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(agentsv1alpha1.AddToScheme(scheme))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
@@ -90,6 +94,22 @@ func StartManager(ctx context.Context) error {
 		}); err != nil {
 		return fmt.Errorf("unable to create controller: %w", err)
 	}
+	if err := addJWTAuthManager(mgr.GetAPIReader(), mgr.Add, jwtAuthManager); err != nil {
+		return err
+	}
 
 	return mgr.Start(ctx)
+}
+
+func addJWTAuthManager(reader client.Reader, add func(manager.Runnable) error, jwtAuthManager *jwtauth.Manager) error {
+	if jwtAuthManager == nil {
+		return nil
+	}
+	if err := jwtAuthManager.SetReader(reader); err != nil {
+		return fmt.Errorf("unable to configure JWT authentication reader: %w", err)
+	}
+	if err := add(jwtAuthManager); err != nil {
+		return fmt.Errorf("unable to add JWT authentication manager: %w", err)
+	}
+	return nil
 }

--- a/pkg/sandbox-gateway/controller/gateway_controller_test.go
+++ b/pkg/sandbox-gateway/controller/gateway_controller_test.go
@@ -18,9 +18,12 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,11 +31,69 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/proxy"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/jwtauth"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
 )
+
+func TestAddJWTAuthManager(t *testing.T) {
+	reader := fake.NewClientBuilder().Build()
+	tests := []struct {
+		name        string
+		manager     func() *jwtauth.Manager
+		addError    error
+		expectAdded bool
+		expectError string
+	}{
+		{name: "nil manager"},
+		{
+			name:        "manager added",
+			manager:     jwtauth.NewManager,
+			expectAdded: true,
+		},
+		{
+			name: "different reader already configured",
+			manager: func() *jwtauth.Manager {
+				jwtManager := jwtauth.NewManager()
+				require.NoError(t, jwtManager.SetReader(fake.NewClientBuilder().Build()))
+				return jwtManager
+			},
+			expectError: "reader is already set",
+		},
+		{
+			name:        "add failure",
+			manager:     jwtauth.NewManager,
+			addError:    errors.New("add failed"),
+			expectAdded: true,
+			expectError: "unable to add JWT authentication manager",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var jwtManager *jwtauth.Manager
+			if tt.manager != nil {
+				jwtManager = tt.manager()
+			}
+			added := false
+			err := addJWTAuthManager(reader, func(runnable manager.Runnable) error {
+				assert.Same(t, jwtManager, runnable)
+				added = true
+				return tt.addError
+			}, jwtManager)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectAdded, added)
+		})
+	}
+}
 
 func TestSandboxReconciler_Reconcile_SandboxNotFound(t *testing.T) {
 	scheme := runtime.NewScheme()

--- a/pkg/sandbox-gateway/filter/config.go
+++ b/pkg/sandbox-gateway/filter/config.go
@@ -20,20 +20,30 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	v3 "github.com/cncf/xds/go/xds/type/v3"
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
+	"golang.org/x/net/http/httpguts"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	"github.com/openkruise/agents/pkg/identity/oidc"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 )
 
 const (
-	DefaultHostHeaderName    = "Host"
-	DefaultSandboxHeaderName = "e2b-sandbox-id"
-	DefaultSandboxPortHeader = "e2b-sandbox-port"
-	DefaultSandboxPort       = "49983"
+	DefaultHostHeaderName           = "Host"
+	DefaultSandboxHeaderName        = "e2b-sandbox-id"
+	DefaultSandboxPortHeader        = "e2b-sandbox-port"
+	DefaultSandboxPort              = "49983"
+	DefaultTrafficAccessTokenHeader = "x-traffic-access-token"
 )
+
+// JWTAuthManager configures and exposes the process-wide JWT verifier.
+type JWTAuthManager interface {
+	Configure(enabled bool) error
+	Current() oidc.Verifier
+}
 
 // Config holds the filter configuration
 type Config struct {
@@ -48,20 +58,35 @@ type Config struct {
 	// EnableAuth enables access token authentication when set to true.
 	// When disabled (default), the gateway skips token validation for backward compatibility.
 	EnableAuth bool `json:"enable-auth,omitempty"`
+	// EnableJWTAuth switches enabled gateway authentication from UUID to JWT.
+	EnableJWTAuth bool `json:"enable-jwt-auth,omitempty"`
+	// TrafficAccessTokenHeader is the request header carrying the traffic access JWT.
+	TrafficAccessTokenHeader string `json:"traffic-access-token-header,omitempty"`
 }
 
 // DefaultConfig returns default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		SandboxHeaderName: DefaultSandboxHeaderName,
-		SandboxPortHeader: DefaultSandboxPortHeader,
-		HostHeaderName:    DefaultHostHeaderName,
-		DefaultPort:       DefaultSandboxPort,
+		SandboxHeaderName:        DefaultSandboxHeaderName,
+		SandboxPortHeader:        DefaultSandboxPortHeader,
+		HostHeaderName:           DefaultHostHeaderName,
+		DefaultPort:              DefaultSandboxPort,
+		TrafficAccessTokenHeader: DefaultTrafficAccessTokenHeader,
 	}
 }
 
 // Validate checks configuration validity
 func (c *Config) Validate() error {
+	if c.EnableJWTAuth && !c.EnableAuth {
+		return fmt.Errorf("enable-jwt-auth requires enable-auth")
+	}
+	headerName := c.GetTrafficAccessTokenHeader()
+	if !httpguts.ValidHeaderFieldName(headerName) || strings.HasPrefix(headerName, ":") {
+		return fmt.Errorf("traffic-access-token-header %q is not a valid HTTP header name", headerName)
+	}
+	if strings.EqualFold(headerName, accessTokenHeader) {
+		return fmt.Errorf("traffic-access-token-header must differ from %s", accessTokenHeader)
+	}
 	return nil
 }
 
@@ -100,14 +125,28 @@ func (c *Config) GetDefaultPort() int {
 	return p
 }
 
+// GetTrafficAccessTokenHeader returns the configured JWT header name.
+func (c *Config) GetTrafficAccessTokenHeader() string {
+	if c.TrafficAccessTokenHeader != "" {
+		return strings.ToLower(c.TrafficAccessTokenHeader)
+	}
+	return DefaultTrafficAccessTokenHeader
+}
+
 // FilterConfig wraps Config and holds the adapter created from the config
 type FilterConfig struct {
 	*Config
-	Adapter *adapters.E2BAdapter
+	Adapter                          *adapters.E2BAdapter
+	jwtAuthManager                   JWTAuthManager
+	trafficAccessTokenHeaderExplicit bool
 }
 
 // NewFilterConfig creates a FilterConfig with an adapter built from the config values
 func NewFilterConfig(cfg *Config) *FilterConfig {
+	return newFilterConfig(cfg, nil)
+}
+
+func newFilterConfig(cfg *Config, jwtAuthManager JWTAuthManager) *FilterConfig {
 	adapter := adapters.NewE2BAdapterWithOptions(
 		0, // port not used by gateway
 		adapters.E2BAdapterOptions{
@@ -118,12 +157,21 @@ func NewFilterConfig(cfg *Config) *FilterConfig {
 		},
 	)
 	return &FilterConfig{
-		Config:  cfg,
-		Adapter: adapter,
+		Config:                           cfg,
+		Adapter:                          adapter,
+		jwtAuthManager:                   jwtAuthManager,
+		trafficAccessTokenHeaderExplicit: cfg.TrafficAccessTokenHeader != "",
 	}
 }
 
-type ConfigParser struct{}
+type ConfigParser struct {
+	jwtAuthManager JWTAuthManager
+}
+
+// NewConfigParser creates a parser wired to the process-wide JWT manager.
+func NewConfigParser(jwtAuthManager JWTAuthManager) *ConfigParser {
+	return &ConfigParser{jwtAuthManager: jwtAuthManager}
+}
 
 func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {
 	cfg := DefaultConfig()
@@ -138,11 +186,24 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 	valueStruct := typedStruct.GetValue()
 	if valueStruct == nil {
 		// No value field, use defaults
-		return NewFilterConfig(cfg), nil
+		if callbacks != nil {
+			if err := p.configureJWT(cfg); err != nil {
+				return nil, err
+			}
+		}
+		parsed := newFilterConfig(cfg, p.jwtAuthManager)
+		parsed.trafficAccessTokenHeaderExplicit = false
+		return parsed, nil
 	}
 
 	// Convert the struct to JSON
-	configBytes, err := json.Marshal(valueStruct.AsMap())
+	values := valueStruct.AsMap()
+	_, jwtModeExplicit := values["enable-jwt-auth"]
+	_, tokenHeaderExplicit := values["traffic-access-token-header"]
+	if callbacks == nil && jwtModeExplicit {
+		return nil, fmt.Errorf("enable-jwt-auth is process-wide and cannot be configured per route")
+	}
+	configBytes, err := json.Marshal(values)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal config value to JSON: %w", err)
 	}
@@ -158,8 +219,27 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
+	if callbacks != nil {
+		if err := p.configureJWT(cfg); err != nil {
+			return nil, err
+		}
+	}
+	parsed := newFilterConfig(cfg, p.jwtAuthManager)
+	parsed.trafficAccessTokenHeaderExplicit = tokenHeaderExplicit
+	return parsed, nil
+}
 
-	return NewFilterConfig(cfg), nil
+func (p *ConfigParser) configureJWT(cfg *Config) error {
+	if p.jwtAuthManager == nil {
+		if cfg.EnableJWTAuth {
+			return fmt.Errorf("JWT authentication manager is not configured")
+		}
+		return nil
+	}
+	if err := p.jwtAuthManager.Configure(cfg.EnableJWTAuth); err != nil {
+		return fmt.Errorf("configure JWT authentication: %w", err)
+	}
+	return nil
 }
 
 func (p *ConfigParser) Merge(parent interface{}, child interface{}) interface{} {
@@ -185,6 +265,16 @@ func (p *ConfigParser) Merge(parent interface{}, child interface{}) interface{} 
 	if childCfg.EnableAuth {
 		merged.EnableAuth = childCfg.EnableAuth
 	}
+	if childCfg.EnableJWTAuth {
+		merged.EnableJWTAuth = childCfg.EnableJWTAuth
+	}
+	if childCfg.trafficAccessTokenHeaderExplicit {
+		merged.TrafficAccessTokenHeader = childCfg.TrafficAccessTokenHeader
+	}
 
-	return NewFilterConfig(merged)
+	jwtAuthManager := parentCfg.jwtAuthManager
+	if childCfg.jwtAuthManager != nil {
+		jwtAuthManager = childCfg.jwtAuthManager
+	}
+	return newFilterConfig(merged, jwtAuthManager)
 }

--- a/pkg/sandbox-gateway/filter/config.go
+++ b/pkg/sandbox-gateway/filter/config.go
@@ -62,6 +62,8 @@ type Config struct {
 	EnableJWTAuth bool `json:"enable-jwt-auth,omitempty"`
 	// TrafficAccessTokenHeader is the request header carrying the traffic access JWT.
 	TrafficAccessTokenHeader string `json:"traffic-access-token-header,omitempty"`
+	// EnableRuntimeMTLS routes requests to the agent-runtime port through the mTLS upstream cluster.
+	EnableRuntimeMTLS bool `json:"enable-runtime-mtls,omitempty"`
 }
 
 // DefaultConfig returns default configuration
@@ -200,8 +202,12 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 	values := valueStruct.AsMap()
 	_, jwtModeExplicit := values["enable-jwt-auth"]
 	_, tokenHeaderExplicit := values["traffic-access-token-header"]
+	_, runtimeMTLSExplicit := values["enable-runtime-mtls"]
 	if callbacks == nil && jwtModeExplicit {
 		return nil, fmt.Errorf("enable-jwt-auth is process-wide and cannot be configured per route")
+	}
+	if callbacks == nil && runtimeMTLSExplicit {
+		return nil, fmt.Errorf("enable-runtime-mtls is process-wide and cannot be configured per route")
 	}
 	configBytes, err := json.Marshal(values)
 	if err != nil {

--- a/pkg/sandbox-gateway/filter/config_test.go
+++ b/pkg/sandbox-gateway/filter/config_test.go
@@ -17,12 +17,40 @@ limitations under the License.
 package filter
 
 import (
+	"errors"
+	"reflect"
+	"strings"
 	"testing"
 
 	v3 "github.com/cncf/xds/go/xds/type/v3"
+	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/openkruise/agents/pkg/identity/oidc"
 )
+
+type fakeJWTAuthManager struct {
+	configureErr   error
+	configuredWith []bool
+	verifier       oidc.Verifier
+}
+
+type fakeConfigCallbackHandler struct{}
+
+func (*fakeConfigCallbackHandler) DefineCounterMetric(string) api.CounterMetric { return nil }
+func (*fakeConfigCallbackHandler) DefineGaugeMetric(string) api.GaugeMetric     { return nil }
+
+func (m *fakeJWTAuthManager) Configure(enabled bool) error {
+	m.configuredWith = append(m.configuredWith, enabled)
+	return m.configureErr
+}
+
+func (m *fakeJWTAuthManager) Current() oidc.Verifier {
+	return m.verifier
+}
 
 func TestConfigValidate(t *testing.T) {
 	tests := []struct {
@@ -146,6 +174,215 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.DefaultPort != "49983" {
 		t.Errorf("DefaultConfig().DefaultPort = %q, want %q", cfg.DefaultPort, "49983")
 	}
+	if cfg.EnableAuth || cfg.EnableJWTAuth {
+		t.Errorf("DefaultConfig() auth modes = (%t, %t), want both false", cfg.EnableAuth, cfg.EnableJWTAuth)
+	}
+	if cfg.GetTrafficAccessTokenHeader() != DefaultTrafficAccessTokenHeader {
+		t.Errorf("GetTrafficAccessTokenHeader() = %q, want %q", cfg.GetTrafficAccessTokenHeader(), DefaultTrafficAccessTokenHeader)
+	}
+}
+
+func TestConfigValidateJWT(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         Config
+		expectError string
+	}{
+		{name: "JWT mode", cfg: Config{EnableAuth: true, EnableJWTAuth: true}},
+		{name: "JWT requires auth", cfg: Config{EnableJWTAuth: true}, expectError: "requires enable-auth"},
+		{name: "custom header", cfg: Config{EnableAuth: true, EnableJWTAuth: true, TrafficAccessTokenHeader: "X-Custom-JWT"}},
+		{name: "invalid header", cfg: Config{EnableAuth: true, EnableJWTAuth: true, TrafficAccessTokenHeader: "bad header"}, expectError: "not a valid HTTP header"},
+		{name: "runtime token conflict", cfg: Config{EnableAuth: true, EnableJWTAuth: true, TrafficAccessTokenHeader: "X-Access-Token"}, expectError: "must differ"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.expectError == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.expectError) {
+				t.Fatalf("Validate() error = %v, want containing %q", err, tt.expectError)
+			}
+		})
+	}
+}
+
+func TestConfigParserJWT(t *testing.T) {
+	tests := []struct {
+		name             string
+		values           map[string]any
+		nilValue         bool
+		manager          *fakeJWTAuthManager
+		expectError      string
+		expectConfigured []bool
+		expectJWT        bool
+		expectHeader     string
+	}{
+		{
+			name:             "global nil value configures JWT disabled",
+			nilValue:         true,
+			manager:          &fakeJWTAuthManager{},
+			expectConfigured: []bool{false},
+			expectHeader:     DefaultTrafficAccessTokenHeader,
+		},
+		{
+			name:             "JWT enabled",
+			values:           map[string]any{"enable-auth": true, "enable-jwt-auth": true},
+			manager:          &fakeJWTAuthManager{},
+			expectConfigured: []bool{true},
+			expectJWT:        true,
+			expectHeader:     DefaultTrafficAccessTokenHeader,
+		},
+		{
+			name:             "JWT disabled",
+			values:           map[string]any{"enable-auth": true},
+			manager:          &fakeJWTAuthManager{},
+			expectConfigured: []bool{false},
+			expectHeader:     DefaultTrafficAccessTokenHeader,
+		},
+		{
+			name:        "missing manager",
+			values:      map[string]any{"enable-auth": true, "enable-jwt-auth": true},
+			expectError: "manager is not configured",
+		},
+		{
+			name:             "manager configuration error",
+			values:           map[string]any{"enable-auth": true, "enable-jwt-auth": true},
+			manager:          &fakeJWTAuthManager{configureErr: errors.New("conflict")},
+			expectError:      "conflict",
+			expectConfigured: []bool{true},
+		},
+		{
+			name:             "custom header is normalized",
+			values:           map[string]any{"enable-auth": true, "enable-jwt-auth": true, "traffic-access-token-header": "X-Custom-JWT"},
+			manager:          &fakeJWTAuthManager{},
+			expectConfigured: []bool{true},
+			expectJWT:        true,
+			expectHeader:     "x-custom-jwt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			typed := &v3.TypedStruct{}
+			if !tt.nilValue {
+				value, err := structpb.NewStruct(tt.values)
+				if err != nil {
+					t.Fatalf("NewStruct() error = %v", err)
+				}
+				typed.Value = value
+			}
+			input, err := anypb.New(typed)
+			if err != nil {
+				t.Fatalf("anypb.New() error = %v", err)
+			}
+			parser := &ConfigParser{}
+			if tt.manager != nil {
+				parser = NewConfigParser(tt.manager)
+			}
+			result, err := parser.Parse(input, &fakeConfigCallbackHandler{})
+			if tt.expectError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.expectError) {
+					t.Fatalf("Parse() error = %v, want containing %q", err, tt.expectError)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Parse() error = %v", err)
+				}
+				cfg := result.(*FilterConfig)
+				if cfg.EnableJWTAuth != tt.expectJWT {
+					t.Errorf("EnableJWTAuth = %t, want %t", cfg.EnableJWTAuth, tt.expectJWT)
+				}
+				if got := cfg.GetTrafficAccessTokenHeader(); got != tt.expectHeader {
+					t.Errorf("JWT header = %q, want %q", got, tt.expectHeader)
+				}
+			}
+			if tt.manager != nil && !reflect.DeepEqual(tt.manager.configuredWith, tt.expectConfigured) {
+				t.Errorf("Configure calls = %v, want %v", tt.manager.configuredWith, tt.expectConfigured)
+			}
+		})
+	}
+}
+
+func TestConfigParserProcessWideJWTMode(t *testing.T) {
+	tests := []struct {
+		name            string
+		childValues     map[string]any
+		parseRouteFirst bool
+		expectError     string
+		expectHeader    string
+	}{
+		{
+			name:            "route parsed first does not configure process mode",
+			childValues:     map[string]any{},
+			parseRouteFirst: true,
+			expectHeader:    "x-global-jwt",
+		},
+		{
+			name:         "explicit route enable is rejected",
+			childValues:  map[string]any{"enable-auth": true, "enable-jwt-auth": true},
+			expectError:  "cannot be configured per route",
+			expectHeader: "x-global-jwt",
+		},
+		{
+			name:         "explicit route disable is rejected",
+			childValues:  map[string]any{"enable-jwt-auth": false},
+			expectError:  "cannot be configured per route",
+			expectHeader: "x-global-jwt",
+		},
+		{
+			name: "explicit route header overrides global header",
+			childValues: map[string]any{
+				"traffic-access-token-header": "x-route-jwt",
+			},
+			expectHeader: "x-route-jwt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := &fakeJWTAuthManager{}
+			parser := NewConfigParser(manager)
+			if tt.parseRouteFirst {
+				_, err := parser.Parse(typedFilterConfig(t, map[string]any{}), nil)
+				require.NoError(t, err)
+				assert.Empty(t, manager.configuredWith)
+			}
+
+			parentInput := typedFilterConfig(t, map[string]any{
+				"enable-auth":                 true,
+				"enable-jwt-auth":             true,
+				"traffic-access-token-header": "x-global-jwt",
+			})
+			parentResult, err := parser.Parse(parentInput, &fakeConfigCallbackHandler{})
+			require.NoError(t, err)
+
+			childResult, err := parser.Parse(typedFilterConfig(t, tt.childValues), nil)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				require.NoError(t, err)
+				merged := parser.Merge(parentResult, childResult).(*FilterConfig)
+				assert.True(t, merged.EnableJWTAuth)
+				assert.Equal(t, tt.expectHeader, merged.GetTrafficAccessTokenHeader())
+			}
+			assert.Equal(t, []bool{true}, manager.configuredWith)
+		})
+	}
+}
+
+func typedFilterConfig(t *testing.T, values map[string]any) *anypb.Any {
+	t.Helper()
+	value, err := structpb.NewStruct(values)
+	require.NoError(t, err)
+	input, err := anypb.New(&v3.TypedStruct{Value: value})
+	require.NoError(t, err)
+	return input
 }
 
 func TestConfigParserParse(t *testing.T) {
@@ -386,5 +623,26 @@ func TestConfigParserMerge(t *testing.T) {
 				t.Error("Merge() returned FilterConfig with nil Adapter")
 			}
 		})
+	}
+}
+
+func TestConfigParserMergeJWT(t *testing.T) {
+	manager := &fakeJWTAuthManager{}
+	parser := NewConfigParser(manager)
+	parent := newFilterConfig(&Config{EnableAuth: true}, manager)
+	child := newFilterConfig(&Config{
+		EnableJWTAuth:            true,
+		TrafficAccessTokenHeader: "x-route-jwt",
+	}, manager)
+
+	merged := parser.Merge(parent, child).(*FilterConfig)
+	if !merged.EnableAuth || !merged.EnableJWTAuth {
+		t.Fatalf("merged auth modes = (%t, %t), want both true", merged.EnableAuth, merged.EnableJWTAuth)
+	}
+	if got := merged.GetTrafficAccessTokenHeader(); got != "x-route-jwt" {
+		t.Errorf("merged JWT header = %q, want %q", got, "x-route-jwt")
+	}
+	if merged.jwtAuthManager != manager {
+		t.Error("merged JWT manager was not preserved")
 	}
 }

--- a/pkg/sandbox-gateway/filter/config_test.go
+++ b/pkg/sandbox-gateway/filter/config_test.go
@@ -230,6 +230,13 @@ func TestConfigParserJWT(t *testing.T) {
 			expectHeader:     DefaultTrafficAccessTokenHeader,
 		},
 		{
+			name:             "global nil value reports manager error",
+			nilValue:         true,
+			manager:          &fakeJWTAuthManager{configureErr: errors.New("conflict")},
+			expectError:      "conflict",
+			expectConfigured: []bool{false},
+		},
+		{
 			name:             "JWT enabled",
 			values:           map[string]any{"enable-auth": true, "enable-jwt-auth": true},
 			manager:          &fakeJWTAuthManager{},
@@ -243,6 +250,13 @@ func TestConfigParserJWT(t *testing.T) {
 			manager:          &fakeJWTAuthManager{},
 			expectConfigured: []bool{false},
 			expectHeader:     DefaultTrafficAccessTokenHeader,
+		},
+		{
+			name:         "JWT requires authentication",
+			values:       map[string]any{"enable-jwt-auth": true},
+			manager:      &fakeJWTAuthManager{},
+			expectError:  "requires enable-auth",
+			expectHeader: DefaultTrafficAccessTokenHeader,
 		},
 		{
 			name:        "missing manager",
@@ -419,7 +433,7 @@ func TestConfigParserParse(t *testing.T) {
 	tests := []struct {
 		name              string
 		input             *anypb.Any
-		wantErr           bool
+		expectError       string
 		wantSandboxHeader string
 		wantHostHeader    string
 		wantPortHeader    string
@@ -433,7 +447,6 @@ func TestConfigParserParse(t *testing.T) {
 				a, _ := anypb.New(ts)
 				return a
 			}(),
-			wantErr:           false,
 			wantSandboxHeader: DefaultSandboxHeaderName,
 			wantHostHeader:    DefaultHostHeaderName,
 			wantPortHeader:    DefaultSandboxPortHeader,
@@ -447,7 +460,6 @@ func TestConfigParserParse(t *testing.T) {
 				a, _ := anypb.New(ts)
 				return a
 			}(),
-			wantErr:           false,
 			wantSandboxHeader: DefaultSandboxHeaderName,
 			wantHostHeader:    DefaultHostHeaderName,
 			wantPortHeader:    DefaultSandboxPortHeader,
@@ -463,7 +475,6 @@ func TestConfigParserParse(t *testing.T) {
 				a, _ := anypb.New(ts)
 				return a
 			}(),
-			wantErr:           false,
 			wantSandboxHeader: "x-custom-sandbox",
 			wantHostHeader:    DefaultHostHeaderName,
 			wantPortHeader:    DefaultSandboxPortHeader,
@@ -482,7 +493,6 @@ func TestConfigParserParse(t *testing.T) {
 				a, _ := anypb.New(ts)
 				return a
 			}(),
-			wantErr:           false,
 			wantSandboxHeader: "x-sandbox",
 			wantHostHeader:    "X-Forwarded-Host",
 			wantPortHeader:    "x-port",
@@ -498,24 +508,28 @@ func TestConfigParserParse(t *testing.T) {
 				a, _ := anypb.New(ts)
 				return a
 			}(),
-			wantErr:           false,
 			wantSandboxHeader: DefaultSandboxHeaderName,
 			wantHostHeader:    DefaultHostHeaderName,
 			wantPortHeader:    DefaultSandboxPortHeader,
 			wantDefaultPort:   DefaultSandboxPort,
 			wantEnableAuth:    true,
 		},
+		{
+			name:        "invalid field type",
+			input:       typedFilterConfig(t, map[string]any{"default-port": true}),
+			expectError: "failed to parse config",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := parser.Parse(tt.input, nil)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("Parse() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if tt.wantErr {
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
 				return
 			}
+			require.NoError(t, err)
 			fc, ok := result.(*FilterConfig)
 			if !ok {
 				t.Fatalf("Parse() returned %T, want *FilterConfig", result)

--- a/pkg/sandbox-gateway/filter/config_test.go
+++ b/pkg/sandbox-gateway/filter/config_test.go
@@ -174,8 +174,8 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.DefaultPort != "49983" {
 		t.Errorf("DefaultConfig().DefaultPort = %q, want %q", cfg.DefaultPort, "49983")
 	}
-	if cfg.EnableAuth || cfg.EnableJWTAuth {
-		t.Errorf("DefaultConfig() auth modes = (%t, %t), want both false", cfg.EnableAuth, cfg.EnableJWTAuth)
+	if cfg.EnableAuth || cfg.EnableJWTAuth || cfg.EnableRuntimeMTLS {
+		t.Errorf("DefaultConfig() enabled modes = (%t, %t, %t), want all false", cfg.EnableAuth, cfg.EnableJWTAuth, cfg.EnableRuntimeMTLS)
 	}
 	if cfg.GetTrafficAccessTokenHeader() != DefaultTrafficAccessTokenHeader {
 		t.Errorf("GetTrafficAccessTokenHeader() = %q, want %q", cfg.GetTrafficAccessTokenHeader(), DefaultTrafficAccessTokenHeader)
@@ -372,6 +372,34 @@ func TestConfigParserProcessWideJWTMode(t *testing.T) {
 				assert.Equal(t, tt.expectHeader, merged.GetTrafficAccessTokenHeader())
 			}
 			assert.Equal(t, []bool{true}, manager.configuredWith)
+		})
+	}
+}
+
+func TestConfigParserProcessWideRuntimeMTLS(t *testing.T) {
+	tests := []struct {
+		name        string
+		callbacks   api.ConfigCallbackHandler
+		value       bool
+		expectError string
+	}{
+		{name: "global enable", callbacks: &fakeConfigCallbackHandler{}, value: true},
+		{name: "global disable", callbacks: &fakeConfigCallbackHandler{}},
+		{name: "route enable rejected", value: true, expectError: "process-wide"},
+		{name: "route disable rejected", expectError: "process-wide"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &ConfigParser{}
+			result, err := parser.Parse(typedFilterConfig(t, map[string]any{"enable-runtime-mtls": tt.value}), tt.callbacks)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.value, result.(*FilterConfig).EnableRuntimeMTLS)
 		})
 	}
 }

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -118,10 +118,8 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 		return api.LocalReply
 	}
 
-	if f.config.EnableAuth {
-		if status := f.authenticate(header, route); status != api.Continue {
-			return status
-		}
+	if status := f.authenticate(header, route); status != api.Continue {
+		return status
 	}
 
 	// Apply extra headers from the adapter (e.g., :path rewrite for kruise custom protocol)
@@ -141,8 +139,18 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 }
 
 func (f *sandboxFilter) authenticate(header api.RequestHeaderMap, route proxyutils.Route) api.StatusType {
-	if f.config.EnableJWTAuth {
+	if route.RequireTrafficAuth {
+		if !f.config.EnableJWTAuth {
+			return f.verifierUnavailable(route.ID)
+		}
 		return f.authenticateJWT(header, route)
+	}
+	if f.config.EnableJWTAuth {
+		header.Del(f.config.GetTrafficAccessTokenHeader())
+		return api.Continue
+	}
+	if !f.config.EnableAuth {
+		return api.Continue
 	}
 	if route.AccessToken == "" {
 		return api.Continue

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -27,6 +27,7 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
+	proxyutils "github.com/openkruise/agents/pkg/utils/proxyutils"
 )
 
 var logger *zap.Logger
@@ -46,17 +47,19 @@ const (
 func FilterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
 	cfg := c.(*FilterConfig)
 	return &sandboxFilter{
-		callbacks: callbacks,
-		config:    cfg.Config,
-		adapter:   cfg.Adapter,
+		callbacks:      callbacks,
+		config:         cfg.Config,
+		adapter:        cfg.Adapter,
+		jwtAuthManager: cfg.jwtAuthManager,
 	}
 }
 
 type sandboxFilter struct {
 	api.PassThroughStreamFilter
-	callbacks api.FilterCallbackHandler
-	config    *Config
-	adapter   *adapters.E2BAdapter
+	callbacks      api.FilterCallbackHandler
+	config         *Config
+	adapter        *adapters.E2BAdapter
+	jwtAuthManager JWTAuthManager
 }
 
 func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream bool) api.StatusType {
@@ -111,21 +114,9 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 		return api.LocalReply
 	}
 
-	// Authenticate the request if auth is enabled and the sandbox has an access token configured.
-	// When EnableAuth is false (default), the gateway skips token validation for backward compatibility.
-	if f.config.EnableAuth && route.AccessToken != "" {
-		requestToken, _ := header.Get(accessTokenHeader)
-		if subtle.ConstantTimeCompare([]byte(requestToken), []byte(route.AccessToken)) != 1 {
-			logger.Warn("Access token mismatch",
-				zap.String("sandboxID", sandboxID))
-			f.callbacks.DecoderFilterCallbacks().SendLocalReply(
-				401,
-				"unauthorized: invalid or missing access token",
-				nil,
-				-1,
-				"unauthorized",
-			)
-			return api.LocalReply
+	if f.config.EnableAuth {
+		if status := f.authenticate(header, route); status != api.Continue {
+			return status
 		}
 	}
 
@@ -139,4 +130,75 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 
 	logger.Debug("Upstream override set successfully", zap.String("upstreamHost", upstreamHost))
 	return api.Continue
+}
+
+func (f *sandboxFilter) authenticate(header api.RequestHeaderMap, route proxyutils.Route) api.StatusType {
+	if f.config.EnableJWTAuth {
+		return f.authenticateJWT(header, route)
+	}
+	if route.AccessToken == "" {
+		return api.Continue
+	}
+	requestToken, _ := header.Get(accessTokenHeader)
+	if subtle.ConstantTimeCompare([]byte(requestToken), []byte(route.AccessToken)) == 1 {
+		return api.Continue
+	}
+	logger.Warn("Access token mismatch", zap.String("sandboxID", route.ID))
+	f.callbacks.DecoderFilterCallbacks().SendLocalReply(
+		401,
+		"unauthorized: invalid or missing access token",
+		nil,
+		-1,
+		"unauthorized",
+	)
+	return api.LocalReply
+}
+
+func (f *sandboxFilter) authenticateJWT(header api.RequestHeaderMap, route proxyutils.Route) api.StatusType {
+	if f.jwtAuthManager == nil {
+		return f.verifierUnavailable(route.ID)
+	}
+	verifier := f.jwtAuthManager.Current()
+	if verifier == nil {
+		return f.verifierUnavailable(route.ID)
+	}
+	headerName := f.config.GetTrafficAccessTokenHeader()
+	rawJWT, _ := header.Get(headerName)
+	claims, err := verifier.Verify(rawJWT)
+	if err != nil {
+		logger.Warn("Traffic access token verification failed", zap.String("sandboxID", route.ID), zap.Error(err))
+		f.callbacks.DecoderFilterCallbacks().SendLocalReply(
+			401,
+			"unauthorized: invalid or missing traffic access token",
+			nil,
+			-1,
+			"unauthorized",
+		)
+		return api.LocalReply
+	}
+	if claims.Sandbox.SandboxID != route.ID || claims.Sandbox.SandboxUID != string(route.UID) {
+		logger.Warn("Traffic access token sandbox mismatch", zap.String("sandboxID", route.ID))
+		f.callbacks.DecoderFilterCallbacks().SendLocalReply(
+			401,
+			"unauthorized: traffic access token does not match sandbox",
+			nil,
+			-1,
+			"unauthorized",
+		)
+		return api.LocalReply
+	}
+	header.Del(headerName)
+	return api.Continue
+}
+
+func (f *sandboxFilter) verifierUnavailable(sandboxID string) api.StatusType {
+	logger.Warn("Traffic access token verifier is unavailable", zap.String("sandboxID", sandboxID))
+	f.callbacks.DecoderFilterCallbacks().SendLocalReply(
+		503,
+		"service unavailable: traffic access token verifier is not ready",
+		nil,
+		-1,
+		"jwt_verifier_not_ready",
+	)
+	return api.LocalReply
 }

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -184,22 +184,22 @@ func (f *sandboxFilter) authenticateJWT(header api.RequestHeaderMap, route proxy
 	if err != nil {
 		logger.Warn("Traffic access token verification failed", zap.String("sandboxID", route.ID), zap.Error(err))
 		f.callbacks.DecoderFilterCallbacks().SendLocalReply(
-			401,
-			"unauthorized: invalid or missing traffic access token",
+			403,
+			"forbidden: invalid or missing traffic access token",
 			nil,
 			-1,
-			"unauthorized",
+			"forbidden",
 		)
 		return api.LocalReply
 	}
 	if claims.Sandbox.SandboxID != route.ID || claims.Sandbox.SandboxUID != string(route.UID) {
 		logger.Warn("Traffic access token sandbox mismatch", zap.String("sandboxID", route.ID))
 		f.callbacks.DecoderFilterCallbacks().SendLocalReply(
-			401,
-			"unauthorized: traffic access token does not match sandbox",
+			403,
+			"forbidden: traffic access token does not match sandbox",
 			nil,
 			-1,
-			"unauthorized",
+			"forbidden",
 		)
 		return api.LocalReply
 	}

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -27,6 +27,7 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
+	"github.com/openkruise/agents/pkg/utils"
 	proxyutils "github.com/openkruise/agents/pkg/utils/proxyutils"
 )
 
@@ -42,6 +43,9 @@ const (
 	// accessTokenHeader is the HTTP header name that clients must set
 	// to carry the sandbox access token for authentication.
 	accessTokenHeader = "x-access-token"
+	// runtimeMTLSMetadataNamespace and runtimeMTLSMetadataKey select the mTLS ORIGINAL_DST cluster.
+	runtimeMTLSMetadataNamespace = "agents.kruise.io/sandbox-gateway"
+	runtimeMTLSMetadataKey       = "upstream-mtls"
 )
 
 func FilterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
@@ -127,6 +131,10 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 
 	upstreamHost := fmt.Sprintf("%s:%d", route.IP, sandboxPort)
 	f.callbacks.StreamInfo().DynamicMetadata().Set("envoy.lb.original_dst", "host", upstreamHost)
+	if f.config.EnableRuntimeMTLS && sandboxPort == utils.RuntimePort {
+		f.callbacks.StreamInfo().DynamicMetadata().Set(runtimeMTLSMetadataNamespace, runtimeMTLSMetadataKey, true)
+		f.callbacks.ClearRouteCache()
+	}
 
 	logger.Debug("Upstream override set successfully", zap.String("upstreamHost", upstreamHost))
 	return api.Continue

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -17,16 +17,31 @@ limitations under the License.
 package filter
 
 import (
+	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/identity/oidc"
 	"github.com/openkruise/agents/pkg/proxy"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 )
+
+type fakeJWTVerifier struct {
+	claims *oidc.TrafficAccessTokenClaims
+	err    error
+	rawJWT string
+}
+
+func (v *fakeJWTVerifier) Verify(rawJWT string) (*oidc.TrafficAccessTokenClaims, error) {
+	v.rawJWT = rawJWT
+	return v.claims, v.err
+}
 
 // mockRequestHeaderMap implements api.RequestHeaderMap for testing
 type mockRequestHeaderMap struct {
@@ -1101,4 +1116,154 @@ func TestDecodeHeadersAuthDisabled(t *testing.T) {
 	metadata := mockCallbacks.streamInfo.dynamicMetadata.data["envoy.lb.original_dst"]
 	assert.NotNil(t, metadata)
 	assert.Equal(t, "10.0.0.5:49983", metadata["host"])
+}
+
+func TestDecodeHeadersJWTAuthentication(t *testing.T) {
+	const (
+		sandboxID  = "default--jwt-sandbox"
+		sandboxUID = "sandbox-uid"
+	)
+	tests := []struct {
+		name             string
+		managerState     string
+		claims           *oidc.TrafficAccessTokenClaims
+		verifyErr        error
+		routeToken       string
+		headerName       string
+		requestJWT       string
+		expectStatus     api.StatusType
+		expectHTTPCode   int
+		expectJWTRemoved bool
+	}{
+		{
+			name:         "valid JWT ignores route UUID",
+			managerState: "ready",
+			claims: &oidc.TrafficAccessTokenClaims{Sandbox: oidc.SandboxClaims{
+				SandboxID: sandboxID, SandboxUID: sandboxUID,
+			}},
+			routeToken:       "different-route-token",
+			requestJWT:       "valid-jwt",
+			expectStatus:     api.Continue,
+			expectJWTRemoved: true,
+		},
+		{
+			name:         "valid JWT with empty route token",
+			managerState: "ready",
+			claims: &oidc.TrafficAccessTokenClaims{Sandbox: oidc.SandboxClaims{
+				SandboxID: sandboxID, SandboxUID: sandboxUID,
+			}},
+			requestJWT:       "valid-jwt",
+			expectStatus:     api.Continue,
+			expectJWTRemoved: true,
+		},
+		{
+			name:         "custom JWT header",
+			managerState: "ready",
+			claims: &oidc.TrafficAccessTokenClaims{Sandbox: oidc.SandboxClaims{
+				SandboxID: sandboxID, SandboxUID: sandboxUID,
+			}},
+			headerName:       "x-custom-jwt",
+			requestJWT:       "custom-jwt",
+			expectStatus:     api.Continue,
+			expectJWTRemoved: true,
+		},
+		{
+			name:           "missing JWT",
+			managerState:   "ready",
+			verifyErr:      errors.New("token must not be empty"),
+			expectStatus:   api.LocalReply,
+			expectHTTPCode: http.StatusUnauthorized,
+		},
+		{
+			name:           "invalid JWT",
+			managerState:   "ready",
+			requestJWT:     "invalid-jwt",
+			verifyErr:      errors.New("invalid signature"),
+			expectStatus:   api.LocalReply,
+			expectHTTPCode: http.StatusUnauthorized,
+		},
+		{
+			name:         "sandbox ID mismatch",
+			managerState: "ready",
+			requestJWT:   "valid-jwt",
+			claims: &oidc.TrafficAccessTokenClaims{Sandbox: oidc.SandboxClaims{
+				SandboxID: "other", SandboxUID: sandboxUID,
+			}},
+			expectStatus:   api.LocalReply,
+			expectHTTPCode: http.StatusUnauthorized,
+		},
+		{
+			name:         "sandbox UID mismatch",
+			managerState: "ready",
+			requestJWT:   "valid-jwt",
+			claims: &oidc.TrafficAccessTokenClaims{Sandbox: oidc.SandboxClaims{
+				SandboxID: sandboxID, SandboxUID: "other",
+			}},
+			expectStatus:   api.LocalReply,
+			expectHTTPCode: http.StatusUnauthorized,
+		},
+		{
+			name:           "manager missing",
+			managerState:   "missing",
+			requestJWT:     "valid-jwt",
+			expectStatus:   api.LocalReply,
+			expectHTTPCode: http.StatusServiceUnavailable,
+		},
+		{
+			name:           "verifier initializing",
+			managerState:   "initializing",
+			requestJWT:     "valid-jwt",
+			expectStatus:   api.LocalReply,
+			expectHTTPCode: http.StatusServiceUnavailable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry.GetRegistry().Clear()
+			t.Cleanup(registry.GetRegistry().Clear)
+			registry.GetRegistry().Update(sandboxID, proxy.Route{
+				ID: sandboxID, UID: types.UID(sandboxUID), IP: "10.0.0.1",
+				State: agentsv1alpha1.SandboxStateRunning, ResourceVersion: "1", AccessToken: tt.routeToken,
+			})
+
+			headerName := tt.headerName
+			if headerName == "" {
+				headerName = DefaultTrafficAccessTokenHeader
+			}
+			cfg := DefaultConfig()
+			cfg.EnableAuth = true
+			cfg.EnableJWTAuth = true
+			cfg.TrafficAccessTokenHeader = headerName
+			callbacks := newMockFilterCallbackHandler()
+			var manager JWTAuthManager
+			var verifier *fakeJWTVerifier
+			switch tt.managerState {
+			case "ready":
+				verifier = &fakeJWTVerifier{claims: tt.claims, err: tt.verifyErr}
+				manager = &fakeJWTAuthManager{verifier: verifier}
+			case "initializing":
+				manager = &fakeJWTAuthManager{}
+			}
+			filter := &sandboxFilter{
+				callbacks: callbacks, config: cfg, adapter: defaultTestAdapter(), jwtAuthManager: manager,
+			}
+			header := newMockRequestHeaderMap()
+			header.Set(DefaultSandboxHeaderName, sandboxID)
+			header.Set(accessTokenHeader, "runtime-token")
+			if tt.requestJWT != "" {
+				header.Set(headerName, tt.requestJWT)
+			}
+
+			status := filter.DecodeHeaders(header, false)
+			assert.Equal(t, tt.expectStatus, status)
+			assert.Equal(t, tt.expectHTTPCode, callbacks.decoderCallbacks.replyStatusCode)
+			assert.Equal(t, "runtime-token", header.GetRaw(accessTokenHeader), "x-access-token must be preserved")
+			_, jwtPresent := header.Get(headerName)
+			assert.Equal(t, !tt.expectJWTRemoved && tt.requestJWT != "", jwtPresent)
+			if verifier != nil {
+				assert.Equal(t, tt.requestJWT, verifier.rawJWT)
+			}
+		})
+	}
 }

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -1252,7 +1252,16 @@ func TestDecodeHeadersJWTAuthentication(t *testing.T) {
 		expectStatus     api.StatusType
 		expectHTTPCode   int
 		expectJWTRemoved bool
+		skipRouteAuth    bool
 	}{
+		{
+			name:             "route without JWT requirement skips verification",
+			managerState:     "missing",
+			requestJWT:       "unused-jwt",
+			expectStatus:     api.Continue,
+			expectJWTRemoved: true,
+			skipRouteAuth:    true,
+		},
 		{
 			name:         "valid JWT ignores route UUID",
 			managerState: "ready",
@@ -1343,6 +1352,7 @@ func TestDecodeHeadersJWTAuthentication(t *testing.T) {
 			registry.GetRegistry().Update(sandboxID, proxy.Route{
 				ID: sandboxID, UID: types.UID(sandboxUID), IP: "10.0.0.1",
 				State: agentsv1alpha1.SandboxStateRunning, ResourceVersion: "1", AccessToken: tt.routeToken,
+				RequireTrafficAuth: !tt.skipRouteAuth,
 			})
 
 			headerName := tt.headerName
@@ -1382,6 +1392,40 @@ func TestDecodeHeadersJWTAuthentication(t *testing.T) {
 			if verifier != nil {
 				assert.Equal(t, tt.requestJWT, verifier.rawJWT)
 			}
+		})
+	}
+}
+
+func TestDecodeHeadersRequiredJWTWithoutJWTMode(t *testing.T) {
+	const sandboxID = "default--jwt-required"
+	tests := []struct {
+		name       string
+		enableAuth bool
+	}{
+		{name: "authentication disabled"},
+		{name: "UUID authentication enabled", enableAuth: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry.GetRegistry().Clear()
+			t.Cleanup(registry.GetRegistry().Clear)
+			registry.GetRegistry().Update(sandboxID, proxy.Route{
+				ID: sandboxID, IP: "10.0.0.1", State: agentsv1alpha1.SandboxStateRunning,
+				ResourceVersion: "1", RequireTrafficAuth: true,
+			})
+
+			cfg := DefaultConfig()
+			cfg.EnableAuth = tt.enableAuth
+			callbacks := newMockFilterCallbackHandler()
+			filter := &sandboxFilter{callbacks: callbacks, config: cfg, adapter: defaultTestAdapter()}
+			header := newMockRequestHeaderMap()
+			header.Set(DefaultSandboxHeaderName, sandboxID)
+
+			status := filter.DecodeHeaders(header, false)
+			assert.Equal(t, api.LocalReply, status)
+			assert.Equal(t, http.StatusServiceUnavailable, callbacks.decoderCallbacks.replyStatusCode)
+			assert.Equal(t, "jwt_verifier_not_ready", callbacks.decoderCallbacks.replyDetails)
 		})
 	}
 }

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -1299,7 +1299,7 @@ func TestDecodeHeadersJWTAuthentication(t *testing.T) {
 			managerState:   "ready",
 			verifyErr:      errors.New("token must not be empty"),
 			expectStatus:   api.LocalReply,
-			expectHTTPCode: http.StatusUnauthorized,
+			expectHTTPCode: http.StatusForbidden,
 		},
 		{
 			name:           "invalid JWT",
@@ -1307,7 +1307,7 @@ func TestDecodeHeadersJWTAuthentication(t *testing.T) {
 			requestJWT:     "invalid-jwt",
 			verifyErr:      errors.New("invalid signature"),
 			expectStatus:   api.LocalReply,
-			expectHTTPCode: http.StatusUnauthorized,
+			expectHTTPCode: http.StatusForbidden,
 		},
 		{
 			name:         "sandbox ID mismatch",
@@ -1317,7 +1317,7 @@ func TestDecodeHeadersJWTAuthentication(t *testing.T) {
 				SandboxID: "other", SandboxUID: sandboxUID,
 			}},
 			expectStatus:   api.LocalReply,
-			expectHTTPCode: http.StatusUnauthorized,
+			expectHTTPCode: http.StatusForbidden,
 		},
 		{
 			name:         "sandbox UID mismatch",
@@ -1327,7 +1327,7 @@ func TestDecodeHeadersJWTAuthentication(t *testing.T) {
 				SandboxID: sandboxID, SandboxUID: "other",
 			}},
 			expectStatus:   api.LocalReply,
-			expectHTTPCode: http.StatusUnauthorized,
+			expectHTTPCode: http.StatusForbidden,
 		},
 		{
 			name:           "manager missing",

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -285,6 +285,7 @@ func (m *mockDecoderFilterCallbacks) SetUpstreamOverrideHost(host string, strict
 type mockFilterCallbackHandler struct {
 	streamInfo       *mockStreamInfo
 	decoderCallbacks *mockDecoderFilterCallbacks
+	clearRouteCalls  int
 }
 
 func newMockFilterCallbackHandler() *mockFilterCallbackHandler {
@@ -298,7 +299,7 @@ func (m *mockFilterCallbackHandler) StreamInfo() api.StreamInfo {
 	return m.streamInfo
 }
 
-func (m *mockFilterCallbackHandler) ClearRouteCache() {}
+func (m *mockFilterCallbackHandler) ClearRouteCache() { m.clearRouteCalls++ }
 
 func (m *mockFilterCallbackHandler) RefreshRouteCache() {}
 
@@ -566,6 +567,123 @@ func TestDecodeHeadersSandboxRunning(t *testing.T) {
 	metadata := mockCallbacks.streamInfo.dynamicMetadata.data["envoy.lb.original_dst"]
 	assert.NotNil(t, metadata)
 	assert.Equal(t, "10.0.0.5:49983", metadata["host"])
+}
+
+func TestDecodeHeadersRuntimeMTLSRouting(t *testing.T) {
+	tests := []struct {
+		name     string
+		enabled  bool
+		request  func() api.RequestHeaderMap
+		wantMTLS bool
+		wantHost string
+		wantPath string
+	}{
+		{
+			name: "disabled default port remains plaintext",
+			request: func() api.RequestHeaderMap {
+				header := newMockRequestHeaderMap()
+				header.Set(DefaultSandboxHeaderName, "default--runtime-mtls")
+				return header
+			},
+			wantHost: "10.0.0.9:49983",
+		},
+		{
+			name:    "enabled default port",
+			enabled: true,
+			request: func() api.RequestHeaderMap {
+				header := newMockRequestHeaderMap()
+				header.Set(DefaultSandboxHeaderName, "default--runtime-mtls")
+				return header
+			},
+			wantMTLS: true,
+			wantHost: "10.0.0.9:49983",
+		},
+		{
+			name:    "enabled explicit runtime port",
+			enabled: true,
+			request: func() api.RequestHeaderMap {
+				header := newMockRequestHeaderMap()
+				header.Set(DefaultSandboxHeaderName, "default--runtime-mtls")
+				header.Set(DefaultSandboxPortHeader, "49983")
+				return header
+			},
+			wantMTLS: true,
+			wantHost: "10.0.0.9:49983",
+		},
+		{
+			name:    "enabled hostname runtime port",
+			enabled: true,
+			request: func() api.RequestHeaderMap {
+				return &mockRequestHeaderMapWithHost{
+					mockRequestHeaderMap: *newMockRequestHeaderMap(),
+					hostValue:            "49983-default--runtime-mtls.example.com",
+				}
+			},
+			wantMTLS: true,
+			wantHost: "10.0.0.9:49983",
+		},
+		{
+			name:    "enabled customized path runtime port",
+			enabled: true,
+			request: func() api.RequestHeaderMap {
+				return &mockRequestHeaderMapCustom{
+					mockRequestHeaderMap: *newMockRequestHeaderMap(),
+					pathValue:            "/kruise/default--runtime-mtls/49983/health",
+				}
+			},
+			wantMTLS: true,
+			wantHost: "10.0.0.9:49983",
+			wantPath: "/health",
+		},
+		{
+			name:    "enabled non-runtime port remains plaintext",
+			enabled: true,
+			request: func() api.RequestHeaderMap {
+				header := newMockRequestHeaderMap()
+				header.Set(DefaultSandboxHeaderName, "default--runtime-mtls")
+				header.Set(DefaultSandboxPortHeader, "8080")
+				return header
+			},
+			wantHost: "10.0.0.9:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := registry.GetRegistry()
+			r.Clear()
+			t.Cleanup(r.Clear)
+			r.Update("default--runtime-mtls", proxy.Route{
+				IP:              "10.0.0.9",
+				State:           agentsv1alpha1.SandboxStateRunning,
+				ResourceVersion: "1",
+			})
+
+			cfg := DefaultConfig()
+			cfg.EnableRuntimeMTLS = tt.enabled
+			callbacks := newMockFilterCallbackHandler()
+			gatewayFilter := &sandboxFilter{callbacks: callbacks, config: cfg, adapter: NewFilterConfig(cfg).Adapter}
+			header := tt.request()
+
+			status := gatewayFilter.DecodeHeaders(header, true)
+
+			assert.Equal(t, api.Continue, status)
+			assert.Equal(t, tt.wantHost, callbacks.streamInfo.dynamicMetadata.data["envoy.lb.original_dst"]["host"])
+			metadata := callbacks.streamInfo.dynamicMetadata.data[runtimeMTLSMetadataNamespace]
+			if tt.wantMTLS {
+				assert.Equal(t, true, metadata[runtimeMTLSMetadataKey])
+				assert.Equal(t, 1, callbacks.clearRouteCalls)
+			} else {
+				assert.Nil(t, metadata)
+				assert.Zero(t, callbacks.clearRouteCalls)
+			}
+			if tt.wantPath != "" {
+				path, ok := header.Get(":path")
+				assert.True(t, ok)
+				assert.Equal(t, tt.wantPath, path)
+			}
+		})
+	}
 }
 
 // TestDecodeHeadersSandboxRunningHostFallback tests successful case via host header

--- a/pkg/sandbox-gateway/jwtauth/manager.go
+++ b/pkg/sandbox-gateway/jwtauth/manager.go
@@ -1,0 +1,377 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package jwtauth manages process-wide initialization of the gateway JWT verifier.
+package jwtauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/openkruise/agents/pkg/identity/oidc"
+)
+
+const (
+	defaultInitialBackoff = time.Second
+	defaultMaxBackoff     = 30 * time.Second
+)
+
+var (
+	// ErrAwaitingConfig indicates that Configure has not accepted a configuration yet.
+	ErrAwaitingConfig = errors.New("JWT authentication is awaiting configuration")
+	// ErrInitializing indicates that an enabled manager has not published a verifier yet.
+	ErrInitializing = errors.New("JWT authentication is initializing")
+)
+
+// State describes the manager's process-level lifecycle.
+type State uint32
+
+const (
+	// AwaitingConfig is the initial state before Configure succeeds.
+	AwaitingConfig State = iota
+	// Disabled indicates that JWT authentication was explicitly disabled.
+	Disabled
+	// Initializing indicates that JWT authentication is enabled but has no verifier yet.
+	Initializing
+	// Ready indicates that a verifier has been published.
+	Ready
+)
+
+// OptionsSource resolves and validates the local OIDC configuration.
+type OptionsSource func() (oidc.Options, error)
+
+// VerifierLoader constructs a verifier using Kubernetes-backed OIDC discovery data.
+type VerifierLoader func(context.Context, client.Reader, oidc.Options) (oidc.Verifier, error)
+
+type verifierHolder struct {
+	verifier oidc.Verifier
+}
+
+// Manager coordinates one-time, process-level OIDC verifier initialization.
+type Manager struct {
+	optionsSource  OptionsSource
+	loader         VerifierLoader
+	initialBackoff time.Duration
+	maxBackoff     time.Duration
+	wake           chan struct{}
+
+	state    atomic.Uint32
+	verifier atomic.Pointer[verifierHolder]
+
+	mu          sync.Mutex
+	configured  bool
+	options     oidc.Options
+	reader      client.Reader
+	started     bool
+	lastFailure error
+}
+
+// NewManager creates a manager using the production OIDC dependencies.
+func NewManager() *Manager {
+	return NewManagerWithDependencies(
+		oidc.OptionsFromEnvironment,
+		oidc.NewVerifier,
+		defaultInitialBackoff,
+		defaultMaxBackoff,
+	)
+}
+
+// NewManagerWithDependencies creates a manager with injectable dependencies.
+func NewManagerWithDependencies(
+	optionsSource OptionsSource,
+	loader VerifierLoader,
+	initialBackoff, maxBackoff time.Duration,
+) *Manager {
+	if initialBackoff < 0 {
+		initialBackoff = 0
+	}
+	if maxBackoff < 0 {
+		maxBackoff = 0
+	}
+	if maxBackoff < initialBackoff {
+		initialBackoff = maxBackoff
+	}
+
+	m := &Manager{
+		optionsSource:  optionsSource,
+		loader:         loader,
+		initialBackoff: initialBackoff,
+		maxBackoff:     maxBackoff,
+		wake:           make(chan struct{}, 1),
+	}
+	m.state.Store(uint32(AwaitingConfig))
+	return m
+}
+
+// Configure selects the manager's immutable enabled or disabled mode.
+// Enabling only resolves local options; verifier construction happens in Start.
+func (m *Manager) Configure(enabled bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.configured {
+		return m.validateRepeatedConfiguration(enabled)
+	}
+
+	if !enabled {
+		m.configured = true
+		m.state.Store(uint32(Disabled))
+		m.notify()
+		return nil
+	}
+	if m.optionsSource == nil {
+		return errors.New("configure JWT authentication: options source is nil")
+	}
+
+	options, err := m.optionsSource()
+	if err != nil {
+		return fmt.Errorf("configure JWT authentication: %w", err)
+	}
+	m.options = options
+	m.configured = true
+	m.state.Store(uint32(Initializing))
+	m.notify()
+	return nil
+}
+
+func (m *Manager) validateRepeatedConfiguration(enabled bool) error {
+	configuredEnabled := State(m.state.Load()) != Disabled
+	if enabled != configuredEnabled {
+		return fmt.Errorf("JWT authentication is already configured with enabled=%t", configuredEnabled)
+	}
+	if !enabled {
+		return nil
+	}
+	if m.optionsSource == nil {
+		return errors.New("reconfigure JWT authentication: options source is nil")
+	}
+
+	options, err := m.optionsSource()
+	if err != nil {
+		return fmt.Errorf("reconfigure JWT authentication: %w", err)
+	}
+	if !reflect.DeepEqual(options, m.options) {
+		return errors.New("JWT authentication is already configured with different options")
+	}
+	return nil
+}
+
+// SetReader provides the single Kubernetes reader used to construct the verifier.
+func (m *Manager) SetReader(reader client.Reader) error {
+	if isNilReader(reader) {
+		return errors.New("JWT authentication reader must not be nil")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.reader != nil {
+		if sameReader(m.reader, reader) {
+			return nil
+		}
+		return errors.New("JWT authentication reader is already set")
+	}
+	m.reader = reader
+	m.notify()
+	return nil
+}
+
+// Start waits for configuration and a reader, then retries verifier construction.
+func (m *Manager) Start(ctx context.Context) error {
+	m.mu.Lock()
+	if m.started {
+		m.mu.Unlock()
+		return errors.New("JWT authentication manager is already started")
+	}
+	m.started = true
+	m.mu.Unlock()
+
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		state, reader, options := m.startupInputs()
+		switch state {
+		case Disabled, Ready:
+			<-ctx.Done()
+			return nil
+		case Initializing:
+			if reader != nil {
+				return m.loadUntilReady(ctx, reader, options)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-m.wake:
+		}
+	}
+}
+
+func (m *Manager) startupInputs() (State, client.Reader, oidc.Options) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return State(m.state.Load()), m.reader, m.options
+}
+
+func (m *Manager) loadUntilReady(ctx context.Context, reader client.Reader, options oidc.Options) error {
+	backoff := m.initialBackoff
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+		if m.loader == nil {
+			m.recordFailure(ctx, errors.New("verifier loader is nil"))
+		} else {
+			verifier, err := m.loader(ctx, reader, options)
+			if err == nil && !isNilVerifier(verifier) {
+				m.verifier.Store(&verifierHolder{verifier: verifier})
+				m.mu.Lock()
+				m.lastFailure = nil
+				m.state.Store(uint32(Ready))
+				m.mu.Unlock()
+				<-ctx.Done()
+				return nil
+			}
+			if err == nil {
+				err = errors.New("verifier loader returned a nil verifier")
+			}
+			m.recordFailure(ctx, err)
+		}
+
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return nil
+		case <-timer.C:
+		}
+		backoff = nextBackoff(backoff, m.maxBackoff)
+	}
+}
+
+func (m *Manager) recordFailure(ctx context.Context, err error) {
+	m.mu.Lock()
+	m.lastFailure = err
+	m.mu.Unlock()
+	log.FromContext(ctx).Error(err, "failed to initialize traffic access token JWT verifier")
+}
+
+func nextBackoff(current, maximum time.Duration) time.Duration {
+	if current >= maximum || current > maximum-current {
+		return maximum
+	}
+	return current * 2
+}
+
+func (m *Manager) notify() {
+	select {
+	case m.wake <- struct{}{}:
+	default:
+	}
+}
+
+// NeedLeaderElection declares that verifier initialization runs in every process.
+func (m *Manager) NeedLeaderElection() bool {
+	return false
+}
+
+// Current returns the published verifier without locking or blocking.
+func (m *Manager) Current() oidc.Verifier {
+	holder := m.verifier.Load()
+	if holder == nil {
+		return nil
+	}
+	return holder.verifier
+}
+
+// Ready reports whether JWT authentication is usable for the accepted mode.
+func (m *Manager) Ready() error {
+	state := State(m.state.Load())
+	switch state {
+	case Disabled, Ready:
+		return nil
+	case AwaitingConfig:
+		return ErrAwaitingConfig
+	case Initializing:
+		m.mu.Lock()
+		lastFailure := m.lastFailure
+		m.mu.Unlock()
+		if lastFailure != nil {
+			return fmt.Errorf("%w: last verifier initialization failed: %w", ErrInitializing, lastFailure)
+		}
+		return ErrInitializing
+	default:
+		return fmt.Errorf("JWT authentication has unknown state %d", state)
+	}
+}
+
+// State returns the manager's current lifecycle state.
+func (m *Manager) State() State {
+	return State(m.state.Load())
+}
+
+func isNilReader(reader client.Reader) bool {
+	return isNilInterface(reader)
+}
+
+func isNilVerifier(verifier oidc.Verifier) bool {
+	return isNilInterface(verifier)
+}
+
+func isNilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+func sameReader(left, right client.Reader) bool {
+	leftValue := reflect.ValueOf(left)
+	rightValue := reflect.ValueOf(right)
+	if leftValue.Type() != rightValue.Type() {
+		return false
+	}
+	if leftValue.Comparable() {
+		return left == right
+	}
+	switch leftValue.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice:
+		return leftValue.Pointer() == rightValue.Pointer()
+	default:
+		return false
+	}
+}

--- a/pkg/sandbox-gateway/jwtauth/manager.go
+++ b/pkg/sandbox-gateway/jwtauth/manager.go
@@ -163,10 +163,6 @@ func (m *Manager) validateRepeatedConfiguration(enabled bool) error {
 	if !enabled {
 		return nil
 	}
-	if m.optionsSource == nil {
-		return errors.New("reconfigure JWT authentication: options source is nil")
-	}
-
 	options, err := m.optionsSource()
 	if err != nil {
 		return fmt.Errorf("reconfigure JWT authentication: %w", err)
@@ -264,12 +260,7 @@ func (m *Manager) loadUntilReady(ctx context.Context, reader client.Reader, opti
 		timer := time.NewTimer(backoff)
 		select {
 		case <-ctx.Done():
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
+			timer.Stop()
 			return nil
 		case <-timer.C:
 		}

--- a/pkg/sandbox-gateway/jwtauth/manager.go
+++ b/pkg/sandbox-gateway/jwtauth/manager.go
@@ -182,9 +182,6 @@ func (m *Manager) SetReader(reader client.Reader) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.reader != nil {
-		if sameReader(m.reader, reader) {
-			return nil
-		}
 		return errors.New("JWT authentication reader is already set")
 	}
 	m.reader = reader
@@ -345,23 +342,6 @@ func isNilInterface(value any) bool {
 	switch reflected.Kind() {
 	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
 		return reflected.IsNil()
-	default:
-		return false
-	}
-}
-
-func sameReader(left, right client.Reader) bool {
-	leftValue := reflect.ValueOf(left)
-	rightValue := reflect.ValueOf(right)
-	if leftValue.Type() != rightValue.Type() {
-		return false
-	}
-	if leftValue.Comparable() {
-		return left == right
-	}
-	switch leftValue.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice:
-		return leftValue.Pointer() == rightValue.Pointer()
 	default:
 		return false
 	}

--- a/pkg/sandbox-gateway/jwtauth/manager_test.go
+++ b/pkg/sandbox-gateway/jwtauth/manager_test.go
@@ -1,0 +1,611 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jwtauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openkruise/agents/pkg/identity/oidc"
+)
+
+const testTimeout = 2 * time.Second
+
+type fakeVerifier struct {
+	name string
+}
+
+func (v *fakeVerifier) Verify(string) (*oidc.TrafficAccessTokenClaims, error) {
+	return nil, nil
+}
+
+type fakeReader struct {
+	name string
+}
+
+func (r *fakeReader) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return nil
+}
+
+func (r *fakeReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	return nil
+}
+
+func testOptions(name string) oidc.Options {
+	return oidc.Options{DiscoveryURL: "https://" + name + ".example.test/.well-known/openid-configuration"}
+}
+
+func newTestManager(options oidc.Options, loader VerifierLoader) *Manager {
+	return NewManagerWithDependencies(func() (oidc.Options, error) {
+		return options, nil
+	}, loader, time.Millisecond, 4*time.Millisecond)
+}
+
+func startManager(t *testing.T, manager *Manager) (context.CancelFunc, <-chan error) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.Start(ctx)
+	}()
+	require.Eventually(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return manager.started
+	}, testTimeout, time.Millisecond)
+	return cancel, done
+}
+
+func stopManager(t *testing.T, cancel context.CancelFunc, done <-chan error) {
+	t.Helper()
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(testTimeout):
+		t.Fatal("manager did not stop after context cancellation")
+	}
+}
+
+func waitForState(t *testing.T, manager *Manager, expected State) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return manager.State() == expected
+	}, testTimeout, time.Millisecond)
+}
+
+func TestManagerReadiness(t *testing.T) {
+	tests := []struct {
+		name        string
+		configure   bool
+		enabled     bool
+		expectState State
+		expectError string
+	}{
+		{
+			name:        "awaiting configuration",
+			expectState: AwaitingConfig,
+			expectError: "awaiting configuration",
+		},
+		{
+			name:        "disabled is ready",
+			configure:   true,
+			enabled:     false,
+			expectState: Disabled,
+		},
+		{
+			name:        "enabled is initializing",
+			configure:   true,
+			enabled:     true,
+			expectState: Initializing,
+			expectError: "initializing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := newTestManager(testOptions("readiness"), nil)
+			if tt.configure {
+				require.NoError(t, manager.Configure(tt.enabled))
+			}
+
+			assert.Equal(t, tt.expectState, manager.State())
+			assert.Nil(t, manager.Current())
+			assert.False(t, manager.NeedLeaderElection())
+			err := manager.Ready()
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			}
+		})
+	}
+}
+
+func TestManagerConfigure(t *testing.T) {
+	optionsA := testOptions("a")
+	optionsB := testOptions("b")
+	tests := []struct {
+		name        string
+		run         func(*Manager, *oidc.Options) error
+		expectState State
+		expectError string
+	}{
+		{
+			name: "disabled configuration is idempotent",
+			run: func(manager *Manager, _ *oidc.Options) error {
+				require.NoError(t, manager.Configure(false))
+				return manager.Configure(false)
+			},
+			expectState: Disabled,
+		},
+		{
+			name: "enabled configuration is idempotent",
+			run: func(manager *Manager, _ *oidc.Options) error {
+				require.NoError(t, manager.Configure(true))
+				return manager.Configure(true)
+			},
+			expectState: Initializing,
+		},
+		{
+			name: "disabled then enabled conflicts",
+			run: func(manager *Manager, _ *oidc.Options) error {
+				require.NoError(t, manager.Configure(false))
+				return manager.Configure(true)
+			},
+			expectState: Disabled,
+			expectError: "already configured with enabled=false",
+		},
+		{
+			name: "enabled then disabled conflicts",
+			run: func(manager *Manager, _ *oidc.Options) error {
+				require.NoError(t, manager.Configure(true))
+				return manager.Configure(false)
+			},
+			expectState: Initializing,
+			expectError: "already configured with enabled=true",
+		},
+		{
+			name: "changed options conflict",
+			run: func(manager *Manager, current *oidc.Options) error {
+				require.NoError(t, manager.Configure(true))
+				*current = optionsB
+				return manager.Configure(true)
+			},
+			expectState: Initializing,
+			expectError: "different options",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current := optionsA
+			manager := NewManagerWithDependencies(func() (oidc.Options, error) {
+				return current, nil
+			}, nil, time.Millisecond, time.Millisecond)
+
+			err := tt.run(manager, &current)
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			}
+			assert.Equal(t, tt.expectState, manager.State())
+		})
+	}
+}
+
+func TestManagerConfigureOptionsError(t *testing.T) {
+	tests := []struct {
+		name        string
+		failures    int
+		configure   func(*Manager) error
+		expectState State
+		expectError string
+		expectCalls int
+	}{
+		{
+			name:     "first failure leaves manager unconfigured",
+			failures: 1,
+			configure: func(manager *Manager) error {
+				return manager.Configure(true)
+			},
+			expectState: AwaitingConfig,
+			expectError: "invalid local options",
+			expectCalls: 1,
+		},
+		{
+			name:     "configuration can retry after source failure",
+			failures: 1,
+			configure: func(manager *Manager) error {
+				require.Error(t, manager.Configure(true))
+				return manager.Configure(true)
+			},
+			expectState: Initializing,
+			expectCalls: 2,
+		},
+		{
+			name: "repeated configuration reports source failure",
+			configure: func(manager *Manager) error {
+				require.NoError(t, manager.Configure(true))
+				return manager.Configure(true)
+			},
+			expectState: Initializing,
+			expectError: "invalid local options",
+			expectCalls: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			manager := NewManagerWithDependencies(func() (oidc.Options, error) {
+				calls++
+				if calls <= tt.failures || (tt.name == "repeated configuration reports source failure" && calls == 2) {
+					return oidc.Options{}, errors.New("invalid local options")
+				}
+				return testOptions("valid"), nil
+			}, nil, time.Millisecond, time.Millisecond)
+
+			err := tt.configure(manager)
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			}
+			assert.Equal(t, tt.expectState, manager.State())
+			assert.Equal(t, tt.expectCalls, calls)
+		})
+	}
+}
+
+func TestManagerSetReader(t *testing.T) {
+	readerA := &fakeReader{name: "a"}
+	readerB := &fakeReader{name: "b"}
+	var typedNil *fakeReader
+	tests := []struct {
+		name        string
+		run         func(*Manager) error
+		expectError string
+	}{
+		{
+			name: "nil reader is rejected",
+			run: func(manager *Manager) error {
+				return manager.SetReader(nil)
+			},
+			expectError: "must not be nil",
+		},
+		{
+			name: "typed nil reader is rejected",
+			run: func(manager *Manager) error {
+				return manager.SetReader(typedNil)
+			},
+			expectError: "must not be nil",
+		},
+		{
+			name: "first reader is accepted",
+			run: func(manager *Manager) error {
+				return manager.SetReader(readerA)
+			},
+		},
+		{
+			name: "same reader is idempotent",
+			run: func(manager *Manager) error {
+				require.NoError(t, manager.SetReader(readerA))
+				return manager.SetReader(readerA)
+			},
+		},
+		{
+			name: "different reader conflicts",
+			run: func(manager *Manager) error {
+				require.NoError(t, manager.SetReader(readerA))
+				return manager.SetReader(readerB)
+			},
+			expectError: "already set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := newTestManager(testOptions("reader"), nil)
+			err := tt.run(manager)
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			}
+		})
+	}
+}
+
+func TestManagerStartupOrder(t *testing.T) {
+	tests := []struct {
+		name  string
+		steps []string
+	}{
+		{
+			name:  "configure reader start",
+			steps: []string{"configure", "reader", "start"},
+		},
+		{
+			name:  "reader start configure",
+			steps: []string{"reader", "start", "configure"},
+		},
+		{
+			name:  "start configure reader",
+			steps: []string{"start", "configure", "reader"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := testOptions(tt.name)
+			reader := &fakeReader{name: tt.name}
+			verifier := &fakeVerifier{name: tt.name}
+			called := make(chan struct{}, 1)
+			manager := newTestManager(options, func(_ context.Context, gotReader client.Reader, gotOptions oidc.Options) (oidc.Verifier, error) {
+				assert.Same(t, reader, gotReader)
+				assert.Equal(t, options, gotOptions)
+				called <- struct{}{}
+				return verifier, nil
+			})
+
+			var cancel context.CancelFunc
+			var done <-chan error
+			for _, step := range tt.steps {
+				switch step {
+				case "configure":
+					require.NoError(t, manager.Configure(true))
+				case "reader":
+					require.NoError(t, manager.SetReader(reader))
+				case "start":
+					cancel, done = startManager(t, manager)
+				default:
+					t.Fatalf("unknown startup step %q", step)
+				}
+			}
+
+			select {
+			case <-called:
+			case <-time.After(testTimeout):
+				t.Fatal("verifier loader was not called")
+			}
+			waitForState(t, manager, Ready)
+			assert.Same(t, verifier, manager.Current())
+			assert.NoError(t, manager.Ready())
+			stopManager(t, cancel, done)
+		})
+	}
+}
+
+func TestManagerRetryAndPublication(t *testing.T) {
+	tests := []struct {
+		name          string
+		failedResults []error
+		expectFailure string
+	}{
+		{
+			name:          "loader errors are retried",
+			failedResults: []error{errors.New("discovery unavailable"), errors.New("JWKS unavailable")},
+			expectFailure: "discovery unavailable",
+		},
+		{
+			name:          "nil verifier is retried",
+			failedResults: []error{nil},
+			expectFailure: "nil verifier",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			verifier := &fakeVerifier{name: tt.name}
+			attempted := make(chan int, len(tt.failedResults)+1)
+			var calls atomic.Int32
+			manager := NewManagerWithDependencies(func() (oidc.Options, error) {
+				return testOptions("retry"), nil
+			}, func(context.Context, client.Reader, oidc.Options) (oidc.Verifier, error) {
+				attempt := int(calls.Add(1))
+				attempted <- attempt
+				if attempt <= len(tt.failedResults) {
+					return nil, tt.failedResults[attempt-1]
+				}
+				return verifier, nil
+			}, 100*time.Millisecond, 100*time.Millisecond)
+			require.NoError(t, manager.Configure(true))
+			require.NoError(t, manager.SetReader(&fakeReader{name: "retry"}))
+			cancel, done := startManager(t, manager)
+
+			select {
+			case <-attempted:
+			case <-time.After(testTimeout):
+				t.Fatal("first verifier attempt did not run")
+			}
+			require.Eventually(t, func() bool {
+				err := manager.Ready()
+				return err != nil && errors.Is(err, ErrInitializing) && strings.Contains(err.Error(), tt.expectFailure)
+			}, testTimeout, time.Millisecond)
+
+			waitForState(t, manager, Ready)
+			assert.Same(t, verifier, manager.Current())
+			expectCalls := int32(len(tt.failedResults) + 1)
+			assert.Equal(t, expectCalls, calls.Load())
+			time.Sleep(20 * time.Millisecond)
+			assert.Equal(t, expectCalls, calls.Load(), "loader must not refresh after readiness")
+			stopManager(t, cancel, done)
+		})
+	}
+}
+
+func TestManagerCurrentAtomicPublication(t *testing.T) {
+	tests := []struct {
+		name    string
+		readers int
+	}{
+		{name: "concurrent readers observe publication", readers: 16},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			verifier := &fakeVerifier{name: "published"}
+			releaseLoader := make(chan struct{})
+			manager := newTestManager(testOptions("atomic"), func(context.Context, client.Reader, oidc.Options) (oidc.Verifier, error) {
+				<-releaseLoader
+				return verifier, nil
+			})
+			require.NoError(t, manager.Configure(true))
+			require.NoError(t, manager.SetReader(&fakeReader{name: "atomic"}))
+			cancel, done := startManager(t, manager)
+
+			results := make(chan oidc.Verifier, tt.readers)
+			var readers sync.WaitGroup
+			for range tt.readers {
+				readers.Add(1)
+				go func() {
+					defer readers.Done()
+					for {
+						if current := manager.Current(); current != nil {
+							results <- current
+							return
+						}
+					}
+				}()
+			}
+			close(releaseLoader)
+			readers.Wait()
+			close(results)
+			for result := range results {
+				assert.Same(t, verifier, result)
+			}
+			stopManager(t, cancel, done)
+		})
+	}
+}
+
+func TestManagerCancellationAndDisabledStart(t *testing.T) {
+	tests := []struct {
+		name        string
+		prepare     func(*Manager, *atomic.Int32)
+		expectCalls int32
+	}{
+		{
+			name: "awaiting configuration",
+			prepare: func(*Manager, *atomic.Int32) {
+			},
+		},
+		{
+			name: "enabled awaiting reader",
+			prepare: func(manager *Manager, _ *atomic.Int32) {
+				require.NoError(t, manager.Configure(true))
+			},
+		},
+		{
+			name: "disabled never loads",
+			prepare: func(manager *Manager, _ *atomic.Int32) {
+				require.NoError(t, manager.Configure(false))
+				require.NoError(t, manager.SetReader(&fakeReader{name: "disabled"}))
+			},
+		},
+		{
+			name: "failed retry wait is cancellable",
+			prepare: func(manager *Manager, calls *atomic.Int32) {
+				require.NoError(t, manager.Configure(true))
+				require.NoError(t, manager.SetReader(&fakeReader{name: "retry cancellation"}))
+				require.Eventually(t, func() bool {
+					return calls.Load() > 0
+				}, testTimeout, time.Millisecond)
+			},
+			expectCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls atomic.Int32
+			manager := NewManagerWithDependencies(func() (oidc.Options, error) {
+				return testOptions("cancellation"), nil
+			}, func(context.Context, client.Reader, oidc.Options) (oidc.Verifier, error) {
+				calls.Add(1)
+				return nil, errors.New("still unavailable")
+			}, time.Hour, time.Hour)
+			cancel, done := startManager(t, manager)
+			tt.prepare(manager, &calls)
+			stopManager(t, cancel, done)
+			assert.Equal(t, tt.expectCalls, calls.Load())
+		})
+	}
+}
+
+func TestManagerStartValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		run         func(*Manager) error
+		expectError string
+	}{
+		{
+			name: "second start is rejected",
+			run: func(manager *Manager) error {
+				cancel, done := startManager(t, manager)
+				defer stopManager(t, cancel, done)
+				return manager.Start(context.Background())
+			},
+			expectError: "already started",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := newTestManager(testOptions("start"), nil)
+			err := tt.run(manager)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+}
+
+func TestBackoff(t *testing.T) {
+	tests := []struct {
+		name         string
+		current      time.Duration
+		maximum      time.Duration
+		expectResult time.Duration
+	}{
+		{name: "doubles below cap", current: time.Second, maximum: 4 * time.Second, expectResult: 2 * time.Second},
+		{name: "caps next interval", current: 3 * time.Second, maximum: 4 * time.Second, expectResult: 4 * time.Second},
+		{name: "stays capped", current: 4 * time.Second, maximum: 4 * time.Second, expectResult: 4 * time.Second},
+		{name: "zero remains zero", current: 0, maximum: 0, expectResult: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectResult, nextBackoff(tt.current, tt.maximum), fmt.Sprintf("backoff for %s", tt.name))
+		})
+	}
+}

--- a/pkg/sandbox-gateway/jwtauth/manager_test.go
+++ b/pkg/sandbox-gateway/jwtauth/manager_test.go
@@ -55,16 +55,6 @@ func (r *fakeReader) List(context.Context, client.ObjectList, ...client.ListOpti
 	return nil
 }
 
-type alternateReader struct{}
-
-func (alternateReader) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
-	return nil
-}
-
-func (alternateReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
-	return nil
-}
-
 type observingContext struct {
 	context.Context
 	doneCalled chan struct{}
@@ -389,11 +379,12 @@ func TestManagerSetReader(t *testing.T) {
 			},
 		},
 		{
-			name: "same reader is idempotent",
+			name: "same reader conflicts",
 			run: func(manager *Manager) error {
 				require.NoError(t, manager.SetReader(readerA))
 				return manager.SetReader(readerA)
 			},
+			expectError: "already set",
 		},
 		{
 			name: "different reader conflicts",
@@ -754,23 +745,6 @@ func TestBackoff(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expectResult, nextBackoff(tt.current, tt.maximum), fmt.Sprintf("backoff for %s", tt.name))
-		})
-	}
-}
-
-func TestReaderReflectionHelpers(t *testing.T) {
-	tests := []struct {
-		name     string
-		left     client.Reader
-		right    client.Reader
-		expected bool
-	}{
-		{name: "different concrete types", left: &fakeReader{name: "left"}, right: alternateReader{}},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, sameReader(tt.left, tt.right))
 		})
 	}
 }

--- a/pkg/sandbox-gateway/jwtauth/manager_test.go
+++ b/pkg/sandbox-gateway/jwtauth/manager_test.go
@@ -55,6 +55,27 @@ func (r *fakeReader) List(context.Context, client.ObjectList, ...client.ListOpti
 	return nil
 }
 
+type alternateReader struct{}
+
+func (alternateReader) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return nil
+}
+
+func (alternateReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	return nil
+}
+
+type observingContext struct {
+	context.Context
+	doneCalled chan struct{}
+	once       sync.Once
+}
+
+func (c *observingContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.doneCalled) })
+	return c.Context.Done()
+}
+
 func testOptions(name string) oidc.Options {
 	return oidc.Options{DiscoveryURL: "https://" + name + ".example.test/.well-known/openid-configuration"}
 }
@@ -63,6 +84,35 @@ func newTestManager(options oidc.Options, loader VerifierLoader) *Manager {
 	return NewManagerWithDependencies(func() (oidc.Options, error) {
 		return options, nil
 	}, loader, time.Millisecond, 4*time.Millisecond)
+}
+
+func TestManagerConstruction(t *testing.T) {
+	tests := []struct {
+		name           string
+		construct      func() *Manager
+		expectInitial  time.Duration
+		expectMaximum  time.Duration
+		expectDefaults bool
+	}{
+		{name: "production defaults", construct: NewManager, expectInitial: defaultInitialBackoff, expectMaximum: defaultMaxBackoff, expectDefaults: true},
+		{name: "negative initial", construct: func() *Manager { return NewManagerWithDependencies(nil, nil, -time.Second, 4*time.Second) }, expectMaximum: 4 * time.Second},
+		{name: "negative maximum", construct: func() *Manager { return NewManagerWithDependencies(nil, nil, 4*time.Second, -time.Second) }},
+		{name: "maximum below initial", construct: func() *Manager { return NewManagerWithDependencies(nil, nil, 4*time.Second, time.Second) }, expectInitial: time.Second, expectMaximum: time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := tt.construct()
+			assert.Equal(t, tt.expectInitial, manager.initialBackoff)
+			assert.Equal(t, tt.expectMaximum, manager.maxBackoff)
+			assert.Equal(t, AwaitingConfig, manager.State())
+			assert.NotNil(t, manager.wake)
+			if tt.expectDefaults {
+				assert.NotNil(t, manager.optionsSource)
+				assert.NotNil(t, manager.loader)
+			}
+		})
+	}
 }
 
 func startManager(t *testing.T, manager *Manager) (context.CancelFunc, <-chan error) {
@@ -132,7 +182,6 @@ func TestManagerReadiness(t *testing.T) {
 			if tt.configure {
 				require.NoError(t, manager.Configure(tt.enabled))
 			}
-
 			assert.Equal(t, tt.expectState, manager.State())
 			assert.Nil(t, manager.Current())
 			assert.False(t, manager.NeedLeaderElection())
@@ -143,6 +192,30 @@ func TestManagerReadiness(t *testing.T) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectError)
 			}
+		})
+	}
+}
+
+func TestManagerConfigureNilOptionsSource(t *testing.T) {
+	tests := []struct {
+		name        string
+		enabled     bool
+		expectError string
+	}{
+		{name: "enabled requires options source", enabled: true, expectError: "options source is nil"},
+		{name: "disabled does not require options source"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewManagerWithDependencies(nil, nil, time.Millisecond, time.Millisecond)
+			err := manager.Configure(tt.enabled)
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
 		})
 	}
 }
@@ -563,6 +636,64 @@ func TestManagerCancellationAndDisabledStart(t *testing.T) {
 	}
 }
 
+func TestManagerStartTerminalState(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "disabled waits for cancellation"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := newTestManager(testOptions("terminal"), nil)
+			require.NoError(t, manager.Configure(false))
+			base, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ctx := &observingContext{Context: base, doneCalled: make(chan struct{})}
+			done := make(chan error, 1)
+			go func() { done <- manager.Start(ctx) }()
+
+			select {
+			case <-ctx.doneCalled:
+			case <-time.After(testTimeout):
+				t.Fatal("manager did not wait for terminal-state cancellation")
+			}
+			cancel()
+			select {
+			case err := <-done:
+				require.NoError(t, err)
+			case <-time.After(testTimeout):
+				t.Fatal("manager did not stop")
+			}
+		})
+	}
+}
+
+func TestManagerNilLoader(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "nil loader is reported"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewManagerWithDependencies(func() (oidc.Options, error) {
+				return testOptions("nil-loader"), nil
+			}, nil, time.Hour, time.Hour)
+			require.NoError(t, manager.Configure(true))
+			require.NoError(t, manager.SetReader(&fakeReader{name: tt.name}))
+			cancel, done := startManager(t, manager)
+			defer cancel()
+			require.Eventually(t, func() bool {
+				err := manager.Ready()
+				return err != nil && strings.Contains(err.Error(), "verifier loader is nil")
+			}, testTimeout, time.Millisecond)
+			stopManager(t, cancel, done)
+		})
+	}
+}
+
 func TestManagerStartValidation(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -590,6 +721,23 @@ func TestManagerStartValidation(t *testing.T) {
 	}
 }
 
+func TestManagerStartCanceled(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "canceled before start"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			manager := newTestManager(testOptions("canceled"), nil)
+			require.NoError(t, manager.Start(ctx))
+		})
+	}
+}
+
 func TestBackoff(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -606,6 +754,39 @@ func TestBackoff(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expectResult, nextBackoff(tt.current, tt.maximum), fmt.Sprintf("backoff for %s", tt.name))
+		})
+	}
+}
+
+func TestReaderReflectionHelpers(t *testing.T) {
+	tests := []struct {
+		name     string
+		left     client.Reader
+		right    client.Reader
+		expected bool
+	}{
+		{name: "different concrete types", left: &fakeReader{name: "left"}, right: alternateReader{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, sameReader(tt.left, tt.right))
+		})
+	}
+}
+
+func TestNilInterfaceScalar(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    any
+		expected bool
+	}{
+		{name: "integer is not nil", value: 42},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isNilInterface(tt.value))
 		})
 	}
 }

--- a/pkg/sandbox-gateway/runtimecredentials/credentials.go
+++ b/pkg/sandbox-gateway/runtimecredentials/credentials.go
@@ -28,8 +28,8 @@ import (
 	"path/filepath"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -78,15 +78,17 @@ type credentialFiles struct {
 }
 
 // Load fetches, validates, and writes the static runtime mTLS credentials.
-func Load(ctx context.Context, client kubernetes.Interface, opts Options) error {
-	if client == nil {
-		return errors.New("Kubernetes client must not be nil")
+func Load(ctx context.Context, reader client.Reader, opts Options) error {
+	if reader == nil {
+		return errors.New("Kubernetes reader must not be nil")
 	}
 	if err := opts.validate(); err != nil {
 		return err
 	}
 
-	secret, err := client.CoreV1().Secrets(opts.SecretNamespace).Get(ctx, opts.SecretName, metav1.GetOptions{})
+	secret := &corev1.Secret{}
+	key := client.ObjectKey{Namespace: opts.SecretNamespace, Name: opts.SecretName}
+	err := reader.Get(ctx, key, secret)
 	if err != nil {
 		return fmt.Errorf("get runtime mTLS Secret %s/%s: %w", opts.SecretNamespace, opts.SecretName, err)
 	}

--- a/pkg/sandbox-gateway/runtimecredentials/credentials.go
+++ b/pkg/sandbox-gateway/runtimecredentials/credentials.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimecredentials
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	DefaultSecretNamespace = "ack-agent-identity"
+	DefaultSecretName      = "ack-agent-identity-sandbox-manager-client-cert"
+	DefaultOutputDirectory = "/var/run/sandbox-gateway/runtime-mtls"
+
+	CertificateKey = "tls.crt"
+	PrivateKeyKey  = "tls.key"
+	CAKey          = "ca.crt"
+
+	CertificateFile = "tls.crt"
+	PrivateKeyFile  = "tls.key"
+	CAFile          = "ca.crt"
+
+	maxCredentialBytes = 1 << 20
+)
+
+// Options identifies the source Secret and destination directory.
+type Options struct {
+	SecretNamespace string
+	SecretName      string
+	OutputDirectory string
+}
+
+// DefaultOptions returns the fixed runtime mTLS credential locations.
+func DefaultOptions() Options {
+	return Options{
+		SecretNamespace: DefaultSecretNamespace,
+		SecretName:      DefaultSecretName,
+		OutputDirectory: DefaultOutputDirectory,
+	}
+}
+
+type credentialFiles struct {
+	certificate []byte
+	privateKey  []byte
+	ca          []byte
+}
+
+// Load fetches, validates, and writes the static runtime mTLS credentials.
+func Load(ctx context.Context, client kubernetes.Interface, opts Options) error {
+	if client == nil {
+		return errors.New("Kubernetes client must not be nil")
+	}
+	if err := opts.validate(); err != nil {
+		return err
+	}
+
+	secret, err := client.CoreV1().Secrets(opts.SecretNamespace).Get(ctx, opts.SecretName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get runtime mTLS Secret %s/%s: %w", opts.SecretNamespace, opts.SecretName, err)
+	}
+	files, err := credentialsFromSecret(secret.Data, time.Now())
+	if err != nil {
+		return fmt.Errorf("validate runtime mTLS Secret %s/%s: %w", opts.SecretNamespace, opts.SecretName, err)
+	}
+	if err := writeCredentialFiles(opts.OutputDirectory, files); err != nil {
+		return fmt.Errorf("write runtime mTLS credentials: %w", err)
+	}
+	return nil
+}
+
+func (o Options) validate() error {
+	if o.SecretNamespace == "" {
+		return errors.New("Secret namespace must not be empty")
+	}
+	if o.SecretName == "" {
+		return errors.New("Secret name must not be empty")
+	}
+	if o.OutputDirectory == "" {
+		return errors.New("output directory must not be empty")
+	}
+	return nil
+}
+
+func credentialsFromSecret(data map[string][]byte, now time.Time) (credentialFiles, error) {
+	certificate, err := requiredData(data, CertificateKey)
+	if err != nil {
+		return credentialFiles{}, err
+	}
+	privateKey, err := requiredData(data, PrivateKeyKey)
+	if err != nil {
+		return credentialFiles{}, err
+	}
+	ca, err := requiredData(data, CAKey)
+	if err != nil {
+		return credentialFiles{}, err
+	}
+	if len(certificate)+len(privateKey)+len(ca) > maxCredentialBytes {
+		return credentialFiles{}, fmt.Errorf("credential data exceeds %d bytes", maxCredentialBytes)
+	}
+
+	pair, err := tls.X509KeyPair(certificate, privateKey)
+	if err != nil {
+		return credentialFiles{}, fmt.Errorf("parse client certificate and private key: %w", err)
+	}
+	leaf, err := x509.ParseCertificate(pair.Certificate[0])
+	if err != nil {
+		return credentialFiles{}, fmt.Errorf("parse client leaf certificate: %w", err)
+	}
+	if now.Before(leaf.NotBefore) {
+		return credentialFiles{}, fmt.Errorf("client certificate is not valid before %s", leaf.NotBefore.UTC().Format(time.RFC3339))
+	}
+	if !now.Before(leaf.NotAfter) {
+		return credentialFiles{}, fmt.Errorf("client certificate expired at %s", leaf.NotAfter.UTC().Format(time.RFC3339))
+	}
+	if !allowsClientAuth(leaf.ExtKeyUsage) {
+		return credentialFiles{}, errors.New("client certificate does not allow ClientAuth")
+	}
+	if err := validateCertificatesPEM(ca); err != nil {
+		return credentialFiles{}, fmt.Errorf("parse CA bundle: %w", err)
+	}
+
+	return credentialFiles{
+		certificate: append([]byte(nil), certificate...),
+		privateKey:  append([]byte(nil), privateKey...),
+		ca:          append([]byte(nil), ca...),
+	}, nil
+}
+
+func requiredData(data map[string][]byte, key string) ([]byte, error) {
+	value := data[key]
+	if len(value) == 0 {
+		return nil, fmt.Errorf("Secret data %q must not be empty", key)
+	}
+	return value, nil
+}
+
+func allowsClientAuth(usages []x509.ExtKeyUsage) bool {
+	if len(usages) == 0 {
+		return true
+	}
+	for _, usage := range usages {
+		if usage == x509.ExtKeyUsageAny || usage == x509.ExtKeyUsageClientAuth {
+			return true
+		}
+	}
+	return false
+}
+
+func validateCertificatesPEM(contents []byte) error {
+	found := false
+	for len(bytes.TrimSpace(contents)) > 0 {
+		contents = bytes.TrimSpace(contents)
+		block, rest := pem.Decode(contents)
+		if block == nil {
+			return errors.New("invalid PEM data")
+		}
+		if block.Type != "CERTIFICATE" {
+			return fmt.Errorf("unexpected PEM block %q", block.Type)
+		}
+		if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+			return err
+		}
+		found = true
+		contents = rest
+	}
+	if !found {
+		return errors.New("no certificates found")
+	}
+	return nil
+}
+
+func writeCredentialFiles(outputDirectory string, files credentialFiles) (err error) {
+	if err := os.MkdirAll(outputDirectory, 0o700); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	if err := os.Chmod(outputDirectory, 0o700); err != nil {
+		return fmt.Errorf("set output directory permissions: %w", err)
+	}
+
+	outputs := []struct {
+		name string
+		data []byte
+		mode os.FileMode
+	}{
+		{name: CertificateFile, data: files.certificate, mode: 0o444},
+		{name: PrivateKeyFile, data: files.privateKey, mode: 0o400},
+		{name: CAFile, data: files.ca, mode: 0o444},
+	}
+	defer func() {
+		if err == nil {
+			return
+		}
+		for _, output := range outputs {
+			path := filepath.Join(outputDirectory, output.name)
+			if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+				err = errors.Join(err, fmt.Errorf("remove partial credential %s: %w", output.name, removeErr))
+			}
+		}
+	}()
+
+	for _, output := range outputs {
+		path := filepath.Join(outputDirectory, output.name)
+		if err = os.WriteFile(path, output.data, output.mode); err != nil {
+			return fmt.Errorf("write %s: %w", output.name, err)
+		}
+	}
+	return nil
+}

--- a/pkg/sandbox-gateway/runtimecredentials/credentials.go
+++ b/pkg/sandbox-gateway/runtimecredentials/credentials.go
@@ -149,8 +149,25 @@ func credentialsFromSecret(data map[string][]byte, now time.Time) (credentialFil
 	if !allowsClientAuth(leaf.ExtKeyUsage) {
 		return credentialFiles{}, errors.New("client certificate does not allow ClientAuth")
 	}
-	if err := validateCertificatesPEM(ca); err != nil {
+	roots, err := certificatePoolFromPEM(ca)
+	if err != nil {
 		return credentialFiles{}, fmt.Errorf("parse CA bundle: %w", err)
+	}
+	intermediates := x509.NewCertPool()
+	for _, rawCertificate := range pair.Certificate[1:] {
+		intermediate, err := x509.ParseCertificate(rawCertificate)
+		if err != nil {
+			return credentialFiles{}, fmt.Errorf("parse client intermediate certificate: %w", err)
+		}
+		intermediates.AddCert(intermediate)
+	}
+	if _, err := leaf.Verify(x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+		CurrentTime:   now,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}); err != nil {
+		return credentialFiles{}, fmt.Errorf("verify client certificate against CA bundle: %w", err)
 	}
 
 	return credentialFiles{
@@ -180,27 +197,30 @@ func allowsClientAuth(usages []x509.ExtKeyUsage) bool {
 	return false
 }
 
-func validateCertificatesPEM(contents []byte) error {
+func certificatePoolFromPEM(contents []byte) (*x509.CertPool, error) {
+	pool := x509.NewCertPool()
 	found := false
 	for len(bytes.TrimSpace(contents)) > 0 {
 		contents = bytes.TrimSpace(contents)
 		block, rest := pem.Decode(contents)
 		if block == nil {
-			return errors.New("invalid PEM data")
+			return nil, errors.New("invalid PEM data")
 		}
 		if block.Type != "CERTIFICATE" {
-			return fmt.Errorf("unexpected PEM block %q", block.Type)
+			return nil, fmt.Errorf("unexpected PEM block %q", block.Type)
 		}
-		if _, err := x509.ParseCertificate(block.Bytes); err != nil {
-			return err
+		certificate, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, err
 		}
+		pool.AddCert(certificate)
 		found = true
 		contents = rest
 	}
 	if !found {
-		return errors.New("no certificates found")
+		return nil, errors.New("no certificates found")
 	}
-	return nil
+	return pool, nil
 }
 
 func writeCredentialFiles(outputDirectory string, files credentialFiles) (err error) {

--- a/pkg/sandbox-gateway/runtimecredentials/credentials.go
+++ b/pkg/sandbox-gateway/runtimecredentials/credentials.go
@@ -33,8 +33,6 @@ import (
 )
 
 const (
-	DefaultSecretNamespace = "ack-agent-identity"
-	DefaultSecretName      = "ack-agent-identity-sandbox-manager-client-cert"
 	DefaultOutputDirectory = "/var/run/sandbox-gateway/runtime-mtls"
 
 	CertificateKey = "tls.crt"
@@ -48,6 +46,11 @@ const (
 	maxCredentialBytes = 1 << 20
 )
 
+const (
+	envSecretNamespace = "RUNTIME_MTLS_SECRET_NAMESPACE"
+	envSecretName      = "RUNTIME_MTLS_SECRET_NAME"
+)
+
 // Options identifies the source Secret and destination directory.
 type Options struct {
 	SecretNamespace string
@@ -55,13 +58,17 @@ type Options struct {
 	OutputDirectory string
 }
 
-// DefaultOptions returns the fixed runtime mTLS credential locations.
-func DefaultOptions() Options {
-	return Options{
-		SecretNamespace: DefaultSecretNamespace,
-		SecretName:      DefaultSecretName,
+// OptionsFromEnvironment returns the configured Secret source and fixed output location.
+func OptionsFromEnvironment() (Options, error) {
+	opts := Options{
+		SecretNamespace: os.Getenv(envSecretNamespace),
+		SecretName:      os.Getenv(envSecretName),
 		OutputDirectory: DefaultOutputDirectory,
 	}
+	if err := opts.validate(); err != nil {
+		return Options{}, fmt.Errorf("load runtime mTLS options: %w", err)
+	}
+	return opts, nil
 }
 
 type credentialFiles struct {

--- a/pkg/sandbox-gateway/runtimecredentials/credentials_test.go
+++ b/pkg/sandbox-gateway/runtimecredentials/credentials_test.go
@@ -33,8 +33,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestOptionsFromEnvironment(t *testing.T) {
@@ -155,26 +156,26 @@ func TestLoad(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		client      kubernetes.Interface
+		reader      client.Reader
 		opts        Options
 		expectError string
 		wantFiles   bool
 	}{
 		{
 			name:      "writes valid credentials",
-			client:    fake.NewSimpleClientset(secret.DeepCopy()),
+			reader:    newFakeReader(t, secret.DeepCopy()),
 			opts:      Options{SecretNamespace: "identity", SecretName: "credentials"},
 			wantFiles: true,
 		},
 		{
 			name:        "Secret not found",
-			client:      fake.NewSimpleClientset(),
+			reader:      newFakeReader(t),
 			opts:        Options{SecretNamespace: "identity", SecretName: "credentials"},
 			expectError: "get runtime mTLS Secret",
 		},
 		{
 			name:        "invalid Secret",
-			client:      fake.NewSimpleClientset(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "identity", Name: "credentials"}}),
+			reader:      newFakeReader(t, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "identity", Name: "credentials"}}),
 			opts:        Options{SecretNamespace: "identity", SecretName: "credentials"},
 			expectError: "validate runtime mTLS Secret",
 		},
@@ -183,7 +184,7 @@ func TestLoad(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.opts.OutputDirectory = t.TempDir()
-			err := Load(context.Background(), tt.client, tt.opts)
+			err := Load(context.Background(), tt.reader, tt.opts)
 			assertErrorContains(t, err, tt.expectError)
 			if tt.wantFiles {
 				assertCredentialFile(t, tt.opts.OutputDirectory, CertificateFile, data[CertificateKey], 0o444)
@@ -198,7 +199,7 @@ func TestLoadValidationAndWriteErrors(t *testing.T) {
 	now := time.Now()
 	data := newCredentialData(t, now.Add(-time.Hour), now.Add(time.Hour), nil)
 	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "identity", Name: "credentials"}, Data: data}
-	client := fake.NewSimpleClientset(secret)
+	reader := newFakeReader(t, secret)
 	filePath := filepath.Join(t.TempDir(), "not-a-directory")
 	if err := os.WriteFile(filePath, []byte("file"), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
@@ -206,24 +207,33 @@ func TestLoadValidationAndWriteErrors(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		client      kubernetes.Interface
+		reader      client.Reader
 		opts        Options
 		expectError string
 	}{
-		{name: "nil client", opts: validOptions(), expectError: "must not be nil"},
-		{name: "invalid options", client: client, opts: Options{}, expectError: "namespace"},
-		{name: "output path is file", client: client, opts: Options{SecretNamespace: "identity", SecretName: "credentials", OutputDirectory: filePath}, expectError: "create output directory"},
+		{name: "nil reader", opts: validOptions(), expectError: "must not be nil"},
+		{name: "invalid options", reader: reader, opts: Options{}, expectError: "namespace"},
+		{name: "output path is file", reader: reader, opts: Options{SecretNamespace: "identity", SecretName: "credentials", OutputDirectory: filePath}, expectError: "create output directory"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assertErrorContains(t, Load(context.Background(), tt.client, tt.opts), tt.expectError)
+			assertErrorContains(t, Load(context.Background(), tt.reader, tt.opts), tt.expectError)
 		})
 	}
 }
 
 func validOptions() Options {
 	return Options{SecretNamespace: "identity", SecretName: "credentials", OutputDirectory: "/tmp/certs"}
+}
+
+func newFakeReader(t *testing.T, objects ...client.Object) client.Reader {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 }
 
 func TestWriteCredentialFilesErrors(t *testing.T) {

--- a/pkg/sandbox-gateway/runtimecredentials/credentials_test.go
+++ b/pkg/sandbox-gateway/runtimecredentials/credentials_test.go
@@ -1,0 +1,346 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimecredentials
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDefaultOptions(t *testing.T) {
+	opts := DefaultOptions()
+	if opts.SecretNamespace != DefaultSecretNamespace || opts.SecretName != DefaultSecretName || opts.OutputDirectory != DefaultOutputDirectory {
+		t.Fatalf("DefaultOptions() = %#v, want fixed defaults", opts)
+	}
+}
+
+func TestOptionsValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        Options
+		expectError string
+	}{
+		{name: "valid", opts: DefaultOptions()},
+		{name: "missing namespace", opts: Options{SecretName: "secret", OutputDirectory: "/tmp/certs"}, expectError: "namespace"},
+		{name: "missing name", opts: Options{SecretNamespace: "namespace", OutputDirectory: "/tmp/certs"}, expectError: "name"},
+		{name: "missing output directory", opts: Options{SecretNamespace: "namespace", SecretName: "secret"}, expectError: "output directory"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.validate()
+			assertErrorContains(t, err, tt.expectError)
+		})
+	}
+}
+
+func TestCredentialsFromSecret(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	valid := newCredentialData(t, now.Add(-time.Hour), now.Add(time.Hour), []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+	other := newCredentialData(t, now.Add(-time.Hour), now.Add(time.Hour), []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+
+	tests := []struct {
+		name        string
+		data        map[string][]byte
+		expectError string
+	}{
+		{name: "valid client auth", data: cloneData(valid)},
+		{name: "valid unrestricted usage", data: newCredentialData(t, now.Add(-time.Hour), now.Add(time.Hour), nil)},
+		{name: "valid any usage", data: newCredentialData(t, now.Add(-time.Hour), now.Add(time.Hour), []x509.ExtKeyUsage{x509.ExtKeyUsageAny})},
+		{name: "missing certificate", data: withoutKey(valid, CertificateKey), expectError: CertificateKey},
+		{name: "missing private key", data: withoutKey(valid, PrivateKeyKey), expectError: PrivateKeyKey},
+		{name: "missing CA", data: withoutKey(valid, CAKey), expectError: CAKey},
+		{name: "invalid certificate", data: replaceData(valid, CertificateKey, []byte("invalid")), expectError: "parse client certificate"},
+		{name: "mismatched private key", data: replaceData(valid, PrivateKeyKey, other[PrivateKeyKey]), expectError: "private key"},
+		{name: "not yet valid", data: newCredentialData(t, now.Add(time.Hour), now.Add(2*time.Hour), []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}), expectError: "not valid before"},
+		{name: "expired", data: newCredentialData(t, now.Add(-2*time.Hour), now.Add(-time.Hour), []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}), expectError: "expired"},
+		{name: "server auth only", data: newCredentialData(t, now.Add(-time.Hour), now.Add(time.Hour), []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}), expectError: "does not allow ClientAuth"},
+		{name: "invalid CA PEM", data: replaceData(valid, CAKey, []byte("invalid")), expectError: "invalid PEM"},
+		{name: "unexpected CA block", data: replaceData(valid, CAKey, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("invalid")})), expectError: "unexpected PEM block"},
+		{name: "invalid CA certificate", data: replaceData(valid, CAKey, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("invalid")})), expectError: "malformed certificate"},
+		{name: "oversized data", data: replaceData(valid, CAKey, []byte(strings.Repeat("x", maxCredentialBytes))), expectError: "exceeds"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files, err := credentialsFromSecret(tt.data, now)
+			assertErrorContains(t, err, tt.expectError)
+			if tt.expectError == "" {
+				if string(files.certificate) != string(tt.data[CertificateKey]) || string(files.privateKey) != string(tt.data[PrivateKeyKey]) || string(files.ca) != string(tt.data[CAKey]) {
+					t.Fatal("credentialsFromSecret() did not preserve Secret data")
+				}
+			}
+		})
+	}
+}
+
+func TestValidateCertificatesPEM(t *testing.T) {
+	now := time.Now()
+	valid := newCredentialData(t, now.Add(-time.Hour), now.Add(time.Hour), nil)[CAKey]
+
+	tests := []struct {
+		name        string
+		contents    []byte
+		expectError string
+	}{
+		{name: "single certificate with whitespace", contents: append(append([]byte(" \n"), valid...), []byte("\n ")...)},
+		{name: "certificate bundle", contents: append(cloneBytes(valid), valid...)},
+		{name: "empty", expectError: "no certificates found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertErrorContains(t, validateCertificatesPEM(tt.contents), tt.expectError)
+		})
+	}
+}
+
+func TestLoad(t *testing.T) {
+	now := time.Now()
+	data := newCredentialData(t, now.Add(-time.Hour), now.Add(time.Hour), []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "identity", Name: "credentials"},
+		Data:       data,
+	}
+
+	tests := []struct {
+		name        string
+		client      kubernetes.Interface
+		opts        Options
+		expectError string
+		wantFiles   bool
+	}{
+		{
+			name:      "writes valid credentials",
+			client:    fake.NewSimpleClientset(secret.DeepCopy()),
+			opts:      Options{SecretNamespace: "identity", SecretName: "credentials"},
+			wantFiles: true,
+		},
+		{
+			name:        "Secret not found",
+			client:      fake.NewSimpleClientset(),
+			opts:        Options{SecretNamespace: "identity", SecretName: "credentials"},
+			expectError: "get runtime mTLS Secret",
+		},
+		{
+			name:        "invalid Secret",
+			client:      fake.NewSimpleClientset(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "identity", Name: "credentials"}}),
+			opts:        Options{SecretNamespace: "identity", SecretName: "credentials"},
+			expectError: "validate runtime mTLS Secret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.opts.OutputDirectory = t.TempDir()
+			err := Load(context.Background(), tt.client, tt.opts)
+			assertErrorContains(t, err, tt.expectError)
+			if tt.wantFiles {
+				assertCredentialFile(t, tt.opts.OutputDirectory, CertificateFile, data[CertificateKey], 0o444)
+				assertCredentialFile(t, tt.opts.OutputDirectory, PrivateKeyFile, data[PrivateKeyKey], 0o400)
+				assertCredentialFile(t, tt.opts.OutputDirectory, CAFile, data[CAKey], 0o444)
+			}
+		})
+	}
+}
+
+func TestLoadValidationAndWriteErrors(t *testing.T) {
+	now := time.Now()
+	data := newCredentialData(t, now.Add(-time.Hour), now.Add(time.Hour), nil)
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "identity", Name: "credentials"}, Data: data}
+	client := fake.NewSimpleClientset(secret)
+	filePath := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(filePath, []byte("file"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		client      kubernetes.Interface
+		opts        Options
+		expectError string
+	}{
+		{name: "nil client", opts: DefaultOptions(), expectError: "must not be nil"},
+		{name: "invalid options", client: client, opts: Options{}, expectError: "namespace"},
+		{name: "output path is file", client: client, opts: Options{SecretNamespace: "identity", SecretName: "credentials", OutputDirectory: filePath}, expectError: "create output directory"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertErrorContains(t, Load(context.Background(), tt.client, tt.opts), tt.expectError)
+		})
+	}
+}
+
+func TestWriteCredentialFilesErrors(t *testing.T) {
+	files := credentialFiles{certificate: []byte("certificate"), privateKey: []byte("key"), ca: []byte("ca")}
+	tests := []struct {
+		name         string
+		blockedFile  string
+		cleanupError bool
+		expectError  string
+	}{
+		{name: "certificate write", blockedFile: CertificateFile, expectError: "write " + CertificateFile},
+		{name: "private key write", blockedFile: PrivateKeyFile, expectError: "write " + PrivateKeyFile},
+		{name: "CA write", blockedFile: CAFile, expectError: "write " + CAFile},
+		{name: "partial file cleanup", blockedFile: CertificateFile, cleanupError: true, expectError: "remove partial credential"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			directory := t.TempDir()
+			blockedPath := filepath.Join(directory, tt.blockedFile)
+			if err := os.Mkdir(blockedPath, 0o700); err != nil {
+				t.Fatalf("Mkdir() error = %v", err)
+			}
+			if tt.cleanupError {
+				if err := os.WriteFile(filepath.Join(blockedPath, "keep"), []byte("data"), 0o600); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+			}
+			err := writeCredentialFiles(directory, files)
+			assertErrorContains(t, err, tt.expectError)
+			for _, name := range []string{CertificateFile, PrivateKeyFile, CAFile} {
+				if tt.cleanupError && name == tt.blockedFile {
+					continue
+				}
+				if _, statErr := os.Stat(filepath.Join(directory, name)); !os.IsNotExist(statErr) {
+					t.Errorf("credential file %s remains after error: %v", name, statErr)
+				}
+			}
+		})
+	}
+}
+
+func newCredentialData(t *testing.T, notBefore, notAfter time.Time, usages []x509.ExtKeyUsage) map[string][]byte {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(CA) error = %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             notBefore.Add(-time.Hour),
+		NotAfter:              notAfter.Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate(CA) error = %v", err)
+	}
+
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(client) error = %v", err)
+	}
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "sandbox-gateway"},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  usages,
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate(client) error = %v", err)
+	}
+	privateKey, err := x509.MarshalPKCS8PrivateKey(clientKey)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey() error = %v", err)
+	}
+	return map[string][]byte{
+		CertificateKey: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER}),
+		PrivateKeyKey:  pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKey}),
+		CAKey:          pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}),
+	}
+}
+
+func cloneData(data map[string][]byte) map[string][]byte {
+	result := make(map[string][]byte, len(data))
+	for key, value := range data {
+		result[key] = cloneBytes(value)
+	}
+	return result
+}
+
+func withoutKey(data map[string][]byte, key string) map[string][]byte {
+	result := cloneData(data)
+	delete(result, key)
+	return result
+}
+
+func replaceData(data map[string][]byte, key string, value []byte) map[string][]byte {
+	result := cloneData(data)
+	result[key] = value
+	return result
+}
+
+func cloneBytes(value []byte) []byte {
+	return append([]byte(nil), value...)
+}
+
+func assertCredentialFile(t *testing.T, directory, name string, want []byte, mode os.FileMode) {
+	t.Helper()
+	path := filepath.Join(directory, name)
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", name, err)
+	}
+	if string(contents) != string(want) {
+		t.Errorf("%s contents differ from Secret data", name)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%s) error = %v", name, err)
+	}
+	if info.Mode().Perm() != mode {
+		t.Errorf("%s mode = %o, want %o", name, info.Mode().Perm(), mode)
+	}
+}
+
+func assertErrorContains(t *testing.T, err error, expectError string) {
+	t.Helper()
+	if expectError == "" {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return
+	}
+	if err == nil || !strings.Contains(err.Error(), expectError) {
+		t.Fatalf("error = %v, want containing %q", err, expectError)
+	}
+}

--- a/pkg/sandbox-gateway/runtimecredentials/credentials_test.go
+++ b/pkg/sandbox-gateway/runtimecredentials/credentials_test.go
@@ -37,10 +37,30 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestDefaultOptions(t *testing.T) {
-	opts := DefaultOptions()
-	if opts.SecretNamespace != DefaultSecretNamespace || opts.SecretName != DefaultSecretName || opts.OutputDirectory != DefaultOutputDirectory {
-		t.Fatalf("DefaultOptions() = %#v, want fixed defaults", opts)
+func TestOptionsFromEnvironment(t *testing.T) {
+	tests := []struct {
+		name        string
+		namespace   string
+		secretName  string
+		expectError string
+	}{
+		{name: "valid", namespace: "identity-system", secretName: "gateway-client-cert"},
+		{name: "missing namespace", secretName: "gateway-client-cert", expectError: "namespace"},
+		{name: "missing name", namespace: "identity-system", expectError: "name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envSecretNamespace, tt.namespace)
+			t.Setenv(envSecretName, tt.secretName)
+			opts, err := OptionsFromEnvironment()
+			assertErrorContains(t, err, tt.expectError)
+			if tt.expectError == "" {
+				if opts.SecretNamespace != tt.namespace || opts.SecretName != tt.secretName || opts.OutputDirectory != DefaultOutputDirectory {
+					t.Fatalf("OptionsFromEnvironment() = %#v", opts)
+				}
+			}
+		})
 	}
 }
 
@@ -50,7 +70,7 @@ func TestOptionsValidate(t *testing.T) {
 		opts        Options
 		expectError string
 	}{
-		{name: "valid", opts: DefaultOptions()},
+		{name: "valid", opts: validOptions()},
 		{name: "missing namespace", opts: Options{SecretName: "secret", OutputDirectory: "/tmp/certs"}, expectError: "namespace"},
 		{name: "missing name", opts: Options{SecretNamespace: "namespace", OutputDirectory: "/tmp/certs"}, expectError: "name"},
 		{name: "missing output directory", opts: Options{SecretNamespace: "namespace", SecretName: "secret"}, expectError: "output directory"},
@@ -190,7 +210,7 @@ func TestLoadValidationAndWriteErrors(t *testing.T) {
 		opts        Options
 		expectError string
 	}{
-		{name: "nil client", opts: DefaultOptions(), expectError: "must not be nil"},
+		{name: "nil client", opts: validOptions(), expectError: "must not be nil"},
 		{name: "invalid options", client: client, opts: Options{}, expectError: "namespace"},
 		{name: "output path is file", client: client, opts: Options{SecretNamespace: "identity", SecretName: "credentials", OutputDirectory: filePath}, expectError: "create output directory"},
 	}
@@ -200,6 +220,10 @@ func TestLoadValidationAndWriteErrors(t *testing.T) {
 			assertErrorContains(t, Load(context.Background(), tt.client, tt.opts), tt.expectError)
 		})
 	}
+}
+
+func validOptions() Options {
+	return Options{SecretNamespace: "identity", SecretName: "credentials", OutputDirectory: "/tmp/certs"}
 }
 
 func TestWriteCredentialFilesErrors(t *testing.T) {

--- a/pkg/sandbox-gateway/runtimecredentials/credentials_test.go
+++ b/pkg/sandbox-gateway/runtimecredentials/credentials_test.go
@@ -98,17 +98,20 @@ func TestCredentialsFromSecret(t *testing.T) {
 		{name: "valid client auth", data: cloneData(valid)},
 		{name: "valid unrestricted usage", data: newCredentialData(t, now.Add(-time.Hour), now.Add(time.Hour), nil)},
 		{name: "valid any usage", data: newCredentialData(t, now.Add(-time.Hour), now.Add(time.Hour), []x509.ExtKeyUsage{x509.ExtKeyUsageAny})},
+		{name: "valid intermediate chain", data: newCredentialDataWithIntermediate(t, now)},
 		{name: "missing certificate", data: withoutKey(valid, CertificateKey), expectError: CertificateKey},
 		{name: "missing private key", data: withoutKey(valid, PrivateKeyKey), expectError: PrivateKeyKey},
 		{name: "missing CA", data: withoutKey(valid, CAKey), expectError: CAKey},
 		{name: "invalid certificate", data: replaceData(valid, CertificateKey, []byte("invalid")), expectError: "parse client certificate"},
 		{name: "mismatched private key", data: replaceData(valid, PrivateKeyKey, other[PrivateKeyKey]), expectError: "private key"},
+		{name: "invalid intermediate certificate", data: replaceData(valid, CertificateKey, append(cloneBytes(valid[CertificateKey]), pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("invalid")})...)), expectError: "parse client intermediate certificate"},
 		{name: "not yet valid", data: newCredentialData(t, now.Add(time.Hour), now.Add(2*time.Hour), []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}), expectError: "not valid before"},
 		{name: "expired", data: newCredentialData(t, now.Add(-2*time.Hour), now.Add(-time.Hour), []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}), expectError: "expired"},
 		{name: "server auth only", data: newCredentialData(t, now.Add(-time.Hour), now.Add(time.Hour), []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}), expectError: "does not allow ClientAuth"},
 		{name: "invalid CA PEM", data: replaceData(valid, CAKey, []byte("invalid")), expectError: "invalid PEM"},
 		{name: "unexpected CA block", data: replaceData(valid, CAKey, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("invalid")})), expectError: "unexpected PEM block"},
 		{name: "invalid CA certificate", data: replaceData(valid, CAKey, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("invalid")})), expectError: "malformed certificate"},
+		{name: "unrelated CA", data: replaceData(valid, CAKey, other[CAKey]), expectError: "verify client certificate against CA bundle"},
 		{name: "oversized data", data: replaceData(valid, CAKey, []byte(strings.Repeat("x", maxCredentialBytes))), expectError: "exceeds"},
 	}
 
@@ -125,7 +128,7 @@ func TestCredentialsFromSecret(t *testing.T) {
 	}
 }
 
-func TestValidateCertificatesPEM(t *testing.T) {
+func TestCertificatePoolFromPEM(t *testing.T) {
 	now := time.Now()
 	valid := newCredentialData(t, now.Add(-time.Hour), now.Add(time.Hour), nil)[CAKey]
 
@@ -141,7 +144,11 @@ func TestValidateCertificatesPEM(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assertErrorContains(t, validateCertificatesPEM(tt.contents), tt.expectError)
+			pool, err := certificatePoolFromPEM(tt.contents)
+			assertErrorContains(t, err, tt.expectError)
+			if tt.expectError == "" && pool == nil {
+				t.Fatal("certificatePoolFromPEM() returned a nil pool")
+			}
 		})
 	}
 }
@@ -320,6 +327,75 @@ func newCredentialData(t *testing.T, notBefore, notAfter time.Time, usages []x50
 		CertificateKey: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER}),
 		PrivateKeyKey:  pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKey}),
 		CAKey:          pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}),
+	}
+}
+
+func newCredentialDataWithIntermediate(t *testing.T, now time.Time) map[string][]byte {
+	t.Helper()
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(root) error = %v", err)
+	}
+	rootTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(10),
+		Subject:               pkix.Name{CommonName: "test-root-ca"},
+		NotBefore:             now.Add(-2 * time.Hour),
+		NotAfter:              now.Add(2 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTemplate, rootTemplate, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate(root) error = %v", err)
+	}
+
+	intermediateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(intermediate) error = %v", err)
+	}
+	intermediateTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(11),
+		Subject:               pkix.Name{CommonName: "test-intermediate-ca"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	intermediateDER, err := x509.CreateCertificate(rand.Reader, intermediateTemplate, rootTemplate, &intermediateKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate(intermediate) error = %v", err)
+	}
+
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(client) error = %v", err)
+	}
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(12),
+		Subject:      pkix.Name{CommonName: "sandbox-gateway"},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, intermediateTemplate, &clientKey.PublicKey, intermediateKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate(client) error = %v", err)
+	}
+	privateKey, err := x509.MarshalPKCS8PrivateKey(clientKey)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey() error = %v", err)
+	}
+	certificateChain := append(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER}),
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: intermediateDER})...,
+	)
+	return map[string][]byte{
+		CertificateKey: certificateChain,
+		PrivateKeyKey:  pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKey}),
+		CAKey:          pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER}),
 	}
 }
 

--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -85,7 +85,18 @@ func NewServer(client client.Client, port int, readinessChecks ...ReadinessCheck
 		memberlistBindPort: getMemberlistBindPort(),
 	}
 	if len(readinessChecks) > 0 {
-		server.readinessCheck = readinessChecks[0]
+		checks := append([]ReadinessCheck(nil), readinessChecks...)
+		server.readinessCheck = func() error {
+			for _, check := range checks {
+				if check == nil {
+					continue
+				}
+				if err := check(); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
 	}
 	return server
 }

--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -42,7 +42,12 @@ const (
 	EnvNamespace          = "PEER_NAMESPACE"
 	EnvLabelSelector      = "PEER_LABEL_SELECTOR"
 	EnvMemberlistBindPort = "MEMBERLIST_BIND_PORT"
+	HealthAPI             = "/healthz"
+	ReadyAPI              = "/readyz"
 )
+
+// ReadinessCheck reports whether the gateway is ready to receive traffic.
+type ReadinessCheck func() error
 
 // getMemberlistBindPort reads the memberlist bind port from environment variable
 // Returns the default port if not set or invalid
@@ -69,21 +74,28 @@ type Server struct {
 	port               int
 	memberlistBindPort int
 	client             client.Client
+	readinessCheck     ReadinessCheck
 }
 
 // NewServer creates a new peer server
-func NewServer(client client.Client, port int) *Server {
-	return &Server{
+func NewServer(client client.Client, port int, readinessChecks ...ReadinessCheck) *Server {
+	server := &Server{
 		port:               normalizePort(port, proxy.SystemPort),
 		client:             client,
 		memberlistBindPort: getMemberlistBindPort(),
 	}
+	if len(readinessChecks) > 0 {
+		server.readinessCheck = readinessChecks[0]
+	}
+	return server
 }
 
 // Start starts the HTTP server for handling refresh requests from peers
 func (s *Server) Start(ctx context.Context) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc(proxy.RefreshAPI, s.handleRefresh)
+	mux.HandleFunc(HealthAPI, s.handleHealth)
+	mux.HandleFunc(ReadyAPI, s.handleReady)
 
 	s.httpServer = &http.Server{
 		Addr:              fmt.Sprintf(":%d", normalizePort(s.port, proxy.SystemPort)),
@@ -127,6 +139,28 @@ func (s *Server) Start(ctx context.Context) error {
 	}()
 
 	return nil
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.readinessCheck != nil {
+		if err := s.readinessCheck(); err != nil {
+			http.Error(w, "gateway is not ready", http.StatusServiceUnavailable)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusOK)
 }
 
 func (s *Server) Stop(ctx context.Context) error {

--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -92,10 +92,7 @@ func NewServer(client client.Client, port int, readinessChecks ...ReadinessCheck
 
 // Start starts the HTTP server for handling refresh requests from peers
 func (s *Server) Start(ctx context.Context) error {
-	mux := http.NewServeMux()
-	mux.HandleFunc(proxy.RefreshAPI, s.handleRefresh)
-	mux.HandleFunc(HealthAPI, s.handleHealth)
-	mux.HandleFunc(ReadyAPI, s.handleReady)
+	mux := s.newServeMux()
 
 	s.httpServer = &http.Server{
 		Addr:              fmt.Sprintf(":%d", normalizePort(s.port, proxy.SystemPort)),
@@ -139,6 +136,14 @@ func (s *Server) Start(ctx context.Context) error {
 	}()
 
 	return nil
+}
+
+func (s *Server) newServeMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc(proxy.RefreshAPI, s.handleRefresh)
+	mux.HandleFunc(HealthAPI, s.handleHealth)
+	mux.HandleFunc(ReadyAPI, s.handleReady)
+	return mux
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/pkg/sandbox-gateway/server/server_test.go
+++ b/pkg/sandbox-gateway/server/server_test.go
@@ -19,6 +19,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -32,6 +33,41 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 )
+
+func TestHealthHandlers(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		method       string
+		readinessErr error
+		expectStatus int
+	}{
+		{name: "health ready", path: HealthAPI, method: http.MethodGet, expectStatus: http.StatusOK},
+		{name: "health method rejected", path: HealthAPI, method: http.MethodPost, expectStatus: http.StatusMethodNotAllowed},
+		{name: "readiness defaults ready", path: ReadyAPI, method: http.MethodGet, expectStatus: http.StatusOK},
+		{name: "readiness succeeds", path: ReadyAPI, method: http.MethodGet, readinessErr: nil, expectStatus: http.StatusOK},
+		{name: "readiness fails", path: ReadyAPI, method: http.MethodGet, readinessErr: errors.New("initializing"), expectStatus: http.StatusServiceUnavailable},
+		{name: "readiness method rejected", path: ReadyAPI, method: http.MethodPost, expectStatus: http.StatusMethodNotAllowed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var checks []ReadinessCheck
+			if tt.name != "readiness defaults ready" && tt.path == ReadyAPI {
+				checks = append(checks, func() error { return tt.readinessErr })
+			}
+			server := NewServer(nil, 0, checks...)
+			request := httptest.NewRequest(tt.method, tt.path, nil)
+			response := httptest.NewRecorder()
+			if tt.path == HealthAPI {
+				server.handleHealth(response, request)
+			} else {
+				server.handleReady(response, request)
+			}
+			assert.Equal(t, tt.expectStatus, response.Code)
+		})
+	}
+}
 
 func TestGetMemberlistBindPort(t *testing.T) {
 	tests := []struct {

--- a/pkg/sandbox-gateway/server/server_test.go
+++ b/pkg/sandbox-gateway/server/server_test.go
@@ -227,11 +227,12 @@ func TestHandleRefresh_RunningState(t *testing.T) {
 	s := &Server{}
 
 	route := proxy.Route{
-		ID:              "test-sandbox-1",
-		IP:              "10.0.0.1",
-		State:           v1alpha1.SandboxStateRunning,
-		ResourceVersion: "1",
-		Owner:           "test-owner",
+		ID:                 "test-sandbox-1",
+		IP:                 "10.0.0.1",
+		State:              v1alpha1.SandboxStateRunning,
+		ResourceVersion:    "1",
+		Owner:              "test-owner",
+		RequireTrafficAuth: true,
 	}
 	body, _ := json.Marshal(route)
 
@@ -248,6 +249,7 @@ func TestHandleRefresh_RunningState(t *testing.T) {
 	assert.Equal(t, "10.0.0.1", got.IP)
 	assert.Equal(t, v1alpha1.SandboxStateRunning, got.State)
 	assert.Equal(t, "test-owner", got.Owner)
+	assert.True(t, got.RequireTrafficAuth)
 }
 
 func TestHandleRefresh_NonRunningState(t *testing.T) {

--- a/pkg/sandbox-gateway/server/server_test.go
+++ b/pkg/sandbox-gateway/server/server_test.go
@@ -36,25 +36,37 @@ import (
 
 func TestHealthHandlers(t *testing.T) {
 	tests := []struct {
-		name         string
-		path         string
-		method       string
-		readinessErr error
-		expectStatus int
+		name            string
+		path            string
+		method          string
+		readinessErrors []error
+		includeNilCheck bool
+		expectCalls     int
+		expectStatus    int
 	}{
 		{name: "health ready", path: HealthAPI, method: http.MethodGet, expectStatus: http.StatusOK},
 		{name: "health method rejected", path: HealthAPI, method: http.MethodPost, expectStatus: http.StatusMethodNotAllowed},
 		{name: "readiness defaults ready", path: ReadyAPI, method: http.MethodGet, expectStatus: http.StatusOK},
-		{name: "readiness succeeds", path: ReadyAPI, method: http.MethodGet, readinessErr: nil, expectStatus: http.StatusOK},
-		{name: "readiness fails", path: ReadyAPI, method: http.MethodGet, readinessErr: errors.New("initializing"), expectStatus: http.StatusServiceUnavailable},
+		{name: "readiness succeeds", path: ReadyAPI, method: http.MethodGet, readinessErrors: []error{nil}, expectCalls: 1, expectStatus: http.StatusOK},
+		{name: "multiple readiness checks succeed", path: ReadyAPI, method: http.MethodGet, readinessErrors: []error{nil, nil}, expectCalls: 2, expectStatus: http.StatusOK},
+		{name: "first readiness check fails fast", path: ReadyAPI, method: http.MethodGet, readinessErrors: []error{errors.New("initializing"), nil}, expectCalls: 1, expectStatus: http.StatusServiceUnavailable},
+		{name: "second readiness check fails", path: ReadyAPI, method: http.MethodGet, readinessErrors: []error{nil, errors.New("initializing")}, expectCalls: 2, expectStatus: http.StatusServiceUnavailable},
+		{name: "nil readiness check is ignored", path: ReadyAPI, method: http.MethodGet, readinessErrors: []error{nil}, includeNilCheck: true, expectCalls: 1, expectStatus: http.StatusOK},
 		{name: "readiness method rejected", path: ReadyAPI, method: http.MethodPost, expectStatus: http.StatusMethodNotAllowed},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var checks []ReadinessCheck
-			if tt.name != "readiness defaults ready" && tt.path == ReadyAPI {
-				checks = append(checks, func() error { return tt.readinessErr })
+			calls := 0
+			checks := make([]ReadinessCheck, 0, len(tt.readinessErrors)+1)
+			if tt.includeNilCheck {
+				checks = append(checks, nil)
+			}
+			for _, readinessErr := range tt.readinessErrors {
+				checks = append(checks, func() error {
+					calls++
+					return readinessErr
+				})
 			}
 			server := NewServer(nil, 0, checks...)
 			request := httptest.NewRequest(tt.method, tt.path, nil)
@@ -65,6 +77,7 @@ func TestHealthHandlers(t *testing.T) {
 				server.handleReady(response, request)
 			}
 			assert.Equal(t, tt.expectStatus, response.Code)
+			assert.Equal(t, tt.expectCalls, calls)
 		})
 	}
 }

--- a/pkg/sandbox-gateway/server/server_test.go
+++ b/pkg/sandbox-gateway/server/server_test.go
@@ -69,6 +69,30 @@ func TestHealthHandlers(t *testing.T) {
 	}
 }
 
+func TestStartRegistersHealthHandlers(t *testing.T) {
+	server := NewServer(nil, 0)
+	mux := server.newServeMux()
+
+	tests := []struct {
+		name         string
+		path         string
+		method       string
+		expectStatus int
+	}{
+		{name: "health route", path: HealthAPI, method: http.MethodGet, expectStatus: http.StatusOK},
+		{name: "readiness route", path: ReadyAPI, method: http.MethodGet, expectStatus: http.StatusOK},
+		{name: "refresh route", path: proxy.RefreshAPI, method: http.MethodGet, expectStatus: http.StatusMethodNotAllowed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest(tt.method, tt.path, nil)
+			response := httptest.NewRecorder()
+			mux.ServeHTTP(response, request)
+			assert.Equal(t, tt.expectStatus, response.Code)
+		})
+	}
+}
+
 func TestGetMemberlistBindPort(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/utils/proxyutils/default_test.go
+++ b/pkg/utils/proxyutils/default_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/identity"
 )
 
 func TestGetRouteFromSandbox(t *testing.T) {
@@ -125,7 +126,7 @@ func TestGetRouteFromSandbox(t *testing.T) {
 					Name:      "jwt-sandbox",
 					Namespace: "default",
 					Annotations: map[string]string{
-						annotationEnableJWTAuth: v1alpha1.True,
+						identity.AnnotationEnableJwtAuth: v1alpha1.True,
 					},
 				},
 				Status: v1alpha1.SandboxStatus{
@@ -150,7 +151,7 @@ func TestGetRouteFromSandbox(t *testing.T) {
 					Name:      "invalid-jwt-annotation-sandbox",
 					Namespace: "default",
 					Annotations: map[string]string{
-						annotationEnableJWTAuth: "True",
+						identity.AnnotationEnableJwtAuth: "True",
 					},
 				},
 				Status: v1alpha1.SandboxStatus{

--- a/pkg/utils/proxyutils/default_test.go
+++ b/pkg/utils/proxyutils/default_test.go
@@ -118,6 +118,55 @@ func TestGetRouteFromSandbox(t *testing.T) {
 				AccessToken: "secret-token-123",
 			},
 		},
+		{
+			name: "sandbox requiring traffic authentication",
+			sandbox: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "jwt-sandbox",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotationEnableJWTAuth: v1alpha1.True,
+					},
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase: v1alpha1.SandboxRunning,
+					Conditions: []metav1.Condition{
+						{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue},
+					},
+					PodInfo: v1alpha1.PodInfo{PodIP: "10.0.0.4"},
+				},
+			},
+			expectedRoute: Route{
+				IP:                 "10.0.0.4",
+				ID:                 "default--jwt-sandbox",
+				State:              v1alpha1.SandboxStateRunning,
+				RequireTrafficAuth: true,
+			},
+		},
+		{
+			name: "traffic authentication annotation requires exact true value",
+			sandbox: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-jwt-annotation-sandbox",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotationEnableJWTAuth: "True",
+					},
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase: v1alpha1.SandboxRunning,
+					Conditions: []metav1.Condition{
+						{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue},
+					},
+					PodInfo: v1alpha1.PodInfo{PodIP: "10.0.0.5"},
+				},
+			},
+			expectedRoute: Route{
+				IP:    "10.0.0.5",
+				ID:    "default--invalid-jwt-annotation-sandbox",
+				State: v1alpha1.SandboxStateRunning,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/utils/proxyutils/route.go
+++ b/pkg/utils/proxyutils/route.go
@@ -24,37 +24,41 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const annotationEnableJWTAuth = "security.agents.kruise.io/enable-jwt-auth"
+
 func GetRouteFromSandbox(s *agentsv1alpha1.Sandbox) Route {
 	state, _ := utils.GetSandboxState(s)
 	if s.Status.PodInfo.PodIP == "" {
 		state = agentsv1alpha1.SandboxStateCreating
 	}
 	return Route{
-		IP:              s.Status.PodInfo.PodIP,
-		ID:              utils.GetSandboxID(s),
-		UID:             s.GetUID(),
-		Owner:           s.GetAnnotations()[agentsv1alpha1.AnnotationOwner],
-		State:           state,
-		ResourceVersion: s.GetResourceVersion(),
-		AccessToken:     s.GetAnnotations()[agentsv1alpha1.AnnotationRuntimeAccessToken],
+		IP:                 s.Status.PodInfo.PodIP,
+		ID:                 utils.GetSandboxID(s),
+		UID:                s.GetUID(),
+		Owner:              s.GetAnnotations()[agentsv1alpha1.AnnotationOwner],
+		State:              state,
+		ResourceVersion:    s.GetResourceVersion(),
+		AccessToken:        s.GetAnnotations()[agentsv1alpha1.AnnotationRuntimeAccessToken],
+		RequireTrafficAuth: s.GetAnnotations()[annotationEnableJWTAuth] == agentsv1alpha1.True,
 	}
 }
 
 // Route represents an internal sandbox routing rule.
 // Moved from pkg/proxy to break the pkg/utils → pkg/proxy layer violation.
 type Route struct {
-	IP              string    `json:"ip"`
-	ID              string    `json:"id"`
-	UID             types.UID `json:"uid"`
-	Owner           string    `json:"owner"`
-	State           string    `json:"state"`
-	ResourceVersion string    `json:"resourceVersion"`
-	AccessToken     string    `json:"accessToken,omitempty"`
+	IP                 string    `json:"ip"`
+	ID                 string    `json:"id"`
+	UID                types.UID `json:"uid"`
+	Owner              string    `json:"owner"`
+	State              string    `json:"state"`
+	ResourceVersion    string    `json:"resourceVersion"`
+	AccessToken        string    `json:"accessToken,omitempty"`
+	RequireTrafficAuth bool      `json:"requireTrafficAuth,omitempty"`
 }
 
 // String implements fmt.Stringer to prevent AccessToken from being leaked in logs.
 // Always prints "***" to avoid revealing whether a token is configured.
 func (r Route) String() string {
-	return fmt.Sprintf("{IP:%s ID:%s UID:%s Owner:%s State:%s ResourceVersion:%s AccessToken:***}",
-		r.IP, r.ID, r.UID, r.Owner, r.State, r.ResourceVersion)
+	return fmt.Sprintf("{IP:%s ID:%s UID:%s Owner:%s State:%s ResourceVersion:%s AccessToken:*** RequireTrafficAuth:%t}",
+		r.IP, r.ID, r.UID, r.Owner, r.State, r.ResourceVersion, r.RequireTrafficAuth)
 }

--- a/pkg/utils/proxyutils/route.go
+++ b/pkg/utils/proxyutils/route.go
@@ -20,11 +20,10 @@ import (
 	"fmt"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/utils"
 	"k8s.io/apimachinery/pkg/types"
 )
-
-const annotationEnableJWTAuth = "security.agents.kruise.io/enable-jwt-auth"
 
 func GetRouteFromSandbox(s *agentsv1alpha1.Sandbox) Route {
 	state, _ := utils.GetSandboxState(s)
@@ -39,7 +38,7 @@ func GetRouteFromSandbox(s *agentsv1alpha1.Sandbox) Route {
 		State:              state,
 		ResourceVersion:    s.GetResourceVersion(),
 		AccessToken:        s.GetAnnotations()[agentsv1alpha1.AnnotationRuntimeAccessToken],
-		RequireTrafficAuth: s.GetAnnotations()[annotationEnableJWTAuth] == agentsv1alpha1.True,
+		RequireTrafficAuth: s.GetAnnotations()[identity.AnnotationEnableJwtAuth] == agentsv1alpha1.True,
 	}
 }
 

--- a/pkg/utils/proxyutils/route_test.go
+++ b/pkg/utils/proxyutils/route_test.go
@@ -34,15 +34,16 @@ func TestRouteString(t *testing.T) {
 		{
 			name: "route with access token masks token value",
 			route: Route{
-				IP:              "10.0.0.1",
-				ID:              "default--my-sandbox",
-				UID:             "uid-123",
-				Owner:           "user1",
-				State:           v1alpha1.SandboxStateRunning,
-				ResourceVersion: "100",
-				AccessToken:     "super-secret-token",
+				IP:                 "10.0.0.1",
+				ID:                 "default--my-sandbox",
+				UID:                "uid-123",
+				Owner:              "user1",
+				State:              v1alpha1.SandboxStateRunning,
+				ResourceVersion:    "100",
+				AccessToken:        "super-secret-token",
+				RequireTrafficAuth: true,
 			},
-			expectContains:   []string{"10.0.0.1", "default--my-sandbox", "uid-123", "user1", "running", "100", "AccessToken:***"},
+			expectContains:   []string{"10.0.0.1", "default--my-sandbox", "uid-123", "user1", "running", "100", "AccessToken:***", "RequireTrafficAuth:true"},
 			expectNotContain: []string{"super-secret-token"},
 		},
 		{
@@ -56,7 +57,7 @@ func TestRouteString(t *testing.T) {
 				ResourceVersion: "50",
 				AccessToken:     "",
 			},
-			expectContains:   []string{"10.0.0.2", "default--no-token", "uid-456", "creating", "50", "AccessToken:***"},
+			expectContains:   []string{"10.0.0.2", "default--no-token", "uid-456", "creating", "50", "AccessToken:***", "RequireTrafficAuth:false"},
 			expectNotContain: nil,
 		},
 	}

--- a/test/e2b/assets/jwt-oidc-provider/Dockerfile
+++ b/test/e2b/assets/jwt-oidc-provider/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.25-bookworm AS builder
+
+WORKDIR /build
+COPY test/e2b/assets/jwt-oidc-provider/main.go .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o jwt-oidc-provider main.go
+
+FROM scratch
+COPY --from=builder /build/jwt-oidc-provider /jwt-oidc-provider
+ENTRYPOINT ["/jwt-oidc-provider"]

--- a/test/e2b/assets/jwt-oidc-provider/main.go
+++ b/test/e2b/assets/jwt-oidc-provider/main.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"math/big"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	keyID          = "e2e-key"
+	identityDir    = "/identity"
+	signingKeyPath = identityDir + "/signing.key"
+	tlsCertPath    = identityDir + "/tls.crt"
+	tlsKeyPath     = identityDir + "/tls.key"
+)
+
+type sandboxClaims struct {
+	SandboxID  string `json:"sandboxId"`
+	SandboxUID string `json:"sandboxUid"`
+}
+
+type tokenClaims struct {
+	Issuer    string        `json:"iss"`
+	Subject   string        `json:"sub"`
+	IssuedAt  int64         `json:"iat"`
+	NotBefore int64         `json:"nbf"`
+	Expiry    int64         `json:"exp"`
+	Sandbox   sandboxClaims `json:"sandbox"`
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	issuer := os.Getenv("OIDC_ISSUER")
+	if issuer == "" {
+		return errors.New("OIDC_ISSUER must not be empty")
+	}
+	privateKey, err := loadPrivateKey(signingKeyPath)
+	if err != nil {
+		return err
+	}
+	if len(os.Args) > 1 && os.Args[1] == "issue" {
+		return issueToken(issuer, privateKey, os.Args[2:])
+	}
+	return serve(issuer, privateKey)
+}
+
+func serve(issuer string, privateKey *rsa.PrivateKey) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]string{
+			"issuer":   issuer,
+			"jwks_uri": issuer + "/jwks",
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{
+			"keys": []map[string]string{{
+				"kty": "RSA",
+				"use": "sig",
+				"alg": "RS256",
+				"kid": keyID,
+				"n":   base64.RawURLEncoding.EncodeToString(privateKey.PublicKey.N.Bytes()),
+				"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(privateKey.PublicKey.E)).Bytes()),
+			}},
+		})
+	})
+
+	server := &http.Server{
+		Addr:              ":8443",
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		TLSConfig:         &tls.Config{MinVersion: tls.VersionTLS12},
+	}
+	return server.ListenAndServeTLS(tlsCertPath, tlsKeyPath)
+}
+
+func issueToken(issuer string, privateKey *rsa.PrivateKey, args []string) error {
+	flags := flag.NewFlagSet("issue", flag.ContinueOnError)
+	sandboxID := flags.String("sandbox-id", "", "sandbox ID")
+	sandboxUID := flags.String("sandbox-uid", "", "sandbox UID")
+	expired := flags.Bool("expired", false, "issue an expired token")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *sandboxID == "" || *sandboxUID == "" {
+		return errors.New("sandbox-id and sandbox-uid must not be empty")
+	}
+
+	now := time.Now()
+	issuedAt := now.Add(-time.Second)
+	expiry := now.Add(5 * time.Minute)
+	if *expired {
+		issuedAt = now.Add(-10 * time.Minute)
+		expiry = now.Add(-2 * time.Minute)
+	}
+	claims := tokenClaims{
+		Issuer:    issuer,
+		Subject:   "jwt-e2e-client",
+		IssuedAt:  issuedAt.Unix(),
+		NotBefore: issuedAt.Unix(),
+		Expiry:    expiry.Unix(),
+		Sandbox: sandboxClaims{
+			SandboxID:  *sandboxID,
+			SandboxUID: *sandboxUID,
+		},
+	}
+	token, err := signToken(privateKey, claims)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(os.Stdout, token)
+	return err
+}
+
+func signToken(privateKey *rsa.PrivateKey, claims tokenClaims) (string, error) {
+	headerJSON, err := json.Marshal(map[string]string{"alg": "RS256", "kid": keyID, "typ": "JWT"})
+	if err != nil {
+		return "", fmt.Errorf("encode JWT header: %w", err)
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("encode JWT claims: %w", err)
+	}
+	unsigned := base64.RawURLEncoding.EncodeToString(headerJSON) + "." + base64.RawURLEncoding.EncodeToString(claimsJSON)
+	digest := sha256.Sum256([]byte(unsigned))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("sign JWT: %w", err)
+	}
+	return unsigned + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func loadPrivateKey(path string) (*rsa.PrivateKey, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read signing key: %w", err)
+	}
+	block, _ := pem.Decode(contents)
+	if block == nil {
+		return nil, errors.New("decode signing key PEM")
+	}
+	if block.Type == "RSA PRIVATE KEY" {
+		key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse PKCS#1 signing key: %w", err)
+		}
+		return key, nil
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse PKCS#8 signing key: %w", err)
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("signing key is not RSA")
+	}
+	return key, nil
+}
+
+func writeJSON(w http.ResponseWriter, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		log.Printf("write JSON response: %v", err)
+	}
+}

--- a/test/e2b/assets/jwt-oidc-provider/provider.yaml
+++ b/test/e2b/assets/jwt-oidc-provider/provider.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jwt-e2e-oidc-provider
+  namespace: sandbox-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jwt-e2e-oidc-provider
+  template:
+    metadata:
+      labels:
+        app: jwt-e2e-oidc-provider
+    spec:
+      containers:
+        - name: provider
+          image: jwt-oidc-provider:latest
+          imagePullPolicy: Never
+          env:
+            - name: OIDC_ISSUER
+              value: https://jwt-e2e-oidc-provider.sandbox-system.svc:8443
+          ports:
+            - name: https
+              containerPort: 8443
+          readinessProbe:
+            tcpSocket:
+              port: https
+            periodSeconds: 1
+            failureThreshold: 60
+          volumeMounts:
+            - name: identity
+              mountPath: /identity
+              readOnly: true
+      volumes:
+        - name: identity
+          secret:
+            secretName: jwt-e2e-oidc-provider
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jwt-e2e-oidc-provider
+  namespace: sandbox-system
+spec:
+  selector:
+    app: jwt-e2e-oidc-provider
+  ports:
+    - name: https
+      port: 8443
+      targetPort: https
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: jwt-e2e-oidc-ca-reader
+  namespace: sandbox-system
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["jwt-e2e-oidc-ca"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jwt-e2e-oidc-ca-reader
+  namespace: sandbox-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: jwt-e2e-oidc-ca-reader
+subjects:
+  - kind: ServiceAccount
+    name: sandbox-gateway
+    namespace: sandbox-system

--- a/test/e2b/assets/runtime-mtls-server/Dockerfile
+++ b/test/e2b/assets/runtime-mtls-server/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.25-bookworm AS builder
+
+WORKDIR /build
+COPY test/e2b/assets/runtime-mtls-server/main.go .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o runtime-mtls-server main.go
+
+FROM scratch
+COPY --from=builder /build/runtime-mtls-server /runtime-mtls-server
+ENTRYPOINT ["/runtime-mtls-server"]

--- a/test/e2b/assets/runtime-mtls-server/main.go
+++ b/test/e2b/assets/runtime-mtls-server/main.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	caPEM, err := os.ReadFile("/tls/ca.crt")
+	if err != nil {
+		log.Fatalf("read client CA: %v", err)
+	}
+	clientCAs := x509.NewCertPool()
+	if !clientCAs.AppendCertsFromPEM(caPEM) {
+		log.Fatal("parse client CA")
+	}
+
+	go func() {
+		plaintextServer := &http.Server{
+			Addr: ":8080",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if _, err := fmt.Fprint(w, "runtime-plaintext-ok"); err != nil {
+					log.Printf("write plaintext response: %v", err)
+				}
+			}),
+		}
+		log.Fatal(plaintextServer.ListenAndServe())
+	}()
+
+	server := &http.Server{
+		Addr: ":49983",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if _, err := fmt.Fprint(w, "runtime-mtls-ok"); err != nil {
+				log.Printf("write mTLS response: %v", err)
+			}
+		}),
+		TLSConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			ClientAuth: tls.RequireAndVerifyClientCert,
+			ClientCAs:  clientCAs,
+		},
+	}
+	log.Fatal(server.ListenAndServeTLS("/tls/tls.crt", "/tls/tls.key"))
+}

--- a/test/e2b/gateway_utils.py
+++ b/test/e2b/gateway_utils.py
@@ -1,0 +1,30 @@
+"""Shared helpers for sandbox-gateway end-to-end tests."""
+
+import json
+import subprocess
+
+
+def get_sandbox_resource(sandbox_id: str) -> dict:
+    """Return the Sandbox resource identified by namespace--name."""
+    namespace, separator, name = sandbox_id.partition("--")
+    if not separator:
+        namespace, name = "default", namespace
+    result = subprocess.run(
+        ["kubectl", "get", "sandbox", name, "-n", namespace, "-o", "json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def get_sandbox_access_token(sandbox_id: str) -> str:
+    """Return the runtime access token annotation, if present."""
+    sandbox = get_sandbox_resource(sandbox_id)
+    annotations = sandbox.get("metadata", {}).get("annotations", {})
+    return annotations.get("agents.kruise.io/runtime-access-token", "")
+
+
+def get_sandbox_uid(sandbox_id: str) -> str:
+    """Return the immutable Sandbox UID."""
+    return get_sandbox_resource(sandbox_id)["metadata"]["uid"]

--- a/test/e2b/pytest.ini
+++ b/test/e2b/pytest.ini
@@ -7,6 +7,7 @@ addopts =
 strict_markers = true
 strict_config = true
 markers =
+    jwt_auth: sandbox-gateway JWT authentication tests requiring a dedicated OIDC provider
     runtime_mtls: sandbox-gateway Runtime mTLS tests requiring dedicated certificates and backend
     flaky: tests with known transient issues (rerun on failure)
     slow: long-running tests

--- a/test/e2b/pytest.ini
+++ b/test/e2b/pytest.ini
@@ -7,6 +7,7 @@ addopts =
 strict_markers = true
 strict_config = true
 markers =
+    runtime_mtls: sandbox-gateway Runtime mTLS tests requiring dedicated certificates and backend
     flaky: tests with known transient issues (rerun on failure)
     slow: long-running tests
 log_cli = false

--- a/test/e2b/pytest.ini
+++ b/test/e2b/pytest.ini
@@ -7,6 +7,8 @@ addopts =
 strict_markers = true
 strict_config = true
 markers =
+    gateway_routing: sandbox-gateway routing tests using the default authentication mode
+    gateway_uuid_auth: sandbox-gateway UUID authentication tests
     jwt_auth: sandbox-gateway JWT authentication tests requiring a dedicated OIDC provider
     runtime_mtls: sandbox-gateway Runtime mTLS tests requiring dedicated certificates and backend
     flaky: tests with known transient issues (rerun on failure)

--- a/test/e2b/test_gateway.py
+++ b/test/e2b/test_gateway.py
@@ -1,34 +1,17 @@
 """Tests for sandbox-gateway routing methods (header-based and host-based)."""
 import json
+import logging
 import subprocess
 import time
 
+import pytest
 import requests
 from e2b_code_interpreter import Sandbox
 
-import logging
+from gateway_utils import get_sandbox_access_token
 
 logger = logging.getLogger(__name__)
-
-
-def get_sandbox_access_token(sandbox_id: str) -> str:
-    """Retrieve the runtime-access-token annotation from a Sandbox CR via kubectl."""
-    if "--" in sandbox_id:
-        parts = sandbox_id.split("--")
-        namespace = parts[0]
-        name = parts[1]
-    else:
-        namespace = "default"
-        name = sandbox_id
-    result = subprocess.run(
-        ["kubectl", "get", "sandbox", name, "-n", namespace, "-o", "json"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    sbx = json.loads(result.stdout)
-    annotations = sbx.get("metadata", {}).get("annotations", {})
-    return annotations.get("agents.kruise.io/runtime-access-token", "")
+pytestmark = pytest.mark.gateway_routing
 
 
 def test_gateway_runtime_mtls_disabled_by_default():
@@ -54,15 +37,15 @@ def test_gateway_runtime_mtls_disabled_by_default():
     assert "original_dst_mtls_cluster" not in envoy_config
 
 
-def test_gateway_header_based_routing(sandbox_context, config):
-    """Test routing via e2b-sandbox-id and e2b-sandbox-port headers."""
-    sandbox: Sandbox = sandbox_context.add(Sandbox.create(
-        template=config.templates.code_interpreter,
-        timeout=120,
-        headers={
-            "x-request-id": sandbox_context.request_id
-        }
-    ))
+def test_gateway_header_and_host_based_routing(sandbox_context, config):
+    """Test header-based and native E2B host-based routing."""
+    sandbox: Sandbox = sandbox_context.add(
+        Sandbox.create(
+            template=config.templates.code_interpreter,
+            timeout=120,
+            headers={"x-request-id": sandbox_context.request_id},
+        )
+    )
     sandbox_id = sandbox.sandbox_id
     logger.info("sandbox-id: %s", sandbox_id)
 
@@ -71,50 +54,32 @@ def test_gateway_header_based_routing(sandbox_context, config):
 
     access_token = get_sandbox_access_token(sandbox_id)
 
-    headers = {
+    header_routing = {
         "e2b-sandbox-id": sandbox_id,
         "e2b-sandbox-port": "49983",
     }
     if access_token:
-        headers["X-Access-Token"] = access_token
+        header_routing["X-Access-Token"] = access_token
 
-    resp = requests.get(
+    header_response = requests.get(
         f"{config.gateway_url}/",
-        headers=headers,
+        headers=header_routing,
         timeout=10,
     )
-    assert resp.status_code != 502, f"Gateway 502: sandbox {sandbox_id} not found or not running"
-    assert resp.status_code != 401, f"Gateway 401: access token mismatch for sandbox {sandbox_id}"
-    assert resp.status_code != 503, f"Gateway 503: upstream connection failed for sandbox {sandbox_id}"
-
-
-def test_gateway_host_based_routing(sandbox_context, config):
-    """Test routing via native E2B host header format: {port}-{sandboxID}.{domain}."""
-    sandbox: Sandbox = sandbox_context.add(Sandbox.create(
-        template=config.templates.code_interpreter,
-        timeout=120,
-        headers={
-            "x-request-id": sandbox_context.request_id
-        }
-    ))
-    sandbox_id = sandbox.sandbox_id
-    logger.info("sandbox-id: %s", sandbox_id)
-
-    # Wait for gateway registry to sync
-    time.sleep(3)
-
-    access_token = get_sandbox_access_token(sandbox_id)
+    assert header_response.status_code not in (401, 502, 503), (
+        f"Header routing failed for sandbox {sandbox_id}: {header_response.status_code}"
+    )
 
     host = f"49983-{sandbox_id}.{config.e2b_domain}"
-    headers = {"Host": host}
+    host_routing = {"Host": host}
     if access_token:
-        headers["X-Access-Token"] = access_token
+        host_routing["X-Access-Token"] = access_token
 
-    resp = requests.get(
+    host_response = requests.get(
         f"{config.gateway_url}/",
-        headers=headers,
+        headers=host_routing,
         timeout=10,
     )
-    assert resp.status_code != 502, f"Gateway 502: sandbox {sandbox_id} not found or not running"
-    assert resp.status_code != 401, f"Gateway 401: access token mismatch for sandbox {sandbox_id}"
-    assert resp.status_code != 503, f"Gateway 503: upstream connection failed for sandbox {sandbox_id}"
+    assert host_response.status_code not in (401, 502, 503), (
+        f"Host routing failed for sandbox {sandbox_id}: {host_response.status_code}"
+    )

--- a/test/e2b/test_gateway.py
+++ b/test/e2b/test_gateway.py
@@ -31,6 +31,29 @@ def get_sandbox_access_token(sandbox_id: str) -> str:
     return annotations.get("agents.kruise.io/runtime-access-token", "")
 
 
+def test_gateway_runtime_mtls_disabled_by_default():
+    """Verify the default deployment keeps Runtime mTLS completely disabled."""
+    deployment = subprocess.run(
+        ["kubectl", "get", "deployment", "sandbox-gateway", "-n", "sandbox-system", "-o", "json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    deployment_spec = json.loads(deployment.stdout)["spec"]["template"]["spec"]
+    init_names = {container["name"] for container in deployment_spec.get("initContainers", [])}
+    assert "runtime-mtls-cert-init" not in init_names
+
+    configmap = subprocess.run(
+        ["kubectl", "get", "configmap", "envoy-config", "-n", "sandbox-system", "-o", "json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    envoy_config = json.loads(configmap.stdout)["data"]["envoy.yaml"]
+    assert "enable-runtime-mtls: false" in envoy_config
+    assert "original_dst_mtls_cluster" not in envoy_config
+
+
 def test_gateway_header_based_routing(sandbox_context, config):
     """Test routing via e2b-sandbox-id and e2b-sandbox-port headers."""
     sandbox: Sandbox = sandbox_context.add(Sandbox.create(
@@ -62,6 +85,7 @@ def test_gateway_header_based_routing(sandbox_context, config):
     )
     assert resp.status_code != 502, f"Gateway 502: sandbox {sandbox_id} not found or not running"
     assert resp.status_code != 401, f"Gateway 401: access token mismatch for sandbox {sandbox_id}"
+    assert resp.status_code != 503, f"Gateway 503: upstream connection failed for sandbox {sandbox_id}"
 
 
 def test_gateway_host_based_routing(sandbox_context, config):
@@ -93,3 +117,4 @@ def test_gateway_host_based_routing(sandbox_context, config):
     )
     assert resp.status_code != 502, f"Gateway 502: sandbox {sandbox_id} not found or not running"
     assert resp.status_code != 401, f"Gateway 401: access token mismatch for sandbox {sandbox_id}"
+    assert resp.status_code != 503, f"Gateway 503: upstream connection failed for sandbox {sandbox_id}"

--- a/test/e2b/test_gateway_auth.py
+++ b/test/e2b/test_gateway_auth.py
@@ -1,195 +1,81 @@
 """Tests for sandbox-gateway access token authentication."""
-import json
-import subprocess
+import logging
 import time
 
+import pytest
 import requests
 from e2b_code_interpreter import Sandbox
 
-import logging
+from gateway_utils import get_sandbox_access_token
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.gateway_uuid_auth
 
 
-def get_sandbox_access_token(sandbox_id: str) -> str:
-    """Retrieve the runtime-access-token annotation from a Sandbox CR via kubectl.
-
-    Args:
-        sandbox_id: The sandbox ID in namespace--name format (e.g., default--my-sandbox).
-
-    Returns:
-        The access token string, or empty string if not set.
-    """
-    # sandbox_id format is "namespace--name", extract both parts
-    if "--" in sandbox_id:
-        parts = sandbox_id.split("--")
-        namespace = parts[0]
-        name = parts[1]
-    else:
-        namespace = "default"
-        name = sandbox_id
-    result = subprocess.run(
-        ["kubectl", "get", "sandbox", name, "-n", namespace, "-o", "json"],
-        capture_output=True,
-        text=True,
-        check=True,
+def test_gateway_uuid_auth(sandbox_context, config):
+    """Verify UUID authentication for header-based and host-based routing."""
+    sandbox: Sandbox = sandbox_context.add(
+        Sandbox.create(
+            template=config.templates.code_interpreter,
+            timeout=120,
+            headers={"x-request-id": sandbox_context.request_id},
+        )
     )
-    sbx = json.loads(result.stdout)
-    annotations = sbx.get("metadata", {}).get("annotations", {})
-    return annotations.get("agents.kruise.io/runtime-access-token", "")
-
-
-def test_gateway_auth_valid_token(sandbox_context, config):
-    """Test that request with valid X-Access-Token header is forwarded successfully."""
-    sandbox: Sandbox = sandbox_context.add(Sandbox.create(
-        template=config.templates.code_interpreter,
-        timeout=120,
-        headers={
-            "x-request-id": sandbox_context.request_id
-        }
-    ))
     sandbox_id = sandbox.sandbox_id
     logger.info("sandbox-id: %s", sandbox_id)
 
     # Wait for gateway registry to sync
     time.sleep(3)
 
-    # Retrieve the access token from the Sandbox CR annotation
     access_token = get_sandbox_access_token(sandbox_id)
-    if access_token:
-        logger.info("access-token: %s...", access_token[:8])
-    else:
-        logger.info("access-token: (empty)")
     assert access_token != "", "Sandbox should have a runtime-access-token annotation"
 
-    # Request with valid token should succeed (not 401 or 502)
-    resp = requests.get(
+    base_headers = {
+        "e2b-sandbox-id": sandbox_id,
+        "e2b-sandbox-port": "49983",
+    }
+    valid_response = requests.get(
         f"{config.gateway_url}/",
-        headers={
-            "e2b-sandbox-id": sandbox_id,
-            "e2b-sandbox-port": "49983",
-            "X-Access-Token": access_token,
-        },
+        headers={**base_headers, "X-Access-Token": access_token},
         timeout=10,
     )
-    assert resp.status_code != 401, (
-        f"Gateway returned 401 with valid token for sandbox {sandbox_id}"
-    )
-    assert resp.status_code != 502, (
-        f"Gateway returned 502: sandbox {sandbox_id} not found or not running"
+    assert valid_response.status_code not in (401, 502, 503), (
+        f"Gateway rejected a valid UUID token: {valid_response.status_code}"
     )
 
-
-def test_gateway_auth_missing_token(sandbox_context, config):
-    """Test that request without X-Access-Token header returns 401."""
-    sandbox: Sandbox = sandbox_context.add(Sandbox.create(
-        template=config.templates.code_interpreter,
-        timeout=120,
-        headers={
-            "x-request-id": sandbox_context.request_id
-        }
-    ))
-    sandbox_id = sandbox.sandbox_id
-    logger.info("sandbox-id: %s", sandbox_id)
-
-    # Wait for gateway registry to sync
-    time.sleep(3)
-
-    # Verify sandbox has an access token configured
-    access_token = get_sandbox_access_token(sandbox_id)
-    assert access_token != "", "Sandbox should have a runtime-access-token annotation"
-
-    # Request without token should be rejected with 401
-    resp = requests.get(
+    missing_response = requests.get(
         f"{config.gateway_url}/",
-        headers={
-            "e2b-sandbox-id": sandbox_id,
-            "e2b-sandbox-port": "49983",
-        },
+        headers=base_headers,
         timeout=10,
     )
-    assert resp.status_code == 401, (
-        f"Expected 401 without token, got {resp.status_code} for sandbox {sandbox_id}"
+    assert missing_response.status_code == 401, (
+        f"Expected 401 without UUID token, got {missing_response.status_code}"
     )
 
-
-def test_gateway_auth_invalid_token(sandbox_context, config):
-    """Test that request with wrong X-Access-Token header returns 401."""
-    sandbox: Sandbox = sandbox_context.add(Sandbox.create(
-        template=config.templates.code_interpreter,
-        timeout=120,
-        headers={
-            "x-request-id": sandbox_context.request_id
-        }
-    ))
-    sandbox_id = sandbox.sandbox_id
-    logger.info("sandbox-id: %s", sandbox_id)
-
-    # Wait for gateway registry to sync
-    time.sleep(3)
-
-    # Verify sandbox has an access token configured
-    access_token = get_sandbox_access_token(sandbox_id)
-    assert access_token != "", "Sandbox should have a runtime-access-token annotation"
-
-    # Request with wrong token should be rejected with 401
-    resp = requests.get(
+    invalid_response = requests.get(
         f"{config.gateway_url}/",
-        headers={
-            "e2b-sandbox-id": sandbox_id,
-            "e2b-sandbox-port": "49983",
-            "X-Access-Token": "wrong-token-value",
-        },
+        headers={**base_headers, "X-Access-Token": "wrong-token-value"},
         timeout=10,
     )
-    assert resp.status_code == 401, (
-        f"Expected 401 with invalid token, got {resp.status_code} for sandbox {sandbox_id}"
+    assert invalid_response.status_code == 401, (
+        f"Expected 401 with invalid UUID token, got {invalid_response.status_code}"
     )
-
-
-def test_gateway_auth_host_based_routing_with_token(sandbox_context, config):
-    """Test that host-based routing also enforces access token authentication."""
-    sandbox: Sandbox = sandbox_context.add(Sandbox.create(
-        template=config.templates.code_interpreter,
-        timeout=120,
-        headers={
-            "x-request-id": sandbox_context.request_id
-        }
-    ))
-    sandbox_id = sandbox.sandbox_id
-    logger.info("sandbox-id: %s", sandbox_id)
-
-    # Wait for gateway registry to sync
-    time.sleep(3)
-
-    # Retrieve the access token
-    access_token = get_sandbox_access_token(sandbox_id)
-    assert access_token != "", "Sandbox should have a runtime-access-token annotation"
 
     host = f"49983-{sandbox_id}.{config.e2b_domain}"
-
-    # Without token -> 401
-    resp_no_token = requests.get(
+    host_missing_response = requests.get(
         f"{config.gateway_url}/",
         headers={"Host": host},
         timeout=10,
     )
-    assert resp_no_token.status_code == 401, (
-        f"Expected 401 without token via host routing, got {resp_no_token.status_code}"
+    assert host_missing_response.status_code == 401, (
+        f"Expected 401 without UUID token via host routing, got {host_missing_response.status_code}"
     )
 
-    # With valid token -> success
-    resp_valid = requests.get(
+    host_valid_response = requests.get(
         f"{config.gateway_url}/",
-        headers={
-            "Host": host,
-            "X-Access-Token": access_token,
-        },
+        headers={"Host": host, "X-Access-Token": access_token},
         timeout=10,
     )
-    assert resp_valid.status_code != 401, (
-        f"Gateway returned 401 with valid token via host routing for sandbox {sandbox_id}"
-    )
-    assert resp_valid.status_code != 502, (
-        f"Gateway returned 502 via host routing: sandbox {sandbox_id} not found or not running"
+    assert host_valid_response.status_code not in (401, 502, 503), (
+        f"Gateway rejected valid UUID token via host routing: {host_valid_response.status_code}"
     )

--- a/test/e2b/test_gateway_jwt_auth.py
+++ b/test/e2b/test_gateway_jwt_auth.py
@@ -13,6 +13,7 @@ from gateway_utils import get_sandbox_access_token, get_sandbox_uid
 
 
 TOKEN_COMMAND = os.environ.get("JWT_E2E_TOKEN_COMMAND", "")
+JWT_AUTH_METADATA_KEY = "security.agents.kruise.io/enable-jwt-auth"
 pytestmark = [
     pytest.mark.jwt_auth,
     pytest.mark.skipif(
@@ -76,15 +77,24 @@ def gateway_request_eventually(
 
 
 def test_gateway_traffic_access_token_jwt(sandbox_context, config):
-    """Verify valid, missing, malformed, expired, and cross-sandbox JWT behavior."""
+    """Verify route-selective JWT authentication and token validation."""
     first: Sandbox = sandbox_context.add(
         Sandbox.create(
             template=config.templates.code_interpreter,
             timeout=120,
+            metadata={JWT_AUTH_METADATA_KEY: "true"},
             headers={"x-request-id": sandbox_context.request_id},
         )
     )
     second: Sandbox = sandbox_context.add(
+        Sandbox.create(
+            template=config.templates.code_interpreter,
+            timeout=120,
+            metadata={JWT_AUTH_METADATA_KEY: "true"},
+            headers={"x-request-id": sandbox_context.request_id},
+        )
+    )
+    public: Sandbox = sandbox_context.add(
         Sandbox.create(
             template=config.templates.code_interpreter,
             timeout=120,
@@ -96,8 +106,15 @@ def test_gateway_traffic_access_token_jwt(sandbox_context, config):
     )
     first_runtime_token = get_sandbox_access_token(first.sandbox_id)
     second_runtime_token = get_sandbox_access_token(second.sandbox_id)
+    public_runtime_token = get_sandbox_access_token(public.sandbox_id)
     assert first_runtime_token, "first Sandbox is missing its runtime access token"
     assert second_runtime_token, "second Sandbox is missing its runtime access token"
+    assert public_runtime_token, "public Sandbox is missing its runtime access token"
+
+    public_response = gateway_request_eventually(
+        config, public.sandbox_id, public_runtime_token, None
+    )
+    assert public_response.status_code in (200, 404), public_response.text
 
     valid = gateway_request_eventually(
         config, first.sandbox_id, first_runtime_token, first_token

--- a/test/e2b/test_gateway_jwt_auth.py
+++ b/test/e2b/test_gateway_jwt_auth.py
@@ -1,0 +1,109 @@
+"""E2E tests for sandbox-gateway TrafficAccessToken JWT authentication."""
+
+import json
+import os
+import shlex
+import subprocess
+import time
+
+import pytest
+import requests
+from e2b_code_interpreter import Sandbox
+
+
+TOKEN_COMMAND = os.environ.get("JWT_E2E_TOKEN_COMMAND", "")
+pytestmark = pytest.mark.skipif(
+    os.environ.get("TRAFFIC_ACCESS_TOKEN_JWT_E2E", "").lower() != "true"
+    or not TOKEN_COMMAND,
+    reason="requires a JWT-enabled gateway and an external token issuer command",
+)
+
+
+def get_sandbox_uid(sandbox_id):
+    namespace, name = sandbox_id.split("--", 1)
+    result = subprocess.run(
+        ["kubectl", "get", "sandbox", name, "-n", namespace, "-o", "json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)["metadata"]["uid"]
+
+
+def issue_traffic_access_token(sandbox_id, sandbox_uid):
+    environment = os.environ.copy()
+    environment["JWT_E2E_SANDBOX_ID"] = sandbox_id
+    environment["JWT_E2E_SANDBOX_UID"] = sandbox_uid
+    result = subprocess.run(
+        shlex.split(TOKEN_COMMAND),
+        capture_output=True,
+        text=True,
+        check=True,
+        env=environment,
+    )
+    token = result.stdout.strip()
+    assert token, "external token issuer command returned an empty token"
+    return token
+
+
+def gateway_request(config, sandbox_id, traffic_access_token=None):
+    headers = {
+        "e2b-sandbox-id": sandbox_id,
+        "e2b-sandbox-port": "49983",
+        # UUID authentication must be bypassed while JWT mode is enabled.
+        "x-access-token": "deliberately-invalid-uuid-token",
+    }
+    if traffic_access_token is not None:
+        headers["x-traffic-access-token"] = traffic_access_token
+    return requests.get(f"{config.gateway_url}/", headers=headers, timeout=10)
+
+
+def gateway_request_eventually(config, sandbox_id, traffic_access_token):
+    deadline = time.monotonic() + 30
+    response = None
+    while time.monotonic() < deadline:
+        response = gateway_request(config, sandbox_id, traffic_access_token)
+        if response.status_code not in (502, 503):
+            return response
+        time.sleep(0.5)
+    raise AssertionError(
+        f"gateway route was not ready for {sandbox_id}: "
+        f"{response.status_code if response is not None else 'no response'} "
+        f"{response.text if response is not None else ''}"
+    )
+
+
+def test_gateway_traffic_access_token_jwt(sandbox_context, config):
+    """Verify valid, missing, malformed, and cross-sandbox JWT behavior."""
+    first: Sandbox = sandbox_context.add(
+        Sandbox.create(
+            template=config.templates.code_interpreter,
+            timeout=120,
+            headers={"x-request-id": sandbox_context.request_id},
+        )
+    )
+    second: Sandbox = sandbox_context.add(
+        Sandbox.create(
+            template=config.templates.code_interpreter,
+            timeout=120,
+            headers={"x-request-id": sandbox_context.request_id},
+        )
+    )
+    first_token = issue_traffic_access_token(
+        first.sandbox_id, get_sandbox_uid(first.sandbox_id)
+    )
+
+    valid = gateway_request_eventually(config, first.sandbox_id, first_token)
+    assert valid.status_code in (200, 404), valid.text
+
+    missing = gateway_request(config, first.sandbox_id)
+    assert missing.status_code == 401, missing.text
+
+    malformed = gateway_request(config, first.sandbox_id, "not-a-jwt")
+    assert malformed.status_code == 401, malformed.text
+
+    second_ready = gateway_request_eventually(config, second.sandbox_id, "not-a-jwt")
+    assert second_ready.status_code == 401, second_ready.text
+
+    replayed = gateway_request(config, second.sandbox_id, first_token)
+    assert replayed.status_code == 401, replayed.text

--- a/test/e2b/test_gateway_jwt_auth.py
+++ b/test/e2b/test_gateway_jwt_auth.py
@@ -122,12 +122,12 @@ def test_gateway_traffic_access_token_jwt(sandbox_context, config):
     assert valid.status_code in (200, 404), valid.text
 
     missing = gateway_request(config, first.sandbox_id, first_runtime_token)
-    assert missing.status_code == 401, missing.text
+    assert missing.status_code == 403, missing.text
 
     malformed = gateway_request(
         config, first.sandbox_id, first_runtime_token, "not-a-jwt"
     )
-    assert malformed.status_code == 401, malformed.text
+    assert malformed.status_code == 403, malformed.text
 
     expired_token = issue_traffic_access_token(
         first.sandbox_id, get_sandbox_uid(first.sandbox_id), expired=True
@@ -135,14 +135,14 @@ def test_gateway_traffic_access_token_jwt(sandbox_context, config):
     expired = gateway_request(
         config, first.sandbox_id, first_runtime_token, expired_token
     )
-    assert expired.status_code == 401, expired.text
+    assert expired.status_code == 403, expired.text
 
     second_ready = gateway_request_eventually(
         config, second.sandbox_id, second_runtime_token, "not-a-jwt"
     )
-    assert second_ready.status_code == 401, second_ready.text
+    assert second_ready.status_code == 403, second_ready.text
 
     replayed = gateway_request(
         config, second.sandbox_id, second_runtime_token, first_token
     )
-    assert replayed.status_code == 401, replayed.text
+    assert replayed.status_code == 403, replayed.text

--- a/test/e2b/test_gateway_jwt_auth.py
+++ b/test/e2b/test_gateway_jwt_auth.py
@@ -12,11 +12,14 @@ from e2b_code_interpreter import Sandbox
 
 
 TOKEN_COMMAND = os.environ.get("JWT_E2E_TOKEN_COMMAND", "")
-pytestmark = pytest.mark.skipif(
-    os.environ.get("TRAFFIC_ACCESS_TOKEN_JWT_E2E", "").lower() != "true"
-    or not TOKEN_COMMAND,
-    reason="requires a JWT-enabled gateway and an external token issuer command",
-)
+pytestmark = [
+    pytest.mark.jwt_auth,
+    pytest.mark.skipif(
+        os.environ.get("TRAFFIC_ACCESS_TOKEN_JWT_E2E", "").lower() != "true"
+        or not TOKEN_COMMAND,
+        reason="requires a JWT-enabled gateway and a token issuer command",
+    ),
+]
 
 
 def get_sandbox_uid(sandbox_id):
@@ -30,19 +33,23 @@ def get_sandbox_uid(sandbox_id):
     return json.loads(result.stdout)["metadata"]["uid"]
 
 
-def issue_traffic_access_token(sandbox_id, sandbox_uid):
-    environment = os.environ.copy()
-    environment["JWT_E2E_SANDBOX_ID"] = sandbox_id
-    environment["JWT_E2E_SANDBOX_UID"] = sandbox_uid
+def issue_traffic_access_token(sandbox_id, sandbox_uid, expired=False):
+    command = shlex.split(TOKEN_COMMAND) + [
+        "--sandbox-id",
+        sandbox_id,
+        "--sandbox-uid",
+        sandbox_uid,
+    ]
+    if expired:
+        command.append("--expired")
     result = subprocess.run(
-        shlex.split(TOKEN_COMMAND),
+        command,
         capture_output=True,
         text=True,
         check=True,
-        env=environment,
     )
     token = result.stdout.strip()
-    assert token, "external token issuer command returned an empty token"
+    assert token, "token issuer command returned an empty token"
     return token
 
 
@@ -74,7 +81,7 @@ def gateway_request_eventually(config, sandbox_id, traffic_access_token):
 
 
 def test_gateway_traffic_access_token_jwt(sandbox_context, config):
-    """Verify valid, missing, malformed, and cross-sandbox JWT behavior."""
+    """Verify valid, missing, malformed, expired, and cross-sandbox JWT behavior."""
     first: Sandbox = sandbox_context.add(
         Sandbox.create(
             template=config.templates.code_interpreter,
@@ -101,6 +108,12 @@ def test_gateway_traffic_access_token_jwt(sandbox_context, config):
 
     malformed = gateway_request(config, first.sandbox_id, "not-a-jwt")
     assert malformed.status_code == 401, malformed.text
+
+    expired_token = issue_traffic_access_token(
+        first.sandbox_id, get_sandbox_uid(first.sandbox_id), expired=True
+    )
+    expired = gateway_request(config, first.sandbox_id, expired_token)
+    assert expired.status_code == 401, expired.text
 
     second_ready = gateway_request_eventually(config, second.sandbox_id, "not-a-jwt")
     assert second_ready.status_code == 401, second_ready.text

--- a/test/e2b/test_gateway_jwt_auth.py
+++ b/test/e2b/test_gateway_jwt_auth.py
@@ -9,7 +9,7 @@ import pytest
 import requests
 from e2b_code_interpreter import Sandbox
 
-from gateway_utils import get_sandbox_uid
+from gateway_utils import get_sandbox_access_token, get_sandbox_uid
 
 
 TOKEN_COMMAND = os.environ.get("JWT_E2E_TOKEN_COMMAND", "")
@@ -43,23 +43,28 @@ def issue_traffic_access_token(sandbox_id, sandbox_uid, expired=False):
     return token
 
 
-def gateway_request(config, sandbox_id, traffic_access_token=None):
+def gateway_request(
+    config, sandbox_id, runtime_access_token, traffic_access_token=None
+):
     headers = {
         "e2b-sandbox-id": sandbox_id,
         "e2b-sandbox-port": "49983",
-        # UUID authentication must be bypassed while JWT mode is enabled.
-        "x-access-token": "deliberately-invalid-uuid-token",
+        "x-access-token": runtime_access_token,
     }
     if traffic_access_token is not None:
         headers["x-traffic-access-token"] = traffic_access_token
     return requests.get(f"{config.gateway_url}/", headers=headers, timeout=10)
 
 
-def gateway_request_eventually(config, sandbox_id, traffic_access_token):
+def gateway_request_eventually(
+    config, sandbox_id, runtime_access_token, traffic_access_token
+):
     deadline = time.monotonic() + 30
     response = None
     while time.monotonic() < deadline:
-        response = gateway_request(config, sandbox_id, traffic_access_token)
+        response = gateway_request(
+            config, sandbox_id, runtime_access_token, traffic_access_token
+        )
         if response.status_code not in (502, 503):
             return response
         time.sleep(0.5)
@@ -89,24 +94,38 @@ def test_gateway_traffic_access_token_jwt(sandbox_context, config):
     first_token = issue_traffic_access_token(
         first.sandbox_id, get_sandbox_uid(first.sandbox_id)
     )
+    first_runtime_token = get_sandbox_access_token(first.sandbox_id)
+    second_runtime_token = get_sandbox_access_token(second.sandbox_id)
+    assert first_runtime_token, "first Sandbox is missing its runtime access token"
+    assert second_runtime_token, "second Sandbox is missing its runtime access token"
 
-    valid = gateway_request_eventually(config, first.sandbox_id, first_token)
+    valid = gateway_request_eventually(
+        config, first.sandbox_id, first_runtime_token, first_token
+    )
     assert valid.status_code in (200, 404), valid.text
 
-    missing = gateway_request(config, first.sandbox_id)
+    missing = gateway_request(config, first.sandbox_id, first_runtime_token)
     assert missing.status_code == 401, missing.text
 
-    malformed = gateway_request(config, first.sandbox_id, "not-a-jwt")
+    malformed = gateway_request(
+        config, first.sandbox_id, first_runtime_token, "not-a-jwt"
+    )
     assert malformed.status_code == 401, malformed.text
 
     expired_token = issue_traffic_access_token(
         first.sandbox_id, get_sandbox_uid(first.sandbox_id), expired=True
     )
-    expired = gateway_request(config, first.sandbox_id, expired_token)
+    expired = gateway_request(
+        config, first.sandbox_id, first_runtime_token, expired_token
+    )
     assert expired.status_code == 401, expired.text
 
-    second_ready = gateway_request_eventually(config, second.sandbox_id, "not-a-jwt")
+    second_ready = gateway_request_eventually(
+        config, second.sandbox_id, second_runtime_token, "not-a-jwt"
+    )
     assert second_ready.status_code == 401, second_ready.text
 
-    replayed = gateway_request(config, second.sandbox_id, first_token)
+    replayed = gateway_request(
+        config, second.sandbox_id, second_runtime_token, first_token
+    )
     assert replayed.status_code == 401, replayed.text

--- a/test/e2b/test_gateway_jwt_auth.py
+++ b/test/e2b/test_gateway_jwt_auth.py
@@ -1,6 +1,5 @@
 """E2E tests for sandbox-gateway TrafficAccessToken JWT authentication."""
 
-import json
 import os
 import shlex
 import subprocess
@@ -9,6 +8,8 @@ import time
 import pytest
 import requests
 from e2b_code_interpreter import Sandbox
+
+from gateway_utils import get_sandbox_uid
 
 
 TOKEN_COMMAND = os.environ.get("JWT_E2E_TOKEN_COMMAND", "")
@@ -20,17 +21,6 @@ pytestmark = [
         reason="requires a JWT-enabled gateway and a token issuer command",
     ),
 ]
-
-
-def get_sandbox_uid(sandbox_id):
-    namespace, name = sandbox_id.split("--", 1)
-    result = subprocess.run(
-        ["kubectl", "get", "sandbox", name, "-n", namespace, "-o", "json"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return json.loads(result.stdout)["metadata"]["uid"]
 
 
 def issue_traffic_access_token(sandbox_id, sandbox_uid, expired=False):

--- a/test/e2b/test_gateway_runtime_mtls.py
+++ b/test/e2b/test_gateway_runtime_mtls.py
@@ -1,0 +1,115 @@
+"""End-to-end coverage for optional sandbox-gateway Runtime mTLS."""
+
+import json
+import os
+import subprocess
+import time
+
+import pytest
+import requests
+
+
+pytestmark = pytest.mark.runtime_mtls
+
+
+def kubectl(*args: str, input_data: str | None = None) -> str:
+    """Run kubectl and return stdout."""
+    result = subprocess.run(
+        ["kubectl", *args],
+        input=input_data,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def wait_for_running_sandbox(name: str, timeout: int = 120) -> None:
+    """Wait until the test Sandbox has a running Pod and gateway route."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        state = kubectl(
+            "get", "sandbox", name, "-n", "default", "-o", "jsonpath={.status.state}",
+        )
+        if state == "Running":
+            time.sleep(3)
+            return
+        time.sleep(2)
+    raise AssertionError(f"Sandbox {name} did not become Running")
+
+
+def wait_for_gateway_response(url: str, headers: dict[str, str], expected_body: str, timeout: int = 60) -> None:
+    """Wait for the test listener and gateway registry to become ready."""
+    deadline = time.time() + timeout
+    last_result = "no request attempted"
+    while time.time() < deadline:
+        try:
+            response = requests.get(url, headers=headers, timeout=10)
+            last_result = f"status={response.status_code}, body={response.text!r}"
+            if response.status_code == 200 and response.text == expected_body:
+                return
+        except requests.RequestException as error:
+            last_result = repr(error)
+        time.sleep(2)
+    raise AssertionError(f"Gateway did not return {expected_body!r}: {last_result}")
+
+
+def test_gateway_runtime_mtls_enabled(config):
+    """Verify port 49983 reaches a backend requiring a valid gateway client certificate."""
+    if os.environ.get("RUNTIME_MTLS_E2E") != "true":
+        pytest.skip("Runtime mTLS E2E environment is not enabled")
+
+    deployment = json.loads(kubectl("get", "deployment", "sandbox-gateway", "-n", "sandbox-system", "-o", "json"))
+    init_names = {container["name"] for container in deployment["spec"]["template"]["spec"].get("initContainers", [])}
+    assert "runtime-mtls-cert-init" in init_names
+
+    envoy_config = kubectl("get", "configmap", "envoy-config", "-n", "sandbox-system", "-o", "jsonpath={.data.envoy\\.yaml}")
+    assert "enable-runtime-mtls: true" in envoy_config
+    assert "original_dst_mtls_cluster" in envoy_config
+
+    sandbox_name = "gateway-runtime-mtls-e2e"
+    manifest = {
+        "apiVersion": "agents.kruise.io/v1alpha1",
+        "kind": "Sandbox",
+        "metadata": {"name": sandbox_name, "namespace": "default"},
+        "spec": {
+            "template": {
+                "spec": {
+                    "containers": [{
+                        "name": "runtime-mtls-server",
+                        "image": "runtime-mtls-server:latest",
+                        "imagePullPolicy": "Never",
+                        "volumeMounts": [{"name": "tls", "mountPath": "/tls", "readOnly": True}],
+                        "readinessProbe": {
+                            "tcpSocket": {"port": 49983},
+                            "periodSeconds": 1,
+                            "failureThreshold": 60,
+                        },
+                    }],
+                    "volumes": [{"name": "tls", "secret": {"secretName": "runtime-mtls-server-tls"}}],
+                },
+            },
+        },
+    }
+
+    kubectl("apply", "-f", "-", input_data=json.dumps(manifest))
+    try:
+        wait_for_running_sandbox(sandbox_name)
+        wait_for_gateway_response(
+            f"{config.gateway_url}/",
+            {
+                "e2b-sandbox-id": f"default--{sandbox_name}",
+                "e2b-sandbox-port": "49983",
+            },
+            "runtime-mtls-ok",
+        )
+        wait_for_gateway_response(
+            f"{config.gateway_url}/",
+            {
+                "e2b-sandbox-id": f"default--{sandbox_name}",
+                "e2b-sandbox-port": "8080",
+            },
+            "runtime-plaintext-ok",
+        )
+    finally:
+        kubectl("delete", "sandbox", sandbox_name, "-n", "default", "--ignore-not-found=true", "--wait=false")

--- a/test/e2b/test_gateway_runtime_mtls.py
+++ b/test/e2b/test_gateway_runtime_mtls.py
@@ -27,15 +27,17 @@ def kubectl(*args: str, input_data: str | None = None) -> str:
 def wait_for_running_sandbox(name: str, timeout: int = 120) -> None:
     """Wait until the test Sandbox has a running Pod and gateway route."""
     deadline = time.time() + timeout
+    phase = ""
     while time.time() < deadline:
-        state = kubectl(
-            "get", "sandbox", name, "-n", "default", "-o", "jsonpath={.status.state}",
+        phase = kubectl(
+            "get", "sandbox", name, "-n", "default", "-o", "jsonpath={.status.phase}",
         )
-        if state == "Running":
+        if phase == "Running":
             time.sleep(3)
             return
         time.sleep(2)
-    raise AssertionError(f"Sandbox {name} did not become Running")
+    details = kubectl("get", "sandbox", name, "-n", "default", "-o", "yaml")
+    raise AssertionError(f"Sandbox {name} did not become Running; phase={phase!r}\n{details}")
 
 
 def wait_for_gateway_response(url: str, headers: dict[str, str], expected_body: str, timeout: int = 60) -> None:


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

- Adds local TrafficAccessToken JWT verification to sandbox-gateway:
  - Loads the identity CA from Kubernetes, performs OIDC discovery, snapshots JWKS public keys, and verifies signatures and required claims.
  - Binds tokens to Sandbox ID and UID, removes the traffic token before proxying, and exposes gateway readiness while the verifier initializes.
  - Keeps UUID authentication as the default and enables JWT mode only when both `enable-auth` and `enable-jwt-auth` are true.
- Adds optional Runtime upstream mTLS to sandbox-gateway:
  - Keeps `runtimeMTLS.enabled=false` by default, preserving the existing plaintext startup and routing behavior without reading the credential Secret.
  - Routes only port `49983` to a dedicated mTLS `ORIGINAL_DST` cluster; all other Sandbox ports remain plaintext.
  - Adds a startup init binary that performs a single client-go `Get` of `ack-agent-identity/ack-agent-identity-sandbox-manager-client-cert`, validates `tls.crt`, `tls.key`, and `ca.crt`, and writes them to an in-memory volume for static Envoy loading.
  - Uses fixed SNI `agentruntime.sandbox.agents.kruise.io` with server SAN validation and fails closed when credentials cannot be loaded.
- Adds Kustomize deployment paths, image/build integration, focused unit tests, and E2E coverage for JWT auth plus Runtime mTLS enabled and disabled scenarios.
- Does not change agent-runtime behavior, token issuance, client token acquisition, Sandbox Manager APIs, or claim/clone behavior.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

- Run package and race tests:

  ```bash
  go test ./pkg/...
  go test -race ./pkg/identity/oidc ./pkg/sandbox-gateway/...
  go vet ./pkg/sandbox-gateway/... ./cmd/sandbox-gateway-cert-init
  ```

- Verify builds and Kustomize deployment rendering:

  ```bash
  make build-sandbox-gateway
  kubectl kustomize config/sandbox-gateway
  kubectl kustomize config/sandbox-gateway-runtime-mtls
  ```

- Run JWT E2E against a configured identity provider:

  ```bash
  TRAFFIC_ACCESS_TOKEN_JWT_E2E=true \
  JWT_E2E_TOKEN_COMMAND=<issuer-command> \
  pytest -p conftest_base test/e2b/test_gateway_jwt_auth.py
  ```

  The issuer command receives `JWT_E2E_SANDBOX_ID` and `JWT_E2E_SANDBOX_UID` and prints the bound JWT.

- The `e2e-e2b-latest` workflow includes Runtime mTLS coverage:
  - Disabled: verifies no certificate init container or mTLS cluster is installed and existing port `49983` plaintext routing still works.
  - Enabled: verifies a successful client-certificate-authenticated request to port `49983` and confirms port `8080` remains plaintext.

Gateway package coverage increased from 85.1% to 90.8%. OIDC coverage is 100%, JWT manager coverage is 96.3%, Filter coverage is 99.4%, registry coverage is 100%, and the Runtime credential package is 97.8%.

### Ⅳ. Special notes for reviews

- JWT mode and Runtime mTLS are independent, process-wide gateway options; both remain disabled by default.
- JWT verification takes a startup snapshot of CA/JWKS data. Audience policy, token issuance, client token delivery, and key refresh are intentionally out of scope.
- Runtime mTLS credentials are loaded once before Envoy starts and are not rotated in place. Secret changes require a gateway Pod rollout.
- Secret RBAC is intentionally provisioned by `ack-agent-identity`, not by the gateway manifests. The CI workflow creates equivalent least-privilege test RBAC only for the enabled E2E scenario.
- The mTLS server identity contract is fixed SNI `agentruntime.sandbox.agents.kruise.io` with certificate SAN `*.sandbox.agents.kruise.io`.
- `config/sandbox-gateway/identity-ca-rbac.yaml` remains separate because the optional identity namespace may not exist when JWT auth is disabled.
