### PR TITLE
feat(identity): issue sandbox access token on claim via TokenKind

### DIFF
--- a/pkg/controller/sandbox/core/sandbox_initializer.go
+++ b/pkg/controller/sandbox/core/sandbox_initializer.go
@@ -172,7 +172,7 @@ func reinitRuntime(ctx context.Context, logger klog.Logger, box *agentsv1alpha1.
 // the exact issue -> propagate -> record implementation used by the claim flow,
 // rather than re-deriving it here.
 //
-// The opt-in gate (IsIdentityProviderRequested) is checked here before invoking
+// The opt-in gate (IsIDTokenRequested) is checked here before invoking
 // ProcessSandboxToken, mirroring the claim/clone flows so all three call sites
 // share the same explicit gating and keep the community baseline inert for
 // non-identity sandboxes. sbxForInit carries the freshly recreated runtime
@@ -181,7 +181,7 @@ func reinitRuntime(ctx context.Context, logger klog.Logger, box *agentsv1alpha1.
 // gate and the annotation patch behave identically to operating on the original
 // sandbox.
 func reinitSecurityToken(ctx context.Context, c client.Client, sbxForInit *agentsv1alpha1.Sandbox) error {
-	if !identity.IsIdentityProviderRequested(sbxForInit) {
+	if !identity.IsIDTokenRequested(sbxForInit) {
 		return nil
 	}
 	logger := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbxForInit))

--- a/pkg/controller/sandbox/core/security_token_reinit_test.go
+++ b/pkg/controller/sandbox/core/security_token_reinit_test.go
@@ -46,7 +46,7 @@ type fakeReinitProvider struct {
 	propagateErr   error
 }
 
-func (f *fakeReinitProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox) (*identity.TokenResponse, error) {
+func (f *fakeReinitProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ identity.TokenKind) (*identity.TokenResponse, error) {
 	f.issueCalls++
 	if f.issueErr != nil {
 		return nil, f.issueErr

--- a/pkg/controller/securitytokenrefresh/core/refresher_test.go
+++ b/pkg/controller/securitytokenrefresh/core/refresher_test.go
@@ -44,7 +44,7 @@ type stubIdentityProvider struct {
 	issueCalls     int
 }
 
-func (s *stubIdentityProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox) (*identity.TokenResponse, error) {
+func (s *stubIdentityProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ identity.TokenKind) (*identity.TokenResponse, error) {
 	s.issueCalls++
 	if s.issueErr != nil {
 		return nil, s.issueErr

--- a/pkg/identity/common_provider.go
+++ b/pkg/identity/common_provider.go
@@ -25,6 +25,13 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 )
 
+// defaultAccessTokenLifetime is the lifetime the community default provider
+// stamps on a TokenKindAccessToken placeholder token. It is intentionally very
+// long (~100 years) so the random token behaves as effectively non-expiring:
+// the default provider has no signing backend that could rotate it, and
+// enterprise deployments override the provider entirely.
+const defaultAccessTokenLifetime = 100 * 365 * 24 * time.Hour
+
 // defaultTokenProvider is the default community implementation that generates
 // random tokens without contacting any external identity provider service.
 // It implements IdentityProvider with no-op propagation.
@@ -36,12 +43,21 @@ func NewDefaultIdentityProvider() IdentityProvider {
 	return &defaultTokenProvider{}
 }
 
-func (u *defaultTokenProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox) (*TokenResponse, error) {
+// IssueToken mints a random placeholder token. For TokenKindAccessToken the
+// token is stamped with a very long validity so it behaves as effectively
+// non-expiring; every other kind uses the short default lifetime. The community
+// default has no signing backend, so the value carries no real credential
+// semantics: enterprise deployments register a gateway-backed provider instead.
+func (u *defaultTokenProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, kind TokenKind) (*TokenResponse, error) {
+	expiry := time.Minute
+	if kind == TokenKindAccessToken {
+		expiry = defaultAccessTokenLifetime
+	}
 	return &TokenResponse{
 		RequestID:             uuid.NewString(),
 		AccessToken:           uuid.NewString(),
 		SandboxClientID:       uuid.NewString(),
-		AccessTokenExpiration: time.Now().Add(time.Minute).Format(time.RFC3339),
+		AccessTokenExpiration: time.Now().Add(expiry).Format(time.RFC3339),
 	}, nil
 }
 

--- a/pkg/identity/common_provider_test.go
+++ b/pkg/identity/common_provider_test.go
@@ -42,14 +42,14 @@ func TestDefaultTokenProvider_IssueToken(t *testing.T) {
 	provider := NewDefaultIdentityProvider()
 	ctx := context.Background()
 
-	resp, err := provider.IssueToken(ctx, nil)
+	resp, err := provider.IssueToken(ctx, nil, TokenKindIDToken)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.NotEmpty(t, resp.RequestID, "RequestID should be a non-empty string")
 	assert.NotEmpty(t, resp.AccessToken, "AccessToken should be a non-empty string")
 
 	// Two calls should produce different tokens.
-	resp2, err := provider.IssueToken(ctx, nil)
+	resp2, err := provider.IssueToken(ctx, nil, TokenKindIDToken)
 	require.NoError(t, err)
 	assert.NotEqual(t, resp.AccessToken, resp2.AccessToken, "each call should produce a unique token")
 }

--- a/pkg/identity/default_provider.go
+++ b/pkg/identity/default_provider.go
@@ -46,9 +46,10 @@ func RegisterProvider(p IdentityProvider) {
 	provider = p
 }
 
-// IssueToken delegates to the registered provider to generate an access token.
-func IssueToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (*TokenResponse, error) {
-	return provider.IssueToken(ctx, sbx)
+// IssueToken delegates to the registered provider to generate a token of the
+// given kind.
+func IssueToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, kind TokenKind) (*TokenResponse, error) {
+	return provider.IssueToken(ctx, sbx, kind)
 }
 
 // PropagateSecurityToken delegates to the registered provider to execute

--- a/pkg/identity/interface.go
+++ b/pkg/identity/interface.go
@@ -34,9 +34,14 @@ import (
 //     directly (no silent degradation to UUID).
 //   - PropagateSecurityToken: executes registered propagators (e.g., write credential files).
 type IdentityProvider interface {
-	// IssueToken generates an access token for the given sandbox.
+	// IssueToken generates a token of the given kind for the sandbox.
 	// The sbx parameter carries the sandbox workload metadata; it may be nil in
 	// future principal-token paths, so implementations must guard against nil.
+	//
+	// kind selects which token to mint: TokenKindIDToken for the ID token
+	// propagated into the sandbox as a credential, and TokenKindAccessToken for
+	// the JWT used to reach the sandbox through the sandbox gateway. Both kinds
+	// return a TokenResponse; callers read the minted token from AccessToken.
 	//
 	// Implementations own the composition of the concrete wire request: they
 	// derive the SandboxInfo projection and any security metadata directly from
@@ -44,7 +49,7 @@ type IdentityProvider interface {
 	// pre-built TokenRequest. This keeps the community baseline free of
 	// enterprise-only request-shaping policy while letting each provider assemble
 	// exactly the atomic request its backend expects.
-	IssueToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (*TokenResponse, error)
+	IssueToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, kind TokenKind) (*TokenResponse, error)
 
 	// PropagateSecurityToken executes post-token processing after a token is issued,
 	// such as writing credentials into the sandbox runtime.

--- a/pkg/identity/process_sandbox_token_test.go
+++ b/pkg/identity/process_sandbox_token_test.go
@@ -45,7 +45,7 @@ type fakeProcessProvider struct {
 	propagateErr   error
 }
 
-func (f *fakeProcessProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox) (*TokenResponse, error) {
+func (f *fakeProcessProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ TokenKind) (*TokenResponse, error) {
 	f.issueCalls++
 	if f.issueErr != nil {
 		return nil, f.issueErr

--- a/pkg/identity/sandbox_token_helper.go
+++ b/pkg/identity/sandbox_token_helper.go
@@ -28,8 +28,8 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 )
 
-// IsIdentityProviderRequested reports whether the sandbox opts into the
-// identity provider issuance path.
+// IsIDTokenRequested reports whether the sandbox opts into the ID token
+// (identity provider) issuance path.
 //
 // The opt-in signal is the presence of a non-empty
 // "security.agents.kruise.io/agent-name" annotation on the sandbox: setting
@@ -42,11 +42,28 @@ import (
 // The check is intentionally annotation-only and value-presence-only: it does
 // NOT validate the value against any naming convention, since the identity
 // provider is the authoritative source of truth for agent-name semantics.
-func IsIdentityProviderRequested(sbx *agentsv1alpha1.Sandbox) bool {
+func IsIDTokenRequested(sbx *agentsv1alpha1.Sandbox) bool {
 	if sbx == nil {
 		return false
 	}
 	return sbx.GetAnnotations()[AnnotationAgentName] != ""
+}
+
+// IsAccessTokenRequested reports whether the sandbox opts into access-token
+// issuance for reaching the sandbox through the gateway.
+//
+// The opt-in signal is a "security.agents.kruise.io/enable-jwt-auth" annotation
+// whose value equals exactly "true". Unlike IsIDTokenRequested (which
+// treats any non-empty value as opt-in because the value carries a meaningful
+// agent name), this predicate is a strict boolean toggle: a nil sandbox, a
+// missing annotation, or any value other than "true" all collapse to "not
+// requested", letting callers short-circuit the issuance path without paying
+// any issuer cost.
+func IsAccessTokenRequested(sbx *agentsv1alpha1.Sandbox) bool {
+	if sbx == nil {
+		return false
+	}
+	return sbx.GetAnnotations()[AnnotationEnableJwtAuth] == agentsv1alpha1.True
 }
 
 // ExtractSecurityMetadata returns a map containing only the sandbox annotations
@@ -98,7 +115,7 @@ func IssueSandboxToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (*Token
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx), "action", "IssueSandboxToken")
 	start := time.Now()
 
-	tokenResp, err := IssueToken(ctx, sbx)
+	tokenResp, err := IssueToken(ctx, sbx, TokenKindIDToken)
 	cost := time.Since(start)
 	if err != nil {
 		log.Error(err, "failed to issue sandbox security token", "cost", cost)
@@ -106,6 +123,33 @@ func IssueSandboxToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (*Token
 	}
 	log.Info("sandbox security token issued", "cost", cost)
 	return tokenResp, nil
+}
+
+// IssueSandboxAccessToken mints the access token used to reach the given
+// sandbox through the sandbox gateway, using the registered IdentityProvider.
+//
+// It reuses the same IdentityProvider as IssueSandboxToken, selecting the
+// access-token kind via TokenKindAccessToken. The provider owns the composition
+// of the concrete wire request (subject, audience, validity, SandboxInfo
+// projection) exactly like it does for security tokens; the minted token is
+// returned in TokenResponse.AccessToken.
+//
+// The function is intentionally side-effect free: it does NOT mutate the
+// sandbox object or persist the response. Callers decide where to carry the
+// returned token (e.g. a transient in-memory field on the claimed sandbox),
+// deliberately keeping the token off the sandbox annotations.
+func IssueSandboxAccessToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (*TokenResponse, error) {
+	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx), "action", "IssueSandboxAccessToken")
+	start := time.Now()
+
+	accessResp, err := IssueToken(ctx, sbx, TokenKindAccessToken)
+	cost := time.Since(start)
+	if err != nil {
+		log.Error(err, "failed to issue sandbox access token", "cost", cost)
+		return nil, fmt.Errorf("failed to issue access token: %w", err)
+	}
+	log.Info("sandbox access token issued", "cost", cost)
+	return accessResp, nil
 }
 
 // PropagateSandboxToken propagates the freshly issued security token to the
@@ -146,7 +190,7 @@ func PropagateSandboxToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tok
 // propagation guarantees a failed delivery never persists a misleading "fresh"
 // expiration that would suppress the refresh controller's retry.
 //
-// Callers gate on IsIdentityProviderRequested before invoking this function (the
+// Callers gate on IsIDTokenRequested before invoking this function (the
 // claim, clone and post-resume paths all do so), so it performs no opt-in check
 // itself and always drives the full lifecycle.
 //

--- a/pkg/identity/sandbox_token_helper_test.go
+++ b/pkg/identity/sandbox_token_helper_test.go
@@ -41,7 +41,7 @@ type fakeIdentityProvider struct {
 	err  error
 }
 
-func (f *fakeIdentityProvider) IssueToken(_ context.Context, sbx *agentsv1alpha1.Sandbox) (*TokenResponse, error) {
+func (f *fakeIdentityProvider) IssueToken(_ context.Context, sbx *agentsv1alpha1.Sandbox, _ TokenKind) (*TokenResponse, error) {
 	f.gotSbx = sbx
 	f.called++
 	return f.resp, f.err
@@ -88,6 +88,131 @@ func TestIssueSandboxToken_Success(t *testing.T) {
 	assert.Same(t, wantResp, gotResp, "response must be returned as-is from the provider")
 	assert.Equal(t, 1, fake.called, "underlying provider must be called exactly once")
 	assert.Same(t, sbx, fake.gotSbx, "sandbox pointer must be forwarded unchanged to the provider")
+}
+
+// kindCapturingProvider is an IdentityProvider stub that additionally records
+// the TokenKind it was invoked with, so tests can assert that
+// IssueSandboxAccessToken selects TokenKindAccessToken rather than the
+// ID-token kind. PropagateSecurityToken is a no-op; only the issuance path is
+// exercised here.
+type kindCapturingProvider struct {
+	gotSbx  *agentsv1alpha1.Sandbox
+	gotKind TokenKind
+	called  int
+
+	resp *TokenResponse
+	err  error
+}
+
+func (p *kindCapturingProvider) IssueToken(_ context.Context, sbx *agentsv1alpha1.Sandbox, kind TokenKind) (*TokenResponse, error) {
+	p.gotSbx = sbx
+	p.gotKind = kind
+	p.called++
+	return p.resp, p.err
+}
+
+func (p *kindCapturingProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse) error {
+	return nil
+}
+
+var _ IdentityProvider = (*kindCapturingProvider)(nil)
+
+// TestIssueSandboxAccessToken exercises the access-token twin of
+// IssueSandboxToken. It shares the same registered IdentityProvider but must
+// select TokenKindAccessToken and, on failure, wrap the provider error with the
+// distinct "failed to issue access token" prefix while preserving the cause via
+// errors.Is. Like its twin, it must forward the sandbox pointer unchanged, call
+// the provider exactly once, return the response as-is on success, and return a
+// nil response on error so callers never persist a zero-value token.
+func TestIssueSandboxAccessToken(t *testing.T) {
+	wantResp := &TokenResponse{
+		RequestID:             "req-access",
+		AccessToken:           "access-tok",
+		SandboxClientID:       "client-access",
+		AccessTokenExpiration: "2099-01-01T00:00:00Z",
+	}
+	rootErr := errors.New("identity provider unavailable")
+
+	tests := []struct {
+		name        string
+		fake        *kindCapturingProvider
+		wantResp    *TokenResponse
+		expectError string
+		wantCause   error
+	}{
+		{
+			name:     "success returns provider response as-is",
+			fake:     &kindCapturingProvider{resp: wantResp},
+			wantResp: wantResp,
+		},
+		{
+			name:        "provider error is wrapped with access-token prefix",
+			fake:        &kindCapturingProvider{err: rootErr},
+			expectError: "failed to issue access token",
+			wantCause:   rootErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			saved := provider
+			RegisterProvider(tt.fake)
+			t.Cleanup(func() { RegisterProvider(saved) })
+
+			sbx := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sbx-access",
+					Namespace: "ns-access",
+					UID:       types.UID("uid-access"),
+				},
+			}
+
+			gotResp, err := IssueSandboxAccessToken(context.Background(), sbx)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Nil(t, gotResp, "response must be nil on error to prevent persisting a zero-value token")
+				assert.Contains(t, err.Error(), tt.expectError,
+					"wrap message must remain stable for downstream phase classification")
+				assert.True(t, errors.Is(err, tt.wantCause),
+					"wrapped error must preserve the original cause via errors.Is")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, gotResp)
+				assert.Same(t, tt.wantResp, gotResp, "response must be returned as-is from the provider")
+			}
+
+			assert.Equal(t, 1, tt.fake.called, "underlying provider must be called exactly once")
+			assert.Same(t, sbx, tt.fake.gotSbx, "sandbox pointer must be forwarded unchanged to the provider")
+			assert.Equal(t, TokenKindAccessToken, tt.fake.gotKind,
+				"IssueSandboxAccessToken must select the access-token kind, not the ID-token kind")
+		})
+	}
+}
+
+// TestIssueSandboxAccessToken_DefaultProviderIntegration sanity-checks the
+// helper against the real defaultTokenProvider (no fake) to ensure the
+// package-level provider wiring works and the community default mints a
+// non-empty, effectively non-expiring access token.
+func TestIssueSandboxAccessToken_DefaultProviderIntegration(t *testing.T) {
+	saved := provider
+	RegisterProvider(NewDefaultIdentityProvider())
+	t.Cleanup(func() { RegisterProvider(saved) })
+
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sbx-access-default",
+			Namespace: "ns-default",
+			UID:       types.UID("uid-access-default"),
+		},
+	}
+
+	resp, err := IssueSandboxAccessToken(context.Background(), sbx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.AccessToken, "default provider must mint a non-empty access token")
+	assert.NotEmpty(t, resp.RequestID, "default provider must mint a non-empty request id")
+	assert.NotEmpty(t, resp.AccessTokenExpiration, "default provider must stamp an expiration on the access token")
 }
 
 // TestExtractSecurityMetadata verifies the prefix filter used to collect
@@ -220,7 +345,7 @@ type annotationReadingProvider struct {
 	gotValue       string
 }
 
-func (p *annotationReadingProvider) IssueToken(_ context.Context, sbx *agentsv1alpha1.Sandbox) (*TokenResponse, error) {
+func (p *annotationReadingProvider) IssueToken(_ context.Context, sbx *agentsv1alpha1.Sandbox, _ TokenKind) (*TokenResponse, error) {
 	p.gotValue = sbx.GetAnnotations()[p.storageAuthKey]
 	return &TokenResponse{AccessToken: "tok"}, nil
 }
@@ -330,7 +455,7 @@ type propagatingFakeProvider struct {
 	err error
 }
 
-func (p *propagatingFakeProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox) (*TokenResponse, error) {
+func (p *propagatingFakeProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ TokenKind) (*TokenResponse, error) {
 	p.issueCalls++
 	return nil, nil
 }
@@ -416,12 +541,12 @@ func TestPropagateSandboxToken(t *testing.T) {
 	}
 }
 
-// TestIsIdentityProviderRequested verifies the opt-in predicate that gates the
+// TestIsIDTokenRequested verifies the opt-in predicate that gates the
 // identity provider issuance path. The contract is: a sandbox opts in iff its
 // Annotations carry a non-empty value under AnnotationAgentName; every other
 // shape (nil sandbox, missing Annotations map, absent key, empty value,
 // near-miss key) must collapse to false so callers can safely short-circuit.
-func TestIsIdentityProviderRequested(t *testing.T) {
+func TestIsIDTokenRequested(t *testing.T) {
 	tests := []struct {
 		name   string
 		sbx    *agentsv1alpha1.Sandbox
@@ -532,7 +657,7 @@ func TestIsIdentityProviderRequested(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, IsIdentityProviderRequested(tt.sbx), tt.reason)
+			assert.Equal(t, tt.want, IsIDTokenRequested(tt.sbx), tt.reason)
 		})
 	}
 }

--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -29,6 +29,22 @@ const (
 	TokenTypeAgent TokenType = "Agent"
 )
 
+// TokenKind selects which token an IdentityProvider mints on a given IssueToken
+// call. A single provider serves both kinds so enterprise deployments register
+// one implementation instead of wiring two separate interfaces.
+type TokenKind string
+
+const (
+	// TokenKindIDToken requests the ID token that is propagated into the sandbox
+	// as a credential. This is the original identity-provider issuance path
+	// (IssueSandboxToken and the security-token refresh flow).
+	TokenKindIDToken TokenKind = "IDToken"
+	// TokenKindAccessToken requests the access token (a JWT) used to reach the
+	// sandbox through the sandbox gateway. Callers read the minted token from
+	// TokenResponse.AccessToken.
+	TokenKindAccessToken TokenKind = "AccessToken"
+)
+
 const (
 	// SecurityMetadataPrefix is the prefix for all security-related annotations.
 	SecurityMetadataPrefix = "security.agents.kruise.io/"
@@ -41,6 +57,13 @@ const (
 	// token. An annotation is used instead of a label so the value is free of
 	// the 63-char / DNS-label constraints and can express richer content.
 	AnnotationAgentName = SecurityMetadataPrefix + "agent-name"
+	// AnnotationEnableJwtAuth is the sandbox Annotation Key whose value "true"
+	// opts the sandbox into the JWT traffic-token issuance path. Unlike
+	// AnnotationAgentName (which carries a meaningful agent name), this is a pure
+	// boolean toggle: the traffic token is minted during claim only when this
+	// annotation equals exactly "true". Any other value (including "1" or "True")
+	// leaves the sandbox out of the issuance path.
+	AnnotationEnableJwtAuth = SecurityMetadataPrefix + "enable-jwt-auth"
 )
 
 // TokenRequest represents a request to issue an identity-aware access token.

--- a/pkg/sandbox-manager/infra/interface.go
+++ b/pkg/sandbox-manager/infra/interface.go
@@ -238,6 +238,16 @@ type Sandbox interface {
 	GetState() (string, string)   // Get Sandbox State (pending, running, paused, killing, etc.)
 	GetTemplate() string          // Get the template name of the Sandbox
 	GetResource() SandboxResource // Get the CPU / Memory requirements of the Sandbox
+	// GetTrafficAccessToken returns the access token minted for accessing this
+	// sandbox through the sandbox gateway. It is a transient, per-claim value
+	// carried in memory (never persisted to the CR); it is empty unless the
+	// sandbox opted into access-token issuance during claim.
+	GetTrafficAccessToken() string
+	// GetTrafficAccessTokenExpiration returns the expiration time (RFC3339) of
+	// the traffic access token minted during claim. Like GetTrafficAccessToken
+	// it is a transient, per-claim value carried in memory; it is empty unless
+	// the sandbox opted into access-token issuance during claim.
+	GetTrafficAccessTokenExpiration() string
 	SetImage(image string)
 	GetImage() string
 	SetPodLabels(labels map[string]string)

--- a/pkg/sandbox-manager/infra/interface_test.go
+++ b/pkg/sandbox-manager/infra/interface_test.go
@@ -212,14 +212,16 @@ func (m *mockSandboxForLabels) Pause(context.Context, PauseOptions) error { retu
 func (m *mockSandboxForLabels) Resume(context.Context, ResumeOptions) error {
 	return nil
 }
-func (m *mockSandboxForLabels) GetSandboxID() string         { return "" }
-func (m *mockSandboxForLabels) GetRoute() proxy.Route        { return proxy.Route{} }
-func (m *mockSandboxForLabels) GetState() (string, string)   { return "", "" }
-func (m *mockSandboxForLabels) GetTemplate() string          { return "" }
-func (m *mockSandboxForLabels) GetResource() SandboxResource { return SandboxResource{} }
-func (m *mockSandboxForLabels) SetImage(string)              {}
-func (m *mockSandboxForLabels) GetImage() string             { return "" }
-func (m *mockSandboxForLabels) SetTimeout(timeout.Options)   {}
+func (m *mockSandboxForLabels) GetSandboxID() string                    { return "" }
+func (m *mockSandboxForLabels) GetRoute() proxy.Route                   { return proxy.Route{} }
+func (m *mockSandboxForLabels) GetState() (string, string)              { return "", "" }
+func (m *mockSandboxForLabels) GetTemplate() string                     { return "" }
+func (m *mockSandboxForLabels) GetResource() SandboxResource            { return SandboxResource{} }
+func (m *mockSandboxForLabels) GetTrafficAccessToken() string           { return "" }
+func (m *mockSandboxForLabels) GetTrafficAccessTokenExpiration() string { return "" }
+func (m *mockSandboxForLabels) SetImage(string)                         {}
+func (m *mockSandboxForLabels) GetImage() string                        { return "" }
+func (m *mockSandboxForLabels) SetTimeout(timeout.Options)              {}
 func (m *mockSandboxForLabels) SaveTimeoutWithPolicy(context.Context, SaveTimeoutOptions, timeout.UpdatePolicy) (TimeoutUpdateResult, error) {
 	return TimeoutUpdateResult{}, nil
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -356,7 +356,7 @@ func runClaimPostProcesses(ctx context.Context, sbx *Sandbox, lockType infra.Loc
 		accessResp, err := identity.IssueSandboxAccessToken(ctx, sbx.Sandbox)
 		metrics.TrafficToken = time.Since(start)
 		if err != nil {
-			return retriableError{Message: fmt.Sprintf("failed to issue access token: %s", err)}
+			return retriableError{Message: err.Error()}
 		}
 		if accessResp != nil {
 			sbx.trafficToken = accessResp

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -327,18 +327,41 @@ func runClaimPostProcesses(ctx context.Context, sbx *Sandbox, lockType infra.Loc
 		log.Info("runtime inited", "cost", metrics.InitRuntime)
 	}
 
+	// TODO: these post-process steps (security token, access token, CSI mount)
+	// currently run sequentially. Independent steps could be executed in
+	// parallel to reduce the overall claim latency; revisit once the ordering
+	// constraints between them are formalized.
+	//
 	// Issue and propagate the identity-provider security token before performing
 	// CSI mounts. This ordering ensures the runtime sidecar (initialized above)
 	// receives the token first, and any downstream storage authentication
 	// decisions made by the provider can rely on the sandbox annotations already
 	// injected by modifyPickedSandbox.
-	if identity.IsIdentityProviderRequested(sbx.Sandbox) {
+	if identity.IsIDTokenRequested(sbx.Sandbox) {
 		var err error
 		metrics.SecurityToken, err = identity.ProcessSandboxToken(ctx, cache.GetClient(), sbx.Sandbox)
 		if err != nil {
 			return retriableError{Message: fmt.Sprintf("failed to process security token: %s", err)}
 		}
 		metrics.Total += metrics.SecurityToken
+	}
+
+	// Mint the sandbox access token when the sandbox opts in. The token is kept
+	// in memory on the claimed sandbox (never persisted to the CR) so the API
+	// layer can return it to the client. Failure is retriable and blocks the
+	// claim, mirroring the security-token step above: a sandbox the client cannot
+	// reach through the gateway should not be returned as successfully claimed.
+	if identity.IsAccessTokenRequested(sbx.Sandbox) {
+		start := time.Now()
+		accessResp, err := identity.IssueSandboxAccessToken(ctx, sbx.Sandbox)
+		metrics.TrafficToken = time.Since(start)
+		if err != nil {
+			return retriableError{Message: fmt.Sprintf("failed to issue access token: %s", err)}
+		}
+		if accessResp != nil {
+			sbx.trafficToken = accessResp
+		}
+		metrics.Total += metrics.TrafficToken
 	}
 
 	if opts.CSIMount != nil {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -4129,7 +4129,7 @@ type mockIdentityProvider struct {
 	propagateFunc  func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error
 }
 
-func (m *mockIdentityProvider) IssueToken(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
+func (m *mockIdentityProvider) IssueToken(ctx context.Context, sbx *v1alpha1.Sandbox, _ identity.TokenKind) (*identity.TokenResponse, error) {
 	if m.issueTokenFunc != nil {
 		return m.issueTokenFunc(ctx, sbx)
 	}
@@ -4275,13 +4275,13 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 			},
 		},
 		{
-			// Verifies the IsIdentityProviderRequested opt-in gate — when the
+			// Verifies the IsIDTokenRequested opt-in gate — when the
 			// sandbox does NOT carry the security.agents.kruise.io/agent-name
 			// annotation, the entire identity provider branch must be skipped: neither
 			// IssueToken nor PropagateSecurityToken may run, no TokenRefreshStatus
 			// annotation may be persisted, and metrics.SecurityToken must remain
 			// zero. This is the dedicated opt-in regression test for the
-			// IsIdentityProviderRequested predicate.
+			// IsIDTokenRequested predicate.
 			name: "skips security token issuance when agent-name annotation is absent",
 			options: infra.ClaimSandboxOptions{
 				User:     user,
@@ -4291,7 +4291,7 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				},
 			},
 			preModifier: func(sbx *v1alpha1.Sandbox) {
-				// Strip the opt-in annotation so IsIdentityProviderRequested returns false.
+				// Strip the opt-in annotation so IsIDTokenRequested returns false.
 				delete(sbx.Annotations, identity.AnnotationAgentName)
 			},
 			mockProvider: &mockIdentityProvider{

--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -166,7 +166,7 @@ func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache inf
 	// Step 6: process security token
 	// Issue and propagate the identity-provider security token before performing
 	// CSI mounts, mirroring the claim flow ordering.
-	if identity.IsIdentityProviderRequested(sbx.Sandbox) {
+	if identity.IsIDTokenRequested(sbx.Sandbox) {
 		metrics.SecurityToken, err = identity.ProcessSandboxToken(ctx, cache.GetClient(), sbx.Sandbox)
 		if err != nil {
 			if !wait.Interrupted(err) {

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -167,6 +167,7 @@ func (i *Infra) ClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions
 		metrics.WaitReady += tryMetrics.WaitReady
 		metrics.InitRuntime += tryMetrics.InitRuntime
 		metrics.SecurityToken += tryMetrics.SecurityToken
+		metrics.TrafficToken += tryMetrics.TrafficToken
 		metrics.CSIMount += tryMetrics.CSIMount
 		metrics.LockType = tryMetrics.LockType
 		metrics.MergePickSandboxFailures(tryMetrics.PickSandboxFailures)

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -32,6 +32,7 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/agent-runtime/storages"
 	"github.com/openkruise/agents/pkg/cache"
+	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/proxy"
 	"github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
@@ -53,6 +54,11 @@ type Sandbox struct {
 	*agentsv1alpha1.Sandbox
 	Cache           cache.Provider
 	storageRegistry storages.VolumeMountProviderRegistry
+	// trafficToken holds the access token response minted for accessing this
+	// sandbox through the sandbox gateway. It is transient and per-claim: set in
+	// memory during runClaimPostProcesses and never persisted to the CR, so
+	// InplaceRefresh / retryUpdate reassigning s.Sandbox do not clear it.
+	trafficToken *identity.TokenResponse
 }
 
 var DefaultDeleteSandbox = deleteSandbox
@@ -193,6 +199,26 @@ func (s *Sandbox) Phase() string {
 
 func (s *Sandbox) GetSandboxID() string {
 	return utils.GetSandboxID(s.Sandbox)
+}
+
+// GetTrafficAccessToken returns the transient access token minted during claim
+// for accessing this sandbox through the sandbox gateway. It is empty unless
+// the sandbox opted in via AnnotationEnableJwtAuth.
+func (s *Sandbox) GetTrafficAccessToken() string {
+	if s.trafficToken == nil {
+		return ""
+	}
+	return s.trafficToken.AccessToken
+}
+
+// GetTrafficAccessTokenExpiration returns the expiration time (RFC3339) of the
+// transient traffic token minted during claim. It is empty unless the sandbox
+// opted in via AnnotationEnableJwtAuth.
+func (s *Sandbox) GetTrafficAccessTokenExpiration() string {
+	if s.trafficToken == nil {
+		return ""
+	}
+	return s.trafficToken.AccessTokenExpiration
 }
 
 func (s *Sandbox) GetRoute() proxy.Route {

--- a/pkg/sandbox-manager/infra/types.go
+++ b/pkg/sandbox-manager/infra/types.go
@@ -128,6 +128,7 @@ type ClaimMetrics struct {
 	InitRuntime         time.Duration
 	CSIMount            time.Duration
 	SecurityToken       time.Duration
+	TrafficToken        time.Duration
 	LockType            LockType
 	LastError           error
 	PickSandboxFailures []PickSandboxFailure
@@ -154,8 +155,8 @@ func (m *ClaimMetrics) String() string {
 		// Replace newlines and control characters to ensure single-line output
 		lastErrStr = sanitizeErrorMessage(m.LastError)
 	}
-	return fmt.Sprintf("ClaimMetrics{Retries: %d, Total: %v, Wait: %v, RetryCost: %v, PickAndLock: %v, LockType: %v, WaitReady: %v, InitRuntime: %v, CSIMount: %v, SecurityToken: %v, LastError: %v}",
-		m.Retries, m.Total, m.Wait, m.RetryCost, m.PickAndLock, m.LockType, m.WaitReady, m.InitRuntime, m.CSIMount, m.SecurityToken, lastErrStr)
+	return fmt.Sprintf("ClaimMetrics{Retries: %d, Total: %v, Wait: %v, RetryCost: %v, PickAndLock: %v, LockType: %v, WaitReady: %v, InitRuntime: %v, CSIMount: %v, SecurityToken: %v, TrafficToken: %v, LastError: %v}",
+		m.Retries, m.Total, m.Wait, m.RetryCost, m.PickAndLock, m.LockType, m.WaitReady, m.InitRuntime, m.CSIMount, m.SecurityToken, m.TrafficToken, lastErrStr)
 }
 
 // RecordPickSandboxFailure records one failed claim attempt and aggregates repeated key/reason pairs.

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -32,20 +32,22 @@ const (
 
 // Sandbox represents an E2B sandbox running as a Kubernetes Pod
 type Sandbox struct {
-	TemplateID      string            `json:"templateID"`
-	SandboxID       string            `json:"sandboxID"`
-	ClientID        string            `json:"clientID"`
-	StartedAt       string            `json:"startedAt"`
-	EndAt           string            `json:"endAt"`
-	EnvdVersion     string            `json:"envdVersion"`
-	EnvdAccessToken string            `json:"envdAccessToken,omitempty"`
-	Domain          string            `json:"domain"`
-	CPUCount        int64             `json:"cpuCount"`
-	MemoryMB        int64             `json:"memoryMB"`
-	DiskSizeMB      int64             `json:"diskSizeMB"`
-	Alias           string            `json:"alias"`
-	Metadata        map[string]string `json:"metadata"`
-	State           string            `json:"state"`
+	TemplateID                   string            `json:"templateID"`
+	SandboxID                    string            `json:"sandboxID"`
+	ClientID                     string            `json:"clientID"`
+	StartedAt                    string            `json:"startedAt"`
+	EndAt                        string            `json:"endAt"`
+	EnvdVersion                  string            `json:"envdVersion"`
+	EnvdAccessToken              string            `json:"envdAccessToken,omitempty"`
+	TrafficAccessToken           string            `json:"trafficAccessToken,omitempty"`
+	TrafficAccessTokenExpiration string            `json:"trafficAccessTokenExpiration,omitempty"`
+	Domain                       string            `json:"domain"`
+	CPUCount                     int64             `json:"cpuCount"`
+	MemoryMB                     int64             `json:"memoryMB"`
+	DiskSizeMB                   int64             `json:"diskSizeMB"`
+	Alias                        string            `json:"alias"`
+	Metadata                     map[string]string `json:"metadata"`
+	State                        string            `json:"state"`
 }
 
 // NewSandboxRequest represents a request to create a new sandbox

--- a/pkg/servers/e2b/sandbox.go
+++ b/pkg/servers/e2b/sandbox.go
@@ -92,6 +92,11 @@ func (sc *Controller) convertToE2BSandbox(sbx infra.Sandbox, accessToken, domain
 		Domain:          domain,
 		EnvdVersion:     "0.2.10",
 		EnvdAccessToken: accessToken,
+		// TrafficAccessToken is the transient access token minted during claim; it
+		// is empty unless the sandbox opted into access-token issuance, so omitempty
+		// hides it on paths (list, etc.) that carry no token.
+		TrafficAccessToken:           sbx.GetTrafficAccessToken(),
+		TrafficAccessTokenExpiration: sbx.GetTrafficAccessTokenExpiration(),
 	}
 	sandbox.State, _ = sbx.GetState()
 	annotations := sbx.GetAnnotations()


### PR DESCRIPTION
Extend the IdentityProvider so a single provider mints two token kinds selected by a TokenKind argument instead of a separate JWT interface:

- TokenKindIDToken: the identity/security token propagated into the sandbox as a credential (original IssueSandboxToken path, gated by IsIDTokenRequested).
- TokenKindAccessToken: the access token (a JWT) used to reach the sandbox through the gateway, minted during claim and returned to the client (IssueSandboxAccessToken, gated by IsAccessTokenRequested).

The claimed access token is held transiently in memory on the sandbox (GetTrafficAccessToken / GetTrafficAccessTokenExpiration) and surfaced on the E2B response (trafficAccessToken / trafficAccessTokenExpiration) without being persisted to the CR. The community default provider mints random placeholder tokens; access tokens get a very long validity via defaultAccessTokenValidity.

The enable-jwt-auth annotation contract is unchanged.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

