### PR TITLE
fix(proxy): make route deletes resourceVersion-aware and unify gateway/manager route tables

### DIFF
--- a/docs/proposals/20260603-route-table-consistency.md
+++ b/docs/proposals/20260603-route-table-consistency.md
@@ -1,0 +1,115 @@
+---
+title: Route Table Consistency for sandbox-manager and sandbox-gateway
+authors:
+- "@PRAteek-singHWY"
+creation-date: 2026-06-03
+last-updated: 2026-06-03
+status: implementable
+---
+
+# Route Table Consistency for sandbox-manager and sandbox-gateway
+
+| Metadata    | Details            |
+|-------------|--------------------|
+| **Author**  | @PRAteek-singHWY   |
+| **Status**  | Implementable      |
+| **Created** | 2026-06-03         |
+
+## Summary
+
+Both the sandbox-manager (`pkg/proxy`) and the sandbox-gateway
+(`pkg/sandbox-gateway/registry`) keep an in-memory route table mapping a sandbox
+ID (`namespace--name`) to its pod IP and state. Entries reach a replica through
+two unordered channels: peer `POST /refresh` pushes (memberlist) and, on the
+gateway, a Sandbox CR-watch controller reconciling from an informer cache. This
+note documents the consistency model those tables must uphold and the design
+that enforces it.
+
+## Motivation
+
+Three defects existed in the consumer side of route synchronization:
+
+1. **Divergent delete semantics.** For an identical `{state: "paused"}` push the
+   manager handler kept the entry (delete only on `dead`) while the gateway
+   handler dropped it (keep only `running`), so the two data planes held
+   different state for the same event.
+2. **Version-blind deletes.** `Update` refused to let an older `resourceVersion`
+   overwrite a newer one, but `Delete` erased the entry — and the recorded
+   version — unconditionally. The next write, however stale, then landed as a
+   fresh first write. With two unordered writers, a delete followed by a
+   lagging-cache update could *resurrect* a removed route, and the Envoy filter
+   would route live traffic to a freed pod IP until the informer converged.
+3. **Inconsistent keying.** The manager's periodic refresh looked routes up by
+   name while storing them under `namespace--name`, making its "skip if
+   unchanged" comparison meaningless.
+
+## Design
+
+### Invariant
+
+A route table entry is only mutated by an event whose `resourceVersion` is at
+least as new as the version currently recorded for that slot — **including
+deletes**. Writers never need to coordinate with each other; the store is the
+single arbiter, and writes from any source are idempotent and commutative under
+resourceVersion ordering.
+
+### Shared store (`pkg/proxy/routestore`)
+
+Both tables delegate to one implementation:
+
+- `Set(id, route)` keeps the existing CAS + `IsResourceVersionNewer` (`>=`)
+  semantics for live entries.
+- `Delete(id, resourceVersion)` replaces the entry with a short-lived
+  **tombstone** stamped with the larger of the deleting event's resourceVersion
+  and the one recorded on the entry (an empty value — e.g. an informer
+  not-found — falls back to the recorded one).
+- A write may replace an active tombstone only if it is **strictly newer**
+  (`IsResourceVersionReallyNewer`, `>`). An equal version is the very write the
+  deletion superseded; accepting it would resurrect the route. A genuine
+  recreate always carries a strictly higher version (etcd resourceVersions are
+  monotonic), so it passes.
+- Tombstones expire after `DefaultTombstoneTTL` (10 minutes — by then the
+  level-triggered reconcilers have converged) and are reclaimed lazily on
+  access, by an inline sweep once a threshold accumulates, and by an explicit
+  `GC()` hooked into the manager's periodic route reconciliation. No new
+  background goroutine is introduced.
+
+### One keep-vs-delete rule
+
+`proxyutils.ShouldDeleteRoute(state)` (`delete iff state == dead`) is the single
+predicate used by both `/refresh` handlers. Every non-dead state — creating,
+available, paused, running — is stored with its state; consumers decide
+routability from `Route.State` (the gateway filter already serves only
+`running`). An identical push therefore produces an identical table on both
+data planes.
+
+### Writers
+
+- Manager `/refresh`, gateway `/refresh`: shared predicate + versioned delete.
+- Gateway CR-watch controller: updates with the object's resourceVersion;
+  deletes pass the observed resourceVersion (deletion-timestamped object) or
+  empty (not-found), falling back to the recorded one.
+- Manager periodic reconciler: orphan deletes pass the route's own
+  resourceVersion and trigger tombstone GC; the refresh path now keys lookups
+  by the full sandbox ID.
+
+## Alternatives
+
+- **Single writer (controller-only or push-only).** Rejected: the push path is
+  the low-latency channel for lifecycle changes, the watch path is the
+  level-triggered backstop; both are wanted. Making the store order-safe keeps
+  both without coordination.
+- **Reference counting / per-id locks.** Heavier than needed; the
+  resourceVersion already provides a total order per object.
+- **Unbounded tombstones.** Correct but leaks memory under churn; TTL + lazy
+  sweep bounds it without a goroutine.
+
+## Test Plan
+
+- Table-driven unit tests on the store: version arbitration, delete-then-stale
+  -write (resurrection guard), equal-version-vs-tombstone, empty-version
+  fallback, expiry, inline GC, concurrent writers under `-race`.
+- Handler tests: both `/refresh` handlers agree on the shared predicate; a
+  paused push no longer drops the gateway entry; a stale running push after a
+  dead push cannot resurrect.
+- Controller tests: deletes are versioned at the controller boundary.

