### PR TITLE
feat(observability): implement end-to-end request ID context propagation

### DIFF
--- a/pkg/sandbox-manager/logs/context.go
+++ b/pkg/sandbox-manager/logs/context.go
@@ -36,3 +36,13 @@ func NewContextFrom(parent context.Context, keysAndValues ...any) context.Contex
 func Extend(ctx context.Context, keysAndValues ...any) context.Context {
 	return utilslogs.Extend(ctx, keysAndValues...)
 }
+
+// WithRequestID returns a new context with the request ID stored as a value.
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	return utilslogs.WithRequestID(ctx, requestID)
+}
+
+// GetRequestID extracts the request ID from the context.
+func GetRequestID(ctx context.Context) string {
+	return utilslogs.GetRequestID(ctx)
+}

--- a/pkg/sandbox-manager/logs/context_test.go
+++ b/pkg/sandbox-manager/logs/context_test.go
@@ -164,3 +164,25 @@ func TestNewContext_DoesNotInheritCancellation(t *testing.T) {
 		// Expected: context remains active
 	}
 }
+
+func TestRequestID(t *testing.T) {
+	requestID := "test-request-id"
+	ctx := context.Background()
+
+	// Test GetRequestID with empty context
+	if got := GetRequestID(ctx); got != "" {
+		t.Errorf("Expected empty request ID, got %s", got)
+	}
+
+	// Test WithRequestID and GetRequestID
+	ctx = WithRequestID(ctx, requestID)
+	if got := GetRequestID(ctx); got != requestID {
+		t.Errorf("Expected request ID %s, got %s", requestID, got)
+	}
+
+	// Test Extend with RequestID
+	extendedCtx := Extend(ctx, "extra", "value")
+	if got := GetRequestID(extendedCtx); got != requestID {
+		t.Errorf("Expected request ID %s to be preserved in extended context, got %s", requestID, got)
+	}
+}

--- a/pkg/servers/web/framework.go
+++ b/pkg/servers/web/framework.go
@@ -76,6 +76,7 @@ func RegisterRoute[T any](mux *http.ServeMux, method, path string, handler Handl
 		// Derive context from request context to inherit cancellation when client disconnects
 		ctx := logs.NewContextFrom(r.Context(),
 			"requestID", requestID, "api", fmt.Sprintf("%s %s", method, path))
+		ctx = logs.WithRequestID(ctx, requestID)
 		log := klog.FromContext(ctx)
 
 		defer func() {

--- a/pkg/utils/logs/context.go
+++ b/pkg/utils/logs/context.go
@@ -39,3 +39,24 @@ func Extend(ctx context.Context, keysAndValues ...any) context.Context {
 	logger := klog.FromContext(ctx)
 	return klog.NewContext(ctx, logger.WithValues(keysAndValues...))
 }
+
+type contextKey string
+
+const (
+	requestIDKey contextKey = "requestID"
+)
+
+// WithRequestID returns a new context with the request ID stored as a value so
+// it can be propagated across the API, manager, and runtime boundaries.
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	return context.WithValue(ctx, requestIDKey, requestID)
+}
+
+// GetRequestID extracts the request ID from the context, returning an empty
+// string when no request ID is present.
+func GetRequestID(ctx context.Context) string {
+	if val, ok := ctx.Value(requestIDKey).(string); ok {
+		return val
+	}
+	return ""
+}

--- a/pkg/utils/runtime/propagation_test.go
+++ b/pkg/utils/runtime/propagation_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+	"github.com/openkruise/agents/pkg/sandbox-manager/logs"
+	"github.com/openkruise/agents/proto/envd/process"
+)
+
+func TestInitRuntimePropagation(t *testing.T) {
+	requestID := "test-propagation-id"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, requestID, r.Header.Get("X-Request-ID"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sbx := newTestSandboxWithURL(server.URL)
+	ctx := logs.WithRequestID(context.Background(), requestID)
+
+	_, err := InitRuntime(ctx, sbx, config.InitRuntimeOptions{SkipRefresh: true}, nil)
+	require.NoError(t, err)
+}
+
+func TestRunCommandWithRuntimePropagation(t *testing.T) {
+	requestID := "test-grpc-propagation-id"
+
+	handler := &mockProcessHandler{
+		startFn: func(ctx context.Context, req *connect.Request[process.StartRequest], stream *connect.ServerStream[process.StartResponse]) error {
+			assert.Equal(t, requestID, req.Header().Get("X-Request-ID"))
+			return stream.Send(&process.StartResponse{Event: &process.ProcessEvent{
+				Event: &process.ProcessEvent_End{End: &process.ProcessEvent_EndEvent{ExitCode: 0, Exited: true}},
+			}})
+		},
+	}
+	_, sbx := newMockRuntimeServer(t, handler)
+
+	ctx := logs.WithRequestID(context.Background(), requestID)
+
+	_, err := RunCommandWithRuntime(ctx, RunCmdFuncArgs{
+		Sbx:           sbx,
+		ProcessConfig: &process.ProcessConfig{Cmd: "test"},
+		Timeout:       5 * time.Second,
+	})
+	require.NoError(t, err)
+}

--- a/pkg/utils/runtime/runtime.go
+++ b/pkg/utils/runtime/runtime.go
@@ -85,6 +85,9 @@ func RunCommandWithRuntime(ctx context.Context, args RunCmdFuncArgs) (RunCommand
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	clientContext, callInfo := connect.NewClientContext(ctxWithTimeout)
+	if requestID := logs.GetRequestID(ctx); requestID != "" {
+		callInfo.RequestHeader().Set("X-Request-ID", requestID)
+	}
 	callInfo.RequestHeader().Set("X-Access-Token", utils.GetAccessToken(sbx))
 	callInfo.RequestHeader().Set("Authorization", "Basic cm9vdDo=") // Basic root:
 
@@ -430,6 +433,9 @@ func InitRuntime(ctx context.Context, sbx *agentsv1alpha1.Sandbox, opts config.I
 		if initErr != nil {
 			log.Error(initErr, "failed to create request")
 			return initErr
+		}
+		if requestID := logs.GetRequestID(ctx); requestID != "" {
+			r.Header.Set("X-Request-ID", requestID)
 		}
 		resp, initErr := proxyutils.ProxyRequest(r)
 		defer func() {


### PR DESCRIPTION
Fixes #335

Re-opening this work. My previous PR (#337) was closed automatically when my fork was
deleted by accident — this is the same change, rebased onto current `master` with
conflicts resolved and tests passing.

## What this adds

End-to-end propagation of a request ID so a request can be traced across the
API / manager / runtime boundaries:

- The web framework generates or accepts an `X-Request-ID` and stores it in the request
  context.
- The runtime client reads it from context and forwards it as a header on both the HTTP
  (`InitRuntime`) and gRPC (`RunCommandWithRuntime`) downstream calls.
- The context helpers (`WithRequestID` / `GetRequestID`) are implemented in the neutral
  `pkg/utils/logs` package, matching where upstream relocated the logging core; the
  `pkg/sandbox-manager/logs` shim re-exports them for existing callers.

## Testing

`go test` passes for `pkg/utils/logs`, `pkg/sandbox-manager/logs`, `pkg/utils/runtime`,
and `pkg/servers/web`; full `go build ./pkg/... ./cmd/...` passes.
