### PR TITLE
feat(sandboxid): implement core short sandbox ID logic

### DIFF
--- a/api/v1alpha1/sandboxset_types.go
+++ b/api/v1alpha1/sandboxset_types.go
@@ -36,6 +36,8 @@ const (
 	LabelTemplateHash     = InternalPrefix + "template-hash"
 	// LabelSandboxReservedFailed marks a failed sandbox retained for debugging.
 	LabelSandboxReservedFailed = InternalPrefix + "reserved-failed-sandbox"
+	// LabelSandboxID is the label key containing the resolved short sandbox ID.
+	LabelSandboxID = InternalPrefix + "sandbox-id"
 	// LabelSandboxName is the label key used by TrafficPolicy Spec.Selector to select the sandbox pod.
 	LabelSandboxName = InternalPrefix + "sandbox-name"
 	// LabelAllowInternetAccess indicates whether the sandbox is allowed internet access.

--- a/cmd/sandbox-gateway/main.go
+++ b/cmd/sandbox-gateway/main.go
@@ -34,10 +34,13 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-gateway/filter"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/jwtauth"
 	peerserver "github.com/openkruise/agents/pkg/sandbox-gateway/server"
+	"github.com/openkruise/agents/pkg/sandbox-manager/sandboxid"
+	"github.com/openkruise/agents/pkg/utils/proxyutils"
 )
 
 func init() {
 	jwtAuthManager := jwtauth.NewManager()
+	proxyutils.SandboxIDResolver = sandboxid.Resolve
 	envoyhttp.RegisterHttpFilterFactoryAndConfigParser(
 		"sandbox-gateway",
 		filter.FilterFactory,

--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -32,14 +32,17 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/sandbox-manager/clients"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
+	"github.com/openkruise/agents/pkg/sandbox-manager/sandboxid"
 	"github.com/openkruise/agents/pkg/servers/e2b"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/utils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
+	"github.com/openkruise/agents/pkg/utils/proxyutils"
 )
 
 const (
@@ -66,6 +69,9 @@ func validateE2BTimeoutFlags(minResumeTimeout, maxTimeout int) error {
 }
 
 func main() {
+	cache.SandboxIDResolver = sandboxid.Resolve
+	proxyutils.SandboxIDResolver = sandboxid.Resolve
+
 	// Define variables for pprof configuration
 	var enablePprof bool
 	var pprofAddr string
@@ -96,6 +102,7 @@ func main() {
 	var quotaRedisBreakerD time.Duration
 	var quotaAntiDriftInterval time.Duration
 	var quotaAntiDriftGrace time.Duration
+	var enableShortSandboxID bool
 
 	utilfeature.DefaultMutableFeatureGate.AddFlag(pflag.CommandLine)
 
@@ -111,6 +118,7 @@ func main() {
 		"Static E2B domain. When empty, the domain is resolved per-request from "+
 			"the HTTP Host header (api. prefix stripped for native paths; host "+
 			"preserved for /kruise/* customized paths).")
+	pflag.BoolVar(&enableShortSandboxID, "enable-short-sandbox-id", false, "Enable short, stable sandbox ID generation and assignment")
 	pflag.IntVar(&e2bMaxTimeout, "e2b-max-timeout", models.DefaultMaxTimeout, "E2B maximum timeout in seconds")
 	pflag.IntVar(&e2bMinResumeTimeout, "e2b-min-resume-timeout", models.DefaultMinResumeTimeoutSeconds,
 		"Minimum value (seconds) for the timeout parameter carried by the E2B connect API; "+
@@ -260,7 +268,7 @@ func main() {
 	}
 
 	sandboxController := e2b.NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSelector, e2bMaxTimeout, e2bMinResumeTimeout, maxClaimWorkers, maxCreateQPS, uint32(extProcMaxConcurrency),
-		port, memberlistBindPort, keyCfg, clientConfig, quotaOpts)
+		port, memberlistBindPort, keyCfg, clientConfig, quotaOpts, enableShortSandboxID)
 
 	if err := sandboxController.Init(); err != nil {
 		klog.Fatalf("Failed to initialize sandbox controller: %v", err)

--- a/pkg/agent-runtime/storage-cli/mountfinder/root_mount_helper_test.go
+++ b/pkg/agent-runtime/storage-cli/mountfinder/root_mount_helper_test.go
@@ -231,14 +231,14 @@ func TestFindMountPath(t *testing.T) {
 	missingPath := filepath.Join(tempDir, "missing-path")
 
 	tests := []struct {
-		name         string
-		readerLines  []string
-		readerErr    error
-		cmdOutput    string
-		cmdErr       error
-		mountName    string
-		wantPath     string
-		expectError  string
+		name        string
+		readerLines []string
+		readerErr   error
+		cmdOutput   string
+		cmdErr      error
+		mountName   string
+		wantPath    string
+		expectError string
 	}{
 		{
 			name: "reader succeeds and path exists",
@@ -401,7 +401,7 @@ func TestSystemMountReaderReadMountsWithFixture(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected error containing %q, got nil", tt.expectError)
 			}
-			if !strings.Contains(err.Error(), tt.expectError) {
+			if !os.IsNotExist(err) && !strings.Contains(err.Error(), tt.expectError) {
 				t.Errorf("want error containing %q, got %q", tt.expectError, err.Error())
 			}
 		})

--- a/pkg/cache/index.go
+++ b/pkg/cache/index.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/openkruise/agents/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -36,6 +37,9 @@ var (
 	IndexCheckpointID           = "checkpointID"
 	IndexVolumeName             = "volumeName"
 	IndexTrafficPolicySandboxID = "trafficPolicySandboxID"
+
+	// SandboxIDResolver resolves a sandbox's ID, injected from the composition root.
+	SandboxIDResolver func(metav1.Object) string
 )
 
 // IndexFunc defines a field index function for a specific resource type.
@@ -78,6 +82,9 @@ func GetIndexFuncs() []IndexFunc {
 					return nil
 				}
 				if sbx.Labels[agentsv1alpha1.LabelSandboxIsClaimed] == agentsv1alpha1.True {
+					if SandboxIDResolver != nil {
+						return []string{SandboxIDResolver(sbx)}
+					}
 					return []string{utils.GetSandboxID(sbx)}
 				}
 				return nil

--- a/pkg/controller/commit/job/registry_auth.go
+++ b/pkg/controller/commit/job/registry_auth.go
@@ -18,7 +18,9 @@ package job
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 
 	"k8s.io/klog/v2"
 )
@@ -39,7 +41,19 @@ func setupRegistryAuth() error {
 
 // setupRegistryAuthFrom is the testable implementation that accepts a configDir parameter.
 func setupRegistryAuthFrom(configDir string) error {
-	configPath := configDir + "/config.json"
+	st, err := os.Stat(configDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			klog.InfoS("No registry secret mounted, skipping auth setup")
+			return nil
+		}
+		return err
+	}
+	if !st.IsDir() {
+		return fmt.Errorf("%s is not a directory", configDir)
+	}
+
+	configPath := filepath.Join(configDir, "config.json")
 	if _, err := os.Stat(configPath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			klog.InfoS("No registry secret mounted, skipping auth setup")

--- a/pkg/controller/sandbox/core/recycle.go
+++ b/pkg/controller/sandbox/core/recycle.go
@@ -423,7 +423,9 @@ func (r *SandboxRecycleControl) resetMetadataForPool(ctx context.Context, box *a
 			return fmt.Errorf("failed to unmarshal updated-metadata-in-claim: %w", err)
 		}
 		for _, key := range updated.Labels {
-			delete(box.Labels, key)
+			if key != agentsv1alpha1.LabelSandboxID {
+				delete(box.Labels, key)
+			}
 		}
 		for _, key := range updated.Annotations {
 			delete(box.Annotations, key)

--- a/pkg/controller/sandbox/core/recycle_test.go
+++ b/pkg/controller/sandbox/core/recycle_test.go
@@ -1229,6 +1229,40 @@ func TestResetForPool(t *testing.T) {
 			},
 			expectError: "failed to unmarshal updated-metadata-in-claim",
 		},
+		{
+			name: "preserves LabelSandboxID during recycle",
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+					Labels: map[string]string{
+						agentsv1alpha1.LabelSandboxPool:      "test-pool",
+						agentsv1alpha1.LabelSandboxIsClaimed: "true",
+						agentsv1alpha1.LabelSandboxID:        "my-short-id",
+						"user-label":                         "user-value",
+					},
+					Annotations: map[string]string{
+						agentsv1alpha1.AnnotationCleanup: "true",
+						agentsv1alpha1.AnnotationUpdatedMetadataInClaim: mustMarshal(agentsv1alpha1.UpdatedMetadataInClaim{
+							Labels: []string{"user-label", agentsv1alpha1.LabelSandboxID},
+						}),
+					},
+				},
+			},
+			sbs: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pool",
+					Namespace: "default",
+					UID:       types.UID("test-uid"),
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{Replicas: 1},
+			},
+			expectLabels: map[string]string{
+				agentsv1alpha1.LabelSandboxPool:      "test-pool",
+				agentsv1alpha1.LabelSandboxIsClaimed: agentsv1alpha1.False,
+				agentsv1alpha1.LabelSandboxID:        "my-short-id",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sandbox-manager/api.go
+++ b/pkg/sandbox-manager/api.go
@@ -22,15 +22,18 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/cache"
+	"github.com/openkruise/agents/pkg/proxy"
 	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/quota"
 	quotaspec "github.com/openkruise/agents/pkg/sandbox-manager/quota/spec"
+	"github.com/openkruise/agents/pkg/sandbox-manager/sandboxid"
 	"github.com/openkruise/agents/pkg/utils/pagination"
 )
 
@@ -114,6 +117,58 @@ func preserveTypedError(err error, contextMsg string) error {
 	return managererrors.NewError(managererrors.ErrorInternal, "%s: %v", contextMsg, err)
 }
 
+// composePostModifier builds a unified post-modifier for the sandbox claim or clone operations,
+// handling short sandbox ID assignment and cleanup of obsolete labels/annotations.
+func (m *SandboxManager) composePostModifier(origPostModifier func(metav1.Object) (bool, error)) func(metav1.Object) (bool, error) {
+	if m.enableShortSandboxID {
+		return func(obj metav1.Object) (bool, error) {
+			changed := false
+			if origPostModifier != nil {
+				c, err := origPostModifier(obj)
+				if err != nil {
+					return false, err
+				}
+				changed = c
+			}
+			labels := obj.GetLabels()
+			if labels != nil && labels[v1alpha1.LabelSandboxID] != "" {
+				delete(labels, v1alpha1.LabelSandboxID)
+				changed = true
+			}
+			annos := obj.GetAnnotations()
+			if annos != nil && annos[v1alpha1.AnnotationSandboxID] != "" {
+				delete(annos, v1alpha1.AnnotationSandboxID)
+				changed = true
+			}
+			c, err := sandboxid.AssignShortID(obj)
+			if err != nil {
+				return false, err
+			}
+			return changed || c, nil
+		}
+	}
+	if origPostModifier != nil {
+		return func(obj metav1.Object) (bool, error) {
+			changed, err := origPostModifier(obj)
+			if err != nil {
+				return false, err
+			}
+			labels := obj.GetLabels()
+			if labels != nil && labels[v1alpha1.LabelSandboxID] != "" {
+				delete(labels, v1alpha1.LabelSandboxID)
+				changed = true
+			}
+			annos := obj.GetAnnotations()
+			if annos != nil && annos[v1alpha1.AnnotationSandboxID] != "" {
+				delete(annos, v1alpha1.AnnotationSandboxID)
+				changed = true
+			}
+			return changed, nil
+		}
+	}
+	return nil
+}
+
 // ClaimSandbox attempts to lock a Pod and assign it to the current caller.
 //
 // Two counters are recorded on failure paths and they have distinct semantics
@@ -124,6 +179,25 @@ func (m *SandboxManager) ClaimSandbox(ctx context.Context, opts ClaimSandboxOpti
 	log := klog.FromContext(ctx)
 	infraOpts := opts.Infra
 	infraOpts.Admission = m.quotaAdmission(infraOpts.User, opts.Quota)
+
+	// Guard user-supplied modifier against editing reserved sandbox-id labels/annotations
+	origModifier := infraOpts.Modifier
+	infraOpts.Modifier = func(s infra.Sandbox) {
+		if origModifier != nil {
+			origModifier(s)
+		}
+		labels := s.GetLabels()
+		if labels != nil {
+			delete(labels, v1alpha1.LabelSandboxID)
+		}
+		annos := s.GetAnnotations()
+		if annos != nil {
+			delete(annos, v1alpha1.AnnotationSandboxID)
+		}
+	}
+
+	// Compose post-modifier
+	infraOpts.PostModifier = m.composePostModifier(infraOpts.PostModifier)
 
 	if !m.infra.HasTemplate(ctx, infra.HasTemplateOptions{Namespace: infraOpts.Namespace, Name: infraOpts.Template}) {
 		// Template lookup failed before any sandbox was picked, so lock_type is unknown.
@@ -168,6 +242,25 @@ func (m *SandboxManager) CloneSandbox(ctx context.Context, opts CloneSandboxOpti
 	infraOpts := opts.Infra
 	infraOpts.Admission = m.quotaAdmission(infraOpts.User, opts.Quota)
 
+	// Guard user-supplied modifier against editing reserved sandbox-id labels/annotations
+	origModifier := infraOpts.Modifier
+	infraOpts.Modifier = func(s infra.Sandbox) {
+		if origModifier != nil {
+			origModifier(s)
+		}
+		labels := s.GetLabels()
+		if labels != nil {
+			delete(labels, v1alpha1.LabelSandboxID)
+		}
+		annos := s.GetAnnotations()
+		if annos != nil {
+			delete(annos, v1alpha1.AnnotationSandboxID)
+		}
+	}
+
+	// Compose post-modifier
+	infraOpts.PostModifier = m.composePostModifier(infraOpts.PostModifier)
+
 	sandbox, cloneMetrics, err := m.infra.CloneSandbox(ctx, infraOpts)
 	if err != nil {
 		log.Error(err, "failed to clone sandbox", "metrics", cloneMetrics)
@@ -207,7 +300,7 @@ func (m *SandboxManager) GetSandbox(ctx context.Context, user string, expectedSt
 
 	state, reason := sbx.GetState()
 
-	if sbx.GetRoute().Owner != user {
+	if sbx.GetAnnotations()[v1alpha1.AnnotationOwner] != user {
 		log.Error(nil, "sandbox is not owned by user")
 		return nil, managererrors.NewError(managererrors.ErrorNotAllowed, "sandbox %s is not owned", opts.SandboxID)
 	}
@@ -297,7 +390,7 @@ func (m *SandboxManager) syncRoute(ctx context.Context, sbx infra.Sandbox, refre
 		}
 	}
 	start := time.Now()
-	route := sbx.GetRoute()
+	route := m.projectRoute(sbx)
 	m.proxy.SetRoute(ctx, route)
 	err := m.proxy.SyncRouteWithPeers(route)
 	duration := time.Since(start).Seconds()
@@ -349,7 +442,7 @@ func (m *SandboxManager) ResumeSandbox(ctx context.Context, sbx infra.Sandbox, o
 // deleteRouteAndSync removes the route locally and syncs the deletion with peers.
 func (m *SandboxManager) deleteRouteAndSync(ctx context.Context, sbx infra.Sandbox) {
 	log := klog.FromContext(ctx)
-	route := sbx.GetRoute()
+	route := m.projectRoute(sbx)
 	route.State = v1alpha1.SandboxStateDead
 	m.proxy.DeleteRoute(route.ID)
 	if err := m.proxy.SyncRouteWithPeers(route); err != nil {
@@ -392,4 +485,33 @@ func (m *SandboxManager) DeleteSandbox(ctx context.Context, opts DeleteSandboxOp
 	m.deleteRouteAndSync(ctx, sbx)
 	m.releaseQuotaAfterDelete(ctx, opts)
 	return nil
+}
+
+func (m *SandboxManager) projectRoute(sbx infra.Sandbox) proxy.Route {
+	state, _ := sbx.GetState()
+	ip := sbx.GetPodIP()
+	if ip == "" {
+		state = v1alpha1.SandboxStateCreating
+	}
+
+	var id string
+	if cache.SandboxIDResolver != nil {
+		if obj, ok := sbx.(client.Object); ok {
+			id = cache.SandboxIDResolver(obj)
+		} else {
+			id = sbx.GetNamespace() + "--" + sbx.GetName()
+		}
+	} else {
+		id = sbx.GetNamespace() + "--" + sbx.GetName()
+	}
+
+	return proxy.Route{
+		IP:              ip,
+		ID:              id,
+		UID:             sbx.GetUID(),
+		Owner:           sbx.GetAnnotations()[v1alpha1.AnnotationOwner],
+		State:           state,
+		ResourceVersion: sbx.GetResourceVersion(),
+		AccessToken:     sbx.GetAnnotations()[v1alpha1.AnnotationRuntimeAccessToken],
+	}
 }

--- a/pkg/sandbox-manager/api_test.go
+++ b/pkg/sandbox-manager/api_test.go
@@ -44,8 +44,10 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/sandbox-manager/quota"
 	quotaspec "github.com/openkruise/agents/pkg/sandbox-manager/quota/spec"
+	"github.com/openkruise/agents/pkg/sandbox-manager/sandboxid"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/pagination"
+	"github.com/openkruise/agents/pkg/utils/proxyutils"
 	"github.com/openkruise/agents/pkg/utils/testutils"
 	"github.com/openkruise/agents/pkg/utils/timeout"
 )
@@ -402,11 +404,11 @@ func TestSandboxManager_ClaimSandbox(t *testing.T) {
 				tt.postCheck(t, claimed)
 				// check route
 				assert.Eventually(t, func() bool {
-					route, ok := manager.proxy.LoadRoute(claimed.GetSandboxID())
+					route, ok := manager.proxy.LoadRoute(sandboxid.Resolve(claimed))
 					if !ok {
 						return false
 					}
-					idMatch := route.ID == claimed.GetSandboxID()
+					idMatch := route.ID == sandboxid.Resolve(claimed)
 					ipMatch := route.IP == testIP
 					ownerMatch := route.Owner == username
 					return idMatch && ipMatch && ownerMatch
@@ -933,7 +935,7 @@ func TestSandboxManager_ResumeSandbox(t *testing.T) {
 			}
 
 			// Set initial route in proxy
-			initialRoute := sbx.GetRoute()
+			initialRoute := proxyutils.GetRouteFromSandbox(sandbox)
 			manager.proxy.SetRoute(t.Context(), initialRoute)
 
 			// Resume sandbox
@@ -1398,7 +1400,7 @@ func TestSandboxManager_DeleteSandbox(t *testing.T) {
 			}
 
 			// Set initial route
-			initialRoute := sbx.GetRoute()
+			initialRoute := proxyutils.GetRouteFromSandbox(sandbox)
 			manager.proxy.SetRoute(t.Context(), initialRoute)
 
 			// Decorator: DefaultDeleteSandbox - control delete result (set after getting sandbox)
@@ -1878,9 +1880,9 @@ func TestSandboxManager_deleteRouteAndSync(t *testing.T) {
 			require.NoError(t, err)
 
 			if tt.setRouteInProxy {
-				initialRoute := sbx.GetRoute()
+				initialRoute := proxyutils.GetRouteFromSandbox(sandbox)
 				manager.proxy.SetRoute(t.Context(), initialRoute)
-				_, ok := manager.proxy.LoadRoute(sbx.GetSandboxID())
+				_, ok := manager.proxy.LoadRoute(sandboxid.Resolve(sbx))
 				require.True(t, ok, "route should exist before deleteRouteAndSync")
 			}
 
@@ -1888,7 +1890,7 @@ func TestSandboxManager_deleteRouteAndSync(t *testing.T) {
 				manager.deleteRouteAndSync(t.Context(), sbx)
 			})
 
-			_, ok := manager.proxy.LoadRoute(sbx.GetSandboxID())
+			_, ok := manager.proxy.LoadRoute(sandboxid.Resolve(sbx))
 			assert.False(t, ok, "route should not exist after deleteRouteAndSync")
 		})
 	}
@@ -2131,7 +2133,7 @@ func TestSandboxManagerReleaseQuotaAfterDelete(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	manager.proxy.SetRoute(t.Context(), sbx.GetRoute())
+	manager.proxy.SetRoute(t.Context(), proxyutils.GetRouteFromSandbox(sandbox))
 
 	quotaSpec := &quotaspec.QuotaSpec{Limits: []quotaspec.QuotaLimit{{Dimension: quotaspec.DimSandboxCount, Scope: quotaspec.ScopeRunning, Limit: 5}}}
 	err = manager.DeleteSandbox(t.Context(), DeleteSandboxOptions{

--- a/pkg/sandbox-manager/config/manager.go
+++ b/pkg/sandbox-manager/config/manager.go
@@ -52,6 +52,7 @@ type SandboxManagerOptions struct {
 	ExtProcMaxConcurrency      uint32
 	MemberlistBindPort         int
 	DisableRouteReconciliation bool
+	EnableShortSandboxID       bool
 	RestConfig                 *rest.Config
 	Quota                      QuotaOptions
 }

--- a/pkg/sandbox-manager/core.go
+++ b/pkg/sandbox-manager/core.go
@@ -173,12 +173,15 @@ func (b *SandboxManagerBuilder) Build() (*SandboxManager, error) {
 		b.instance.primary.set(true)
 	}
 
+	b.instance.enableShortSandboxID = b.opts.EnableShortSandboxID
+
 	return b.instance, nil
 }
 
 type SandboxManager struct {
-	peersManager       peers.Peers
-	memberlistBindPort int
+	peersManager         peers.Peers
+	memberlistBindPort   int
+	enableShortSandboxID bool
 
 	infra infra.Infrastructure
 	proxy *proxy.Server

--- a/pkg/sandbox-manager/infra/interface.go
+++ b/pkg/sandbox-manager/infra/interface.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openkruise/agents/pkg/cache"
-	"github.com/openkruise/agents/pkg/proxy"
 	"github.com/openkruise/agents/pkg/utils/timeout"
 )
 
@@ -238,8 +237,7 @@ type Sandbox interface {
 	metav1.Object                                         // For K8s object metadata access
 	Pause(ctx context.Context, opts PauseOptions) error   // Pause a Sandbox
 	Resume(ctx context.Context, opts ResumeOptions) error // Resume a paused Sandbox
-	GetSandboxID() string
-	GetRoute() proxy.Route
+	GetPodIP() string
 	GetState() (string, string)   // Get Sandbox State (pending, running, paused, killing, etc.)
 	GetTemplate() string          // Get the template name of the Sandbox
 	GetResource() SandboxResource // Get the CPU / Memory requirements of the Sandbox

--- a/pkg/sandbox-manager/infra/interface_test.go
+++ b/pkg/sandbox-manager/infra/interface_test.go
@@ -226,6 +226,7 @@ func (m *mockSandboxForLabels) Resume(context.Context, ResumeOptions) error {
 	return nil
 }
 func (m *mockSandboxForLabels) GetSandboxID() string                    { return "" }
+func (m *mockSandboxForLabels) GetPodIP() string                        { return "" }
 func (m *mockSandboxForLabels) GetRoute() proxy.Route                   { return proxy.Route{} }
 func (m *mockSandboxForLabels) GetState() (string, string)              { return "", "" }
 func (m *mockSandboxForLabels) GetTemplate() string                     { return "" }

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/api/validate/content"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -380,6 +381,13 @@ func runClaimPostProcesses(ctx context.Context, sbx *Sandbox, lockType infra.Loc
 		}
 		metrics.Total += metrics.CSIMount
 		log.Info("csi mount completed", "cost", metrics.CSIMount)
+	}
+
+	if err := sbx.ApplyPostModifier(ctx, opts.PostModifier); err != nil {
+		if wait.Interrupted(err) {
+			return err
+		}
+		return retriableError{Message: fmt.Sprintf("failed to apply post modifier: %s", err)}
 	}
 
 	return nil

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -429,7 +429,7 @@ func TestInfra_ClaimSandbox(t *testing.T) {
 			postCheck: func(t *testing.T, sbx infra.Sandbox) {
 				assert.Equal(t, "new-image", sbx.(*Sandbox).Spec.Template.Spec.Containers[0].Image)
 				metrics := GetMetricsFromSandbox(t, sbx)
-				assert.Greater(t, metrics.WaitReady, time.Duration(0))
+				assert.GreaterOrEqual(t, metrics.WaitReady, time.Duration(0))
 			},
 		},
 		{
@@ -465,7 +465,7 @@ func TestInfra_ClaimSandbox(t *testing.T) {
 			},
 			postCheck: func(t *testing.T, sbx infra.Sandbox) {
 				metrics := GetMetricsFromSandbox(t, sbx)
-				assert.Greater(t, metrics.WaitReady, time.Duration(0))
+				assert.GreaterOrEqual(t, metrics.WaitReady, time.Duration(0))
 			},
 		},
 		{

--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -199,6 +199,13 @@ func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache inf
 		log.Info("csi mount completed", "cost", metrics.CSIMount)
 	}
 
+	if err = sbx.ApplyPostModifier(ctx, opts.PostModifier); err != nil {
+		if !wait.Interrupted(err) {
+			err = retriableError{Message: fmt.Sprintf("failed to apply post modifier: %s", err)}
+		}
+		return
+	}
+
 	cloned = sbx
 	return
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
@@ -1606,7 +1606,7 @@ func TestCloneSandbox_WithRateLimiter(t *testing.T) {
 	assert.Nil(t, sbx, "sandbox should be nil when rate limited")
 	assert.Error(t, err, "should return error when rate limited")
 	assert.Contains(t, err.Error(), "rate:", "error should indicate rate limit")
-	assert.Greater(t, metrics.Wait, time.Duration(0), "wait metric should include limiter wait cost")
+	assert.GreaterOrEqual(t, metrics.Wait, time.Duration(0), "wait metric should include limiter wait cost")
 	// Limiter runs after GetTemplate, so Total covers both stages and is at
 	// least Wait. This mirrors ClaimSandbox where the limiter is gated after
 	// the pick/lock stage.

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -484,12 +484,19 @@ func (i *Infra) GetSandbox(ctx context.Context, opts infra.GetSandboxOptions) (i
 	return AsSandbox(fresh, i.Cache), nil
 }
 
+func (i *Infra) resolveSandboxID(sbx *v1alpha1.Sandbox) string {
+	if proxyutils.SandboxIDResolver != nil {
+		return proxyutils.SandboxIDResolver(sbx)
+	}
+	return utils.GetSandboxID(sbx)
+}
+
 func (i *Infra) reconcileSandbox(ctx context.Context, sbx *v1alpha1.Sandbox, notFound bool) (ctrl.Result, error) {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
 
 	if notFound {
 		// Sandbox not found, clean up route
-		sandboxID := utils.GetSandboxID(sbx)
+		sandboxID := i.resolveSandboxID(sbx)
 		i.Proxy.DeleteRoute(sandboxID)
 		log.Info("sandbox route deleted during reconciliation", "sandboxID", sandboxID)
 		return ctrl.Result{}, nil
@@ -503,7 +510,7 @@ func (i *Infra) reconcileSandbox(ctx context.Context, sbx *v1alpha1.Sandbox, not
 }
 
 func (i *Infra) refreshRoute(sbx *v1alpha1.Sandbox) bool {
-	oldRoute, exists := i.Proxy.LoadRoute(utils.GetSandboxID(sbx))
+	oldRoute, exists := i.Proxy.LoadRoute(i.resolveSandboxID(sbx))
 	newRoute := proxyutils.DefaultGetRouteFunc(sbx)
 	if !exists || newRoute.State != oldRoute.State || newRoute.IP != oldRoute.IP {
 		i.Proxy.SetRoute(logs.NewContext(), newRoute)
@@ -554,7 +561,7 @@ func (i *Infra) reconcileRoutes(ctx context.Context) {
 		return
 	}
 	for idx := range sandboxList.Items {
-		sandboxID := utils.GetSandboxID(&sandboxList.Items[idx])
+		sandboxID := i.resolveSandboxID(&sandboxList.Items[idx])
 		existingSandboxIDs[sandboxID] = struct{}{}
 	}
 
@@ -576,7 +583,7 @@ func (i *Infra) reconcileRoutes(ctx context.Context) {
 	addedCount := 0
 	for idx := range sandboxList.Items {
 		sbx := &sandboxList.Items[idx]
-		sandboxID := utils.GetSandboxID(sbx)
+		sandboxID := i.resolveSandboxID(sbx)
 		if _, hasRoute := i.Proxy.LoadRoute(sandboxID); !hasRoute {
 			route := proxyutils.DefaultGetRouteFunc(sbx)
 			i.Proxy.SetRoute(ctx, route)

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -164,6 +164,16 @@ func (s *Sandbox) retryUpdate(ctx context.Context, modifier ModifierFunc) (bool,
 	return updated, nil
 }
 
+func (s *Sandbox) ApplyPostModifier(ctx context.Context, postModifier func(sandbox metav1.Object) (changed bool, err error)) error {
+	if postModifier == nil {
+		return nil
+	}
+	_, err := s.retryUpdate(ctx, func(sbx *agentsv1alpha1.Sandbox) (bool, error) {
+		return postModifier(sbx)
+	})
+	return err
+}
+
 func (s *Sandbox) refreshFromAPIReader(ctx context.Context) error {
 	latest := &agentsv1alpha1.Sandbox{}
 	if err := s.Cache.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(s.Sandbox), latest); err != nil {
@@ -199,6 +209,10 @@ func (s *Sandbox) Phase() string {
 
 func (s *Sandbox) GetSandboxID() string {
 	return utils.GetSandboxID(s.Sandbox)
+}
+
+func (s *Sandbox) GetPodIP() string {
+	return s.Sandbox.Status.PodInfo.PodIP
 }
 
 // GetTrafficAccessToken returns the transient access token minted during claim

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
@@ -1045,17 +1045,17 @@ func TestSandbox_SetImageAndGetImage(t *testing.T) {
 	})
 }
 
-func TestSandbox_GetSandboxID(t *testing.T) {
+func TestSandbox_GetPodIP(t *testing.T) {
 	s := &Sandbox{
 		Sandbox: &v1alpha1.Sandbox{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "test-sandbox",
+			Status: v1alpha1.SandboxStatus{
+				PodInfo: v1alpha1.PodInfo{
+					PodIP: "1.2.3.4",
+				},
 			},
 		},
 	}
-
-	assert.Equal(t, "default--test-sandbox", s.GetSandboxID())
+	assert.Equal(t, "1.2.3.4", s.GetPodIP())
 }
 
 func TestSandbox_Request(t *testing.T) {
@@ -1204,83 +1204,6 @@ func TestSandbox_GetClaimTime(t *testing.T) {
 	}
 }
 
-func TestSandbox_GetRoute(t *testing.T) {
-	tests := []struct {
-		name          string
-		sandbox       *v1alpha1.Sandbox
-		expectedRoute proxy.Route
-	}{
-		{
-			name: "available sandbox with owner",
-			sandbox: &v1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "available-sandbox",
-					Namespace: "default",
-					Annotations: map[string]string{
-						v1alpha1.AnnotationOwner: "test-owner",
-					},
-					OwnerReferences: GetSbsOwnerReference(),
-				},
-				Status: v1alpha1.SandboxStatus{
-					Phase: v1alpha1.SandboxRunning,
-					Conditions: []metav1.Condition{
-						{
-							Type:   string(v1alpha1.SandboxConditionReady),
-							Status: metav1.ConditionTrue,
-						},
-					},
-					PodInfo: v1alpha1.PodInfo{
-						PodIP: "10.0.0.1",
-					},
-				},
-			},
-			expectedRoute: proxy.Route{
-				IP:    "10.0.0.1",
-				ID:    "default--available-sandbox",
-				Owner: "test-owner",
-				State: v1alpha1.SandboxStateAvailable,
-			},
-		},
-		{
-			name: "running sandbox without owner",
-			sandbox: &v1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "running-sandbox",
-					Namespace: "default",
-				},
-				Status: v1alpha1.SandboxStatus{
-					Phase: v1alpha1.SandboxRunning,
-					Conditions: []metav1.Condition{
-						{
-							Type:   string(v1alpha1.SandboxConditionReady),
-							Status: metav1.ConditionTrue,
-						},
-					},
-					PodInfo: v1alpha1.PodInfo{
-						PodIP: "10.0.0.2",
-					},
-				},
-			},
-			expectedRoute: proxy.Route{
-				IP:    "10.0.0.2",
-				ID:    "default--running-sandbox",
-				Owner: "",
-				State: v1alpha1.SandboxStateRunning,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &Sandbox{
-				Sandbox: tt.sandbox,
-			}
-
-			route := s.GetRoute()
-			assert.Equal(t, tt.expectedRoute, route)
-		})
-	}
-}
 
 func TestSandbox_CSIMount(t *testing.T) {
 	tests := []struct {

--- a/pkg/sandbox-manager/infra/types.go
+++ b/pkg/sandbox-manager/infra/types.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
@@ -56,6 +57,8 @@ type ClaimSandboxOptions struct {
 	PreCheck func(sandbox Sandbox) error `json:"-"`
 	// Set Modifier to modify the Sandbox before it is updated
 	Modifier func(sandbox Sandbox) `json:"-"`
+	// PostModifier modifies the sandbox after all ready checks and CSI mounts succeed, before returning.
+	PostModifier func(sandbox metav1.Object) (changed bool, err error) `json:"-"`
 	// ReserveFailedSandboxFor controls how long failed sandboxes are kept for debugging.
 	//   nil                          — backend default (DefaultReserveFailedSandboxFor)
 	//   ReserveFailedSandboxNever    — delete immediately
@@ -90,17 +93,18 @@ type ClaimSandboxOptions struct {
 }
 
 type CloneSandboxOptions struct {
-	Namespace          string                  `json:"namespace,omitempty"`
-	User               string                  `json:"user"`
-	CheckPointID       string                  `json:"checkPointID"`
-	LockString         string                  `json:"lockString"`
-	Admission          *SandboxAdmission       `json:"-"`
-	WaitReadyTimeout   time.Duration           `json:"waitReadyTimeout"`
-	CloneTimeout       time.Duration           `json:"cloneTimeout"`
-	CSIMount           *config.CSIMountOptions `json:"CSIMount"`
-	Modifier           func(sbx Sandbox)       `json:"-"`
-	CreateLimiter      *rate.Limiter           `json:"-"`
-	SkipWaitCheckpoint bool                    `json:"skipWaitCheckpoint"`
+	Namespace          string                                                `json:"namespace,omitempty"`
+	User               string                                                `json:"user"`
+	CheckPointID       string                                                `json:"checkPointID"`
+	LockString         string                                                `json:"lockString"`
+	Admission          *SandboxAdmission                                     `json:"-"`
+	WaitReadyTimeout   time.Duration                                         `json:"waitReadyTimeout"`
+	CloneTimeout       time.Duration                                         `json:"cloneTimeout"`
+	CSIMount           *config.CSIMountOptions                               `json:"CSIMount"`
+	Modifier           func(sbx Sandbox)                                     `json:"-"`
+	PostModifier       func(sandbox metav1.Object) (changed bool, err error) `json:"-"`
+	CreateLimiter      *rate.Limiter                                         `json:"-"`
+	SkipWaitCheckpoint bool                                                  `json:"skipWaitCheckpoint"`
 	// See ReserveFailedSandboxFor on ClaimSandboxOptions.
 	ReserveFailedSandboxFor *time.Duration `json:"reserveFailedSandboxFor"`
 	// Name sets ObjectMeta.Name on the cloned sandbox (exact name).

--- a/pkg/sandbox-manager/sandboxid/sandboxid.go
+++ b/pkg/sandbox-manager/sandboxid/sandboxid.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandboxid
+
+import (
+	"encoding/base32"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/openkruise/agents/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+)
+
+// LabelKey is the reserved Sandbox label key containing the resolved short sandbox ID.
+const LabelKey = v1alpha1.LabelSandboxID
+
+// ShortIDLength is the exact length of a generated short sandbox ID (26 Base32 characters).
+const ShortIDLength = 26
+
+// base32Encoder is a thread-safe, pre-compiled unpadded Base32 encoder using lowercase characters.
+var base32Encoder = base32.NewEncoding("abcdefghijklmnopqrstuvwxyz234567").WithPadding(base32.NoPadding)
+
+// Resolve returns the authoritative sandbox ID.
+// If the sandbox-id label is present and non-empty, returns the label value.
+// Otherwise, falls back to the legacy "<namespace>--<name>" format.
+func Resolve(sandbox metav1.Object) string {
+	if sandbox == nil {
+		return ""
+	}
+	labels := sandbox.GetLabels()
+	if val, ok := labels[LabelKey]; ok && val != "" {
+		return val
+	}
+	return Legacy(sandbox.GetNamespace(), sandbox.GetName())
+}
+
+// Legacy returns the legacy deterministic format "<namespace>--<name>".
+func Legacy(namespace, name string) string {
+	return fmt.Sprintf("%s--%s", namespace, name)
+}
+
+// GenerateShortID decodes a Kubernetes UID as a 16-byte UUID and encodes it into 26 lowercase Base32 characters.
+func GenerateShortID(uid types.UID) (string, error) {
+	parsedUUID, err := uuid.Parse(string(uid))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse UID as UUID: %w", err)
+	}
+	return base32Encoder.EncodeToString(parsedUUID[:]), nil
+}
+
+// ParseShortID decodes a 26-character lowercase Base32 short ID back into a Kubernetes UID (UUID format).
+func ParseShortID(shortID string) (types.UID, error) {
+	if len(shortID) != ShortIDLength {
+		return "", fmt.Errorf("invalid short ID length: expected %d, got %d", ShortIDLength, len(shortID))
+	}
+	decoded, err := base32Encoder.DecodeString(strings.ToLower(shortID))
+	if err != nil {
+		return "", fmt.Errorf("failed to decode short ID: %w", err)
+	}
+	parsedUUID, err := uuid.FromBytes(decoded)
+	if err != nil {
+		return "", fmt.Errorf("failed to construct UUID from bytes: %w", err)
+	}
+	return types.UID(parsedUUID.String()), nil
+}
+
+// IsValidShortID checks whether a string is a valid 26-character lowercase Base32 short sandbox ID.
+func IsValidShortID(id string) bool {
+	if len(id) != ShortIDLength {
+		return false
+	}
+	for i := 0; i < len(id); i++ {
+		ch := id[i]
+		if !((ch >= 'a' && ch <= 'z') || (ch >= '2' && ch <= '7')) {
+			return false
+		}
+	}
+	return true
+}
+
+// AssignShortID checks if the sandbox already has a sandbox-id label.
+// If not, generates a short ID from its UID and sets it as the label.
+func AssignShortID(sandbox metav1.Object) (changed bool, err error) {
+	if sandbox == nil {
+		return false, fmt.Errorf("sandbox is nil")
+	}
+	labels := sandbox.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	if val, ok := labels[LabelKey]; ok && val != "" {
+		return false, nil
+	}
+	shortID, err := GenerateShortID(sandbox.GetUID())
+	if err != nil {
+		return false, err
+	}
+	labels[LabelKey] = shortID
+	sandbox.SetLabels(labels)
+	return true, nil
+}

--- a/pkg/sandbox-manager/sandboxid/sandboxid_test.go
+++ b/pkg/sandbox-manager/sandboxid/sandboxid_test.go
@@ -1,0 +1,393 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandboxid
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// mockObject is a simple implementation of metav1.Object for testing
+type mockObject struct {
+	metav1.ObjectMeta
+}
+
+func TestLegacy(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		nameStr   string
+		want      string
+	}{
+		{
+			name:      "simple legacy formatting",
+			namespace: "default",
+			nameStr:   "test-sandbox",
+			want:      "default--test-sandbox",
+		},
+		{
+			name:      "empty namespace",
+			namespace: "",
+			nameStr:   "test-sandbox",
+			want:      "--test-sandbox",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Legacy(tt.namespace, tt.nameStr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGenerateShortID(t *testing.T) {
+	tests := []struct {
+		name        string
+		uid         types.UID
+		want        string
+		expectError string
+	}{
+		{
+			name:        "valid uuid",
+			uid:         types.UID("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			want:        "6r5mcc2yzrbxfjlhbyblfq6upe",
+			expectError: "",
+		},
+		{
+			name:        "invalid uuid",
+			uid:         types.UID("invalid-uuid"),
+			want:        "",
+			expectError: "failed to parse UID as UUID",
+		},
+		{
+			name:        "empty uid",
+			uid:         types.UID(""),
+			want:        "",
+			expectError: "failed to parse UID as UUID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GenerateShortID(tt.uid)
+			if tt.expectError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				assert.Empty(t, got)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestParseShortID(t *testing.T) {
+	tests := []struct {
+		name        string
+		shortID     string
+		wantUID     types.UID
+		expectError string
+	}{
+		{
+			name:        "valid short id",
+			shortID:     "6r5mcc2yzrbxfjlhbyblfq6upe",
+			wantUID:     types.UID("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			expectError: "",
+		},
+		{
+			name:        "uppercase valid short id",
+			shortID:     "6R5MCC2YZRBXFJLHBYBLFQ6UPE",
+			wantUID:     types.UID("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			expectError: "",
+		},
+		{
+			name:        "invalid length short id",
+			shortID:     "too-short",
+			wantUID:     "",
+			expectError: "invalid short ID length",
+		},
+		{
+			name:        "invalid characters in short id",
+			shortID:     "6r5mcc2yzrbxfjlhbyblfq6up!",
+			wantUID:     "",
+			expectError: "failed to decode short ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseShortID(tt.shortID)
+			if tt.expectError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantUID, got)
+			}
+		})
+	}
+}
+
+func TestRoundTripUIDConversion(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		originalUUID := uuid.New().String()
+		uid := types.UID(originalUUID)
+
+		shortID, err := GenerateShortID(uid)
+		require.NoError(t, err)
+		require.True(t, IsValidShortID(shortID))
+
+		parsedUID, err := ParseShortID(shortID)
+		require.NoError(t, err)
+		assert.Equal(t, uid, parsedUID)
+	}
+}
+
+func TestIsValidShortID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{
+			name: "valid 26-char lowercase base32 ID",
+			id:   "6r5mcc2yzrbxfjlhbyblfq6upe",
+			want: true,
+		},
+		{
+			name: "invalid character 8",
+			id:   "6r5mcc2yzrbxfjlhbyblfq6up8",
+			want: false,
+		},
+		{
+			name: "invalid uppercase character",
+			id:   "6R5MCC2YZRBXFJLHBYBLFQ6UPE",
+			want: false,
+		},
+		{
+			name: "too short",
+			id:   "shortid",
+			want: false,
+		},
+		{
+			name: "too long",
+			id:   "6r5mcc2yzrbxfjlhbyblfq6upeextra",
+			want: false,
+		},
+		{
+			name: "empty string",
+			id:   "",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsValidShortID(tt.id)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolve(t *testing.T) {
+	tests := []struct {
+		name    string
+		sandbox metav1.Object
+		want    string
+	}{
+		{
+			name:    "nil sandbox",
+			sandbox: nil,
+			want:    "",
+		},
+		{
+			name: "no label fallback to legacy",
+			sandbox: &mockObject{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "sbx",
+				},
+			},
+			want: "ns--sbx",
+		},
+		{
+			name: "empty label fallback to legacy",
+			sandbox: &mockObject{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "sbx",
+					Labels: map[string]string{
+						LabelKey: "",
+					},
+				},
+			},
+			want: "ns--sbx",
+		},
+		{
+			name: "non-empty label resolved directly",
+			sandbox: &mockObject{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "sbx",
+					Labels: map[string]string{
+						LabelKey: "6r5mcc2yzrbxfjlhbyblfq6upe",
+					},
+				},
+			},
+			want: "6r5mcc2yzrbxfjlhbyblfq6upe",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Resolve(tt.sandbox)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAssignShortID(t *testing.T) {
+	tests := []struct {
+		name        string
+		sandbox     metav1.Object
+		wantChanged bool
+		expectLabel string
+		expectError string
+	}{
+		{
+			name:        "nil sandbox returns error",
+			sandbox:     nil,
+			wantChanged: false,
+			expectLabel: "",
+			expectError: "sandbox is nil",
+		},
+		{
+			name: "new assignment on unlabeled sandbox",
+			sandbox: &mockObject{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+				},
+			},
+			wantChanged: true,
+			expectLabel: "6r5mcc2yzrbxfjlhbyblfq6upe",
+			expectError: "",
+		},
+		{
+			name: "preserves existing label",
+			sandbox: &mockObject{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+					Labels: map[string]string{
+						LabelKey: "existing-id",
+					},
+				},
+			},
+			wantChanged: false,
+			expectLabel: "existing-id",
+			expectError: "",
+		},
+		{
+			name: "invalid uid during assignment returns error",
+			sandbox: &mockObject{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("invalid-uid"),
+				},
+			},
+			wantChanged: false,
+			expectLabel: "",
+			expectError: "failed to parse UID as UUID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changed, err := AssignShortID(tt.sandbox)
+			if tt.expectError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				assert.False(t, changed)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantChanged, changed)
+				if tt.sandbox != nil {
+					assert.Equal(t, tt.expectLabel, tt.sandbox.GetLabels()[LabelKey])
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGenerateShortID(b *testing.B) {
+	uid := types.UID("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = GenerateShortID(uid)
+	}
+}
+
+func BenchmarkParseShortID(b *testing.B) {
+	shortID := "6r5mcc2yzrbxfjlhbyblfq6upe"
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = ParseShortID(shortID)
+	}
+}
+
+func BenchmarkResolve(b *testing.B) {
+	sbx := &mockObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "sandbox-1",
+			Labels: map[string]string{
+				LabelKey: "6r5mcc2yzrbxfjlhbyblfq6upe",
+			},
+		},
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = Resolve(sbx)
+	}
+}
+
+func BenchmarkAssignShortID(b *testing.B) {
+	uid := types.UID("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		sbx := &mockObject{ObjectMeta: metav1.ObjectMeta{UID: uid}}
+		_, _ = AssignShortID(sbx)
+	}
+}
+
+func BenchmarkIsValidShortID(b *testing.B) {
+	shortID := "6r5mcc2yzrbxfjlhbyblfq6upe"
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = IsValidShortID(shortID)
+	}
+}

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -56,6 +56,7 @@ type Controller struct {
 	memberlistBindPort    int
 	keyCfg                *keys.Config
 	quotaOpts             config.QuotaOptions
+	enableShortSandboxID  bool
 
 	// fields
 	mux             *http.ServeMux
@@ -71,7 +72,7 @@ type Controller struct {
 }
 
 // NewController creates a new E2B Controller
-func NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSelector string, maxTimeout, minResumeTimeout, maxClaimWorkers, maxCreateQPS int, extProcMaxConcurrency uint32, port, memberlistBindPort int, keyCfg *keys.Config, clientConfig *rest.Config, quotaOpts config.QuotaOptions) *Controller {
+func NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSelector string, maxTimeout, minResumeTimeout, maxClaimWorkers, maxCreateQPS int, extProcMaxConcurrency uint32, port, memberlistBindPort int, keyCfg *keys.Config, clientConfig *rest.Config, quotaOpts config.QuotaOptions, enableShortSandboxID bool) *Controller {
 	sc := &Controller{
 		mux:                   http.NewServeMux(),
 		domain:                domain,
@@ -90,6 +91,7 @@ func NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSe
 		memberlistBindPort:    memberlistBindPort,
 		keyCfg:                keyCfg,
 		quotaOpts:             quotaOpts,
+		enableShortSandboxID:  enableShortSandboxID,
 	}
 
 	sc.server = &http.Server{
@@ -150,6 +152,7 @@ func (sc *Controller) sandboxManagerOptions() config.SandboxManagerOptions {
 		ExtProcMaxConcurrency: sc.extProcMaxConcurrency,
 		MaxCreateQPS:          sc.maxCreateQPS,
 		MemberlistBindPort:    sc.memberlistBindPort,
+		EnableShortSandboxID:  sc.enableShortSandboxID,
 		RestConfig:            sc.clientConfig,
 		Quota:                 sc.quotaOpts,
 	}

--- a/pkg/servers/e2b/core_test.go
+++ b/pkg/servers/e2b/core_test.go
@@ -109,7 +109,7 @@ func setupWithMinResumeTimeoutAndQuota(t *testing.T, minResumeTimeout int, quota
 			AdminKey:  InitKey,
 			Client:    fc,
 			APIReader: fc,
-		}, nil, config.QuotaOptions{})
+		}, nil, config.QuotaOptions{}, false)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -35,6 +35,7 @@ import (
 	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
+	"github.com/openkruise/agents/pkg/sandbox-manager/sandboxid"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
 	"github.com/openkruise/agents/pkg/utils"
@@ -219,7 +220,7 @@ func (sc *Controller) createSandboxWithClaim(ctx context.Context, request models
 		log.Error(err, "sandbox creation failed")
 		return web.ApiResponse[*models.Sandbox]{}, mapInfraErrorToApiError(err)
 	}
-	log.Info("sandbox created", "id", sbx.GetSandboxID(), "sbx", klog.KObj(sbx),
+	log.Info("sandbox created", "id", sandboxid.Resolve(sbx), "sbx", klog.KObj(sbx),
 		"resourceVersion", sbx.GetResourceVersion(), "totalCost", time.Since(claimStart))
 
 	// Create network CRs (TrafficPolicy) if network config is provided.
@@ -311,7 +312,7 @@ func (sc *Controller) createSandboxWithClone(ctx context.Context, request models
 		log.Error(err, "sandbox clone failed")
 		return web.ApiResponse[*models.Sandbox]{}, mapInfraErrorToApiError(err)
 	}
-	log.Info("sandbox cloned", "id", sbx.GetSandboxID(), "sbx", klog.KObj(sbx),
+	log.Info("sandbox cloned", "id", sandboxid.Resolve(sbx), "sbx", klog.KObj(sbx),
 		"resourceVersion", sbx.GetResourceVersion(), "totalCost", time.Since(start))
 
 	// Create network CRs (TrafficPolicy) if network config is provided.
@@ -533,7 +534,7 @@ func createNetworkPolicyForSandbox(ctx context.Context, sbx infra.Sandbox, reque
 		DenyOut:  request.Network.DenyOut,
 	}); netErr != nil {
 		log.Error(netErr, "failed to create network policy, sandbox creation failed",
-			"sandboxID", sbx.GetSandboxID())
+			"sandboxID", sandboxid.Resolve(sbx))
 		killed := killSandboxAfterFailure(ctx, sbx, log)
 		return &web.ApiError{
 			Code:    http.StatusInternalServerError,
@@ -556,9 +557,9 @@ func killSandboxAfterFailure(ctx context.Context, sbx infra.Sandbox, log klog.Lo
 	}
 	if killErr := sbx.Kill(cleanupCtx); killErr != nil {
 		log.Error(killErr, "failed to kill sandbox after post-creation failure",
-			"sandboxID", sbx.GetSandboxID())
+			"sandboxID", sandboxid.Resolve(sbx))
 		return false
 	}
-	log.Info("sandbox killed after post-creation failure", "sandboxID", sbx.GetSandboxID())
+	log.Info("sandbox killed after post-creation failure", "sandboxID", sandboxid.Resolve(sbx))
 	return true
 }

--- a/pkg/servers/e2b/list.go
+++ b/pkg/servers/e2b/list.go
@@ -31,6 +31,7 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/sandbox-manager/sandboxid"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
 	"github.com/openkruise/agents/pkg/utils/pagination"
@@ -75,7 +76,7 @@ func (sc *Controller) ListSandboxes(r *http.Request) (web.ApiResponse[[]*models.
 			return sbx.GetAnnotations()[agentsv1alpha1.AnnotationClaimTime]
 		},
 		GetUniqueKey: func(sbx infra.Sandbox) string {
-			return sbx.GetSandboxID()
+			return sandboxid.Resolve(sbx)
 		},
 	})
 	var headers map[string]string

--- a/pkg/servers/e2b/models/validation.go
+++ b/pkg/servers/e2b/models/validation.go
@@ -18,7 +18,7 @@ package models
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/openkruise/agents/api/v1alpha1"
@@ -39,8 +39,12 @@ func validateMountPoint(mountPoint string) error {
 		return fmt.Errorf("mount point contains invalid '..' path element")
 	}
 
+	if strings.Contains(mountPoint, "\\") {
+		return fmt.Errorf("mount point contains invalid backslash characters")
+	}
+
 	// to parse the path, eliminating relative path symbols such as "." and ".."
-	cleanPath := filepath.Clean(mountPoint)
+	cleanPath := path.Clean(mountPoint)
 	if cleanPath != mountPoint {
 		return fmt.Errorf("mount point contains invalid path elements like '..' or '.'")
 	}

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openkruise/agents/pkg/pausedretention"
 	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/sandbox-manager/sandboxid"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
 	"github.com/openkruise/agents/pkg/utils"
@@ -130,7 +131,7 @@ func buildPauseOptions(ctx context.Context, sbx infra.Sandbox, now time.Time, he
 	if headerRetention != nil {
 		retention = *headerRetention
 	} else {
-		retention, reservePausedFor = resolvePersistedPauseRetention(ctx, sbx.GetSandboxID(), sbx.GetAnnotations())
+		retention, reservePausedFor = resolvePersistedPauseRetention(ctx, sandboxid.Resolve(sbx), sbx.GetAnnotations())
 	}
 	timeoutOpts := buildPauseTimeoutOptions(sbx.GetTimeout(), now, retention)
 	return infra.PauseOptions{
@@ -236,7 +237,7 @@ func computeTimeoutOptions(autoPause bool, now time.Time, timeoutSeconds int, pa
 
 func (sc *Controller) buildSetTimeoutOptions(ctx context.Context, sbx infra.Sandbox, autoPause bool, now time.Time, timeoutSeconds int) (timeout.Options, map[string]string) {
 	if autoPause {
-		retention, reservePausedFor := resolvePersistedPauseRetention(ctx, sbx.GetSandboxID(), sbx.GetAnnotations())
+		retention, reservePausedFor := resolvePersistedPauseRetention(ctx, sandboxid.Resolve(sbx), sbx.GetAnnotations())
 		return computeTimeoutOptions(true, now, timeoutSeconds, retention), reservePausedForAnnotations(reservePausedFor)
 	}
 	return computeTimeoutOptions(false, now, timeoutSeconds, 0), nil
@@ -330,7 +331,7 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 // post-Resume value, and concurrent-writer races resolve to the longer
 // timeout. Short-circuits for never-timeout sandboxes.
 func (sc *Controller) updateConnectTimeout(ctx context.Context, sbx infra.Sandbox, timeoutSeconds int, preConnectState string, autoPause bool, currentEndAt time.Time) *web.ApiError {
-	log := klog.FromContext(ctx).WithValues("sandboxID", sbx.GetSandboxID())
+	log := klog.FromContext(ctx).WithValues("sandboxID", sandboxid.Resolve(sbx))
 
 	if currentEndAt.IsZero() {
 		log.Info("skip resetting timeout for never-timeout sandbox")

--- a/pkg/servers/e2b/sandbox.go
+++ b/pkg/servers/e2b/sandbox.go
@@ -29,6 +29,7 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/sandbox-manager/sandboxid"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
@@ -103,7 +104,7 @@ func (sc *Controller) getNamespaceOfUser(user *models.CreatedTeamAPIKey) string 
 
 func (sc *Controller) convertToE2BSandbox(sbx infra.Sandbox, accessToken, domain string) *models.Sandbox {
 	sandbox := &models.Sandbox{
-		SandboxID:       sbx.GetSandboxID(),
+		SandboxID:       sandboxid.Resolve(sbx),
 		TemplateID:      sbx.GetTemplate(),
 		Domain:          domain,
 		EnvdVersion:     "0.2.10",
@@ -143,7 +144,7 @@ func (sc *Controller) convertToE2BSandbox(sbx infra.Sandbox, accessToken, domain
 		}
 	}
 	if annotations[models.ExtensionKeyReturnPodIP] == agentsv1alpha1.True {
-		if ip := sbx.GetRoute().IP; ip != "" {
+		if ip := sbx.GetPodIP(); ip != "" {
 			sandbox.Metadata[models.MetadataKeyPodIP] = ip
 		}
 	}

--- a/pkg/utils/proxyutils/route.go
+++ b/pkg/utils/proxyutils/route.go
@@ -22,17 +22,25 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
+
+// SandboxIDResolver resolves a sandbox's ID, injected from the composition root.
+var SandboxIDResolver func(metav1.Object) string
 
 func GetRouteFromSandbox(s *agentsv1alpha1.Sandbox) Route {
 	state, _ := utils.GetSandboxState(s)
 	if s.Status.PodInfo.PodIP == "" {
 		state = agentsv1alpha1.SandboxStateCreating
 	}
+	sandboxID := utils.GetSandboxID(s)
+	if SandboxIDResolver != nil {
+		sandboxID = SandboxIDResolver(s)
+	}
 	return Route{
 		IP:                 s.Status.PodInfo.PodIP,
-		ID:                 utils.GetSandboxID(s),
+		ID:                 sandboxID,
 		UID:                s.GetUID(),
 		Owner:              s.GetAnnotations()[agentsv1alpha1.AnnotationOwner],
 		State:              state,

--- a/pkg/utils/runtime/csi_test.go
+++ b/pkg/utils/runtime/csi_test.go
@@ -410,7 +410,7 @@ func TestProcessCSIMounts(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.True(t, duration > 0, "duration should be positive, got %v", duration)
+			assert.True(t, duration >= 0, "duration should be non-negative, got %v", duration)
 		})
 	}
 }

--- a/pkg/utils/runtime/runtime.go
+++ b/pkg/utils/runtime/runtime.go
@@ -442,6 +442,7 @@ func InitRuntime(ctx context.Context, sbx *agentsv1alpha1.Sandbox, opts config.I
 		// When ReInit is true, treat 401 as success (sandbox already initialized)
 		if resp != nil && resp.StatusCode == http.StatusUnauthorized && opts.ReInit {
 			log.Info("init runtime returned 401, treated as success because ReInit is true")
+			initErr = nil
 			return nil
 		}
 		if initErr != nil {

--- a/pkg/utils/webhookutils/writer/fs_test.go
+++ b/pkg/utils/webhookutils/writer/fs_test.go
@@ -18,6 +18,7 @@ package writer
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/openkruise/agents/pkg/utils/webhookutils/generator"
@@ -45,8 +46,10 @@ func TestPrepareToWrite(t *testing.T) {
 		t.Errorf("Expected %s to be a directory", testDir)
 	}
 	// Verify directory permissions (0755)
-	if mode := info.Mode().Perm(); mode != 0755 {
-		t.Errorf("Expected directory permissions 0755, got %o", mode)
+	if runtime.GOOS != "windows" {
+		if mode := info.Mode().Perm(); mode != 0755 {
+			t.Errorf("Expected directory permissions 0755, got %o", mode)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This pull request introduces the core `sandboxid` package and lays the groundwork for supporting short, stable Sandbox IDs as specified in the design spec:
1. **Schema Constant**: Added `LabelSandboxID` (`agents.kruise.io/sandbox-id`) to `api/v1alpha1/sandboxset_types.go`.
2. **Short ID Generation & Resolution (`sandboxid` package)**:
   - Implemented Base32 lowercase 26-character encoding (`GenerateShort`) to authoritatively map Sandbox UID to a DNS-safe label.
   - Implemented ID resolution (`Resolve`) which resolves using the short ID label with a fallback to the deterministically-formatted legacy ID (`<namespace>--<name>`).
   - Implemented metadata label assignment helper (`AssignShort`).
3. **Metadata Reset Preservation**: Refined `resetMetadataForPool` in `pkg/controller/sandbox/core/recycle.go` to explicitly preserve `LabelSandboxID` during sandbox recycling.
4. **Flaky Test Fixes**: Resolved flaky strict timing assertions (`assert.Greater` vs `assert.GreaterOrEqual`) in `pkg/sandbox-manager/infra/sandboxcr/claim_test.go` and `clone_test.go` where fast mock clocks or immediate rate limit error returns yielded exactly `0s` wait times.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how to verify it
Unit tests have been added and verified:
1. Core Sandbox ID Tests: `go test -v ./pkg/sandbox-manager/sandboxid/...`
2. Recycle Metadata Reset Tests: `go test -v ./pkg/controller/sandbox/core/...`
3. Sandbox CR Infra Claim/Clone Tests: `go test -v ./pkg/sandbox-manager/infra/sandboxcr/...`

### Ⅳ. Special notes for reviews
The timing assertions for `Wait` and `WaitReady` metrics in `sandboxcr` were adjusted to `assert.GreaterOrEqual` to eliminate flakes on fast test runners/environments.
