### PR TITLE
feat(storage): add related tests for oss volume with kms byok

### DIFF
--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -2639,14 +2639,14 @@ func TestBuildClaimOptions_CSIMount_Test(t *testing.T) {
 				csiutils.BuildStorageAuthAnnotation = func(_ context.Context, _ client.Client, mounts []agentsv1alpha1.CSIMountConfig) (string, string, error) {
 					type storageAuthItem struct {
 						CredentialProviderName string            `json:"credentialProviderName"`
-						Attributes            map[string]string `json:"attributes,omitempty"`
+						Attributes             map[string]string `json:"attributes,omitempty"`
 					}
 					var items []storageAuthItem
 					for _, m := range mounts {
 						if cpName, ok := m.Attributes["credentialProviderName"]; ok {
 							items = append(items, storageAuthItem{
 								CredentialProviderName: cpName,
-								Attributes:            map[string]string{"sub-path": m.SubPath},
+								Attributes:             map[string]string{"sub-path": m.SubPath},
 							})
 						}
 					}
@@ -2700,6 +2700,101 @@ func TestBuildClaimOptions_CSIMount_Test(t *testing.T) {
 				attrs, ok := items[0]["attributes"].(map[string]interface{})
 				require.True(t, ok, "attributes should be a map")
 				assert.Equal(t, "user-data", attrs["sub-path"], "sub-path attribute mismatch")
+			},
+		},
+		{
+			name: "CSI mount with credentialProviderName and kmsKeyId injects storage-auth annotation with kms-key-id",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim-csi-kms",
+					Namespace: "default",
+					UID:       "test-uid-kms",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "test-template",
+					DynamicVolumesMount: []agentsv1alpha1.CSIMountConfig{
+						{
+							PvName:    "test-pv-nas",
+							MountPath: "/workspace",
+							SubPath:   "encrypted-data",
+							Attributes: map[string]string{
+								"credentialProviderName": "oss-rw",
+								"kmsKeyId":               "cmk-12345",
+							},
+						},
+					},
+				},
+			},
+			setup: func(t *testing.T) {
+				// Register the BuildStorageAuthAnnotation hook to simulate enterprise deployment with kmsKeyId support
+				origHook := csiutils.BuildStorageAuthAnnotation
+				t.Cleanup(func() { csiutils.BuildStorageAuthAnnotation = origHook })
+				csiutils.BuildStorageAuthAnnotation = func(_ context.Context, _ client.Client, mounts []agentsv1alpha1.CSIMountConfig) (string, string, error) {
+					type storageAuthItem struct {
+						CredentialProviderName string            `json:"credentialProviderName"`
+						Attributes             map[string]string `json:"attributes,omitempty"`
+					}
+					var items []storageAuthItem
+					for _, m := range mounts {
+						if cpName, ok := m.Attributes["credentialProviderName"]; ok {
+							attrs := map[string]string{"sub-path": m.SubPath}
+							if kmsKeyId, ok := m.Attributes["kmsKeyId"]; ok && kmsKeyId != "" {
+								attrs["kms-key-id"] = kmsKeyId
+							}
+							items = append(items, storageAuthItem{
+								CredentialProviderName: cpName,
+								Attributes:             attrs,
+							})
+						}
+					}
+					if len(items) == 0 {
+						return "", "", nil
+					}
+					data, err := json.Marshal(items)
+					if err != nil {
+						return "", "", err
+					}
+					return "security.agents.kruise.io/storage-auth", string(data), nil
+				}
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-template",
+					Namespace: "default",
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Runtimes: []agentsv1alpha1.RuntimeConfig{
+						{Name: agentsv1alpha1.RuntimeConfigForInjectAgentRuntime},
+					},
+				},
+			},
+			expectError:        false,
+			expectedMountCount: 1,
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				require.NotNil(t, opts.CSIMount, "CSIMount should not be nil")
+				// Invoke the Modifier to verify storage-auth annotation injection
+				mockSandbox := &sandboxcr.Sandbox{
+					Sandbox: &agentsv1alpha1.Sandbox{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-sandbox",
+							Namespace: "default",
+						},
+					},
+				}
+				opts.Modifier(mockSandbox)
+				// Verify storage-auth annotation is set with correct JSON content including kms-key-id
+				storageAuthVal := mockSandbox.GetAnnotations()["security.agents.kruise.io/storage-auth"]
+				assert.NotEmpty(t, storageAuthVal, "storage-auth annotation should be injected")
+				// Parse and verify the JSON structure
+				var items []map[string]interface{}
+				err := json.Unmarshal([]byte(storageAuthVal), &items)
+				require.NoError(t, err, "storage-auth should be valid JSON")
+				assert.Len(t, items, 1, "Expected 1 storage auth item")
+				assert.Equal(t, "oss-rw", items[0]["credentialProviderName"], "credentialProviderName mismatch")
+				attrs, ok := items[0]["attributes"].(map[string]interface{})
+				require.True(t, ok, "attributes should be a map")
+				assert.Equal(t, "encrypted-data", attrs["sub-path"], "sub-path attribute mismatch")
+				assert.Equal(t, "cmk-12345", attrs["kms-key-id"], "kms-key-id attribute mismatch")
 			},
 		},
 		{

--- a/pkg/identity/sandbox_token_helper_test.go
+++ b/pkg/identity/sandbox_token_helper_test.go
@@ -387,6 +387,36 @@ func TestIssueSandboxToken_ProviderCanReadSandboxAnnotations(t *testing.T) {
 		"provider must be able to read annotations directly from the forwarded sandbox")
 }
 
