### PR TITLE
fix: e2b describe dead sandboxes and map not-ready running state

### DIFF
--- a/pkg/servers/e2b/sandbox.go
+++ b/pkg/servers/e2b/sandbox.go
@@ -76,6 +76,22 @@ func (sc *Controller) getSandboxOfUser(ctx context.Context, sandboxID string, ex
 	return sbx, nil
 }
 
+func isSandboxViewable(sbx infra.Sandbox) bool {
+	state, reason := sbx.GetState()
+	if state == agentsv1alpha1.SandboxStateCreating {
+		return false
+	}
+	if state != agentsv1alpha1.SandboxStateDead {
+		return true
+	}
+	switch reason {
+	case "ResourceSucceeded", "ResourceFailed", "ResourceTerminating", "ResourceDeleted":
+		return false
+	default:
+		return true
+	}
+}
+
 func (sc *Controller) getNamespaceOfUser(user *models.CreatedTeamAPIKey) string {
 	team := keys.TeamForKey(user)
 	// Keys in the admin team can access resources in cluster scope
@@ -98,7 +114,17 @@ func (sc *Controller) convertToE2BSandbox(sbx infra.Sandbox, accessToken, domain
 		TrafficAccessToken:           sbx.GetTrafficAccessToken(),
 		TrafficAccessTokenExpiration: sbx.GetTrafficAccessTokenExpiration(),
 	}
-	sandbox.State, _ = sbx.GetState()
+	// A sandbox in the Running phase that is claimed but not yet ready is
+	// reported as "dead" by GetSandboxState because the Ready condition is
+	// unsatisfied. The underlying phase is Running, so surface it as
+	// "running" to E2B API clients — this avoids returning the unparsable
+	// "dead" state to E2B SDK clients while reflecting that the sandbox is
+	// still live.
+	state, reason := sbx.GetState()
+	if state == agentsv1alpha1.SandboxStateDead && reason == "RunningResourceClaimedButNotReady" {
+		state = agentsv1alpha1.SandboxStateRunning
+	}
+	sandbox.State = state
 	annotations := sbx.GetAnnotations()
 	labels := sbx.GetLabels()
 

--- a/pkg/servers/e2b/sandbox_test.go
+++ b/pkg/servers/e2b/sandbox_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -137,6 +138,169 @@ func TestConvertToE2BSandboxPodIPMetadata(t *testing.T) {
 			if exists {
 				assert.Equal(t, tt.expectValue, value)
 			}
+		})
+	}
+}
+
+func TestConvertToE2BSandboxStateMapping(t *testing.T) {
+	// All cases use a claimed sandbox (no OwnerReferences) so that
+	// GetSandboxState uses the claimed-branch logic.
+	tests := []struct {
+		name      string
+		sandbox   *agentsv1alpha1.Sandbox
+		wantState string
+	}{
+		{
+			name: "running but not ready is surfaced as running",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+					Conditions: []metav1.Condition{
+						{Type: string(agentsv1alpha1.SandboxConditionReady), Status: metav1.ConditionFalse},
+					},
+				},
+			},
+			wantState: agentsv1alpha1.SandboxStateRunning,
+		},
+		{
+			name: "running and ready is running",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+					Conditions: []metav1.Condition{
+						{Type: string(agentsv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue},
+					},
+				},
+			},
+			wantState: agentsv1alpha1.SandboxStateRunning,
+		},
+		{
+			name: "terminating stays dead",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxTerminating,
+				},
+			},
+			wantState: agentsv1alpha1.SandboxStateDead,
+		},
+		{
+			name: "paused is paused",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused: true,
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+				},
+			},
+			wantState: agentsv1alpha1.SandboxStatePaused,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := &sandboxcr.Sandbox{Sandbox: tt.sandbox}
+			got := (&Controller{}).convertToE2BSandbox(sbx, "", "")
+			assert.Equal(t, tt.wantState, got.State)
+		})
+	}
+}
+
+func TestIsSandboxViewable(t *testing.T) {
+	// All cases use a claimed sandbox (no OwnerReferences) so that
+	// GetSandboxState uses the claimed-branch logic.
+	pastTime := metav1.NewTime(time.Now().Add(-time.Hour))
+	tests := []struct {
+		name        string
+		sandbox     *agentsv1alpha1.Sandbox
+		wantVisible bool
+	}{
+		// non-viewable: terminal dead reasons
+		{
+			name: "Terminating phase is not viewable",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxTerminating},
+			},
+			wantVisible: false,
+		},
+		{
+			name: "Failed phase is not viewable",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxFailed},
+			},
+			wantVisible: false,
+		},
+		{
+			name: "Succeeded phase is not viewable",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxSucceeded},
+			},
+			wantVisible: false,
+		},
+		{
+			name: "DeletionTimestamp set is not viewable",
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &pastTime},
+			},
+			wantVisible: false,
+		},
+		// non-viewable: SandboxStateCreating
+		{
+			name: "Pending phase creating is not viewable",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{Phase: agentsv1alpha1.SandboxPending},
+			},
+			wantVisible: false,
+		},
+		// viewable: other dead reasons
+		{
+			name: "ShutdownTimeReached dead reason is viewable",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{ShutdownTime: &pastTime},
+			},
+			wantVisible: true,
+		},
+		{
+			name: "Running phase not ready is viewable",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+					Conditions: []metav1.Condition{
+						{Type: string(agentsv1alpha1.SandboxConditionReady), Status: metav1.ConditionFalse},
+					},
+				},
+			},
+			wantVisible: true,
+		},
+		// viewable: normal live states
+		{
+			name: "Running and ready is viewable",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+					Conditions: []metav1.Condition{
+						{Type: string(agentsv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue},
+					},
+				},
+			},
+			wantVisible: true,
+		},
+		{
+			name: "Paused is viewable",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Spec: agentsv1alpha1.SandboxSpec{Paused: true},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+				},
+			},
+			wantVisible: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := &sandboxcr.Sandbox{Sandbox: tt.sandbox}
+			assert.Equal(t, tt.wantVisible, isSandboxViewable(sbx))
 		})
 	}
 }

