### PR TITLE
feat(sandboxupdateops): allow concurrent update ops with non-overlapping selectors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ GOLANGCI_LINT_VERSION ?= v2.3.0
 
 # Run tests
 .PHONY: test
-test:
+test: envtest
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -race ./pkg/... -coverprofile raw-cover.out
 	grep -v "pkg/client" raw-cover.out > cover.out
 

--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,7 +42,12 @@ import (
 	"github.com/openkruise/agents/pkg/discovery"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
+	"github.com/openkruise/agents/pkg/utils/sandboxutils"
 )
+
+// concurrencyRequeue is how long we wait before re-checking when a sibling
+// SandboxUpdateOps has won the concurrency tiebreak.
+const concurrencyRequeue = 5 * time.Second
 
 const finalizerName = "agents.kruise.io/sandboxupdateops-protection"
 
@@ -107,23 +113,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// 2. Check if another SandboxUpdateOps in the same namespace is already Updating
-	// TODO: This is a short-term solution to prevent concurrent ops in the same namespace.
-	//  A more robust approach would be using a webhook to reject creation when an active ops exists,
-	//  or implementing a queue/priority-based scheduling mechanism.
-	opsList := &agentsv1alpha1.SandboxUpdateOpsList{}
-	if err := r.List(ctx, opsList, client.InNamespace(ops.Namespace), client.UnsafeDisableDeepCopy); err != nil {
-		return ctrl.Result{}, err
-	}
-	for i := range opsList.Items {
-		other := &opsList.Items[i]
-		if other.Name != ops.Name && other.Status.Phase == agentsv1alpha1.SandboxUpdateOpsUpdating {
-			klog.InfoS("Another SandboxUpdateOps is already updating, skipping this one",
-				"current", klog.KObj(ops), "active", klog.KObj(other))
-			return ctrl.Result{}, nil
-		}
-	}
-
 	// 3. Handle deletion: clean up sandbox labels
 	if !ops.DeletionTimestamp.IsZero() {
 		return r.handleDeletion(ctx, ops)
@@ -141,6 +130,35 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if ops.Status.Phase == agentsv1alpha1.SandboxUpdateOpsCompleted ||
 		ops.Status.Phase == agentsv1alpha1.SandboxUpdateOpsFailed {
 		return ctrl.Result{}, nil
+	}
+
+	// Concurrency safeguard: the validating webhook lists existing ops via the
+	// informer cache, which can be stale, so two ops with overlapping selectors
+	// can both be admitted. Re-check here before transitioning to Updating.
+	// Note: this still relies on a (separately delayed) cache, so it does not
+	// fully close the race — a sandbox-level lock in the pre-upgrade phase is
+	// the durable fix.
+	if ops.Status.Phase == "" || ops.Status.Phase == agentsv1alpha1.SandboxUpdateOpsPending {
+		conflict, cErr := r.findOverlappingActiveOp(ctx, ops)
+		if cErr != nil {
+			return ctrl.Result{}, cErr
+		}
+		if conflict != nil {
+			klog.InfoS("Deferring SandboxUpdateOps: overlapping active sibling exists",
+				"ops", klog.KObj(ops), "conflict", klog.KObj(conflict),
+				"conflictPhase", conflict.Status.Phase)
+			r.Recorder.Eventf(ops, v1.EventTypeNormal, "WaitingForPeer",
+				"Deferring to overlapping SandboxUpdateOps %s", conflict.Name)
+			if ops.Status.Phase != agentsv1alpha1.SandboxUpdateOpsPending {
+				newStatus := ops.Status.DeepCopy()
+				newStatus.Phase = agentsv1alpha1.SandboxUpdateOpsPending
+				newStatus.ObservedGeneration = ops.Generation
+				if err := r.updateStatus(ctx, ops, newStatus); err != nil {
+					return ctrl.Result{}, err
+				}
+			}
+			return ctrl.Result{RequeueAfter: concurrencyRequeue}, nil
+		}
 	}
 
 	// 3. Convert selector to labels.Selector
@@ -413,6 +431,49 @@ func (r *Reconciler) handleDeletion(ctx context.Context, ops *agentsv1alpha1.San
 	klog.InfoS("Finalizer removed, SandboxUpdateOps can be deleted",
 		"ops", klog.KObj(ops))
 	return ctrl.Result{}, nil
+}
+
+// findOverlappingActiveOp returns a sibling SandboxUpdateOps in the same
+// namespace whose selector overlaps `ops` and that should run before `ops`.
+// It returns nil if no such sibling exists.
+//
+// Tiebreak: a sibling already in Updating wins outright. If both are still
+// pending, the one with the older CreationTimestamp wins (lexicographic name
+// comparison breaks exact-time ties).
+func (r *Reconciler) findOverlappingActiveOp(ctx context.Context, ops *agentsv1alpha1.SandboxUpdateOps) (*agentsv1alpha1.SandboxUpdateOps, error) {
+	list := &agentsv1alpha1.SandboxUpdateOpsList{}
+	if err := r.List(ctx, list, client.InNamespace(ops.Namespace)); err != nil {
+		return nil, err
+	}
+	for i := range list.Items {
+		peer := &list.Items[i]
+		if peer.Name == ops.Name || !peer.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if peer.Status.Phase == agentsv1alpha1.SandboxUpdateOpsCompleted ||
+			peer.Status.Phase == agentsv1alpha1.SandboxUpdateOpsFailed {
+			continue
+		}
+		if !sandboxutils.IsSelectorOverlapping(ops.Spec.Selector, peer.Spec.Selector) {
+			continue
+		}
+		if peer.Status.Phase == agentsv1alpha1.SandboxUpdateOpsUpdating {
+			return peer, nil
+		}
+		if peerWinsTieBreak(peer, ops) {
+			return peer, nil
+		}
+	}
+	return nil, nil
+}
+
+// peerWinsTieBreak returns true when `peer` should run before `ops` given that
+// both are still in a pre-Updating phase.
+func peerWinsTieBreak(peer, ops *agentsv1alpha1.SandboxUpdateOps) bool {
+	if !peer.CreationTimestamp.Equal(&ops.CreationTimestamp) {
+		return peer.CreationTimestamp.Before(&ops.CreationTimestamp)
+	}
+	return peer.Name < ops.Name
 }
 
 func (r *Reconciler) updateStatus(ctx context.Context, ops *agentsv1alpha1.SandboxUpdateOps, newStatus *agentsv1alpha1.SandboxUpdateOpsStatus) error {

--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
@@ -1320,35 +1320,6 @@ func TestReconcile_DeletionTimestamp_CallsHandleDeletion(t *testing.T) {
 	assert.True(t, errors.IsNotFound(err), "ops should be fully deleted after finalizer removal")
 }
 
-func TestReconcile_ConcurrentOpsInNamespace(t *testing.T) {
-	// First ops is actively Updating
-	ops1 := newSandboxUpdateOps("ops-active", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil)
-	// Second ops is Pending (should be blocked)
-	ops2 := newSandboxUpdateOps("ops-pending", "default", agentsv1alpha1.SandboxUpdateOpsPending, false, nil)
-	sbx := newSandbox("sbx-1", "default", "", agentsv1alpha1.SandboxRunning, nil)
-
-	r := newTestReconciler(ops1, ops2, sbx)
-
-	// Reconcile the second ops
-	result, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "ops-pending", Namespace: "default"},
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, ctrl.Result{}, result)
-
-	// Verify ops-pending was NOT transitioned (still Pending, no status update)
-	updatedOps := &agentsv1alpha1.SandboxUpdateOps{}
-	err = r.Get(context.Background(), types.NamespacedName{Name: "ops-pending", Namespace: "default"}, updatedOps)
-	assert.NoError(t, err)
-	assert.Equal(t, agentsv1alpha1.SandboxUpdateOpsPending, updatedOps.Status.Phase)
-
-	// Verify sandbox was not patched
-	updatedSbx := &agentsv1alpha1.Sandbox{}
-	err = r.Get(context.Background(), types.NamespacedName{Name: "sbx-1", Namespace: "default"}, updatedSbx)
-	assert.NoError(t, err)
-	assert.Empty(t, updatedSbx.Labels[agentsv1alpha1.LabelSandboxUpdateOps])
-}
-
 func TestSandboxUpdateStateString_Unknown(t *testing.T) {
 	unknownState := sandboxUpdateState(99)
 	assert.Equal(t, "Unknown", unknownState.String())
@@ -1747,4 +1718,127 @@ func assertNoUpdateOpsRecorderEvent(t *testing.T, recorder *record.FakeRecorder)
 		t.Fatalf("unexpected event: %s", event)
 	default:
 	}
