### PR TITLE
feat(sandboxclaim): propagate designated claim annotations to pod template

### DIFF
--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -41,6 +41,7 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/utils"
+	annotationutils "github.com/openkruise/agents/pkg/utils/annotations"
 	"github.com/openkruise/agents/pkg/utils/csiutils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 	"github.com/openkruise/agents/pkg/utils/timeout"
@@ -314,6 +315,12 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 				labels[k] = v
 			}
 			sbx.SetPodLabels(labels)
+
+			// propagate user annotations to podtemplate. Keys with internal
+			// reserved prefixes (annotationutils.BlackListPrefix) are filtered
+			// out so propagated annotations cannot interfere with the sandbox
+			// controller itself.
+			infra.MergePodAnnotations(sbx, annotationutils.FilterBlackListed(claim.Spec.Annotations))
 
 			// apply shutdownTime
 			if claim.Spec.ShutdownTime != nil {

--- a/pkg/sandbox-manager/infra/interface.go
+++ b/pkg/sandbox-manager/infra/interface.go
@@ -242,6 +242,8 @@ type Sandbox interface {
 	GetImage() string
 	SetPodLabels(labels map[string]string)
 	GetPodLabels() map[string]string
+	SetPodAnnotations(annotations map[string]string)
+	GetPodAnnotations() map[string]string
 	SetTimeout(opts timeout.Options)
 	SaveTimeoutWithPolicy(ctx context.Context, opts SaveTimeoutOptions, policy timeout.UpdatePolicy) (TimeoutUpdateResult, error)
 	GetTimeout() timeout.Options
@@ -271,6 +273,23 @@ func MergePodLabels(sbx Sandbox, labels map[string]string) {
 		existing[k] = v
 	}
 	sbx.SetPodLabels(existing)
+}
+
+// MergePodAnnotations merges the given annotations into the sandbox's pod
+// template annotations. Existing annotations with the same key are overwritten.
+// The sandbox's pod template annotations map is initialized if necessary.
+func MergePodAnnotations(sbx Sandbox, annotations map[string]string) {
+	if len(annotations) == 0 {
+		return
+	}
+	existing := sbx.GetPodAnnotations()
+	if existing == nil {
+		existing = make(map[string]string, len(annotations))
+	}
+	for k, v := range annotations {
+		existing[k] = v
+	}
+	sbx.SetPodAnnotations(existing)
 }
 
 type CheckpointInfo struct {

--- a/pkg/sandbox-manager/infra/interface_test.go
+++ b/pkg/sandbox-manager/infra/interface_test.go
@@ -187,13 +187,14 @@ func TestCalculateResourceFromContainers(t *testing.T) {
 }
 
 // mockSandboxForLabels is a minimal Sandbox implementation for testing
-// MergePodLabels. Only GetPodLabels and SetPodLabels have real logic;
-// all other methods return zero values. When hasTemplate is false, both
-// GetPodLabels and SetPodLabels are no-ops, simulating a nil pod template.
+// MergePodLabels and MergePodAnnotations. Only the pod label/annotation
+// accessors have real logic; all other methods return zero values. When
+// hasTemplate is false, the accessors are no-ops, simulating a nil pod template.
 type mockSandboxForLabels struct {
 	metav1.ObjectMeta
-	podLabels   map[string]string
-	hasTemplate bool
+	podLabels      map[string]string
+	podAnnotations map[string]string
+	hasTemplate    bool
 }
 
 func (m *mockSandboxForLabels) GetPodLabels() map[string]string {
@@ -207,6 +208,18 @@ func (m *mockSandboxForLabels) SetPodLabels(labels map[string]string) {
 		return
 	}
 	m.podLabels = labels
+}
+func (m *mockSandboxForLabels) GetPodAnnotations() map[string]string {
+	if !m.hasTemplate {
+		return nil
+	}
+	return m.podAnnotations
+}
+func (m *mockSandboxForLabels) SetPodAnnotations(annotations map[string]string) {
+	if !m.hasTemplate {
+		return
+	}
+	m.podAnnotations = annotations
 }
 func (m *mockSandboxForLabels) Pause(context.Context, PauseOptions) error { return nil }
 func (m *mockSandboxForLabels) Resume(context.Context, ResumeOptions) error {
@@ -367,4 +380,84 @@ func TestMergePodLabels_Idempotent(t *testing.T) {
 		"env":  "prod",
 		"tier": "frontend",
 	}, got)
+}
+
+func TestMergePodAnnotations(t *testing.T) {
+	tests := []struct {
+		name                string
+		existingAnnotations map[string]string
+		inputAnnotations    map[string]string
+		wantAnnotations     map[string]string
+	}{
+		{
+			name:                "nil existing annotations - initializes and sets all",
+			existingAnnotations: nil,
+			inputAnnotations:    map[string]string{"a": "1", "b": "2"},
+			wantAnnotations:     map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			name:                "empty input annotations - no change",
+			existingAnnotations: map[string]string{"a": "1"},
+			inputAnnotations:    map[string]string{},
+			wantAnnotations:     map[string]string{"a": "1"},
+		},
+		{
+			name:                "nil input annotations - no change",
+			existingAnnotations: map[string]string{"a": "1"},
+			inputAnnotations:    nil,
+			wantAnnotations:     map[string]string{"a": "1"},
+		},
+		{
+			name:                "overwrite existing annotation with same key",
+			existingAnnotations: map[string]string{"a": "old", "b": "keep"},
+			inputAnnotations:    map[string]string{"a": "new"},
+			wantAnnotations:     map[string]string{"a": "new", "b": "keep"},
+		},
+		{
+			name:                "add new annotations to existing",
+			existingAnnotations: map[string]string{"a": "1"},
+			inputAnnotations:    map[string]string{"b": "2", "c": "3"},
+			wantAnnotations:     map[string]string{"a": "1", "b": "2", "c": "3"},
+		},
+		{
+			name:                "both nil - no change",
+			existingAnnotations: nil,
+			inputAnnotations:    nil,
+			wantAnnotations:     nil,
+		},
+		{
+			name:                "kubernetes-style dotted annotation keys",
+			existingAnnotations: map[string]string{"agents.kruise.io/a": "1"},
+			inputAnnotations:    map[string]string{"agents.kruise.io/b": "2"},
+			wantAnnotations:     map[string]string{"agents.kruise.io/a": "1", "agents.kruise.io/b": "2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := &mockSandboxForLabels{podAnnotations: tt.existingAnnotations, hasTemplate: true}
+			MergePodAnnotations(sbx, tt.inputAnnotations)
+			got := sbx.GetPodAnnotations()
+			if len(got) != len(tt.wantAnnotations) {
+				t.Errorf("MergePodAnnotations() count = %d, want %d, got=%v, want=%v", len(got), len(tt.wantAnnotations), got, tt.wantAnnotations)
+				return
+			}
+			for k, wantVal := range tt.wantAnnotations {
+				if gotVal, ok := got[k]; !ok || gotVal != wantVal {
+					t.Errorf("MergePodAnnotations() annotation[%q] = %q, want %q", k, gotVal, wantVal)
+				}
+			}
+		})
+	}
+}
+
+func TestMergePodAnnotations_NilTemplate(t *testing.T) {
+	// When the sandbox's pod template is nil, GetPodAnnotations returns nil and
+	// SetPodAnnotations is a no-op. MergePodAnnotations should not panic and the
+	// annotations are silently dropped.
+	sbx := &mockSandboxForLabels{}
+	assert.NotPanics(t, func() {
+		MergePodAnnotations(sbx, map[string]string{"a": "1", "b": "2"})
+	})
+	assert.Nil(t, sbx.GetPodAnnotations())
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -241,6 +241,19 @@ func (s *Sandbox) SetPodLabels(labels map[string]string) {
 	}
 }
 
+func (s *Sandbox) GetPodAnnotations() map[string]string {
+	if s.Spec.Template != nil {
+		return s.Spec.Template.Annotations
+	}
+	return nil
+}
+
+func (s *Sandbox) SetPodAnnotations(annotations map[string]string) {
+	if s.Spec.Template != nil {
+		s.Spec.Template.Annotations = annotations
+	}
+}
+
 // SetImage sets the image of the first container
 func (s *Sandbox) SetImage(image string) {
 	if s.Spec.Template != nil {

--- a/pkg/servers/e2b/metadata.go
+++ b/pkg/servers/e2b/metadata.go
@@ -17,9 +17,11 @@ limitations under the License.
 package e2b
 
 import (
-	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	annotationutils "github.com/openkruise/agents/pkg/utils/annotations"
 )
 
 var (
-	BlackListPrefix = []string{agentsv1alpha1.E2BPrefix, agentsv1alpha1.InternalPrefix}
+	// BlackListPrefix aliases the shared internal annotation prefix blacklist
+	// so user metadata keys can never collide with internally reserved keys.
+	BlackListPrefix = annotationutils.BlackListPrefix
 )

--- a/pkg/utils/annotations/blacklist.go
+++ b/pkg/utils/annotations/blacklist.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"strings"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+// BlackListPrefix lists annotation key prefixes reserved for internal use.
+// Keys with these prefixes are managed by the sandbox controller and
+// sandbox-manager themselves, so user-supplied metadata must never carry
+// them and they must never be propagated onto user-facing resources such
+// as the pod template.
+var BlackListPrefix = []string{agentsv1alpha1.E2BPrefix, agentsv1alpha1.InternalPrefix}
+
+// IsBlackListed reports whether the given annotation key matches one of the
+// internal reserved prefixes in BlackListPrefix.
+func IsBlackListed(key string) bool {
+	for _, prefix := range BlackListPrefix {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterBlackListed returns the subset of the given annotations whose keys
+// do not match any internal reserved prefix. It returns nil when no
+// annotation is eligible.
+func FilterBlackListed(annotations map[string]string) map[string]string {
+	if len(annotations) == 0 {
+		return nil
+	}
+	var filtered map[string]string
+	for k, v := range annotations {
+		if IsBlackListed(k) {
+			continue
+		}
+		if filtered == nil {
+			filtered = make(map[string]string)
+		}
+		filtered[k] = v
+	}
+	return filtered
+}

--- a/pkg/utils/annotations/blacklist_test.go
+++ b/pkg/utils/annotations/blacklist_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+func TestIsBlackListed(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want bool
+	}{
+		{
+			name: "internal prefix is blacklisted",
+			key:  agentsv1alpha1.InternalPrefix + "sandbox-claim-name",
+			want: true,
+		},
+		{
+			name: "e2b prefix is blacklisted",
+			key:  agentsv1alpha1.E2BPrefix + "template-id",
+			want: true,
+		},
+		{
+			name: "plain user key is allowed",
+			key:  "team.example.com/owner",
+			want: false,
+		},
+		{
+			name: "security prefix is allowed since it does not match internal prefix literally",
+			key:  "security.agents.kruise.io/agent-name",
+			want: false,
+		},
+		{
+			name: "internal prefix without trailing path is allowed",
+			key:  "agents.kruise.io",
+			want: false,
+		},
+		{
+			name: "empty key is allowed",
+			key:  "",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsBlackListed(tt.key))
+		})
+	}
+}
+
+func TestFilterBlackListed(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]string
+		want  map[string]string
+	}{
+		{
+			name:  "nil input returns nil",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name:  "empty input returns nil",
+			input: map[string]string{},
+			want:  nil,
+		},
+		{
+			name: "all keys blacklisted returns nil",
+			input: map[string]string{
+				agentsv1alpha1.InternalPrefix + "claim-time": "now",
+				agentsv1alpha1.E2BPrefix + "template-id":     "tpl",
+			},
+			want: nil,
+		},
+		{
+			name: "user keys pass through",
+			input: map[string]string{
+				"team.example.com/owner": "alice",
+				"plain-key":              "v",
+			},
+			want: map[string]string{
+				"team.example.com/owner": "alice",
+				"plain-key":              "v",
+			},
+		},
+		{
+			name: "mixed keys keep only non-blacklisted ones",
+			input: map[string]string{
+				agentsv1alpha1.InternalPrefix + "claim-time": "now",
+				"security.agents.kruise.io/agent-name":       "agent",
+				"team.example.com/owner":                     "alice",
+			},
+			want: map[string]string{
+				"security.agents.kruise.io/agent-name": "agent",
+				"team.example.com/owner":               "alice",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, FilterBlackListed(tt.input))
+		})
+	}
+}

