### PR TITLE
fix(sandboxclaim): make claim batch size flag actually take effect

### DIFF
--- a/pkg/controller/sandboxclaim/core/constants.go
+++ b/pkg/controller/sandboxclaim/core/constants.go
@@ -18,14 +18,17 @@ package core
 
 import "time"
 
-const (
+// Bound to controller flags, so declared as vars rather than consts.
+var (
 	// MaxClaimBatchSize is the maximum number of sandboxes to claim in a single reconcile cycle.
 	// This prevents overwhelming the API server with too many concurrent updates
 	MaxClaimBatchSize = 50
 
 	// InitialClaimBatchSize is the initial batch size for concurrent claim operations.
 	InitialClaimBatchSize = 5
+)
 
+const (
 	// DefaultReplicasCount is the default number of sandboxes to claim if not specified in spec.
 	DefaultReplicasCount = 1
 

--- a/pkg/controller/sandboxclaim/sandboxclaim_controller.go
+++ b/pkg/controller/sandboxclaim/sandboxclaim_controller.go
@@ -52,12 +52,12 @@ import (
 
 func init() {
 	flag.IntVar(&concurrentReconciles, "sandboxclaim-workers", concurrentReconciles, "Max concurrent workers for SandboxClaim controller.")
-	flag.IntVar(&maxClaimBatchSize, "sandboxclaim-max-batch-size", maxClaimBatchSize, "Maximum batch size for claiming sandboxes in a single reconcile cycle")
+	flag.IntVar(&core.MaxClaimBatchSize, "sandboxclaim-max-batch-size", core.MaxClaimBatchSize, "Maximum batch size for claiming sandboxes in a single reconcile cycle")
+	flag.IntVar(&core.InitialClaimBatchSize, "sandboxclaim-initial-batch-size", core.InitialClaimBatchSize, "Initial batch size for concurrent claim operations")
 }
 
 var (
 	concurrentReconciles = 500
-	maxClaimBatchSize    = 10
 	controllerKind       = agentsv1alpha1.GroupVersion.WithKind("SandboxClaim")
 )
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The `-sandboxclaim-max-batch-size` flag has never had any effect. It was
bound to a package variable `maxClaimBatchSize` (default 10) that no code
reads, while the claim logic uses the `core.MaxClaimBatchSize` constant
(50). So setting the flag did nothing, and its advertised default (10) did
not even match the effective value (50).

This PR:
- Wires `-sandboxclaim-max-batch-size` to `core.MaxClaimBatchSize` (turned
  into a var) so it actually takes effect.
- Adds `-sandboxclaim-initial-batch-size` to also tune the initial ramp-up
  size (`core.InitialClaimBatchSize`).
- Removes the now-unused `maxClaimBatchSize` variable.

**No behavior change by default:** the effective defaults stay 50 / 5. Only
the flag's advertised default is corrected (10 → 50).

6 insertions, 3 deletions across two files.

### Ⅱ. Does this pull request fix one issue?

NONE. Found while trying to tune claim throughput and noticing the flag had
no effect.

### Ⅲ. Describe how to verify it

- **Before:** start the controller with `-sandboxclaim-max-batch-size=100`.
  The claim loop still batches at 50 (the constant) — the flag is ignored.
- **After:** the same flag caps the batch at 100; `-sandboxclaim-initial-batch-size`
  likewise controls the ramp-up start.
- **Default unchanged:** with no flags, batch size stays 50 and initial 5,
  identical to before.

```bash
go build ./pkg/controller/sandboxclaim/...
go test ./pkg/controller/sandboxclaim/...
```

### Ⅳ. Special notes for reviews

- `const` → `var` for the two batch sizes is required so they can be bound
  to flags via `flag.IntVar`.
- Effective runtime defaults are unchanged (50 / 5). No deployment manifest
  in this repo passes the flag, so wiring it up cannot alter existing
  behavior; only explicit user-provided values now take effect.
- The flag has been non-functional since it was introduced (PR #114), so no
  existing user could have depended on it working.
