### PR TITLE
feat(e2b): add prometheus metrics for core API operations

### DIFF
--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -94,7 +94,17 @@ func resolveServerTimeout(seconds int) time.Duration {
 }
 
 // CreateSandbox allocates a Pod as a new sandbox
-func (sc *Controller) CreateSandbox(r *http.Request) (web.ApiResponse[*models.Sandbox], *web.ApiError) {
+func (sc *Controller) CreateSandbox(r *http.Request) (resp web.ApiResponse[*models.Sandbox], apiErr *web.ApiError) {
+	start := time.Now()
+	defer func() {
+		result := ResultSuccess
+		if apiErr != nil {
+			result = ResultError
+		}
+		apiOperationDuration.WithLabelValues("create", result).Observe(time.Since(start).Seconds())
+		apiOperationTotal.WithLabelValues("create", result).Inc()
+	}()
+
 	ctx := r.Context()
 	log := klog.FromContext(ctx)
 	user := GetUserFromContext(ctx)

--- a/pkg/servers/e2b/metrics.go
+++ b/pkg/servers/e2b/metrics.go
@@ -21,6 +21,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
+const (
+	ResultSuccess = "success"
+	ResultError   = "error"
+)
+
 var (
 	// snapshotDuration tracks snapshot creation latency.
 	snapshotDuration = prometheus.NewHistogramVec(
@@ -40,8 +45,32 @@ var (
 		},
 		[]string{"namespace", "result"},
 	)
+
+	// apiOperationDuration tracks E2B API operation latency.
+	apiOperationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "sandbox_api_operation_duration_seconds",
+			Help:    "E2B API operation latency in seconds",
+			Buckets: prometheus.ExponentialBuckets(0.02, 2, 12), // 20ms -> ~41s
+		},
+		[]string{"operation", "result"},
+	)
+
+	// apiOperationTotal tracks total E2B API operations.
+	apiOperationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sandbox_api_operation_total",
+			Help: "Total number of E2B API operations",
+		},
+		[]string{"operation", "result"},
+	)
 )
 
 func init() {
-	metrics.Registry.MustRegister(snapshotDuration, snapshotTotal)
+	metrics.Registry.MustRegister(
+		snapshotDuration,
+		snapshotTotal,
+		apiOperationDuration,
+		apiOperationTotal,
+	)
 }

--- a/pkg/servers/e2b/services.go
+++ b/pkg/servers/e2b/services.go
@@ -33,7 +33,17 @@ import (
 )
 
 // DescribeSandbox returns details of a specific sandbox
