### PR TITLE
fix(server): add ReadTimeout, WriteTimeout and IdleTimeout to HTTP servers

### DIFF
--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -112,6 +112,9 @@ func (s *Server) Run() error {
 		Addr:              fmt.Sprintf(":%d", SystemPort),
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       consts.HTTPReadTimeout,
+		WriteTimeout:      consts.HTTPWriteTimeout,
+		IdleTimeout:       consts.HTTPIdleTimeout,
 	}
 
 	// GRPC

--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openkruise/agents/pkg/proxy"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/utils"
 )
 
@@ -89,6 +90,9 @@ func (s *Server) Start(ctx context.Context) error {
 		Addr:              fmt.Sprintf(":%d", normalizePort(s.port, proxy.SystemPort)),
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       consts.HTTPReadTimeout,
+		WriteTimeout:      consts.HTTPWriteTimeout,
+		IdleTimeout:       consts.HTTPIdleTimeout,
 	}
 
 	// Get node name from environment variables

--- a/pkg/sandbox-gateway/server/server_test.go
+++ b/pkg/sandbox-gateway/server/server_test.go
@@ -137,6 +137,19 @@ func TestNewServer(t *testing.T) {
 	}
 }
 
+func TestServerTimeouts(t *testing.T) {
+	s := NewServer(nil, 8080)
+	err := s.Start(t.Context())
+	// Start will fail because HOSTNAME is not set, but we only need to check if httpServer was created
+	assert.Error(t, err)
+	assert.NotNil(t, s.httpServer)
+	if s.httpServer != nil {
+		assert.Equal(t, "30s", s.httpServer.ReadTimeout.String())
+		assert.Equal(t, "2m0s", s.httpServer.WriteTimeout.String())
+		assert.Equal(t, "2m0s", s.httpServer.IdleTimeout.String())
+	}
+}
+
 func TestHandleRefresh_MethodNotAllowed(t *testing.T) {
 	s := &Server{}
 

--- a/pkg/sandbox-manager/consts/consts.go
+++ b/pkg/sandbox-manager/consts/consts.go
@@ -35,6 +35,11 @@ const (
 	ExtProcPort               = 9002
 	DefaultExtProcConcurrency = 1000
 	ShutdownTimeout           = 90 * time.Second
+
+	// HTTP server timeout constants to mitigate Slowloris-style DoS attacks.
+	HTTPReadTimeout  = 30 * time.Second
+	HTTPWriteTimeout = 120 * time.Second
+	HTTPIdleTimeout  = 120 * time.Second
 )
 
 const (

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -96,6 +96,9 @@ func NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSe
 		Addr:              fmt.Sprintf(":%d", port),
 		Handler:           sc.mux,
 		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       consts.HTTPReadTimeout,
+		WriteTimeout:      consts.HTTPWriteTimeout,
+		IdleTimeout:       consts.HTTPIdleTimeout,
 	}
 
 	return sc


### PR DESCRIPTION
Fixes #346

Re-opening this fix. My previous PR (#347) was closed automatically when my fork was
deleted by accident — this is the same change, rebased onto current `master` with
conflicts resolved and tests passing.

## Problem

The HTTP servers set only `ReadHeaderTimeout` and leave `ReadTimeout`, `WriteTimeout`, and
`IdleTimeout` unset, which leaves them exposed to Slowloris-style slow-request DoS (a client
can hold a connection open indefinitely).

## Fix

Add `ReadTimeout`, `WriteTimeout`, and `IdleTimeout` (as named constants) to all three HTTP
servers (`pkg/proxy/server.go`, `pkg/sandbox-gateway/server/server.go`,
`pkg/servers/e2b/core.go`).

## Note for reviewers (relates to #320)

`WriteTimeout` is set to 120s to stay well above the longest expected handler. If any
legitimate handler (e.g. a checkpoint/pause flow) can run longer than 120s, it would be cut
by the server-wide `WriteTimeout` and should get a per-handler override instead. Worth
confirming against the concern raised in #320 before merge.

## Testing

New `TestServerTimeouts`; `go test` passes for the affected packages; full
`go build ./pkg/... ./cmd/...` passes.
