### PR TITLE
fix: harden API key persistence and sandbox owner labels

### DIFF
--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/api/validate/content"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -752,6 +753,17 @@ func performLockSandbox(ctx context.Context, sbx *Sandbox, lockType infra.LockTy
 	log := klog.FromContext(ctx)
 	c := cache.GetClient()
 	utils.LockSandbox(sbx.Sandbox, opts.LockString, opts.User)
+	// sync user annotation to pod label. Annotation values are unrestricted but
+	// label values are not, so reject an owner that cannot be a valid label.
+	if errs := content.IsLabelValue(opts.User); len(errs) > 0 {
+		return fmt.Errorf("invalid owner %q for pod label %s: %s", opts.User, v1alpha1.AnnotationOwner, strings.Join(errs, "; "))
+	}
+	podLabels := sbx.GetPodLabels()
+	if podLabels == nil {
+		podLabels = make(map[string]string, 1)
+	}
+	podLabels[v1alpha1.AnnotationOwner] = opts.User
+	sbx.SetPodLabels(podLabels)
 	var updated *v1alpha1.Sandbox
 	var err error
 	if lockType == infra.LockTypeCreate {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -62,6 +62,11 @@ func ValidateAndInitClaimOptions(opts infra.ClaimSandboxOptions) (infra.ClaimSan
 	if opts.User == "" {
 		return infra.ClaimSandboxOptions{}, fmt.Errorf("user is required")
 	}
+	// Owner is also synced to a pod label (AnnotationOwner key). Annotation
+	// values are unrestricted but label values are not, so reject early.
+	if errs := content.IsLabelValue(opts.User); len(errs) > 0 {
+		return infra.ClaimSandboxOptions{}, fmt.Errorf("invalid owner %q for pod label %s: %s", opts.User, v1alpha1.AnnotationOwner, strings.Join(errs, "; "))
+	}
 	if opts.Template == "" {
 		return infra.ClaimSandboxOptions{}, fmt.Errorf("template is required")
 	}
@@ -753,11 +758,10 @@ func performLockSandbox(ctx context.Context, sbx *Sandbox, lockType infra.LockTy
 	log := klog.FromContext(ctx)
 	c := cache.GetClient()
 	utils.LockSandbox(sbx.Sandbox, opts.LockString, opts.User)
-	// sync user annotation to pod label. Annotation values are unrestricted but
-	// label values are not, so reject an owner that cannot be a valid label.
-	if errs := content.IsLabelValue(opts.User); len(errs) > 0 {
-		return fmt.Errorf("invalid owner %q for pod label %s: %s", opts.User, v1alpha1.AnnotationOwner, strings.Join(errs, "; "))
-	}
+	// Sync owner onto the pod template as a label so selectors/policies can
+	// match it. Reuse AnnotationOwner as the label key so the value stays
+	// aligned with the sandbox owner annotation written by LockSandbox.
+	// opts.User was validated as a label value in ValidateAndInitClaimOptions.
 	podLabels := sbx.GetPodLabels()
 	if podLabels == nil {
 		podLabels = make(map[string]string, 1)

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -344,6 +344,17 @@ func TestInfra_ClaimSandbox(t *testing.T) {
 			},
 		},
 		{
+			name:      "claim syncs owner to pod label",
+			available: 2,
+			options: infra.ClaimSandboxOptions{
+				User:     user,
+				Template: existTemplate,
+			},
+			postCheck: func(t *testing.T, sbx infra.Sandbox) {
+				assert.Equal(t, user, sbx.GetPodLabels()[v1alpha1.AnnotationOwner])
+			},
+		},
+		{
 			name:      "claim with no template",
 			available: 1,
 			options: infra.ClaimSandboxOptions{
@@ -358,6 +369,15 @@ func TestInfra_ClaimSandbox(t *testing.T) {
 				Template: existTemplate,
 			},
 			expectError: "user is required",
+		},
+		{
+			name:      "claim with invalid owner label value",
+			available: 1,
+			options: infra.ClaimSandboxOptions{
+				User:     "invalid owner",
+				Template: existTemplate,
+			},
+			expectError: "invalid owner",
 		},
 		{
 			name:      "claim with no available pods",

--- a/pkg/servers/e2b/keys/secret.go
+++ b/pkg/servers/e2b/keys/secret.go
@@ -171,7 +171,9 @@ func (k *secretKeyStorage) Init(ctx context.Context) error {
 			Name:      "admin",
 			Team:      models.AdminTeam(),
 		}
-		if err := k.retryUpdateSecret(ctx, AdminKeyID.String(), adminKey); err != nil && !apierrors.IsConflict(err) {
+		if _, err := k.retryPatchSecretKey(ctx, k.APIReader, AdminKeyID.String(), func(*corev1.Secret) *models.CreatedTeamAPIKey {
+			return adminKey
+		}); err != nil && !apierrors.IsConflict(err) {
 			return err
 		} else if err == nil {
 			log.Info("create admin key success", "id", adminKey.ID)
@@ -340,36 +342,38 @@ func (k *secretKeyStorage) LoadByID(_ context.Context, id string) (*models.Creat
 	return cloneCreatedTeamAPIKey(value.(*models.CreatedTeamAPIKey)), true
 }
 
-func (k *secretKeyStorage) retryUpdateSecret(ctx context.Context, id string, apiKey *models.CreatedTeamAPIKey) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		return k.updateSecret(ctx, id, apiKey)
-	})
-}
-
-func (k *secretKeyStorage) retryCreateKey(ctx context.Context, id string, apiKey *models.CreatedTeamAPIKey) (*models.CreatedTeamAPIKey, error) {
-	var createdKey *models.CreatedTeamAPIKey
+func (k *secretKeyStorage) retryPatchSecretKey(
+	ctx context.Context,
+	reader client.Reader,
+	id string,
+	prepare func(*corev1.Secret) *models.CreatedTeamAPIKey,
+) (*models.CreatedTeamAPIKey, error) {
+	var patchedKey *models.CreatedTeamAPIKey
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		key, err := k.createKeyInSecret(ctx, id, apiKey)
-		if err != nil {
+		secret := &corev1.Secret{}
+		if err := reader.Get(ctx, client.ObjectKey{Namespace: k.Namespace, Name: KeySecretName}, secret); err != nil {
 			return err
 		}
-		createdKey = key
+		apiKey := prepare(secret)
+		if err := k.patchSecretKey(ctx, secret, id, apiKey); err != nil {
+			return err
+		}
+		patchedKey = apiKey
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return createdKey, nil
+	return patchedKey, nil
 }
 
-func (k *secretKeyStorage) updateSecret(ctx context.Context, id string, apiKey *models.CreatedTeamAPIKey) error {
-	secret := &corev1.Secret{}
-	if err := k.APIReader.Get(ctx, client.ObjectKey{Namespace: k.Namespace, Name: KeySecretName}, secret); err != nil {
-		return err
-	}
+func (k *secretKeyStorage) patchSecretKey(ctx context.Context, secret *corev1.Secret, id string, apiKey *models.CreatedTeamAPIKey) error {
+	base := secret.DeepCopy()
+
 	if secret.Data == nil {
 		secret.Data = make(map[string][]byte)
 	}
+
 	if apiKey != nil {
 		marshaled, err := marshalAPIKey(apiKey)
 		if err != nil {
@@ -377,41 +381,34 @@ func (k *secretKeyStorage) updateSecret(ctx context.Context, id string, apiKey *
 		}
 		secret.Data[id] = marshaled
 	} else {
+		// Avoid a no-op write and informer event when the key is already absent.
+		if _, ok := secret.Data[id]; !ok {
+			return nil
+		}
 		delete(secret.Data, id)
 	}
-	return k.Client.Update(ctx, secret)
+
+	// Upsert reruns team dedup against the read snapshot, so guard the
+	// read-decide-write with an optimistic lock. Deleting a single key needs no
+	// lock: a merge patch nulling one key leaves concurrent changes to other
+	// keys intact. The admin key is never deleted, so the data map never
+	// serializes (via omitempty) to "data":null, which would clobber the map.
+	var patch client.Patch
+	if apiKey != nil {
+		patch = client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})
+	} else {
+		patch = client.MergeFrom(base)
+	}
+	if err := k.Client.Patch(ctx, secret, patch); err != nil {
+		return err
+	}
+	return nil
 }
 
-func (k *secretKeyStorage) createKeyInSecret(ctx context.Context, id string, apiKey *models.CreatedTeamAPIKey) (*models.CreatedTeamAPIKey, error) {
-	secret := &corev1.Secret{}
-	if err := k.APIReader.Get(ctx, client.ObjectKey{Namespace: k.Namespace, Name: KeySecretName}, secret); err != nil {
-		return nil, err
-	}
-	if secret.Data == nil {
-		secret.Data = make(map[string][]byte)
-	}
-
-	keyToStore := *apiKey
-	keyToStore.Team = cloneTeam(TeamForKey(apiKey))
-	if existingTeam, ok := findTeamByNameInSecret(secret, keyToStore.Team.Name); ok {
-		keyToStore.Team = existingTeam
-	}
-
-	marshaled, err := marshalAPIKey(&keyToStore)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal api-key: %w", err)
-	}
-	secret.Data[id] = marshaled
-	if err := k.Client.Update(ctx, secret); err != nil {
-		return nil, err
-	}
-	return &keyToStore, nil
-}
-
-// findTeamByNameInSecret scans the raw secret data instead of the in-memory cache
-// (idxByTeam) to guarantee consistency with the exact secret revision being updated.
-// During retryCreateKey, each retry re-reads the secret from the API server; using
-// the cache here could miss teams created by other replicas between retries.
+// findTeamByNameInSecret scans the Secret snapshot instead of idxByTeam so team
+// selection and the optimistic-lock patch use the same API-server revision.
+// Each retry re-reads the Secret from the API reader, so the create prepare
+// callback observes teams created by other replicas between attempts.
 func findTeamByNameInSecret(secret *corev1.Secret, teamName string) (*models.Team, bool) {
 	for _, bytes := range secret.Data {
 		apiKey, err := unmarshalStoredAPIKey(bytes, false)
@@ -491,7 +488,14 @@ func (k *secretKeyStorage) CreateKey(ctx context.Context, key *models.CreatedTea
 	}
 
 	log.Info("api-key generated", "id", apiKey.ID)
-	createdKey, err := k.retryCreateKey(ctx, newID.String(), apiKey)
+	createdKey, err := k.retryPatchSecretKey(ctx, k.APIReader, newID.String(), func(secret *corev1.Secret) *models.CreatedTeamAPIKey {
+		keyToStore := *apiKey
+		keyToStore.Team = cloneTeam(TeamForKey(apiKey))
+		if existingTeam, ok := findTeamByNameInSecret(secret, keyToStore.Team.Name); ok {
+			keyToStore.Team = existingTeam
+		}
+		return &keyToStore
+	})
 	if err != nil {
 		log.Error(err, "failed to update api-key")
 		return nil, err
@@ -506,7 +510,9 @@ func (k *secretKeyStorage) DeleteKey(ctx context.Context, key *models.CreatedTea
 	if key.ID == AdminKeyID {
 		return ErrAdminKeyUndeletable
 	}
-	err := k.retryUpdateSecret(ctx, key.ID.String(), nil)
+	_, err := k.retryPatchSecretKey(ctx, k.APIReader, key.ID.String(), func(*corev1.Secret) *models.CreatedTeamAPIKey {
+		return nil
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/servers/e2b/keys/secret.go
+++ b/pkg/servers/e2b/keys/secret.go
@@ -161,9 +161,11 @@ func (k *secretKeyStorage) Init(ctx context.Context) error {
 		return err
 	}
 
-	// create admin key if needed
+	// create admin key if needed. Presence is keyed by AdminKeyID because that is
+	// the Secret.Data map key used by patch/refresh; checking k.AdminKey (the raw
+	// key string) would miss an already-persisted admin entry and re-patch on every Init.
 	// all replicas does the same operation, no matter who eventually wins the race.
-	if _, ok := secret.Data[k.AdminKey]; !ok {
+	if _, ok := secret.Data[AdminKeyID.String()]; !ok {
 		adminKey := &models.CreatedTeamAPIKey{
 			CreatedAt: time.Now(),
 			ID:        AdminKeyID,

--- a/pkg/servers/e2b/keys/secret.go
+++ b/pkg/servers/e2b/keys/secret.go
@@ -358,6 +358,8 @@ func (k *secretKeyStorage) retryPatchSecretKey(
 		if err := k.patchSecretKey(ctx, secret, id, apiKey); err != nil {
 			return err
 		}
+		// On delete, prepare returns nil; a nil patchedKey with a nil error
+		// means the deletion patch succeeded (or was already a no-op).
 		patchedKey = apiKey
 		return nil
 	})
@@ -367,6 +369,8 @@ func (k *secretKeyStorage) retryPatchSecretKey(
 	return patchedKey, nil
 }
 
+// patchSecretKey upserts or deletes one Secret.Data entry. A nil apiKey means
+// delete the key at id; a non-nil apiKey means create or update that entry.
 func (k *secretKeyStorage) patchSecretKey(ctx context.Context, secret *corev1.Secret, id string, apiKey *models.CreatedTeamAPIKey) error {
 	base := secret.DeepCopy()
 

--- a/pkg/servers/e2b/keys/secret_test.go
+++ b/pkg/servers/e2b/keys/secret_test.go
@@ -44,18 +44,18 @@ import (
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 )
 
-type updateHookClient struct {
+type patchHookClient struct {
 	client.Client
-	updateHook func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error
+	patchHook func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error
 }
 
-func (c *updateHookClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	if c.updateHook != nil {
-		if err := c.updateHook(ctx, obj, opts...); err != nil {
+func (c *patchHookClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if c.patchHook != nil {
+		if err := c.patchHook(ctx, obj, patch, opts...); err != nil {
 			return err
 		}
 	}
-	return c.Client.Update(ctx, obj, opts...)
+	return c.Client.Patch(ctx, obj, patch, opts...)
 }
 
 type getHookClient struct {
@@ -278,32 +278,28 @@ func TestSecretKeyStorage_Init(t *testing.T) {
 			name: "conflict while creating admin key tolerated",
 			prepare: func(t *testing.T) (*secretKeyStorage, client.Client) {
 				_, c := newSecretStorageForTest(t, map[string][]byte{})
-				var updated int32
-				hookClient := &updateHookClient{
+				hookClient := &patchHookClient{
 					Client: c,
-					updateHook: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
-						if atomic.AddInt32(&updated, 1) == 1 {
-							return apierrors.NewConflict(schema.GroupResource{Group: "", Resource: "secrets"}, KeySecretName, errors.New("conflict"))
-						}
-						return nil
+					patchHook: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						return apierrors.NewConflict(schema.GroupResource{Group: "", Resource: "secrets"}, KeySecretName, errors.New("conflict"))
 					},
 				}
 				return NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage), c
 			},
 		},
 		{
-			name: "non-conflict update error returned",
+			name: "non-conflict patch error returned",
 			prepare: func(t *testing.T) (*secretKeyStorage, client.Client) {
 				_, c := newSecretStorageForTest(t, map[string][]byte{})
-				hookClient := &updateHookClient{
+				hookClient := &patchHookClient{
 					Client: c,
-					updateHook: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
-						return errors.New("update failed")
+					patchHook: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						return errors.New("patch failed")
 					},
 				}
 				return NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage), c
 			},
-			expectError: "update failed",
+			expectError: "patch failed",
 		},
 	}
 
@@ -350,27 +346,31 @@ func TestSecretKeyStorage_Refresh(t *testing.T) {
 	require.Error(t, storage.refresh(context.Background(), c))
 }
 
-func TestSecretKeyStorage_UpdateAndRetry(t *testing.T) {
+func TestSecretKeyStorage_PatchSecretKey(t *testing.T) {
 	tests := []struct {
 		name        string
 		run         func(t *testing.T) error
 		expectError string
 	}{
 		{
-			name: "update get error",
+			name: "patch missing secret",
 			run: func(t *testing.T) error {
 				c := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 				storage := NewSecretKeyStorage(c, c, nil, "default", "admin-key").(*secretKeyStorage)
-				return storage.updateSecret(context.Background(), "id", &models.CreatedTeamAPIKey{ID: uuid.New(), Key: "x"})
+				_, err := storage.retryPatchSecretKey(context.Background(), c, "id", func(*corev1.Secret) *models.CreatedTeamAPIKey {
+					return &models.CreatedTeamAPIKey{ID: uuid.New(), Key: "x"}
+				})
+				return err
 			},
 			expectError: "not found",
 		},
 		{
-			name: "update with nil data map creates map",
+			name: "upsert with nil data map creates map",
 			run: func(t *testing.T) error {
 				storage, c := newSecretStorageForTest(t, nil)
 				k := &models.CreatedTeamAPIKey{ID: uuid.New(), Key: "x", Name: "name"}
-				err := storage.updateSecret(context.Background(), k.ID.String(), k)
+				secret := getSecretForTest(t, c)
+				err := storage.patchSecretKey(context.Background(), secret, k.ID.String(), k)
 				if err == nil {
 					secret := getSecretForTest(t, c)
 					assert.Contains(t, secret.Data, k.ID.String())
@@ -379,13 +379,14 @@ func TestSecretKeyStorage_UpdateAndRetry(t *testing.T) {
 			},
 		},
 		{
-			name: "update delete branch",
+			name: "delete existing key",
 			run: func(t *testing.T) error {
 				k := &models.CreatedTeamAPIKey{ID: uuid.New(), Key: "x", Name: "name"}
 				b, err := json.Marshal(k)
 				require.NoError(t, err)
 				storage, c := newSecretStorageForTest(t, map[string][]byte{k.ID.String(): b})
-				err = storage.updateSecret(context.Background(), k.ID.String(), nil)
+				secret := getSecretForTest(t, c)
+				err = storage.patchSecretKey(context.Background(), secret, k.ID.String(), nil)
 				if err == nil {
 					secret := getSecretForTest(t, c)
 					assert.NotContains(t, secret.Data, k.ID.String())
@@ -400,30 +401,70 @@ func TestSecretKeyStorage_UpdateAndRetry(t *testing.T) {
 				oldMarshal := marshalAPIKey
 				marshalAPIKey = func(_ *models.CreatedTeamAPIKey) ([]byte, error) { return nil, fmt.Errorf("boom") }
 				t.Cleanup(func() { marshalAPIKey = oldMarshal })
-				return storage.updateSecret(context.Background(), "id", &models.CreatedTeamAPIKey{ID: uuid.New(), Key: "x"})
+				secret := getSecretForTest(t, storage.Client)
+				return storage.patchSecretKey(context.Background(), secret, "id", &models.CreatedTeamAPIKey{ID: uuid.New(), Key: "x"})
 			},
 			expectError: "failed to marshal",
 		},
 		{
-			name: "retry handles conflict",
+			name: "delete preserves concurrent secret update",
 			run: func(t *testing.T) error {
-				_, c := newSecretStorageForTest(t, map[string][]byte{})
-				var updated int32
-				hookClient := &updateHookClient{
+				toDelete := &models.CreatedTeamAPIKey{ID: uuid.New(), Key: "to-delete", Name: "delete-me", Team: &models.Team{ID: uuid.New(), Name: "team-a"}}
+				toDeleteBytes, err := json.Marshal(toDelete)
+				require.NoError(t, err)
+				// A persistent key mirrors the always-present admin key: the data
+				// map is never emptied, so the delete merge patch nulls only the
+				// removed key rather than the whole map.
+				persistent := &models.CreatedTeamAPIKey{ID: uuid.New(), Key: "keep", Name: "keep-me", Team: &models.Team{ID: uuid.New(), Name: "team-b"}}
+				persistentBytes, err := json.Marshal(persistent)
+				require.NoError(t, err)
+				_, c := newSecretStorageForTest(t, map[string][]byte{
+					toDelete.ID.String():   toDeleteBytes,
+					persistent.ID.String(): persistentBytes,
+				})
+
+				concurrentID := uuid.NewString()
+				var patchCalls atomic.Int32
+				hookClient := &patchHookClient{
 					Client: c,
-					updateHook: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
-						if atomic.AddInt32(&updated, 1) == 1 {
-							return apierrors.NewConflict(schema.GroupResource{Resource: "secrets"}, KeySecretName, errors.New("conflict"))
+					patchHook: func(ctx context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						if patchCalls.Add(1) != 1 {
+							return nil
 						}
-						return nil
+						secret := &corev1.Secret{}
+						require.NoError(t, c.Get(ctx, client.ObjectKey{Namespace: "default", Name: KeySecretName}, secret))
+						if secret.Data == nil {
+							secret.Data = make(map[string][]byte)
+						}
+						secret.Data[concurrentID] = []byte("concurrent")
+						return c.Update(ctx, secret)
 					},
 				}
 				storage := NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage)
-				err := storage.retryUpdateSecret(context.Background(), uuid.NewString(), &models.CreatedTeamAPIKey{ID: uuid.New(), Key: "x"})
-				if err == nil {
-					assert.GreaterOrEqual(t, atomic.LoadInt32(&updated), int32(2))
+				if _, err := storage.retryPatchSecretKey(t.Context(), hookClient, toDelete.ID.String(), func(*corev1.Secret) *models.CreatedTeamAPIKey {
+					return nil
+				}); err != nil {
+					return err
 				}
-				return err
+				secret := getSecretForTest(t, c)
+				assert.NotContains(t, secret.Data, toDelete.ID.String())
+				assert.Contains(t, secret.Data, persistent.ID.String())
+				assert.Contains(t, secret.Data, concurrentID)
+				return nil
+			},
+		},
+		{
+			name: "delete of absent key issues no write",
+			run: func(t *testing.T) error {
+				_, c := newSecretStorageForTest(t, map[string][]byte{})
+				hookClient := &patchHookClient{
+					Client: c,
+					patchHook: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						return errors.New("patch must not be called")
+					},
+				}
+				storage := NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage)
+				return storage.patchSecretKey(t.Context(), getSecretForTest(t, c), uuid.NewString(), nil)
 			},
 		},
 	}
@@ -499,21 +540,39 @@ func TestSecretKeyStorage_CreateKey(t *testing.T) {
 			expectError: "failed to generate unique api-key",
 		},
 		{
-			name: "update error",
+			name: "patch error",
 			run: func(t *testing.T) error {
 				user := &models.CreatedTeamAPIKey{ID: uuid.New(), CreatedBy: &models.TeamUser{ID: uuid.New()}}
 				_, c := newSecretStorageForTest(t, map[string][]byte{})
-				hookClient := &updateHookClient{
+				hookClient := &patchHookClient{
 					Client: c,
-					updateHook: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
-						return errors.New("update failed")
+					patchHook: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						return errors.New("patch failed")
 					},
 				}
 				storageErr := NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage)
 				_, err := storageErr.CreateKey(context.Background(), user, CreateKeyOptions{Name: "name"})
 				return err
 			},
-			expectError: "update failed",
+			expectError: "patch failed",
+		},
+		{
+			name: "create and delete read through APIReader",
+			run: func(t *testing.T) error {
+				_, c := newSecretStorageForTest(t, map[string][]byte{})
+				cacheClient := &getHookClient{
+					Client: c,
+					getHook: func(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return errors.New("cache client Get must not be used")
+					},
+				}
+				storage := NewSecretKeyStorage(cacheClient, c, nil, "default", "admin-key").(*secretKeyStorage)
+				created, err := storage.CreateKey(t.Context(), &models.CreatedTeamAPIKey{ID: uuid.New(), Team: models.AdminTeam()}, CreateKeyOptions{Name: "name"})
+				if err != nil {
+					return err
+				}
+				return storage.DeleteKey(t.Context(), created)
+			},
 		},
 		{
 			name: "success defaults missing user team to admin team",
@@ -540,11 +599,11 @@ func TestSecretKeyStorage_CreateKey(t *testing.T) {
 				existingBytes, err := json.Marshal(existingKey)
 				require.NoError(t, err)
 
-				var updated int32
-				hookClient := &updateHookClient{
+				var patched int32
+				hookClient := &patchHookClient{
 					Client: c,
-					updateHook: func(ctx context.Context, _ client.Object, _ ...client.UpdateOption) error {
-						if atomic.AddInt32(&updated, 1) != 1 {
+					patchHook: func(ctx context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						if atomic.AddInt32(&patched, 1) != 1 {
 							return nil
 						}
 						secret := getSecretForTest(t, c)
@@ -552,8 +611,7 @@ func TestSecretKeyStorage_CreateKey(t *testing.T) {
 							secret.Data = map[string][]byte{}
 						}
 						secret.Data[existingKey.ID.String()] = existingBytes
-						require.NoError(t, c.Update(ctx, secret))
-						return apierrors.NewConflict(schema.GroupResource{Group: "", Resource: "secrets"}, KeySecretName, errors.New("conflict"))
+						return c.Update(ctx, secret)
 					},
 				}
 				storage := NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage)
@@ -572,6 +630,7 @@ func TestSecretKeyStorage_CreateKey(t *testing.T) {
 				require.Equal(t, existingTeam, key.Team)
 
 				secret := getSecretForTest(t, c)
+				require.Contains(t, secret.Data, existingKey.ID.String())
 				require.Contains(t, secret.Data, key.ID.String())
 				var storedKey models.CreatedTeamAPIKey
 				require.NoError(t, json.Unmarshal(secret.Data[key.ID.String()], &storedKey))
@@ -845,7 +904,7 @@ func TestSecretKeyStorage_LoadInvalidStoredQuotaAsUnlimited(t *testing.T) {
 	}
 }
 
-func TestSecretKeyStorage_CreateKeyInSecretErrors(t *testing.T) {
+func TestSecretKeyStorage_RetryPatchSecretKeyErrors(t *testing.T) {
 	tests := []struct {
 		name        string
 		run         func(t *testing.T) error
@@ -856,10 +915,13 @@ func TestSecretKeyStorage_CreateKeyInSecretErrors(t *testing.T) {
 			run: func(t *testing.T) error {
 				c := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 				storage := NewSecretKeyStorage(c, c, nil, "default", "admin-key").(*secretKeyStorage)
-				_, err := storage.createKeyInSecret(t.Context(), uuid.NewString(), &models.CreatedTeamAPIKey{
+				apiKey := &models.CreatedTeamAPIKey{
 					ID:   uuid.New(),
 					Key:  uuid.NewString(),
 					Name: "new",
+				}
+				_, err := storage.retryPatchSecretKey(t.Context(), c, uuid.NewString(), func(*corev1.Secret) *models.CreatedTeamAPIKey {
+					return apiKey
 				})
 				return err
 			},
@@ -872,34 +934,40 @@ func TestSecretKeyStorage_CreateKeyInSecretErrors(t *testing.T) {
 				oldMarshal := marshalAPIKey
 				marshalAPIKey = func(_ *models.CreatedTeamAPIKey) ([]byte, error) { return nil, fmt.Errorf("marshal failed") }
 				t.Cleanup(func() { marshalAPIKey = oldMarshal })
-				_, err := storage.createKeyInSecret(t.Context(), uuid.NewString(), &models.CreatedTeamAPIKey{
+				apiKey := &models.CreatedTeamAPIKey{
 					ID:   uuid.New(),
 					Key:  uuid.NewString(),
 					Name: "new",
+				}
+				_, err := storage.retryPatchSecretKey(t.Context(), storage.Client, uuid.NewString(), func(*corev1.Secret) *models.CreatedTeamAPIKey {
+					return apiKey
 				})
 				return err
 			},
 			expectError: "failed to marshal",
 		},
 		{
-			name: "update error",
+			name: "patch error",
 			run: func(t *testing.T) error {
 				_, c := newSecretStorageForTest(t, map[string][]byte{})
-				hookClient := &updateHookClient{
+				hookClient := &patchHookClient{
 					Client: c,
-					updateHook: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
-						return errors.New("update failed")
+					patchHook: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						return errors.New("patch failed")
 					},
 				}
 				storage := NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage)
-				_, err := storage.createKeyInSecret(t.Context(), uuid.NewString(), &models.CreatedTeamAPIKey{
+				apiKey := &models.CreatedTeamAPIKey{
 					ID:   uuid.New(),
 					Key:  uuid.NewString(),
 					Name: "new",
+				}
+				_, err := storage.retryPatchSecretKey(t.Context(), hookClient, uuid.NewString(), func(*corev1.Secret) *models.CreatedTeamAPIKey {
+					return apiKey
 				})
 				return err
 			},
-			expectError: "update failed",
+			expectError: "patch failed",
 		},
 	}
 
@@ -1026,9 +1094,9 @@ func TestSecretKeyStorage_DeleteAndList(t *testing.T) {
 	storage2, c2 := newSecretStorageForTest(t, map[string][]byte{})
 	key2, err := storage2.CreateKey(context.Background(), user, CreateKeyOptions{Name: "name"})
 	require.NoError(t, err)
-	hookClient := &updateHookClient{
+	hookClient := &patchHookClient{
 		Client: c2,
-		updateHook: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+		patchHook: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
 			return errors.New("delete failed")
 		},
 	}
@@ -1518,10 +1586,7 @@ func TestSecretKeyStorage_CreateKeyWaitsForInformerRefresh(t *testing.T) {
 				Data:       map[string][]byte{},
 			}).Build()
 			cachedClient := &staleSecretReadClient{Client: apiClient}
-			cachedClient.SetSecret(&corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: KeySecretName, Namespace: "default"},
-				Data:       map[string][]byte{},
-			})
+			cachedClient.SetSecret(getSecretForTest(t, apiClient))
 			storage := NewSecretKeyStorage(cachedClient, apiClient, nil, "default", "admin-key").(*secretKeyStorage)
 			storage.triggerRefresh()
 
@@ -1593,7 +1658,7 @@ func TestSecretKeyStorage_DeleteKeyWaitsForInformerRefresh(t *testing.T) {
 			}
 			apiClient := fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(staleSecret.DeepCopy()).Build()
 			cachedClient := &staleSecretReadClient{Client: apiClient}
-			cachedClient.SetSecret(staleSecret)
+			cachedClient.SetSecret(getSecretForTest(t, apiClient))
 			storage := NewSecretKeyStorage(cachedClient, apiClient, nil, "default", "admin-key").(*secretKeyStorage)
 			storage.storeKey(apiKey)
 			storage.triggerRefresh()

--- a/pkg/servers/e2b/keys/secret_test.go
+++ b/pkg/servers/e2b/keys/secret_test.go
@@ -243,21 +243,24 @@ func TestSecretKeyStorage_Init(t *testing.T) {
 			expectError: "not found",
 		},
 		{
-			name: "admin key exists",
+			name: "admin key exists under id",
 			prepare: func(t *testing.T) (*secretKeyStorage, client.Client) {
 				admin := &models.CreatedTeamAPIKey{ID: AdminKeyID, Key: "admin-key", Name: "admin"}
 				b, err := json.Marshal(admin)
 				require.NoError(t, err)
 				return newSecretStorageForTest(t, map[string][]byte{
-					"admin-key":         b,
 					AdminKeyID.String(): b,
 				})
 			},
-			assertion: func(t *testing.T, storage *secretKeyStorage, _ client.Client) {
+			assertion: func(t *testing.T, storage *secretKeyStorage, c client.Client) {
 				loaded, found := storage.LoadByID(context.Background(), AdminKeyID.String())
 				require.True(t, found)
 				require.Equal(t, "admin-key", loaded.Key)
 				require.Equal(t, models.AdminTeam(), loaded.Team)
+				secret := getSecretForTest(t, c)
+				assert.Len(t, secret.Data, 1)
+				_, hasLegacy := secret.Data["admin-key"]
+				assert.False(t, hasLegacy)
 			},
 		},
 		{
@@ -272,6 +275,25 @@ func TestSecretKeyStorage_Init(t *testing.T) {
 				var admin models.CreatedTeamAPIKey
 				require.NoError(t, json.Unmarshal(bytes, &admin))
 				require.Equal(t, models.AdminTeam(), admin.Team)
+			},
+		},
+		{
+			name: "legacy admin-key map entry gets id-keyed entry",
+			prepare: func(t *testing.T) (*secretKeyStorage, client.Client) {
+				admin := &models.CreatedTeamAPIKey{ID: AdminKeyID, Key: "admin-key", Name: "admin"}
+				b, err := json.Marshal(admin)
+				require.NoError(t, err)
+				return newSecretStorageForTest(t, map[string][]byte{
+					"admin-key": b,
+				})
+			},
+			assertion: func(t *testing.T, storage *secretKeyStorage, c client.Client) {
+				secret := getSecretForTest(t, c)
+				_, ok := secret.Data[AdminKeyID.String()]
+				assert.True(t, ok)
+				loaded, found := storage.LoadByID(context.Background(), AdminKeyID.String())
+				require.True(t, found)
+				require.Equal(t, "admin-key", loaded.Key)
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

- Replace whole-Secret API-key writes with retrying merge patches so concurrent replicas preserve unrelated key entries.
- Keep team UUID deduplication consistent by preparing upserts from the same API-server Secret revision guarded by an optimistic lock.
- Validate sandbox owners as Kubernetes label values and mirror the owner annotation into the claimed Pod template labels.
- Add regression coverage for concurrent Secret updates, APIReader usage, owner-label synchronization, and invalid owners.

## Why

The Secret-backed API-key store used whole-object updates, which could hit resourceVersion conflicts or interfere with concurrent key mutations across sandbox-manager replicas. Sandbox claims also recorded the owner only as an annotation, leaving the Pod template without the corresponding owner label.

## Impact

API-key create and delete operations now avoid clobbering unrelated concurrent entries, while preserving the existing team identity rules. Claimed Pods carry the sandbox owner label, and invalid owner values fail before persistence.

## Validation

- `env GOFLAGS=-mod=readonly GOCACHE=/private/tmp/go-build-cache go test ./pkg/servers/e2b/keys ./pkg/sandbox-manager/infra/sandboxcr -count=1`
- `env GOFLAGS=-mod=readonly GOCACHE=/private/tmp/go-build-cache go test -race ./pkg/servers/e2b/keys -run 'TestSecretKeyStorage_(PatchSecretKey|CreateKey)$' -count=10`
- `git diff --check upstream/master...HEAD`
- `gofmt -l pkg/servers/e2b/keys/secret.go pkg/servers/e2b/keys/secret_test.go pkg/sandbox-manager/infra/sandboxcr/claim.go pkg/sandbox-manager/infra/sandboxcr/claim_test.go` (no output)
