### PR TITLE
feat(checkpoint): set PersistentContents filesystem for upgrade checkpoints

### DIFF
--- a/pkg/controller/sandbox/core/checkpoint.go
+++ b/pkg/controller/sandbox/core/checkpoint.go
@@ -101,7 +101,7 @@ func (c *CheckpointControl) AssumePodCheckpointed(ctx context.Context, pod *core
 		c.recorder.Event(box, corev1.EventTypeWarning, agentsv1alpha1.SandboxPausedReasonCheckpointFailed, cond.Message)
 		return true
 	} else if len(cpList) == 0 {
-		if _, err := c.createCheckpoint(ctx, box, agentsv1alpha1.CheckpointTypePodInfo); err != nil {
+		if _, err := c.createCheckpoint(ctx, box, agentsv1alpha1.CheckpointTypePodInfo, nil); err != nil {
 			klog.ErrorS(err, "Failed to create checkpoint", "sandbox", klog.KObj(box))
 			cond.Reason = agentsv1alpha1.SandboxPausedReasonCheckpointFailed
 			cond.Message = fmt.Sprintf("Failed to create checkpoint: %v", err)
@@ -180,7 +180,7 @@ func (c *CheckpointControl) Cleanup(ctx context.Context, box *agentsv1alpha1.San
 // checkpoint name. Idempotency within the same reconcile cycle is guaranteed
 // by the caller, which only invokes this function when no existing checkpoint
 // is found for the sandbox (see AssumePodCheckpointed).
-func (c *CheckpointControl) createCheckpoint(ctx context.Context, box *agentsv1alpha1.Sandbox, checkpointType string) (string, error) {
+func (c *CheckpointControl) createCheckpoint(ctx context.Context, box *agentsv1alpha1.Sandbox, checkpointType string, persistentContents []string) (string, error) {
 	cpName := box.Name + "-" + utils.RandStringN(8)
 	cp := &agentsv1alpha1.Checkpoint{
 		ObjectMeta: metav1.ObjectMeta{
@@ -195,7 +195,8 @@ func (c *CheckpointControl) createCheckpoint(ctx context.Context, box *agentsv1a
 			},
 		},
 		Spec: agentsv1alpha1.CheckpointSpec{
-			SandboxName: &box.Name,
+			SandboxName:        &box.Name,
+			PersistentContents: persistentContents,
 		},
 	}
 	ScaleExpectation.ExpectScale(GetControllerKey(box), expectations.Create, cpName)
@@ -237,7 +238,7 @@ func (c *CheckpointControl) EnsureCheckpointForUpgrade(ctx context.Context, box 
 	}
 
 	if len(cpList) == 0 {
-		cpName, err := c.createCheckpoint(ctx, box, agentsv1alpha1.CheckpointTypeUpgrade)
+		cpName, err := c.createCheckpoint(ctx, box, agentsv1alpha1.CheckpointTypeUpgrade, []string{agentsv1alpha1.CheckpointPersistentContentFilesystem})
 		if err != nil {
 			return false, "", fmt.Errorf("failed to create checkpoint for upgrade: %w", err)
 		}

--- a/pkg/controller/sandbox/core/checkpoint_test.go
+++ b/pkg/controller/sandbox/core/checkpoint_test.go
@@ -790,7 +790,7 @@ func TestCreateCheckpoint(t *testing.T) {
 	box := newCheckpointTestSandbox()
 	ctrl, cli, recorder := newCheckpointTestControlWithRecorder()
 
-	name, err := ctrl.createCheckpoint(context.TODO(), box, agentsv1alpha1.CheckpointTypePodInfo)
+	name, err := ctrl.createCheckpoint(context.TODO(), box, agentsv1alpha1.CheckpointTypePodInfo, nil)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, name)
 
@@ -1034,16 +1034,20 @@ func TestEnsureCheckpointForUpgrade(t *testing.T) {
 			expectError: "checkpoint test-sandbox-cp1 failed during upgrade",
 		},
 		{
-			name:         "list error - returns error",
-			interceptors: interceptor.Funcs{List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error { return fmt.Errorf("list unavailable") }},
-			expectDone:   false,
-			expectError:  "failed to list checkpoints for upgrade",
+			name: "list error - returns error",
+			interceptors: interceptor.Funcs{List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return fmt.Errorf("list unavailable")
+			}},
+			expectDone:  false,
+			expectError: "failed to list checkpoints for upgrade",
 		},
 		{
-			name:         "create error - returns error",
-			interceptors: interceptor.Funcs{Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error { return fmt.Errorf("create denied") }},
-			expectDone:   false,
-			expectError:  "failed to create checkpoint for upgrade",
+			name: "create error - returns error",
+			interceptors: interceptor.Funcs{Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+				return fmt.Errorf("create denied")
+			}},
+			expectDone:  false,
+			expectError: "failed to create checkpoint for upgrade",
 		},
 	}
 
@@ -1088,10 +1092,10 @@ func TestEnsureCheckpointForUpgrade(t *testing.T) {
 
 func TestGetCheckpointIDForUpgrade(t *testing.T) {
 	tests := []struct {
-		name        string
-		existingCPs []client.Object
+		name         string
+		existingCPs  []client.Object
 		interceptors interceptor.Funcs
-		expectID    string
+		expectID     string
 	}{
 		{
 			name: "checkpoint with ID - returns ID",
@@ -1116,9 +1120,11 @@ func TestGetCheckpointIDForUpgrade(t *testing.T) {
 			expectID: "",
 		},
 		{
-			name:         "list error - returns empty",
-			interceptors: interceptor.Funcs{List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error { return fmt.Errorf("list error") }},
-			expectID:     "",
+			name: "list error - returns empty",
+			interceptors: interceptor.Funcs{List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return fmt.Errorf("list error")
+			}},
+			expectID: "",
 		},
 	}
 
@@ -1165,8 +1171,10 @@ func TestCleanupForUpgrade(t *testing.T) {
 			expectRemain: 0,
 		},
 		{
-			name:         "list error - no panic",
-			interceptors: interceptor.Funcs{List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error { return fmt.Errorf("list error") }},
+			name: "list error - no panic",
+			interceptors: interceptor.Funcs{List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return fmt.Errorf("list error")
+			}},
 			expectRemain: 0,
 		},
 		{
@@ -1225,7 +1233,7 @@ func TestCreateCheckpoint_AlreadyExists(t *testing.T) {
 	recorder := record.NewFakeRecorder(10)
 	ctrl := NewCheckpointControl(cli, recorder)
 
-	_, err := ctrl.createCheckpoint(context.TODO(), box, agentsv1alpha1.CheckpointTypePodInfo)
+	_, err := ctrl.createCheckpoint(context.TODO(), box, agentsv1alpha1.CheckpointTypePodInfo, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 }


### PR DESCRIPTION
## Summary

When creating a checkpoint for the CheckpointRestore upgrade scenario, the resulting Checkpoint CR was missing `Spec.PersistentContents`. This caused the checkpoint controller to not snapshot the writable filesystem layer, preventing proper restoration when the new pod was created.

## Changes

- Added `persistentContents []string` parameter to `createCheckpoint` function
- `EnsureCheckpointForUpgrade` now passes `[CheckpointPersistentContentFilesystem]` so the checkpoint controller snapshots the writable layer
- `AssumePodCheckpointed` (pause/resume path) passes `nil` to preserve existing behavior
- Updated test call sites accordingly

## Test Plan

- [x] Unit tests pass (`go test ./pkg/controller/sandbox/core/`)
- [ ] CI sandbox-upgrade E2E tests pass