### PR TITLE
feat(sandbox): add CheckpointRestore upgrade strategy with UpgradeControl

### DIFF
--- a/api/v1alpha1/checkpoint_types.go
+++ b/api/v1alpha1/checkpoint_types.go
@@ -34,6 +34,9 @@ const (
 	// CheckpointTypePodInfo indicates this checkpoint stores pod info delta
 	CheckpointTypePodInfo = "pod-info"
 
+	// CheckpointTypeUpgrade indicates this checkpoint is created for sandbox upgrade
+	CheckpointTypeUpgrade = "upgrade"
+
 	CheckpointPersistentContentMemory     = "memory"
 	CheckpointPersistentContentFilesystem = "filesystem"
 )

--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -142,6 +142,11 @@ type SandboxUpgradePolicyType string
 const (
 	// SandboxUpgradePolicyRecreate means sandbox will be updated by recreating the pod.
 	SandboxUpgradePolicyRecreate SandboxUpgradePolicyType = "Recreate"
+
+	// SandboxUpgradePolicyCheckpointRestore means sandbox will be updated by checkpointing
+	// the pod, deleting it, and restoring from the checkpoint. This preserves the writable
+	// layer of containers whose image is unchanged during the upgrade.
+	SandboxUpgradePolicyCheckpointRestore SandboxUpgradePolicyType = "CheckpointRestore"
 )
 
 // SandboxUpgradePolicy defines the upgrade strategy for the sandbox.
