### PR TITLE
fix(securitytokenrefresh): treat absent RuntimeInitialized condition as serving

### DIFF
--- a/pkg/controller/securitytokenrefresh/predicate.go
+++ b/pkg/controller/securitytokenrefresh/predicate.go
@@ -118,13 +118,25 @@ func isRefreshTarget(obj client.Object) bool {
 // gating on them lets the refresh always fire while a serving runtime exists,
 // breaking the loop.
 //
-// A serving runtime requires BOTH:
-//   - Phase == Running: a bound pod whose containers have started. This excludes
-//     Paused (pod deleted), Resuming, Pending/creating and recreate-Upgrading,
-//     where there is no reachable runtime and a propagate would fail.
-//   - RuntimeInitialized == True: the agent-runtime sidecar finished
-//     (re-)initialization and can accept a token. Resume resets this to False,
-//     so a resuming pod is correctly excluded until its runtime is re-inited.
+// A serving runtime requires Phase == Running: a bound pod whose containers
+// have started. This excludes Paused (pod deleted), Resuming, Pending/creating
+// and recreate-Upgrading, where there is no reachable runtime and a propagate
+// would fail.
+//
+// The RuntimeInitialized condition is only ever set during a resume /
+// recreate-upgrade RE-initialization cycle (EnsureSandboxResumed and
+// performRecreateUpgrade); the initial claim flow initializes the runtime
+// out-of-band (sandbox-manager InitRuntime) and never writes this condition.
+// So its semantics are:
+//   - absent: the sandbox never went through a resume/recreate re-init cycle,
+//     so a Running pod is already serving (the common freshly-claimed case).
+//     Treating absent as "not serving" would wedge every never-paused sandbox,
+//     deferring its token refresh forever.
+//   - present and True: the runtime finished (re-)initialization and can accept
+//     a token.
+//   - present and non-True: resume/recreate re-init is still in progress (Resume
+//     resets this to False), so the resuming pod is correctly excluded until its
+//     runtime is re-inited.
 //
 // A non-Sandbox object (which never reaches this controller) reports false.
 func hasServingRuntime(obj client.Object) bool {
@@ -136,7 +148,7 @@ func hasServingRuntime(obj client.Object) bool {
 		return false
 	}
 	cond := utils.GetSandboxCondition(&box.Status, string(agentsv1alpha1.RuntimeInitialized))
-	return cond != nil && cond.Status == metav1.ConditionTrue
+	return cond == nil || cond.Status == metav1.ConditionTrue
 }
 
 // tokenStatusAnnotation returns the raw value of the token-status annotation,

--- a/pkg/controller/securitytokenrefresh/predicate_test.go
+++ b/pkg/controller/securitytokenrefresh/predicate_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
@@ -136,8 +137,11 @@ func TestNeedsRefreshPredicate(t *testing.T) {
 
 	// notServing/serving pair share the same (unchanged) annotation so only the
 	// serving-runtime transition can drive the predicate decision. A serving
-	// runtime requires BOTH Phase==Running and RuntimeInitialized==True; the gate
-	// is intentionally token-independent (never the aggregate Ready condition).
+	// runtime requires Phase==Running; the RuntimeInitialized condition gates
+	// only resume/recreate re-init (absent or True == serving). Here notServing
+	// leaves Phase unset so it is not serving, while serving sets Phase==Running
+	// and RuntimeInitialized==True. The gate is intentionally token-independent
+	// (never the aggregate Ready condition).
 	notServing := newSandbox("a", true, sampleStatus, false)
 	serving := newSandbox("a", true, sampleStatus, false)
 	serving.Status.Phase = agentsv1alpha1.SandboxRunning
@@ -175,6 +179,83 @@ func TestNeedsRefreshPredicate(t *testing.T) {
 	t.Run("lose serving runtime (serving -> none) with unchanged annotation is dropped", func(t *testing.T) {
 		assert.False(t, p.Update(event.UpdateEvent{ObjectOld: serving, ObjectNew: notServing}))
 	})
+}
+
+// sampleServingStatus is a valid token-status annotation reused by the
+// hasServingRuntime table. The annotation content is irrelevant to the gate
+// (which looks only at Phase and the RuntimeInitialized condition) but keeps
+// the helper sandboxes shaped like real refresh targets.
+const sampleServingStatus = `{"accessTokenExpiration":"2099-01-01T00:00:00Z"}`
+
+// TestHasServingRuntime pins down the token-independent serving gate. The key
+// regression it guards is the freshly-claimed case: a Running sandbox whose
+// RuntimeInitialized condition is ABSENT (the condition is only ever written
+// during a resume/recreate re-init cycle) must still count as serving, so its
+// token refresh is not deferred forever.
+func TestHasServingRuntime(t *testing.T) {
+	// withInitCond returns a claimed sandbox at the given phase carrying a
+	// RuntimeInitialized condition with the given status.
+	withInitCond := func(phase agentsv1alpha1.SandboxPhase, status metav1.ConditionStatus) *agentsv1alpha1.Sandbox {
+		s := newSandbox("a", true, sampleServingStatus, false)
+		s.Status.Phase = phase
+		s.Status.Conditions = []metav1.Condition{{
+			Type:   string(agentsv1alpha1.RuntimeInitialized),
+			Status: status,
+		}}
+		return s
+	}
+	// runningNoCond is a Running sandbox with no RuntimeInitialized condition,
+	// mirroring a freshly-claimed sandbox that never went through a
+	// resume/recreate re-init cycle.
+	runningNoCond := newSandbox("a", true, sampleServingStatus, false)
+	runningNoCond.Status.Phase = agentsv1alpha1.SandboxRunning
+
+	tests := []struct {
+		name string
+		obj  client.Object
+		want bool
+	}{
+		{
+			name: "running with RuntimeInitialized True -> serving",
+			obj:  withInitCond(agentsv1alpha1.SandboxRunning, metav1.ConditionTrue),
+			want: true,
+		},
+		{
+			name: "running with RuntimeInitialized condition absent -> serving (freshly claimed)",
+			obj:  runningNoCond,
+			want: true,
+		},
+		{
+			name: "running with RuntimeInitialized False (resume re-init in progress) -> not serving",
+			obj:  withInitCond(agentsv1alpha1.SandboxRunning, metav1.ConditionFalse),
+			want: false,
+		},
+		{
+			name: "paused phase -> not serving even with RuntimeInitialized True",
+			obj:  withInitCond(agentsv1alpha1.SandboxPaused, metav1.ConditionTrue),
+			want: false,
+		},
+		{
+			name: "resuming phase -> not serving",
+			obj:  withInitCond(agentsv1alpha1.SandboxResuming, metav1.ConditionFalse),
+			want: false,
+		},
+		{
+			name: "empty phase (pending/creating) -> not serving",
+			obj:  newSandbox("a", true, sampleServingStatus, false),
+			want: false,
+		},
+		{
+			name: "non-Sandbox object -> not serving",
+			obj:  &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hasServingRuntime(tt.obj))
+		})
+	}
 }
 
 func TestTokenStatusAnnotation(t *testing.T) {

--- a/pkg/controller/securitytokenrefresh/token_refresh_controller_test.go
+++ b/pkg/controller/securitytokenrefresh/token_refresh_controller_test.go
@@ -140,7 +140,12 @@ func TestReconcile(t *testing.T) {
 		// RuntimeInitialized=True so the timing branches run. The gate is
 		// token-independent (never the aggregate Ready condition).
 		notServing bool
-		refresher  *fakeRefresher
+		// runningNoInitCond sets Phase=Running but leaves the RuntimeInitialized
+		// condition ABSENT, mirroring a freshly-claimed sandbox that never went
+		// through a resume/recreate re-init cycle. Such a sandbox is serving and
+		// must NOT have its refresh deferred.
+		runningNoInitCond bool
+		refresher         *fakeRefresher
 		// expected outcomes
 		expectErr        string
 		expectRequeueMin time.Duration
@@ -340,6 +345,26 @@ func TestReconcile(t *testing.T) {
 			expectCalls:               0,
 			expectAnnotationUnchanged: true,
 		},
+		{
+			// A freshly-claimed sandbox is Running but never had the
+			// RuntimeInitialized condition written (that condition only appears
+			// during resume/recreate re-init). Its runtime was initialized by the
+			// claim flow and is serving, so an absent condition must NOT defer the
+			// refresh; the token has to be rotated like any other serving sandbox.
+			name:              "running sandbox without RuntimeInitialized condition refreshes when due",
+			status:            `{"accessTokenExpiration":"` + expireNow + `"}`,
+			claimed:           true,
+			runningNoInitCond: true,
+			refresher: &fakeRefresher{
+				resp: &identity.TokenResponse{
+					AccessToken:           "new-token",
+					AccessTokenExpiration: now.Add(2 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			expectErr:   "",
+			expectCalls: 1,
+			expectEvent: "TokenRefreshed",
+		},
 	}
 
 	cleanup := withFlags(defaultRefreshLeadTime, 0, defaultRefreshRetryAfter)
@@ -353,10 +378,12 @@ func TestReconcile(t *testing.T) {
 				sbx.Namespace = sandboxNs
 				if !tt.notServing {
 					sbx.Status.Phase = agentsv1alpha1.SandboxRunning
-					sbx.Status.Conditions = []metav1.Condition{{
-						Type:   string(agentsv1alpha1.RuntimeInitialized),
-						Status: metav1.ConditionTrue,
-					}}
+					if !tt.runningNoInitCond {
+						sbx.Status.Conditions = []metav1.Condition{{
+							Type:   string(agentsv1alpha1.RuntimeInitialized),
+							Status: metav1.ConditionTrue,
+						}}
+					}
 				}
 			}
 			r, rec, c := newReconciler(t, tt.refresher, now, sbx)


### PR DESCRIPTION
…as serving

hasServingRuntime gated a serving runtime on both Phase==Running AND the RuntimeInitialized condition being present and True. But that condition is only ever written during a resume / recreate-upgrade re-initialization cycle (EnsureSandboxResumed and performRecreateUpgrade); a freshly-claimed sandbox that goes Pending -> Running and is never paused has its runtime initialized out-of-band by the claim flow and never carries this condition.

As a result, hasServingRuntime returned false for such Running-and-Ready sandboxes, and the token-refresh reconciler deferred their refresh forever: the workqueue was never armed with a RequeueAfter and no serving-runtime predicate transition ever fired, so the security token was never rotated.

Treat an absent RuntimeInitialized condition on a Running sandbox as serving, matching the sandbox controller's own EnsureSandboxUpdated logic (which only waits for re-init when the condition is present and not True). Only an explicitly non-True condition (resume/recreate re-init in progress) now defers the refresh. The gate stays token-independent (never the aggregate Ready condition), so the expired-token deadlock it was designed to avoid is preserved.

Add TestHasServingRuntime covering all branches and a TestReconcile case asserting a Running sandbox without the condition refreshes when due.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

