### PR TITLE
fix(sandboxset): fix TOCTOU race condition

### DIFF
--- a/pkg/controller/sandboxset/rolling_update.go
+++ b/pkg/controller/sandboxset/rolling_update.go
@@ -18,7 +18,6 @@ package sandboxset
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -236,6 +235,9 @@ func (r *Reconciler) performRollingUpdate(
 }
 
 // deleteSandboxForUpdate deletes a sandbox as part of rolling update.
+// It re-fetches the sandbox from the API server to close the TOCTOU window
+// between buildUpdateGroups (where sandbox claim status is checked) and the
+// actual deletion.
 func (r *Reconciler) deleteSandboxForUpdate(ctx context.Context, sbs *agentsv1alpha1.SandboxSet, sbx *agentsv1alpha1.Sandbox, lock string) error {
 	log := logf.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
 	log.V(utils.DebugLogLevel).Info("deleting sandbox for rolling update")
@@ -243,19 +245,38 @@ func (r *Reconciler) deleteSandboxForUpdate(ctx context.Context, sbs *agentsv1al
 	if sbx.DeletionTimestamp != nil {
 		return nil
 	}
-	if sbx.Annotations[agentsv1alpha1.AnnotationLock] != "" && sbx.Annotations[agentsv1alpha1.AnnotationOwner] != consts.OwnerManagerScaleDown {
-		log.Info("sandbox to be deleted claimed before performed, skip")
-		return errors.New("sandbox to be deleted claimed before performed, skip")
+
+	// Re-fetch the sandbox from the API server to get the latest state.
+	// This closes the TOCTOU race window: between buildUpdateGroups() and
+	// this function, a SandboxClaim may have claimed the sandbox.
+	fresh := &agentsv1alpha1.Sandbox{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(sbx), fresh); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to re-fetch sandbox before delete: %s", err)
 	}
 
-	// Deep copy the sandbox before mutating it to avoid corrupting the informer cache.
-	sbx = sbx.DeepCopy()
+	// Re-verify that the sandbox is still unclaimed.
+	if isSandboxClaimed(fresh) {
+		log.Info("sandbox was claimed since initial check, skipping deletion")
+		return nil
+	}
 
-	utils.LockSandbox(sbx, lock, consts.OwnerManagerScaleDown)
-	if err := r.Update(ctx, sbx); err != nil {
+	// Re-verify that the sandbox is not locked by someone else.
+	if fresh.Annotations[agentsv1alpha1.AnnotationLock] != "" && fresh.Annotations[agentsv1alpha1.AnnotationOwner] != consts.OwnerManagerScaleDown {
+		log.Info("sandbox to be deleted claimed before performed, skip")
+		return nil
+	}
+
+	// Deep copy the fresh sandbox before mutating it.
+	fresh = fresh.DeepCopy()
+
+	utils.LockSandbox(fresh, lock, consts.OwnerManagerScaleDown)
+	if err := r.Update(ctx, fresh); err != nil {
 		return fmt.Errorf("failed to lock sandbox when delete: %s", err)
 	}
-	if err := r.Delete(ctx, sbx); err != nil {
+	if err := r.Delete(ctx, fresh); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
@@ -263,6 +284,6 @@ func (r *Reconciler) deleteSandboxForUpdate(ctx context.Context, sbs *agentsv1al
 		return err
 	}
 
-	r.Recorder.Eventf(sbs, "Normal", "RollingUpdate", "Deleted sandbox %s for update", klog.KObj(sbx))
+	r.Recorder.Eventf(sbs, "Normal", "RollingUpdate", "Deleted sandbox %s for update", klog.KObj(fresh))
 	return nil
 }

--- a/pkg/controller/sandboxset/rolling_update_test.go
+++ b/pkg/controller/sandboxset/rolling_update_test.go
@@ -687,3 +687,146 @@ func TestFindOldestSandboxes(t *testing.T) {
 		})
 	}
 }
