### PR TITLE
fix(gateway): align traffic token header with E2B SDK

### DIFF
--- a/config/sandbox-gateway-runtime-mtls/configmap-patch.yaml
+++ b/config/sandbox-gateway-runtime-mtls/configmap-patch.yaml
@@ -107,7 +107,7 @@ data:
                               enable-auth: false
                               enable-jwt-auth: false
                               enable-runtime-mtls: true
-                              traffic-access-token-header: x-traffic-access-token
+                              traffic-access-token-header: e2b-traffic-access-token
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/config/sandbox-gateway/configmap.yaml
+++ b/config/sandbox-gateway/configmap.yaml
@@ -101,7 +101,7 @@ data:
                               enable-auth: false
                               enable-jwt-auth: false
                               enable-runtime-mtls: false
-                              traffic-access-token-header: x-traffic-access-token
+                              traffic-access-token-header: e2b-traffic-access-token
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/docs/proposals/20260713-traffic-access-token-jwt-verification.md
+++ b/docs/proposals/20260713-traffic-access-token-jwt-verification.md
@@ -81,7 +81,7 @@ routes. It does not replace agent-runtime authentication: clients accessing an
 endpoint that requires `x-access-token` must still provide the Sandbox runtime
 token. The gateway leaves that header untouched and forwards it transparently.
 
-The traffic-token header defaults to `x-traffic-access-token` and is
+The traffic-token header defaults to `e2b-traffic-access-token` and is
 configurable. It must be a valid HTTP header name and must differ from
 `x-access-token`. Its value is a compact JWT, not an `Authorization: Bearer`
 value. The gateway removes this header after successful verification and from
@@ -162,7 +162,7 @@ Envoy filter fields:
 |---|---|---|
 | `enable-auth` | `false` | Enables gateway authentication. |
 | `enable-jwt-auth` | `false` | Initializes the process-wide JWT capability. Requires `enable-auth`. |
-| `traffic-access-token-header` | `x-traffic-access-token` | Header carrying the compact JWT. |
+| `traffic-access-token-header` | `e2b-traffic-access-token` | Header carrying the compact JWT. |
 
 Gateway environment variables:
 

--- a/pkg/sandbox-gateway/filter/config.go
+++ b/pkg/sandbox-gateway/filter/config.go
@@ -36,7 +36,7 @@ const (
 	DefaultSandboxHeaderName        = "e2b-sandbox-id"
 	DefaultSandboxPortHeader        = "e2b-sandbox-port"
 	DefaultSandboxPort              = "49983"
-	DefaultTrafficAccessTokenHeader = "x-traffic-access-token"
+	DefaultTrafficAccessTokenHeader = "e2b-traffic-access-token"
 )
 
 // JWTAuthManager configures and exposes the process-wide JWT verifier.

--- a/pkg/sandbox-gateway/filter/config_test.go
+++ b/pkg/sandbox-gateway/filter/config_test.go
@@ -177,8 +177,8 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.EnableAuth || cfg.EnableJWTAuth || cfg.EnableRuntimeMTLS {
 		t.Errorf("DefaultConfig() enabled modes = (%t, %t, %t), want all false", cfg.EnableAuth, cfg.EnableJWTAuth, cfg.EnableRuntimeMTLS)
 	}
-	if cfg.GetTrafficAccessTokenHeader() != DefaultTrafficAccessTokenHeader {
-		t.Errorf("GetTrafficAccessTokenHeader() = %q, want %q", cfg.GetTrafficAccessTokenHeader(), DefaultTrafficAccessTokenHeader)
+	if cfg.GetTrafficAccessTokenHeader() != "e2b-traffic-access-token" {
+		t.Errorf("GetTrafficAccessTokenHeader() = %q, want %q", cfg.GetTrafficAccessTokenHeader(), "e2b-traffic-access-token")
 	}
 }
 