@@ -335,6 +340,11 @@ const (
 	SandboxUpgradingReasonPostUpgradeFailed = "PostUpgradeFailed"
 	SandboxUpgradingReasonSucceeded         = "Succeeded"
 	SandboxUpgradingReasonUpgradePodFailed  = "UpgradePodFailed"
+
+	// SandboxUpgradingReasonCheckpointing indicates a checkpoint is being created before pod deletion.
+	SandboxUpgradingReasonCheckpointing = "Checkpointing"
+	// SandboxUpgradingReasonCheckpointFailed indicates the checkpoint creation failed during upgrade.
+	SandboxUpgradingReasonCheckpointFailed = "CheckpointFailed"
 
 	// SandboxConditionPaused Reason
 	SandboxPausedReasonPausing             = "Pausing"

--- a/api/v1alpha1/sandboxupdateops_types.go
+++ b/api/v1alpha1/sandboxupdateops_types.go
@@ -48,8 +48,28 @@ type SandboxUpdateOpsSpec struct {
 	Paused bool `json:"paused,omitempty"`
 }
 
+// SandboxUpdateOpsStrategyType defines the type of update strategy.
+type SandboxUpdateOpsStrategyType string
+
+const (
+	// SandboxUpdateOpsStrategyRecreate means sandboxes will be updated by recreating the pod.
+	// This is the default strategy.
+	SandboxUpdateOpsStrategyRecreate SandboxUpdateOpsStrategyType = "Recreate"
+
+	// SandboxUpdateOpsStrategyCheckpointRestore means sandboxes will be updated by
+	// checkpointing the pod, deleting it, and restoring from the checkpoint.
+	// This preserves the writable layer of containers whose image is unchanged.
+	SandboxUpdateOpsStrategyCheckpointRestore SandboxUpdateOpsStrategyType = "CheckpointRestore"
+)
+
 // SandboxUpdateOpsStrategy defines the strategy for batch sandbox updates.
 type SandboxUpdateOpsStrategy struct {
+	// Type specifies the update strategy type.
+	// When empty, defaults to Recreate.
+	// Supported values: Recreate, CheckpointRestore.
+	// +optional
+	Type SandboxUpdateOpsStrategyType `json:"type,omitempty"`
+
 	// MaxUnavailable is the maximum number of sandboxes that can be upgrading at the same time.
 	// Value can be an absolute number (e.g., 5) or a percentage of total sandboxes (e.g., 10%).
 	// +optional

--- a/config/crd/bases/agents.kruise.io_sandboxupdateops.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxupdateops.yaml
@@ -190,6 +190,12 @@ spec:
                       MaxUnavailable is the maximum number of sandboxes that can be upgrading at the same time.
                       Value can be an absolute number (e.g., 5) or a percentage of total sandboxes (e.g., 10%).
                     x-kubernetes-int-or-string: true
+                  type:
+                    description: |-
+                      Type specifies the update strategy type.
+                      When empty, defaults to Recreate.
+                      Supported values: Recreate, CheckpointRestore.
+                    type: string
                 type: object
             required:
             - selector

--- a/pkg/controller/sandbox/core/checkpoint.go
+++ b/pkg/controller/sandbox/core/checkpoint.go
@@ -46,6 +46,7 @@ type CheckpointControl struct {
 const (
 	EventCheckpointStarted   = "CheckpointStarted"
 	EventCheckpointSucceeded = "CheckpointSucceeded"
+	EventCheckpointFailed    = "CheckpointFailed"
 )
 
 // NewCheckpointControl creates a new CheckpointControl.
@@ -91,7 +92,7 @@ func (c *CheckpointControl) AssumePodCheckpointed(ctx context.Context, pod *core
 		utils.SetSandboxCondition(newStatus, *cond)
 	}
 
-	cpList, err := listCheckpointsForSandbox(ctx, c.Client, box)
+	cpList, err := listCheckpointsForSandbox(ctx, c.Client, box, agentsv1alpha1.CheckpointTypePodInfo)
 	if err != nil {
 		klog.ErrorS(err, "Failed to list checkpoints", "sandbox", klog.KObj(box))
 		cond.Reason = agentsv1alpha1.SandboxPausedReasonCheckpointFailed
@@ -100,7 +101,7 @@ func (c *CheckpointControl) AssumePodCheckpointed(ctx context.Context, pod *core
 		c.recorder.Event(box, corev1.EventTypeWarning, agentsv1alpha1.SandboxPausedReasonCheckpointFailed, cond.Message)
 		return true
 	} else if len(cpList) == 0 {
-		if err := c.createCheckpoint(ctx, box); err != nil {
+		if err := c.createCheckpoint(ctx, box, agentsv1alpha1.CheckpointTypePodInfo); err != nil {
 			klog.ErrorS(err, "Failed to create checkpoint", "sandbox", klog.KObj(box))
 			cond.Reason = agentsv1alpha1.SandboxPausedReasonCheckpointFailed
 			cond.Message = fmt.Sprintf("Failed to create checkpoint: %v", err)
@@ -137,7 +138,7 @@ func (c *CheckpointControl) GetPodTemplateDelta(ctx context.Context, box *agents
 	if !utilfeature.DefaultFeatureGate.Enabled(features.SandboxPauseCheckpointGate) {
 		return nil
 	}
-	cpList, cpErr := listCheckpointsForSandbox(ctx, c.Client, box)
+	cpList, cpErr := listCheckpointsForSandbox(ctx, c.Client, box, agentsv1alpha1.CheckpointTypePodInfo)
 	if cpErr != nil {
 		klog.ErrorS(cpErr, "Failed to list checkpoints for resume, proceeding without", "sandbox", klog.KObj(box))
 		return nil
@@ -156,7 +157,7 @@ func (c *CheckpointControl) Cleanup(ctx context.Context, box *agentsv1alpha1.San
 	if !utilfeature.DefaultFeatureGate.Enabled(features.SandboxPauseCheckpointGate) {
 		return
 	}
-	cpList, cpErr := listCheckpointsForSandbox(ctx, c.Client, box)
+	cpList, cpErr := listCheckpointsForSandbox(ctx, c.Client, box, agentsv1alpha1.CheckpointTypePodInfo)
 	if cpErr != nil {
 		klog.ErrorS(cpErr, "Failed to list checkpoints for cleanup", "sandbox", klog.KObj(box))
 		return
@@ -179,7 +180,7 @@ func (c *CheckpointControl) Cleanup(ctx context.Context, box *agentsv1alpha1.San
 // checkpoint name. Idempotency within the same reconcile cycle is guaranteed
 // by the caller, which only invokes this function when no existing checkpoint
 // is found for the sandbox (see AssumePodCheckpointed).
-func (c *CheckpointControl) createCheckpoint(ctx context.Context, box *agentsv1alpha1.Sandbox) error {
+func (c *CheckpointControl) createCheckpoint(ctx context.Context, box *agentsv1alpha1.Sandbox, checkpointType string) error {
 	cpName := box.Name + "-" + utils.RandStringN(8)
 	cp := &agentsv1alpha1.Checkpoint{
 		ObjectMeta: metav1.ObjectMeta{
@@ -190,7 +191,7 @@ func (c *CheckpointControl) createCheckpoint(ctx context.Context, box *agentsv1a
 			},
 			Labels: map[string]string{
 				agentsv1alpha1.CheckpointLabelSandboxName: box.Name,
-				agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointTypePodInfo,
+				agentsv1alpha1.CheckpointLabelType:        checkpointType,
 			},
 		},
 		Spec: agentsv1alpha1.CheckpointSpec{
@@ -212,6 +213,82 @@ func (c *CheckpointControl) recordCheckpointEvent(box *agentsv1alpha1.Sandbox, e
 		return
 	}
 	c.recorder.Eventf(box, eventType, reason, messageFmt, args...)
+}
+
+// EnsureCheckpointForUpgrade ensures a Checkpoint CR exists for the sandbox and
+// returns true once the checkpoint has succeeded. If no checkpoint exists, it
+// creates one and returns false. If the checkpoint is still in progress, it
+// returns false. If the checkpoint failed, it returns an error.
+//
+// This is used by the CheckpointRestore upgrade strategy to snapshot the pod's
+// writable layer before deleting and recreating the pod.
+func (c *CheckpointControl) EnsureCheckpointForUpgrade(ctx context.Context, box *agentsv1alpha1.Sandbox) (bool, error) {
+	cpList, err := listCheckpointsForSandbox(ctx, c.Client, box, agentsv1alpha1.CheckpointTypeUpgrade)
+	if err != nil {
+		return false, fmt.Errorf("failed to list checkpoints for upgrade: %w", err)
+	}
+
+	if len(cpList) == 0 {
+		if err := c.createCheckpoint(ctx, box, agentsv1alpha1.CheckpointTypeUpgrade); err != nil {
+			return false, fmt.Errorf("failed to create checkpoint for upgrade: %w", err)
+		}
+		return false, nil
+	}
+
+	cp := &cpList[0]
+	switch cp.Status.Phase {
+	case agentsv1alpha1.CheckpointSucceeded:
+		c.recordCheckpointEvent(box, corev1.EventTypeNormal, EventCheckpointSucceeded,
+			"Checkpoint %s succeeded for upgrade", cp.Name)
+		return true, nil
+	case agentsv1alpha1.CheckpointFailed:
+		c.recordCheckpointEvent(box, corev1.EventTypeWarning, EventCheckpointFailed,
+			"Checkpoint %s failed during upgrade: %s", cp.Name, cp.Status.Message)
+		return false, fmt.Errorf("checkpoint %s failed during upgrade: %s", cp.Name, cp.Status.Message)
+	default:
+		klog.InfoS("Waiting for checkpoint to complete before upgrade",
+			"sandbox", klog.KObj(box), "checkpoint", cp.Name, "phase", cp.Status.Phase)
+		return false, nil
+	}
+}
+
+// GetCheckpointIDForUpgrade retrieves the checkpoint ID from the latest
+// checkpoint for upgrade purposes. The checkpoint ID is used to restore the
+// pod's writable layer when creating the new pod. Unlike GetPodTemplateDelta,
+// this does not check the SandboxPauseCheckpointGate feature gate because the
+// CheckpointRestore strategy is an explicit opt-in.
+func (c *CheckpointControl) GetCheckpointIDForUpgrade(ctx context.Context, box *agentsv1alpha1.Sandbox) string {
+	cpList, cpErr := listCheckpointsForSandbox(ctx, c.Client, box, agentsv1alpha1.CheckpointTypeUpgrade)
+	if cpErr != nil {
+		klog.ErrorS(cpErr, "Failed to list checkpoints for upgrade ID, proceeding without", "sandbox", klog.KObj(box))
+		return ""
+	}
+	for i := range cpList {
+		if cpList[i].Status.CheckpointId != "" {
+			return cpList[i].Status.CheckpointId
+		}
+	}
+	return ""
+}
+
+// CleanupForUpgrade deletes all upgrade Checkpoint CRs for the given sandbox
+// after a successful upgrade. Unlike Cleanup, this does not check the
+// SandboxPauseCheckpointGate feature gate.
+func (c *CheckpointControl) CleanupForUpgrade(ctx context.Context, box *agentsv1alpha1.Sandbox) {
+	cpList, cpErr := listCheckpointsForSandbox(ctx, c.Client, box, agentsv1alpha1.CheckpointTypeUpgrade)
+	if cpErr != nil {
+		klog.ErrorS(cpErr, "Failed to list checkpoints for upgrade cleanup", "sandbox", klog.KObj(box))
+		return
+	}
+	for i := range cpList {
+		ScaleExpectation.ExpectScale(GetControllerKey(box), expectations.Delete, cpList[i].Name)
+		if delErr := c.Delete(ctx, &cpList[i]); delErr != nil && !errors.IsNotFound(delErr) {
+			ScaleExpectation.ObserveScale(GetControllerKey(box), expectations.Delete, cpList[i].Name)
+			klog.ErrorS(delErr, "Failed to delete checkpoint after upgrade", "sandbox", klog.KObj(box), "checkpoint", cpList[i].Name)
+		} else {
+			klog.InfoS("Deleted checkpoint after successful upgrade", "sandbox", klog.KObj(box), "checkpoint", cpList[i].Name)
+		}
+	}
 }
 
 // validateContainerImages compares each user container's Image in the live Pod
@@ -243,14 +320,14 @@ func validateContainerImages(pod *corev1.Pod, box *agentsv1alpha1.Sandbox) error
 	return nil
 }
 
-// listCheckpointsForSandbox returns all pod-info Checkpoint CRs for the given sandbox,
-// sorted newest-first by creation timestamp.
-func listCheckpointsForSandbox(ctx context.Context, cli client.Client, box *agentsv1alpha1.Sandbox) ([]agentsv1alpha1.Checkpoint, error) {
+// listCheckpointsForSandbox returns all Checkpoint CRs of the given type for the
+// given sandbox, sorted newest-first by creation timestamp.
+func listCheckpointsForSandbox(ctx context.Context, cli client.Client, box *agentsv1alpha1.Sandbox, checkpointType string) ([]agentsv1alpha1.Checkpoint, error) {
 	cpList := &agentsv1alpha1.CheckpointList{}
 	err := cli.List(ctx, cpList,
 		client.InNamespace(box.Namespace),
 		client.MatchingFields{fieldindex.IndexNameForOwnerRefUID: string(box.UID)},
-		client.MatchingLabels{agentsv1alpha1.CheckpointLabelType: agentsv1alpha1.CheckpointTypePodInfo},
+		client.MatchingLabels{agentsv1alpha1.CheckpointLabelType: checkpointType},
 		client.UnsafeDisableDeepCopy,
 	)
 	if err != nil {
@@ -259,8 +336,18 @@ func listCheckpointsForSandbox(ctx context.Context, cli client.Client, box *agen
 	if len(cpList.Items) == 0 {
 		return nil, nil
 	}
-	sort.Slice(cpList.Items, func(i, j int) bool {
-		return cpList.Items[j].CreationTimestamp.Before(&cpList.Items[i].CreationTimestamp)
+	// Filter out Checkpoints that are being deleted.
+	items := make([]agentsv1alpha1.Checkpoint, 0, len(cpList.Items))
+	for i := range cpList.Items {
+		if cpList.Items[i].DeletionTimestamp.IsZero() {
+			items = append(items, cpList.Items[i])
+		}
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[j].CreationTimestamp.Before(&items[i].CreationTimestamp)
 	})
-	return cpList.Items, nil
+	return items, nil
 }

--- a/pkg/controller/sandbox/core/checkpoint.go
+++ b/pkg/controller/sandbox/core/checkpoint.go
@@ -101,7 +101,7 @@ func (c *CheckpointControl) AssumePodCheckpointed(ctx context.Context, pod *core
 		c.recorder.Event(box, corev1.EventTypeWarning, agentsv1alpha1.SandboxPausedReasonCheckpointFailed, cond.Message)
 		return true
 	} else if len(cpList) == 0 {
-		if err := c.createCheckpoint(ctx, box, agentsv1alpha1.CheckpointTypePodInfo); err != nil {
+		if _, err := c.createCheckpoint(ctx, box, agentsv1alpha1.CheckpointTypePodInfo); err != nil {
 			klog.ErrorS(err, "Failed to create checkpoint", "sandbox", klog.KObj(box))
 			cond.Reason = agentsv1alpha1.SandboxPausedReasonCheckpointFailed
 			cond.Message = fmt.Sprintf("Failed to create checkpoint: %v", err)
@@ -180,7 +180,7 @@ func (c *CheckpointControl) Cleanup(ctx context.Context, box *agentsv1alpha1.San
 // checkpoint name. Idempotency within the same reconcile cycle is guaranteed
 // by the caller, which only invokes this function when no existing checkpoint
 // is found for the sandbox (see AssumePodCheckpointed).
-func (c *CheckpointControl) createCheckpoint(ctx context.Context, box *agentsv1alpha1.Sandbox, checkpointType string) error {
+func (c *CheckpointControl) createCheckpoint(ctx context.Context, box *agentsv1alpha1.Sandbox, checkpointType string) (string, error) {
 	cpName := box.Name + "-" + utils.RandStringN(8)
 	cp := &agentsv1alpha1.Checkpoint{
 		ObjectMeta: metav1.ObjectMeta{
@@ -201,11 +201,11 @@ func (c *CheckpointControl) createCheckpoint(ctx context.Context, box *agentsv1a
 	ScaleExpectation.ExpectScale(GetControllerKey(box), expectations.Create, cpName)
 	if err := c.Create(ctx, cp); err != nil {
 		ScaleExpectation.ObserveScale(GetControllerKey(box), expectations.Create, cpName)
-		return fmt.Errorf("failed to create checkpoint CR: %w", err)
+		return "", fmt.Errorf("failed to create checkpoint CR: %w", err)
 	}
 	c.recordCheckpointEvent(box, corev1.EventTypeNormal, EventCheckpointStarted, "Checkpoint %s created, waiting for completion", cpName)
 	klog.InfoS("Created checkpoint CR", "sandbox", klog.KObj(box), "checkpoint", cpName)
-	return nil
+	return cpName, nil
 }
 
 func (c *CheckpointControl) recordCheckpointEvent(box *agentsv1alpha1.Sandbox, eventType, reason, messageFmt string, args ...any) {
@@ -220,19 +220,28 @@ func (c *CheckpointControl) recordCheckpointEvent(box *agentsv1alpha1.Sandbox, e
 // creates one and returns false. If the checkpoint is still in progress, it
 // returns false. If the checkpoint failed, it returns an error.
 //
-// This is used by the CheckpointRestore upgrade strategy to snapshot the pod's
-// writable layer before deleting and recreating the pod.
-func (c *CheckpointControl) EnsureCheckpointForUpgrade(ctx context.Context, box *agentsv1alpha1.Sandbox) (bool, error) {
+// The returned string is the checkpoint CR name (empty when short-circuited or
+// on error before a checkpoint is found/created).
+//
+// If the sandbox does not use the CheckpointRestore upgrade strategy, this
+// method short-circuits and returns (true, "", nil) so the caller can proceed to
+// the UpgradePod step without any checkpointing.
+func (c *CheckpointControl) EnsureCheckpointForUpgrade(ctx context.Context, box *agentsv1alpha1.Sandbox) (bool, string, error) {
+	if box.Spec.UpgradePolicy == nil || box.Spec.UpgradePolicy.Type != agentsv1alpha1.SandboxUpgradePolicyCheckpointRestore {
+		return true, "", nil
+	}
+
 	cpList, err := listCheckpointsForSandbox(ctx, c.Client, box, agentsv1alpha1.CheckpointTypeUpgrade)
 	if err != nil {
-		return false, fmt.Errorf("failed to list checkpoints for upgrade: %w", err)
+		return false, "", fmt.Errorf("failed to list checkpoints for upgrade: %w", err)
 	}
 
 	if len(cpList) == 0 {
-		if err := c.createCheckpoint(ctx, box, agentsv1alpha1.CheckpointTypeUpgrade); err != nil {
-			return false, fmt.Errorf("failed to create checkpoint for upgrade: %w", err)
+		cpName, err := c.createCheckpoint(ctx, box, agentsv1alpha1.CheckpointTypeUpgrade)
+		if err != nil {
+			return false, "", fmt.Errorf("failed to create checkpoint for upgrade: %w", err)
 		}
-		return false, nil
+		return false, cpName, nil
 	}
 
 	cp := &cpList[0]
@@ -240,15 +249,15 @@ func (c *CheckpointControl) EnsureCheckpointForUpgrade(ctx context.Context, box 
 	case agentsv1alpha1.CheckpointSucceeded:
 		c.recordCheckpointEvent(box, corev1.EventTypeNormal, EventCheckpointSucceeded,
 			"Checkpoint %s succeeded for upgrade", cp.Name)
-		return true, nil
+		return true, cp.Name, nil
 	case agentsv1alpha1.CheckpointFailed:
 		c.recordCheckpointEvent(box, corev1.EventTypeWarning, EventCheckpointFailed,
 			"Checkpoint %s failed during upgrade: %s", cp.Name, cp.Status.Message)
-		return false, fmt.Errorf("checkpoint %s failed during upgrade: %s", cp.Name, cp.Status.Message)
+		return false, cp.Name, fmt.Errorf("checkpoint %s failed during upgrade: %s", cp.Name, cp.Status.Message)
 	default:
 		klog.InfoS("Waiting for checkpoint to complete before upgrade",
 			"sandbox", klog.KObj(box), "checkpoint", cp.Name, "phase", cp.Status.Phase)
-		return false, nil
+		return false, cp.Name, nil
 	}
 }
 

--- a/pkg/controller/sandbox/core/checkpoint_test.go
+++ b/pkg/controller/sandbox/core/checkpoint_test.go
@@ -358,6 +358,64 @@ func TestListCheckpointsForSandbox(t *testing.T) {
 			expectEmpty: true,
 			expectError: "",
 		},
+		{
+			name: "all checkpoints being deleted - returns nil",
+			checkpoints: []agentsv1alpha1.Checkpoint{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-sandbox-deleted",
+						Namespace:         "default",
+						CreationTimestamp: metav1.Now(),
+						DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+						Finalizers:        []string{"foregroundDeletion"},
+						OwnerReferences:   []metav1.OwnerReference{ownerRef},
+						Labels: map[string]string{
+							agentsv1alpha1.CheckpointLabelSandboxName: "test-sandbox",
+							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointTypePodInfo,
+						},
+					},
+				},
+			},
+			sandboxUID:  sandboxUID,
+			expectEmpty: true,
+			expectError: "",
+		},
+		{
+			name: "mix of deleted and active checkpoints - only returns active",
+			checkpoints: []agentsv1alpha1.Checkpoint{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-sandbox-deleted",
+						Namespace:         "default",
+						CreationTimestamp: metav1.NewTime(metav1.Now().Add(-5 * 60 * 1e9)),
+						DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+						Finalizers:        []string{"foregroundDeletion"},
+						OwnerReferences:   []metav1.OwnerReference{ownerRef},
+						Labels: map[string]string{
+							agentsv1alpha1.CheckpointLabelSandboxName: "test-sandbox",
+							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointTypePodInfo,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-sandbox-active",
+						Namespace:         "default",
+						CreationTimestamp: metav1.Now(),
+						OwnerReferences:   []metav1.OwnerReference{ownerRef},
+						Labels: map[string]string{
+							agentsv1alpha1.CheckpointLabelSandboxName: "test-sandbox",
+							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointTypePodInfo,
+						},
+					},
+				},
+			},
+			sandboxUID:      sandboxUID,
+			expectEmpty:     false,
+			expectError:     "",
+			expectedCPName:  "test-sandbox-active",
+			expectedCPCount: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -376,7 +434,7 @@ func TestListCheckpointsForSandbox(t *testing.T) {
 					UID:       tt.sandboxUID,
 				},
 			}
-			cpList, err := listCheckpointsForSandbox(context.TODO(), cli, box)
+			cpList, err := listCheckpointsForSandbox(context.TODO(), cli, box, agentsv1alpha1.CheckpointTypePodInfo)
 			if tt.expectError == "" {
 				assert.NoError(t, err)
 			} else {
@@ -732,7 +790,7 @@ func TestCreateCheckpoint(t *testing.T) {
 	box := newCheckpointTestSandbox()
 	ctrl, cli, recorder := newCheckpointTestControlWithRecorder()
 
-	err := ctrl.createCheckpoint(context.TODO(), box)
+	err := ctrl.createCheckpoint(context.TODO(), box, agentsv1alpha1.CheckpointTypePodInfo)
 	assert.NoError(t, err)
 
 	cpList := &agentsv1alpha1.CheckpointList{}
@@ -942,7 +1000,7 @@ func TestCreateCheckpoint_AlreadyExists(t *testing.T) {
 	recorder := record.NewFakeRecorder(10)
 	ctrl := NewCheckpointControl(cli, recorder)
 
-	err := ctrl.createCheckpoint(context.TODO(), box)
+	err := ctrl.createCheckpoint(context.TODO(), box, agentsv1alpha1.CheckpointTypePodInfo)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 }

--- a/pkg/controller/sandbox/core/checkpoint_test.go
+++ b/pkg/controller/sandbox/core/checkpoint_test.go
@@ -790,8 +790,9 @@ func TestCreateCheckpoint(t *testing.T) {
 	box := newCheckpointTestSandbox()
 	ctrl, cli, recorder := newCheckpointTestControlWithRecorder()
 
-	err := ctrl.createCheckpoint(context.TODO(), box, agentsv1alpha1.CheckpointTypePodInfo)
+	name, err := ctrl.createCheckpoint(context.TODO(), box, agentsv1alpha1.CheckpointTypePodInfo)
 	assert.NoError(t, err)
+	assert.NotEmpty(t, name)
 
 	cpList := &agentsv1alpha1.CheckpointList{}
 	err = cli.List(context.TODO(), cpList, client.InNamespace(box.Namespace))
@@ -1063,8 +1064,11 @@ func TestEnsureCheckpointForUpgrade(t *testing.T) {
 			cli := builder.Build()
 			ctrl := NewCheckpointControl(cli, record.NewFakeRecorder(10))
 			box := newCheckpointTestSandbox()
+			box.Spec.UpgradePolicy = &agentsv1alpha1.SandboxUpgradePolicy{
+				Type: agentsv1alpha1.SandboxUpgradePolicyCheckpointRestore,
+			}
 
-			done, err := ctrl.EnsureCheckpointForUpgrade(context.TODO(), box)
+			done, _, err := ctrl.EnsureCheckpointForUpgrade(context.TODO(), box)
 			assert.Equal(t, tt.expectDone, done)
 			if tt.expectError == "" {
 				assert.NoError(t, err)
@@ -1221,7 +1225,7 @@ func TestCreateCheckpoint_AlreadyExists(t *testing.T) {
 	recorder := record.NewFakeRecorder(10)
 	ctrl := NewCheckpointControl(cli, recorder)
 
-	err := ctrl.createCheckpoint(context.TODO(), box, agentsv1alpha1.CheckpointTypePodInfo)
+	_, err := ctrl.createCheckpoint(context.TODO(), box, agentsv1alpha1.CheckpointTypePodInfo)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 }

--- a/pkg/controller/sandbox/core/checkpoint_test.go
+++ b/pkg/controller/sandbox/core/checkpoint_test.go
@@ -982,6 +982,227 @@ func TestGetPodTemplateDelta_ListError(t *testing.T) {
 	assert.Nil(t, delta)
 }
 
+func newUpgradeCheckpointTestCP(name string, box *agentsv1alpha1.Sandbox, phase agentsv1alpha1.CheckpointPhase) *agentsv1alpha1.Checkpoint {
+	cp := newCheckpointTestCP(name, box, phase)
+	cp.Labels[agentsv1alpha1.CheckpointLabelType] = agentsv1alpha1.CheckpointTypeUpgrade
+	return cp
+}
+
+func TestEnsureCheckpointForUpgrade(t *testing.T) {
+	tests := []struct {
+		name          string
+		existingCPs   []client.Object
+		interceptors  interceptor.Funcs
+		expectDone    bool
+		expectError   string
+		expectCreated bool
+	}{
+		{
+			name:          "no existing checkpoint - creates one and returns false",
+			existingCPs:   nil,
+			expectDone:    false,
+			expectError:   "",
+			expectCreated: true,
+		},
+		{
+			name: "checkpoint in progress - returns false",
+			existingCPs: []client.Object{
+				newUpgradeCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointCreating),
+			},
+			expectDone:  false,
+			expectError: "",
+		},
+		{
+			name: "checkpoint succeeded - returns true",
+			existingCPs: []client.Object{
+				newUpgradeCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded),
+			},
+			expectDone:  true,
+			expectError: "",
+		},
+		{
+			name: "checkpoint failed - returns error",
+			existingCPs: []client.Object{
+				func() *agentsv1alpha1.Checkpoint {
+					cp := newUpgradeCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointFailed)
+					cp.Status.Message = "checkpoint timeout"
+					return cp
+				}(),
+			},
+			expectDone:  false,
+			expectError: "checkpoint test-sandbox-cp1 failed during upgrade",
+		},
+		{
+			name:         "list error - returns error",
+			interceptors: interceptor.Funcs{List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error { return fmt.Errorf("list unavailable") }},
+			expectDone:   false,
+			expectError:  "failed to list checkpoints for upgrade",
+		},
+		{
+			name:         "create error - returns error",
+			interceptors: interceptor.Funcs{Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error { return fmt.Errorf("create denied") }},
+			expectDone:   false,
+			expectError:  "failed to create checkpoint for upgrade",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = clientgoscheme.AddToScheme(scheme)
+			_ = agentsv1alpha1.AddToScheme(scheme)
+			builder := fake.NewClientBuilder().WithScheme(scheme).
+				WithIndex(&agentsv1alpha1.Checkpoint{}, fieldindex.IndexNameForOwnerRefUID, fieldindex.OwnerIndexFunc).
+				WithStatusSubresource(&agentsv1alpha1.Checkpoint{})
+			if tt.interceptors.List != nil || tt.interceptors.Create != nil {
+				builder = builder.WithInterceptorFuncs(tt.interceptors)
+			}
+			for _, o := range tt.existingCPs {
+				builder = builder.WithObjects(o)
+			}
+			cli := builder.Build()
+			ctrl := NewCheckpointControl(cli, record.NewFakeRecorder(10))
+			box := newCheckpointTestSandbox()
+
+			done, err := ctrl.EnsureCheckpointForUpgrade(context.TODO(), box)
+			assert.Equal(t, tt.expectDone, done)
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			}
+			if tt.expectCreated {
+				cpList := &agentsv1alpha1.CheckpointList{}
+				_ = cli.List(context.TODO(), cpList, client.InNamespace(box.Namespace))
+				assert.Len(t, cpList.Items, 1)
+				assert.Equal(t, agentsv1alpha1.CheckpointTypeUpgrade, cpList.Items[0].Labels[agentsv1alpha1.CheckpointLabelType])
+			}
+		})
+	}
+}
+
+func TestGetCheckpointIDForUpgrade(t *testing.T) {
+	tests := []struct {
+		name        string
+		existingCPs []client.Object
+		interceptors interceptor.Funcs
+		expectID    string
+	}{
+		{
+			name: "checkpoint with ID - returns ID",
+			existingCPs: []client.Object{
+				func() *agentsv1alpha1.Checkpoint {
+					cp := newUpgradeCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded)
+					cp.Status.CheckpointId = "cp-id-123"
+					return cp
+				}(),
+			},
+			expectID: "cp-id-123",
+		},
+		{
+			name: "checkpoint without ID - returns empty",
+			existingCPs: []client.Object{
+				newUpgradeCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointCreating),
+			},
+			expectID: "",
+		},
+		{
+			name:     "no checkpoints - returns empty",
+			expectID: "",
+		},
+		{
+			name:         "list error - returns empty",
+			interceptors: interceptor.Funcs{List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error { return fmt.Errorf("list error") }},
+			expectID:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = clientgoscheme.AddToScheme(scheme)
+			_ = agentsv1alpha1.AddToScheme(scheme)
+			builder := fake.NewClientBuilder().WithScheme(scheme).
+				WithIndex(&agentsv1alpha1.Checkpoint{}, fieldindex.IndexNameForOwnerRefUID, fieldindex.OwnerIndexFunc)
+			if tt.interceptors.List != nil {
+				builder = builder.WithInterceptorFuncs(tt.interceptors)
+			}
+			for _, o := range tt.existingCPs {
+				builder = builder.WithObjects(o)
+			}
+			cli := builder.Build()
+			ctrl := NewCheckpointControl(cli, record.NewFakeRecorder(10))
+			box := newCheckpointTestSandbox()
+
+			id := ctrl.GetCheckpointIDForUpgrade(context.TODO(), box)
+			assert.Equal(t, tt.expectID, id)
+		})
+	}
+}
+
+func TestCleanupForUpgrade(t *testing.T) {
+	tests := []struct {
+		name         string
+		existingCPs  []client.Object
+		interceptors interceptor.Funcs
+		expectRemain int
+	}{
+		{
+			name: "deletes all upgrade checkpoints",
+			existingCPs: []client.Object{
+				newUpgradeCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded),
+				newUpgradeCheckpointTestCP("test-sandbox-cp2", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded),
+			},
+			expectRemain: 0,
+		},
+		{
+			name:         "no checkpoints - no-op",
+			expectRemain: 0,
+		},
+		{
+			name:         "list error - no panic",
+			interceptors: interceptor.Funcs{List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error { return fmt.Errorf("list error") }},
+			expectRemain: 0,
+		},
+		{
+			name: "delete error - continues and logs",
+			existingCPs: []client.Object{
+				newUpgradeCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded),
+			},
+			interceptors: interceptor.Funcs{Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+				return fmt.Errorf("delete forbidden")
+			}},
+			expectRemain: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = clientgoscheme.AddToScheme(scheme)
+			_ = agentsv1alpha1.AddToScheme(scheme)
+			builder := fake.NewClientBuilder().WithScheme(scheme).
+				WithIndex(&agentsv1alpha1.Checkpoint{}, fieldindex.IndexNameForOwnerRefUID, fieldindex.OwnerIndexFunc)
+			if tt.interceptors.List != nil || tt.interceptors.Delete != nil {
+				builder = builder.WithInterceptorFuncs(tt.interceptors)
+			}
+			for _, o := range tt.existingCPs {
+				builder = builder.WithObjects(o)
+			}
+			cli := builder.Build()
+			ctrl := NewCheckpointControl(cli, record.NewFakeRecorder(10))
+			box := newCheckpointTestSandbox()
+
+			ctrl.CleanupForUpgrade(context.TODO(), box)
+
+			remaining := &agentsv1alpha1.CheckpointList{}
+			_ = cli.List(context.TODO(), remaining, client.InNamespace(box.Namespace))
+			assert.Len(t, remaining.Items, tt.expectRemain)
+		})
+	}
+}
+
 func TestCreateCheckpoint_AlreadyExists(t *testing.T) {
 	enableCheckpointGate(t)
 	box := newCheckpointTestSandbox()

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -138,9 +138,12 @@ func (r *commonControl) EnsureSandboxUpdated(ctx context.Context, args EnsureFun
 		}
 	}
 
-	// For non-Recreate upgrade policy (e.g., sandbox-manager triggered inplace update via annotation),
-	// perform inplace update directly without entering the full upgrade lifecycle (PreUpgrade -> UpgradePod -> PostUpgrade).
-	if box.Spec.UpgradePolicy == nil || box.Spec.UpgradePolicy.Type != agentsv1alpha1.SandboxUpgradePolicyRecreate {
+	// For upgrade policies that do not require pod replacement (e.g.,
+	// sandbox-manager triggered inplace update via annotation), perform
+	// inplace update directly without entering the full upgrade lifecycle
+	// (PreUpgrade -> UpgradePod -> PostUpgrade). Recreate and CheckpointRestore
+	// are excluded here because they require the full lifecycle.
+	if !RequiresPodReplacementUpgrade(box) {
 		done, err := r.handleInplaceUpdateSandbox(ctx, args)
 		if err != nil {
 			return err

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -22,9 +22,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -35,7 +33,6 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/agent-runtime/storages"
 	"github.com/openkruise/agents/pkg/utils"
-	"github.com/openkruise/agents/pkg/utils/expectations"
 	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
 )
 
@@ -69,9 +66,16 @@ type commonControl struct {
 	lifecycleHookFunc    LifecycleHookFunc
 	initializer          SandboxInitializer
 	recycleControl       *SandboxRecycleControl
+	upgradeControl       *UpgradeControl
 }
 
 func NewCommonControl(args SandboxControlArgs) SandboxControl {
+	initializer := &defaultSandboxInitializer{
+		client:          args.Client,
+		apiReader:       args.APIReader,
+		storageRegistry: storages.NewStorageProvider(),
+		recorder:        args.Recorder,
+	}
 	control := &commonControl{
 		Client:               args.Client,
 		recorder:             args.Recorder,
@@ -80,13 +84,9 @@ func NewCommonControl(args SandboxControlArgs) SandboxControl {
 		checkpointControl:    args.CheckpointControl,
 		podControl:           args.PodControl,
 		lifecycleHookFunc:    ExecuteLifecycleHook,
-		initializer: &defaultSandboxInitializer{
-			client:          args.Client,
-			apiReader:       args.APIReader,
-			storageRegistry: storages.NewStorageProvider(),
-			recorder:        args.Recorder,
-		},
-		recycleControl: NewSandboxRecycleControl(args.Client, args.Recorder, args.RecycleConfig),
+		initializer:          initializer,
+		recycleControl:       NewSandboxRecycleControl(args.Client, args.Recorder, args.RecycleConfig),
+		upgradeControl:       NewUpgradeControl(args.Client, args.CheckpointControl, args.PodControl, ExecuteLifecycleHook, initializer),
 	}
 	return control
 }
@@ -343,132 +343,10 @@ func normalizeImageRef(img string) string {
 	return reference.TagNameOnly(named).String()
 }
 
-// hasUpgradeAction checks if the sandbox has a non-empty upgrade action configured.
-// If pre is true, checks PreUpgrade; otherwise checks PostUpgrade.
-func hasUpgradeAction(box *agentsv1alpha1.Sandbox, pre bool) bool {
-	if box.Spec.Lifecycle == nil {
-		return false
-	}
-	var action *agentsv1alpha1.UpgradeAction
-	if pre {
-		action = box.Spec.Lifecycle.PreUpgrade
-	} else {
-		action = box.Spec.Lifecycle.PostUpgrade
-	}
-	if action == nil || action.Exec == nil || len(action.Exec.Command) == 0 {
-		return false
-	}
-	return true
-}
-
-func (r *commonControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureFuncArgs) (retErr error) {
-	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
-
-	// Set Ready=False during upgrade
-	utils.SetSandboxCondition(newStatus, metav1.Condition{
-		Type:               string(agentsv1alpha1.SandboxConditionReady),
-		Status:             metav1.ConditionFalse,
-		Reason:             agentsv1alpha1.SandboxReadyReasonUpgrading,
-		Message:            "sandbox is upgrading",
-		LastTransitionTime: metav1.Now(),
-	})
-	upgradeCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionUpgrading))
-	// Phase 1: First entry - execute preUpgrade and initialize
-	if upgradeCond == nil {
-		upgradeCond = &metav1.Condition{
-			Type:               string(agentsv1alpha1.SandboxConditionUpgrading),
-			Status:             metav1.ConditionFalse,
-			Reason:             agentsv1alpha1.SandboxUpgradingReasonPreUpgrade,
-			LastTransitionTime: metav1.Now(),
-		}
-		utils.SetSandboxCondition(newStatus, *upgradeCond)
-	}
-
-	switch upgradeCond.Reason {
-	case agentsv1alpha1.SandboxUpgradingReasonPreUpgrade, agentsv1alpha1.SandboxUpgradingReasonPreUpgradeFailed:
-		// Execute preUpgrade if configured
-		if hasUpgradeAction(box, true) {
-			var action *agentsv1alpha1.UpgradeAction
-			if box.Spec.Lifecycle != nil {
-				action = box.Spec.Lifecycle.PreUpgrade
-			}
-			result := r.executeUpgradeAction(ctx, pod, box, action)
-			klog.InfoS("preUpgrade result", "sandbox", klog.KObj(box), "succeeded", result.Succeeded, "message", result.Message)
-			if !result.Succeeded {
-				// Record preUpgrade action failed
-				upgradeCond.Message = result.Message
-				upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonPreUpgradeFailed
-				utils.SetSandboxCondition(newStatus, *upgradeCond)
-				return nil
-			}
-		}
-
-		// transfer to UpgradePod
-		klog.InfoS("preUpgrade completed, transitioning to UpgradePod", "sandbox", klog.KObj(box))
-		upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonUpgradePod
-		upgradeCond.Message = ""
-		utils.SetSandboxCondition(newStatus, *upgradeCond)
-		fallthrough
-	case agentsv1alpha1.SandboxUpgradingReasonUpgradePod, agentsv1alpha1.SandboxUpgradingReasonUpgradePodFailed:
-		done, err := r.performRecreateUpgrade(ctx, args)
-		if err != nil {
-			klog.ErrorS(err, "UpgradePod step failed", "sandbox", klog.KObj(box))
-			return err
-		} else if !done {
-			klog.InfoS("UpgradePod step in progress", "sandbox", klog.KObj(box))
-			return nil // upgrade in progress
-		}
-
-		klog.InfoS("UpgradePod step completed, transitioning to PostUpgrade", "sandbox", klog.KObj(box))
-
-		// Re-fetch the Pod after recreate upgrade, since the old pod object is stale (deleted and replaced).
-		var freshPod corev1.Pod
-		if err := r.Get(ctx, types.NamespacedName{Namespace: box.Namespace, Name: box.Name}, &freshPod); err != nil {
-			klog.ErrorS(err, "Failed to re-fetch pod after recreate upgrade", "sandbox", klog.KObj(box))
-			return err
-		}
-		pod = &freshPod
-
-		// UpgradePod step completed
-		upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonPostUpgrade
-		upgradeCond.Message = ""
-		utils.SetSandboxCondition(newStatus, *upgradeCond)
-		fallthrough
-	case agentsv1alpha1.SandboxUpgradingReasonPostUpgrade, agentsv1alpha1.SandboxUpgradingReasonPostUpgradeFailed:
-		// Execute postUpgrade if configured
-		if hasUpgradeAction(box, false) {
-			var action *agentsv1alpha1.UpgradeAction
-			if box.Spec.Lifecycle != nil {
-				action = box.Spec.Lifecycle.PostUpgrade
-			}
-			result := r.executeUpgradeAction(ctx, pod, box, action)
-			klog.InfoS("postUpgrade result", "sandbox", klog.KObj(box), "succeeded", result.Succeeded, "message", result.Message)
-			if !result.Succeeded {
-				// Record postUpgrade action failed
-				upgradeCond.Message = result.Message
-				upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonPostUpgradeFailed
-				utils.SetSandboxCondition(newStatus, *upgradeCond)
-				return nil
-			}
-		}
-
-		klog.InfoS("postUpgrade completed, transitioning to Succeeded", "sandbox", klog.KObj(box))
-		upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonSucceeded
-		upgradeCond.Status = metav1.ConditionTrue
-		upgradeCond.Message = ""
-		upgradeCond.LastTransitionTime = metav1.Now()
-		utils.SetSandboxCondition(newStatus, *upgradeCond)
-		newStatus.Phase = agentsv1alpha1.SandboxRunning
-		utils.SetSandboxCondition(newStatus, metav1.Condition{
-			Type:               string(agentsv1alpha1.SandboxConditionReady),
-			Status:             metav1.ConditionTrue,
-			Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
-			Message:            "",
-			LastTransitionTime: metav1.Now(),
-		})
-	}
-
-	return nil
+// EnsureSandboxUpgraded delegates to UpgradeControl which manages the full upgrade
+// state machine: PreUpgrade → (Checkpointing) → UpgradePod → PostUpgrade → Succeeded.
+func (r *commonControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureFuncArgs) error {
+	return r.upgradeControl.EnsureSandboxUpgraded(ctx, args)
 }
 
 func (r *commonControl) EnsureSandboxTerminated(ctx context.Context, args EnsureFuncArgs) error {
@@ -503,119 +381,4 @@ func (r *commonControl) handleInplaceUpdateSandbox(ctx context.Context, args Ens
 		recorder: r.recorder,
 	}
 	return handleInPlaceUpdateCommon(ctx, handler, pod, box, newStatus)
-}
-
-// performRecreateUpgrade handles the Recreate upgrade step (delete old pod + create new pod).
-func (r *commonControl) performRecreateUpgrade(ctx context.Context, args EnsureFuncArgs) (bool, error) {
-	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
-
-	// Step 1: Delete old Pod (has old template hash)
-	if pod != nil && pod.Labels[agentsv1alpha1.PodLabelTemplateHash] != newStatus.UpdateRevision {
-		if !pod.DeletionTimestamp.IsZero() {
-			klog.InfoS("Waiting for pod deletion to complete", "sandbox", klog.KObj(box))
-			return false, nil
-		}
-		// Delete pod
-		ScaleExpectation.ExpectScale(GetControllerKey(box), expectations.Delete, box.Name)
-		if err := r.Delete(ctx, pod); err != nil {
-			ScaleExpectation.ObserveScale(GetControllerKey(box), expectations.Delete, box.Name)
-			if !errors.IsNotFound(err) {
-				klog.ErrorS(err, "Failed to delete pod for upgrade", "sandbox", klog.KObj(box))
-				return false, err
-			}
-		}
-		klog.InfoS("Deleted old pod for upgrade", "sandbox", klog.KObj(box))
-		return false, nil
-	}
-
-	// Step 2: Create new Pod (old pod deleted)
-	if pod == nil {
-		klog.InfoS("Creating new pod for upgrade", "sandbox", klog.KObj(box))
-		newPod, err := r.podControl.CreatePod(ctx, CreatePodArgs{Box: box, NewStatus: newStatus})
-		if err != nil {
-			klog.ErrorS(err, "Failed to create new pod for upgrade", "sandbox", klog.KObj(box))
-			return false, err
-		}
-		if newPod != nil {
-			klog.InfoS("New pod created for upgrade", "sandbox", klog.KObj(box), "pod", klog.KObj(newPod))
-		}
-		return false, nil
-	}
-
-	if pod.Status.PodIP != "" && pod.Spec.NodeName != "" {
-		newStatus.NodeName = pod.Spec.NodeName
-		newStatus.SandboxIp = pod.Status.PodIP
-		newStatus.PodInfo = agentsv1alpha1.PodInfo{
-			PodIP:    pod.Status.PodIP,
-			NodeName: pod.Spec.NodeName,
-			PodUID:   pod.UID,
-		}
-	}
-
-	// Step 3: Wait for new Pod to be running and ready
-	pCond := utils.GetPodCondition(&pod.Status, corev1.PodReady)
-	cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionUpgrading))
-	if pCond == nil || pCond.Status != corev1.ConditionTrue {
-		klog.InfoS("Waiting for new pod to be ready", "sandbox", klog.KObj(box))
-		for _, cStatus := range pod.Status.ContainerStatuses {
-			if cStatus.State.Waiting != nil {
-				reason := cStatus.State.Waiting.Reason
-				// PodInitializing and ContainerCreating are normal transient states during startup, skip them
-				if reason == WaitingReasonPodInitializing || reason == WaitingReasonContainerCreating {
-					continue
-				}
-				// Other waiting reasons indicate container startup failure
-				klog.InfoS("container waiting with abnormal reason", "sandbox", klog.KObj(box),
-					"container", cStatus.Name, "reason", reason, "message", cStatus.State.Waiting.Message)
-				cond.Reason = agentsv1alpha1.SandboxUpgradingReasonUpgradePodFailed
-				cond.Message = fmt.Sprintf("container %s: %s - %s", cStatus.Name, reason, cStatus.State.Waiting.Message)
-				utils.SetSandboxCondition(newStatus, *cond)
-			} else if cStatus.State.Terminated != nil {
-				klog.InfoS("container terminated unexpectedly", "sandbox", klog.KObj(box),
-					"container", cStatus.Name, "reason", cStatus.State.Terminated.Reason,
-					"exitCode", cStatus.State.Terminated.ExitCode, "message", cStatus.State.Terminated.Message)
-				cond.Reason = agentsv1alpha1.SandboxUpgradingReasonUpgradePodFailed
-				cond.Message = fmt.Sprintf("container %s: terminated with exit code %d - %s",
-					cStatus.Name, cStatus.State.Terminated.ExitCode, cStatus.State.Terminated.Reason)
-				utils.SetSandboxCondition(newStatus, *cond)
-			}
-		}
-		return false, nil
-	}
-
-	// Step 4: Perform post-recreate-upgrade initialization (re-init runtime, re-mount CSI).
-	if err := r.initializer.Initialize(ctx, box, newStatus); err != nil {
-		return false, err
-	}
-
-	return true, nil
-}
-
-// upgradeActionResult represents the result of executing an upgrade hook.
-type upgradeActionResult struct {
-	Succeeded bool
-	Message   string
-}
-
-// executeUpgradeAction executes an upgrade action and returns the result.
-// If action is nil (not configured), it returns success directly.
-// If pod is nil and action is configured, it returns failure.
-func (r *commonControl) executeUpgradeAction(ctx context.Context, pod *corev1.Pod, box *agentsv1alpha1.Sandbox, action *agentsv1alpha1.UpgradeAction) upgradeActionResult {
-	if action == nil {
-		return upgradeActionResult{Succeeded: true, Message: "no hook configured, skipped"}
-	}
-	if pod == nil {
-		return upgradeActionResult{Succeeded: false, Message: "pod not found, cannot execute hook"}
-	}
-
-	exitCode, stdout, stderr, err := r.lifecycleHookFunc(ctx, box, action)
-	if err != nil {
-		msg := fmt.Sprintf("hook execution error: %v, stderr: %s, stdout: %s", err, stderr, stdout)
-		return upgradeActionResult{Succeeded: false, Message: utils.TruncateConditionMessage(msg)}
-	}
-	if exitCode != 0 {
-		msg := fmt.Sprintf("hook failed with exit code %d, stderr: %s, stdout: %s", exitCode, stderr, stdout)
-		return upgradeActionResult{Succeeded: false, Message: utils.TruncateConditionMessage(msg)}
-	}
-	return upgradeActionResult{Succeeded: true, Message: fmt.Sprintf("hook succeeded, stdout: %s", stdout)}
 }

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -2533,18 +2533,24 @@ func TestCommonControl_performRecreateUpgrade_PodTerminating(t *testing.T) {
 	}
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	podCtrl := NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox)
+	checkpointCtrl := NewCheckpointControl(fakeClient, record.NewFakeRecorder(10))
+	initializer := &defaultSandboxInitializer{recorder: record.NewFakeRecorder(10)}
 	control := &commonControl{
 		Client:               fakeClient,
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
-		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+		podControl:           podCtrl,
+		checkpointControl:    checkpointCtrl,
+		initializer:          initializer,
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, ExecuteLifecycleHook, initializer),
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
 		UpdateRevision: "new-rev",
 	}
 
-	done, err := control.performRecreateUpgrade(context.TODO(), EnsureFuncArgs{Pod: pod, Box: box, NewStatus: newStatus})
+	done, err := control.upgradeControl.performRecreateUpgrade(context.TODO(), EnsureFuncArgs{Pod: pod, Box: box, NewStatus: newStatus})
 	if err != nil {
 		t.Fatalf("performRecreateUpgrade() unexpected error: %v", err)
 	}
@@ -2588,18 +2594,24 @@ func TestCommonControl_performRecreateUpgrade_NewPodNotReady(t *testing.T) {
 	}
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	podCtrl := NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox)
+	checkpointCtrl := NewCheckpointControl(fakeClient, record.NewFakeRecorder(10))
+	initializer := &defaultSandboxInitializer{recorder: record.NewFakeRecorder(10)}
 	control := &commonControl{
 		Client:               fakeClient,
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
-		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+		podControl:           podCtrl,
+		checkpointControl:    checkpointCtrl,
+		initializer:          initializer,
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, ExecuteLifecycleHook, initializer),
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
 		UpdateRevision: "new-rev",
 	}
 
-	done, err := control.performRecreateUpgrade(context.TODO(), EnsureFuncArgs{Pod: pod, Box: box, NewStatus: newStatus})
+	done, err := control.upgradeControl.performRecreateUpgrade(context.TODO(), EnsureFuncArgs{Pod: pod, Box: box, NewStatus: newStatus})
 	if err != nil {
 		t.Fatalf("performRecreateUpgrade() unexpected error: %v", err)
 	}
@@ -2827,18 +2839,24 @@ func TestCommonControl_performRecreateUpgrade_PodReadyFalse(t *testing.T) {
 	}
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	podCtrl := NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox)
+	checkpointCtrl := NewCheckpointControl(fakeClient, record.NewFakeRecorder(10))
+	initializer := &defaultSandboxInitializer{recorder: record.NewFakeRecorder(10)}
 	control := &commonControl{
 		Client:               fakeClient,
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
-		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+		podControl:           podCtrl,
+		checkpointControl:    checkpointCtrl,
+		initializer:          initializer,
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, ExecuteLifecycleHook, initializer),
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
 		UpdateRevision: "new-rev",
 	}
 
-	done, err := control.performRecreateUpgrade(context.TODO(), EnsureFuncArgs{Pod: pod, Box: box, NewStatus: newStatus})
+	done, err := control.upgradeControl.performRecreateUpgrade(context.TODO(), EnsureFuncArgs{Pod: pod, Box: box, NewStatus: newStatus})
 	if err != nil {
 		t.Fatalf("performRecreateUpgrade() unexpected error: %v", err)
 	}
@@ -3264,18 +3282,24 @@ func TestCommonControl_performRecreateUpgrade_InitializerPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			podCtrl := NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox)
+			checkpointCtrl := NewCheckpointControl(fakeClient, record.NewFakeRecorder(10))
+			initializer := &mockSandboxInitializer{err: tt.initErr}
 			control := &commonControl{
 				Client:               fakeClient,
 				recorder:             record.NewFakeRecorder(10),
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
-				initializer:          &mockSandboxInitializer{err: tt.initErr},
+				podControl:           podCtrl,
+				checkpointControl:    checkpointCtrl,
+				initializer:          initializer,
+				upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, ExecuteLifecycleHook, initializer),
 			}
 
 			newStatus := &agentsv1alpha1.SandboxStatus{
 				UpdateRevision: "new-rev",
 			}
 
-			done, err := control.performRecreateUpgrade(context.TODO(), EnsureFuncArgs{
+			done, err := control.upgradeControl.performRecreateUpgrade(context.TODO(), EnsureFuncArgs{
 				Pod:       readyPod(),
 				Box:       baseSandbox(),
 				NewStatus: newStatus,

--- a/pkg/controller/sandbox/core/pod_control.go
+++ b/pkg/controller/sandbox/core/pod_control.go
@@ -53,18 +53,34 @@ type CreatePodArgs struct {
 	Box              *agentsv1alpha1.Sandbox
 	NewStatus        *agentsv1alpha1.SandboxStatus
 	PodTemplateDelta *runtime.RawExtension
+	CheckpointID     string
 }
 
 // PodControl manages Pod creation for sandbox controllers.
 type PodControl struct {
 	client.Client
-	recorder    record.EventRecorder
-	generatePod PodGenerateFunc
+	recorder                 record.EventRecorder
+	generatePod              PodGenerateFunc
+	checkpointIDAnnotationKey string
 }
 
 // NewPodControl creates a new PodControl.
 func NewPodControl(cli client.Client, recorder record.EventRecorder, genFn PodGenerateFunc) *PodControl {
-	return &PodControl{Client: cli, recorder: recorder, generatePod: genFn}
+	return &PodControl{
+		Client:                   cli,
+		recorder:                 recorder,
+		generatePod:              genFn,
+	}
+}
+
+// SetCheckpointIDAnnotationKey overrides the annotation key used to store the
+// checkpoint ID on the Pod. This is configured via the controller flag
+// --checkpoint-id-annotation-key. If not set, no checkpoint ID annotation
+// is written to pods.
+func (c *PodControl) SetCheckpointIDAnnotationKey(key string) {
+	if key != "" {
+		c.checkpointIDAnnotationKey = key
+	}
 }
 
 // CreatePod generates and creates a Pod for the given sandbox.
@@ -81,6 +97,16 @@ func (c *PodControl) CreatePod(ctx context.Context, args CreatePodArgs) (*corev1
 	pod, err := c.generatePod(ctx, PodGenerateArgs{Client: c.Client, Box: box, NewStatus: args.NewStatus})
 	if err != nil {
 		return nil, err
+	}
+
+	// Set checkpoint ID annotation for CheckpointRestore upgrade.
+	// The checkpoint controller uses this to restore the pod's writable layer.
+	// Only set the annotation when a custom key is configured via the controller flag.
+	if args.CheckpointID != "" && c.checkpointIDAnnotationKey != "" {
+		if pod.Annotations == nil {
+			pod.Annotations = map[string]string{}
+		}
+		pod.Annotations[c.checkpointIDAnnotationKey] = args.CheckpointID
 	}
 
 	// Apply checkpoint pod template delta if present (resume path).

--- a/pkg/controller/sandbox/core/pod_control.go
+++ b/pkg/controller/sandbox/core/pod_control.go
@@ -59,17 +59,17 @@ type CreatePodArgs struct {
 // PodControl manages Pod creation for sandbox controllers.
 type PodControl struct {
 	client.Client
-	recorder                 record.EventRecorder
-	generatePod              PodGenerateFunc
+	recorder                  record.EventRecorder
+	generatePod               PodGenerateFunc
 	checkpointIDAnnotationKey string
 }
 
 // NewPodControl creates a new PodControl.
 func NewPodControl(cli client.Client, recorder record.EventRecorder, genFn PodGenerateFunc) *PodControl {
 	return &PodControl{
-		Client:                   cli,
-		recorder:                 recorder,
-		generatePod:              genFn,
+		Client:      cli,
+		recorder:    recorder,
+		generatePod: genFn,
 	}
 }
 

--- a/pkg/controller/sandbox/core/pod_control_test.go
+++ b/pkg/controller/sandbox/core/pod_control_test.go
@@ -185,3 +185,87 @@ func TestCreatePod(t *testing.T) {
 		})
 	}
 }
+
+func TestCreatePodCheckpointAnnotation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	baseBox := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+		},
+	}
+
+	tests := []struct {
+		name              string
+		checkpointID      string
+		annotationKey     string // empty means not configured (default)
+		expectAnnotation  bool
+		expectKey         string
+		expectValue       string
+	}{
+		{
+			name:             "annotation key not configured - no annotation set",
+			checkpointID:     "cp-123",
+			annotationKey:    "",
+			expectAnnotation: false,
+		},
+		{
+			name:             "annotation key configured with checkpoint ID - annotation set",
+			checkpointID:     "cp-123",
+			annotationKey:    "agents.kruise.io/checkpoint-id",
+			expectAnnotation: true,
+			expectKey:        "agents.kruise.io/checkpoint-id",
+			expectValue:      "cp-123",
+		},
+		{
+			name:             "annotation key configured but checkpoint ID empty - no annotation set",
+			checkpointID:     "",
+			annotationKey:    "agents.kruise.io/checkpoint-id",
+			expectAnnotation: false,
+		},
+		{
+			name:             "custom annotation key - annotation set with custom key",
+			checkpointID:     "cp-456",
+			annotationKey:    "custom.io/my-checkpoint",
+			expectAnnotation: true,
+			expectKey:        "custom.io/my-checkpoint",
+			expectValue:      "cp-456",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+			recorder := record.NewFakeRecorder(10)
+			podControl := NewPodControl(fc, recorder, simplePodGenFunc)
+			if tt.annotationKey != "" {
+				podControl.SetCheckpointIDAnnotationKey(tt.annotationKey)
+			}
+
+			box := baseBox.DeepCopy()
+			args := CreatePodArgs{
+				Box:          box,
+				NewStatus:    &agentsv1alpha1.SandboxStatus{},
+				CheckpointID: tt.checkpointID,
+			}
+
+			pod, err := podControl.CreatePod(context.TODO(), args)
+			require.NoError(t, err)
+			require.NotNil(t, pod)
+
+			if tt.expectAnnotation {
+				assert.Equal(t, tt.expectValue, pod.Annotations[tt.expectKey],
+					"checkpoint annotation should be set with key %q", tt.expectKey)
+			} else {
+				// Verify no checkpoint-related annotation exists.
+				// The pod may still have the CreatedBy annotation from generation.
+				for k := range pod.Annotations {
+					assert.NotContains(t, k, "checkpoint", "unexpected checkpoint annotation: %s", k)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/sandbox/core/upgrade_control.go
+++ b/pkg/controller/sandbox/core/upgrade_control.go
@@ -64,11 +64,20 @@ func NewUpgradeControl(
 	}
 }
 
+// RequiresPodReplacementUpgrade returns true when the sandbox's upgrade policy
+// requires pod replacement (Recreate or CheckpointRestore). These policies enter
+// the full upgrade lifecycle (PreUpgrade → Checkpointing → UpgradePod → PostUpgrade).
+func RequiresPodReplacementUpgrade(box *agentsv1alpha1.Sandbox) bool {
+	return box.Spec.UpgradePolicy != nil &&
+		(box.Spec.UpgradePolicy.Type == agentsv1alpha1.SandboxUpgradePolicyRecreate ||
+			box.Spec.UpgradePolicy.Type == agentsv1alpha1.SandboxUpgradePolicyCheckpointRestore)
+}
+
 // EnsureSandboxUpgraded drives the sandbox upgrade state machine.
 //
 // The state transitions are:
 //
-//	PreUpgrade → (CheckpointRestore? → Checkpointing →) UpgradePod → PostUpgrade → Succeeded
+//	PreUpgrade → Checkpointing → UpgradePod → PostUpgrade → Succeeded
 //
 // Each reconcile cycle processes exactly one state and returns nil so the
 // controller can persist the updated condition before re-entering the next
@@ -118,30 +127,26 @@ func (r *UpgradeControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureF
 			}
 		}
 
-		// For CheckpointRestore, transition to Checkpointing; otherwise to UpgradePod.
-		if isCheckpointRestore {
-			klog.InfoS("preUpgrade completed, transitioning to Checkpointing", "sandbox", klog.KObj(box))
-			upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonCheckpointing
-		} else {
-			klog.InfoS("preUpgrade completed, transitioning to UpgradePod", "sandbox", klog.KObj(box))
-			upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonUpgradePod
-		}
+		// Always transition to Checkpointing; EnsureCheckpointForUpgrade will
+		// short-circuit and return done=true if CheckpointRestore is not enabled.
+		klog.InfoS("preUpgrade completed, transitioning to Checkpointing", "sandbox", klog.KObj(box))
+		upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonCheckpointing
 		upgradeCond.Message = ""
 		utils.SetSandboxCondition(newStatus, *upgradeCond)
-		return nil
+		fallthrough
 	case agentsv1alpha1.SandboxUpgradingReasonCheckpointing, agentsv1alpha1.SandboxUpgradingReasonCheckpointFailed:
-		checkpointDone, err := r.checkpointControl.EnsureCheckpointForUpgrade(ctx, box)
+		checkpointDone, cpName, err := r.checkpointControl.EnsureCheckpointForUpgrade(ctx, box)
 		if err != nil {
-			klog.ErrorS(err, "Checkpoint failed during upgrade", "sandbox", klog.KObj(box))
+			klog.ErrorS(err, "Checkpoint failed during upgrade", "sandbox", klog.KObj(box), "checkpoint", cpName)
 			upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonCheckpointFailed
 			upgradeCond.Message = err.Error()
 			utils.SetSandboxCondition(newStatus, *upgradeCond)
 			return err
 		}
 		if !checkpointDone {
-			klog.InfoS("Waiting for checkpoint to complete", "sandbox", klog.KObj(box))
+			klog.InfoS("Waiting for checkpoint to complete", "sandbox", klog.KObj(box), "checkpoint", cpName)
 			upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonCheckpointing
-			upgradeCond.Message = "Waiting for checkpoint to complete before pod deletion"
+			upgradeCond.Message = fmt.Sprintf("Waiting for checkpoint %s to complete before pod deletion", cpName)
 			utils.SetSandboxCondition(newStatus, *upgradeCond)
 			return nil
 		}

--- a/pkg/controller/sandbox/core/upgrade_control.go
+++ b/pkg/controller/sandbox/core/upgrade_control.go
@@ -1,0 +1,362 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/utils"
+	"github.com/openkruise/agents/pkg/utils/expectations"
+)
+
+// UpgradeControl manages the sandbox upgrade lifecycle state machine.
+// It orchestrates the full upgrade flow: PreUpgrade → (Checkpointing) →
+// UpgradePod → PostUpgrade → Succeeded, delegating pod operations to
+// PodControl and checkpoint operations to CheckpointControl.
+type UpgradeControl struct {
+	client.Client
+	checkpointControl *CheckpointControl
+	podControl        *PodControl
+	lifecycleHookFunc LifecycleHookFunc
+	initializer       SandboxInitializer
+}
+
+// NewUpgradeControl creates a new UpgradeControl.
+//
+// podControl is passed in as a parameter so that callers can inject a
+// customised PodControl (e.g. with a different PodGenerateFunc) when needed.
+func NewUpgradeControl(
+	cli client.Client,
+	checkpointControl *CheckpointControl,
+	podControl *PodControl,
+	lifecycleHookFunc LifecycleHookFunc,
+	initializer SandboxInitializer,
+) *UpgradeControl {
+	return &UpgradeControl{
+		Client:            cli,
+		checkpointControl: checkpointControl,
+		podControl:        podControl,
+		lifecycleHookFunc: lifecycleHookFunc,
+		initializer:       initializer,
+	}
+}
+
+// EnsureSandboxUpgraded drives the sandbox upgrade state machine.
+//
+// The state transitions are:
+//
+//	PreUpgrade → (CheckpointRestore? → Checkpointing →) UpgradePod → PostUpgrade → Succeeded
+//
+// Each reconcile cycle processes exactly one state and returns nil so the
+// controller can persist the updated condition before re-entering the next
+// state. Failed states (PreUpgradeFailed, CheckpointFailed, UpgradePodFailed,
+// PostUpgradeFailed) are retried on subsequent reconciles.
+func (r *UpgradeControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureFuncArgs) (retErr error) {
+	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
+	isCheckpointRestore := box.Spec.UpgradePolicy != nil &&
+		box.Spec.UpgradePolicy.Type == agentsv1alpha1.SandboxUpgradePolicyCheckpointRestore
+
+	// Set Ready=False during upgrade
+	utils.SetSandboxCondition(newStatus, metav1.Condition{
+		Type:               string(agentsv1alpha1.SandboxConditionReady),
+		Status:             metav1.ConditionFalse,
+		Reason:             agentsv1alpha1.SandboxReadyReasonUpgrading,
+		Message:            "sandbox is upgrading",
+		LastTransitionTime: metav1.Now(),
+	})
+	upgradeCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionUpgrading))
+	// Phase 1: First entry - execute preUpgrade and initialize
+	if upgradeCond == nil {
+		upgradeCond = &metav1.Condition{
+			Type:               string(agentsv1alpha1.SandboxConditionUpgrading),
+			Status:             metav1.ConditionFalse,
+			Reason:             agentsv1alpha1.SandboxUpgradingReasonPreUpgrade,
+			LastTransitionTime: metav1.Now(),
+		}
+		utils.SetSandboxCondition(newStatus, *upgradeCond)
+	}
+
+	switch upgradeCond.Reason {
+	case agentsv1alpha1.SandboxUpgradingReasonPreUpgrade, agentsv1alpha1.SandboxUpgradingReasonPreUpgradeFailed:
+		// Execute preUpgrade if configured
+		if hasUpgradeAction(box, true) {
+			var action *agentsv1alpha1.UpgradeAction
+			if box.Spec.Lifecycle != nil {
+				action = box.Spec.Lifecycle.PreUpgrade
+			}
+			result := r.executeUpgradeAction(ctx, pod, box, action)
+			klog.InfoS("preUpgrade result", "sandbox", klog.KObj(box), "succeeded", result.Succeeded, "message", result.Message)
+			if !result.Succeeded {
+				// Record preUpgrade action failed
+				upgradeCond.Message = result.Message
+				upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonPreUpgradeFailed
+				utils.SetSandboxCondition(newStatus, *upgradeCond)
+				return nil
+			}
+		}
+
+		// For CheckpointRestore, transition to Checkpointing; otherwise to UpgradePod.
+		if isCheckpointRestore {
+			klog.InfoS("preUpgrade completed, transitioning to Checkpointing", "sandbox", klog.KObj(box))
+			upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonCheckpointing
+		} else {
+			klog.InfoS("preUpgrade completed, transitioning to UpgradePod", "sandbox", klog.KObj(box))
+			upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonUpgradePod
+		}
+		upgradeCond.Message = ""
+		utils.SetSandboxCondition(newStatus, *upgradeCond)
+		return nil
+	case agentsv1alpha1.SandboxUpgradingReasonCheckpointing, agentsv1alpha1.SandboxUpgradingReasonCheckpointFailed:
+		checkpointDone, err := r.checkpointControl.EnsureCheckpointForUpgrade(ctx, box)
+		if err != nil {
+			klog.ErrorS(err, "Checkpoint failed during upgrade", "sandbox", klog.KObj(box))
+			upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonCheckpointFailed
+			upgradeCond.Message = err.Error()
+			utils.SetSandboxCondition(newStatus, *upgradeCond)
+			return err
+		}
+		if !checkpointDone {
+			klog.InfoS("Waiting for checkpoint to complete", "sandbox", klog.KObj(box))
+			upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonCheckpointing
+			upgradeCond.Message = "Waiting for checkpoint to complete before pod deletion"
+			utils.SetSandboxCondition(newStatus, *upgradeCond)
+			return nil
+		}
+		klog.InfoS("Checkpoint succeeded, transitioning to UpgradePod", "sandbox", klog.KObj(box))
+		upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonUpgradePod
+		upgradeCond.Message = ""
+		utils.SetSandboxCondition(newStatus, *upgradeCond)
+		fallthrough
+	case agentsv1alpha1.SandboxUpgradingReasonUpgradePod, agentsv1alpha1.SandboxUpgradingReasonUpgradePodFailed:
+		done, err := r.performRecreateUpgrade(ctx, args)
+		if err != nil {
+			klog.ErrorS(err, "UpgradePod step failed", "sandbox", klog.KObj(box))
+			return err
+		} else if !done {
+			klog.InfoS("UpgradePod step in progress", "sandbox", klog.KObj(box))
+			return nil // upgrade in progress
+		}
+
+		klog.InfoS("UpgradePod step completed, transitioning to PostUpgrade", "sandbox", klog.KObj(box))
+
+		// Re-fetch the Pod after recreate upgrade, since the old pod object is stale (deleted and replaced).
+		var freshPod corev1.Pod
+		if err := r.Get(ctx, types.NamespacedName{Namespace: box.Namespace, Name: box.Name}, &freshPod); err != nil {
+			klog.ErrorS(err, "Failed to re-fetch pod after recreate upgrade", "sandbox", klog.KObj(box))
+			return err
+		}
+		pod = &freshPod
+
+		// UpgradePod step completed
+		upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonPostUpgrade
+		upgradeCond.Message = ""
+		utils.SetSandboxCondition(newStatus, *upgradeCond)
+		fallthrough
+	case agentsv1alpha1.SandboxUpgradingReasonPostUpgrade, agentsv1alpha1.SandboxUpgradingReasonPostUpgradeFailed:
+		// Execute postUpgrade if configured
+		if hasUpgradeAction(box, false) {
+			var action *agentsv1alpha1.UpgradeAction
+			if box.Spec.Lifecycle != nil {
+				action = box.Spec.Lifecycle.PostUpgrade
+			}
+			result := r.executeUpgradeAction(ctx, pod, box, action)
+			klog.InfoS("postUpgrade result", "sandbox", klog.KObj(box), "succeeded", result.Succeeded, "message", result.Message)
+			if !result.Succeeded {
+				// Record postUpgrade action failed
+				upgradeCond.Message = result.Message
+				upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonPostUpgradeFailed
+				utils.SetSandboxCondition(newStatus, *upgradeCond)
+				return nil
+			}
+		}
+
+		klog.InfoS("postUpgrade completed, transitioning to Succeeded", "sandbox", klog.KObj(box))
+		upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonSucceeded
+		upgradeCond.Status = metav1.ConditionTrue
+		upgradeCond.Message = ""
+		upgradeCond.LastTransitionTime = metav1.Now()
+		utils.SetSandboxCondition(newStatus, *upgradeCond)
+		newStatus.Phase = agentsv1alpha1.SandboxRunning
+		utils.SetSandboxCondition(newStatus, metav1.Condition{
+			Type:               string(agentsv1alpha1.SandboxConditionReady),
+			Status:             metav1.ConditionTrue,
+			Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
+			Message:            "",
+			LastTransitionTime: metav1.Now(),
+		})
+	}
+
+	return nil
+}
+
+// performRecreateUpgrade handles the Recreate upgrade step (delete old pod + create new pod).
+// For CheckpointRestore policy, it restores the PodTemplateDelta when creating the new pod
+// and cleans up checkpoint CRs after successful upgrade.
+func (r *UpgradeControl) performRecreateUpgrade(ctx context.Context, args EnsureFuncArgs) (bool, error) {
+	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
+
+	isCheckpointRestore := box.Spec.UpgradePolicy != nil &&
+		box.Spec.UpgradePolicy.Type == agentsv1alpha1.SandboxUpgradePolicyCheckpointRestore
+
+	// Step 1: Delete old Pod (has old template hash)
+	if pod != nil && pod.Labels[agentsv1alpha1.PodLabelTemplateHash] != newStatus.UpdateRevision {
+		if !pod.DeletionTimestamp.IsZero() {
+			klog.InfoS("Waiting for pod deletion to complete", "sandbox", klog.KObj(box))
+			return false, nil
+		}
+		// Delete pod
+		ScaleExpectation.ExpectScale(GetControllerKey(box), expectations.Delete, box.Name)
+		if err := r.Delete(ctx, pod); err != nil {
+			ScaleExpectation.ObserveScale(GetControllerKey(box), expectations.Delete, box.Name)
+			if !errors.IsNotFound(err) {
+				klog.ErrorS(err, "Failed to delete pod for upgrade", "sandbox", klog.KObj(box))
+				return false, err
+			}
+		}
+		klog.InfoS("Deleted old pod for upgrade", "sandbox", klog.KObj(box))
+		return false, nil
+	}
+
+	// Step 2: Create new Pod (old pod deleted)
+	if pod == nil {
+		klog.InfoS("Creating new pod for upgrade", "sandbox", klog.KObj(box))
+		createArgs := CreatePodArgs{Box: box, NewStatus: newStatus}
+		// For CheckpointRestore, set the checkpoint ID annotation so the
+		// checkpoint controller can restore the pod's writable layer.
+		if isCheckpointRestore {
+			createArgs.CheckpointID = r.checkpointControl.GetCheckpointIDForUpgrade(ctx, box)
+		}
+		newPod, err := r.podControl.CreatePod(ctx, createArgs)
+		if err != nil {
+			klog.ErrorS(err, "Failed to create new pod for upgrade", "sandbox", klog.KObj(box))
+			return false, err
+		}
+		if newPod != nil {
+			klog.InfoS("New pod created for upgrade", "sandbox", klog.KObj(box), "pod", klog.KObj(newPod))
+		}
+		return false, nil
+	}
+
+	if pod.Status.PodIP != "" && pod.Spec.NodeName != "" {
+		newStatus.NodeName = pod.Spec.NodeName
+		newStatus.SandboxIp = pod.Status.PodIP
+		newStatus.PodInfo = agentsv1alpha1.PodInfo{
+			PodIP:    pod.Status.PodIP,
+			NodeName: pod.Spec.NodeName,
+			PodUID:   pod.UID,
+		}
+	}
+
+	// Step 3: Wait for new Pod to be running and ready
+	pCond := utils.GetPodCondition(&pod.Status, corev1.PodReady)
+	cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionUpgrading))
+	if pCond == nil || pCond.Status != corev1.ConditionTrue {
+		klog.InfoS("Waiting for new pod to be ready", "sandbox", klog.KObj(box))
+		for _, cStatus := range pod.Status.ContainerStatuses {
+			if cStatus.State.Waiting != nil {
+				reason := cStatus.State.Waiting.Reason
+				// PodInitializing and ContainerCreating are normal transient states during startup, skip them
+				if reason == WaitingReasonPodInitializing || reason == WaitingReasonContainerCreating {
+					continue
+				}
+				// Other waiting reasons indicate container startup failure
+				klog.InfoS("container waiting with abnormal reason", "sandbox", klog.KObj(box),
+					"container", cStatus.Name, "reason", reason, "message", cStatus.State.Waiting.Message)
+				cond.Reason = agentsv1alpha1.SandboxUpgradingReasonUpgradePodFailed
+				cond.Message = fmt.Sprintf("container %s: %s - %s", cStatus.Name, reason, cStatus.State.Waiting.Message)
+				utils.SetSandboxCondition(newStatus, *cond)
+			} else if cStatus.State.Terminated != nil {
+				klog.InfoS("container terminated unexpectedly", "sandbox", klog.KObj(box),
+					"container", cStatus.Name, "reason", cStatus.State.Terminated.Reason,
+					"exitCode", cStatus.State.Terminated.ExitCode, "message", cStatus.State.Terminated.Message)
+				cond.Reason = agentsv1alpha1.SandboxUpgradingReasonUpgradePodFailed
+				cond.Message = fmt.Sprintf("container %s: terminated with exit code %d - %s",
+					cStatus.Name, cStatus.State.Terminated.ExitCode, cStatus.State.Terminated.Reason)
+				utils.SetSandboxCondition(newStatus, *cond)
+			}
+		}
+		return false, nil
+	}
+
+	// Step 4: Perform post-recreate-upgrade initialization (re-init runtime, re-mount CSI).
+	if err := r.initializer.Initialize(ctx, box, newStatus); err != nil {
+		return false, err
+	}
+
+	// Step 5: For CheckpointRestore, clean up checkpoint CRs after successful upgrade.
+	if isCheckpointRestore {
+		r.checkpointControl.CleanupForUpgrade(ctx, box)
+	}
+
+	return true, nil
+}
+
+// upgradeActionResult represents the result of executing an upgrade hook.
+type upgradeActionResult struct {
+	Succeeded bool
+	Message   string
+}
+
+// executeUpgradeAction executes an upgrade action and returns the result.
+// If action is nil (not configured), it returns success directly.
+// If pod is nil and action is configured, it returns failure.
+func (r *UpgradeControl) executeUpgradeAction(ctx context.Context, pod *corev1.Pod, box *agentsv1alpha1.Sandbox, action *agentsv1alpha1.UpgradeAction) upgradeActionResult {
+	if action == nil {
+		return upgradeActionResult{Succeeded: true, Message: "no hook configured, skipped"}
+	}
+	if pod == nil {
+		return upgradeActionResult{Succeeded: false, Message: "pod not found, cannot execute hook"}
+	}
+
+	exitCode, stdout, stderr, err := r.lifecycleHookFunc(ctx, box, action)
+	if err != nil {
+		msg := fmt.Sprintf("hook execution error: %v, stderr: %s, stdout: %s", err, stderr, stdout)
+		return upgradeActionResult{Succeeded: false, Message: utils.TruncateConditionMessage(msg)}
+	}
+	if exitCode != 0 {
+		msg := fmt.Sprintf("hook failed with exit code %d, stderr: %s, stdout: %s", exitCode, stderr, stdout)
+		return upgradeActionResult{Succeeded: false, Message: utils.TruncateConditionMessage(msg)}
+	}
+	return upgradeActionResult{Succeeded: true, Message: fmt.Sprintf("hook succeeded, stdout: %s", stdout)}
+}
+
+// hasUpgradeAction checks if the sandbox has a non-empty upgrade action configured.
+// If pre is true, checks PreUpgrade; otherwise checks PostUpgrade.
+func hasUpgradeAction(box *agentsv1alpha1.Sandbox, pre bool) bool {
+	if box.Spec.Lifecycle == nil {
+		return false
+	}
+	var action *agentsv1alpha1.UpgradeAction
+	if pre {
+		action = box.Spec.Lifecycle.PreUpgrade
+	} else {
+		action = box.Spec.Lifecycle.PostUpgrade
+	}
+	if action == nil || action.Exec == nil || len(action.Exec.Command) == 0 {
+		return false
+	}
+	return true
+}

--- a/pkg/controller/sandbox/core/upgrade_control.go
+++ b/pkg/controller/sandbox/core/upgrade_control.go
@@ -193,6 +193,11 @@ func (r *UpgradeControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureF
 			}
 		}
 
+		// For CheckpointRestore, clean up checkpoint CRs after the entire upgrade succeeds.
+		if isCheckpointRestore {
+			r.checkpointControl.CleanupForUpgrade(ctx, box)
+		}
+
 		klog.InfoS("postUpgrade completed, transitioning to Succeeded", "sandbox", klog.KObj(box))
 		upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonSucceeded
 		upgradeCond.Status = metav1.ConditionTrue
@@ -213,8 +218,7 @@ func (r *UpgradeControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureF
 }
 
 // performRecreateUpgrade handles the Recreate upgrade step (delete old pod + create new pod).
-// For CheckpointRestore policy, it restores the PodTemplateDelta when creating the new pod
-// and cleans up checkpoint CRs after successful upgrade.
+// For CheckpointRestore policy, it restores the PodTemplateDelta when creating the new pod.
 func (r *UpgradeControl) performRecreateUpgrade(ctx context.Context, args EnsureFuncArgs) (bool, error) {
 	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
 
@@ -304,11 +308,6 @@ func (r *UpgradeControl) performRecreateUpgrade(ctx context.Context, args Ensure
 	// Step 4: Perform post-recreate-upgrade initialization (re-init runtime, re-mount CSI).
 	if err := r.initializer.Initialize(ctx, box, newStatus); err != nil {
 		return false, err
-	}
-
-	// Step 5: For CheckpointRestore, clean up checkpoint CRs after successful upgrade.
-	if isCheckpointRestore {
-		r.checkpointControl.CleanupForUpgrade(ctx, box)
 	}
 
 	return true, nil

--- a/pkg/controller/sandbox/core/upgrade_control_test.go
+++ b/pkg/controller/sandbox/core/upgrade_control_test.go
@@ -112,14 +112,19 @@ func newTestCommonControl(hookFunc LifecycleHookFunc, objects ...client.Object) 
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = agentsv1alpha1.AddToScheme(scheme)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	checkpointCtrl := NewCheckpointControl(fakeClient, record.NewFakeRecorder(100))
+	podCtrl := NewPodControl(fakeClient, record.NewFakeRecorder(100), GeneratePodFromSandbox)
+	initializer := &defaultSandboxInitializer{recorder: record.NewFakeRecorder(10)}
 	return &commonControl{
 		Client:               fakeClient,
 		recorder:             record.NewFakeRecorder(100),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		rateLimiter:          NewRateLimiter(),
-		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(100), GeneratePodFromSandbox),
+		checkpointControl:    checkpointCtrl,
+		podControl:           podCtrl,
 		lifecycleHookFunc:    hookFunc,
-		initializer:          &defaultSandboxInitializer{recorder: record.NewFakeRecorder(10)},
+		initializer:          initializer,
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, hookFunc, initializer),
 	}
 }
 
@@ -166,7 +171,7 @@ func TestExecuteUpgradeAction(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := newTestCommonControl(tt.hookFunc, box.DeepCopy(), pod.DeepCopy())
-			result := ctrl.executeUpgradeAction(context.Background(), pod, box, action)
+			result := ctrl.upgradeControl.executeUpgradeAction(context.Background(), pod, box, action)
 			assert.Equal(t, tt.expectSuccess, result.Succeeded)
 			assert.Contains(t, result.Message, tt.expectContains)
 			// Verify truncation: message must not exceed MaxConditionMessageLen + len("...")

--- a/pkg/controller/sandbox/core/upgrade_control_test.go
+++ b/pkg/controller/sandbox/core/upgrade_control_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,6 +34,7 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/utils"
+	"github.com/openkruise/agents/pkg/utils/fieldindex"
 	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
 )
 
@@ -813,6 +815,667 @@ func TestEnsureInplaceUpgrade(t *testing.T) {
 						condType, expectedStatus, cond.Status, cond.Reason, cond.Message)
 				}
 			}
+		})
+	}
+}
+
+// newTestCommonControlWithCheckpointIndex creates a commonControl with field index support
+// for Checkpoint CRs, needed for CheckpointRestore upgrade tests.
+func newTestCommonControlWithCheckpointIndex(hookFunc LifecycleHookFunc, objects ...client.Object) *commonControl {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithIndex(&agentsv1alpha1.Checkpoint{}, fieldindex.IndexNameForOwnerRefUID, fieldindex.OwnerIndexFunc).
+		WithStatusSubresource(&agentsv1alpha1.Checkpoint{}).
+		WithObjects(objects...).Build()
+	checkpointCtrl := NewCheckpointControl(fakeClient, record.NewFakeRecorder(100))
+	podCtrl := NewPodControl(fakeClient, record.NewFakeRecorder(100), GeneratePodFromSandbox)
+	initializer := &defaultSandboxInitializer{recorder: record.NewFakeRecorder(10)}
+	return &commonControl{
+		Client:               fakeClient,
+		recorder:             record.NewFakeRecorder(100),
+		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
+		rateLimiter:          NewRateLimiter(),
+		checkpointControl:    checkpointCtrl,
+		podControl:           podCtrl,
+		lifecycleHookFunc:    hookFunc,
+		initializer:          initializer,
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, hookFunc, initializer),
+	}
+}
+
+func newCheckpointRestoreSandbox(lifecycle *agentsv1alpha1.SandboxLifecycle) *agentsv1alpha1.Sandbox {
+	box := newUpgradeTestSandbox(lifecycle, &agentsv1alpha1.SandboxUpgradePolicy{
+		Type: agentsv1alpha1.SandboxUpgradePolicyCheckpointRestore,
+	})
+	box.UID = types.UID("sandbox-uid-001")
+	return box
+}
+
+func newUpgradeCheckpoint(name string, box *agentsv1alpha1.Sandbox, phase agentsv1alpha1.CheckpointPhase) *agentsv1alpha1.Checkpoint {
+	return &agentsv1alpha1.Checkpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: box.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(box, sandboxControllerKind),
+			},
+			Labels: map[string]string{
+				agentsv1alpha1.CheckpointLabelSandboxName: box.Name,
+				agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointTypeUpgrade,
+			},
+		},
+		Status: agentsv1alpha1.CheckpointStatus{
+			Phase: phase,
+		},
+	}
+}
+
+func TestEnsureSandboxUpgraded_CheckpointRestore(t *testing.T) {
+	now := metav1.Now()
+
+	tests := []struct {
+		name            string
+		pod             *corev1.Pod
+		box             *agentsv1alpha1.Sandbox
+		existingStatus  *agentsv1alpha1.SandboxStatus
+		existingCPs     []client.Object
+		mockHookFunc    LifecycleHookFunc
+		expectErr       bool
+		expectPhase     agentsv1alpha1.SandboxPhase
+		expectReason    string
+		expectCondition map[string]metav1.ConditionStatus
+	}{
+		{
+			name: "CheckpointRestore - PreUpgrade transitions to Checkpointing",
+			pod:  newRunningPod(),
+			box:  newCheckpointRestoreSandbox(nil),
+			existingStatus: &agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxUpgrading,
+			},
+			mockHookFunc: mockLifecycleHookFunc(0, "", "", nil),
+			expectErr:    false,
+			expectPhase:  agentsv1alpha1.SandboxUpgrading,
+			expectReason: agentsv1alpha1.SandboxUpgradingReasonCheckpointing,
+		},
+		{
+			name: "CheckpointRestore - Checkpointing in progress, waits",
+			pod:  newRunningPod(),
+			box:  newCheckpointRestoreSandbox(nil),
+			existingStatus: &agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxUpgrading,
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionUpgrading),
+						Status:             metav1.ConditionFalse,
+						Reason:             agentsv1alpha1.SandboxUpgradingReasonCheckpointing,
+						LastTransitionTime: now,
+					},
+				},
+			},
+			existingCPs: []client.Object{
+				newUpgradeCheckpoint("test-sandbox-cp1", newCheckpointRestoreSandbox(nil), agentsv1alpha1.CheckpointCreating),
+			},
+			mockHookFunc: mockLifecycleHookFunc(0, "", "", nil),
+			expectErr:    false,
+			expectPhase:  agentsv1alpha1.SandboxUpgrading,
+			expectReason: agentsv1alpha1.SandboxUpgradingReasonCheckpointing,
+		},
+		{
+			name: "CheckpointRestore - Checkpoint succeeded, transitions to UpgradePod",
+			pod: func() *corev1.Pod {
+				p := newRunningPod()
+				p.Labels[agentsv1alpha1.PodLabelTemplateHash] = "old-revision"
+				return p
+			}(),
+			box: newCheckpointRestoreSandbox(nil),
+			existingStatus: &agentsv1alpha1.SandboxStatus{
+				Phase:          agentsv1alpha1.SandboxUpgrading,
+				UpdateRevision: "new-revision",
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionUpgrading),
+						Status:             metav1.ConditionFalse,
+						Reason:             agentsv1alpha1.SandboxUpgradingReasonCheckpointing,
+						LastTransitionTime: now,
+					},
+				},
+			},
+			existingCPs: []client.Object{
+				newUpgradeCheckpoint("test-sandbox-cp1", newCheckpointRestoreSandbox(nil), agentsv1alpha1.CheckpointSucceeded),
+			},
+			mockHookFunc: mockLifecycleHookFunc(0, "", "", nil),
+			expectErr:    false,
+			expectPhase:  agentsv1alpha1.SandboxUpgrading,
+			expectReason: agentsv1alpha1.SandboxUpgradingReasonUpgradePod,
+		},
+		{
+			name: "CheckpointRestore - Checkpoint failed, returns error",
+			pod:  newRunningPod(),
+			box:  newCheckpointRestoreSandbox(nil),
+			existingStatus: &agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxUpgrading,
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionUpgrading),
+						Status:             metav1.ConditionFalse,
+						Reason:             agentsv1alpha1.SandboxUpgradingReasonCheckpointing,
+						LastTransitionTime: now,
+					},
+				},
+			},
+			existingCPs: []client.Object{
+				func() *agentsv1alpha1.Checkpoint {
+					cp := newUpgradeCheckpoint("test-sandbox-cp1", newCheckpointRestoreSandbox(nil), agentsv1alpha1.CheckpointFailed)
+					cp.Status.Message = "checkpoint timeout"
+					return cp
+				}(),
+			},
+			mockHookFunc: mockLifecycleHookFunc(0, "", "", nil),
+			expectErr:    true,
+			expectPhase:  agentsv1alpha1.SandboxUpgrading,
+			expectReason: agentsv1alpha1.SandboxUpgradingReasonCheckpointFailed,
+		},
+		{
+			name: "CheckpointRestore - PostUpgrade succeeds with cleanup",
+			pod: func() *corev1.Pod {
+				p := newRunningPod()
+				p.Labels[agentsv1alpha1.PodLabelTemplateHash] = "new-revision"
+				p.Spec.NodeName = "node-1"
+				p.Status.PodIP = "10.0.0.2"
+				return p
+			}(),
+			box: newCheckpointRestoreSandbox(nil),
+			existingStatus: &agentsv1alpha1.SandboxStatus{
+				Phase:          agentsv1alpha1.SandboxUpgrading,
+				UpdateRevision: "new-revision",
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionUpgrading),
+						Status:             metav1.ConditionFalse,
+						Reason:             agentsv1alpha1.SandboxUpgradingReasonPostUpgrade,
+						LastTransitionTime: now,
+					},
+				},
+			},
+			existingCPs: []client.Object{
+				newUpgradeCheckpoint("test-sandbox-cp1", newCheckpointRestoreSandbox(nil), agentsv1alpha1.CheckpointSucceeded),
+			},
+			mockHookFunc: mockLifecycleHookFunc(0, "", "", nil),
+			expectErr:    false,
+			expectPhase:  agentsv1alpha1.SandboxRunning,
+			expectReason: agentsv1alpha1.SandboxUpgradingReasonSucceeded,
+			expectCondition: map[string]metav1.ConditionStatus{
+				string(agentsv1alpha1.SandboxConditionReady):     metav1.ConditionTrue,
+				string(agentsv1alpha1.SandboxConditionUpgrading): metav1.ConditionTrue,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objects []client.Object
+			if tt.pod != nil {
+				objects = append(objects, tt.pod.DeepCopy())
+			}
+			objects = append(objects, tt.existingCPs...)
+
+			control := newTestCommonControlWithCheckpointIndex(tt.mockHookFunc, objects...)
+			newStatus := tt.existingStatus.DeepCopy()
+
+			args := EnsureFuncArgs{
+				Pod:       tt.pod,
+				Box:       tt.box,
+				NewStatus: newStatus,
+			}
+
+			err := control.EnsureSandboxUpgraded(context.TODO(), args)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("EnsureSandboxUpgraded() error = %v, wantErr %v", err, tt.expectErr)
+				return
+			}
+
+			if tt.expectPhase != "" && newStatus.Phase != tt.expectPhase {
+				t.Errorf("Expected phase %q, got %q", tt.expectPhase, newStatus.Phase)
+			}
+
+			if tt.expectReason != "" {
+				cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionUpgrading))
+				if cond == nil {
+					t.Errorf("Expected Upgrading condition to exist")
+				} else if cond.Reason != tt.expectReason {
+					t.Errorf("Expected reason %q, got %q", tt.expectReason, cond.Reason)
+				}
+			}
+
+			for condType, expectedStatus := range tt.expectCondition {
+				cond := utils.GetSandboxCondition(newStatus, condType)
+				if cond == nil {
+					t.Errorf("Expected condition %q to exist", condType)
+					continue
+				}
+				if cond.Status != expectedStatus {
+					t.Errorf("Expected condition %q status %q, got %q", condType, expectedStatus, cond.Status)
+				}
+			}
+		})
+	}
+}
+
+func TestPerformRecreateUpgrade_ContainerStatuses(t *testing.T) {
+	now := metav1.Now()
+
+	tests := []struct {
+		name            string
+		pod             *corev1.Pod
+		box             *agentsv1alpha1.Sandbox
+		existingStatus  *agentsv1alpha1.SandboxStatus
+		mockHookFunc    LifecycleHookFunc
+		expectErr       bool
+		expectPhase     agentsv1alpha1.SandboxPhase
+		expectReason    string
+		expectCondition map[string]metav1.ConditionStatus
+	}{
+		{
+			name: "pod not ready with container waiting abnormal reason sets UpgradePodFailed",
+			pod: func() *corev1.Pod {
+				p := newRunningPod()
+				p.Labels[agentsv1alpha1.PodLabelTemplateHash] = "new-revision"
+				p.Status.Phase = corev1.PodPending
+				p.Status.Conditions = nil
+				p.Status.ContainerStatuses = []corev1.ContainerStatus{
+					{
+						Name: "sandbox",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason:  "CrashLoopBackOff",
+								Message: "container is in crash loop",
+							},
+						},
+					},
+				}
+				return p
+			}(),
+			box: newUpgradeTestSandbox(nil, nil),
+			existingStatus: &agentsv1alpha1.SandboxStatus{
+				Phase:          agentsv1alpha1.SandboxUpgrading,
+				UpdateRevision: "new-revision",
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionUpgrading),
+						Status:             metav1.ConditionFalse,
+						Reason:             agentsv1alpha1.SandboxUpgradingReasonUpgradePod,
+						LastTransitionTime: now,
+					},
+				},
+			},
+			mockHookFunc:  mockLifecycleHookFunc(0, "", "", nil),
+			expectErr:     false,
+			expectPhase:   agentsv1alpha1.SandboxUpgrading,
+			expectReason:  agentsv1alpha1.SandboxUpgradingReasonUpgradePodFailed,
+			expectCondition: map[string]metav1.ConditionStatus{
+				string(agentsv1alpha1.SandboxConditionUpgrading): metav1.ConditionFalse,
+			},
+		},
+		{
+			name: "pod not ready with container terminated sets UpgradePodFailed",
+			pod: func() *corev1.Pod {
+				p := newRunningPod()
+				p.Labels[agentsv1alpha1.PodLabelTemplateHash] = "new-revision"
+				p.Status.Phase = corev1.PodPending
+				p.Status.Conditions = nil
+				p.Status.ContainerStatuses = []corev1.ContainerStatus{
+					{
+						Name: "sandbox",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								Reason:   "Error",
+								ExitCode: 1,
+								Message:  "container exited with error",
+							},
+						},
+					},
+				}
+				return p
+			}(),
+			box: newUpgradeTestSandbox(nil, nil),
+			existingStatus: &agentsv1alpha1.SandboxStatus{
+				Phase:          agentsv1alpha1.SandboxUpgrading,
+				UpdateRevision: "new-revision",
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionUpgrading),
+						Status:             metav1.ConditionFalse,
+						Reason:             agentsv1alpha1.SandboxUpgradingReasonUpgradePod,
+						LastTransitionTime: now,
+					},
+				},
+			},
+			mockHookFunc:  mockLifecycleHookFunc(0, "", "", nil),
+			expectErr:     false,
+			expectPhase:   agentsv1alpha1.SandboxUpgrading,
+			expectReason:  agentsv1alpha1.SandboxUpgradingReasonUpgradePodFailed,
+			expectCondition: map[string]metav1.ConditionStatus{
+				string(agentsv1alpha1.SandboxConditionUpgrading): metav1.ConditionFalse,
+			},
+		},
+		{
+			name: "pod not ready with PodInitializing (normal transient) does not set UpgradePodFailed",
+			pod: func() *corev1.Pod {
+				p := newRunningPod()
+				p.Labels[agentsv1alpha1.PodLabelTemplateHash] = "new-revision"
+				p.Status.Phase = corev1.PodPending
+				p.Status.Conditions = nil
+				p.Status.ContainerStatuses = []corev1.ContainerStatus{
+					{
+						Name: "sandbox",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason:  WaitingReasonPodInitializing,
+								Message: "pod is initializing",
+							},
+						},
+					},
+				}
+				return p
+			}(),
+			box: newUpgradeTestSandbox(nil, nil),
+			existingStatus: &agentsv1alpha1.SandboxStatus{
+				Phase:          agentsv1alpha1.SandboxUpgrading,
+				UpdateRevision: "new-revision",
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionUpgrading),
+						Status:             metav1.ConditionFalse,
+						Reason:             agentsv1alpha1.SandboxUpgradingReasonUpgradePod,
+						LastTransitionTime: now,
+					},
+				},
+			},
+			mockHookFunc:  mockLifecycleHookFunc(0, "", "", nil),
+			expectErr:     false,
+			expectPhase:   agentsv1alpha1.SandboxUpgrading,
+			expectReason:  agentsv1alpha1.SandboxUpgradingReasonUpgradePod,
+			expectCondition: map[string]metav1.ConditionStatus{
+				string(agentsv1alpha1.SandboxConditionUpgrading): metav1.ConditionFalse,
+			},
+		},
+		{
+			name: "pod not ready with ContainerCreating (normal transient) does not set UpgradePodFailed",
+			pod: func() *corev1.Pod {
+				p := newRunningPod()
+				p.Labels[agentsv1alpha1.PodLabelTemplateHash] = "new-revision"
+				p.Status.Phase = corev1.PodPending
+				p.Status.Conditions = nil
+				p.Status.ContainerStatuses = []corev1.ContainerStatus{
+					{
+						Name: "sandbox",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason:  WaitingReasonContainerCreating,
+								Message: "container is being created",
+							},
+						},
+					},
+				}
+				return p
+			}(),
+			box: newUpgradeTestSandbox(nil, nil),
+			existingStatus: &agentsv1alpha1.SandboxStatus{
+				Phase:          agentsv1alpha1.SandboxUpgrading,
+				UpdateRevision: "new-revision",
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionUpgrading),
+						Status:             metav1.ConditionFalse,
+						Reason:             agentsv1alpha1.SandboxUpgradingReasonUpgradePod,
+						LastTransitionTime: now,
+					},
+				},
+			},
+			mockHookFunc:  mockLifecycleHookFunc(0, "", "", nil),
+			expectErr:     false,
+			expectPhase:   agentsv1alpha1.SandboxUpgrading,
+			expectReason:  agentsv1alpha1.SandboxUpgradingReasonUpgradePod,
+			expectCondition: map[string]metav1.ConditionStatus{
+				string(agentsv1alpha1.SandboxConditionUpgrading): metav1.ConditionFalse,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objects []client.Object
+			if tt.pod != nil {
+				objects = append(objects, tt.pod.DeepCopy())
+			}
+
+			control := newTestCommonControl(tt.mockHookFunc, objects...)
+			newStatus := tt.existingStatus.DeepCopy()
+
+			args := EnsureFuncArgs{
+				Pod:       tt.pod,
+				Box:       tt.box,
+				NewStatus: newStatus,
+			}
+
+			err := control.EnsureSandboxUpgraded(context.TODO(), args)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("EnsureSandboxUpgraded() error = %v, wantErr %v", err, tt.expectErr)
+				return
+			}
+
+			if tt.expectPhase != "" && newStatus.Phase != tt.expectPhase {
+				t.Errorf("Expected phase %q, got %q", tt.expectPhase, newStatus.Phase)
+			}
+
+			if tt.expectReason != "" {
+				cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionUpgrading))
+				if cond == nil {
+					t.Errorf("Expected Upgrading condition to exist")
+				} else if cond.Reason != tt.expectReason {
+					t.Errorf("Expected reason %q, got %q", tt.expectReason, cond.Reason)
+				}
+			}
+
+			for condType, expectedStatus := range tt.expectCondition {
+				cond := utils.GetSandboxCondition(newStatus, condType)
+				if cond == nil {
+					t.Errorf("Expected condition %q to exist", condType)
+					continue
+				}
+				if cond.Status != expectedStatus {
+					t.Errorf("Expected condition %q status %q, got %q", condType, expectedStatus, cond.Status)
+				}
+			}
+		})
+	}
+}
+
+func TestPerformRecreateUpgrade_CheckpointRestore_CreatePod(t *testing.T) {
+	now := metav1.Now()
+
+	// CheckpointRestore with pod=nil in UpgradePod state should create a new pod
+	// with the checkpoint ID annotation.
+	box := newCheckpointRestoreSandbox(nil)
+	pod := newRunningPod()
+	pod.Labels[agentsv1alpha1.PodLabelTemplateHash] = "old-revision"
+
+	// Create a checkpoint with an ID so GetCheckpointIDForUpgrade returns it
+	cp := newUpgradeCheckpoint("test-sandbox-cp1", box, agentsv1alpha1.CheckpointSucceeded)
+	cp.Status.CheckpointId = "cp-id-restore-123"
+
+	control := newTestCommonControlWithCheckpointIndex(
+		mockLifecycleHookFunc(0, "", "", nil),
+		pod.DeepCopy(),
+		cp,
+	)
+
+	newStatus := &agentsv1alpha1.SandboxStatus{
+		Phase:          agentsv1alpha1.SandboxUpgrading,
+		UpdateRevision: "new-revision",
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(agentsv1alpha1.SandboxConditionUpgrading),
+				Status:             metav1.ConditionFalse,
+				Reason:             agentsv1alpha1.SandboxUpgradingReasonUpgradePod,
+				LastTransitionTime: now,
+			},
+		},
+	}
+
+	// First call: pod has old-revision hash, so it gets deleted (Step 1)
+	args := EnsureFuncArgs{
+		Pod:       pod,
+		Box:       box,
+		NewStatus: newStatus,
+	}
+	err := control.EnsureSandboxUpgraded(context.TODO(), args)
+	assert.NoError(t, err)
+
+	// Second call: pod is nil (deleted), so it creates a new pod with checkpoint ID (Step 2)
+	newStatus2 := &agentsv1alpha1.SandboxStatus{
+		Phase:          agentsv1alpha1.SandboxUpgrading,
+		UpdateRevision: "new-revision",
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(agentsv1alpha1.SandboxConditionUpgrading),
+				Status:             metav1.ConditionFalse,
+				Reason:             agentsv1alpha1.SandboxUpgradingReasonUpgradePod,
+				LastTransitionTime: now,
+			},
+		},
+	}
+	args2 := EnsureFuncArgs{
+		Pod:       nil,
+		Box:       box,
+		NewStatus: newStatus2,
+	}
+	err = control.EnsureSandboxUpgraded(context.TODO(), args2)
+	assert.NoError(t, err)
+
+	// Verify a new pod was created
+	createdPod := &corev1.Pod{}
+	err = control.Get(context.TODO(), types.NamespacedName{Namespace: box.Namespace, Name: box.Name}, createdPod)
+	assert.NoError(t, err)
+	assert.Equal(t, "new-revision", createdPod.Labels[agentsv1alpha1.PodLabelTemplateHash])
+}
+
+func TestExecuteUpgradeAction_NilAction(t *testing.T) {
+	ctrl := newTestCommonControl(mockLifecycleHookFunc(0, "", "", nil))
+	box := newUpgradeTestSandbox(nil, nil)
+	result := ctrl.upgradeControl.executeUpgradeAction(context.Background(), newRunningPod(), box, nil)
+	assert.True(t, result.Succeeded)
+	assert.Contains(t, result.Message, "no hook configured")
+}
+
+func TestExecuteUpgradeAction_NilPod(t *testing.T) {
+	ctrl := newTestCommonControl(mockLifecycleHookFunc(0, "", "", nil))
+	box := newUpgradeTestSandbox(nil, nil)
+	action := &agentsv1alpha1.UpgradeAction{
+		Exec:           &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "echo test"}},
+		TimeoutSeconds: 30,
+	}
+	result := ctrl.upgradeControl.executeUpgradeAction(context.Background(), nil, box, action)
+	assert.False(t, result.Succeeded)
+	assert.Contains(t, result.Message, "pod not found")
+}
+
+func TestHasUpgradeAction(t *testing.T) {
+	tests := []struct {
+		name     string
+		box      *agentsv1alpha1.Sandbox
+		pre      bool
+		expected bool
+	}{
+		{
+			name:     "nil lifecycle returns false",
+			box:      &agentsv1alpha1.Sandbox{},
+			pre:      true,
+			expected: false,
+		},
+		{
+			name: "lifecycle with nil preUpgrade action returns false",
+			box: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					Lifecycle: &agentsv1alpha1.SandboxLifecycle{},
+				},
+			},
+			pre:      true,
+			expected: false,
+		},
+		{
+			name: "lifecycle with nil postUpgrade action returns false",
+			box: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					Lifecycle: &agentsv1alpha1.SandboxLifecycle{},
+				},
+			},
+			pre:      false,
+			expected: false,
+		},
+		{
+			name: "lifecycle with preUpgrade action but nil exec returns false",
+			box: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					Lifecycle: &agentsv1alpha1.SandboxLifecycle{
+						PreUpgrade: &agentsv1alpha1.UpgradeAction{},
+					},
+				},
+			},
+			pre:      true,
+			expected: false,
+		},
+		{
+			name: "lifecycle with preUpgrade action and empty command returns false",
+			box: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					Lifecycle: &agentsv1alpha1.SandboxLifecycle{
+						PreUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec: &corev1.ExecAction{},
+						},
+					},
+				},
+			},
+			pre:      true,
+			expected: false,
+		},
+		{
+			name: "lifecycle with preUpgrade action and exec command returns true",
+			box: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					Lifecycle: &agentsv1alpha1.SandboxLifecycle{
+						PreUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec: &corev1.ExecAction{Command: []string{"echo", "test"}},
+						},
+					},
+				},
+			},
+			pre:      true,
+			expected: true,
+		},
+		{
+			name: "lifecycle with postUpgrade action and exec command returns true",
+			box: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					Lifecycle: &agentsv1alpha1.SandboxLifecycle{
+						PostUpgrade: &agentsv1alpha1.UpgradeAction{
+							Exec: &corev1.ExecAction{Command: []string{"echo", "test"}},
+						},
+					},
+				},
+			},
+			pre:      false,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, hasUpgradeAction(tt.box, tt.pre))
 		})
 	}
 }

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -499,7 +499,7 @@ func (r *SandboxReconciler) calculateStatus(ctx context.Context, args core.Ensur
 			newStatus.Phase = agentsv1alpha1.SandboxPaused
 			// Check for upgrade: if template has changed (hash mismatch), transition to Upgrading phase
 		} else if pod != nil && pod.Labels[agentsv1alpha1.PodLabelTemplateHash] != newStatus.UpdateRevision &&