--- a/pkg/proxy/metrics_test.go
+++ b/pkg/proxy/metrics_test.go
@@ -53,7 +53,7 @@ func TestRoutesTotal_DecrementOnDelete(t *testing.T) {
 	s.SetRoute(context.Background(), Route{ID: "metrics-3", IP: "1.2.3.4", ResourceVersion: "1"})
 
 	before := testutil.ToFloat64(routeCount)
-	s.DeleteRoute("metrics-3")
+	s.DeleteRoute("metrics-3", "2")
 	after := testutil.ToFloat64(routeCount)
 
 	assert.Equal(t, float64(-1), after-before)
@@ -63,7 +63,7 @@ func TestRoutesTotal_NoDecrementOnDeleteNonExistent(t *testing.T) {
 	s := newTestServer(nil)
 
 	before := testutil.ToFloat64(routeCount)
-	s.DeleteRoute("non-existent-route")
+	s.DeleteRoute("non-existent-route", "")
 	after := testutil.ToFloat64(routeCount)
 
 	assert.Equal(t, float64(0), after-before)

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/openkruise/agents/pkg/peers"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
-	"github.com/openkruise/agents/pkg/utils/expectations"
 	"github.com/openkruise/agents/pkg/utils/proxyutils"
 )
 
@@ -41,30 +40,15 @@ type Route = proxyutils.Route
 
 func (s *Server) SetRoute(ctx context.Context, route Route) {
 	log := klog.FromContext(ctx)
-	log.Info("try to set route", "new", route)
-	for {
-		old, loaded := s.routes.LoadOrStore(route.ID, route)
-		if !loaded {
-			// First write, success directly
-			routeCount.Inc()
-			return
-		}
-
-		oldRoute := old.(Route)
-		if !expectations.IsResourceVersionNewer(oldRoute.ResourceVersion, route.ResourceVersion) {
-			// New version is not newer than old version, skip write
-			log.Info("received route is not newer than the existing one, skip write", "old", oldRoute)
-			return
-		}
-
-		// Attempt CAS update
-		if s.routes.CompareAndSwap(route.ID, old, route) {
-			// Successfully replaced
-			log.Info("successfully set route", "route", route)
-			return
-		}
-		// CAS failed, modified by another goroutine, retry
+	applied, becameLive := s.routes.Set(route.ID, route)
+	if !applied {
+		log.Info("received route is not newer than the existing one, skip write", "route", route)
+		return
 	}
+	if becameLive {
+		routeCount.Inc()
+	}
+	log.Info("successfully set route", "route", route)
 }
 
 func (s *Server) SyncRouteWithPeers(route Route) error {
@@ -121,20 +105,21 @@ func (s *Server) SyncRouteWithPeers(route Route) error {
 }
 
 func (s *Server) LoadRoute(id string) (Route, bool) {
-	raw, ok := s.routes.Load(id)
-	if !ok {
-		return Route{}, false
-	}
-	return raw.(Route), true
+	return s.routes.Get(id)
 }
 
 func (s *Server) ListRoutes() []Route {
-	routes := make([]Route, 0)
-	s.routes.Range(func(key, value any) bool {
-		routes = append(routes, value.(Route))
-		return true
-	})
+	m := s.routes.List()
+	routes := make([]Route, 0, len(m))
+	for _, route := range m {
+		routes = append(routes, route)
+	}
 	return routes
+}
+
+// GC reclaims expired route tombstones. The periodic route reconciler calls it.
+func (s *Server) GC() {
+	s.routes.GC()
 }
 
 func (s *Server) ListPeers() []peers.Peer {
@@ -144,8 +129,11 @@ func (s *Server) ListPeers() []peers.Peer {
 	return nil
 }
 
-func (s *Server) DeleteRoute(id string) {
-	if _, loaded := s.routes.LoadAndDelete(id); loaded {
+// DeleteRoute removes a route, leaving a versioned tombstone so a stale write
+// cannot resurrect it. resourceVersion is the version of the deleting event; an
+// empty value falls back to the resourceVersion currently recorded for the route.
+func (s *Server) DeleteRoute(id string, resourceVersion string) {
+	if s.routes.Delete(id, resourceVersion) {
 		routeCount.Dec()
 	}
 }

--- a/pkg/proxy/routes_test.go
+++ b/pkg/proxy/routes_test.go
@@ -179,7 +179,7 @@ func TestDeleteRoute(t *testing.T) {
 	ctx := context.Background()
 	s.SetRoute(ctx, Route{ID: "sb-1", IP: "1.1.1.1", ResourceVersion: "1"})
 
-	s.DeleteRoute("sb-1")
+	s.DeleteRoute("sb-1", "2")
 
 	_, ok := s.LoadRoute("sb-1")
 	assert.False(t, ok)
@@ -188,7 +188,19 @@ func TestDeleteRoute(t *testing.T) {
 func TestDeleteRoute_NonExistent(t *testing.T) {
 	s := newTestServer(nil)
 	// Should not panic
-	s.DeleteRoute("nonexistent")
+	s.DeleteRoute("nonexistent", "")
+}
+
+func TestDeleteRoute_StaleWriteCannotResurrect(t *testing.T) {
+	s := newTestServer(nil)
+	ctx := context.Background()
+	s.SetRoute(ctx, Route{ID: "sb-1", IP: "1.1.1.1", ResourceVersion: "10"})
+	s.DeleteRoute("sb-1", "11")
+
+	// A stale write at the old version must not bring the route back.
+	s.SetRoute(ctx, Route{ID: "sb-1", IP: "1.1.1.1", ResourceVersion: "10"})
+	_, ok := s.LoadRoute("sb-1")
+	assert.False(t, ok, "stale write after delete must not resurrect the route")
 }
 
 // ---- ListPeers tests ----
@@ -371,8 +383,8 @@ func (m *muxRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func TestSyncRouteWithPeers_TwoNodes_Memberlist(t *testing.T) {
 	// Start two real HTTP servers (acting as proxy system servers on dynamic ports)
-	server1 := &Server{}
-	server2 := &Server{}
+	server1 := NewServer(config.SandboxManagerOptions{})
+	server2 := NewServer(config.SandboxManagerOptions{})
 
 	// Set up HTTP handlers for /refresh on both servers
 	mux1 := http.NewServeMux()

--- a/pkg/proxy/routestore/store.go
+++ b/pkg/proxy/routestore/store.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package routestore provides a concurrent, resourceVersion-aware route table
+// shared by the proxy (sandbox-manager) and the registry (sandbox-gateway).
+//
+// Route changes reach a replica out of order: peer /refresh pushes can be
+// reordered or retried, and the informer-driven controller can reconcile from a
+// cache that lags the API server. The store preserves a single invariant against
+// that disorder — a route is only mutated by an event whose resourceVersion is at
+// least as new as the one currently recorded.
+//
+// Crucially, this invariant is enforced on deletes as well as writes. A plain map
+// delete would erase the recorded resourceVersion, so the very next write — no
+// matter how stale — would land as a fresh first write and win unconditionally,
+// resurrecting a route a newer event already removed. To prevent that, a delete
+// leaves a short-lived tombstone carrying the resourceVersion observed at deletion
+// time; a later write must beat that resourceVersion to take effect. Tombstones
+// expire after a TTL (by which point the cluster has converged) and are reclaimed
+// lazily on access plus an inline sweep, so the store needs no background goroutine.
+package routestore
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/openkruise/agents/pkg/utils/expectations"
+	"github.com/openkruise/agents/pkg/utils/proxyutils"
+)
+
+const (
+	// DefaultTombstoneTTL is how long a delete tombstone is retained so that a
+	// stale or reordered write cannot resurrect a route a newer event removed.
+	// After this window the cluster is expected to have converged on the deletion.
+	DefaultTombstoneTTL = 10 * time.Minute
+
+	// gcThreshold is the tombstone count above which Set/Delete sweep expired
+	// tombstones inline, bounding memory without a background goroutine.
+	gcThreshold = 256
+)
+
+// entry is a single slot in the store: either a live route or a tombstone.
+type entry struct {
+	route     proxyutils.Route
+	tombstone bool
+	// rv is the resourceVersion governing this slot: the route's resourceVersion
+	// for a live entry, or the resourceVersion observed at deletion for a tombstone.
+	rv       string
+	expireAt time.Time // tombstone expiry; zero for live entries
+}
+
+// Store is a concurrent, resourceVersion-aware route table. The zero value is not
+// usable; construct one with New.
+type Store struct {
+	entries      sync.Map // id(string) -> *entry
+	tombstoneTTL time.Duration
+	now          func() time.Time
+	// tombstones is an approximate count of tombstone slots, used only to decide
+	// when to run the inline sweep. It is allowed to drift; correctness never
+	// depends on it because expiry is also checked lazily on access.
+	tombstones atomic.Int64
+}
+
+// Option configures a Store.
+type Option func(*Store)
+
+// WithTombstoneTTL overrides the tombstone retention window.
+func WithTombstoneTTL(ttl time.Duration) Option {
+	return func(s *Store) {
+		if ttl > 0 {
+			s.tombstoneTTL = ttl
+		}
+	}
+}
+
+// WithClock overrides the time source. Intended for tests.
+func WithClock(now func() time.Time) Option {
+	return func(s *Store) {
+		if now != nil {
+			s.now = now
+		}
+	}
+}
+
+// New returns a ready-to-use Store.
+func New(opts ...Option) *Store {
+	s := &Store{
+		tombstoneTTL: DefaultTombstoneTTL,
+		now:          time.Now,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// expired reports whether e is a tombstone that has outlived its TTL.
+func (s *Store) expired(e *entry, now time.Time) bool {
+	return e.tombstone && !e.expireAt.IsZero() && now.After(e.expireAt)
+}
+
+// Get returns the live route for id. A tombstone (expired or not) is reported as absent.
+func (s *Store) Get(id string) (proxyutils.Route, bool) {
+	raw, ok := s.entries.Load(id)
+	if !ok {
+		return proxyutils.Route{}, false
+	}
+	e := raw.(*entry)
+	if e.tombstone {
+		return proxyutils.Route{}, false
+	}
+	return e.route, true
+}
+
+// Set records route under id if no newer version is already present.
+//
+// applied reports whether the write took effect; becameLive additionally reports
+// whether it turned an absent/tombstoned slot into a live route (so callers can
+// keep an O(1) live-route gauge).
+func (s *Store) Set(id string, route proxyutils.Route) (applied bool, becameLive bool) {
+	now := s.now()
+	newE := &entry{route: route, rv: route.ResourceVersion}
+	for {
+		raw, loaded := s.entries.LoadOrStore(id, newE)
+		if !loaded {
+			// Slot was genuinely absent: first write.
+			return true, true
+		}
+		old := raw.(*entry)
+
+		if old.tombstone {
+			// An active tombstone may only be overwritten by a STRICTLY newer
+			// event — an equal resourceVersion is the very write the deletion
+			// superseded, so accepting it would resurrect the route. An expired
+			// tombstone is treated as absent.
+			if !s.expired(old, now) && !expectations.IsResourceVersionReallyNewer(old.rv, route.ResourceVersion) {
+				return false, false
+			}
+			if s.entries.CompareAndSwap(id, raw, newE) {
+				s.tombstones.Add(-1)
+				return true, true
+			}
+			continue
+		}
+
+		// Live entry: refuse an older-or-equal-but-older resourceVersion.
+		if !expectations.IsResourceVersionNewer(old.rv, route.ResourceVersion) {
+			return false, false
+		}
+		if s.entries.CompareAndSwap(id, raw, newE) {
+			return true, false
+		}
+	}
+}
+
+// Delete removes the route for id, leaving a tombstone stamped with the most
+// recent resourceVersion known for the slot (the larger of resourceVersion and
+// the resourceVersion currently recorded). An empty resourceVersion — e.g. an
+// informer not-found delete — falls back to the recorded one. removed reports
+// whether a live route was actually turned into a tombstone.
+func (s *Store) Delete(id string, resourceVersion string) (removed bool) {
+	now := s.now()
+	for {
+		raw, ok := s.entries.Load(id)
+		if !ok {
+			// Nothing recorded yet; still drop a tombstone so an in-flight
+			// stale write for this id cannot land as a fresh first write.
+			tomb := &entry{tombstone: true, rv: resourceVersion, expireAt: now.Add(s.tombstoneTTL)}
+			if _, loaded := s.entries.LoadOrStore(id, tomb); !loaded {
+				s.tombstones.Add(1)
+				s.maybeGC(now)
+				return false
+			}
+			continue // raced with an insert; retry and handle as existing
+		}
+
+		old := raw.(*entry)
+		tombRV := resourceVersion
+		if expectations.IsResourceVersionNewer(resourceVersion, old.rv) {
+			// old.rv is the same-or-newer of the two; keep it as the tombstone rv.
+			tombRV = old.rv
+		}
+		tomb := &entry{tombstone: true, rv: tombRV, expireAt: now.Add(s.tombstoneTTL)}
+		if !s.entries.CompareAndSwap(id, raw, tomb) {
+			continue
+		}
+		if old.tombstone {
+			// Refreshed an existing tombstone; live count unchanged.
+			s.maybeGC(now)
+			return false
+		}
+		s.tombstones.Add(1)
+		s.maybeGC(now)
+		return true
+	}
+}
+
+// List returns a snapshot of all live routes keyed by id.
+func (s *Store) List() map[string]proxyutils.Route {
+	result := make(map[string]proxyutils.Route)
+	s.entries.Range(func(k, v any) bool {
+		if e := v.(*entry); !e.tombstone {
+			result[k.(string)] = e.route
+		}
+		return true
+	})
+	return result
+}
+
+// Len returns the number of live routes.
+func (s *Store) Len() int {
+	n := 0
+	s.entries.Range(func(_, v any) bool {
+		if !v.(*entry).tombstone {
+			n++
+		}
+		return true
+	})
+	return n
+}
+
+// GC reclaims expired tombstones. It is safe to call concurrently and is cheap
+// when there is nothing to reclaim.
+func (s *Store) GC() {
+	s.gc(s.now())
+}
+
+// maybeGC sweeps only once tombstones have accumulated past the threshold, so the
+// common path stays allocation- and scan-free.
+func (s *Store) maybeGC(now time.Time) {
+	if s.tombstones.Load() > gcThreshold {
+		s.gc(now)
+	}
+}
+
+func (s *Store) gc(now time.Time) {
+	s.entries.Range(func(k, v any) bool {
+		if e := v.(*entry); s.expired(e, now) {
+			if s.entries.CompareAndDelete(k, v) {
+				s.tombstones.Add(-1)
+			}
+		}
+		return true
+	})
+}
+
+// Clear drops all entries. It is not safe to call concurrently with other
+// operations and is intended for tests.
+func (s *Store) Clear() {
+	s.entries = sync.Map{}
+	s.tombstones.Store(0)
+}

--- a/pkg/proxy/routestore/store_test.go
+++ b/pkg/proxy/routestore/store_test.go
@@ -1,0 +1,277 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routestore_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openkruise/agents/pkg/proxy/routestore"
+	"github.com/openkruise/agents/pkg/utils/proxyutils"
+)
+
+// fakeClock is a controllable time source for tombstone-expiry tests.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+func rt(id, rv, state, ip string) proxyutils.Route {
+	return proxyutils.Route{ID: id, ResourceVersion: rv, State: state, IP: ip}
+}
+
+// step is one operation against the store plus its expected outcome.
+type step struct {
+	op string // "set" | "delete" | "advance" | "gc"
+
+	id    string
+	rv    string
+	state string
+	ip    string
+	dur   time.Duration
+
+	// expectations for set/delete
+	wantApplied    bool
+	wantBecameLive bool
+	wantRemoved    bool
+
+	// post-condition: look up checkID and assert presence/value
+	checkID     string
+	wantPresent bool
+	wantIP      string
+	wantLen     int
+	checkLen    bool
+}
+
+func TestStore_Sequences(t *testing.T) {
+	const ttl = time.Minute
+	tests := []struct {
+		name  string
+		steps []step
+	}{
+		{
+			name: "first write then newer write wins, older write is ignored",
+			steps: []step{
+				{op: "set", id: "a", rv: "10", state: "running", ip: "1.1.1.1", wantApplied: true, wantBecameLive: true, checkID: "a", wantPresent: true, wantIP: "1.1.1.1"},
+				{op: "set", id: "a", rv: "20", state: "running", ip: "2.2.2.2", wantApplied: true, wantBecameLive: false, checkID: "a", wantPresent: true, wantIP: "2.2.2.2"},
+				{op: "set", id: "a", rv: "15", state: "running", ip: "3.3.3.3", wantApplied: false, checkID: "a", wantPresent: true, wantIP: "2.2.2.2", checkLen: true, wantLen: 1},
+			},
+		},
+		{
+			name: "equal resourceVersion is accepted (matches Update's >= semantics)",
+			steps: []step{
+				{op: "set", id: "a", rv: "10", state: "running", ip: "1.1.1.1", wantApplied: true, wantBecameLive: true},
+				{op: "set", id: "a", rv: "10", state: "running", ip: "9.9.9.9", wantApplied: true, wantBecameLive: false, checkID: "a", wantPresent: true, wantIP: "9.9.9.9"},
+			},
+		},
+		{
+			name: "delete removes the live route",
+			steps: []step{
+				{op: "set", id: "a", rv: "10", state: "running", ip: "1.1.1.1", wantApplied: true, wantBecameLive: true},
+				{op: "delete", id: "a", rv: "11", wantRemoved: true, checkID: "a", wantPresent: false, checkLen: true, wantLen: 0},
+			},
+		},
+		{
+			name: "RESURRECTION GUARD: a stale write after delete is rejected",
+			steps: []step{
+				{op: "set", id: "a", rv: "10", state: "running", ip: "1.1.1.1", wantApplied: true, wantBecameLive: true},
+				{op: "delete", id: "a", rv: "11", wantRemoved: true},
+				// A lagging-cache controller re-adds the old running state: must not resurrect.
+				{op: "set", id: "a", rv: "10", state: "running", ip: "1.1.1.1", wantApplied: false, wantBecameLive: false, checkID: "a", wantPresent: false, checkLen: true, wantLen: 0},
+			},
+		},
+		{
+			name: "a genuinely newer event after delete is allowed (recreate)",
+			steps: []step{
+				{op: "set", id: "a", rv: "10", state: "running", ip: "1.1.1.1", wantApplied: true, wantBecameLive: true},
+				{op: "delete", id: "a", rv: "11", wantRemoved: true},
+				{op: "set", id: "a", rv: "20", state: "running", ip: "5.5.5.5", wantApplied: true, wantBecameLive: true, checkID: "a", wantPresent: true, wantIP: "5.5.5.5", checkLen: true, wantLen: 1},
+			},
+		},
+		{
+			name: "delete with empty resourceVersion falls back to the recorded one",
+			steps: []step{
+				{op: "set", id: "a", rv: "100", state: "running", ip: "1.1.1.1", wantApplied: true, wantBecameLive: true},
+				{op: "delete", id: "a", rv: "", wantRemoved: true},
+				{op: "set", id: "a", rv: "99", state: "running", ip: "1.1.1.1", wantApplied: false, checkID: "a", wantPresent: false},
+				{op: "set", id: "a", rv: "101", state: "running", ip: "7.7.7.7", wantApplied: true, wantBecameLive: true, checkID: "a", wantPresent: true, wantIP: "7.7.7.7"},
+			},
+		},
+		{
+			name: "a write equal to the tombstone version is rejected (strict newer required)",
+			steps: []step{
+				{op: "set", id: "a", rv: "100", state: "running", ip: "1.1.1.1", wantApplied: true, wantBecameLive: true},
+				{op: "delete", id: "a", rv: "", wantRemoved: true}, // tombstone rv = 100 (from the entry)
+				{op: "set", id: "a", rv: "100", state: "running", ip: "1.1.1.1", wantApplied: false, checkID: "a", wantPresent: false},
+			},
+		},
+		{
+			name: "tombstone expiry lets a later write through",
+			steps: []step{
+				{op: "set", id: "a", rv: "100", state: "running", ip: "1.1.1.1", wantApplied: true, wantBecameLive: true},
+				{op: "delete", id: "a", rv: "100", wantRemoved: true},
+				// Before expiry the stale write is still blocked.
+				{op: "set", id: "a", rv: "50", state: "running", ip: "1.1.1.1", wantApplied: false},
+				{op: "advance", dur: 2 * time.Minute},
+				// After expiry the tombstone is treated as absent.
+				{op: "set", id: "a", rv: "50", state: "running", ip: "8.8.8.8", wantApplied: true, wantBecameLive: true, checkID: "a", wantPresent: true, wantIP: "8.8.8.8"},
+			},
+		},
+		{
+			name: "deleting an unknown id still blocks an in-flight stale write",
+			steps: []step{
+				{op: "delete", id: "a", rv: "100", wantRemoved: false},
+				{op: "set", id: "a", rv: "50", state: "running", ip: "1.1.1.1", wantApplied: false, checkID: "a", wantPresent: false},
+			},
+		},
+		{
+			name: "deleting a tombstone again does not report a removal",
+			steps: []step{
+				{op: "set", id: "a", rv: "10", state: "running", ip: "1.1.1.1", wantApplied: true, wantBecameLive: true},
+				{op: "delete", id: "a", rv: "11", wantRemoved: true},
+				{op: "delete", id: "a", rv: "12", wantRemoved: false},
+			},
+		},
+		{
+			name: "GC before expiry keeps the tombstone effective",
+			steps: []step{
+				{op: "set", id: "a", rv: "10", state: "running", ip: "1.1.1.1", wantApplied: true, wantBecameLive: true},
+				{op: "delete", id: "a", rv: "11", wantRemoved: true},
+				{op: "gc"},
+				{op: "set", id: "a", rv: "10", state: "running", ip: "1.1.1.1", wantApplied: false, checkID: "a", wantPresent: false},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clock := &fakeClock{t: time.Unix(0, 0)}
+			s := routestore.New(routestore.WithTombstoneTTL(ttl), routestore.WithClock(clock.Now))
+			for i, st := range tt.steps {
+				switch st.op {
+				case "set":
+					applied, becameLive := s.Set(st.id, rt(st.id, st.rv, st.state, st.ip))
+					assert.Equalf(t, st.wantApplied, applied, "step %d set applied", i)
+					assert.Equalf(t, st.wantBecameLive, becameLive, "step %d set becameLive", i)
+				case "delete":
+					removed := s.Delete(st.id, st.rv)
+					assert.Equalf(t, st.wantRemoved, removed, "step %d delete removed", i)
+				case "advance":
+					clock.advance(st.dur)
+				case "gc":
+					s.GC()
+				default:
+					t.Fatalf("unknown op %q", st.op)
+				}
+
+				if st.checkID != "" {
+					got, ok := s.Get(st.checkID)
+					assert.Equalf(t, st.wantPresent, ok, "step %d Get(%s) presence", i, st.checkID)
+					if st.wantPresent && ok {
+						assert.Equalf(t, st.wantIP, got.IP, "step %d Get(%s) ip", i, st.checkID)
+					}
+				}
+				if st.checkLen {
+					assert.Equalf(t, st.wantLen, s.Len(), "step %d Len", i)
+				}
+			}
+		})
+	}
+}
+
+func TestStore_List(t *testing.T) {
+	s := routestore.New()
+	_, _ = s.Set("a", rt("a", "1", "running", "1.1.1.1"))
+	_, _ = s.Set("b", rt("b", "1", "paused", "2.2.2.2"))
+	s.Delete("b", "2")
+
+	got := s.List()
+	assert.Len(t, got, 1)
+	assert.Contains(t, got, "a")
+	assert.NotContains(t, got, "b")
+}
+
+func TestStore_GCReclaimsExpiredTombstones(t *testing.T) {
+	clock := &fakeClock{t: time.Unix(0, 0)}
+	s := routestore.New(routestore.WithTombstoneTTL(time.Minute), routestore.WithClock(clock.Now))
+
+	_, _ = s.Set("a", rt("a", "1", "running", "1.1.1.1"))
+	s.Delete("a", "2")
+	clock.advance(2 * time.Minute)
+	s.GC()
+
+	// After GC of an expired tombstone, even an older-versioned write is accepted.
+	applied, becameLive := s.Set("a", rt("a", "1", "running", "9.9.9.9"))
+	assert.True(t, applied)
+	assert.True(t, becameLive)
+	got, ok := s.Get("a")
+	assert.True(t, ok)
+	assert.Equal(t, "9.9.9.9", got.IP)
+}
+
+func TestStore_Clear(t *testing.T) {
+	s := routestore.New()
+	_, _ = s.Set("a", rt("a", "1", "running", "1.1.1.1"))
+	s.Clear()
+	_, ok := s.Get("a")
+	assert.False(t, ok)
+	assert.Equal(t, 0, s.Len())
+}
+
+// TestStore_ConcurrentWritersConverge ensures the store is race-free and that the
+// highest resourceVersion wins regardless of interleaving.
+func TestStore_ConcurrentWritersConverge(t *testing.T) {
+	s := routestore.New()
+	const writers = 16
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for v := 1; v <= 50; v++ {
+				rv := fmt.Sprintf("%d", n*100+v)
+				_, _ = s.Set("a", rt("a", rv, "running", rv))
+				if v%10 == 0 {
+					s.Delete("a", rv)
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// Whatever the final state, the store must be internally consistent: a present
+	// route's IP matches its resourceVersion (we encoded them identically above).
+	if got, ok := s.Get("a"); ok {
+		assert.Equal(t, got.ResourceVersion, got.IP)
+	}
+}

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -33,11 +33,12 @@ import (
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
 
-	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/peers"
+	"github.com/openkruise/agents/pkg/proxy/routestore"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/utils"
+	"github.com/openkruise/agents/pkg/utils/proxyutils"
 )
 
 const (
@@ -76,7 +77,7 @@ type Server struct {
 	// http
 	httpSrv *http.Server
 	// internal
-	routes  sync.Map
+	routes  *routestore.Store
 	adapter RequestAdapter
 	LBEntry string // entry of load balancer, usually a service
 	// peers - now managed by Peers
@@ -88,6 +89,7 @@ type Server struct {
 func NewServer(opts config.SandboxManagerOptions) *Server {
 	s := &Server{
 		extProcMaxConcurrentStreams: opts.ExtProcMaxConcurrency,
+		routes:                      routestore.New(),
 	}
 	return s
 }
@@ -162,8 +164,8 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("failed to unmarshal body: %s", err.Error()), http.StatusBadRequest)
 		return
 	}
-	if route.State == v1alpha1.SandboxStateDead {
-		s.DeleteRoute(route.ID)
+	if proxyutils.ShouldDeleteRoute(route.State) {
+		s.DeleteRoute(route.ID, route.ResourceVersion)
 		log.V(utils.DebugLogLevel + 1).Info("route deleted")
 	} else {
 		s.SetRoute(ctx, route)

--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -203,7 +203,7 @@ func TestServer_handleRefresh(t *testing.T) {
 					State:           v1alpha1.SandboxStateRunning,
 					ResourceVersion: "1",
 				}
-				s.routes.Store(route.ID, route)
+				s.routes.Set(route.ID, route)
 			}
 
 			// Create request
@@ -218,7 +218,7 @@ func TestServer_handleRefresh(t *testing.T) {
 
 			// Verify route deletion
 			if tt.expectDeleted {
-				_, loaded := s.routes.Load("sandbox-1")
+				_, loaded := s.LoadRoute("sandbox-1")
 				assert.False(t, loaded, "route should be deleted")
 			}
 
@@ -230,10 +230,10 @@ func TestServer_handleRefresh(t *testing.T) {
 				} else if tt.name == "available state should set route" {
 					routeID = "sandbox-3"
 				}
-				rawRoute, loaded := s.routes.Load(routeID)
+				route, loaded := s.LoadRoute(routeID)
 				assert.True(t, loaded, "route should be set")
 				if loaded {
-					assert.Equal(t, tt.expectTrafficAuth, rawRoute.(Route).RequireTrafficAuth)
+					assert.Equal(t, tt.expectTrafficAuth, route.RequireTrafficAuth)
 				}
 			}
 		})

--- a/pkg/sandbox-gateway/controller/gateway_controller.go
+++ b/pkg/sandbox-gateway/controller/gateway_controller.go
@@ -48,8 +48,10 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	var sandbox agentsv1alpha1.Sandbox
 	if err := r.Get(ctx, req.NamespacedName, &sandbox); err != nil {
 		if errors.IsNotFound(err) {
+			// No object to read a resourceVersion from; the registry falls back to
+			// the resourceVersion already recorded for this route.
 			logger.Info("sandbox deleted, removing from registry", "key", key)
-			registry.GetRegistry().Delete(key)
+			registry.GetRegistry().Delete(key, "")
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -57,7 +59,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	if sandbox.DeletionTimestamp != nil {
 		logger.Info("sandbox being deleted, removing from registry", "key", key)
-		registry.GetRegistry().Delete(key)
+		registry.GetRegistry().Delete(key, sandbox.GetResourceVersion())
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/sandbox-gateway/controller/gateway_controller_test.go
+++ b/pkg/sandbox-gateway/controller/gateway_controller_test.go
@@ -281,7 +281,7 @@ func TestSandboxReconciler_Reconcile_SandboxWithPodIP(t *testing.T) {
 	}
 
 	// Cleanup
-	registry.GetRegistry().Delete("default--running-sandbox")
+	registry.GetRegistry().Delete("default--running-sandbox", "")
 }
 
 func TestSandboxReconciler_Reconcile_UpdateExistingRegistryEntry(t *testing.T) {
@@ -332,7 +332,7 @@ func TestSandboxReconciler_Reconcile_UpdateExistingRegistryEntry(t *testing.T) {
 	}
 
 	// Cleanup
-	registry.GetRegistry().Delete("default--update-sandbox")
+	registry.GetRegistry().Delete("default--update-sandbox", "")
 }
 
 func TestSandboxReconciler_Reconcile_DifferentNamespaces(t *testing.T) {
@@ -408,7 +408,7 @@ func TestSandboxReconciler_Reconcile_DifferentNamespaces(t *testing.T) {
 			}
 
 			// Cleanup
-			registry.GetRegistry().Delete(expectedKey)
+			registry.GetRegistry().Delete(expectedKey, "")
 		})
 	}
 }
@@ -495,7 +495,7 @@ func TestSandboxReconciler_Reconcile_ConcurrentUpdates(t *testing.T) {
 			t.Errorf("Expected IP %s, got %s", expectedIP, route.IP)
 		}
 		// Cleanup
-		registry.GetRegistry().Delete(key)
+		registry.GetRegistry().Delete(key, "")
 	}
 }
 
@@ -608,7 +608,7 @@ func TestSandboxReconciler_Reconcile_SandboxWithIPv6(t *testing.T) {
 	}
 
 	// Cleanup
-	registry.GetRegistry().Delete("default--ipv6-sandbox")
+	registry.GetRegistry().Delete("default--ipv6-sandbox", "")
 }
 
 func TestSandboxReconciler_Reconcile_MultipleReconciles(t *testing.T) {
@@ -662,7 +662,7 @@ func TestSandboxReconciler_Reconcile_MultipleReconciles(t *testing.T) {
 	}
 
 	// Cleanup
-	registry.GetRegistry().Delete("default--multi-reconcile-sandbox")
+	registry.GetRegistry().Delete("default--multi-reconcile-sandbox", "")
 }
 
 func TestSandboxReconciler_Reconcile_SandboxNameWithSpecialCharacters(t *testing.T) {
@@ -738,7 +738,7 @@ func TestSandboxReconciler_Reconcile_SandboxNameWithSpecialCharacters(t *testing
 			}
 
 			// Cleanup
-			registry.GetRegistry().Delete(expectedKey)
+			registry.GetRegistry().Delete(expectedKey, "")
 		})
 	}
 }
@@ -874,5 +874,62 @@ func TestSandboxReconciler_Reconcile_UnexpectedGetError(t *testing.T) {
 	}
 	if result.Requeue {
 		t.Error("Expected no requeue on error")
+	}
+}
+
+// TestSandboxReconciler_Reconcile_DeleteIsVersioned verifies the controller's
+// delete leaves a versioned tombstone, so a stale write from the other writer
+// (a lagging-cache /refresh push) cannot resurrect the route. This is the
+// dual-writer resurrection guard at the controller boundary.
+func TestSandboxReconciler_Reconcile_DeleteIsVersioned(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	registry.GetRegistry().Clear()
+	defer registry.GetRegistry().Delete("default--race-sandbox", "")
+
+	// The route is currently live at resourceVersion 100.
+	registry.GetRegistry().Update("default--race-sandbox", proxy.Route{
+		ID:              "default--race-sandbox",
+		IP:              "10.0.0.1",
+		State:           agentsv1alpha1.SandboxStateRunning,
+		ResourceVersion: "100",
+	})
+
+	// The Sandbox is being deleted; the controller observes the deletion-timestamped
+	// object and removes the route (with the object's newer resourceVersion).
+	now := metav1.Now()
+	sandbox := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "race-sandbox",
+			Namespace:         "default",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"test-finalizer"},
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sandbox).Build()
+	reconciler := &SandboxReconciler{Client: client, Scheme: scheme}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "race-sandbox", Namespace: "default"}}
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := registry.GetRegistry().Get("default--race-sandbox"); ok {
+		t.Fatal("expected route deleted after controller observed deletion")
+	}
+
+	// A stale running push at the old resourceVersion must not resurrect the route.
+	resurrected := registry.GetRegistry().Update("default--race-sandbox", proxy.Route{
+		ID:              "default--race-sandbox",
+		IP:              "10.0.0.1",
+		State:           agentsv1alpha1.SandboxStateRunning,
+		ResourceVersion: "100",
+	})
+	if resurrected {
+		t.Fatal("stale write should have been rejected by the tombstone")
+	}
+	if _, ok := registry.GetRegistry().Get("default--race-sandbox"); ok {
+		t.Fatal("route must stay deleted after a stale write")
 	}
 }

