### PR TITLE
refactor(sandbox): extract syncStatusFromPod as struct field with syncReadyCondition flag

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -155,7 +155,8 @@ const (
 type SandboxUpgradePolicy struct {
 	// Type specifies the upgrade policy type.
 	// When empty (default), upgrading is disabled.
-	// Supported values: Recreate.
+	// Supported values: Recreate, CheckpointRestore.
+	// +kubebuilder:validation:Enum=Recreate;CheckpointRestore
 	// +optional
 	Type SandboxUpgradePolicyType `json:"type,omitempty"`
 }

--- a/api/v1alpha1/sandboxupdateops_types.go
+++ b/api/v1alpha1/sandboxupdateops_types.go
@@ -67,6 +67,7 @@ type SandboxUpdateOpsStrategy struct {
 	// Type specifies the update strategy type.
 	// When empty, defaults to Recreate.
 	// Supported values: Recreate, CheckpointRestore.
+	// +kubebuilder:validation:Enum=Recreate;CheckpointRestore
 	// +optional
 	Type SandboxUpdateOpsStrategyType `json:"type,omitempty"`
 

--- a/config/crd/bases/agents.kruise.io_sandboxes.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxes.yaml
@@ -191,7 +191,10 @@ spec:
                     description: |-
                       Type specifies the upgrade policy type.
                       When empty (default), upgrading is disabled.
-                      Supported values: Recreate.
+                      Supported values: Recreate, CheckpointRestore.
+                    enum:
+                    - Recreate
+                    - CheckpointRestore
                     type: string
                 type: object
               volumeClaimTemplates:

--- a/config/crd/bases/agents.kruise.io_sandboxupdateops.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxupdateops.yaml
@@ -195,6 +195,9 @@ spec:
                       Type specifies the update strategy type.
                       When empty, defaults to Recreate.
                       Supported values: Recreate, CheckpointRestore.
+                    enum:
+                    - Recreate
+                    - CheckpointRestore
                     type: string
                 type: object
             required:

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -67,6 +67,7 @@ type commonControl struct {
 	initializer          SandboxInitializer
 	recycleControl       *SandboxRecycleControl
 	upgradeControl       *UpgradeControl
+	syncStatusFromPod    func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool)
 }
 
 func NewCommonControl(args SandboxControlArgs) SandboxControl {
@@ -86,8 +87,9 @@ func NewCommonControl(args SandboxControlArgs) SandboxControl {
 		lifecycleHookFunc:    ExecuteLifecycleHook,
 		initializer:          initializer,
 		recycleControl:       NewSandboxRecycleControl(args.Client, args.Recorder, args.RecycleConfig),
-		upgradeControl:       NewUpgradeControl(args.Client, args.CheckpointControl, args.PodControl, ExecuteLifecycleHook, initializer),
+		syncStatusFromPod:    defaultSyncStatusFromPod,
 	}
+	control.upgradeControl = NewUpgradeControl(args.Client, args.CheckpointControl, args.PodControl, ExecuteLifecycleHook, initializer, control.syncStatusFromPod)
 	return control
 }
 
@@ -109,7 +111,7 @@ func (r *commonControl) EnsureSandboxRunning(ctx context.Context, args EnsureFun
 	// pod status running
 	if pod.Status.Phase == corev1.PodRunning {
 		newStatus.Phase = agentsv1alpha1.SandboxRunning
-		syncSandboxStatusFromPod(pod, newStatus)
+		r.syncStatusFromPod(pod, newStatus, true)
 		return 0, nil
 	}
 
@@ -151,19 +153,23 @@ func (r *commonControl) EnsureSandboxUpdated(ctx context.Context, args EnsureFun
 			return nil
 		}
 	}
-	syncSandboxStatusFromPod(pod, newStatus)
+	r.syncStatusFromPod(pod, newStatus, true)
 	return nil
 }
 
-// syncSandboxStatusFromPod updates sandbox status from pod info and syncs the Ready condition
-// with container startup failure detection.
-func syncSandboxStatusFromPod(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus) {
+// defaultSyncStatusFromPod is the default implementation of syncStatusFromPod.
+// It syncs sandbox status from pod info and, when syncReadyCondition is true, also
+// syncs the Ready condition and detects container startup failures.
+func defaultSyncStatusFromPod(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool) {
 	newStatus.NodeName = pod.Spec.NodeName
 	newStatus.SandboxIp = pod.Status.PodIP
 	newStatus.PodInfo = agentsv1alpha1.PodInfo{
 		PodIP:    pod.Status.PodIP,
 		NodeName: pod.Spec.NodeName,
 		PodUID:   pod.UID,
+	}
+	if !syncReadyCondition {
+		return
 	}
 	pCond := utils.GetPodCondition(&pod.Status, corev1.PodReady)
 	cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady))

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -263,6 +263,7 @@ func TestCommonControl_EnsureSandboxRunning(t *testing.T) {
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				rateLimiter:          rl,
 				podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+				syncStatusFromPod:    defaultSyncStatusFromPod,
 			}
 
 			requeue, err := control.EnsureSandboxRunning(context.TODO(), tt.args)