+// TestIssueSandboxToken_ProviderCanReadStorageAuthWithKmsKeyId verifies that the
+// sandbox pointer forwarded to IdentityProvider carries storage-auth annotations
+// that include kms-key-id attributes for KMS server-side encryption support.
+func TestIssueSandboxToken_ProviderCanReadStorageAuthWithKmsKeyId(t *testing.T) {
+	const storageAuthAnnotationKey = SecurityMetadataPrefix + "storage-auth"
+
+	saved := provider
+	reader := &annotationReadingProvider{storageAuthKey: storageAuthAnnotationKey}
+	RegisterProvider(reader)
+	t.Cleanup(func() { RegisterProvider(saved) })
+
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sbx-kms-annotation",
+			Namespace: "ns",
+			UID:       types.UID("uid-kms-annotation"),
+			Annotations: map[string]string{
+				storageAuthAnnotationKey: `[{"credentialProviderName":"oss-rw","attributes":{"bucket-name":"my-bucket","sub-path":"user-data","kms-key-id":"cmk-12345"}}]`,
+			},
+		},
+	}
+
+	_, err := IssueSandboxToken(context.Background(), sbx)
+	require.NoError(t, err)
+	assert.Equal(t,
+		`[{"credentialProviderName":"oss-rw","attributes":{"bucket-name":"my-bucket","sub-path":"user-data","kms-key-id":"cmk-12345"}}]`,
+		reader.gotValue,
+		"provider must be able to read storage-auth annotations with kms-key-id from the forwarded sandbox")
+}
+
 // TestIssueSandboxToken_ProviderError guarantees the helper surfaces provider
 // errors wrapped with the documented message and returns a nil response so that
 // callers never accidentally persist a stale or zero-value token.

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -372,6 +372,29 @@ func TestCreateSandboxWithClaim_CSIMount(t *testing.T) {
 			expectCSIMount:     true,
 			expectedMountCount: 2,
 		},