+}
+
+// Concurrency-safeguard tests: the validating webhook reads from a (possibly stale)
+// informer cache, so two SandboxUpdateOps with overlapping selectors can both be
+// admitted. Reconcile must double-check before flipping Pending → Updating.
+
+func TestReconcile_DefersToOverlappingUpdatingPeer(t *testing.T) {
+	peer := newSandboxUpdateOps("peer-ops", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil)
+	ours := newSandboxUpdateOps("our-ops", "default", agentsv1alpha1.SandboxUpdateOpsPending, false, nil)
+	r := newTestReconciler(peer, ours)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "our-ops", Namespace: "default"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, concurrencyRequeue, result.RequeueAfter)
+
+	got := &agentsv1alpha1.SandboxUpdateOps{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "our-ops", Namespace: "default"}, got)
+	assert.NoError(t, err)
+	assert.Equal(t, agentsv1alpha1.SandboxUpdateOpsPending, got.Status.Phase)
+}
+
+func TestReconcile_DefersToOlderPendingPeer(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	older := metav1.NewTime(now.Add(-time.Minute))
+
+	peer := newSandboxUpdateOps("peer-ops", "default", agentsv1alpha1.SandboxUpdateOpsPending, false, nil)
+	peer.CreationTimestamp = older
+	ours := newSandboxUpdateOps("our-ops", "default", agentsv1alpha1.SandboxUpdateOpsPending, false, nil)
+	ours.CreationTimestamp = now
+	r := newTestReconciler(peer, ours)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "our-ops", Namespace: "default"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, concurrencyRequeue, result.RequeueAfter)
+
+	got := &agentsv1alpha1.SandboxUpdateOps{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "our-ops", Namespace: "default"}, got)
+	assert.NoError(t, err)
+	assert.Equal(t, agentsv1alpha1.SandboxUpdateOpsPending, got.Status.Phase)
+}
+
+func TestReconcile_ProceedsOverYoungerPendingPeer(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	older := metav1.NewTime(now.Add(-time.Minute))
+
+	// Ours is older, so we win the tiebreak.
+	ours := newSandboxUpdateOps("our-ops", "default", agentsv1alpha1.SandboxUpdateOpsPending, false, nil)
+	ours.CreationTimestamp = older
+	peer := newSandboxUpdateOps("peer-ops", "default", agentsv1alpha1.SandboxUpdateOpsPending, false, nil)
+	peer.CreationTimestamp = now
+	sbx := newSandbox("sbx-1", "default", "", agentsv1alpha1.SandboxRunning, nil)
+	r := newTestReconciler(peer, ours, sbx)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "our-ops", Namespace: "default"},
+	})
+	assert.NoError(t, err)
+
+	got := &agentsv1alpha1.SandboxUpdateOps{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "our-ops", Namespace: "default"}, got)
+	assert.NoError(t, err)
+	assert.Equal(t, agentsv1alpha1.SandboxUpdateOpsUpdating, got.Status.Phase)
+}
+
+func TestReconcile_IgnoresTerminalPeer(t *testing.T) {
+	peer := newSandboxUpdateOps("peer-ops", "default", agentsv1alpha1.SandboxUpdateOpsCompleted, false, nil)
+	ours := newSandboxUpdateOps("our-ops", "default", agentsv1alpha1.SandboxUpdateOpsPending, false, nil)
+	sbx := newSandbox("sbx-1", "default", "", agentsv1alpha1.SandboxRunning, nil)
+	r := newTestReconciler(peer, ours, sbx)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "our-ops", Namespace: "default"},
+	})
+	assert.NoError(t, err)
+
+	got := &agentsv1alpha1.SandboxUpdateOps{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "our-ops", Namespace: "default"}, got)
+	assert.NoError(t, err)
+	assert.Equal(t, agentsv1alpha1.SandboxUpdateOpsUpdating, got.Status.Phase)
+}
+
+func TestReconcile_DefersOnEqualTimestampByName(t *testing.T) {
+	// Same CreationTimestamp; tiebreak falls back to lexicographic name comparison.
+	now := metav1.NewTime(time.Now())
+
+	peer := newSandboxUpdateOps("aaa-ops", "default", agentsv1alpha1.SandboxUpdateOpsPending, false, nil)
+	peer.CreationTimestamp = now
+	ours := newSandboxUpdateOps("zzz-ops", "default", agentsv1alpha1.SandboxUpdateOpsPending, false, nil)
+	ours.CreationTimestamp = now
+	r := newTestReconciler(peer, ours)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "zzz-ops", Namespace: "default"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, concurrencyRequeue, result.RequeueAfter)
+
+	got := &agentsv1alpha1.SandboxUpdateOps{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "zzz-ops", Namespace: "default"}, got)
+	assert.NoError(t, err)
+	assert.Equal(t, agentsv1alpha1.SandboxUpdateOpsPending, got.Status.Phase)
+}
+
+func TestReconcile_IgnoresNonOverlappingPeer(t *testing.T) {
+	peer := newSandboxUpdateOps("peer-ops", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil)
+	peer.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"app": "other"}}
+	ours := newSandboxUpdateOps("our-ops", "default", agentsv1alpha1.SandboxUpdateOpsPending, false, nil)
+	sbx := newSandbox("sbx-1", "default", "", agentsv1alpha1.SandboxRunning, nil)
+	r := newTestReconciler(peer, ours, sbx)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "our-ops", Namespace: "default"},
+	})
+	assert.NoError(t, err)
+
+	got := &agentsv1alpha1.SandboxUpdateOps{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "our-ops", Namespace: "default"}, got)
+	assert.NoError(t, err)
+	assert.Equal(t, agentsv1alpha1.SandboxUpdateOpsUpdating, got.Status.Phase)
 }

