### PR TITLE
fix(peers): reconcile memberlist peers after split brain

### DIFF
--- a/pkg/peers/memberlist.go
+++ b/pkg/peers/memberlist.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -30,6 +32,7 @@ import (
 	"github.com/openkruise/agents/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -47,6 +50,10 @@ const (
 	DefaultSuspicionMult = 4
 	// DefaultRetransmitMult is the multiplier for the number of retransmissions
 	DefaultRetransmitMult = 4
+	// DefaultReconcileInterval keeps Kubernetes discovery as a low-frequency recovery backstop.
+	DefaultReconcileInterval = 60 * time.Second
+	// reconcileJitterFactor spreads Kubernetes list calls from concurrently started replicas.
+	reconcileJitterFactor = 0.1
 )
 
 type MemberlistPeers struct {
@@ -60,18 +67,23 @@ type MemberlistPeers struct {
 	config  *memberlist.Config
 	localIP string
 
-	started atomic.Bool
-	stopCh  chan struct{}
+	started  atomic.Bool
+	stopCh   chan struct{}
+	stopOnce sync.Once
+
+	reconcileInterval time.Duration
+	reconcileWG       sync.WaitGroup
 }
 
 // NewMemberlistPeers creates a new MemberlistPeers instance
 func NewMemberlistPeers(apiReader ctrlclient.Reader, nodeName string, namespace, peerSelector string) *MemberlistPeers {
 	return &MemberlistPeers{
-		apiReader:    apiReader,
-		sysNs:        namespace,
-		peerSelector: peerSelector,
-		localName:    nodeName,
-		stopCh:       make(chan struct{}),
+		apiReader:         apiReader,
+		sysNs:             namespace,
+		peerSelector:      peerSelector,
+		localName:         nodeName,
+		stopCh:            make(chan struct{}),
+		reconcileInterval: DefaultReconcileInterval,
 	}
 }
 
@@ -106,41 +118,9 @@ func (m *MemberlistPeers) Start(ctx context.Context, bindPort int) error {
 
 	// Get existing peers from Kubernetes API for initial join
 	log.Info("discovering existing peers for memberlist join", "localURL", localURL)
-	apiReader := m.apiReader
-	selector, err := labels.Parse(m.peerSelector)
+	existingPeers, err := m.discoverPeerAddresses(ctx, bindPort, localURL)
 	if err != nil {
-		return fmt.Errorf("failed to parse peer selector: %w", err)
-	}
-	peerList := &corev1.PodList{}
-	if err := apiReader.List(ctx, peerList, &ctrlclient.ListOptions{
-		Namespace:     m.sysNs,
-		LabelSelector: selector,
-	}); err != nil {
-		return fmt.Errorf("failed to list peer pods: %w", err)
-	}
-	log.Info("listed peers for memberlist join", "count", len(peerList.Items))
-
-	// Build list of existing peer IPs for initial join
-	existingPeers := make([]string, 0)
-	for _, peer := range peerList.Items {
-		// AnnotationMemberlistURL is generally not needed in production when all replicas use the same memberlist port.
-		// In scenarios like unit tests or single-host multi-replica deployments where a fixed port cannot be guaranteed
-		// for all replicas, this annotation can be used as a way to specify a custom address.
-		memberlistURL := peer.Annotations[agentsv1alpha1.AnnotationMemberlistURL]
-		if memberlistURL == "" {
-			ip := peer.Status.PodIP
-			if ip == "" {
-				log.Info("ignoring peer with empty IP", "ip", ip, "peer", klog.KObj(&peer))
-				continue
-			}
-			memberlistURL = fmt.Sprintf("%s:%d", ip, bindPort)
-		}
-		if memberlistURL == localURL {
-			continue
-		}
-		// Memberlist uses the bind port for gossip
-		existingPeers = append(existingPeers, memberlistURL)
-		log.Info("adding peer for memberlist join", "memberlistURL", memberlistURL, "pod", klog.KObj(&peer))
+		return err
 	}
 	log.Info("found existing peers for memberlist join", "count", len(existingPeers))
 
@@ -193,6 +173,11 @@ func (m *MemberlistPeers) Start(ctx context.Context, bindPort int) error {
 	}
 
 	m.started.Store(true)
+	m.reconcileWG.Add(1)
+	go func() {
+		defer m.reconcileWG.Done()
+		m.runPeerReconciliation(ctx, bindPort, localURL)
+	}()
 	log.Info("memberlist started", "addr", bindAddr, "port", bindPort, "name", m.localName)
 
 	return nil
@@ -204,7 +189,10 @@ func (m *MemberlistPeers) Stop() error {
 		return nil
 	}
 
-	close(m.stopCh)
+	m.stopOnce.Do(func() {
+		close(m.stopCh)
+	})
+	m.reconcileWG.Wait()
 
 	// Gracefully leave the cluster
 	if err := m.list.Leave(5 * time.Second); err != nil {
@@ -216,6 +204,121 @@ func (m *MemberlistPeers) Stop() error {
 	}
 
 	m.started.Store(false)
+	return nil
+}
+
+// discoverPeerAddresses lists the desired memberlist peers from Kubernetes.
+// Initial discovery and periodic reconciliation share this method so they use
+// identical namespace, selector, annotation, and address resolution rules.
+func (m *MemberlistPeers) discoverPeerAddresses(ctx context.Context, bindPort int, localURL string) ([]string, error) {
+	selector, err := labels.Parse(m.peerSelector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse peer selector: %w", err)
+	}
+
+	peerList := &corev1.PodList{}
+	if err := m.apiReader.List(ctx, peerList, &ctrlclient.ListOptions{
+		Namespace:     m.sysNs,
+		LabelSelector: selector,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to list peer pods: %w", err)
+	}
+
+	log := klog.FromContext(ctx)
+	addressSet := make(map[string]struct{}, len(peerList.Items))
+	for i := range peerList.Items {
+		peer := &peerList.Items[i]
+
+		// AnnotationMemberlistURL is generally not needed in production when all replicas use the same memberlist port.
+		// In scenarios like unit tests or single-host multi-replica deployments where a fixed port cannot be guaranteed
+		// for all replicas, this annotation can be used as a way to specify a custom address.
+		memberlistURL := peer.Annotations[agentsv1alpha1.AnnotationMemberlistURL]
+		if memberlistURL == "" {
+			if peer.Status.PodIP == "" {
+				log.V(4).Info("ignoring peer with empty IP", "peer", klog.KObj(peer))
+				continue
+			}
+			memberlistURL = fmt.Sprintf("%s:%d", peer.Status.PodIP, bindPort)
+		}
+		if memberlistURL == localURL {
+			continue
+		}
+		addressSet[memberlistURL] = struct{}{}
+	}
+
+	addresses := make([]string, 0, len(addressSet))
+	for address := range addressSet {
+		addresses = append(addresses, address)
+	}
+	sort.Strings(addresses)
+	return addresses, nil
+}
+
+// runPeerReconciliation periodically rediscovers peer addresses so a failed
+// initial join or a healed network partition does not leave permanent split-brain clusters.
+func (m *MemberlistPeers) runPeerReconciliation(ctx context.Context, bindPort int, localURL string) {
+	interval := m.reconcileInterval
+	if interval <= 0 {
+		interval = DefaultReconcileInterval
+	}
+	timer := time.NewTimer(wait.Jitter(interval, reconcileJitterFactor))
+	defer timer.Stop()
+
+	log := klog.FromContext(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-m.stopCh:
+			return
+		case <-timer.C:
+			if err := m.reconcilePeers(ctx, bindPort, localURL); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				log.Error(err, "failed to reconcile memberlist peers")
+			}
+			timer.Reset(wait.Jitter(interval, reconcileJitterFactor))
+		}
+	}
+}
+
+// reconcilePeers rejoins desired Kubernetes peers that are not currently alive.
+func (m *MemberlistPeers) reconcilePeers(ctx context.Context, bindPort int, localURL string) error {
+	if !m.started.Load() || m.list == nil {
+		return fmt.Errorf("memberlist not started")
+	}
+
+	desiredPeers, err := m.discoverPeerAddresses(ctx, bindPort, localURL)
+	if err != nil {
+		return err
+	}
+
+	alivePeers := make(map[string]struct{})
+	for _, member := range m.list.Members() {
+		if member.State != memberlist.StateAlive {
+			continue
+		}
+		alivePeers[fmt.Sprintf("%s:%d", member.Addr.String(), member.Port)] = struct{}{}
+	}
+
+	missingPeers := make([]string, 0, len(desiredPeers))
+	for _, address := range desiredPeers {
+		if _, alive := alivePeers[address]; !alive {
+			missingPeers = append(missingPeers, address)
+		}
+	}
+	if len(missingPeers) == 0 {
+		return nil
+	}
+
+	log := klog.FromContext(ctx)
+	log.Info("reconciling memberlist peers", "count", len(missingPeers), "peers", missingPeers)
+	joined, err := m.list.Join(missingPeers)
+	if err != nil {
+		return fmt.Errorf("failed to join discovered memberlist peers after joining %d: %w", joined, err)
+	}
+	log.Info("reconciled memberlist peers", "joined", joined)
 	return nil
 }
 

--- a/pkg/peers/memberlist_test.go
+++ b/pkg/peers/memberlist_test.go
@@ -18,14 +18,35 @@ package peers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func addDiscoveredPeerPod(t *testing.T, ctx context.Context, c client.Client, name string, port int) {
+	t.Helper()
+	require.NoError(t, c.Create(ctx, &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: Namespace,
+			Labels: map[string]string{
+				LabelSelectorKey: LabelSelectorValue,
+			},
+			Annotations: map[string]string{
+				agentsv1alpha1.AnnotationMemberlistURL: fmt.Sprintf("127.0.0.1:%d", port),
+			},
+		},
+		Status: v1.PodStatus{PodIP: "127.0.0.1"},
+	}))
+}
 
 // TestMemberlistPeers_Start_Stop tests basic start and stop functionality
 func TestMemberlistPeers_Start_Stop(t *testing.T) {
@@ -270,4 +291,129 @@ func TestMemberlistPeers_Join_PartialFailure(t *testing.T) {
 	defer func() { _ = peer.Stop() }()
 
 	assert.True(t, peer.started.Load())
+}
+
+func TestMemberlistPeers_DiscoverPeerAddresses(t *testing.T) {
+	const (
+		bindPort = 7946
+		localURL = "10.0.0.1:7946"
+	)
+
+	tests := []struct {
+		name string
+		pod  v1.Pod
+		want []string
+	}{
+		{
+			name: "pod IP uses bind port",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "peer-ip",
+					Namespace: Namespace,
+					Labels:    map[string]string{LabelSelectorKey: LabelSelectorValue},
+				},
+				Status: v1.PodStatus{PodIP: "10.0.0.2"},
+			},
+			want: []string{"10.0.0.2:7946"},
+		},
+		{
+			name: "annotation overrides pod IP",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "peer-annotation",
+					Namespace:   Namespace,
+					Labels:      map[string]string{LabelSelectorKey: LabelSelectorValue},
+					Annotations: map[string]string{agentsv1alpha1.AnnotationMemberlistURL: "peer.example:9000"},
+				},
+				Status: v1.PodStatus{PodIP: "10.0.0.3"},
+			},
+			want: []string{"peer.example:9000"},
+		},
+		{
+			name: "empty pod IP is ignored",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "peer-pending",
+					Namespace: Namespace,
+					Labels:    map[string]string{LabelSelectorKey: LabelSelectorValue},
+				},
+			},
+			want: []string{},
+		},
+		{
+			name: "local address is ignored",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "self",
+					Namespace:   Namespace,
+					Labels:      map[string]string{LabelSelectorKey: LabelSelectorValue},
+					Annotations: map[string]string{agentsv1alpha1.AnnotationMemberlistURL: localURL},
+				},
+				Status: v1.PodStatus{PodIP: "10.0.0.1"},
+			},
+			want: []string{},
+		},
+		{
+			name: "selector mismatch is ignored",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unrelated",
+					Namespace: Namespace,
+					Labels:    map[string]string{LabelSelectorKey: "false"},
+				},
+				Status: v1.PodStatus{PodIP: "10.0.0.4"},
+			},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).WithObjects(&tt.pod).Build()
+			peer := NewMemberlistPeers(fc, "self", Namespace, LabelSelector)
+
+			got, err := peer.discoverPeerAddresses(t.Context(), bindPort, localURL)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMemberlistPeers_ReconcilesSplitBrain(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	client1 := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()
+	client2 := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()
+
+	peer1, port1, err := CreateTestPeer(ctx, client1, "reconcile-node-1")
+	require.NoError(t, err)
+	peer2, port2, err := CreateTestPeer(ctx, client2, "reconcile-node-2")
+	require.NoError(t, err)
+
+	// Each node initially discovers only itself, creating two independent memberlist clusters.
+	peer1.reconcileInterval = 20 * time.Millisecond
+	peer2.reconcileInterval = 20 * time.Millisecond
+	require.NoError(t, peer1.Start(ctx, port1))
+	require.NoError(t, peer2.Start(ctx, port2))
+	t.Cleanup(func() {
+		cancel()
+		_ = peer1.Stop()
+		_ = peer2.Stop()
+	})
+	require.Empty(t, peer1.GetPeers())
+	require.Empty(t, peer2.GetPeers())
+
+	// Kubernetes now exposes both desired peers to each partition. Periodic
+	// reconciliation should provide the missing join addresses and heal the split.
+	addDiscoveredPeerPod(t, ctx, client1, "reconcile-node-2", port2)
+	addDiscoveredPeerPod(t, ctx, client2, "reconcile-node-1", port1)
+
+	require.Eventually(t, func() bool {
+		return len(peer1.GetPeers()) == 1 && len(peer2.GetPeers()) == 1
+	}, 5*time.Second, 50*time.Millisecond)
+	assert.Equal(t, "reconcile-node-2", peer1.GetPeers()[0].Name)
+	assert.Equal(t, "reconcile-node-1", peer2.GetPeers()[0].Name)
+
+	// Reconciling an already healthy cluster is a no-op.
+	require.NoError(t, peer1.reconcilePeers(ctx, port1, fmt.Sprintf("127.0.0.1:%d", port1)))
+	assert.Len(t, peer1.GetPeers(), 1)
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
This PR enables `MemberlistPeers` to recover from split-brain scenarios caused by a failed initial join or a healed network partition.

Currently, Kubernetes peer discovery and `memberlist.Join` only run during startup. If the initial join fails, the process continues as a standalone memberlist node and never rediscovers its intended peers. Likewise, disconnected memberlist partitions have no Kubernetes-backed path to rejoin after connectivity recovers.

The change:
- Reuses the existing namespace, label selector, Pod IP, and `AnnotationMemberlistURL` rules for both initial discovery and reconciliation.
- Rediscovers desired peer addresses every 60 seconds with 10% jitter to spread Kubernetes API requests across replicas.
- Calls `memberlist.Join` only for desired peers that are not currently alive.
- Stops and waits for the reconciliation goroutine before memberlist shutdown.

Normal membership detection remains handled by memberlist gossip and push/pull. The periodic Kubernetes lookup is only a low-frequency recovery backstop.

### Ⅱ. Does this pull request fix one issue?
Refs #413

This implements the split-brain scope confirmed by the maintainer in https://github.com/openkruise/agents/issues/413#issuecomment-4978172819. It intentionally does not include the route-sync transport, retry, or fan-out changes originally discussed in the issue.

### Ⅲ. Describe how to verify it
The following focused validations pass with Go 1.25.0:

1. `go test ./pkg/peers -count=1`
2. `go test -race ./pkg/peers -count=1`
3. `go test ./pkg/peers -run '^TestMemberlistPeers_ReconcilesSplitBrain$' -count=10`

The new tests cover:
- Existing Pod IP and annotation-based memberlist address resolution.
- Ignoring the local node, empty Pod IPs, and selector mismatches.
- Two initially isolated memberlist nodes automatically converging after Kubernetes exposes each peer to the other partition.
- Healthy peer reconciliation remaining a no-op.

### Ⅳ. Special notes for reviews
- The change is limited to `pkg/peers/memberlist.go` and `pkg/peers/memberlist_test.go`.
- No public interface, command-line option, or sandbox-manager/gateway wiring changes are introduced.
- The commit is signed off.