+
+// TestDeleteSandboxForUpdate_TOCTOU verifies that when a sandbox is claimed
+// between buildUpdateGroups (which initially selects it as unclaimed) and
+// deleteSandboxForUpdate, the sandbox is NOT deleted. This closes the TOCTOU
+// race condition window.
+func TestDeleteSandboxForUpdate_TOCTOU(t *testing.T) {
+	ctx := t.Context()
+	now := time.Now()
+
+	k8sClient := NewClient()
+	eventRecorder := record.NewFakeRecorder(20)
+	reconciler := &Reconciler{
+		Client:   k8sClient,
+		Scheme:   testScheme,
+		Recorder: eventRecorder,
+		Codec:    serializer.NewCodecFactory(testScheme).LegacyCodec(v1alpha1.SchemeGroupVersion),
+	}
+
+	sbs := newSandboxSetForUpdate(3, nil)
+	sbs.UID = "uid-123"
+	sbs.Status.UpdateRevision = "new-hash"
+	assert.NoError(t, k8sClient.Create(ctx, sbs))
+
+	// Create an unclaimed available sandbox with old revision.
+	sbx := newSandbox("to-claim", "old-hash", v1alpha1.SandboxStateAvailable, false, now)
+	sbx.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(sbs, v1alpha1.SandboxSetControllerKind),
+	}
+	assert.NoError(t, k8sClient.Create(ctx, sbx))
+
+	// Simulate TOCTOU: get a stale reference (before claim), then claim the
+	// sandbox behind the controller's back.
+	staleCopy := sbx.DeepCopy()
+
+	// Claim the sandbox: set claimed label and remove owner reference.
+	fresh := &v1alpha1.Sandbox{}
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), fresh))
+	fresh.Labels[v1alpha1.LabelSandboxIsClaimed] = "true"
+	fresh.OwnerReferences = nil
+	assert.NoError(t, k8sClient.Update(ctx, fresh))
+
+	// Now attempt to delete using the stale copy (as deleteSandboxForUpdate would).
+	// The function should re-fetch, detect the claim, and skip deletion.
+	lock := "test-lock"
+	err := reconciler.deleteSandboxForUpdate(ctx, sbs, staleCopy, lock)
+	assert.NoError(t, err, "deleteSandboxForUpdate should silently skip (return nil) when sandbox was claimed")
+
+	// Verify the sandbox still exists and was NOT deleted.
+	exists := &v1alpha1.Sandbox{}
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), exists))
+	assert.Nil(t, exists.DeletionTimestamp, "sandbox should NOT have been deleted after claim")
+	assert.Equal(t, "true", exists.Labels[v1alpha1.LabelSandboxIsClaimed])
+}
+
+// TestDeleteSandboxForUpdate_LockedByOthers_TOCTOU verifies that when a sandbox
+// is locked by another owner between selection and deletion, it is skipped.
+func TestDeleteSandboxForUpdate_LockedByOthers_TOCTOU(t *testing.T) {
+	ctx := t.Context()
+	now := time.Now()
+
+	k8sClient := NewClient()
+	eventRecorder := record.NewFakeRecorder(20)
+	reconciler := &Reconciler{
+		Client:   k8sClient,
+		Scheme:   testScheme,
+		Recorder: eventRecorder,
+		Codec:    serializer.NewCodecFactory(testScheme).LegacyCodec(v1alpha1.SchemeGroupVersion),
+	}
+
+	sbs := newSandboxSetForUpdate(3, nil)
+	sbs.UID = "uid-123"
+	sbs.Status.UpdateRevision = "new-hash"
+	assert.NoError(t, k8sClient.Create(ctx, sbs))
+
+	sbx := newSandbox("to-lock", "old-hash", v1alpha1.SandboxStateAvailable, false, now)
+	sbx.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(sbs, v1alpha1.SandboxSetControllerKind),
+	}
+	assert.NoError(t, k8sClient.Create(ctx, sbx))
+
+	// Get a stale reference, then lock the sandbox by a different owner.
+	staleCopy := sbx.DeepCopy()
+
+	fresh := &v1alpha1.Sandbox{}
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), fresh))
+	if fresh.Annotations == nil {
+		fresh.Annotations = map[string]string{}
+	}
+	fresh.Annotations[v1alpha1.AnnotationLock] = "other-lock"
+	fresh.Annotations[v1alpha1.AnnotationOwner] = "other-owner"
+	assert.NoError(t, k8sClient.Update(ctx, fresh))
+
+	lock := "test-lock"
+	err := reconciler.deleteSandboxForUpdate(ctx, sbs, staleCopy, lock)
+	assert.NoError(t, err, "should silently skip when locked by someone else")
+
+	exists := &v1alpha1.Sandbox{}
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), exists))
+	assert.Nil(t, exists.DeletionTimestamp, "sandbox should NOT have been deleted when locked")
+	assert.Equal(t, "other-lock", exists.Annotations[v1alpha1.AnnotationLock])
+}
+
+// TestScaleDownSandbox_TOCTOU verifies that scaleDownSandbox also re-fetches
+// the sandbox and skips deletion when the sandbox was claimed.
+func TestScaleDownSandbox_TOCTOU(t *testing.T) {
+	ctx := t.Context()
+	now := time.Now()
+
+	k8sClient := NewClient()
+	eventRecorder := record.NewFakeRecorder(20)
+	reconciler := &Reconciler{
+		Client:   k8sClient,
+		Scheme:   testScheme,
+		Recorder: eventRecorder,
+		Codec:    serializer.NewCodecFactory(testScheme).LegacyCodec(v1alpha1.SchemeGroupVersion),
+	}
+
+	sbx := newSandbox("to-scale-down", "old-hash", v1alpha1.SandboxStateAvailable, false, now)
+	sbx.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(&v1alpha1.SandboxSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", UID: "uid-123"},
+		}, v1alpha1.SandboxSetControllerKind),
+	}
+	assert.NoError(t, k8sClient.Create(ctx, sbx))
+
+	// Get a stale reference, then claim the sandbox.
+	staleCopy := sbx.DeepCopy()
+
+	fresh := &v1alpha1.Sandbox{}
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), fresh))
+	fresh.Labels[v1alpha1.LabelSandboxIsClaimed] = "true"
+	fresh.OwnerReferences = nil
+	assert.NoError(t, k8sClient.Update(ctx, fresh))
+
+	lock := "test-scale-lock"
+	err := reconciler.scaleDownSandbox(ctx, staleCopy, lock)
+	assert.NoError(t, err, "scaleDownSandbox should silently skip when sandbox was claimed")
+
+	exists := &v1alpha1.Sandbox{}
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), exists))
+	assert.Nil(t, exists.DeletionTimestamp, "sandbox should NOT have been deleted after claim")
+	assert.Equal(t, "true", exists.Labels[v1alpha1.LabelSandboxIsClaimed])
+}