--- a/pkg/sandbox-gateway/registry/registry.go
+++ b/pkg/sandbox-gateway/registry/registry.go
@@ -17,17 +17,20 @@ limitations under the License.
 package registry
 
 import (
-	"sync"
-
 	"github.com/openkruise/agents/pkg/proxy"
-	"github.com/openkruise/agents/pkg/utils/expectations"
+	"github.com/openkruise/agents/pkg/proxy/routestore"
 )
 
+// Registry is the sandbox-gateway's route table. It is written by two unordered
+// sources — peer /refresh pushes and the Sandbox CR-watch controller — so it
+// delegates to routestore, which keeps the resourceVersion ordering invariant
+// across both writes and deletes and therefore prevents either writer from
+// resurrecting a route a newer event already removed.
 type Registry struct {
-	entries sync.Map
+	store *routestore.Store
 }
 
-var registryInstance Registry
+var registryInstance = Registry{store: routestore.New()}
 
 func GetRegistry() *Registry {
 	return &registryInstance
@@ -35,53 +38,33 @@ func GetRegistry() *Registry {
 
 // Get returns the full route.
 func (r *Registry) Get(id string) (proxy.Route, bool) {
-	raw, ok := r.entries.Load(id)
-	if !ok {
-		return proxy.Route{}, false
-	}
-	return raw.(proxy.Route), true
+	return r.store.Get(id)
 }
 
-// Update sets the route with resourceVersion check using CAS pattern.
-// Returns true if the update was applied, false if skipped due to older resourceVersion.
+// Update sets the route with a resourceVersion check.
+// Returns true if the update was applied, false if skipped due to an older resourceVersion.
 func (r *Registry) Update(id string, route proxy.Route) bool {
-	for {
-		old, loaded := r.entries.LoadOrStore(id, route)
-		if !loaded {
-			// First write, success directly
-			return true
-		}
-
-		oldRoute := old.(proxy.Route)
-		if !expectations.IsResourceVersionNewer(oldRoute.ResourceVersion, route.ResourceVersion) {
-			// New version is not newer than old version, skip write
-			return false
-		}
-
-		// Attempt CAS update
-		if r.entries.CompareAndSwap(id, old, route) {
-			// Successfully replaced
-			return true
-		}
-		// CAS failed, modified by another goroutine, retry
-	}
+	applied, _ := r.store.Set(id, route)
+	return applied
 }
 
-// Delete removes the entry for the given sandbox ID.
-func (r *Registry) Delete(id string) {
-	r.entries.Delete(id)
+// Delete removes the entry for the given sandbox ID, leaving a versioned
+// tombstone so a stale write cannot resurrect it. resourceVersion is the version
+// of the deleting event; an empty value falls back to the recorded one.
+func (r *Registry) Delete(id string, resourceVersion string) {
+	r.store.Delete(id, resourceVersion)
 }
 
 // List returns all routes in the registry.
 func (r *Registry) List() map[string]proxy.Route {
-	result := make(map[string]proxy.Route)
-	r.entries.Range(func(key, value any) bool {
-		result[key.(string)] = value.(proxy.Route)
-		return true
-	})
-	return result
+	return r.store.List()
+}
+
+// GC reclaims expired tombstones.
+func (r *Registry) GC() {
+	r.store.GC()
 }
 
 func (r *Registry) Clear() {
-	r.entries = sync.Map{}
+	r.store.Clear()
 }

--- a/pkg/sandbox-gateway/registry/registry_test.go
+++ b/pkg/sandbox-gateway/registry/registry_test.go
@@ -62,13 +62,21 @@ func TestGetUpdateDelete(t *testing.T) {
 	}
 
 	// Delete
-	r.Delete("default--app1")
+	r.Delete("default--app1", "1002")
 	if _, ok := r.Get("default--app1"); ok {
 		t.Fatal("expected not found after delete")
 	}
 
+	// A stale write after delete must not resurrect the route.
+	if r.Update("default--app1", proxy.Route{IP: "10.0.0.9", ResourceVersion: "1001"}) {
+		t.Fatal("expected stale write after delete to be rejected")
+	}
+	if _, ok := r.Get("default--app1"); ok {
+		t.Fatal("expected route to stay deleted after stale write")
+	}
+
 	// Delete non-existent key should not panic
-	r.Delete("nonexistent--key")
+	r.Delete("nonexistent--key", "")
 }
 
 func TestUpdate(t *testing.T) {
@@ -136,7 +144,7 @@ func TestConcurrentAccess(t *testing.T) {
 			key := "ns--app"
 			r.Update(key, proxy.Route{IP: "10.0.0.1", ResourceVersion: strconv.Itoa(i)})
 			r.Get(key)
-			r.Delete(key)
+			r.Delete(key, strconv.Itoa(i))
 		}(i)
 	}
 	wg.Wait()

--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -29,12 +29,12 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/peers"
 	"github.com/openkruise/agents/pkg/proxy"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/utils"
+	"github.com/openkruise/agents/pkg/utils/proxyutils"
 )
 
 // Environment variable names for peer discovery
@@ -216,17 +216,19 @@ func (s *Server) handleRefresh(w http.ResponseWriter, r *http.Request) {
 
 	log.V(utils.DebugLogLevel).Info("Received route refresh", "route", route)
 
-	// Handle based on state
-	if route.State == v1alpha1.SandboxStateRunning {
-		// Update the route
+	// Decide keep-vs-delete with the same rule the manager uses, so an identical
+	// push produces an identical table on both data planes. A non-running but
+	// non-dead state (e.g. paused) is stored with its state; the filter gates on
+	// running, so storing it is harmless and keeps the two planes consistent.
+	if proxyutils.ShouldDeleteRoute(route.State) {
+		registry.GetRegistry().Delete(route.ID, route.ResourceVersion)
+		log.Info("Route deleted via refresh", "id", route.ID)
+	} else {
 		if registry.GetRegistry().Update(route.ID, route) {
-			log.Info("Route updated via refresh", "id", route.ID, "ip", route.IP)
+			log.Info("Route updated via refresh", "id", route.ID, "ip", route.IP, "state", route.State)
 		} else {
 			log.V(utils.DebugLogLevel).Info("Route update skipped due to older resourceVersion", "id", route.ID)
 		}
-	} else {
-		// Delete the route if the sandbox is dead
-		registry.GetRegistry().Delete(route.ID)
 	}
 
 	w.WriteHeader(http.StatusNoContent)

--- a/pkg/sandbox-gateway/server/server_test.go
+++ b/pkg/sandbox-gateway/server/server_test.go
@@ -298,37 +298,83 @@ func TestHandleRefresh_NonRunningState(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestHandleRefresh_AvailableState(t *testing.T) {
-	// Clear registry and add a route first
+// TestHandleRefresh_NonDeadStatesKept verifies that the gateway keeps a route for
+// every non-dead state — including paused and available — rather than dropping it.
+// This is the consistency fix: only "dead" deletes, matching the manager handler,
+// so an identical push produces an identical table on both data planes. The filter
+// still refuses to route to a non-running entry, so keeping it is harmless.
+func TestHandleRefresh_NonDeadStatesKept(t *testing.T) {
+	tests := []struct {
+		name  string
+		state string
+	}{
+		{name: "paused is kept", state: v1alpha1.SandboxStatePaused},
+		{name: "available is kept", state: v1alpha1.SandboxStateAvailable},
+		{name: "creating is kept", state: v1alpha1.SandboxStateCreating},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry.GetRegistry().Clear()
+			registry.GetRegistry().Update("test-sandbox-3", proxy.Route{
+				ID:              "test-sandbox-3",
+				IP:              "10.0.0.3",
+				State:           v1alpha1.SandboxStateRunning,
+				ResourceVersion: "1",
+			})
+
+			s := &Server{}
+			route := proxy.Route{
+				ID:              "test-sandbox-3",
+				IP:              "10.0.0.3",
+				State:           tt.state,
+				ResourceVersion: "2",
+			}
+			body, _ := json.Marshal(route)
+			req := httptest.NewRequest(http.MethodPost, proxy.RefreshAPI, bytes.NewReader(body))
+			rr := httptest.NewRecorder()
+
+			s.handleRefresh(rr, req)
+
+			assert.Equal(t, http.StatusNoContent, rr.Code)
+
+			// Route is kept, with its new state recorded.
+			got, ok := registry.GetRegistry().Get("test-sandbox-3")
+			assert.True(t, ok)
+			assert.Equal(t, tt.state, got.State)
+		})
+	}
+}
+
+// TestHandleRefresh_StaleWriteCannotResurrect verifies that once a dead push has
+// removed a route, a stale (older-resourceVersion) running push cannot bring it back.
+func TestHandleRefresh_StaleWriteCannotResurrect(t *testing.T) {
 	registry.GetRegistry().Clear()
-	registry.GetRegistry().Update("test-sandbox-3", proxy.Route{
-		ID:              "test-sandbox-3",
-		IP:              "10.0.0.3",
+	registry.GetRegistry().Update("test-sandbox-5", proxy.Route{
+		ID:              "test-sandbox-5",
+		IP:              "10.0.0.5",
 		State:           v1alpha1.SandboxStateRunning,
-		ResourceVersion: "1",
+		ResourceVersion: "10",
 	})
 
 	s := &Server{}
-
-	// Available state is treated as non-running and will delete the route
-	route := proxy.Route{
-		ID:              "test-sandbox-3",
-		IP:              "10.0.0.3",
-		State:           v1alpha1.SandboxStateAvailable,
-		ResourceVersion: "2",
+	post := func(route proxy.Route) {
+		body, _ := json.Marshal(route)
+		req := httptest.NewRequest(http.MethodPost, proxy.RefreshAPI, bytes.NewReader(body))
+		rr := httptest.NewRecorder()
+		s.handleRefresh(rr, req)
+		assert.Equal(t, http.StatusNoContent, rr.Code)
 	}
-	body, _ := json.Marshal(route)
 
-	req := httptest.NewRequest(http.MethodPost, proxy.RefreshAPI, bytes.NewReader(body))
-	rr := httptest.NewRecorder()
+	// Dead push removes it.
+	post(proxy.Route{ID: "test-sandbox-5", IP: "10.0.0.5", State: v1alpha1.SandboxStateDead, ResourceVersion: "11"})
+	if _, ok := registry.GetRegistry().Get("test-sandbox-5"); ok {
+		t.Fatal("expected route deleted after dead push")
+	}
 
-	s.handleRefresh(rr, req)
-
-	assert.Equal(t, http.StatusNoContent, rr.Code)
-
-	// Verify route was deleted (only Running state keeps routes)
-	_, ok := registry.GetRegistry().Get("test-sandbox-3")
-	assert.False(t, ok)
+	// A stale running push (older resourceVersion) must not resurrect it.
+	post(proxy.Route{ID: "test-sandbox-5", IP: "10.0.0.5", State: v1alpha1.SandboxStateRunning, ResourceVersion: "10"})
+	_, ok := registry.GetRegistry().Get("test-sandbox-5")
+	assert.False(t, ok, "stale running push must not resurrect a deleted route")
 }
 
 func TestHandleRefresh_UpdateExistingRoute(t *testing.T) {

--- a/pkg/sandbox-manager/api.go
+++ b/pkg/sandbox-manager/api.go
@@ -351,7 +351,7 @@ func (m *SandboxManager) deleteRouteAndSync(ctx context.Context, sbx infra.Sandb
 	log := klog.FromContext(ctx)
 	route := sbx.GetRoute()
 	route.State = v1alpha1.SandboxStateDead
-	m.proxy.DeleteRoute(route.ID)
+	m.proxy.DeleteRoute(route.ID, route.ResourceVersion)
 	if err := m.proxy.SyncRouteWithPeers(route); err != nil {
 		log.Error(err, "failed to sync route with peers")
 	}

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -488,9 +488,11 @@ func (i *Infra) reconcileSandbox(ctx context.Context, sbx *v1alpha1.Sandbox, not
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
 
 	if notFound {
-		// Sandbox not found, clean up route
+		// Sandbox not found, clean up route. The resourceVersion (empty for a
+		// not-found object) lets DeleteRoute fall back to the recorded one so the
+		// delete is versioned and a stale write cannot resurrect the route.
 		sandboxID := utils.GetSandboxID(sbx)
-		i.Proxy.DeleteRoute(sandboxID)
+		i.Proxy.DeleteRoute(sandboxID, sbx.GetResourceVersion())
 		log.Info("sandbox route deleted during reconciliation", "sandboxID", sandboxID)
 		return ctrl.Result{}, nil
 	}
@@ -563,7 +565,7 @@ func (i *Infra) reconcileRoutes(ctx context.Context) {
 	deletedCount := 0
 	for _, route := range routes {
 		if _, exists := existingSandboxIDs[route.ID]; !exists {
-			i.Proxy.DeleteRoute(route.ID)
+			i.Proxy.DeleteRoute(route.ID, route.ResourceVersion)
 			deletedCount++
 			expectations.ResourceVersionExpectationDelete(&metav1.ObjectMeta{
 				UID: route.UID,
@@ -588,4 +590,8 @@ func (i *Infra) reconcileRoutes(ctx context.Context) {
 	if deletedCount > 0 || addedCount > 0 {
 		log.Info("route reconciliation completed", "orphanedRoutesDeleted", deletedCount, "missingRoutesAdded", addedCount, "totalRoutes", len(routes)+addedCount-deletedCount)
 	}
+
+	// Reclaim expired delete tombstones now that the table has been reconciled
+	// against the cache; this is the route store's only GC trigger on this plane.
+	i.Proxy.GC()
 }

--- a/pkg/utils/proxyutils/route.go
+++ b/pkg/utils/proxyutils/route.go
@@ -42,6 +42,17 @@ func GetRouteFromSandbox(s *agentsv1alpha1.Sandbox) Route {
 	}
 }
 
+// ShouldDeleteRoute reports whether a route in the given sandbox state should be
+// removed from a route table rather than stored.
+//
+// Only a terminal (dead) sandbox loses its route. Every other state — including
+// creating, paused and running — is stored with its state, and consumers (e.g.
+// the gateway filter) decide routability from Route.State. Centralising this rule
+// keeps the manager and gateway /refresh handlers from diverging on the same event.
+func ShouldDeleteRoute(state string) bool {
+	return state == agentsv1alpha1.SandboxStateDead
+}
+
 // Route represents an internal sandbox routing rule.
 // Moved from pkg/proxy to break the pkg/utils → pkg/proxy layer violation.
 type Route struct {

--- a/pkg/utils/proxyutils/route_test.go
+++ b/pkg/utils/proxyutils/route_test.go
@@ -74,3 +74,23 @@ func TestRouteString(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldDeleteRoute(t *testing.T) {
+	tests := []struct {
+		name  string
+		state string
+		want  bool
+	}{
+		{name: "dead is deleted", state: v1alpha1.SandboxStateDead, want: true},
+		{name: "running is kept", state: v1alpha1.SandboxStateRunning, want: false},
+		{name: "paused is kept", state: v1alpha1.SandboxStatePaused, want: false},
+		{name: "creating is kept", state: v1alpha1.SandboxStateCreating, want: false},
+		{name: "available is kept", state: v1alpha1.SandboxStateAvailable, want: false},
+		{name: "empty state is kept", state: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ShouldDeleteRoute(tt.state))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #492

Re-opening this fix. My previous PR (#493) was closed automatically when my fork was
deleted by accident — this is the same change, rebased onto current `master` with
conflicts resolved and tests passing.

## Scope note

The original issue described three problems. Re-checking against current `master`, the
third (the manager's `refreshRoute` looking routes up by name instead of the full sandbox
ID) has **already been fixed upstream** — `refreshRoute` now uses `GetSandboxID`. So this PR
addresses only the **two consistency problems that still persist**:

### 1. The two `/refresh` handlers interpret the same message differently
For an identical `{state: "paused"}` push, the manager keeps the entry
(`pkg/proxy/server.go`, delete only on `dead`) while the gateway drops it
(`pkg/sandbox-gateway/server/server.go`, update only on `running`). The two data planes end
up holding different state for the same sandbox.

### 2. Delete ignores resourceVersion
`Registry.Update` refuses to let an older event overwrite a newer one, but `Registry.Delete`
(and the manager's `DeleteRoute`) clear the entry unconditionally. So after a delete, the
next write — however stale — lands as a fresh first write and wins. With two writers racing
on the gateway (the `/refresh` push and the CR-watch controller), a delete followed by a
lagging-cache `Update` resurrects a removed route, and the Envoy filter then routes live
traffic to a freed/recycled pod IP until the informer catches up.

## What changed

- New `pkg/proxy/routestore`: a resourceVersion-aware route table that keeps ordering across
  deletes via short-lived tombstones (lazy expiry + inline sweep, no background goroutine);
  used by both the gateway registry and the proxy server.
- A tombstone can only be overwritten by a strictly newer resourceVersion, so a write equal
  to the deleted version cannot resurrect the route.
- One shared keep-vs-delete predicate (`proxyutils.ShouldDeleteRoute`, delete iff `dead`)
  used by both `/refresh` handlers, so an identical push produces an identical table on both
  planes.
- The deleting event's resourceVersion is threaded through every delete call site.
- A design note in `docs/proposals/` documents the route-table consistency model.

## Testing

Table-driven tests for `routestore` (first write, newer/older/equal-version, delete-then-
stale-write, tombstone expiry, concurrent writers), plus handler/registry/controller tests.
`go build ./pkg/... ./cmd/...` and focused `go test` on the changed packages pass.
