### PR TITLE
fix(storages): make CSI NodePublishVolume idempotent via a deterministic VolumeId

### DIFF
--- a/pkg/agent-runtime/storages/utils.go
+++ b/pkg/agent-runtime/storages/utils.go
@@ -17,21 +17,24 @@ limitations under the License.
 package storages
 
 import (
-	"math/rand"
-	"time"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
-const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
-
-func generateRandomString(length int) string {
-	rand.Seed(time.Now().UnixNano())
-	b := make([]byte, length)
-	for i := range b {
-		b[i] = charset[rand.Intn(len(charset))] // #nosec G404 -- non-security random for temp names
-	}
-	return string(b)
+// deterministicVolumeID returns a stable CSI volume id for a (PV, target path)
+// pair. The CSI spec requires NodePublishVolume to be idempotent keyed on
+// (volume_id, target_path): a previously random id meant every resume re-mount
+// looked like a brand-new publish to the driver, stacking mounts. A stable id
+// lets a spec-compliant driver short-circuit an already-published volume.
+// The target path is hashed (it contains '/'), keeping the id bounded while
+// remaining unique per target so the same PV mounted at different paths does
+// not collide.
+func deterministicVolumeID(pvName, targetPath string) string {
+	sum := sha256.Sum256([]byte(targetPath))
+	return fmt.Sprintf("%s-%s", pvName, hex.EncodeToString(sum[:])[:12])
 }
 
 func IsPureReadOnly(accessModes []corev1.PersistentVolumeAccessMode) bool {

--- a/pkg/agent-runtime/storages/utils_test.go
+++ b/pkg/agent-runtime/storages/utils_test.go
@@ -79,40 +79,26 @@ func TestIsPureReadOnly(t *testing.T) {
 	}
 }
 
-func TestGenerateRandomString(t *testing.T) {
-	tests := []struct {
-		name     string
-		length   int
-		expected int
-	}{
-		{
-			name:     "zero length",
-			length:   0,
-			expected: 0,
-		},
-		{
-			name:     "positive length",
-			length:   5,
-			expected: 5,
-		},
-		{
-			name:     "large length",
-			length:   10,
-			expected: 10,
-		},
-	}
+func TestDeterministicVolumeID(t *testing.T) {
+	// Same (pv, target) must always yield the same id so a resume re-mount is
+	// idempotent per the CSI spec.
+	id1 := deterministicVolumeID("pv-a", "/mnt/data")
+	id2 := deterministicVolumeID("pv-a", "/mnt/data")
+	assert.Equal(t, id1, id2, "same pv+target must produce a stable volume id")
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := generateRandomString(tt.length)
-			assert.Len(t, result, tt.expected)
+	// The id must contain the PV name (existing callers/tests rely on this).
+	assert.Contains(t, id1, "pv-a")
 
-			if tt.length > 0 {
-				// Verify that the string contains only characters from the charset
-				for _, char := range result {
-					assert.Contains(t, charset, string(char))
-				}
-			}
-		})
-	}
+	// Same PV mounted at a different target path must not collide.
+	assert.NotEqual(t, id1, deterministicVolumeID("pv-a", "/mnt/other"),
+		"different target paths must produce different volume ids")
+
+	// Different PVs at the same target path must not collide.
+	assert.NotEqual(t, id1, deterministicVolumeID("pv-b", "/mnt/data"),
+		"different PVs must produce different volume ids")
+
+	// Empty target path is still stable and well-formed.
+	assert.Equal(t,
+		deterministicVolumeID("pv-a", ""),
+		deterministicVolumeID("pv-a", ""))
 }

--- a/pkg/agent-runtime/storages/volume_mount_provider.go
+++ b/pkg/agent-runtime/storages/volume_mount_provider.go
@@ -55,7 +55,7 @@ func (p *MountProvider) GenerateCSINodePublishVolumeRequest(
 		volumeCapability.AccessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY
 	}
 	csiReq := &csi.NodePublishVolumeRequest{
-		VolumeId:         fmt.Sprintf("%v-%s", persistentVolumeObj.Name, generateRandomString(6)),
+		VolumeId:         deterministicVolumeID(persistentVolumeObj.Name, containerMountTarget),
 		TargetPath:       containerMountTarget, // mount target path in container
 		VolumeCapability: volumeCapability,
 		Readonly:         isReadOnly,

--- a/pkg/agent-runtime/storages/volume_mount_provider_test.go
+++ b/pkg/agent-runtime/storages/volume_mount_provider_test.go
@@ -289,11 +289,23 @@ func TestMountProvider_GenerateNodePublishVolumeRequest_Idempotency(t *testing.T
 	secondResult, err := m.GenerateCSINodePublishVolumeRequest(ctx, targetPath, pv, false, secret)
 	require.NoError(t, err)
 
+	// The VolumeId must be stable across calls: NodePublishVolume is idempotent
+	// on (volume_id, target_path), so a resume re-mount of an already-published
+	// volume must not look like a brand-new publish to the driver.
+	assert.Equal(t, firstResult.VolumeId, secondResult.VolumeId,
+		"VolumeId must be deterministic for the same pv+target path")
 	assert.Equal(t, firstResult.TargetPath, secondResult.TargetPath)
 	assert.Equal(t, firstResult.Readonly, secondResult.Readonly)
 	assert.Equal(t, firstResult.VolumeContext, secondResult.VolumeContext)
 	assert.Equal(t, firstResult.Secrets, secondResult.Secrets)
 	assert.Equal(t, firstResult.VolumeCapability, secondResult.VolumeCapability)
+
+	// A different target path for the same PV must yield a different VolumeId so
+	// multi-mount configurations do not collide.
+	otherResult, err := m.GenerateCSINodePublishVolumeRequest(ctx, targetPath+"-2", pv, false, secret)
+	require.NoError(t, err)
+	assert.NotEqual(t, firstResult.VolumeId, otherResult.VolumeId,
+		"different target paths must produce different VolumeIds")
 }
 
 func BenchmarkMountProvider_GenerateNodePublishVolumeRequest(b *testing.B) {


### PR DESCRIPTION
Fixes #408

Re-opening this fix. My previous PR (#409) was closed automatically when my fork was
deleted by accident — this is the same change, rebased onto current `master` with
conflicts resolved and tests passing.

## Problem

`NodePublishVolume` derived the CSI `VolumeId` with a random suffix
(`fmt.Sprintf("%v-%s", pv.Name, generateRandomString(6))`). On resume, the re-mount
therefore used a different `VolumeId` than the original mount, so the operation was not
idempotent and could leave stale mounts behind.

## Fix

Derive a **deterministic** `VolumeId` from the PV name and the target path (SHA-256,
truncated), so re-mounting the same volume at the same path yields the same `VolumeId`
and `NodePublishVolume` becomes idempotent. The base64-encoded request contract is
unchanged; only the id derivation changed.

## Testing

Strengthened `TestDeterministicVolumeID` and idempotency assertions;
`go test ./pkg/agent-runtime/storages/...` passes; full `go build ./pkg/... ./cmd/...` passes.
Change stays entirely within `pkg/agent-runtime/storages`.