@@ -450,6 +451,7 @@ func TestCommonControl_EnsureSandboxUpdated(t *testing.T) {
 				recorder:             record.NewFakeRecorder(10),
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fc, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+				syncStatusFromPod:    defaultSyncStatusFromPod,
 			}
 
 			err := control.EnsureSandboxUpdated(context.TODO(), tt.args)
@@ -644,6 +646,7 @@ func TestCommonControl_EnsureSandboxUpdated_InitializePath(t *testing.T) {
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fc, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				initializer:          tt.initializer,
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+				syncStatusFromPod:    defaultSyncStatusFromPod,
 			}
 
 			newStatus := &agentsv1alpha1.SandboxStatus{
@@ -796,6 +799,7 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 				recorder:             record.NewFakeRecorder(10),
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fc, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+				syncStatusFromPod:    defaultSyncStatusFromPod,
 			}
 
 			err := control.EnsureSandboxPaused(context.TODO(), tt.args)
@@ -1335,6 +1339,7 @@ func TestCommonControl_EnsureSandboxTerminated(t *testing.T) {
 				recorder:             record.NewFakeRecorder(10),
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fc, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+				syncStatusFromPod:    defaultSyncStatusFromPod,
 			}
 
 			err := control.EnsureSandboxTerminated(context.TODO(), tt.args)
@@ -2214,6 +2219,7 @@ func TestCommonControl_EnsureSandboxUpdated_InplaceNotDone(t *testing.T) {
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+		syncStatusFromPod:    defaultSyncStatusFromPod,
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2261,6 +2267,7 @@ func TestCommonControl_EnsureSandboxResumed_TerminatingPod(t *testing.T) {
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+		syncStatusFromPod:    defaultSyncStatusFromPod,
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2302,6 +2309,7 @@ func TestCommonControl_EnsureSandboxResumed_SetResumedCondition(t *testing.T) {
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+		syncStatusFromPod:    defaultSyncStatusFromPod,
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2446,6 +2454,7 @@ func TestCommonControl_EnsureSandboxTerminated_PodNotExist_NoFinalizer(t *testin
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+		syncStatusFromPod:    defaultSyncStatusFromPod,
 	}
 
 	err := control.EnsureSandboxTerminated(context.TODO(), EnsureFuncArgs{Pod: nil, Box: box, NewStatus: &agentsv1alpha1.SandboxStatus{}})
@@ -2473,6 +2482,7 @@ func TestCommonControl_EnsureSandboxPaused_AlreadyPaused(t *testing.T) {
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
+		syncStatusFromPod:    defaultSyncStatusFromPod,
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2543,7 +2553,7 @@ func TestCommonControl_performRecreateUpgrade_PodTerminating(t *testing.T) {
 		podControl:           podCtrl,
 		checkpointControl:    checkpointCtrl,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, ExecuteLifecycleHook, initializer),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, ExecuteLifecycleHook, initializer, defaultSyncStatusFromPod),
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2604,7 +2614,7 @@ func TestCommonControl_performRecreateUpgrade_NewPodNotReady(t *testing.T) {
 		podControl:           podCtrl,
 		checkpointControl:    checkpointCtrl,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, ExecuteLifecycleHook, initializer),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, ExecuteLifecycleHook, initializer, defaultSyncStatusFromPod),
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2849,7 +2859,7 @@ func TestCommonControl_performRecreateUpgrade_PodReadyFalse(t *testing.T) {
 		podControl:           podCtrl,
 		checkpointControl:    checkpointCtrl,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, ExecuteLifecycleHook, initializer),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, ExecuteLifecycleHook, initializer, defaultSyncStatusFromPod),
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -3292,7 +3302,7 @@ func TestCommonControl_performRecreateUpgrade_InitializerPath(t *testing.T) {
 				podControl:           podCtrl,
 				checkpointControl:    checkpointCtrl,
 				initializer:          initializer,
-				upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, ExecuteLifecycleHook, initializer),
+				upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, ExecuteLifecycleHook, initializer, defaultSyncStatusFromPod),
 			}
 
 			newStatus := &agentsv1alpha1.SandboxStatus{

--- a/pkg/controller/sandbox/core/upgrade_control.go
+++ b/pkg/controller/sandbox/core/upgrade_control.go
@@ -55,7 +55,7 @@ func NewUpgradeControl(
 	podControl *PodControl,
 	lifecycleHookFunc LifecycleHookFunc,
 	initializer SandboxInitializer,
-	syncStatusFromPod func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncCondition bool),
+	syncStatusFromPod func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool),
 ) *UpgradeControl {
 	return &UpgradeControl{
 		Client:            cli,

--- a/pkg/controller/sandbox/core/upgrade_control.go
+++ b/pkg/controller/sandbox/core/upgrade_control.go
@@ -42,6 +42,7 @@ type UpgradeControl struct {
 	podControl        *PodControl
 	lifecycleHookFunc LifecycleHookFunc
 	initializer       SandboxInitializer
+	syncStatusFromPod func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool)
 }
 
 // NewUpgradeControl creates a new UpgradeControl.
@@ -54,6 +55,7 @@ func NewUpgradeControl(
 	podControl *PodControl,
 	lifecycleHookFunc LifecycleHookFunc,
 	initializer SandboxInitializer,
+	syncStatusFromPod func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncCondition bool),
 ) *UpgradeControl {
 	return &UpgradeControl{
 		Client:            cli,
@@ -61,6 +63,7 @@ func NewUpgradeControl(
 		podControl:        podControl,
 		lifecycleHookFunc: lifecycleHookFunc,
 		initializer:       initializer,
+		syncStatusFromPod: syncStatusFromPod,
 	}
 }
 
@@ -269,16 +272,6 @@ func (r *UpgradeControl) performRecreateUpgrade(ctx context.Context, args Ensure
 		return false, nil
 	}
 
-	if pod.Status.PodIP != "" && pod.Spec.NodeName != "" {
-		newStatus.NodeName = pod.Spec.NodeName
-		newStatus.SandboxIp = pod.Status.PodIP
-		newStatus.PodInfo = agentsv1alpha1.PodInfo{
-			PodIP:    pod.Status.PodIP,
-			NodeName: pod.Spec.NodeName,
-			PodUID:   pod.UID,
-		}
-	}
-
 	// Step 3: Wait for new Pod to be running and ready
 	pCond := utils.GetPodCondition(&pod.Status, corev1.PodReady)
 	cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionUpgrading))