--- a/pkg/servers/e2b/services.go
+++ b/pkg/servers/e2b/services.go
@@ -38,14 +38,19 @@ func (sc *Controller) DescribeSandbox(r *http.Request) (web.ApiResponse[*models.
 	log := klog.FromContext(r.Context())
 	log.Info("describe sandbox", "id", id)
 
-	// Use liveSandboxStates so that dead sandboxes return 404 (NotFound).
-	// The E2B SDK's SandboxState enum does not include "dead", so returning it
-	// would cause a ValueError on the client side. A dead sandbox is effectively
-	// unusable, so treating it as not-found from the API perspective is correct.
-	sbx, err := sc.getSandboxOfUser(r.Context(), id, liveSandboxStates)
+	// Use claimedSandboxStates so that transient dead states can be inspected
+	// before deciding whether the sandbox is still viewable from the E2B API.
+	sbx, err := sc.getSandboxOfUser(r.Context(), id, claimedSandboxStates)
 	if err != nil {
 		log.Error(err, "failed to get sandbox", "id", id)
 		return web.ApiResponse[*models.Sandbox]{}, err
+	}
+	if !isSandboxViewable(sbx) {
+		log.Info("sandbox is not viewable, treating as not found", "id", id)
+		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
+			Code:    http.StatusNotFound,
+			Message: fmt.Sprintf("Cannot get sandbox %s: sandbox not found", id),
+		}
 	}
 
 	domain, apiErr := sc.resolveSandboxDomain(r)
@@ -86,6 +91,12 @@ func (sc *Controller) DeleteSandbox(r *http.Request) (web.ApiResponse[struct{}],
 	sbx, apiError := sc.getSandboxOfUser(r.Context(), id, claimedSandboxStates)
 	if apiError != nil {
 		log.Error(apiError, "failed to get sandbox, just return success", "id", id)
+		return web.ApiResponse[struct{}]{
+			Code: http.StatusNoContent,
+		}, nil
+	}
+	if !isSandboxViewable(sbx) {
+		log.Info("sandbox is not viewable, just return success", "id", id)
 		return web.ApiResponse[struct{}]{
 			Code: http.StatusNoContent,
 		}, nil

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -2238,6 +2238,38 @@ func TestDeleteSandboxDeadClaimedSandbox(t *testing.T) {
 	require.True(t, apierrors.IsNotFound(getErr), "expected sandbox to be deleted, got error: %v", getErr)
 }
 
+func TestDeleteSandboxTerminalDeadClaimedSandbox(t *testing.T) {
+	controller, fc, teardown := Setup(t)
+	defer teardown()
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+		Team: models.AdminTeam(),
+	}
+	sandbox := CreateClaimedSandboxCR(t, controller, Namespace, "terminal-dead-delete", "test-template", user.ID.String(), nil)
+	sandboxID := fmt.Sprintf("%s--%s", sandbox.Namespace, sandbox.Name)
+	UpdateSandboxWhen(t, fc, sandboxID, Immediately, DoSetSandboxStatus(v1alpha1.SandboxTerminating, "", metav1.ConditionFalse))
+
+	deleteCalls := 0
+	origDeleteSandbox := sandboxcr.DefaultDeleteSandbox
+	sandboxcr.DefaultDeleteSandbox = func(ctx context.Context, sbx *v1alpha1.Sandbox, client ctrlclient.Client) error {
+		deleteCalls++
+		return origDeleteSandbox(ctx, sbx, client)
+	}
+	t.Cleanup(func() { sandboxcr.DefaultDeleteSandbox = origDeleteSandbox })
+
+	deleteResp, apiErr := controller.DeleteSandbox(NewRequest(t, nil, nil, map[string]string{
+		"sandboxID": sandboxID,
+	}, user))
+
+	require.Nil(t, apiErr)
+	assert.Equal(t, http.StatusNoContent, deleteResp.Code)
+	assert.Equal(t, 0, deleteCalls)
+	assert.NoError(t, fc.Get(t.Context(), ctrlclient.ObjectKey{Namespace: sandbox.Namespace, Name: sandbox.Name}, &v1alpha1.Sandbox{}))
+}
+
 func TestDescribeSandboxDeadClaimedSandbox(t *testing.T) {
 	controller, fc, teardown := Setup(t)
 	defer teardown()
@@ -2256,9 +2288,36 @@ func TestDescribeSandboxDeadClaimedSandbox(t *testing.T) {
 		"sandboxID": sandboxID,
 	}, user))
 
-	// A dead sandbox should be treated as not found from the E2B API perspective,
-	// because the E2B SDK cannot parse the "dead" state. Returning 404 allows
-	// clients to detect sandbox removal via SandboxNotFoundException.
+	// The sandbox is in the Running phase with Ready=False, which
+	// GetSandboxState reports as ("dead", "RunningResourceClaimedButNotReady").
+	// DescribeSandbox uses claimedSandboxStates so the sandbox is found, and
+	// convertToE2BSandbox surfaces the state as "running" because the
+	// underlying phase is Running and the sandbox is still live.
+	assert.Nil(t, apiErr)
+	require.NotNil(t, describeResp.Body)
+	assert.Equal(t, v1alpha1.SandboxStateRunning, describeResp.Body.State)
+}
+
+func TestDescribeSandboxTerminalDeadClaimedSandbox(t *testing.T) {
+	controller, fc, teardown := Setup(t)
+	defer teardown()
+
+	user := &models.CreatedTeamAPIKey{
+		ID:   keys.AdminKeyID,
+		Key:  InitKey,
+		Name: "admin",
+		Team: models.AdminTeam(),
+	}
+	sandbox := CreateClaimedSandboxCR(t, controller, Namespace, "terminal-dead-describe", "test-template", user.ID.String(), nil)
+	sandboxID := fmt.Sprintf("%s--%s", sandbox.Namespace, sandbox.Name)
+	UpdateSandboxWhen(t, fc, sandboxID, Immediately, DoSetSandboxStatus(v1alpha1.SandboxTerminating, "", metav1.ConditionFalse))
+
+	describeResp, apiErr := controller.DescribeSandbox(NewRequest(t, nil, nil, map[string]string{
+		"sandboxID": sandboxID,
+	}, user))
+
+	// Terminal dead states (for example, Terminating) are not viewable and
+	// should be treated as missing from the E2B API perspective.
 	assert.Nil(t, describeResp.Body)
 	require.NotNil(t, apiErr)
 	assert.Equal(t, http.StatusNotFound, apiErr.Code)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR changes the E2B `DescribeSandbox` API to inspect claimed sandboxes in `dead` state, return transient Running/NotReady sandboxes as `running`, and treat terminal-dead or creating sandboxes as not found.

1. **`DescribeSandbox` uses `claimedSandboxStates`** (running, paused, dead) instead of `liveSandboxStates` (running, paused), then filters the result through `isSandboxViewable` before responding.
2. **`convertToE2BSandbox` maps `RunningResourceClaimedButNotReady` to `running`** — when a sandbox is in the Running phase but the Ready condition is not yet satisfied, `GetSandboxState` reports it as `("dead", "RunningResourceClaimedButNotReady")`. The API now surfaces this as `"running"` because the underlying phase is Running and the sandbox is still live, avoiding the E2B SDK `ValueError` on the unparseable `"dead"` state.

### Ⅱ. Does this pull request fix one issue?

fixes #693

### Ⅲ. Describe how to verify it

1. Run unit tests: `go test ./pkg/servers/e2b/ -run 'TestConvertToE2BSandbox|TestDescribeSandbox' -count=1 -v`
2. Verify that a sandbox in Running phase with Ready=False returns state `"running"` (not `"dead"` or 404)
3. Verify that a terminal-dead sandbox (Terminating phase) returns 404 as not found
4. Verify that reserved-failed sandboxes still return 404

### Ⅳ. Special notes for reviews

- The standard E2B Python SDK's `SandboxState` enum only has `running` and `paused` — it does not include `dead`. Returning `"dead"` would cause `ValueError: 'dead' is not a valid SandboxState` in `SandboxDetail.from_dict()`.
- The `RunningResourceClaimedButNotReady` case is the most common "dead" state for claimed sandboxes — it occurs whenever a sandbox is in the Running phase but hasn't reached Ready yet. Mapping it to `"running"` is semantically correct because the underlying phase IS Running.
- Terminal-dead sandboxes (Terminating, Succeeded, Failed, Deleted) and creating sandboxes are treated as not found from the E2B API perspective.
- `convertToE2BSandbox` is shared by all E2B API endpoints (describe, connect, create, list), so the state mapping applies uniformly.
- this solve part of the issues picture in proposal https://github.com/openkruise/agents/pull/653, which potentially can solve other parts of sandbox states handling such as routing