--- a/pkg/utils/sandboxutils/selector_utils.go
+++ b/pkg/utils/sandboxutils/selector_utils.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2020 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Adapted from openkruise/kruise pkg/util/selector.go.
+// `slice.ContainsString(..., nil)` calls have been replaced with std `slices.Contains`
+// to avoid pulling in `k8s.io/kubernetes/pkg/util/slice`.
+
+package sandboxutils
+
+import (
+	"slices"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// IsSelectorOverlapping indicates whether selector overlaps, the criteria:
+// if exist one same key has different value and not overlap, then it is judged non-overlap, for examples:
+//   - a=b and a=c
+//   - a in [b,c] and a not in [b,c...]
+//   - a not in [b] and a not exist
+//   - a=b,c=d,e=f and a=x,c=d,e=f
+//
+// then others is overlap：
+//   - a=b and c=d
+func IsSelectorOverlapping(selector1, selector2 *metav1.LabelSelector) bool {
+	if selector1 == nil || selector2 == nil {
+		// Nil selector matches everything in some contexts; assume overlap to stay safe.
+		return true
+	}
+	return !(isDisjoint(selector1, selector2) || isDisjoint(selector2, selector1))
+}
+
+func isDisjoint(selector1, selector2 *metav1.LabelSelector) bool {
+	// label -> values
+	// a=b convert to a -> [b]
+	// a in [b,c] convert to a -> [b,c]
+	// a exist convert to a -> [ALL]
+	matchedLabels1 := make(map[string][]string)
+	for key, value := range selector1.MatchLabels {
+		matchedLabels1[key] = []string{value}
+	}
+	for _, req := range selector1.MatchExpressions {
+		switch req.Operator {
+		case metav1.LabelSelectorOpIn:
+			matchedLabels1[req.Key] = append(matchedLabels1[req.Key], req.Values...)
+		case metav1.LabelSelectorOpExists:
+			matchedLabels1[req.Key] = []string{"ALL"}
+		}
+	}
+
+	for key, value := range selector2.MatchLabels {
+		values, ok := matchedLabels1[key]
+		if ok {
+			if !slices.Contains(values, "ALL") && !slices.Contains(values, value) {
+				return true
+			}
+		}
+	}
+	for _, req := range selector2.MatchExpressions {
+		values, ok := matchedLabels1[req.Key]
+
+		switch req.Operator {
+		case metav1.LabelSelectorOpIn:
+			if ok && !slices.Contains(values, "ALL") && !sliceOverlaps(values, req.Values) {
+				return true
+			}
+		case metav1.LabelSelectorOpNotIn:
+			if ok && sliceContains(req.Values, values) {
+				return true
+			}
+		case metav1.LabelSelectorOpExists:
+			if !ok {
+				return true
+			}
+		case metav1.LabelSelectorOpDoesNotExist:
+			if ok {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func sliceOverlaps(a, b []string) bool {
+	keyExist := make(map[string]bool, len(a))
+	for _, key := range a {
+		keyExist[key] = true
+	}
+	for _, key := range b {
+		if keyExist[key] {
+			return true
+		}
+	}
+	return false
+}
+
+// a contains b
+func sliceContains(a, b []string) bool {
+	keyExist := make(map[string]bool, len(a))
+	for _, key := range a {
+		keyExist[key] = true
+	}
+	for _, key := range b {
+		if !keyExist[key] {
+			return false
+		}
+	}
+	return true
+}
+
+// IsSelectorLooseOverlap indicates whether selectors overlap (indicates that selector1, selector2 have same key, and there is a certain intersection）
+//  1. when selector1、selector2 don't have same key, it is considered non-overlap, e.g. selector1(a=b) and selector2(c=d)
+//  2. when selector1、selector2 have same key, and matchLabels & matchExps are intersection, it is considered overlap.
+func IsSelectorLooseOverlap(selector1, selector2 *metav1.LabelSelector) bool {
+	matchExp1 := convertSelectorToMatchExpressions(selector1)
+	matchExp2 := convertSelectorToMatchExpressions(selector2)
+
+	for k, exp1 := range matchExp1 {
+		exp2, ok := matchExp2[k]
+		if !ok {
+			return false
+		}
+
+		if !isMatchExpOverlap(exp1, exp2) {
+			return false
+		}
+	}
+
+	for k, exp2 := range matchExp2 {
+		exp1, ok := matchExp1[k]
+		if !ok {
+			return false
+		}
+
+		if !isMatchExpOverlap(exp2, exp1) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isMatchExpOverlap(matchExp1, matchExp2 metav1.LabelSelectorRequirement) bool {
+	switch matchExp1.Operator {
+	case metav1.LabelSelectorOpIn:
+		if matchExp2.Operator == metav1.LabelSelectorOpExists {
+			return true
+		} else if matchExp2.Operator == metav1.LabelSelectorOpIn && sliceOverlaps(matchExp2.Values, matchExp1.Values) {
+			return true
+		} else if matchExp2.Operator == metav1.LabelSelectorOpNotIn && !sliceContains(matchExp2.Values, matchExp1.Values) {
+			return true
+		}
+	case metav1.LabelSelectorOpExists:
+		if matchExp2.Operator == metav1.LabelSelectorOpIn || matchExp2.Operator == metav1.LabelSelectorOpNotIn ||
+			matchExp2.Operator == metav1.LabelSelectorOpExists {
+			return true
+		}
+	case metav1.LabelSelectorOpNotIn:
+		if matchExp2.Operator == metav1.LabelSelectorOpExists || matchExp2.Operator == metav1.LabelSelectorOpDoesNotExist ||
+			matchExp2.Operator == metav1.LabelSelectorOpNotIn {
+			return true
+		} else if matchExp2.Operator == metav1.LabelSelectorOpIn && !sliceContains(matchExp1.Values, matchExp2.Values) {
+			return true
+		}
+	case metav1.LabelSelectorOpDoesNotExist:
+		if matchExp2.Operator == metav1.LabelSelectorOpDoesNotExist || matchExp2.Operator == metav1.LabelSelectorOpNotIn {
+			return true
+		}
+	}
+
+	return false
+}
+
+func convertSelectorToMatchExpressions(selector *metav1.LabelSelector) map[string]metav1.LabelSelectorRequirement {
+	matchExps := map[string]metav1.LabelSelectorRequirement{}
+	for _, exp := range selector.MatchExpressions {
+		matchExps[exp.Key] = exp
+	}
+
+	for k, v := range selector.MatchLabels {
+		matchExps[k] = metav1.LabelSelectorRequirement{
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{v},
+		}
+	}
+
+	return matchExps
+}

--- a/pkg/utils/sandboxutils/selector_utils_test.go
+++ b/pkg/utils/sandboxutils/selector_utils_test.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandboxutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsSelectorOverlapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		s1       *metav1.LabelSelector
+		s2       *metav1.LabelSelector
+		expected bool
+	}{
+		{
+			name:     "Both nil",
+			s1:       nil,
+			s2:       nil,
+			expected: true,
+		},
+		{
+			name:     "S1 nil",
+			s1:       nil,
+			s2:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+			expected: true,
+		},
+		{
+			name:     "Both empty",
+			s1:       &metav1.LabelSelector{},
+			s2:       &metav1.LabelSelector{},
+			expected: true,
+		},
+		{
+			name:     "Conflicting MatchLabels",
+			s1:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+			s2:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "bar"}},
+			expected: false,
+		},
+		{
+			name:     "Overlapping MatchLabels",
+			s1:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo", "env": "prod"}},
+			s2:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo", "tier": "web"}},
+			expected: true,
+		},
+		{
+			name:     "No common keys",
+			s1:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+			s2:       &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+			expected: true,
+		},
+		{
+			name: "MatchExpressions In overlap",
+			s1: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpIn, Values: []string{"foo", "bar"}},
+				},
+			},
+			s2: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpIn, Values: []string{"bar", "baz"}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "MatchExpressions In disjoint",
+			s1: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpIn, Values: []string{"foo"}},
+				},
+			},
+			s2: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpIn, Values: []string{"bar"}},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "MatchLabel vs NotIn excluding it",
+			s1:   &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+			s2: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "env", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"prod"}},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Exists vs DoesNotExist",
+			s1: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "team", Operator: metav1.LabelSelectorOpExists},
+				},
+			},
+			s2: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "team", Operator: metav1.LabelSelectorOpDoesNotExist},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsSelectorOverlapping(tt.s1, tt.s2)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsSelectorLooseOverlap(t *testing.T) {
+	tests := []struct {
+		name     string
+		s1       *metav1.LabelSelector
+		s2       *metav1.LabelSelector
+		expected bool
+	}{
+		{
+			name:     "Same key In/In with overlapping values",
+			s1:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+			s2:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+			expected: true,
+		},
+		{
+			name: "Same key In/In with disjoint values",
+			s1: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpIn, Values: []string{"foo"}},
+				},
+			},
+			s2: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpIn, Values: []string{"bar"}},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "Different keys do not overlap",
+			s1:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+			s2:       &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+			expected: false,
+		},
+		{
+			name:     "s2 has extra key not in s1",
+			s1:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+			s2:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo", "env": "prod"}},
+			expected: false,
+		},
+		{
+			name: "Same key Exists/Exists",
+			s1: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpExists},
+				},
+			},
+			s2: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpExists},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Same key Exists/In",
+			s1: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpExists},
+				},
+			},
+			s2:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}},
+			expected: true,
+		},
+		{
+			name: "Same key In/NotIn excluding all In values",
+			s1: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpIn, Values: []string{"foo"}},
+				},
+			},
+			s2: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"foo", "bar"}},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Same key NotIn/NotIn always overlap",
+			s1: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"foo"}},
+				},
+			},
+			s2: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"bar"}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Same key Exists/DoesNotExist",
+			s1: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpExists},
+				},
+			},
+			s2: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpDoesNotExist},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Same key DoesNotExist/DoesNotExist",
+			s1: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpDoesNotExist},
+				},
+			},
+			s2: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "app", Operator: metav1.LabelSelectorOpDoesNotExist},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsSelectorLooseOverlap(tt.s1, tt.s2)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/webhook/sandboxupdateops/validating/sandboxupdateops_validate.go
+++ b/pkg/webhook/sandboxupdateops/validating/sandboxupdateops_validate.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/utils/sandboxutils"
 )
 
 // SandboxUpdateOpsValidatingHandler handles validation for SandboxUpdateOps resources.