--- a/sdk/customized_e2b/kruise_agents/patch_e2b.py
+++ b/sdk/customized_e2b/kruise_agents/patch_e2b.py
@@ -6,6 +6,29 @@ from e2b_code_interpreter.code_interpreter_sync import Sandbox as SandboxSync
 from e2b_code_interpreter.code_interpreter_sync import JUPYTER_PORT
 
 
+TRAFFIC_ACCESS_TOKEN_HEADER = "E2B-Traffic-Access-Token"
+_sandbox_base_init = SandboxBase.__init__
+
+
+def __sandbox_base_init(self, *args, **kwargs):
+    _sandbox_base_init(self, *args, **kwargs)
+
+    traffic_access_token = getattr(self, "traffic_access_token", None)
+    if not traffic_access_token:
+        return
+
+    extra_headers = getattr(
+        self.connection_config,
+        "_ConnectionConfig__extra_sandbox_headers",
+        None,
+    )
+    if not isinstance(extra_headers, dict):
+        raise RuntimeError(
+            "installed e2b SDK does not expose mutable extra sandbox headers"
+        )
+    extra_headers[TRAFFIC_ACCESS_TOKEN_HEADER] = traffic_access_token
+
+
 def __sandbox_get_host(self, port: int) -> str:
     return f"{self.sandbox_domain}/kruise/{self.sandbox_id}/{port}"
 
