### PR TITLE
feat(observability): add memberlist peer-state metrics and key-cache hit/miss counters

### DIFF
--- a/pkg/peers/memberlist.go
+++ b/pkg/peers/memberlist.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -62,6 +63,12 @@ type MemberlistPeers struct {
 
 	started atomic.Bool
 	stopCh  chan struct{}
+
+	// startTime records when Start() began binding memberlist; used together
+	// with firstJoinObserved to publish sandbox_peer_join_duration_seconds
+	// exactly once per process.
+	startTime         time.Time
+	firstJoinObserved sync.Once
 }
 
 // NewMemberlistPeers creates a new MemberlistPeers instance
@@ -93,6 +100,7 @@ func (m *MemberlistPeers) Start(ctx context.Context, bindPort int) error {
 	if m.started.Load() {
 		return fmt.Errorf("memberlist already started")
 	}
+	m.startTime = time.Now()
 
 	// Get pod IP for memberlist binding
 	localIP := m.localIP
@@ -313,6 +321,13 @@ func (e *eventDelegate) NotifyJoin(node *memberlist.Node) {
 		return
 	}
 	klog.FromContext(e.logCtx).Info("peer joined", "name", node.Name, "ip", node.Addr.String())
+	recordPeerAlive(node.Name)
+	// Observe the time-to-first-peer histogram exactly once per process.
+	if !e.parent.startTime.IsZero() {
+		e.parent.firstJoinObserved.Do(func() {
+			observePeerJoinDuration(time.Since(e.parent.startTime).Seconds())
+		})
+	}
 }
 
 func (e *eventDelegate) NotifyLeave(node *memberlist.Node) {
@@ -320,6 +335,7 @@ func (e *eventDelegate) NotifyLeave(node *memberlist.Node) {
 		return
 	}
 	klog.FromContext(e.logCtx).Info("peer left", "name", node.Name, "ip", node.Addr.String())
+	recordPeerDead(node.Name)
 }
 
 func (e *eventDelegate) NotifyUpdate(*memberlist.Node) {

--- a/pkg/peers/metrics.go
+++ b/pkg/peers/metrics.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package peers
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	peerStateAlive = "alive"
+	peerStateDead  = "dead"
+)
+
+var (
+	// sandbox_peer_state is a per-(node,state) gauge that reports 1 for the
+	// peer's current state and 0 for other states. Today only "alive" and
+	// "dead" are tracked via the memberlist event delegate; "suspect" would
+	// require periodic polling of memberlist.Members() and is left for a
+	// follow-up.
+	peerStateGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sandbox_peer_state",
+			Help: "Current memberlist peer state (1 for active state, 0 otherwise). state ∈ {alive, dead}.",
+		},
+		[]string{"node", "state"},
+	)
+
+	// sandbox_peer_join_duration_seconds is observed once per local node, the
+	// first time another peer joins the cluster after Start(). It captures the
+	// wall-clock time from local memberlist startup to first observed peer.
+	peerJoinDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "sandbox_peer_join_duration_seconds",
+			Help:    "Duration from local memberlist Start() to first observed peer join in seconds.",
+			Buckets: prometheus.ExponentialBuckets(0.1, 2, 12), // 100ms -> ~6.8m
+		},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(peerStateGauge, peerJoinDuration)
+}
+
+// recordPeerAlive flips the gauge to mark `node` alive and clears its dead bit.
+func recordPeerAlive(node string) {
+	peerStateGauge.WithLabelValues(node, peerStateAlive).Set(1)
+	peerStateGauge.WithLabelValues(node, peerStateDead).Set(0)
+}
+
+// recordPeerDead flips the gauge to mark `node` dead and clears its alive bit.
+func recordPeerDead(node string) {
+	peerStateGauge.WithLabelValues(node, peerStateAlive).Set(0)
+	peerStateGauge.WithLabelValues(node, peerStateDead).Set(1)
+}
+
+// observePeerJoinDuration records the time-to-first-peer for the local node.
+// Callers should ensure this is invoked at most once per process via sync.Once.
+func observePeerJoinDuration(seconds float64) {
+	peerJoinDuration.Observe(seconds)
+}