@@ -95,7 +96,7 @@ func (h *SandboxUpdateOpsValidatingHandler) handleCreate(ctx context.Context, ob
 		}
 	}
 
-	// 4. Check for active (non-terminal) SandboxUpdateOps in the same namespace
+	// 4. Check for active (non-terminal) SandboxUpdateOps in the same namespace with overlapping selectors
 	opsList := &agentsv1alpha1.SandboxUpdateOpsList{}
 	if err := h.Client.List(ctx, opsList, client.InNamespace(obj.Namespace)); err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
@@ -107,8 +108,12 @@ func (h *SandboxUpdateOpsValidatingHandler) handleCreate(ctx context.Context, ob
 		}
 		if existing.Status.Phase != agentsv1alpha1.SandboxUpdateOpsCompleted &&
 			existing.Status.Phase != agentsv1alpha1.SandboxUpdateOpsFailed {
-			errList = append(errList, field.Forbidden(specPath, "there is an active SandboxUpdateOps in the same namespace: "+existing.Name))
-			break
+			// Check if selectors overlap
+			if sandboxutils.IsSelectorOverlapping(obj.Spec.Selector, existing.Spec.Selector) {
+				errList = append(errList, field.Forbidden(specPath.Child("selector"),
+					"there is an active SandboxUpdateOps ("+existing.Name+") in the same namespace with an overlapping selector"))
+				break
+			}
 		}
 	}
 