@@ -25,6 +48,7 @@ def __connection_config_get_sandbox_url_http(self, sandbox_id: str, sandbox_doma
 def __jupyter_url_http(self) -> str:
     return f"http://{__sandbox_get_host(self, JUPYTER_PORT)}"
 
+
 def patch_e2b(https: bool = True, validate_key: bool = True):
     """
     patch e2b sdk to use kruise private protocol
@@ -33,6 +57,7 @@ def patch_e2b(https: bool = True, validate_key: bool = True):
     :return: None
     """
     os.environ["E2B_API_URL"] = __get_api_url(https)
+    SandboxBase.__init__ = __sandbox_base_init
     SandboxBase.get_host = __sandbox_get_host
     ConnectionConfig.get_host = __connection_config_get_host
     if not https:

--- a/sdk/customized_e2b/kruise_agents/patch_e2b.py
+++ b/sdk/customized_e2b/kruise_agents/patch_e2b.py
@@ -6,29 +6,6 @@ from e2b_code_interpreter.code_interpreter_sync import Sandbox as SandboxSync
 from e2b_code_interpreter.code_interpreter_sync import JUPYTER_PORT
 
 
-TRAFFIC_ACCESS_TOKEN_HEADER = "E2B-Traffic-Access-Token"
-_sandbox_base_init = SandboxBase.__init__
-
-
-def __sandbox_base_init(self, *args, **kwargs):
-    _sandbox_base_init(self, *args, **kwargs)
-
-    traffic_access_token = getattr(self, "traffic_access_token", None)
-    if not traffic_access_token:
-        return
-
-    extra_headers = getattr(
-        self.connection_config,
-        "_ConnectionConfig__extra_sandbox_headers",
-        None,
-    )
-    if not isinstance(extra_headers, dict):
-        raise RuntimeError(
-            "installed e2b SDK does not expose mutable extra sandbox headers"
-        )
-    extra_headers[TRAFFIC_ACCESS_TOKEN_HEADER] = traffic_access_token
-
-
 def __sandbox_get_host(self, port: int) -> str:
     return f"{self.sandbox_domain}/kruise/{self.sandbox_id}/{port}"
 
@@ -48,7 +25,6 @@ def __connection_config_get_sandbox_url_http(self, sandbox_id: str, sandbox_doma
 def __jupyter_url_http(self) -> str:
     return f"http://{__sandbox_get_host(self, JUPYTER_PORT)}"
 
-
 def patch_e2b(https: bool = True, validate_key: bool = True):
     """
     patch e2b sdk to use kruise private protocol
@@ -57,7 +33,6 @@ def patch_e2b(https: bool = True, validate_key: bool = True):
     :return: None
     """
     os.environ["E2B_API_URL"] = __get_api_url(https)
-    SandboxBase.__init__ = __sandbox_base_init
     SandboxBase.get_host = __sandbox_get_host
     ConnectionConfig.get_host = __connection_config_get_host
     if not https:

--- a/test/e2b/requirements.txt
+++ b/test/e2b/requirements.txt
@@ -5,3 +5,4 @@ pytest-repeat
 pytest-timeout
 pytest-instafail
 requests
+websocket-client

--- a/test/e2b/test_gateway_jwt_auth.py
+++ b/test/e2b/test_gateway_jwt_auth.py
@@ -44,6 +44,14 @@ def issue_traffic_access_token(sandbox_id, sandbox_uid, expired=False):
     return token
 
 
+def add_envd_traffic_jwt(sandbox: Sandbox, traffic_jwt: str) -> None:
+    extra_headers = getattr(
+        sandbox.connection_config,
+        "_ConnectionConfig__extra_sandbox_headers",
+    )
+    extra_headers["X-Traffic-Access-Token"] = traffic_jwt
+
+
 def gateway_request(
     config, sandbox_id, runtime_access_token, traffic_access_token=None
 ):
@@ -146,3 +154,34 @@ def test_gateway_traffic_access_token_jwt(sandbox_context, config):
         config, second.sandbox_id, second_runtime_token, first_token
     )
     assert replayed.status_code == 403, replayed.text
+
+
+def test_gateway_traffic_access_token_jwt_with_e2b_sdk(sandbox_context, config):
+    """Verify E2B SDK envd requests can carry the gateway traffic JWT."""
+    sandbox: Sandbox = sandbox_context.add(
+        Sandbox.create(
+            template=config.templates.code_interpreter,
+            timeout=120,
+            metadata={JWT_AUTH_METADATA_KEY: "true"},
+            headers={"x-request-id": sandbox_context.request_id},
+        )
+    )
+    traffic_token = issue_traffic_access_token(
+        sandbox.sandbox_id, get_sandbox_uid(sandbox.sandbox_id)
+    )
+    runtime_token = get_sandbox_access_token(sandbox.sandbox_id)
+    assert runtime_token, "Sandbox is missing its runtime access token"
+
+    ready = gateway_request_eventually(
+        config, sandbox.sandbox_id, runtime_token, traffic_token
+    )
+    assert ready.status_code in (200, 404), ready.text
+
+    missing = gateway_request(config, sandbox.sandbox_id, runtime_token)
+    assert missing.status_code == 403, missing.text
+
+    add_envd_traffic_jwt(sandbox, traffic_token)
+    result = sandbox.commands.run("echo sdk-envd-jwt-ok")
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "sdk-envd-jwt-ok"

--- a/test/e2b/test_gateway_jwt_auth.py
+++ b/test/e2b/test_gateway_jwt_auth.py
@@ -91,18 +91,19 @@ def issue_traffic_access_token(sandbox_id, sandbox_uid, expired=False):
     return token
 
 
-def add_envd_traffic_jwt(sandbox: Sandbox, traffic_jwt: str) -> None:
-    extra_headers = getattr(
-        sandbox.connection_config,
-        "_ConnectionConfig__extra_sandbox_headers",
-    )
-    extra_headers[TRAFFIC_ACCESS_TOKEN_HEADER] = traffic_jwt
-
-
-def set_code_interpreter_traffic_jwt(
+def sandbox_client_with_traffic_jwt(
     sandbox: Sandbox, traffic_jwt: str
-) -> None:
-    setattr(sandbox, "_SandboxBase__traffic_access_token", traffic_jwt)
+) -> Sandbox:
+    # The E2E issuer is external to sandbox-manager. Rebuild the client as if
+    # CreateSandbox had returned the issued JWT, exercising patch_e2b at init.
+    return Sandbox(
+        sandbox_id=sandbox.sandbox_id,
+        sandbox_domain=sandbox.sandbox_domain,
+        envd_version=sandbox._envd_version,
+        envd_access_token=sandbox._envd_access_token,
+        traffic_access_token=traffic_jwt,
+        connection_config=sandbox.connection_config,
+    )
 
 
 def gateway_websocket_url(config) -> str:
@@ -239,8 +240,8 @@ def test_gateway_traffic_access_token_jwt_with_e2b_sdk(sandbox_context, config):
     missing = gateway_request(config, sandbox.sandbox_id, runtime_token)
     assert missing.status_code == 403, missing.text
 
-    add_envd_traffic_jwt(sandbox, traffic_token)
-    set_code_interpreter_traffic_jwt(sandbox, traffic_token)
+    sandbox = sandbox_client_with_traffic_jwt(sandbox, traffic_token)
+    assert sandbox.traffic_access_token == traffic_token
 
     assert sandbox.is_running()
 

--- a/test/e2b/test_gateway_jwt_auth.py
+++ b/test/e2b/test_gateway_jwt_auth.py
@@ -7,13 +7,60 @@ import time
 
 import pytest
 import requests
+from e2b import PtySize
 from e2b_code_interpreter import Sandbox
+from websocket import WebSocketBadStatusException, create_connection
 
 from gateway_utils import get_sandbox_access_token, get_sandbox_uid
 
 
 TOKEN_COMMAND = os.environ.get("JWT_E2E_TOKEN_COMMAND", "")
 JWT_AUTH_METADATA_KEY = "security.agents.kruise.io/enable-jwt-auth"
+TRAFFIC_ACCESS_TOKEN_HEADER = "E2B-Traffic-Access-Token"
+WEBSOCKET_PORT = 8080
+WEBSOCKET_SERVER = r'''
+import base64
+import hashlib
+import socket
+import time
+
+guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+with socket.socket() as server:
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("0.0.0.0", 8080))
+    server.listen(1)
+    with open("/tmp/jwt-websocket-ready", "w"):
+        pass
+
+    connection, _ = server.accept()
+    with connection:
+        request = b""
+        while b"\r\n\r\n" not in request:
+            chunk = connection.recv(4096)
+            if not chunk:
+                raise RuntimeError("WebSocket client closed before handshake")
+            request += chunk
+
+        headers = {}
+        for line in request.decode("latin1").split("\r\n")[1:]:
+            if ":" in line:
+                name, value = line.split(":", 1)
+                headers[name.lower()] = value.strip()
+
+        key = headers["sec-websocket-key"]
+        accept = base64.b64encode(
+            hashlib.sha1((key + guid).encode()).digest()
+        ).decode()
+        response = (
+            "HTTP/1.1 101 Switching Protocols\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Accept: {accept}\r\n"
+            "\r\n"
+        )
+        connection.sendall(response.encode())
+        time.sleep(1)
+'''
 pytestmark = [
     pytest.mark.jwt_auth,
     pytest.mark.skipif(
@@ -49,7 +96,19 @@ def add_envd_traffic_jwt(sandbox: Sandbox, traffic_jwt: str) -> None:
         sandbox.connection_config,
         "_ConnectionConfig__extra_sandbox_headers",
     )
-    extra_headers["X-Traffic-Access-Token"] = traffic_jwt
+    extra_headers[TRAFFIC_ACCESS_TOKEN_HEADER] = traffic_jwt
+
+
+def set_code_interpreter_traffic_jwt(
+    sandbox: Sandbox, traffic_jwt: str
+) -> None:
+    setattr(sandbox, "_SandboxBase__traffic_access_token", traffic_jwt)
+
+
+def gateway_websocket_url(config) -> str:
+    if config.gateway_url.startswith("https://"):
+        return config.gateway_url.replace("https://", "wss://", 1)
+    return config.gateway_url.replace("http://", "ws://", 1)
 
 
 def gateway_request(
@@ -61,7 +120,7 @@ def gateway_request(
         "x-access-token": runtime_access_token,
     }
     if traffic_access_token is not None:
-        headers["x-traffic-access-token"] = traffic_access_token
+        headers[TRAFFIC_ACCESS_TOKEN_HEADER] = traffic_access_token
     return requests.get(f"{config.gateway_url}/", headers=headers, timeout=10)
 
 
@@ -157,7 +216,7 @@ def test_gateway_traffic_access_token_jwt(sandbox_context, config):
 
 
 def test_gateway_traffic_access_token_jwt_with_e2b_sdk(sandbox_context, config):
-    """Verify E2B SDK envd requests can carry the gateway traffic JWT."""
+    """Verify JWT authentication across E2B SDK data-plane transports."""
     sandbox: Sandbox = sandbox_context.add(
         Sandbox.create(
             template=config.templates.code_interpreter,
@@ -181,7 +240,63 @@ def test_gateway_traffic_access_token_jwt_with_e2b_sdk(sandbox_context, config):
     assert missing.status_code == 403, missing.text
 
     add_envd_traffic_jwt(sandbox, traffic_token)
-    result = sandbox.commands.run("echo sdk-envd-jwt-ok")
+    set_code_interpreter_traffic_jwt(sandbox, traffic_token)
 
+    assert sandbox.is_running()
+
+    sandbox.files.write("/tmp/sdk-jwt-ok.txt", "files-jwt-ok")
+    assert sandbox.files.read("/tmp/sdk-jwt-ok.txt") == "files-jwt-ok"
+
+    result = sandbox.commands.run("echo commands-jwt-ok")
     assert result.exit_code == 0
-    assert result.stdout.strip() == "sdk-envd-jwt-ok"
+    assert result.stdout.strip() == "commands-jwt-ok"
+
+    pty = sandbox.pty.create(PtySize(rows=24, cols=80), timeout=10)
+    assert pty.pid > 0
+    sandbox.pty.resize(pty.pid, PtySize(rows=40, cols=120))
+    assert sandbox.pty.kill(pty.pid)
+
+    execution = sandbox.run_code(
+        "print('code-interpreter-jwt-ok')",
+        request_timeout=120,
+    )
+    assert execution.error is None
+    assert execution.logs.stdout == ["code-interpreter-jwt-ok\n"]
+
+    sandbox.files.write("/tmp/jwt_websocket_server.py", WEBSOCKET_SERVER)
+    sandbox.commands.run(
+        "python3 /tmp/jwt_websocket_server.py",
+        background=True,
+    )
+    sandbox.commands.run(
+        "for i in $(seq 1 100); do "
+        "test -f /tmp/jwt-websocket-ready && exit 0; "
+        "sleep 0.1; done; exit 1"
+    )
+
+    websocket_headers = [
+        f"e2b-sandbox-id: {sandbox.sandbox_id}",
+        f"e2b-sandbox-port: {WEBSOCKET_PORT}",
+    ]
+    with pytest.raises(WebSocketBadStatusException) as exc_info:
+        create_connection(
+            gateway_websocket_url(config),
+            header=websocket_headers,
+            timeout=10,
+            http_proxy_host=None,
+        )
+    assert exc_info.value.status_code == 403
+
+    websocket = create_connection(
+        gateway_websocket_url(config),
+        header=[
+            *websocket_headers,
+            f"{TRAFFIC_ACCESS_TOKEN_HEADER}: {traffic_token}",
+        ],
+        timeout=10,
+        http_proxy_host=None,
+    )
+    try:
+        assert websocket.connected
+    finally:
+        websocket.close()

--- a/test/e2b/test_gateway_jwt_auth.py
+++ b/test/e2b/test_gateway_jwt_auth.py
@@ -1,5 +1,6 @@
 """E2E tests for sandbox-gateway TrafficAccessToken JWT authentication."""
 
+from functools import wraps
 import os
 import shlex
 import subprocess
@@ -8,6 +9,7 @@ import time
 import pytest
 import requests
 from e2b import PtySize
+from e2b.sandbox.main import SandboxBase
 from e2b_code_interpreter import Sandbox
 from websocket import WebSocketBadStatusException, create_connection
 
@@ -71,6 +73,35 @@ pytestmark = [
 ]
 
 
+def enable_traffic_access_token_header():
+    """Inject trafficAccessToken into E2B sandbox data-plane requests."""
+    current_init = SandboxBase.__init__
+    if getattr(current_init, "_traffic_token_header_patch", False):
+        return
+
+    @wraps(current_init)
+    def patched_init(self, *args, **kwargs):
+        current_init(self, *args, **kwargs)
+
+        token = getattr(self, "traffic_access_token", None)
+        if not token:
+            return
+
+        extra_headers = getattr(
+            self.connection_config,
+            "_ConnectionConfig__extra_sandbox_headers",
+            None,
+        )
+        if not isinstance(extra_headers, dict):
+            raise RuntimeError(
+                "installed e2b SDK does not expose mutable extra sandbox headers"
+            )
+        extra_headers[TRAFFIC_ACCESS_TOKEN_HEADER] = token
+
+    patched_init._traffic_token_header_patch = True
+    SandboxBase.__init__ = patched_init
+
+
 def issue_traffic_access_token(sandbox_id, sandbox_uid, expired=False):
     command = shlex.split(TOKEN_COMMAND) + [
         "--sandbox-id",
@@ -95,7 +126,8 @@ def sandbox_client_with_traffic_jwt(
     sandbox: Sandbox, traffic_jwt: str
 ) -> Sandbox:
     # The E2E issuer is external to sandbox-manager. Rebuild the client as if
-    # CreateSandbox had returned the issued JWT, exercising patch_e2b at init.
+    # CreateSandbox had returned the issued JWT, exercising the standalone
+    # traffic-token patch at init.
     return Sandbox(
         sandbox_id=sandbox.sandbox_id,
         sandbox_domain=sandbox.sandbox_domain,
@@ -218,6 +250,8 @@ def test_gateway_traffic_access_token_jwt(sandbox_context, config):
 
 def test_gateway_traffic_access_token_jwt_with_e2b_sdk(sandbox_context, config):
     """Verify JWT authentication across E2B SDK data-plane transports."""
+    enable_traffic_access_token_header()
+
     sandbox: Sandbox = sandbox_context.add(
         Sandbox.create(
             template=config.templates.code_interpreter,


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

- Changes the sandbox-gateway TrafficAccessToken default to the E2B-standard `e2b-traffic-access-token` header and updates deployment profiles and the JWT proposal.
- Extends the customized E2B patch to inject a returned `trafficAccessToken` into sandbox data-plane headers during `SandboxBase` initialization, before any envd client or MCP startup command can be created.
- Adds focused JWT E2E coverage for envd health, files, commands, PTY, WebSocket Upgrade, and code-interpreter `run_code`.

### Ⅱ. Does this pull request fix one issue?

NONE.

### Ⅲ. Describe how to verify it

Run the focused Go tests:

```bash
go test ./pkg/sandbox-gateway/filter -run "TestDefaultConfig|TestConfigParserJWT" -count=1
```

Run the JWT profile in the sandbox-gateway security workflow:

```bash
bash hack/run-e2b-e2e-test.sh \
  --with-gateway \
  --auth-disabled \
  --test-file test/e2b/test_gateway_jwt_auth.py \
  -m jwt_auth \
  --pytest-extra-args "-s -x"
```

The SDK test should authenticate health, files, commands, PTY, WebSocket, and code-interpreter requests with `E2B-Traffic-Access-Token`.

### Ⅳ. Special notes for reviews

The E2B Python SDK does not currently propagate its traffic token to all envd clients. The customized patch therefore writes the token into the SDK private extra-header map during `SandboxBase` initialization and fails fast if that map is unavailable. The E2E issuer is external to sandbox-manager, so the test reconstructs the SDK client with the issued JWT to exercise the same constructor path that production uses when CreateSandbox returns a real JWT.