--- a/pkg/peers/metrics_test.go
+++ b/pkg/peers/metrics_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package peers
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestRecordPeerAlive_AndDead(t *testing.T) {
+	const node = "test-node-1"
+
+	// Reset both gauges for this node so we get a clean view.
+	peerStateGauge.DeleteLabelValues(node, peerStateAlive)
+	peerStateGauge.DeleteLabelValues(node, peerStateDead)
+
+	recordPeerAlive(node)
+	if v := testutil.ToFloat64(peerStateGauge.WithLabelValues(node, peerStateAlive)); v != 1 {
+		t.Errorf("after recordPeerAlive: alive gauge = %v, want 1", v)
+	}
+	if v := testutil.ToFloat64(peerStateGauge.WithLabelValues(node, peerStateDead)); v != 0 {
+		t.Errorf("after recordPeerAlive: dead gauge = %v, want 0", v)
+	}
+
+	recordPeerDead(node)
+	if v := testutil.ToFloat64(peerStateGauge.WithLabelValues(node, peerStateAlive)); v != 0 {
+		t.Errorf("after recordPeerDead: alive gauge = %v, want 0", v)
+	}
+	if v := testutil.ToFloat64(peerStateGauge.WithLabelValues(node, peerStateDead)); v != 1 {
+		t.Errorf("after recordPeerDead: dead gauge = %v, want 1", v)
+	}
+}
+
+func TestRecordPeerAlive_DoesNotAffectOtherNodes(t *testing.T) {
+	const a = "node-a-isolation"
+	const b = "node-b-isolation"
+
+	peerStateGauge.DeleteLabelValues(a, peerStateAlive)
+	peerStateGauge.DeleteLabelValues(b, peerStateAlive)
+
+	recordPeerAlive(a)
+	if v := testutil.ToFloat64(peerStateGauge.WithLabelValues(b, peerStateAlive)); v != 0 {
+		t.Errorf("recordPeerAlive(%q) should not touch node %q's alive gauge, got %v", a, b, v)
+	}
+}
+
+func TestObservePeerJoinDuration(t *testing.T) {
+	dtoMetric := &dto.Metric{}
+	if err := peerJoinDuration.Write(dtoMetric); err != nil {
+		t.Fatalf("histogram Write failed before: %v", err)
+	}
+	before := dtoMetric.GetHistogram().GetSampleCount()
+
+	observePeerJoinDuration(0.42)
+
+	dtoMetric = &dto.Metric{}
+	if err := peerJoinDuration.Write(dtoMetric); err != nil {
+		t.Fatalf("histogram Write failed after: %v", err)
+	}
+	after := dtoMetric.GetHistogram().GetSampleCount()
+
+	if after != before+1 {
+		t.Errorf("histogram sample count = %d after one observation, want %d", after, before+1)
+	}
+}

--- a/pkg/servers/e2b/keys/metrics.go
+++ b/pkg/servers/e2b/keys/metrics.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keys
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Storage backend label values.
+const (
+	storageLabelMySQL  = "mysql"
+	storageLabelSecret = "secret"
+)
+
+// Key-type label values, matching the two distinct lookup paths exposed by
+// every KeyStorage implementation.
+const (
+	keyTypeByKey = "by_key"
+	keyTypeByID  = "by_id"
+)
+
+var (
+	// e2b_key_cache_hits_total counts API key lookups that were answered from
+	// the in-memory cache, without falling through to the storage backend.
+	cacheHits = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "e2b_key_cache_hits_total",
+			Help: "Total number of API key cache hits, partitioned by storage backend and key-type lookup path.",
+		},
+		[]string{"storage", "key_type"},
+	)
+
+	// e2b_key_cache_misses_total counts API key lookups that missed the
+	// in-memory cache. For mysql this also implies a DB round-trip; for the
+	// secret backend it implies the key wasn't present at all.
+	cacheMisses = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "e2b_key_cache_misses_total",
+			Help: "Total number of API key cache misses, partitioned by storage backend and key-type lookup path.",
+		},
+		[]string{"storage", "key_type"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(cacheHits, cacheMisses)
+}
+
+// recordCacheHit increments the cache-hit counter for the given backend and lookup path.
+func recordCacheHit(storage, keyType string) {
+	cacheHits.WithLabelValues(storage, keyType).Inc()
+}
+
+// recordCacheMiss increments the cache-miss counter for the given backend and lookup path.
+func recordCacheMiss(storage, keyType string) {
+	cacheMisses.WithLabelValues(storage, keyType).Inc()
+}