--- a/pkg/utils/inplaceupdate/inplace_update.go
+++ b/pkg/utils/inplaceupdate/inplace_update.go
@@ -203,6 +203,18 @@ func DefaultGeneratePatchBodyFunc(opts InPlaceUpdateOptions) string {
 		annotationsPatch[k] = v
 	}
 
+	// Propagate template annotations to the pod, mirroring the label
+	// propagation above. Only annotations whose values differ from the pod's
+	// current ones are patched. This is an additive strategic merge that never
+	// removes system-injected annotations (e.g., CNI status, in-place state).
+	if box.Spec.Template != nil {
+		for k, v := range box.Spec.Template.Annotations {
+			if pod.Annotations[k] != v {
+				annotationsPatch[k] = v
+			}
+		}
+	}
+
 	if len(labelsPatch) == 0 && len(annotationsPatch) == 0 && len(patchSpec.Containers) == 0 {
 		return ""
 	}

--- a/pkg/utils/inplaceupdate/inplace_update_test.go
+++ b/pkg/utils/inplaceupdate/inplace_update_test.go
@@ -2115,6 +2115,110 @@ func TestDefaultGeneratePatchBodyFunc_ExtensionAnnotations(t *testing.T) {
 	}
 }
 
+// TestDefaultGeneratePatchBodyFunc_TemplateAnnotations verifies that annotations
+// declared on the sandbox template are propagated to the pod, mirroring the
+// existing template-label propagation behavior.
+func TestDefaultGeneratePatchBodyFunc_TemplateAnnotations(t *testing.T) {
+	tests := []struct {
+		name                string
+		templateAnnotations map[string]string
+		podAnnotations      map[string]string
+		expectPatched       map[string]string
+		expectNotPatched    []string
+	}{
+		{
+			name:                "new template annotation is patched to pod",
+			templateAnnotations: map[string]string{"ansm.alibabacloud.com/dns-zone": "zone-a"},
+			podAnnotations:      nil,
+			expectPatched:       map[string]string{"ansm.alibabacloud.com/dns-zone": "zone-a"},
+		},
+		{
+			name:                "changed template annotation overrides pod value",
+			templateAnnotations: map[string]string{"ansm.alibabacloud.com/dns-zone": "zone-b"},
+			podAnnotations:      map[string]string{"ansm.alibabacloud.com/dns-zone": "zone-a"},
+			expectPatched:       map[string]string{"ansm.alibabacloud.com/dns-zone": "zone-b"},
+		},
+		{
+			name:                "annotation already in sync is not patched again",
+			templateAnnotations: map[string]string{"ansm.alibabacloud.com/dns-zone": "zone-a"},
+			podAnnotations:      map[string]string{"ansm.alibabacloud.com/dns-zone": "zone-a"},
+			expectNotPatched:    []string{"ansm.alibabacloud.com/dns-zone"},
+		},
+		{
+			name: "multiple template annotations propagate together",
+			templateAnnotations: map[string]string{
+				"ansm.alibabacloud.com/dns-zone":           "zone-a",
+				"ansm.alibabacloud.com/networkservicerule": "rule-1",
+			},
+			podAnnotations: nil,
+			expectPatched: map[string]string{
+				"ansm.alibabacloud.com/dns-zone":           "zone-a",
+				"ansm.alibabacloud.com/networkservicerule": "rule-1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			box := &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Annotations: tt.templateAnnotations},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "c", Image: "img:1"}},
+							},
+						},
+					},
+				},
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "p",
+					Namespace:   "default",
+					Annotations: tt.podAnnotations,
+					// Same revision so no image/resource/hash change is produced;
+					// only annotation propagation should drive the patch.
+					Labels: map[string]string{agentsv1alpha1.PodLabelTemplateHash: "rev-annot"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "img:1"}},
+				},
+			}
+
+			body := DefaultGeneratePatchBodyFunc(InPlaceUpdateOptions{
+				Box:      box,
+				Pod:      pod,
+				Revision: "rev-annot",
+			})
+
+			annotations := map[string]any{}
+			if body != "" {
+				var decoded map[string]any
+				if err := json.Unmarshal([]byte(body), &decoded); err != nil {
+					t.Fatalf("unmarshal patch: %v", err)
+				}
+				if metadata, ok := decoded["metadata"].(map[string]any); ok {
+					if a, ok := metadata["annotations"].(map[string]any); ok {
+						annotations = a
+					}
+				}
+			}
+
+			for k, v := range tt.expectPatched {
+				if annotations[k] != v {
+					t.Errorf("expected annotation %s=%s, got %v", k, v, annotations[k])
+				}
+			}
+			for _, k := range tt.expectNotPatched {
+				if _, exists := annotations[k]; exists {
+					t.Errorf("annotation %s already in sync should not be patched again", k)
+				}
+			}
+		})
+	}
+}
+
 func TestCheckResizeQoSChange(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
…plate

SandboxClaim annotations were only copied onto the Sandbox object, while labels were propagated to both the Sandbox and its pod template. Some annotations need to reach the pod template so the resulting Pod carries them, but propagating all of them would leak internal annotations (e.g. e2b/runtime tokens).

Add an allowlist-based propagation for pod-template annotations:

- Add GetPodAnnotations/SetPodAnnotations to the infra.Sandbox interface and sandboxcr.Sandbox, plus a MergePodAnnotations helper mirroring the existing pod-label handling.
- Introduce a pluggable allowlist in the sandboxclaim core package with RegisterPodPropagatableAnnotationKeys/Prefixes registration hooks so internal/enterprise code can extend it via init() without touching the propagation logic. Both exact-key and prefix matching are supported; the community default is empty (no annotation propagated).
- Wire filtered propagation into the claim Modifier so only allowlisted annotations are merged onto the pod template.

Covered by table-driven unit tests for the merge helper and the allowlist predicate/filter.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