-			box.Spec.UpgradePolicy != nil && box.Spec.UpgradePolicy.Type == agentsv1alpha1.SandboxUpgradePolicyRecreate {
+			core.RequiresPodReplacementUpgrade(box) {
 			klog.InfoS("Detected upgrade trigger", "sandbox", klog.KObj(box),
 				"podRevision", pod.Labels[agentsv1alpha1.PodLabelTemplateHash],
 				"sandboxRevision", newStatus.UpdateRevision)

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -60,6 +60,9 @@ func init() {
 			"so a stopping csi-sidecar can unmount stale volumes during prestop/SIGTERM. Empty disables the behavior.")
 	flag.StringVar(&csiResetSignalFileName, "csi-reset-signal-file", csiResetSignalFileName,
 		"Name of the reset signal file written into --csi-reset-signal-dir before recycle.")
+	flag.StringVar(&checkpointIDAnnotationKey, "checkpoint-id-annotation-key", checkpointIDAnnotationKey,
+		"Annotation key for the checkpoint ID used to restore the pod's writable layer during CheckpointRestore upgrade. "+
+			"If empty, no checkpoint ID annotation is set on pods.")
 }
 
 var (
@@ -70,6 +73,7 @@ var (
 	recycleFailureShutdownGrace = 5 * time.Minute
 	csiResetSignalDir           = ""
 	csiResetSignalFileName      = "reset"
+	checkpointIDAnnotationKey   = ""
 )
 
 const (
@@ -117,6 +121,7 @@ func Add(mgr manager.Manager, metricsCleanup Enqueuer) error {
 	recorder := mgr.GetEventRecorderFor("sandbox")
 	checkpointControl := core.NewCheckpointControl(mgr.GetClient(), recorder)
 	podControl := core.NewPodControl(mgr.GetClient(), recorder, core.GeneratePodFromSandbox)
+	podControl.SetCheckpointIDAnnotationKey(checkpointIDAnnotationKey)
 	err := (&SandboxReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),

--- a/pkg/controller/sandboxupdateops/patch.go
+++ b/pkg/controller/sandboxupdateops/patch.go
@@ -75,9 +75,13 @@ func (r *Reconciler) applySandboxPatch(ctx context.Context, sbx *agentsv1alpha1.
 		modified.Spec.Template = merged
 	}
 
-	// 2. Set UpgradePolicy to Recreate
+	// 2. Set UpgradePolicy based on strategy type
+	policyType := agentsv1alpha1.SandboxUpgradePolicyRecreate
+	if ops.Spec.UpdateStrategy.Type == agentsv1alpha1.SandboxUpdateOpsStrategyCheckpointRestore {
+		policyType = agentsv1alpha1.SandboxUpgradePolicyCheckpointRestore
+	}
 	modified.Spec.UpgradePolicy = &agentsv1alpha1.SandboxUpgradePolicy{
-		Type: agentsv1alpha1.SandboxUpgradePolicyRecreate,
+		Type: policyType,
 	}
 
 	// 3. Set Lifecycle

--- a/pkg/webhook/sandboxupdateops/validating/sandboxupdateops_validate.go
+++ b/pkg/webhook/sandboxupdateops/validating/sandboxupdateops_validate.go
@@ -18,10 +18,13 @@ package validating
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
 
 	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -95,7 +98,19 @@ func (h *SandboxUpdateOpsValidatingHandler) handleCreate(ctx context.Context, ob
 		}
 	}
 
-	// 4. Check for active (non-terminal) SandboxUpdateOps in the same namespace
+	// 4. When using CheckpointRestore strategy, the patch must not modify container images.
+	// CheckpointRestore preserves the writable layer of containers whose image is unchanged;
+	// changing an image would invalidate the checkpoint.
+	if obj.Spec.UpdateStrategy.Type == agentsv1alpha1.SandboxUpdateOpsStrategyCheckpointRestore && len(obj.Spec.Patch.Raw) > 0 {
+		patchTmpl := &corev1.PodTemplateSpec{}
+		if err := json.Unmarshal(obj.Spec.Patch.Raw, patchTmpl); err != nil {
+			errList = append(errList, field.Invalid(specPath.Child("patch"), obj.Spec.Patch, "failed to parse patch as PodTemplateSpec: "+err.Error()))
+		} else if msg := validateNoImageChange(patchTmpl); msg != "" {
+			errList = append(errList, field.Forbidden(specPath.Child("patch"), msg))
+		}
+	}
+
+	// 5. Check for active (non-terminal) SandboxUpdateOps in the same namespace
 	opsList := &agentsv1alpha1.SandboxUpdateOpsList{}
 	if err := h.Client.List(ctx, opsList, client.InNamespace(obj.Namespace)); err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
@@ -116,6 +131,22 @@ func (h *SandboxUpdateOpsValidatingHandler) handleCreate(ctx context.Context, ob
 		return admission.Errored(http.StatusUnprocessableEntity, errList.ToAggregate())
 	}
 	return admission.Allowed("")
+}
+
+// validateNoImageChange checks whether the given patch template modifies any container
+// or init container image. Returns a non-empty string describing the violation if found.
+func validateNoImageChange(tmpl *corev1.PodTemplateSpec) string {
+	for _, c := range tmpl.Spec.Containers {
+		if c.Image != "" {
+			return fmt.Sprintf("CheckpointRestore strategy does not support modifying container images (container %q)", c.Name)
+		}
+	}
+	for _, c := range tmpl.Spec.InitContainers {
+		if c.Image != "" {
+			return fmt.Sprintf("CheckpointRestore strategy does not support modifying init container images (container %q)", c.Name)
+		}
+	}
+	return ""
 }
 
 func (h *SandboxUpdateOpsValidatingHandler) handleUpdate(req admission.Request, newObj *agentsv1alpha1.SandboxUpdateOps) admission.Response {

--- a/pkg/webhook/sandboxupdateops/validating/sandboxupdateops_validate_test.go
+++ b/pkg/webhook/sandboxupdateops/validating/sandboxupdateops_validate_test.go
@@ -428,3 +428,65 @@ func TestPathAndEnabled(t *testing.T) {
 	require.Equal(t, "/validate-sandboxupdateops", h.Path())
 	require.True(t, h.Enabled())
 }
+
+func TestCreate_CheckpointRestoreWithImageChange_Rejected(t *testing.T) {
+	obj := validOps()
+	obj.Spec.UpdateStrategy.Type = v1alpha1.SandboxUpdateOpsStrategyCheckpointRestore
+	obj.Spec.Patch = mustMarshalPatch(corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main", Image: "nginx:1.22"}},
+		},
+	})
+	h := newTestHandler()
+	resp := h.Handle(context.TODO(), makeCreateRequest(t, obj))
+	require.False(t, resp.Allowed)
+	require.Contains(t, resp.Result.Message, "CheckpointRestore strategy does not support modifying container images")
+}
+
+func TestCreate_CheckpointRestoreWithInitImageChange_Rejected(t *testing.T) {
+	obj := validOps()
+	obj.Spec.UpdateStrategy.Type = v1alpha1.SandboxUpdateOpsStrategyCheckpointRestore
+	obj.Spec.Patch = mustMarshalPatch(corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "init", Image: "busybox:1.28"}},
+		},
+	})
+	h := newTestHandler()
+	resp := h.Handle(context.TODO(), makeCreateRequest(t, obj))
+	require.False(t, resp.Allowed)
+	require.Contains(t, resp.Result.Message, "CheckpointRestore strategy does not support modifying init container images")
+}
+
+func TestCreate_CheckpointRestoreWithoutImageChange_Allowed(t *testing.T) {
+	obj := validOps()
+	obj.Spec.UpdateStrategy.Type = v1alpha1.SandboxUpdateOpsStrategyCheckpointRestore
+	obj.Spec.Patch = mustMarshalPatch(corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main", Env: []corev1.EnvVar{{Name: "FOO", Value: "bar"}}}},
+		},
+	})
+	h := newTestHandler()
+	resp := h.Handle(context.TODO(), makeCreateRequest(t, obj))
+	require.True(t, resp.Allowed)
+}
+
+func TestCreate_CheckpointRestoreNoPatch_Allowed(t *testing.T) {
+	obj := validOps()
+	obj.Spec.UpdateStrategy.Type = v1alpha1.SandboxUpdateOpsStrategyCheckpointRestore
+	h := newTestHandler()
+	resp := h.Handle(context.TODO(), makeCreateRequest(t, obj))
+	require.True(t, resp.Allowed)
+}
+
+func TestCreate_RecreateWithImageChange_Allowed(t *testing.T) {
+	obj := validOps()
+	obj.Spec.UpdateStrategy.Type = v1alpha1.SandboxUpdateOpsStrategyRecreate
+	obj.Spec.Patch = mustMarshalPatch(corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main", Image: "nginx:1.22"}},
+		},
+	})
+	h := newTestHandler()
+	resp := h.Handle(context.TODO(), makeCreateRequest(t, obj))
+	require.True(t, resp.Allowed)
+}