--- a/pkg/servers/e2b/keys/metrics_test.go
+++ b/pkg/servers/e2b/keys/metrics_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keys
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRecordCacheHit_IncrementsCounter(t *testing.T) {
+	cacheHits.DeleteLabelValues(storageLabelMySQL, keyTypeByKey)
+
+	recordCacheHit(storageLabelMySQL, keyTypeByKey)
+	recordCacheHit(storageLabelMySQL, keyTypeByKey)
+
+	got := testutil.ToFloat64(cacheHits.WithLabelValues(storageLabelMySQL, keyTypeByKey))
+	if got != 2 {
+		t.Errorf("cache hits counter = %v, want 2", got)
+	}
+}
+
+func TestRecordCacheMiss_IncrementsCounter(t *testing.T) {
+	cacheMisses.DeleteLabelValues(storageLabelSecret, keyTypeByID)
+
+	recordCacheMiss(storageLabelSecret, keyTypeByID)
+
+	got := testutil.ToFloat64(cacheMisses.WithLabelValues(storageLabelSecret, keyTypeByID))
+	if got != 1 {
+		t.Errorf("cache misses counter = %v, want 1", got)
+	}
+}
+
+func TestCacheCounters_LabelIsolation(t *testing.T) {
+	// Ensure incrementing one (storage,key_type) partition does not leak into another.
+	cacheHits.DeleteLabelValues(storageLabelMySQL, keyTypeByKey)
+	cacheHits.DeleteLabelValues(storageLabelMySQL, keyTypeByID)
+	cacheHits.DeleteLabelValues(storageLabelSecret, keyTypeByKey)
+
+	recordCacheHit(storageLabelMySQL, keyTypeByKey)
+
+	if got := testutil.ToFloat64(cacheHits.WithLabelValues(storageLabelMySQL, keyTypeByID)); got != 0 {
+		t.Errorf("by_id counter unexpectedly incremented: got %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(cacheHits.WithLabelValues(storageLabelSecret, keyTypeByKey)); got != 0 {
+		t.Errorf("secret backend counter unexpectedly incremented: got %v, want 0", got)
+	}
+}

--- a/pkg/servers/e2b/keys/mysql.go
+++ b/pkg/servers/e2b/keys/mysql.go
@@ -285,8 +285,10 @@ func (k *mysqlKeyStorage) Stop() {
 func (k *mysqlKeyStorage) LoadByKey(ctx context.Context, key string) (*models.CreatedTeamAPIKey, bool) {
 	hash := k.hashKey(key)
 	if apiKey := k.cacheGetByKey(hash); apiKey != nil {
+		recordCacheHit(storageLabelMySQL, keyTypeByKey)
 		return apiKey, true
 	}
+	recordCacheMiss(storageLabelMySQL, keyTypeByKey)
 	apiKey, err := k.loadCreatedKeyByHashFromDB(ctx, hash)
 	if err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -301,8 +303,10 @@ func (k *mysqlKeyStorage) LoadByKey(ctx context.Context, key string) (*models.Cr
 // LoadByID resolves an API key by uid (cache + DB).
 func (k *mysqlKeyStorage) LoadByID(ctx context.Context, id string) (*models.CreatedTeamAPIKey, bool) {
 	if apiKey := k.cacheGetByID(id); apiKey != nil {
+		recordCacheHit(storageLabelMySQL, keyTypeByID)
 		return apiKey, true
 	}
+	recordCacheMiss(storageLabelMySQL, keyTypeByID)
 	apiKey, err := k.loadCreatedKeyByUIDFromDB(ctx, id)
 	if err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {

--- a/pkg/servers/e2b/keys/secret.go
+++ b/pkg/servers/e2b/keys/secret.go
@@ -327,16 +327,20 @@ func (k *secretKeyStorage) Stop() {
 func (k *secretKeyStorage) LoadByKey(_ context.Context, key string) (*models.CreatedTeamAPIKey, bool) {
 	value, ok := k.idxByKey.Load(key)
 	if !ok {
+		recordCacheMiss(storageLabelSecret, keyTypeByKey)
 		return nil, false
 	}
+	recordCacheHit(storageLabelSecret, keyTypeByKey)
 	return cloneCreatedTeamAPIKey(value.(*models.CreatedTeamAPIKey)), true
 }
 
 func (k *secretKeyStorage) LoadByID(_ context.Context, id string) (*models.CreatedTeamAPIKey, bool) {
 	value, ok := k.idxByID.Load(id)
 	if !ok {
+		recordCacheMiss(storageLabelSecret, keyTypeByID)
 		return nil, false
 	}
+	recordCacheHit(storageLabelSecret, keyTypeByID)
 	return cloneCreatedTeamAPIKey(value.(*models.CreatedTeamAPIKey)), true
 }
 

--- a/pkg/utils/webhookutils/configuration/configuration.go
+++ b/pkg/utils/webhookutils/configuration/configuration.go
@@ -68,7 +68,7 @@ func Ensure(kubeClient clientset.Interface, handlers map[string]admission.Handle
 			return err
 		}
 		if _, ok := handlers[path]; !ok {
-			klog.Warningf("Ignore webhook for %s in configuration", path)
+			klog.InfoS("ignoring webhook entry without matching handler", "path", path)
 			continue
 		}
 		if wh.ClientConfig.Service != nil {
@@ -91,7 +91,7 @@ func Ensure(kubeClient clientset.Interface, handlers map[string]admission.Handle
 			return err
 		}
 		if _, ok := handlers[path]; !ok {
-			klog.Warningf("Ignore webhook for %s in configuration", path)
+			klog.InfoS("ignoring webhook entry without matching handler", "path", path)
 			continue
 		}
 		if wh.ClientConfig.Service != nil {

--- a/pkg/utils/webhookutils/writer/secret.go
+++ b/pkg/utils/webhookutils/writer/secret.go
@@ -121,11 +121,11 @@ func (s *secretCertWriter) overwrite(resourceVersion string) (
 	secret.ResourceVersion = resourceVersion
 	secret, err = s.Clientset.CoreV1().Secrets(secret.Namespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
 	if err != nil {
-		klog.Infof("Cert writer update secret failed: %v", err)
+		klog.ErrorS(err, "cert writer secret update failed", "secret", secret.Name)
 		return certs, err
 	}
-	klog.Infof("Cert writer update secret %s resourceVersion from %s to %s",
-		secret.Name, resourceVersion, secret.ResourceVersion)
+	klog.InfoS("cert writer secret updated",
+		"secret", secret.Name, "fromResourceVersion", resourceVersion, "toResourceVersion", secret.ResourceVersion)
 	return certs, err
 }
 

--- a/pkg/webhook/webhook_controller.go
+++ b/pkg/webhook/webhook_controller.go
@@ -105,14 +105,14 @@ func New(cfg *rest.Config, handlers map[string]admission.Handler) (*Controller, 
 		AddFunc: func(obj interface{}) {
 			conf := obj.(*admissionregistrationv1.MutatingWebhookConfiguration)
 			if conf.Name == mutatingWebhookConfigurationName {
-				klog.Infof("MutatingWebhookConfiguration %s added", mutatingWebhookConfigurationName)
+				klog.InfoS("MutatingWebhookConfiguration event", "event", "added", "name", mutatingWebhookConfigurationName)
 				c.queue.Add("")
 			}
 		},
 		UpdateFunc: func(old, cur interface{}) {
 			conf := cur.(*admissionregistrationv1.MutatingWebhookConfiguration)
 			if conf.Name == mutatingWebhookConfigurationName {
-				klog.Infof("MutatingWebhookConfiguration %s update", mutatingWebhookConfigurationName)
+				klog.InfoS("MutatingWebhookConfiguration event", "event", "updated", "name", mutatingWebhookConfigurationName)
 				c.queue.Add("")
 			}
 		},


### PR DESCRIPTION
Part of #353

Re-opening this work. My previous PR (#355) was closed automatically when my fork was
deleted by accident — this is the same change, rebased onto current `master` with
conflicts resolved and tests passing.

## What this adds

Operator-facing observability for the peer/key-cache subsystems:

- **memberlist peer-state metrics** — gauge for peer alive/dead state and a peer-join
  duration observation.
- **key-cache hit/miss counters** for the E2B key store (`pkg/servers/e2b/keys`),
  recorded on the lookup paths while preserving upstream's defensive-copy semantics.
- **structured-log cleanup** in the webhook controller add/update handlers.

New metrics live in `pkg/peers/metrics.go` and `pkg/servers/e2b/keys/metrics.go`; neither
package imports `pkg/features`.

## Testing

`go test ./pkg/peers/... ./pkg/servers/e2b/keys/...` passes; full `go build ./pkg/... ./cmd/...` passes.

Note: `sandbox_peer_state` series are flipped alive→dead rather than deleted on permanent
departure (label set grows with churn); left as a documented follow-up, matching the
original design.