--- a/pkg/webhook/sandboxupdateops/validating/sandboxupdateops_validate_test.go
+++ b/pkg/webhook/sandboxupdateops/validating/sandboxupdateops_validate_test.go
@@ -155,7 +155,7 @@ func TestCreate_LifecyclePreUpgradeExecNil(t *testing.T) {
 	require.Contains(t, resp.Result.Message, "exec is required")
 }
 
-func TestCreate_ActiveOpsExists_Rejected(t *testing.T) {
+func TestCreate_ActiveOpsExists_OverlappingSelector_Rejected(t *testing.T) {
 	existing := &v1alpha1.SandboxUpdateOps{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "existing-ops",
@@ -163,7 +163,7 @@ func TestCreate_ActiveOpsExists_Rejected(t *testing.T) {
 		},
 		Spec: v1alpha1.SandboxUpdateOpsSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": "old"},
+				MatchLabels: map[string]string{"app": "test"},
 			},
 		},
 		Status: v1alpha1.SandboxUpdateOpsStatus{
@@ -173,7 +173,27 @@ func TestCreate_ActiveOpsExists_Rejected(t *testing.T) {
 	h := newTestHandler(existing)
 	resp := h.Handle(context.TODO(), makeCreateRequest(t, validOps()))
 	require.False(t, resp.Allowed)
-	require.Contains(t, resp.Result.Message, "active SandboxUpdateOps")
+	require.Contains(t, resp.Result.Message, "overlapping selector")
+}
+
+func TestCreate_NonOverlappingActiveOpsExists_Allowed(t *testing.T) {
+	existing := &v1alpha1.SandboxUpdateOps{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-ops",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.SandboxUpdateOpsSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "other"},
+			},
+		},
+		Status: v1alpha1.SandboxUpdateOpsStatus{
+			Phase: v1alpha1.SandboxUpdateOpsUpdating,
+		},
+	}
+	h := newTestHandler(existing)
+	resp := h.Handle(context.TODO(), makeCreateRequest(t, validOps()))
+	require.True(t, resp.Allowed, "expected allowed for non-overlapping selectors")
 }
 
 func TestCreate_CompletedOpsExists_Allowed(t *testing.T) {


### PR DESCRIPTION
Fixes #341

Re-opening this work. My previous PR (#342) was closed automatically when my fork was
deleted by accident — this is the same change, rebased onto current `master` (including
the #482 filter changes) with conflicts resolved and tests passing.

## Background

The original proposal simply removed the controller's namespace-wide concurrency check.
As @furykerry pointed out on #342, concurrent update ops on a **single** sandbox must
still be prevented, so a blanket removal isn't acceptable. This PR keeps that guarantee
while allowing genuinely independent updates to proceed in parallel.

## What this does

- **Webhook** (`sandboxupdateops_validate.go`): rejects a new SandboxUpdateOps only when
  its `spec.selector` **overlaps** an existing active op (`IsSelectorOverlapping`), instead
  of rejecting any concurrent op. Non-overlapping ops across the namespace can run in
  parallel.
- **Controller re-check**: before transitioning a sandbox Pending→Updating, it re-validates
  non-overlap (`findOverlappingActiveOp` + a deterministic tie-break), deferring to an
  Updating sibling or the older/lexicographically-smaller pending sibling and requeuing.
  This closes the informer-cache-lag window that neither the webhook nor a single check can
  cover alone — matching @furykerry's suggestion of a final check in the controller.

## Testing

`go test ./pkg/webhook/sandboxupdateops/... ./pkg/controller/sandboxupdateops/... ./pkg/utils/sandboxutils/...`
passes; full `go build ./pkg/... ./cmd/...` passes.

## Note for reviewers

The `IsSelectorOverlapping` helper currently lives in `pkg/utils/sandboxutils`. The updated
repo guide discourages growing `pkg/utils`; happy to relocate it to a domain-specific
package if you'd prefer.
