### PR TITLE
docs(proposal): add agent-runtime component and helper-mode proposals

### DIFF
--- a/docs/proposals/20260708-agent-runtime-helper-mode.md
+++ b/docs/proposals/20260708-agent-runtime-helper-mode.md
@@ -1,0 +1,392 @@
+---
+title: Agent Runtime Helper Mode (in-container helper over socket)
+authors:
+  - "@jicheng"
+reviewers:
+  - "@TBD"
+creation-date: 2026-07-08
+last-updated: 2026-07-20
+status: implementable
+see-also:
+  - "/docs/proposals/20260720-agent-runtime-component.md"
+  - "/docs/proposals/20251218-sandbox-inplace-update.md"
+---
+
+# Agent Runtime Helper Mode (in-container helper over socket)
+
+## Table of Contents
+
+- [Agent Runtime Helper Mode (in-container helper over socket)](#agent-runtime-helper-mode-in-container-helper-over-socket)
+  - [Table of Contents](#table-of-contents)
+  - [Glossary](#glossary)
+  - [Summary](#summary)
+  - [Motivation](#motivation)
+    - [Goals](#goals)
+    - [Non-Goals/Future Work](#non-goalsfuture-work)
+  - [Current State](#current-state)
+    - [Mode Selection](#mode-selection)
+    - [Executor Abstraction and Sidecar Delegation](#executor-abstraction-and-sidecar-delegation)
+  - [Proposal](#proposal)
+    - [Architecture Overview](#architecture-overview)
+    - [User Stories](#user-stories)
+    - [Design Decisions](#design-decisions)
+      - [D1. Transport: UNIX Domain Socket over shared emptyDir](#d1-transport-unix-domain-socket-over-shared-emptydir)
+      - [D2. Protocol: reuse connectrpc](#d2-protocol-reuse-connectrpc)
+      - [D3. State ownership: Fat Helper + sidecar relay](#d3-state-ownership-fat-helper--sidecar-relay)
+      - [D4. Mode selection: explicit `--runtime-mode` (local | helper)](#d4-mode-selection-explicit---runtime-mode-local--helper)
+      - [D5. Helper delivery and lifecycle](#d5-helper-delivery-and-lifecycle)
+      - [D6. cgroup: native placement](#d6-cgroup-native-placement)
+      - [D7. Security](#d7-security)
+      - [D8. Helper interface scope](#d8-helper-interface-scope)
+    - [Component Changes](#component-changes)
+    - [Requirements](#requirements)
+      - [Functional Requirements](#functional-requirements)
+      - [Non-Functional Requirements](#non-functional-requirements)
+    - [Risks and Mitigations](#risks-and-mitigations)
+  - [Alternatives](#alternatives)
+  - [Upgrade Strategy](#upgrade-strategy)
+  - [Test Plan](#test-plan)
+  - [Implementation Plan (Phased)](#implementation-plan-phased)
+  - [Implementation History](#implementation-history)
+
+## Glossary
+
+- **agent-runtime**: The runtime service that exposes E2B/envd-compatible OpenAPI, process, and filesystem
+  capabilities. Located at `pkg/agent-runtime`.
+- **Local mode**: agent-runtime runs directly inside the business container and executes operations natively.
+- **Helper mode**: agent-runtime runs as a sidecar (control plane) while a lightweight `agent-helper` process runs
+  inside the business container (data plane). They communicate over a UNIX domain socket.
+- **agent-helper**: The lightweight in-container data-plane binary used only in helper mode
+  (`cmd/agent-helper`, `pkg/agent-runtime/helper`).
+- **Executor**: A per-service abstraction (`ProcessExecutor`, `FilesystemExecutor`, `MountExecutor`) that isolates the
+  deployment-mode-specific execution strategy.
+
+## Summary
+
+agent-runtime supports a Local mode, where it runs directly inside the business container and executes every operation
+natively. Local mode has the best execution fidelity but mixes the control plane with the workload and is intrusive to
+the user image.
+
+This proposal introduces **Helper mode**, the second supported mode alongside Local. The agent-runtime control plane
+(HTTP/HTTPS serving, auth, TLS, routing, streaming relay) stays in the sidecar, while a lightweight `agent-helper` binary
+runs inside the business container and performs the actual process / filesystem / file-transfer / cgroup / metrics /
+port-forward operations natively. The sidecar and the helper communicate over a UNIX domain socket placed on a shared
+`emptyDir` volume, using the existing connectrpc service specs.
+
+Helper mode combines the **execution fidelity of Local mode** (native `os/exec`, native cgroup FD placement, native
+user DB and filesystem view) with the **control-plane isolation of a sidecar**: the control plane runs in a
+non-privileged sidecar while user workloads still execute with native fidelity in the business container, with no need
+for `CAP_SYS_ADMIN` or host PID visibility.
+
+## Motivation
+
+Local mode runs the full agent-runtime inside the business container. It executes with native fidelity but has
+structural drawbacks:
+
+- It is intrusive to the user image: the runtime control plane (HTTP serving, auth, TLS) is co-located with the user's
+  workload, enlarging the trust and failure surface inside the business container.
+- It couples the control plane with the workload lifecycle, so runtime upgrades and workload changes cannot evolve
+  independently.
+
+Helper mode resolves this by keeping the control plane in a **non-privileged sidecar** while running a small native
+**data-plane** process (`agent-helper`) inside the business container. This preserves local-mode execution fidelity
+(native `os/exec`, native cgroup FD placement, native filesystem/user view — hence gzip/Range file transfer, race-free
+cgroup placement, and atomic freeze) while isolating the control plane, and without granting the sidecar any elevated
+privileges. The executor interfaces already anticipate a future executor (the code comments mention
+`(Future) CRIExecutor: execution via CRI API (DaemonSet)`), so the abstraction cost is low.
+
+## Current State
+
+### Mode Selection
+
+Mode is selected by the `--runtime-mode` flag (`cmd/agent-runtime/options/flag.go`, `parser.go`):
+
+- `local` (default) → agent-runtime executes the data plane natively in this container.
+- `helper` → agent-runtime delegates the data plane to the in-container helper over the UDS at `--helper-socket`.
+
+The related flags are `--helper-socket` (default `/var/run/agent-helper/helper.sock`) and `--helper-ready-timeout`
+(default `120s`). `ServerConfig` (`pkg/agent-runtime/server.go`) carries `RuntimeMode`, `HelperSocket`,
+`HelperReadyTimeout`, and exposes `IsHelperMode()`. There are exactly two modes: `local` and `helper`.
+
+### Executor Abstraction and Sidecar Delegation
+
+Data-plane services keep a consistent executor abstraction so mode selection is a wiring decision:
+
+- Process: `ProcessExecutor` → `LocalExecutor` (`pkg/agent-runtime/services/process/executor.go`).
+- Filesystem: `FilesystemExecutor` → `LocalFilesystemExecutor` (`pkg/agent-runtime/services/filesystem/executor.go`).
+- Mount: `MountExecutor` → `LocalMountExecutor` / `HelperMountExecutor`
+  (`pkg/agent-runtime/openapi/extendedapi/mount_executor.go`).
+
+In helper mode the sidecar wires the delegation in `pkg/agent-runtime/routers.go` and reaches the helper through
+`pkg/agent-runtime/helperclient`. Rather than one typed executor per service, delegation takes two shapes:
+
+- **Process and Filesystem** are relayed with a **transparent connectrpc reverse-proxy** (`helperclient.NewReverseProxy`,
+  mounted at the spec path prefixes in `mountHelperProxy`). Both sides serve the identical specs, so unary and streaming
+  RPCs relay unchanged.
+- **FileIO, Freeze, and Metrics** are reached through **typed connectrpc clients** on `helperclient.Client`; the native
+  API handlers and `pickFreezer` consume them (`FileIOClient`, `Freezer()`, `MetricsProvider()`).
+
+cgroup management uses `Cgroup2Manager` (with a `NoopManager` fallback), wired in `cmd/agent-runtime/main.go` (local) and
+`cmd/agent-helper/main.go` (helper).
+
+## Proposal
+
+### Architecture Overview
+
+```mermaid
+graph TB
+    Client[External Client E2B SDK] -->|HTTP/HTTPS + Bearer/Signing| SC
+
+    subgraph Pod
+        subgraph Sidecar[sidecar container: agent-runtime]
+            SC[Gin Server: auth / TLS / routing / stream relay]
+            RP[reverse-proxy: process / filesystem]
+            TC[typed clients: fileio / freeze / metrics]
+            CSI[CSI socket / mount-root]
+            SC --> RP
+            SC --> TC
+        end
+
+        subgraph Biz[business container]
+            HP[agent-helper: connectrpc over UDS]
+            SVC[process / filesystem / fileio / freeze / metrics / port]
+            HP --> SVC
+            SVC --> NAT[native exec / filesystem / cgroup / socat]
+        end
+
+        SOCK[(shared emptyDir: helper.sock)]
+        RP -->|connectrpc over UDS| SOCK
+        TC -->|connectrpc over UDS| SOCK
+        SOCK --> HP
+    end
+```
+
+- The sidecar keeps: HTTP/HTTPS serving, auth (Bearer/Signing), CORS, routing, streaming relay, the `/init` state
+  machine, and the CSI mount socket + mount-root discovery.
+- The helper performs: process spawn/signal/stdin/PTY, filesystem operations, file byte read/write (fileio), cgroup
+  placement and freeze/thaw, metrics sampling, and port-forward socat — all natively inside the business container.
+- The transport is a UNIX domain socket on an `emptyDir` volume shared by both containers. The helper also serves a
+  plain `GET /health` on the same socket for readiness and exec-probe use.
+
+### User Stories
+
+- As a platform operator, I want to run the runtime control plane in a non-privileged sidecar while still executing
+  user workloads with native fidelity, so I can avoid granting `CAP_SYS_ADMIN` to the sidecar.
+- As a sandbox user, I want file upload/download to support gzip and Range and processes to be placed into the correct
+  cgroup without races, even when the runtime is deployed as a sidecar.
+
+### Design Decisions
+
+#### D1. Transport: UNIX Domain Socket over shared emptyDir
+
+Use a UNIX domain socket (default `/var/run/agent-helper/helper.sock`) on an `emptyDir` volume mounted into both the
+sidecar and the business container. The helper creates the socket directory with mode `0700` and the socket file with
+mode `0600` (`pkg/agent-runtime/helper/server.go`).
+
+- Pros: filesystem-permission based access control, no port conflicts, naturally scoped to the Pod.
+- Alternative: loopback TCP (Pod containers share the network namespace). Simpler but any process in the business
+  container can reach the port, weaker security, and requires port management. Kept as an optional fallback.
+
+#### D2. Protocol: reuse connectrpc
+
+The helper implements the existing connectrpc service specs over the UDS, served via `h2c` (cleartext HTTP/2) so
+client- and server-streaming work. The sidecar reaches them either as connectrpc clients (fileio/freeze/metrics) or via
+a transparent reverse-proxy (process/filesystem).
+
+- Reuses existing protobuf specs; no new wire protocol.
+- Native support for server-streaming (`ConnectToProcess`, `WatchDir`) and client-streaming (`StreamInput`, fileio
+  `WriteFile`) that relays transparently (the reverse-proxy sets `FlushInterval = -1`).
+- Lets the helper reuse the existing local service implementations almost verbatim.
+
+#### D3. State ownership: Fat Helper + sidecar relay
+
+The helper owns the process map, PTY, and streaming state (it is effectively a minimal agent-runtime running the
+process + filesystem + fileio + freeze + metrics + port services in "local" execution mode, exposed over the UDS). For
+process and filesystem the sidecar is a transparent reverse-proxy; for fileio/freeze/metrics it uses typed clients.
+
+- Rejected alternative "Thin Helper" (helper exposes low-level primitives, sidecar holds the process map): would
+  require tunneling stdout/stderr streams back to the sidecar, which is complex and error prone.
+
+#### D4. Mode selection: explicit `--runtime-mode` (local | helper)
+
+The mode is a two-state flag:
+
+```
+--runtime-mode = local | helper        (default: local)
+--helper-socket = /var/run/agent-helper/helper.sock
+--helper-ready-timeout = 120s
+```
+
+`ServerConfig` carries `RuntimeMode`, `HelperSocket`, `HelperReadyTimeout` and `IsHelperMode()`. Service wiring branches
+on helper mode in `routers.go` (reverse-proxy + typed clients). There are exactly two modes, `local` and `helper`.
+
+#### D5. Helper delivery and lifecycle
+
+The helper runs as a process inside the business container. Delivery and launch:
+
+- Binary delivery + launch: the container image entrypoint (`cmd/agent-runtime/entrypoint.sh` and its internal
+  counterpart `entrypoint_inner.sh`) selects a topology via `RUNTIME_MODE` (`envd` | `local` | `helper`, default
+  `envd`). In `helper` mode it stages `agent-helper` (and `envd-run.sh`) into the shared `ENVD_DIR` for the business
+  container, then `exec`s agent-runtime as the sidecar control plane with `--runtime-mode=helper`.
+- Readiness: at startup the sidecar blocks on `helperclient.WaitReady`, which probes `GET /health` over the UDS with
+  exponential backoff until the socket serves or `--helper-ready-timeout` elapses (`cmd/agent-runtime/main.go`).
+- Crash/restart: process state lives in the helper; a helper restart loses it (equivalent to a container restart and
+  acceptable). The reverse-proxy returns `502 Bad Gateway` on a broken relay; freeze returns `503` when no freezer is
+  available, so callers see a clear error instead of hanging.
+- Injection (future): automated injection of the shared `emptyDir`, the helper launch (postStart or `envd-run.sh`), the
+  exec-probe wiring, and RBAC via the controller/webhook is not yet implemented and is tracked as a separate phase.
+
+#### D6. cgroup: native placement
+
+Because the helper runs natively in the business container, it uses `Cgroup2Manager` with `CLONE_INTO_CGROUP` FD
+placement directly, falling back to `NoopManager` when cgroup v2 is unavailable. The same manager satisfies the
+`Freezer` contract, so the Freeze service drives `cgroup.freeze` on exactly the cgroups the helper placed processes
+into. Placement is atomic (no `echo $$ > cgroup.procs` race) and freeze is applied without per-type races. Freeze/thaw
+and metrics are read/written natively by the helper.
+
+#### D7. Security
+
+The helper's goal is that it can only be invoked by the agent-runtime sidecar in the same Pod. Because the business
+container's main process may run under the same uid as the sidecar, UDS file permissions alone cannot block a same-uid
+impostor, so a layered defense is used:
+
+- Auth stays terminated at the sidecar (Bearer/Signing unchanged); the helper trusts only the UDS peer.
+- Transport: the helper listens only on the UDS and exposes no network port; the socket lives on a private path, dir
+  mode `0700`, socket mode `0600`.
+- Peer verification: on accept, the helper reads the peer uid via `SO_PEERCRED` (`peercred_linux.go`) and rejects
+  connections whose uid is not in the `--allowed-peer-uid` allowlist. The check is **uid-only** by design — the kernel
+  fills the uid at connect time and it cannot be forged, and it is stable across restarts; pid is intentionally not
+  pinned because pids are recycled and would break legitimate reconnection after an agent-runtime restart.
+- Fail-open where enforcement is impossible: when the allowlist is empty (not yet wired by the controller) or the
+  platform cannot read peer credentials (non-Linux; `peercred_other.go`), the connection is allowed but logged so the
+  gap stays observable.
+- Capability boundary: the helper strictly inherits the business container's runtime identity and never elevates
+  privileges; over-privileged operations fail natively (EPERM) and are propagated faithfully, without fallback or
+  simulation.
+- Application-layer shared secret (future/optional): an internal token between sidecar and helper to further defend
+  against same-uid impersonation is not implemented yet.
+
+#### D8. Helper interface scope
+
+The helper is primarily a data plane (connectrpc over UDS). It hosts no HTTP business endpoints (auth/signing/TLS/CORS/
+routing all stay in the sidecar), with one exception: a plain `GET /health` used purely for reachability. The decision
+criterion is "must the real execution behind an endpoint happen inside the business container".
+
+The helper implements (native data-plane capabilities inside the business container):
+
+- connectrpc Process service: List / Start / Connect / Update / StreamInput / SendInput / SendSignal.
+- connectrpc Filesystem service: Stat / MakeDir / Move / ListDir / Remove / WatchDir / CreateWatcher /
+  GetWatcherEvents / RemoveWatcher.
+- connectrpc FileIO service: byte read/write (ranged `ReadFile`, streamed `WriteFile`), `Compose`, and `CreateSymlink`
+  — backing `GET /files`, `POST /files`, `POST /files/compose`, and the mount symlink (signing stays in the sidecar).
+- connectrpc Freeze service: native cgroup freeze/unfreeze backing `/freeze`, `/unfreeze`, and `/init` deferred thaw.
+- connectrpc Metrics service: native metrics reading backing `/metrics`.
+- connectrpc PortForward control service (`ListPorts`/`WatchPorts`/`OpenPort`/`ClosePort`) plus the autonomous port
+  scanner+forwarder; the socat data plane never crosses the UDS. It is mounted only when port scanning is enabled.
+- Plain `GET /health` for readiness/exec-probe reachability (not a connectrpc method).
+
+The helper does not implement (all stay in the sidecar):
+
+- `POST /init`: auth/token/env/user/workdir are control-plane responsibilities; only its freeze/unfreeze side effects
+  are delegated to the helper.
+- `GET /envs`: data comes from the sidecar's in-memory `Defaults.EnvVars`, unrelated to the business container.
+- Auth (Bearer/Signing), TLS, CORS, routing, and the HTTP-level file transfer (gzip/Range/multipart) which the sidecar
+  rebuilds on top of the helper's identity byte stream.
+
+In one line: the helper is a minimal agent-runtime running the process + filesystem + fileio + freeze + metrics + port
+connectrpc services in "local" mode (plus a bare health endpoint), exposed over the UDS; the sidecar degenerates into a
+transparent proxy (process/filesystem) and typed client (fileio/freeze/metrics) for these services.
+
+### Component Changes
+
+| Component | Change | Status |
+|---|---|---|
+| `cmd/agent-runtime/options` | Add `--runtime-mode` (local\|helper), `--helper-socket`, `--helper-ready-timeout`. | done |
+| `pkg/agent-runtime/server.go` (`ServerConfig`) | Add `RuntimeMode`, `HelperSocket`, `HelperReadyTimeout`, `IsHelperMode()`. | done |
+| `pkg/agent-runtime/routers.go` | Helper-mode wiring: reverse-proxy process/filesystem; `pickFreezer`/`pickMountExecutor`; typed fileio/metrics clients. | done |
+| **new** `pkg/agent-runtime/helperclient` | UDS-dialing connectrpc clients (FileIO/Freeze/Metrics), reverse-proxy, freezer/metrics adapters, `WaitReady`. | done |
+| **new** `pkg/agent-runtime/services/fileio` | Native byte transfer service (ReadFile/WriteFile/Compose/CreateSymlink). | done |
+| **new** `pkg/agent-runtime/services/freeze` | Native cgroup freeze/thaw service with serialization lock. | done |
+| **new** `pkg/agent-runtime/services/metrics` | Native CPU/memory/disk sampling service. | done |
+| `pkg/agent-runtime/services/port` | Autonomous scanner+forwarder and PortForward control service. | done |
+| `pkg/agent-runtime/openapi/extendedapi` (mount) | CSI socket + mount-root stay in the sidecar; symlink delegated via `HelperMountExecutor` → helper FileIO. | done |
+| `pkg/agent-runtime/openapi/nativeapi` | `/files*` byte transfer via `FileIOClient`; `/metrics` via helper `MetricsProvider`; freeze via helper `Freezer`. | done |
+| **new** `cmd/agent-helper/main.go` + `pkg/agent-runtime/helper/` | Helper server on the UDS (process/filesystem/fileio/freeze/metrics/port + `GET /health`), SO_PEERCRED uid allowlist, `health` exec-probe subcommand. | done |
+| `cmd/agent-runtime/entrypoint*.sh` | `RUNTIME_MODE` staging/launch for envd\|local\|helper. | done |
+| **new (later phase)** `pkg/controller`, `pkg/webhook`, deploy manifests | Inject and launch the helper; add the shared `emptyDir` volume, exec probe, and RBAC. | future |
+
+### Requirements
+
+#### Functional Requirements
+
+- FR1: A `helper` runtime mode is selectable via `--runtime-mode=helper`.
+- FR2: In helper mode, process, filesystem, file transfer, freeze, metrics, mount symlink, and port-forward operations
+  execute inside the business container namespaces via the helper.
+- FR3: The sidecar terminates auth/TLS and relays streaming RPCs to the helper transparently.
+- FR4: Existing Local behavior is unchanged when `--runtime-mode` is not set to `helper`.
+
+#### Non-Functional Requirements
+
+- NFR1: The sidecar requires no elevated privileges (no `CAP_SYS_ADMIN`, no host PID visibility) in helper mode.
+- NFR2: File transfer supports gzip and HTTP Range in both modes; the helper streams identity bytes and the sidecar
+  rebuilds encoding/Range/Content-Length on top.
+- NFR3: The sidecar handles helper unavailability gracefully (bounded readiness wait, reverse-proxy `502`, freeze `503`).
+- NFR4: The helper never elevates privileges and only serves the authorized sidecar uid (SO_PEERCRED allowlist).
+
+### Risks and Mitigations
+
+- Helper injection ownership (controller/webhook vs `envd-run.sh`) is a cross-component concern; align with the
+  controller owners before implementing the injection phase.
+- The SO_PEERCRED allowlist currently fails open when unset; until the controller wires `--allowed-peer-uid`, same-uid
+  isolation relies on socket permissions only. Track wiring the allowlist as part of the injection phase.
+- Shared `emptyDir` + UDS permissions must match the business container's runtime user; validate uid/gid mapping.
+- PTY/streaming over UDS: verify connectrpc server-streaming backpressure and keepalive behavior end to end.
+- Mount boundary: the CSI socket + mount-root live in the sidecar while the symlink is created in the business container
+  via the helper; keep this split explicit as mount features evolve.
+
+## Alternatives
+
+- **Local mode only**: retains the intrusiveness and control/data-plane coupling that motivate this proposal.
+- **Thin Helper (primitives only)**: rejected in D3 due to stream-tunneling complexity.
+- **Loopback TCP transport**: rejected as the default in D1 for security; retained as an optional fallback.
+- **Typed HelperExecutor per service** (original design): superseded for process/filesystem by the transparent
+  reverse-proxy, which avoids re-implementing streaming relay; typed clients are retained for fileio/freeze/metrics.
+
+## Upgrade Strategy
+
+- The default `--runtime-mode` is `local` and the default `RUNTIME_MODE` is `envd`, so existing deployments require no
+  change.
+- Opting in requires `RUNTIME_MODE=helper` (entrypoint) / `--runtime-mode=helper` (server), adding the shared
+  `emptyDir` volume, and launching `agent-helper` in the business container.
+- The external port and API contract are unchanged across modes, so clients (SDK, gateway, sandbox-manager) need no
+  changes.
+
+## Test Plan
+
+- Unit tests for the helper server endpoints (`pkg/agent-runtime/helper`), the SO_PEERCRED listener (with an injected
+  `peerUID`), the health handler/`CheckHealth`, and the helperclient (reverse-proxy, freezer/metrics adapters,
+  `WaitReady`) against a fake UDS connectrpc server. Table-driven per repo convention.
+- Unit tests for mode selection and config (`IsHelperMode`) and the mount executor helper branch.
+- Integration test: sidecar + helper over a real UDS covering process start/connect/signal/stdin/PTY resize, filesystem
+  CRUD + watch, file upload/download (gzip/Range), compose, freeze/unfreeze, metrics, and port forward.
+- E2E test extending `test/e2e` to cover the helper deployment topology.
+
+## Implementation Plan (Phased)
+
+- PR1 (done): `--runtime-mode` (local|helper) + `ServerConfig` fields + `helperclient` UDS client/readiness wait.
+- PR2 (done): `cmd/agent-helper` + `pkg/agent-runtime/helper` connectrpc server (process/filesystem) reusing the local
+  implementations.
+- PR3 (done): process/filesystem transparent reverse-proxy relay + end-to-end wiring (including PTY/streaming).
+- PR4 (done): fileio/freeze/metrics services + typed helper clients + native API delegation.
+- PR5 (done): mount symlink helper branch, port scanner/forwarder + PortForward control service, health endpoint +
+  `agent-helper health` exec probe, SO_PEERCRED uid allowlist.
+- PR6 (future, cross-component): controller/webhook injection of helper delivery and launch, shared `emptyDir`, exec
+  probe, RBAC + deploy manifests; wire `--allowed-peer-uid`.
+
+## Implementation History
+
+- [ ] 2026-07-08: Initial draft.
+- [x] 2026-07-20: Updated to reflect the implemented design — `local|helper` two-state mode, transparent reverse-proxy
+  for process/filesystem plus typed fileio/freeze/metrics clients, helper fileio/freeze/metrics/port services, plain
+  `GET /health` + `agent-helper health` exec probe, and uid-only SO_PEERCRED allowlist with fail-open. Controller/webhook
+  injection remains the outstanding phase.

--- a/docs/proposals/20260720-agent-runtime-component.md
+++ b/docs/proposals/20260720-agent-runtime-component.md
@@ -1,0 +1,423 @@
+---
+title: Agent Runtime (envd-compatible in-sandbox runtime)
+authors:
+  - "@jicheng"
+reviewers:
+  - "@TBD"
+creation-date: 2026-07-20
+last-updated: 2026-07-20
+status: implementable
+see-also:
+  - "/docs/proposals/20260708-agent-runtime-helper-mode.md"
+  - "/docs/proposals/20260608-dynamic-csi-mount.md"
+  - "/docs/proposals/20260702-sandbox-otel-distributed-tracing-en.md"
+---
+
+# Agent Runtime (envd-compatible in-sandbox runtime)
+
+## Table of Contents
+
+- [Agent Runtime (envd-compatible in-sandbox runtime)](#agent-runtime-envd-compatible-in-sandbox-runtime)
+  - [Table of Contents](#table-of-contents)
+  - [Glossary](#glossary)
+  - [Summary](#summary)
+  - [Motivation](#motivation)
+    - [Goals](#goals)
+    - [Non-Goals/Future Work](#non-goalsfuture-work)
+  - [Proposal](#proposal)
+    - [Architecture Overview](#architecture-overview)
+    - [Control Plane vs Data Plane](#control-plane-vs-data-plane)
+    - [HTTP API Surface](#http-api-surface)
+      - [Native (E2B/envd-compatible) API](#native-e2benvd-compatible-api)
+      - [Extended API (CSI mount)](#extended-api-csi-mount)
+      - [ConnectRPC services](#connectrpc-services)
+    - [Data-plane Services](#data-plane-services)
+    - [Cross-cutting Concerns](#cross-cutting-concerns)
+      - [Authentication and signing](#authentication-and-signing)
+      - [User and path resolution](#user-and-path-resolution)
+      - [cgroup v2, freeze/thaw and pause/resume](#cgroup-v2-freezethaw-and-pauseresume)
+      - [`/init` lifecycle and idempotency](#init-lifecycle-and-idempotency)
+      - [Metadata (MMDS) and metrics](#metadata-mmds-and-metrics)
+      - [Logging and observability](#logging-and-observability)
+      - [TLS/mTLS](#tlsmtls)
+    - [Deployment Modes](#deployment-modes)
+      - [D1. `envd` mode](#d1-envd-mode)
+      - [D2. `local` mode](#d2-local-mode)
+      - [D3. `helper` mode (agent-helper sub-module)](#d3-helper-mode-agent-helper-sub-module)
+    - [Sub-module: agent-helper](#sub-module-agent-helper)
+    - [Startup and staging](#startup-and-staging)
+    - [Requirements](#requirements)
+      - [Functional Requirements](#functional-requirements)
+      - [Non-Functional Requirements](#non-functional-requirements)
+    - [Risks and Mitigations](#risks-and-mitigations)
+  - [Alternatives](#alternatives)
+  - [Upgrade Strategy](#upgrade-strategy)
+  - [Test Plan](#test-plan)
+  - [Implementation Plan (Phased)](#implementation-plan-phased)
+  - [Implementation History](#implementation-history)
+
+## Glossary
+
+- **agent-runtime**: The in-sandbox runtime service that exposes an E2B/envd-compatible HTTP API plus ConnectRPC
+  process/filesystem services, extended with CSI mounting, cgroup freeze/thaw, and port forwarding. Code lives under
+  `pkg/agent-runtime/` and `cmd/agent-runtime/`.
+- **agent-helper**: A lightweight in-container data-plane binary used only in helper mode. It serves the process,
+  filesystem, fileio, freeze, metrics and port-forward ConnectRPC services over a UNIX domain socket. Code lives under
+  `pkg/agent-runtime/helper/` and `cmd/agent-helper/`.
+- **envd**: The E2B community sandbox daemon whose HTTP/RPC contract agent-runtime is compatible with, so the E2B SDK and
+  the sandbox-manager/gateway can talk to it unchanged.
+- **Control plane**: HTTP/HTTPS serving, auth/signing, TLS, CORS, routing, `/init` state, and streaming relay.
+- **Data plane**: The native execution behind an endpoint — process spawn/PTY/signal, filesystem CRUD/watch, file byte
+  read/write, cgroup placement/freeze, metrics sampling, and port forwarding.
+- **UDS**: UNIX domain socket used as the sidecar↔helper transport in helper mode.
+- **Executor**: A per-service abstraction (`ProcessExecutor`, `FilesystemExecutor`, `MountExecutor`) that isolates the
+  deployment-mode-specific execution strategy.
+
+## Summary
+
+`agent-runtime` is the process that runs inside (or beside) every sandbox Pod and gives the outside world a uniform,
+E2B/envd-compatible way to drive that sandbox: start and attach to processes, read and write files, mount storage,
+sample metrics, freeze/thaw the workload around pause/resume, and forward listening ports to the Pod gateway. It is one
+of the five OpenKruise Agents components and is the single API endpoint the sandbox-manager, sandbox-gateway and the E2B
+SDK talk to on the standard port `49983`.
+
+This proposal documents the agent-runtime component as a whole: its control-plane/data-plane split, its HTTP and
+ConnectRPC surface, the cross-cutting concerns (auth/signing, cgroup freeze, `/init` lifecycle, TLS, metrics), and — as a
+first-class sub-module — the three deployment modes it supports (`envd`, `local`, `helper`). Helper mode (the
+`agent-helper` binary) is treated here as a data-plane sub-module of agent-runtime rather than a standalone component,
+because it exists only to serve agent-runtime's sidecar over a UDS and shares the same service implementations. The
+detailed helper-mode design is captured separately in
+[20260708-agent-runtime-helper-mode.md](./20260708-agent-runtime-helper-mode.md); this document is the umbrella that
+places it in the context of the whole runtime.
+
+## Motivation
+
+agent-runtime has grown organically alongside the controller, sandbox-manager and gateway, and now carries a broad
+surface: E2B compatibility, CSI mounting, cgroup freeze semantics for pause/resume, and a sidecar/helper split. That
+breadth is spread across many packages (`openapi/`, `services/`, `auth/`, `host/`, `helper/`, `helperclient/`), and the
+only existing design record is the narrow helper-mode proposal. There is no single document that:
+
+- states the component's responsibilities and the invariants that keep it E2B-compatible,
+- names the control-plane/data-plane boundary that every deployment mode must preserve,
+- enumerates the API surface and which parts are backed natively vs delegated to the helper, and
+- explains how the three deployment modes relate, so contributors can reason about where new behavior belongs.
+
+Writing this down reduces onboarding cost, prevents accidental control-plane/data-plane coupling, and gives a stable
+reference for future work (CRI executor, CA bundle install, richer metrics).
+
+### Goals
+
+- Provide a component-level design record for agent-runtime that is faithful to the current implementation.
+- Define the control-plane/data-plane boundary and the executor abstraction as an explicit invariant.
+- Document the full HTTP and ConnectRPC surface and its E2B/envd-compatibility guarantees.
+- Position `agent-helper` as a data-plane sub-module of agent-runtime and cross-reference the helper-mode proposal.
+- Capture the deployment modes (`envd`/`local`/`helper`) and how a single image and entrypoint select between them.
+
+### Non-Goals/Future Work
+
+- The full helper-mode design detail (transport, peer verification, per-service delegation) — owned by
+  [20260708-agent-runtime-helper-mode.md](./20260708-agent-runtime-helper-mode.md).
+- Controller/webhook injection of the helper (shared `emptyDir`, postStart launch, exec-probe wiring, RBAC/manifests)
+  remains future work and is only sketched here.
+- A CRI/DaemonSet-based executor is anticipated by the interfaces but out of scope.
+- Changing the external E2B/envd contract is a non-goal; compatibility is an invariant.
+
+## Proposal
+
+### Architecture Overview
+
+agent-runtime is a Gin HTTP(S) server that fronts a set of ConnectRPC services and native OS operations. It binds
+`0.0.0.0:49983` (aligned with community envd, see `cmd/agent-runtime/options/flag.go`) and optionally an HTTPS listener
+that shares the same `gin.Engine` and routes.
+
+```mermaid
+graph TB
+    Client[E2B SDK / sandbox-manager / gateway] -->|HTTP/HTTPS :49983| GIN
+
+    subgraph Runtime[agent-runtime process]
+        GIN[Gin engine: CORS + user + Bearer auth]
+        NAT[native API: /init /files /envs /metrics /freeze /unfreeze]
+        EXT[extended API: /v1/storage/mounts]
+        PROC[ConnectRPC Process]
+        FS[ConnectRPC Filesystem]
+        GIN --> NAT
+        GIN --> EXT
+        GIN --> PROC
+        GIN --> FS
+    end
+
+    NAT --> CG[(cgroup v2)]
+    NAT --> DISK[(filesystem)]
+    EXT --> CSI[(CSI NodePublishVolume)]
+    PROC --> OSX[os/exec + PTY]
+```
+
+The same binary supports three deployment topologies, selected by `--runtime-mode` and the entrypoint's `RUNTIME_MODE`
+(see [Deployment Modes](#deployment-modes)). In helper mode the process/filesystem routes and the file/metric/freeze
+data plane are relayed to the `agent-helper` sub-module over a UDS, while everything else stays in the sidecar.
+
+### Control Plane vs Data Plane
+
+The central invariant is a clean split:
+
+- **Control plane (always in agent-runtime):** HTTP/HTTPS serving, CORS, Bearer auth and file signing, TLS/mTLS
+  termination, route composition, the `/init` state machine (token, default user/workdir, env vars, idempotency gate),
+  server-/client-streaming relay, and the CSI driver socket + mount-root discovery.
+- **Data plane (native, mode-dependent placement):** process spawn/PTY/signal/stdin, filesystem CRUD/watch, file byte
+  read/write (fileio), cgroup placement and freeze/thaw, metrics sampling, and port forwarding via socat.
+
+Each data-plane service is reached through an executor interface so the deployment mode is a wiring decision, not a
+behavior change:
+
+- Process: `ProcessExecutor` (`pkg/agent-runtime/services/process/executor.go`), local executor in
+  `executor_local.go`; the interface already anticipates a future `CRIExecutor`.
+- Filesystem: `FilesystemExecutor` (`pkg/agent-runtime/services/filesystem/executor.go`) with `LocalFilesystemExecutor`.
+- Mount: `MountExecutor` (`pkg/agent-runtime/openapi/extendedapi/mount_executor.go`) with `LocalMountExecutor` and
+  `HelperMountExecutor`.
+
+Mode-specific wiring is concentrated in `pkg/agent-runtime/routers.go` via `pickFreezer` and `pickMountExecutor`, and by
+mounting either the local process/filesystem services or a transparent reverse-proxy to the helper.
+
+### HTTP API Surface
+
+#### Native (E2B/envd-compatible) API
+
+Registered in `pkg/agent-runtime/openapi/nativeapi/api_def.go` (`WrapOpenAPIAsNativeE2BRoutes`):
+
+| Method + Path | Responsibility |
+|---|---|
+| `GET /health` | Public liveness probe; returns `204 No Content` with `Cache-Control: no-store`. Registered in `routers.go`, excluded from auth and access logging. |
+| `GET /envs` | Returns the runtime's default env vars (from in-memory `Defaults.EnvVars`). |
+| `GET /files` | File download. Supports `Accept-Encoding: gzip`, HTTP `Range` (`206`), conditional `If-Modified-Since`/`If-None-Match`/`If-Range` (`304`), and `Content-Disposition`. Uses `http.ServeContent` locally. |
+| `POST /files` | File upload. Supports `multipart/form-data` and raw `application/octet-stream`, `Content-Encoding: gzip`, parent-dir creation, and ownership by resolved user. |
+| `POST /files/compose` | Concatenate an ordered list of source files into a destination and remove sources; local path uses temp-file + atomic rename (`copy_file_range` via `ReadFrom`). |
+| `POST /init` | Sandbox lifecycle init: set access token, default user/workdir, env vars, and (deferred) thaw on resume. Idempotent via a timestamp gate. |
+| `POST /freeze`, `POST /unfreeze` | Orchestrator-driven cgroup freeze/thaw around pause/resume. |
+| `GET /metrics` | Point-in-time CPU/memory/disk sample. |
+
+E2B/envd compatibility (status codes, headers, gzip/Range semantics, `/init` token rules) is an invariant; deviations
+are called out in code comments (e.g. no MMDS-gated token reset in the K8s sidecar).
+
+#### Extended API (CSI mount)
+
+Registered in `pkg/agent-runtime/openapi/extendedapi/`:
+
+| Method + Path | Responsibility |
+|---|---|
+| `POST /v1/storage/mounts` | Mount a CSI volume: resolve a `MountProvider` by driver, find the mount-root from `/proc/mounts`, run CSI `NodePublishVolume`, then create a user-facing symlink. Retries with exponential backoff. |
+
+Providers self-register into a global registry (`registry.go`) from `init()`; the built-in `CSIMountProvider` supports
+Alibaba Cloud NAS/OSS/CustomFuse drivers and injects `sandboxId` for OSS `agent-identity` auth from the token dir. See
+[20260608-dynamic-csi-mount.md](./20260608-dynamic-csi-mount.md) for the mount design.
+
+#### ConnectRPC services
+
+Process and Filesystem are exposed as ConnectRPC services at their spec path prefixes (e.g. `/process.Process/Start`),
+mounted onto the Gin engine in `routers.go`. Protobuf specs live under `pkg/agent-runtime/services/spec/`.
+
+### Data-plane Services
+
+Under `pkg/agent-runtime/services/`, each service is a native implementation that can run either in-process (local) or
+inside the helper:
+
+- **process**: process lifecycle and I/O — `List`/`Start`/`Connect`/`Update`/`StreamInput`/`SendInput`/`SendSignal`,
+  including PTY allocation, TTY resize, and a persistent stdin proxy. Native cgroup FD placement via
+  `clone3(CLONE_INTO_CGROUP)` when a manager is present.
+- **filesystem**: metadata operations — `Stat`/`MakeDir`/`Move`/`ListDir`/`Remove` plus recursive `WatchDir`/watcher
+  registry.
+- **fileio**: byte transfer backing `GET`/`POST /files` and `/files/compose` — ranged `ReadFile` (returns metadata then
+  ordered chunks), streamed `WriteFile`, `Compose`, and `CreateSymlink` (used by the helper mount executor). Provides
+  full gzip/Range fidelity for file transfer.
+- **freeze**: cgroup `freeze`/`unfreeze` over the `user`/`pty`/`socat` process-type set, with a context-cancellable
+  serialization lock so a resume thaw can never be stranded.
+- **metrics**: CPU/memory/disk sampling via `host.MetricsProvider` (gopsutil), sampled from the local host — which, in
+  helper mode, is the business container itself.
+- **port**: an autonomous scanner discovers listening TCP ports and a forwarder runs socat to the Pod gateway; a
+  `PortForward` control service exposes `ListPorts`/`WatchPorts`/`OpenPort`/`ClosePort`. The socat data plane never
+  crosses the UDS.
+- **cgroups**: `Cgroup2Manager` (FD placement + `Freezer`) and a `NoopManager` fallback for cgroup-less environments.
+- **symlink**: shared symlink creation with target-visibility waiting used by fileio/mount.
+
+### Cross-cutting Concerns
+
+#### Authentication and signing
+
+`auth.BearerAuthMiddleware` validates `X-Access-Token` against configured tokens; `GET /health`, `GET /files`,
+`POST /files` are allow-listed. When no tokens are configured, auth is a pass-through. For file endpoints,
+`auth.ValidateSigning` supports signed URLs: `v1_base64(sha256(path:operation:username:accessToken[:expiration]))`,
+allowing time-bounded download/upload without sending the token. The access token is established via `/init`.
+
+#### User and path resolution
+
+`permissions.GetUser` resolves named users from `/etc/passwd`, and for numeric UIDs falls back to a uid lookup or a
+synthesized minimal identity — important for distroless/`runAsUser`-numeric images. `permissions.ExpandAndResolve`
+expands `~`, resolves relative paths against the workdir, and `EnsureDirs` creates parent dirs with correct uid/gid.
+This logic is shared by the local handlers and the helper's fileio/filesystem services so behavior is identical across
+modes.
+
+#### cgroup v2, freeze/thaw and pause/resume
+
+Processes are placed into per-type cgroups (`user`/`pty`/`socat`) via `Cgroup2Manager` FDs; `ProcessTypeSystem` is
+reserved for agent-runtime's own processes and is never frozen. Freeze/thaw writes `cgroup.freeze`, which survives VM
+snapshots, so the orchestrator freezes just before snapshot and the matching thaw runs on `/init` (resume). This gives
+atomic, race-free freeze semantics (no `echo $$ > cgroup.procs` race, no per-type freeze races).
+
+#### `/init` lifecycle and idempotency
+
+`POST /init` (`nativeapi/init_api_impl.go`) validates the token outside the idempotency gate, then applies env
+vars/user/workdir/token under a lock guarded by a strictly increasing `Timestamp` (`lastSetTime`), skipping stale
+replays. It always defers an unfreeze of the user cgroups (even on a skipped write) so a freshly snapshotted sandbox is
+never left frozen, writes an initialized marker, and starts a Downward-API file watcher for token auto-recovery across
+container restarts. `CaBundle` is accepted but not yet installed (logged as a TODO).
+
+#### Metadata (MMDS) and metrics
+
+`host/mmds.go` polls an AWS-compatible metadata endpoint (`169.254.169.254`) with a short-lived token to learn the
+sandbox ID, template ID, and logs-collector address, writing `.E2B_SANDBOX_ID`/`.E2B_TEMPLATE_ID` under `/run/e2b`.
+`host/metrics.go` provides CPU/memory/disk via a swappable `MetricsProvider` (real gopsutil provider by default; in
+helper mode the sidecar swaps in one that samples via the helper's Metrics RPC).
+
+#### Logging and observability
+
+Logging uses klog via `logs.NewLoggerContext`/`NewNamedLogger`, with per-component named loggers and a monotonic
+`operation_id` attached by a ConnectRPC unary interceptor and the streaming log wrappers. This complements the OTEL
+tracing work in [20260702-sandbox-otel-distributed-tracing-en.md](./20260702-sandbox-otel-distributed-tracing-en.md).
+
+#### TLS/mTLS
+
+When enabled, an HTTPS server shares the same `gin.Engine`; `buildTLSConfig` loads the cert/key (TLS 1.2+) and, when a CA
+file is provided, enables `VerifyClientCertIfGiven` for mutual TLS. Both HTTP and HTTPS are shut down gracefully on
+SIGINT/SIGTERM.
+
+### Deployment Modes
+
+A single image (built from `dockerfiles/agent-runtime.Dockerfile`) supports three topologies. The entrypoint scripts
+`cmd/agent-runtime/entrypoint.sh` and `entrypoint_inner.sh` stage binaries into `ENVD_DIR` and pick a mode from
+`RUNTIME_MODE` (default `envd` for backward compatibility). The Go server itself selects `local` vs `helper` via
+`--runtime-mode` (`ServerConfig.RuntimeMode`, `IsHelperMode()`).
+
+#### D1. `envd` mode
+
+Backward-compatible topology: the entrypoint stages the community `envd` binary and `envd-run.sh` and the business
+container launches envd. agent-runtime's own server is not the data plane here; this mode exists for images that still
+run upstream envd.
+
+#### D2. `local` mode
+
+agent-runtime runs directly inside the business container and executes every operation natively (native `os/exec`,
+native cgroup FD placement, native filesystem/user view). This has the best execution fidelity but mixes the control
+plane with the workload and is intrusive to the user image. `ServerConfig.RuntimeMode == "local"` (the default).
+
+#### D3. `helper` mode (agent-helper sub-module)
+
+agent-runtime runs as a **sidecar control plane**; a lightweight `agent-helper` runs inside the **business container**
+as the data plane, and the two communicate over a UDS on a shared `emptyDir`. This combines local-mode execution
+fidelity with sidecar isolation, without requiring `CAP_SYS_ADMIN` or host PID visibility. The full design (transport,
+peer verification, per-service delegation) is in
+[20260708-agent-runtime-helper-mode.md](./20260708-agent-runtime-helper-mode.md). At startup the sidecar blocks on
+`helperclient.WaitReady` (exponential backoff on `GET /health` over the UDS) before serving traffic.
+
+### Sub-module: agent-helper
+
+`agent-helper` (`cmd/agent-helper/main.go`, `pkg/agent-runtime/helper/`) is the in-container data-plane counterpart used
+only in helper mode. It is intentionally a **sub-module of agent-runtime**, not a separate component: it reuses the exact
+same service implementations (process, filesystem, fileio, freeze, metrics, port) that local mode uses, exposed over a
+UDS instead of TCP.
+
+- **Transport & serving**: listens on a UDS (default `/var/run/agent-helper/helper.sock`, mode `0600`, dir `0700`),
+  serves connectrpc over `h2c` so client-/server-streaming work, plus a plain `GET /health` for the readiness probe.
+- **Services**: mounts process + filesystem + fileio + freeze + metrics, and (when port scanning is enabled) the
+  `PortForward` control service, all in local execution mode.
+- **Security boundary**: an `SO_PEERCRED` peer-uid allowlist restricts which local peer (the sidecar uid) may connect;
+  the helper never elevates privileges and propagates native EPERM faithfully.
+- **cgroup/metrics**: uses a real `Cgroup2Manager` for native FD placement/freeze and samples metrics from its own host
+  (the business container), which is more faithful than the sidecar probing across namespaces.
+- **Identity**: resolves the default user from `--default-user` or its own effective uid, mirroring the business
+  container's `runAsUser` (including numeric/distroless cases).
+- **Health subcommand**: `agent-helper health` performs a one-shot probe of the UDS for use as a Kubernetes exec probe,
+  since kubelet cannot HTTP-probe a UDS-only server directly.
+
+On the sidecar side, `pkg/agent-runtime/helperclient/` provides the UDS-dialing connectrpc clients (`FileIO`, `Freeze`,
+`Metrics`), a transparent connectrpc reverse-proxy for process/filesystem (`FlushInterval = -1` so streaming relays
+unbuffered), a `Freezer`/`MetricsProvider` adapter, and the readiness wait.
+
+### Startup and staging
+
+`cmd/agent-runtime/main.go` initializes flags, the cgroup manager, and the `ServerConfig`, waits for helper readiness in
+helper mode, builds the HTTP server, optionally runs a start command and the local port forwarder (skipped in helper
+mode, since the helper owns port forwarding), then serves. The entrypoint scripts stage the correct binary set per
+`RUNTIME_MODE`; `entrypoint_inner.sh` additionally delivers internal-only artifacts (the `sandbox-runtime-storage`
+binary and optional `run_with_envs.sh`).
+
+### Requirements
+
+#### Functional Requirements
+
+- FR1: agent-runtime MUST expose the E2B/envd-compatible native API (`/health`, `/envs`, `/files`, `/files/compose`,
+  `/init`, `/freeze`, `/unfreeze`, `/metrics`) on port 49983 with the documented status codes and headers.
+- FR2: It MUST expose the extended CSI mount API (`POST /v1/storage/mounts`) with a pluggable provider registry.
+- FR3: It MUST expose the Process and Filesystem ConnectRPC services (including PTY and streaming).
+- FR4: `/init` MUST be idempotent under a timestamp gate and MUST always be able to thaw on resume.
+- FR5: The data plane MUST be reachable identically in `local` and `helper` modes via the executor/relay abstraction,
+  without changing the external contract.
+
+#### Non-Functional Requirements
+
+- NFR1: In helper mode the sidecar MUST require no elevated privileges (no `CAP_SYS_ADMIN`, no host PID visibility).
+- NFR2: File transfer MUST support gzip and HTTP Range in every mode.
+- NFR3: Freeze/thaw MUST be atomic (no `echo $$` race) and survive VM snapshots.
+- NFR4: The sidecar MUST handle helper unavailability gracefully (bounded readiness wait, reverse-proxy `502`,
+  freeze `503` when no freezer).
+- NFR5: Cyclomatic complexity stays within the repo limit (gocyclo max 32) and all code carries the Apache header.
+
+### Risks and Mitigations
+
+- **Control/data-plane coupling drift**: new endpoints might execute business-container work in the sidecar. Mitigation:
+  route every data-plane operation through an executor or the helper relay; keep `pickFreezer`/`pickMountExecutor` the
+  single wiring point.
+- **E2B compatibility regressions**: subtle header/status differences break the SDK. Mitigation: keep the E2B contract
+  as an invariant, cover it with the E2B pytest suite under `test/e2b`.
+- **Helper injection is unowned**: automated injection of the helper (shared `emptyDir`, postStart launch, exec probe,
+  RBAC) is not yet implemented and spans controller/webhook. Mitigation: track as a dedicated phase; align with
+  controller owners.
+- **CA bundle not installed**: `/init` accepts `CaBundle` but does not install it. Mitigation: document as a known gap
+  and implement for mTLS-to-egress scenarios.
+
+## Alternatives
+
+- **Keep only local mode**: simplest, but forces the full runtime into the user image and couples control plane with the
+  workload. Rejected for multi-tenant isolation needs.
+- **Make agent-helper a separate top-level component**: rejected — it shares agent-runtime's service implementations and
+  exists solely to serve the sidecar; treating it as a sub-module keeps the code and the contract unified.
+
+## Upgrade Strategy
+
+- The default `RUNTIME_MODE` is `envd` and the default `--runtime-mode` is `local`, so existing deployments are
+  unaffected.
+- Opting into helper mode requires setting `RUNTIME_MODE=helper` (entrypoint) / `--runtime-mode=helper` (server), adding
+  the shared `emptyDir` volume, and launching `agent-helper` in the business container.
+- Port and API contract are unchanged across modes, so clients (SDK, gateway, sandbox-manager) need no changes.
+
+## Test Plan
+
+- Unit tests per package (target ≥80%): auth/signing, encoding/Range, upload/download/compose, `/init` idempotency,
+  freeze/metrics services, mount executors, helper server endpoints, peercred, and helperclient (with a fake UDS
+  connectrpc server). Table-driven per repo convention.
+- E2B compatibility: the `test/e2b` pytest suite exercises the external contract.
+- E2E: `test/e2e` covers the local and helper deployment topologies end to end (out of scope to run here).
+
+## Implementation Plan (Phased)
+
+Most of the component is already implemented; the remaining work is the helper injection phase.
+
+- P1 (done): native + extended HTTP API, process/filesystem ConnectRPC, auth/signing, TLS, cgroup freeze, `/init`.
+- P2 (done): fileio/freeze/metrics/port services and the `local`/`helper` executor split + reverse-proxy relay.
+- P3 (done): `agent-helper` binary, UDS serving, SO_PEERCRED, health exec probe, helperclient + readiness.
+- P4 (future): controller/webhook injection of the helper (shared `emptyDir`, postStart launch, exec-probe wiring,
+  RBAC/manifests).
+- P5 (future): `CaBundle` install; richer metrics; anticipated `CRIExecutor`.
+
+## Implementation History
+
+- [ ] 2026-07-20: Initial component-level draft; positions agent-helper as a sub-module and references the helper-mode
+  proposal.


### PR DESCRIPTION
Add a component-level design proposal for agent-runtime (20260720) covering the control-plane/data-plane split, the three deployment modes (envd/local/helper), the executor abstraction, the HTTP/ConnectRPC API surface, and cross-cutting concerns (auth, TLS, logging, metrics, MMDS).

Add the agent-runtime helper-mode proposal (20260708) describing the sidecar control plane plus an in-container agent-helper data plane over a UNIX domain socket: connectrpc reverse-proxy for process/filesystem, typed clients for fileio/freeze/metrics, native cgroup placement, SO_PEERCRED uid allowlist, and the health exec probe, aligned with the current implementation.

English-only; no zh_CN companion.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