--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -396,22 +396,42 @@ func (r *Reconciler) createSandbox(ctx context.Context, sbs *agentsv1alpha1.Sand
 func (r *Reconciler) scaleDownSandbox(ctx context.Context, sbx *agentsv1alpha1.Sandbox, lock string) (err error) {
 	log := logf.FromContext(ctx).WithValues("sandbox", client.ObjectKeyFromObject(sbx)).V(utils.DebugLogLevel)
 	log.Info("try to scale down sandbox")
-	if sbx.Annotations[agentsv1alpha1.AnnotationLock] != "" && sbx.Annotations[agentsv1alpha1.AnnotationOwner] != consts.OwnerManagerScaleDown {
-		log.Info("sandbox to be scaled down claimed before performed, skip")
-		return errors.New("sandbox to be scaled down claimed before performed, skip")
+
+	// Re-fetch the sandbox from the API server to get the latest state.
+	// This closes the TOCTOU race window where a SandboxClaim may claim
+	// the sandbox between selection and deletion.
+	fresh := &agentsv1alpha1.Sandbox{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(sbx), fresh); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to re-fetch sandbox before scale down: %s", err)
 	}
-	// Deep copy the sandbox before mutating it to avoid corrupting the informer cache.
-	sbx = sbx.DeepCopy()
-	utils.LockSandbox(sbx, lock, consts.OwnerManagerScaleDown)
-	if err = r.Update(ctx, sbx); err != nil {
+
+	// Re-verify that the sandbox is still unclaimed.
+	if isSandboxClaimed(fresh) {
+		log.Info("sandbox was claimed since initial check, skipping scale down")
+		return nil
+	}
+
+	// Re-verify that the sandbox is not locked by someone else.
+	if fresh.Annotations[agentsv1alpha1.AnnotationLock] != "" && fresh.Annotations[agentsv1alpha1.AnnotationOwner] != consts.OwnerManagerScaleDown {
+		log.Info("sandbox to be scaled down claimed before performed, skip")
+		return nil
+	}
+
+	// Deep copy the fresh sandbox before mutating it.
+	fresh = fresh.DeepCopy()
+	utils.LockSandbox(fresh, lock, consts.OwnerManagerScaleDown)
+	if err = r.Update(ctx, fresh); err != nil {
 		return fmt.Errorf("failed to lock sandbox when scaling down: %s", err)
 	}
-	if err = r.Delete(ctx, sbx); err != nil {
+	if err = r.Delete(ctx, fresh); err != nil {
 		log.Error(err, "failed to delete sandbox")
 		return err
 	}
 	log.Info("sandbox locked and deleted")
-	r.Recorder.Eventf(sbx, corev1.EventTypeNormal, EventSandboxScaledDown, "Sandbox %s locked and deleted", klog.KObj(sbx))
+	r.Recorder.Eventf(fresh, corev1.EventTypeNormal, EventSandboxScaledDown, "Sandbox %s locked and deleted", klog.KObj(fresh))
 	return nil
 }
 

--- a/pkg/controller/sandboxset/sandboxset_controller_test.go
+++ b/pkg/controller/sandboxset/sandboxset_controller_test.go
@@ -676,7 +676,7 @@ func TestReconcile_ScaleDown(t *testing.T) {
 			checkFunc: func(t *testing.T, sandboxes []v1alpha1.Sandbox) {
 				assert.Equal(t, 1, len(sandboxes))
 			},
-			expectError: true,
+			expectEvents: []string{},
 		},
 		{
 			name:     "scale down manager-owned locked sandboxes",
@@ -860,7 +860,7 @@ func TestCompareScaleDownPriority(t *testing.T) {
 		}
 		return &v1alpha1.Sandbox{
 			Status: v1alpha1.SandboxStatus{
-				Phase:        phase,
+				Phase:         phase,
 				RecycledCount: recycledCount,
 				Conditions: []metav1.Condition{
 					{Type: string(v1alpha1.SandboxConditionReady), Status: readyStatus},


### PR DESCRIPTION


<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Fixes a Time-of-Check-Time-of-Use (TOCTOU) race condition in the SandboxSet controller where sandboxes claimed by SandboxClaim between the claim-status check and deletion could be unexpectedly deleted during rolling updates or scale-downs.
In deleteSandboxForUpdate() and scaleDownSandbox(), the controller now re-fetches the sandbox from the API server before locking and deleting, then re-verifies both isSandboxClaimed() and the lock annotation on the fresh copy. If the sandbox became claimed after the initial selection, the deletion is skipped gracefully (returns nil).

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #394 
### Ⅲ. Describe how to verify it
`go test ./pkg/controller/sandboxset/`


Unit tests added:
TestDeleteSandboxForUpdate_TOCTOU
TestDeleteSandboxForUpdate_LockedByOthers_TOCTOU
TestScaleDownSandbox_TOCTOU

### Ⅳ. Special notes for reviews
- The errors package import was removed from rollingupdate.go (the only usage was errors.New which was replaced by return nil).
- The behavior change from return error on locked/claimed sandbox to return nil (skip silently) is intentional. Both deleteSandboxForUpdate and scaleDownSandbox are called from DoItSlowlyWithInputs, which counts returned errors as failures.