+		{
+			name: "csi mount with kmsKeyId attribute for KMS server-side encryption",
+			request: models.NewSandboxRequest{
+				TemplateID: "test-template",
+				Extensions: models.NewSandboxRequestExtension{
+					CSIMount: models.CSIMountExtension{
+						MountConfigs: []v1alpha1.CSIMountConfig{
+							{
+								PvName:    "pv-oss-kms",
+								MountPath: "/data-encrypted",
+								SubPath:   "user-kms-data",
+								Attributes: map[string]string{
+									"credentialProviderName": "oss-rw",
+									"kmsKeyId":               "cmk-12345",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectCSIMount:     true,
+			expectedMountCount: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -386,6 +409,29 @@ func TestCreateSandboxWithClaim_CSIMount(t *testing.T) {
 			hasCSIMount := len(tt.request.Extensions.CSIMount.MountConfigs) > 0
 			if hasCSIMount != tt.expectCSIMount {
 				t.Errorf("expectCSIMount mismatch: expected %v, got %v", tt.expectCSIMount, hasCSIMount)
+			}
+
+			// Verify Attributes survive JSON marshal/unmarshal round-trip
+			for i, mc := range tt.request.Extensions.CSIMount.MountConfigs {
+				if mc.Attributes == nil {
+					continue
+				}
+				data, err := json.Marshal(mc)
+				if err != nil {
+					t.Fatalf("mount config[%d]: failed to marshal: %v", i, err)
+				}
+				var decoded v1alpha1.CSIMountConfig
+				if err := json.Unmarshal(data, &decoded); err != nil {
+					t.Fatalf("mount config[%d]: failed to unmarshal: %v", i, err)
+				}
+				for k, v := range mc.Attributes {
+					got, ok := decoded.Attributes[k]
+					if !ok {
+						t.Errorf("mount config[%d]: attribute %q lost after JSON round-trip", i, k)
+					} else if got != v {
+						t.Errorf("mount config[%d]: attribute %q = %q, want %q", i, k, got, v)
+					}
+				}
 			}
 		})
 	}
@@ -1123,6 +1169,14 @@ func TestInjectStorageAuthAnnotation(t *testing.T) {
 			expectAnnotation:   true,
 			expectedKey:        "security.agents.kruise.io/storage-auth",
 			expectedValue:      `[{"credentialProviderName":"provider-x"}]`,
+		},
+		{
+			name:             "storage-auth with kmsKeyId attribute is injected",
+			key:              "security.agents.kruise.io/storage-auth",
+			value:            `[{"credentialProviderName":"oss-rw","attributes":{"bucket-name":"my-bucket","kms-key-id":"cmk-12345"}}]`,
+			expectAnnotation: true,
+			expectedKey:      "security.agents.kruise.io/storage-auth",
+			expectedValue:    `[{"credentialProviderName":"oss-rw","attributes":{"bucket-name":"my-bucket","kms-key-id":"cmk-12345"}}]`,
 		},
 	}
 

--- a/pkg/utils/csiutils/storages_provider.go
+++ b/pkg/utils/csiutils/storages_provider.go
@@ -152,7 +152,8 @@ func (h *CSIMountHandler) CSIMountOptionsConfig(ctx context.Context, mountReques
 // before generating the CSI NodePublishVolume request. It is nil by default in
 // community builds; enterprise deployments register an implementation via init()
 // to inject provider-specific attributes (e.g., sandboxCredentialProviderName
-// for agent-identity authentication).
+// for agent-identity authentication, kmsKeyId and encrypted for KMS
+// server-side encryption).
 //
 // The hook receives the mount request and the PV's VolumeAttributes map (already
 // a deep copy). It may modify volumeAttributes in place.
@@ -165,7 +166,7 @@ var NodePublishVolumeEnricher func(ctx context.Context, mountRequest v1alpha1.CS
 //
 // Enterprise deployments register an implementation via init() to provide
 // agent-identity storage authentication (credential metadata construction,
-// enrichment, and serialization).
+// enrichment, and serialization), including kms-key-id for KMS encryption.
 //
 // Returns:
 //   - annotationKey: the annotation key to set on the sandbox (e.g., "security.agents.kruise.io/storage-auth")

--- a/pkg/utils/csiutils/storages_provider_test.go
+++ b/pkg/utils/csiutils/storages_provider_test.go
@@ -1097,6 +1097,65 @@ func TestGenerateNodePublishVolumeRequest_NodePublishVolumeEnricher(t *testing.T
 	assert.Equal(t, "agent-identity", capturedAttrs["authType"])
 }
 
+func TestGenerateNodePublishVolumeRequest_NodePublishVolumeEnricher_KmsKeyId(t *testing.T) {
+	ctx := context.Background()
+	initObjs := []client.Object{
+		&corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: "pv-enricher-kms-test"},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					CSI: &corev1.CSIPersistentVolumeSource{
+						Driver: "nas-driver",
+						VolumeAttributes: map[string]string{
+							"authType": "agent-identity",
+						},
+					},
+				},
+			},
+		},
+	}
+	c, _, err := cachetest.NewTestCache(t, initObjs...)
+	require.NoError(t, err)
+
+	registry := &mockStorageProviderRegistry{
+		supportedDrivers: map[string]bool{"nas-driver": true},
+		providers:        map[string]storages.VolumeMountProvider{"nas-driver": &mockVolumeMountProvider{}},
+	}
+	handler := NewCSIMountHandler(c.GetClient(), c.GetAPIReader(), registry, utils.DefaultSandboxDeployNamespace)
+
+	// Save and restore the package-level hook
+	saved := NodePublishVolumeEnricher
+	var capturedAttrs map[string]string
+	NodePublishVolumeEnricher = func(_ context.Context, req v1alpha1.CSIMountConfig, volumeAttributes map[string]string) {
+		// Simulate internal implementation injecting kmsKeyId and encrypted attributes
+		if credName := req.Attributes["credentialProviderName"]; credName != "" {
+			volumeAttributes["sandboxCredentialProviderName"] = credName
+		}
+		if kmsKeyId := req.Attributes["kmsKeyId"]; kmsKeyId != "" {
+			volumeAttributes["kmsKeyId"] = kmsKeyId
+			volumeAttributes["encrypted"] = "kms"
+		}
+		capturedAttrs = volumeAttributes
+	}
+	t.Cleanup(func() { NodePublishVolumeEnricher = saved })
+
+	_, csiReq, err := handler.GenerateNodePublishVolumeRequest(ctx, v1alpha1.CSIMountConfig{
+		PvName:    "pv-enricher-kms-test",
+		MountPath: "/mnt/data",
+		Attributes: map[string]string{
+			"credentialProviderName": "oss-rw",
+			"kmsKeyId":              "cmk-12345",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, csiReq)
+	// Verify the hook was called and enriched VolumeAttributes correctly.
+	assert.Equal(t, "oss-rw", capturedAttrs["sandboxCredentialProviderName"])
+	assert.Equal(t, "cmk-12345", capturedAttrs["kmsKeyId"])
+	assert.Equal(t, "kms", capturedAttrs["encrypted"])
+	assert.Equal(t, "agent-identity", capturedAttrs["authType"])
+}
+
 func TestMergeAndValidatePaths(t *testing.T) {
 	tests := []struct {
 		name                   string


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

This PR adds test coverage and documentation for KMS BYOK (Bring Your Own Key) server-side encryption support in OSS volume mounts.
Specifically, it:
- Adds tests verifying that kmsKeyId can be passed through CSIMountConfig.Attributes from both the E2B API (NewSandboxRequest) and the SandboxClaim spec.
- Adds a test confirming that the NodePublishVolumeEnricher hook correctly injects kmsKeyId and encrypted=kms into CSI VolumeAttributes for the NodePublish request.
- Adds a test verifying that the storage-auth annotation carries kms-key-id through the identity token issuance path.
- Updates doc comments on NodePublishVolumeEnricher and BuildStorageAuthAnnotation to reflect KMS encryption parameters.
The actual enrichment and annotation-building logic is implemented behind enterprise-specific hooks (NodePublishVolumeEnricher, BuildStorageAuthAnnotation) which are registered in internal builds. This PR ensures the community codebase correctly plumbs and validates these attributes end-to-end.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how to verify it

All new tests should pass. Existing tests should remain unaffected since the hooks default to nil in community builds.

### Ⅳ. Special notes for reviews

- The core implementation of KMS encryption enrichment lives in internal (enterprise) packages that register the NodePublishVolumeEnricher and BuildStorageAuthAnnotation hooks via init(). This PR only adds the test harnesses and comment updates on the community side.
- Tests simulate the enterprise behavior by temporarily assigning the hook variables with test-local implementations and cleaning up via t.Cleanup.
- No behavioral change to the community build — all hooks remain nil by default and the new code paths are exercised only through the test-injected implementations.