-func (sc *Controller) DescribeSandbox(r *http.Request) (web.ApiResponse[*models.Sandbox], *web.ApiError) {
+func (sc *Controller) DescribeSandbox(r *http.Request) (resp web.ApiResponse[*models.Sandbox], apiErr *web.ApiError) {
+	start := time.Now()
+	defer func() {
+		result := ResultSuccess
+		if apiErr != nil {
+			result = ResultError
+		}
+		apiOperationDuration.WithLabelValues("describe", result).Observe(time.Since(start).Seconds())
+		apiOperationTotal.WithLabelValues("describe", result).Inc()
+	}()
+
 	id := r.PathValue("sandboxID")
 	log := klog.FromContext(r.Context())
 	log.Info("describe sandbox", "id", id)
@@ -59,7 +69,17 @@ func (sc *Controller) DescribeSandbox(r *http.Request) (web.ApiResponse[*models.
 }
 
 // DeleteSandbox deletes a specific sandbox
-func (sc *Controller) DeleteSandbox(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
+func (sc *Controller) DeleteSandbox(r *http.Request) (resp web.ApiResponse[struct{}], apiErr *web.ApiError) {
+	start := time.Now()
+	defer func() {
+		result := ResultSuccess
+		if apiErr != nil {
+			result = ResultError
+		}
+		apiOperationDuration.WithLabelValues("delete", result).Observe(time.Since(start).Seconds())
+		apiOperationTotal.WithLabelValues("delete", result).Inc()
+	}()
+
 	id := r.PathValue("sandboxID")
 	log := klog.FromContext(r.Context())
 	user := GetUserFromContext(r.Context())

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -2550,3 +2550,22 @@ func TestCreateSandbox_EmptyHostDoesNotClaim(t *testing.T) {
 	require.NotNil(t, resp.Body)
 	assert.Equal(t, "example.com", resp.Body.Domain)
 }
+
+func TestDescribeSandboxFailure(t *testing.T) {
+	controller, _, teardown := Setup(t)
+	defer teardown()
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "test-user",
+	}
+
+	t.Run("sandbox not found", func(t *testing.T) {
+		_, apiError := controller.DescribeSandbox(NewRequest(t, nil, nil, map[string]string{
+			"sandboxID": "non-existent-id",
+		}, user))
+		assert.NotNil(t, apiError)
+		assert.Equal(t, http.StatusNotFound, apiError.Code)
+	})
+}

--- a/pkg/servers/e2b/snapshot.go
+++ b/pkg/servers/e2b/snapshot.go
@@ -30,11 +30,20 @@ import (
 	"github.com/openkruise/agents/pkg/servers/web"
 )
 
-func (sc *Controller) CreateSnapshot(r *http.Request) (web.ApiResponse[*models.Snapshot], *web.ApiError) {
+func (sc *Controller) CreateSnapshot(r *http.Request) (resp web.ApiResponse[*models.Snapshot], apiErr *web.ApiError) {
+	start := time.Now()
+	defer func() {
+		result := ResultSuccess
+		if apiErr != nil {
+			result = ResultError
+		}
+		apiOperationDuration.WithLabelValues("snapshot", result).Observe(time.Since(start).Seconds())
+		apiOperationTotal.WithLabelValues("snapshot", result).Inc()
+	}()
+
 	ctx := r.Context()
 	sandboxID := r.PathValue("sandboxID")
 	log := klog.FromContext(ctx)
-	start := time.Now()
 	request, parseErr := sc.parseCreateSnapshotRequest(r)
 	if parseErr != nil {
 		return web.ApiResponse[*models.Snapshot]{}, parseErr

--- a/pkg/servers/e2b/timeout.go
+++ b/pkg/servers/e2b/timeout.go
@@ -32,7 +32,17 @@ import (
 )
 
 // SetSandboxTimeout sets the timeout of a claimed sandbox
-func (sc *Controller) SetSandboxTimeout(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
+func (sc *Controller) SetSandboxTimeout(r *http.Request) (resp web.ApiResponse[struct{}], apiErr *web.ApiError) {
+	start := time.Now()
+	defer func() {
+		result := ResultSuccess
+		if apiErr != nil {
+			result = ResultError
+		}
+		apiOperationDuration.WithLabelValues("timeout", result).Observe(time.Since(start).Seconds())
+		apiOperationTotal.WithLabelValues("timeout", result).Inc()
+	}()
+
 	err := sc.setSandboxTimeout(r)
 	if err != nil {
 		if err.Code != http.StatusNotFound {


### PR DESCRIPTION
Fixes #332

Re-opening this work. My previous PR (#333) was closed automatically when my fork was
deleted by accident — this is the same change, rebased onto current `master` (clean
auto-merge) with tests passing.

## What this adds

Prometheus metrics for the core E2B API operations (`pkg/servers/e2b`):

- `sandbox_api_operation_duration_seconds` histogram and `sandbox_api_operation_total`
  counter, labeled by operation and result (`ResultSuccess` / `ResultError`), recorded via
  `defer` on the create / describe / delete / snapshot / timeout handlers.
- Registered on the controller-runtime registry alongside the existing snapshot metrics.

## Testing

Added `TestDescribeSandboxFailure` (error-path coverage); focused `go test ./pkg/servers/e2b/...`
run passes; full `go build ./pkg/... ./cmd/...` passes. All changes stay within the
`pkg/servers/e2b` API layer.
