### PR TITLE
fix(e2b): stabilize flaky background command kill test

### DIFF
--- a/test/e2b/test_commands_run.py
+++ b/test/e2b/test_commands_run.py
@@ -102,24 +102,25 @@ def test_commands_background_execution(sandbox_context, config):
         }
     ))
 
-    # Start a long-running command in background
-    command = sbx.commands.run('echo start; sleep 5; echo end', background=True)
+    # Keep the process alive until kill(). A short sleep + full stream drain races
+    # natural exit: SendSignal then fails with "os: process already finished".
+    command = sbx.commands.run('echo start; sleep 60; echo end', background=True)
 
-    # Collect output through iteration
     stdout_output = []
     stderr_output = []
+    saw_start = False
 
-    try:
-        for stdout, stderr, _ in command:
-            if stdout:
-                stdout_output.append(stdout)
-            if stderr:
-                stderr_output.append(stderr)
-    except Exception:
-        pass  # Command might be killed
+    for stdout, stderr, _ in command:
+        if stdout:
+            stdout_output.append(stdout)
+            if "start" in stdout:
+                saw_start = True
+                break
+        if stderr:
+            stderr_output.append(stderr)
 
-    # Kill the command
-    command.kill()
+    assert saw_start, "expected background command to emit start before kill"
+    assert command.kill(), "expected kill() to succeed while the process is still running"
 
 
 def test_commands_realtime_callbacks(sandbox_context, config):


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Hardens the flaky E2E `test/e2b/test_commands_run.py::test_commands_background_execution` so `command.kill()` no longer races the process's natural exit.

Previously the test started `echo start; sleep 5; echo end`, fully drained the output stream (so the process could already have exited with status 0), then unconditionally called `kill()`. When that race hit, agent-runtime `SendSignal` returned `Code.internal: error sending signal: os: process already finished`, and the SDK surfaced it as `SandboxException`.

This change:
- keeps the background process alive with `sleep 60`
- kills after the first `start` stdout event (mid-stream)
- asserts `kill()` succeeds while the process is still running

### Ⅱ. Does this pull request fix one issue?

fixes #650

### Ⅲ. Describe how to verify it

- Review the updated test logic in `test/e2b/test_commands_run.py`
- CI: E2B E2E workflows (`E2E for E2B SDK - latest`, including MySQL key-storage / sandbox-gateway matrices) should no longer flake on `test_commands_background_execution`

### Ⅳ. Special notes for reviews

- Preferred smallest fix from #650 (test hardening). Runtime `SendSignal` still maps "already finished" to `Code.internal` in upstream envd; a follow-up can make kill idempotent there if desired.
- `python3 -m py_compile test/e2b/test_commands_run.py` passed locally. Full E2E was not run in this environment (per project guidelines).