### PR DESCRIPTION
## Summary

This PR implements the `CheckpointRestore` upgrade strategy for Sandboxes, enabling zero-downtime upgrades by checkpointing the sandbox writable layer before pod recreation and restoring it afterward.

## Key Changes

### New: UpgradeControl state machine (`upgrade_control.go`)
- Extracted upgrade logic from `commonControl` into a dedicated `UpgradeControl` struct
- State machine flow: `PreUpgrade → Checkpointing → UpgradePod → PostUpgrade → Succeeded`
- `Checkpointing` state uses `fallthrough` to seamlessly transition to `UpgradePod` once checkpoint completes

### API changes
- Added `CheckpointRestore` upgrade policy type to `Sandbox` and `SandboxUpdateOps` CRDs
- Added `CheckpointTypePodInfo` checkpoint type label for upgrade-specific checkpoints
- Generated CRD manifests updated

### CheckpointControl enhancements (`checkpoint.go`)
- `EnsureCheckpointForUpgrade`: creates a Checkpoint CR for the sandbox being upgraded
- `GetCheckpointIDForUpgrade`: retrieves the checkpoint ID from the latest completed checkpoint
- `CleanupForUpgrade`: cleans up checkpoint resources after upgrade completes
- `listCheckpointsForSandbox`: filters out Checkpoints with non-nil `DeletionTimestamp` to avoid using stale checkpoints being deleted

### Configurable checkpoint annotation key
- Removed hardcoded `AnnotationCheckpointID` constant from `annotations.go`
- Added `--checkpoint-id-annotation-key` controller flag; when empty, no checkpoint ID annotation is written to pods
- `PodControl.CreatePod` guards against empty key/ID before writing annotation

### SandboxUpdateOps integration (`patch.go`)
- Updated to support the new `CheckpointRestore` upgrade policy

## Test Coverage
- Added 2 test cases for DeletionTimestamp filtering in `TestListCheckpointsForSandbox`
- Added `TestCreatePodCheckpointAnnotation` with 4 cases covering annotation key configuration behavior
- Updated existing upgrade tests in `common_control_test.go` and `upgrade_control_test.go`

## Review Guidance
- Focus review on `upgrade_control.go` state machine logic, especially the `fallthrough` from `Checkpointing` to `UpgradePod`
- Verify `listCheckpointsForSandbox` DeletionTimestamp filtering is correct
- Check that the configurable annotation key properly handles empty/default cases