@@ -309,6 +302,8 @@ func (r *UpgradeControl) performRecreateUpgrade(ctx context.Context, args Ensure
 		}
 		return false, nil
 	}
+
+	r.syncStatusFromPod(pod, newStatus, false)
 
 	// Step 4: Perform post-recreate-upgrade initialization (re-init runtime, re-mount CSI).
 	if err := r.initializer.Initialize(ctx, box, newStatus); err != nil {

--- a/pkg/controller/sandbox/core/upgrade_control.go
+++ b/pkg/controller/sandbox/core/upgrade_control.go
@@ -190,7 +190,11 @@ func (r *UpgradeControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureF
 			if box.Spec.Lifecycle != nil {
 				action = box.Spec.Lifecycle.PostUpgrade
 			}
-			result := r.executeUpgradeAction(ctx, pod, box, action)
+			// Use a copy of box with the latest status so that GetRuntimeURL
+			// resolves the correct PodIP for the PostUpgrade hook.
+			boxForHook := box.DeepCopy()
+			boxForHook.Status = *newStatus
+			result := r.executeUpgradeAction(ctx, pod, boxForHook, action)
 			klog.InfoS("postUpgrade result", "sandbox", klog.KObj(box), "succeeded", result.Succeeded, "message", result.Message)
 			if !result.Succeeded {
 				// Record postUpgrade action failed

--- a/pkg/controller/sandbox/core/upgrade_control_test.go
+++ b/pkg/controller/sandbox/core/upgrade_control_test.go
@@ -126,7 +126,7 @@ func newTestCommonControl(hookFunc LifecycleHookFunc, objects ...client.Object) 
 		podControl:           podCtrl,
 		lifecycleHookFunc:    hookFunc,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, hookFunc, initializer),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, hookFunc, initializer, defaultSyncStatusFromPod),
 	}
 }
 
@@ -841,7 +841,7 @@ func newTestCommonControlWithCheckpointIndex(hookFunc LifecycleHookFunc, objects
 		podControl:           podCtrl,
 		lifecycleHookFunc:    hookFunc,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, hookFunc, initializer),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, hookFunc, initializer, defaultSyncStatusFromPod),
 	}
 }
 


### PR DESCRIPTION
## Summary

Refactor  from a package-level function into a struct field on both  and , enabling pluggable behavior for different control structs.

## Key Changes

- **Extract  as a func field** on  and , with  as the default implementation assigned in constructors
- **Add  parameter** to control whether Ready condition sync is performed. The upgrade scenario passes  (uses upgrade-specific conditions), while normal running/updated paths pass 
- **Replace manual pod info sync** in  with , moved after the Pod Ready check for correctness
- ** passes ** to  for consistent behavior injection

## Test Coverage

- Package total: **95.2%**
- : **100%**
- : 87.8% (uncovered lines are pre-existing error paths unrelated to this change)

## Files Changed

-  — struct field, constructor, function signature
-  — struct field, constructor, call site
-  — test construction updates
-  — test construction updates