### PR TITLE
    feat(identity): mirror agent-name annotation to sandbox and pod template labels

### DIFF
--- a/api/v1alpha1/sandboxclaim_types.go
+++ b/api/v1alpha1/sandboxclaim_types.go
@@ -59,12 +59,17 @@ type SandboxClaimSpec struct {
 
 	// Labels contains key-value pairs to be added as labels
 	// to claimed Sandbox resources and synced to sandbox template labels.
+	// This is the recommended place for security.agents.kruise.io/agent-name,
+	// which the claim flow stores on the Sandbox and Pod labels.
 	// +optional
 	// +mapType=granular
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// Annotations contains key-value pairs to be added as annotations
-	// to claimed Sandbox resources
+	// to claimed Sandbox resources.
+	// security.agents.kruise.io/agent-name is also accepted here for
+	// compatibility, but it is converted to the labels above instead of being
+	// persisted as an annotation; Labels wins when both carry it.
 	// +optional
 	// +mapType=granular
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
@@ -62,7 +62,10 @@ spec:
                   type: string
                 description: |-
                   Annotations contains key-value pairs to be added as annotations
-                  to claimed Sandbox resources
+                  to claimed Sandbox resources.
+                  security.agents.kruise.io/agent-name is also accepted here for
+                  compatibility, but it is converted to the labels above instead of being
+                  persisted as an annotation; Labels wins when both carry it.
                 type: object
                 x-kubernetes-map-type: granular
               claimTimeout:
@@ -160,6 +163,8 @@ spec:
                 description: |-
                   Labels contains key-value pairs to be added as labels
                   to claimed Sandbox resources and synced to sandbox template labels.
+                  This is the recommended place for security.agents.kruise.io/agent-name,
+                  which the claim flow stores on the Sandbox and Pod labels.
                 type: object
                 x-kubernetes-map-type: granular
               replicas:

--- a/pkg/controller/sandbox/core/recycle.go
+++ b/pkg/controller/sandbox/core/recycle.go
@@ -398,6 +398,18 @@ func (r *SandboxRecycleControl) handleRecycleFailed(ctx context.Context, box *ag
 	return retainDuration, nil
 }
 
+// resetMetadataForPool clears the claim-time metadata of a recycled sandbox and
+// hands it back to its SandboxSet, so the next claimer starts from a clean slate.
+//
+// TODO: the security.agents.kruise.io/agent-name key is not reset here. The
+// claim flow converges that key against the agent name the new claim requests
+// (see reconcileAgentNameLabels in the sandbox-manager infra layer), so a
+// recycled sandbox can never leak the previous claimer's identity into a token
+// issuance. What remains is visibility: while the sandbox sits unclaimed in the
+// pool it still carries the previous label, so a label selector (e.g. a
+// SecurityProfile) can still match it. Clearing it here has to cover
+// box.Spec.Template.Labels as well, which this function does not touch today
+// for any user label, so it is left to a follow-up together with that gap.
 func (r *SandboxRecycleControl) resetMetadataForPool(ctx context.Context, box *agentsv1alpha1.Sandbox, sbs *agentsv1alpha1.SandboxSet) error {
 	patch := client.MergeFrom(box.DeepCopy())
 

--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -36,6 +36,7 @@ import (
 	"github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/controller/sandboxset"
 	"github.com/openkruise/agents/pkg/features"
+	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
@@ -325,6 +326,7 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 		ReserveFailedSandboxFor: reserveFailedSandboxFor,
 		CreateOnNoStock:         claim.Spec.CreateOnNoStock,
 		UserMetadataKeys:        sandboxcr.BuildUserMetadataKeys(claim.Spec.Labels, claim.Spec.Annotations),
+		AgentName:               resolveClaimAgentName(claim),
 		Claim:                   claim,
 	}
 
@@ -398,6 +400,20 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 	}
 
 	return sandboxcr.ValidateAndInitClaimOptions(opts)
+}
+
+// resolveClaimAgentName resolves the agent name a SandboxClaim requests. Labels
+// are the carrier the claim API converges on, so spec.labels wins; spec.annotations
+// stays accepted as an input channel for callers written against the earlier
+// annotation-based contract, and the infra layer stores the resolved value on
+// the sandbox and pod labels either way. An empty result means the claim asks
+// for no agent identity, which makes the infra layer strip a label a previous
+// claim left on the pooled sandbox.
+func resolveClaimAgentName(claim *agentsv1alpha1.SandboxClaim) string {
+	if name := claim.Spec.Labels[identity.AnnotationAgentName]; name != "" {
+		return name
+	}
+	return claim.Spec.Annotations[identity.AnnotationAgentName]
 }
 
 // buildCSIMountOptions generates CSI mount options and storage-auth annotation

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -37,12 +37,71 @@ import (
 	"github.com/openkruise/agents/pkg/agent-runtime/storages"
 	"github.com/openkruise/agents/pkg/cache/cachetest"
 	"github.com/openkruise/agents/pkg/features"
+	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/utils/csiutils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 )
+
+// TestResolveClaimAgentName verifies which SandboxClaim field the agent name is
+// read from: spec.labels is the carrier the claim API converges on and therefore
+// wins, spec.annotations stays accepted for callers written against the earlier
+// annotation-based contract, and an absent key resolves to empty so the infra
+// layer strips a label a previous claim left on the pooled sandbox.
+func TestResolveClaimAgentName(t *testing.T) {
+	tests := []struct {
+		name        string
+		labels      map[string]string
+		annotations map[string]string
+		want        string
+		reason      string
+	}{
+		{
+			name:   "resolved from spec.labels",
+			labels: map[string]string{identity.AnnotationAgentName: "label-agent"},
+			want:   "label-agent",
+			reason: "labels are the recommended input for the agent name",
+		},
+		{
+			name:        "resolved from spec.annotations for compatibility",
+			annotations: map[string]string{identity.AnnotationAgentName: "annotation-agent"},
+			want:        "annotation-agent",
+			reason:      "callers on the earlier contract must keep working",
+		},
+		{
+			name:        "labels win when both carry the key",
+			labels:      map[string]string{identity.AnnotationAgentName: "label-agent"},
+			annotations: map[string]string{identity.AnnotationAgentName: "annotation-agent"},
+			want:        "label-agent",
+			reason:      "the carrier field is authoritative on conflict",
+		},
+		{
+			name:   "absent key resolves to empty",
+			reason: "an empty expected value strips residual labels during claim",
+		},
+		{
+			name:        "empty label value falls back to the annotation",
+			labels:      map[string]string{identity.AnnotationAgentName: ""},
+			annotations: map[string]string{identity.AnnotationAgentName: "annotation-agent"},
+			want:        "annotation-agent",
+			reason:      "an empty label expresses no intent and must not mask the annotation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claim := &agentsv1alpha1.SandboxClaim{
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					Labels:      tt.labels,
+					Annotations: tt.annotations,
+				},
+			}
+			assert.Equal(t, tt.want, resolveClaimAgentName(claim), tt.reason)
+		})
+	}
+}
 
 func TestNewCommonControl(t *testing.T) {
 	scheme := runtime.NewScheme()

--- a/pkg/identity/agent_name_label.go
+++ b/pkg/identity/agent_name_label.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// ValidateAgentName reports whether an agent-name value can be mirrored into
+// Kubernetes labels. An empty value is valid: it means the sandbox is not
+// opted into the identity issuance path. Request parsing layers call this to
+// reject an invalid user-supplied agent name up front, before any sandbox is
+// picked or created; the sandboxcr infra layer reuses it when mirroring the
+// annotation into the sandbox and pod template labels during claim and clone.
+func ValidateAgentName(agentName string) error {
+	if agentName == "" {
+		return nil
+	}
+	if errs := validation.IsValidLabelValue(agentName); len(errs) > 0 {
+		return fmt.Errorf("annotation %s value %q is not a valid label value: %s",
+			AnnotationAgentName, agentName, strings.Join(errs, "; "))
+	}
+	return nil
+}

--- a/pkg/identity/agent_name_label_test.go
+++ b/pkg/identity/agent_name_label_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateAgentName exercises the standalone validator consumed by the
+// E2B parse layer: an empty value (not opted in) and any valid Kubernetes
+// label value must pass, while values violating label-value constraints must
+// be rejected with an error naming the annotation key.
+func TestValidateAgentName(t *testing.T) {
+	tests := []struct {
+		name        string
+		agentName   string
+		expectError string
+	}{
+		{
+			name:      "empty value is valid",
+			agentName: "",
+		},
+		{
+			name:      "valid label value passes",
+			agentName: "my-agent_v1.0",
+		},
+		{
+			name:        "value exceeding 63 characters is rejected",
+			agentName:   strings.Repeat("a", 64),
+			expectError: "is not a valid label value",
+		},
+		{
+			name:        "value with invalid characters is rejected",
+			agentName:   "agent/with/slashes",
+			expectError: "is not a valid label value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAgentName(tt.agentName)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				assert.Contains(t, err.Error(), AnnotationAgentName,
+					"error must name the offending annotation key for diagnosability")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/identity/sandbox_token_helper.go
+++ b/pkg/identity/sandbox_token_helper.go
@@ -28,25 +28,49 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 )
 
+// GetAgentName returns the agent name that binds the sandbox to a logical
+// agent identity, reading the "security.agents.kruise.io/agent-name" key.
+//
+// Labels are the carrier of that key (see AnnotationAgentName): the claim and
+// clone flows converge the requested agent name onto the sandbox and pod
+// template labels and drop the annotation form, so a sandbox that reached the
+// apiserver exposes the agent name as a label. The annotation is still read
+// first because two states legitimately carry it there: sandboxes created
+// before labels became the carrier, and the in-flight object inside a claim or
+// clone request whose labels have not been converged yet.
+//
+// This function is the single legitimate accessor for the agent name: gates
+// and providers must resolve it through this helper (directly or via
+// IsIDTokenRequested / ExtractSecurityMetadata) instead of reading the
+// annotation or label themselves, so the resolution rule lives in exactly
+// one place. A nil sandbox resolves to the empty string.
+func GetAgentName(sbx *agentsv1alpha1.Sandbox) string {
+	if sbx == nil {
+		return ""
+	}
+	if name := sbx.GetAnnotations()[AnnotationAgentName]; name != "" {
+		return name
+	}
+	return sbx.GetLabels()[AnnotationAgentName]
+}
+
 // IsIDTokenRequested reports whether the sandbox opts into the ID token
 // (identity provider) issuance path.
 //
-// The opt-in signal is the presence of a non-empty
-// "security.agents.kruise.io/agent-name" annotation on the sandbox: setting
-// this annotation expresses the user's intent to bind the sandbox to a logical
+// The opt-in signal is a non-empty agent name resolved by GetAgentName: the
+// "security.agents.kruise.io/agent-name" label written by the claim and clone
+// flows, or the annotation on sandboxes that predate labels as the carrier.
+// Setting either expresses the user's intent to bind the sandbox to a logical
 // agent identity, which is the precondition for the identity provider to mint a
-// security token. A nil sandbox, a sandbox without Annotations, or one whose
-// value for that key is empty all collapse to "not requested", letting callers
+// security token. A nil sandbox, or one carrying the key in neither source (or
+// only with an empty value), collapses to "not requested", letting callers
 // short-circuit the issuance path without paying any provider cost.
 //
-// The check is intentionally annotation-only and value-presence-only: it does
-// NOT validate the value against any naming convention, since the identity
-// provider is the authoritative source of truth for agent-name semantics.
+// The check is intentionally value-presence-only: it does NOT validate the
+// value against any naming convention, since the identity provider is the
+// authoritative source of truth for agent-name semantics.
 func IsIDTokenRequested(sbx *agentsv1alpha1.Sandbox) bool {
-	if sbx == nil {
-		return false
-	}
-	return sbx.GetAnnotations()[AnnotationAgentName] != ""
+	return GetAgentName(sbx) != ""
 }
 
 // IsAccessTokenRequested reports whether the sandbox opts into access-token
@@ -71,6 +95,12 @@ func IsAccessTokenRequested(sbx *agentsv1alpha1.Sandbox) bool {
 // include security metadata in token issuance requests should call this helper
 // instead of re-implementing the prefix filter.
 //
+// The agent-name key is the one security key carried by labels rather than
+// annotations (see GetAgentName): the value resolved from the sandbox labels is
+// backfilled into the returned map under the same key, so providers observe the
+// agent name without knowing where it is stored. All other security keys remain
+// annotation-only and are never read from labels.
+//
 // A nil sandbox results in a nil map. The returned map is never nil when the
 // sandbox is non-nil, even if no matching annotations exist, so providers can
 // safely iterate over it.
@@ -78,7 +108,13 @@ func ExtractSecurityMetadata(sbx *agentsv1alpha1.Sandbox) map[string]string {
 	if sbx == nil {
 		return nil
 	}
-	return ExtractSecurityMetadataFromMap(sbx.GetAnnotations())
+	metadata := ExtractSecurityMetadataFromMap(sbx.GetAnnotations())
+	if metadata[AnnotationAgentName] == "" {
+		if name := GetAgentName(sbx); name != "" {
+			metadata[AnnotationAgentName] = name
+		}
+	}
+	return metadata
 }
 
 // ExtractSecurityMetadataFromMap returns a new map containing only the entries

--- a/pkg/identity/sandbox_token_helper_test.go
+++ b/pkg/identity/sandbox_token_helper_test.go
@@ -216,8 +216,10 @@ func TestIssueSandboxAccessToken_DefaultProviderIntegration(t *testing.T) {
 }
 
 // TestExtractSecurityMetadata verifies the prefix filter used to collect
-// security-prefixed annotations into a metadata map. Providers call this helper
-// when they want to include security metadata in token issuance requests.
+// security-prefixed annotations into a metadata map, plus the agent-name
+// backfill: when the annotation does not carry the agent name, the value
+// resolved from the sandbox labels is added under the same key so providers
+// observe label-driven opt-ins. All other security keys stay annotation-only.
 func TestExtractSecurityMetadata(t *testing.T) {
 	const tenantKey = SecurityMetadataPrefix + "tenant"
 	const projectKey = SecurityMetadataPrefix + "project"
@@ -268,6 +270,56 @@ func TestExtractSecurityMetadata(t *testing.T) {
 						"agents.kruise.io/team":          "infra",
 						"security-fake.agents.kruise.io": "no",
 						"x-security.agents.kruise.io/y":  "no",
+					},
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "agent-name label is backfilled when annotation is absent",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sbx",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						tenantKey: "t1",
+					},
+					Labels: map[string]string{
+						AnnotationAgentName: "label-agent",
+					},
+				},
+			},
+			want: map[string]string{
+				tenantKey:           "t1",
+				AnnotationAgentName: "label-agent",
+			},
+		},
+		{
+			name: "agent-name annotation is not overridden by a conflicting label",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sbx",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						AnnotationAgentName: "anno-agent",
+					},
+					Labels: map[string]string{
+						AnnotationAgentName: "label-agent",
+					},
+				},
+			},
+			want: map[string]string{
+				AnnotationAgentName: "anno-agent",
+			},
+		},
+		{
+			name: "other security-prefixed labels are never backfilled",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sbx",
+					Namespace: "ns",
+					Labels: map[string]string{
+						tenantKey: "t1",
 					},
 				},
 			},
@@ -542,10 +594,12 @@ func TestPropagateSandboxToken(t *testing.T) {
 }
 
 // TestIsIDTokenRequested verifies the opt-in predicate that gates the
-// identity provider issuance path. The contract is: a sandbox opts in iff its
-// Annotations carry a non-empty value under AnnotationAgentName; every other
-// shape (nil sandbox, missing Annotations map, absent key, empty value,
-// near-miss key) must collapse to false so callers can safely short-circuit.
+// identity provider issuance path. The contract is dual-source: a sandbox
+// opts in iff GetAgentName resolves a non-empty value, i.e. its Annotations
+// carry a non-empty value under AnnotationAgentName or, when the annotation
+// is absent, its Labels do under the same key; every other shape (nil
+// sandbox, missing maps, absent key, empty value, near-miss key) must
+// collapse to false so callers can safely short-circuit.
 func TestIsIDTokenRequested(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -653,11 +707,142 @@ func TestIsIDTokenRequested(t *testing.T) {
 			want:   true,
 			reason: "presence of other annotations must not interfere with the opt-in decision",
 		},
+		{
+			name: "agent-name label only returns true",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sbx",
+					Namespace: "ns",
+					Labels: map[string]string{
+						AnnotationAgentName: "label-agent",
+					},
+				},
+			},
+			want:   true,
+			reason: "a label-only opt-in (e.g. SandboxClaim spec.labels) must trigger the provider path",
+		},
+		{
+			name: "agent-name label present but empty returns false",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sbx",
+					Namespace: "ns",
+					Labels: map[string]string{
+						AnnotationAgentName: "",
+					},
+				},
+			},
+			want:   false,
+			reason: "an empty label value carries no agent identity, mirroring the annotation contract",
+		},
+		{
+			name: "empty annotation with non-empty label returns true",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sbx",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						AnnotationAgentName: "",
+					},
+					Labels: map[string]string{
+						AnnotationAgentName: "label-agent",
+					},
+				},
+			},
+			want:   true,
+			reason: "an empty annotation is treated as absent, so the label fallback must apply",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, IsIDTokenRequested(tt.sbx), tt.reason)
+		})
+	}
+}
+
+// TestGetAgentName verifies the dual-source resolution contract of the
+// agent-name key: the annotation is the primary source, the label is the
+// fallback when the annotation is absent or empty, and the annotation wins
+// when both carry different values. This helper is the single legitimate
+// accessor for the agent name, so its precedence rules anchor every gate and
+// provider that consumes it.
+func TestGetAgentName(t *testing.T) {
+	tests := []struct {
+		name   string
+		sbx    *agentsv1alpha1.Sandbox
+		want   string
+		reason string
+	}{
+		{
+			name:   "nil sandbox resolves to empty",
+			sbx:    nil,
+			want:   "",
+			reason: "a nil sandbox must resolve to no agent name without panicking",
+		},
+		{
+			name: "no annotations and no labels resolves to empty",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "sbx", Namespace: "ns"},
+			},
+			want:   "",
+			reason: "nil maps on both sources must resolve to no agent name",
+		},
+		{
+			name: "annotation only resolves to annotation value",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "sbx",
+					Namespace:   "ns",
+					Annotations: map[string]string{AnnotationAgentName: "anno-agent"},
+				},
+			},
+			want:   "anno-agent",
+			reason: "the annotation-driven path must keep its existing behavior",
+		},
+		{
+			name: "label only resolves to label value",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sbx",
+					Namespace: "ns",
+					Labels:    map[string]string{AnnotationAgentName: "label-agent"},
+				},
+			},
+			want:   "label-agent",
+			reason: "the label fallback must serve label-driven opt-ins such as SandboxClaim spec.labels",
+		},
+		{
+			name: "conflicting annotation and label resolves to annotation value",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "sbx",
+					Namespace:   "ns",
+					Annotations: map[string]string{AnnotationAgentName: "anno-agent"},
+					Labels:      map[string]string{AnnotationAgentName: "label-agent"},
+				},
+			},
+			want:   "anno-agent",
+			reason: "the annotation must win on conflict, matching the mirror-overwrite semantics of claim and clone",
+		},
+		{
+			name: "empty annotation falls back to label value",
+			sbx: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "sbx",
+					Namespace:   "ns",
+					Annotations: map[string]string{AnnotationAgentName: ""},
+					Labels:      map[string]string{AnnotationAgentName: "label-agent"},
+				},
+			},
+			want:   "label-agent",
+			reason: "an empty annotation is treated as absent rather than masking the label",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, GetAgentName(tt.sbx), tt.reason)
 		})
 	}
 }

--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -51,11 +51,31 @@ const (
 	// AgentKeyTokenRefreshStatus is the Sandbox Annotation Key,
 	// used to store the JSON serialized result of TokenRefreshStatus.
 	AgentKeyTokenRefreshStatus = SecurityMetadataPrefix + "token-status"
-	// AnnotationAgentName is the sandbox Annotation Key whose presence opts the
+	// AnnotationAgentName is the sandbox metadata key whose presence opts the
 	// sandbox into the identity provider issuance path. Its value carries the
 	// logical agent name that the identity provider uses to mint the security
-	// token. An annotation is used instead of a label so the value is free of
-	// the 63-char / DNS-label constraints and can express richer content.
+	// token.
+	//
+	// Labels are the carrier of this key: the claim and clone flows store the
+	// requested agent name on the sandbox labels and the pod template labels
+	// under this key, so label-based consumers can select on it on both the
+	// Sandbox and its Pod. The annotation form is an input channel only — E2B
+	// request metadata and SandboxClaim spec.annotations may carry it — and the
+	// sandbox-manager infra layer drops it while converging the labels, so it is
+	// never persisted on a Sandbox. Sandboxes whose pod template is resolved
+	// through TemplateRef carry no inline template, so only the sandbox label is
+	// written and the pod does not receive the label.
+	//
+	// The value must satisfy Kubernetes label-value constraints (63-char limit,
+	// restricted character set). The E2B create path rejects user-supplied
+	// non-conforming values at request parse time (see ValidateAgentName), and
+	// claim and clone reject values injected after parsing as a terminal bad
+	// request.
+	//
+	// GetAgentName resolves the key for consumers and still reads the annotation
+	// before the label, which covers sandboxes created before labels became the
+	// carrier and the in-flight state of a request whose labels have not been
+	// converged yet.
 	AnnotationAgentName = SecurityMetadataPrefix + "agent-name"
 	// AnnotationEnableJwtAuth is the sandbox Annotation Key whose value "true"
 	// opts the sandbox into the JWT traffic-token issuance path. Unlike

--- a/pkg/sandbox-manager/infra/sandboxcr/agent_name_label.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/agent_name_label.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandboxcr
+
+import (
+	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/identity"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+)
+
+// resolveCloneAgentName resolves the expected agent name for a clone: the value
+// carried by the request wins, and when it is empty the value persisted with
+// the checkpoint applies, so a snapshot keeps its identity binding without the
+// caller having to repeat it. An empty result means the clone is bound to no
+// agent identity, and reconcileAgentNameLabels then strips the label the cloned
+// pod template inherited from the source sandbox.
+func resolveCloneAgentName(opts infra.CloneSandboxOptions, cp *v1alpha1.Checkpoint) string {
+	if opts.AgentName != "" {
+		return opts.AgentName
+	}
+	if cp == nil {
+		return ""
+	}
+	return cp.GetAnnotations()[identity.AnnotationAgentName]
+}
+
+// reconcileAgentNameLabels converges the identity.AnnotationAgentName key on a
+// sandbox towards agentName, the expected value the caller resolved from its
+// own protocol input (E2B request metadata, SandboxClaim spec, checkpoint).
+// Labels are the storage and consumption carrier for the agent name; the
+// annotation is only an input channel and never survives this function.
+//
+// The convergence is expressed against the expected value, not against
+// whatever the sandbox already carries, because a pooled sandbox may still
+// carry the label written for a previous claim. Deriving the value from the
+// object could not tell that residue apart from a label the current caller
+// supplied on purpose (e.g. SandboxClaim spec.labels), so:
+//
+//   - a non-empty agentName is written to the sandbox labels and the pod
+//     template labels, overwriting any pre-existing value there;
+//   - an empty agentName removes the key from both, so a sandbox claimed
+//     without an agent name can never inherit the previous claimer's identity;
+//   - the annotation is removed in both cases, so the agent name is only ever
+//     persisted on labels.
+//
+// A non-empty value that is not a valid Kubernetes label value (63-char limit,
+// restricted character set) returns an error before anything is mutated, so
+// callers can reject the request instead of failing later on an apiserver
+// write. The E2B create parse path already rejects user-supplied invalid names
+// via identity.ValidateAgentName, so this check is the backstop for values
+// injected after parsing (deployment-specific modifiers, values restored from
+// checkpoints).
+//
+// The pod template labels are only touched when Spec.Template is present,
+// matching the existing pod-label semantics of the claim flow: sandboxes whose
+// pod template is resolved through TemplateRef carry no inline template to
+// mutate, so only the sandbox label is written there and the pod does not
+// receive the label.
+func reconcileAgentNameLabels(sbx *v1alpha1.Sandbox, agentName string) error {
+	if sbx == nil {
+		return nil
+	}
+	if err := identity.ValidateAgentName(agentName); err != nil {
+		return err
+	}
+	// The annotation is an input channel only: drop it whether or not an agent
+	// name was requested, so it never reaches the apiserver.
+	delete(sbx.Annotations, identity.AnnotationAgentName)
+	if agentName == "" {
+		delete(sbx.Labels, identity.AnnotationAgentName)
+		if sbx.Spec.Template != nil {
+			delete(sbx.Spec.Template.Labels, identity.AnnotationAgentName)
+		}
+		return nil
+	}
+	if sbx.Labels == nil {
+		sbx.Labels = make(map[string]string, 1)
+	}
+	sbx.Labels[identity.AnnotationAgentName] = agentName
+	if sbx.Spec.Template != nil {
+		if sbx.Spec.Template.Labels == nil {
+			sbx.Spec.Template.Labels = make(map[string]string, 1)
+		}
+		sbx.Spec.Template.Labels[identity.AnnotationAgentName] = agentName
+	}
+	return nil
+}

--- a/pkg/sandbox-manager/infra/sandboxcr/agent_name_label_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/agent_name_label_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandboxcr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/identity"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+)
+
+// TestReconcileAgentNameLabels exercises the convergence of the agent-name key
+// towards the expected value the caller resolved from its own protocol input: a
+// valid value must be written to both the sandbox labels and the pod template
+// labels (overwriting whatever was there), an empty value must strip both so a
+// pooled sandbox cannot leak the previous claimer's identity, the annotation
+// form must never survive either way, and a value violating Kubernetes
+// label-value constraints must be rejected before anything is mutated.
+func TestReconcileAgentNameLabels(t *testing.T) {
+	newTemplate := func(labels map[string]string) *corev1.PodTemplateSpec {
+		return &corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		sbx            *v1alpha1.Sandbox
+		agentName      string
+		expectError    string
+		wantLabel      string // expected sandbox label value; "" means the key must be absent
+		wantPodLabel   string // expected pod template label value; "" means the key must be absent
+		wantAnnotation string // expected annotation value; "" means the key must be absent
+		checkPodLabels bool   // whether the sandbox carries an inline pod template to verify
+		reason         string
+	}{
+		{
+			name:   "nil sandbox is a no-op",
+			sbx:    nil,
+			reason: "defensive guard mirroring identity.IsIDTokenRequested's nil tolerance",
+		},
+		{
+			name: "no expected value on a clean sandbox leaves it untouched",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "sbx-a"},
+				Spec: v1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: newTemplate(nil),
+					},
+				},
+			},
+			checkPodLabels: true,
+			reason:         "non-identity sandboxes must stay inert",
+		},
+		{
+			name: "no expected value strips residual labels",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "sbx-b",
+					Labels: map[string]string{identity.AnnotationAgentName: "previous-agent"},
+				},
+				Spec: v1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: newTemplate(map[string]string{identity.AnnotationAgentName: "previous-agent"}),
+					},
+				},
+			},
+			checkPodLabels: true,
+			reason:         "a pooled sandbox must never inherit the previous claimer's identity",
+		},
+		{
+			name: "annotation input is dropped even without an expected value",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "sbx-c",
+					Annotations: map[string]string{identity.AnnotationAgentName: "annotation-agent"},
+				},
+				Spec: v1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: newTemplate(nil),
+					},
+				},
+			},
+			checkPodLabels: true,
+			reason:         "only the resolved expected value is authoritative, never the annotation",
+		},
+		{
+			name: "expected value is written to sandbox and pod template labels",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "sbx-d"},
+				Spec: v1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: newTemplate(nil),
+					},
+				},
+			},
+			agentName:      "my-agent",
+			wantLabel:      "my-agent",
+			wantPodLabel:   "my-agent",
+			checkPodLabels: true,
+			reason:         "the canonical convergence path",
+		},
+		{
+			name: "expected value overwrites drifting labels and drops the annotation",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "sbx-e",
+					Annotations: map[string]string{identity.AnnotationAgentName: "annotation-agent"},
+					Labels:      map[string]string{identity.AnnotationAgentName: "stale-agent"},
+				},
+				Spec: v1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: newTemplate(map[string]string{identity.AnnotationAgentName: "stale-agent"}),
+					},
+				},
+			},
+			agentName:      "my-agent",
+			wantLabel:      "my-agent",
+			wantPodLabel:   "my-agent",
+			checkPodLabels: true,
+			reason:         "labels are the carrier and the resolved value is the only source",
+		},
+		{
+			name: "nil pod template writes the sandbox label only",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "sbx-f"},
+			},
+			agentName: "my-agent",
+			wantLabel: "my-agent",
+			reason:    "TemplateRef-resolved sandboxes carry no inline template to mutate",
+		},
+		{
+			name: "value exceeding 63 characters is rejected",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "sbx-g",
+					Annotations: map[string]string{identity.AnnotationAgentName: strings.Repeat("a", 64)},
+				},
+				Spec: v1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: newTemplate(nil),
+					},
+				},
+			},
+			agentName:      strings.Repeat("a", 64),
+			expectError:    "is not a valid label value",
+			wantAnnotation: strings.Repeat("a", 64),
+			checkPodLabels: true,
+			reason:         "fail fast instead of letting the apiserver reject the write",
+		},
+		{
+			name: "value with invalid characters is rejected",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "sbx-h"},
+				Spec: v1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+						Template: newTemplate(nil),
+					},
+				},
+			},
+			agentName:      "agent/with/slashes",
+			expectError:    "is not a valid label value",
+			checkPodLabels: true,
+			reason:         "label values allow only alphanumerics, '-', '_' and '.'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := reconcileAgentNameLabels(tt.sbx, tt.agentName)
+
+			if tt.expectError != "" {
+				require.Error(t, err, tt.reason)
+				assert.Contains(t, err.Error(), tt.expectError)
+				assert.Contains(t, err.Error(), identity.AnnotationAgentName,
+					"error must name the offending key for diagnosability")
+			} else {
+				require.NoError(t, err, tt.reason)
+			}
+			if tt.sbx == nil {
+				return
+			}
+
+			if tt.wantLabel != "" {
+				assert.Equal(t, tt.wantLabel, tt.sbx.Labels[identity.AnnotationAgentName])
+			} else {
+				assert.NotContains(t, tt.sbx.Labels, identity.AnnotationAgentName)
+			}
+			if tt.checkPodLabels && tt.sbx.Spec.Template != nil {
+				if tt.wantPodLabel != "" {
+					assert.Equal(t, tt.wantPodLabel, tt.sbx.Spec.Template.Labels[identity.AnnotationAgentName])
+				} else {
+					assert.NotContains(t, tt.sbx.Spec.Template.Labels, identity.AnnotationAgentName)
+				}
+			}
+			// A rejected value must leave the object exactly as it was, so the
+			// annotation is only expected to survive on the error paths.
+			if tt.wantAnnotation != "" {
+				assert.Equal(t, tt.wantAnnotation, tt.sbx.Annotations[identity.AnnotationAgentName])
+			} else {
+				assert.NotContains(t, tt.sbx.Annotations, identity.AnnotationAgentName,
+					"the annotation is an input channel and must never be persisted")
+			}
+		})
+	}
+}
+
+// TestResolveCloneAgentName verifies the precedence a clone applies when
+// resolving the expected agent name: the request wins so a caller can rebind or
+// drop the identity, and the value persisted with the checkpoint keeps a
+// snapshot's binding alive when the request stays silent.
+func TestResolveCloneAgentName(t *testing.T) {
+	newCheckpoint := func(annotations map[string]string) *v1alpha1.Checkpoint {
+		return &v1alpha1.Checkpoint{ObjectMeta: metav1.ObjectMeta{Annotations: annotations}}
+	}
+
+	tests := []struct {
+		name   string
+		opts   infra.CloneSandboxOptions
+		cp     *v1alpha1.Checkpoint
+		want   string
+		reason string
+	}{
+		{
+			name:   "request value wins over the checkpoint",
+			opts:   infra.CloneSandboxOptions{AgentName: "request-agent"},
+			cp:     newCheckpoint(map[string]string{identity.AnnotationAgentName: "checkpoint-agent"}),
+			want:   "request-agent",
+			reason: "the caller must be able to rebind the clone to another agent",
+		},
+		{
+			name:   "checkpoint value applies when the request is silent",
+			cp:     newCheckpoint(map[string]string{identity.AnnotationAgentName: "checkpoint-agent"}),
+			want:   "checkpoint-agent",
+			reason: "a snapshot keeps its identity binding without the caller repeating it",
+		},
+		{
+			name:   "no value anywhere resolves to empty",
+			cp:     newCheckpoint(nil),
+			reason: "an unbound clone must have the inherited pod template label stripped",
+		},
+		{
+			name:   "nil checkpoint resolves to empty",
+			reason: "defensive guard: callers must not panic on a missing checkpoint",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveCloneAgentName(tt.opts, tt.cp), tt.reason)
+		})
+	}
+}

--- a/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils.go
@@ -68,17 +68,34 @@ func copyPreservedAnnotations(src, dst map[string]string) map[string]string {
 	return dst
 }
 
+// PropagateAnnotationsToCheckpoint copies the annotations a clone needs from a
+// Sandbox to its Checkpoint.
+//
+// The agent name is carried by the sandbox labels rather than its annotations,
+// so it is persisted explicitly here. The Checkpoint is internal storage, not
+// an API surface, so keeping the annotation form there costs nothing and keeps
+// checkpoints written by earlier versions — which carry the annotation on the
+// sandbox itself — readable by the clone path.
 func PropagateAnnotationsToCheckpoint(sbx *v1alpha1.Sandbox, cp *v1alpha1.Checkpoint) {
 	sbxAnnotations := sbx.GetAnnotations()
-	if sbxAnnotations == nil {
+	agentName := identity.GetAgentName(sbx)
+	if len(sbxAnnotations) == 0 && agentName == "" {
 		return
 	}
-	cp.SetAnnotations(copyPreservedAnnotations(sbxAnnotations, cp.GetAnnotations()))
+	annotations := copyPreservedAnnotations(sbxAnnotations, cp.GetAnnotations())
+	if agentName != "" {
+		annotations[identity.AnnotationAgentName] = agentName
+	}
+	cp.SetAnnotations(annotations)
 }
 
 // RestoreAnnotationsFromCheckpoint copies necessary annotations from a Checkpoint back to a Sandbox.
 // This is the reverse of propagateAnnotationsToCheckpoint, used during clone to restore
 // annotations that were previously propagated from the original sandbox to the checkpoint.
+//
+// The agent name is restored as an annotation here, but the clone flow converges
+// it onto the labels and drops the annotation again (see
+// reconcileAgentNameLabels), so it never reaches the apiserver in that form.
 func RestoreAnnotationsFromCheckpoint(cp *v1alpha1.Checkpoint, sbx *v1alpha1.Sandbox) {
 	cpAnnotations := cp.GetAnnotations()
 	if cpAnnotations == nil {

--- a/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils_test.go
@@ -176,6 +176,50 @@ func TestPropagateAnnotationsToCheckpoint(t *testing.T) {
 				identity.AnnotationAgentName: "my-agent",
 			},
 		},
+		{
+			// Labels are the carrier of the agent name, so the value must be
+			// persisted even though it is absent from the sandbox annotations;
+			// otherwise a clone of this snapshot would lose the identity binding.
+			name: "agent name on labels only - persisted as a checkpoint annotation",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{identity.AnnotationAgentName: "label-agent"},
+					Annotations: map[string]string{
+						csiKey: `[{"driver":"nfs"}]`,
+					},
+				},
+			},
+			cp: &v1alpha1.Checkpoint{},
+			expectedAnnotation: map[string]string{
+				csiKey:                       `[{"driver":"nfs"}]`,
+				identity.AnnotationAgentName: "label-agent",
+			},
+		},
+		{
+			name: "agent name on labels only without annotations - checkpoint annotations created",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{identity.AnnotationAgentName: "label-agent"},
+				},
+			},
+			cp: &v1alpha1.Checkpoint{},
+			expectedAnnotation: map[string]string{
+				identity.AnnotationAgentName: "label-agent",
+			},
+		},
+		{
+			name: "annotation form wins over the label, matching GetAgentName",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{identity.AnnotationAgentName: "label-agent"},
+					Annotations: map[string]string{identity.AnnotationAgentName: "annotation-agent"},
+				},
+			},
+			cp: &v1alpha1.Checkpoint{},
+			expectedAnnotation: map[string]string{
+				identity.AnnotationAgentName: "annotation-agent",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -42,6 +42,7 @@ import (
 	"github.com/openkruise/agents/pkg/controller/sandboxset"
 	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/logs"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
@@ -220,7 +221,13 @@ func TryClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions, pickCa
 	// Step 2: Modify and lock sandbox. All modifications to be applied to the Sandbox should be performed here.
 	if err = modifyPickedSandbox(sbx, lockType, opts); err != nil {
 		log.Error(err, "failed to modify picked sandbox")
-		err = retriableError{Message: fmt.Sprintf("failed to modify picked sandbox: %s", err)}
+		// An already-classified manager error (e.g. ErrorBadRequest from the
+		// agent-name label convergence) is terminal: keep it unwrapped so the
+		// retry loop stops and its ErrorCode reaches the HTTP status mapping.
+		var mErr *managererrors.Error
+		if !errors.As(err, &mErr) {
+			err = retriableError{Message: fmt.Sprintf("failed to modify picked sandbox: %s", err)}
+		}
 		return
 	}
 
@@ -717,6 +724,21 @@ func modifyPickedSandbox(sbx *Sandbox, lockType infra.LockType, opts infra.Claim
 	}
 
 	sbx.SetAnnotations(annotations)
+
+	// Converge the agent-name labels on the sandbox and the pod template towards
+	// opts.AgentName so label-based consumers observe the agent name on both the
+	// Sandbox and its Pod. The controller syncs metadata-only pod template
+	// changes onto the live pod, so pooled sandboxes whose pod already exists
+	// pick the label up without recreation. Running this after opts.Modifier
+	// also drops the annotation form of the key, whichever caller injected it,
+	// keeping labels the only carrier. An invalid label value is a terminal user
+	// error: reject the claim instead of retrying a deterministic apiserver
+	// validation failure. The E2B parse layer already rejects invalid
+	// user-supplied names up front, so this backstop only fires for values
+	// injected after parsing.
+	if err := reconcileAgentNameLabels(sbx.Sandbox, opts.AgentName); err != nil {
+		return managererrors.NewError(managererrors.ErrorBadRequest, "%s", err.Error())
+	}
 	return nil
 }
 

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -2364,6 +2364,115 @@ func TestModifyPickedSandbox_CSIMount(t *testing.T) {
 	}
 }
 
+// TestModifyPickedSandbox_AgentNameLabels verifies that modifyPickedSandbox
+// converges the agent-name key towards opts.AgentName: the value is written to
+// both the sandbox labels and the pod template labels, a claim that requests no
+// agent name strips the label a previous claim left on the pooled sandbox, the
+// annotation form injected by opts.Modifier never survives, and values that
+// violate Kubernetes label-value constraints are rejected with a terminal
+// ErrorBadRequest so the claim retry loop stops instead of retrying a
+// deterministic failure.
+func TestModifyPickedSandbox_AgentNameLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		agentName      string
+		existingLabels map[string]string
+		modifier       func(sbx infra.Sandbox)
+		expectErrCode  managererrors.ErrorCode // empty means no error expected
+		wantLabel      string                  // expected label value; "" means the key must be absent
+		reason         string
+	}{
+		{
+			name:      "requested agent name is written to sandbox and pod labels",
+			agentName: "my-agent",
+			wantLabel: "my-agent",
+			reason:    "the canonical claim path",
+		},
+		{
+			name:   "no requested agent name leaves a clean sandbox untouched",
+			reason: "non-identity claims must stay inert",
+		},
+		{
+			name:           "no requested agent name strips a residual label",
+			existingLabels: map[string]string{identity.AnnotationAgentName: "previous-agent"},
+			reason:         "a recycled sandbox must not leak the previous claimer's identity",
+		},
+		{
+			name: "annotation injected by the modifier is dropped",
+			modifier: func(sbx infra.Sandbox) {
+				sbx.SetAnnotations(map[string]string{identity.AnnotationAgentName: "annotation-agent"})
+			},
+			reason: "only opts.AgentName is authoritative, the annotation is not a carrier",
+		},
+		{
+			name:          "invalid agent name is rejected as terminal bad request",
+			agentName:     strings.Repeat("a", 64),
+			expectErrCode: managererrors.ErrorBadRequest,
+			reason:        "a deterministic apiserver validation failure must not be retried",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The sandbox and the pod template must carry independent maps so the
+			// assertions below cannot pass by both reading the same one.
+			cloneLabels := func() map[string]string {
+				if tt.existingLabels == nil {
+					return nil
+				}
+				labels := make(map[string]string, len(tt.existingLabels))
+				for k, v := range tt.existingLabels {
+					labels[k] = v
+				}
+				return labels
+			}
+			sbx := &Sandbox{
+				Sandbox: &v1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-sandbox",
+						Namespace: "default",
+						Labels:    cloneLabels(),
+					},
+					Spec: v1alpha1.SandboxSpec{
+						EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+							Template: &corev1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{Labels: cloneLabels()},
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{Name: "main", Image: "test-image"}},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := modifyPickedSandbox(sbx, infra.LockTypeUpdate, infra.ClaimSandboxOptions{
+				Modifier:  tt.modifier,
+				AgentName: tt.agentName,
+			})
+
+			if tt.expectErrCode != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectErrCode, managererrors.GetErrCode(err), tt.reason)
+				return
+			}
+
+			require.NoError(t, err, tt.reason)
+			if tt.wantLabel != "" {
+				assert.Equal(t, tt.wantLabel, sbx.GetLabels()[identity.AnnotationAgentName],
+					"sandbox label must carry the requested agent name")
+				assert.Equal(t, tt.wantLabel, sbx.GetPodLabels()[identity.AnnotationAgentName],
+					"pod template label must carry the requested agent name")
+			} else {
+				assert.NotContains(t, sbx.GetLabels(), identity.AnnotationAgentName, tt.reason)
+				assert.NotContains(t, sbx.GetPodLabels(), identity.AnnotationAgentName, tt.reason)
+			}
+			assert.NotContains(t, sbx.GetAnnotations(), identity.AnnotationAgentName,
+				"the annotation is an input channel and must never be persisted")
+		})
+	}
+}
+
 // TestTryClaimSandbox_LockConflict tests the error handling in TryClaimSandbox when
 // performLockSandbox fails (claim.go lines 168-179). It verifies:
 // - Conflict error: ResourceVersionExpectation is set and a retriableError is returned.
@@ -4167,8 +4276,9 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 		{
 			name: "issue security token success and propagate",
 			options: infra.ClaimSandboxOptions{
-				User:     user,
-				Template: existTemplate,
+				User:      user,
+				Template:  existTemplate,
+				AgentName: "test-agent",
 				InitRuntime: &config.InitRuntimeOptions{
 					AccessToken: "original-uuid-token",
 				},
@@ -4197,8 +4307,9 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 		{
 			name: "issue security token failure returns retriable error",
 			options: infra.ClaimSandboxOptions{
-				User:     user,
-				Template: existTemplate,
+				User:      user,
+				Template:  existTemplate,
+				AgentName: "test-agent",
 				InitRuntime: &config.InitRuntimeOptions{
 					AccessToken: "original-uuid-token",
 				},
@@ -4217,8 +4328,9 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 		{
 			name: "propagate security token failure returns retriable error",
 			options: infra.ClaimSandboxOptions{
-				User:     user,
-				Template: existTemplate,
+				User:      user,
+				Template:  existTemplate,
+				AgentName: "test-agent",
 				InitRuntime: &config.InitRuntimeOptions{
 					AccessToken: "original-uuid-token",
 				},
@@ -4236,8 +4348,9 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 		{
 			name: "security token is issued even when access token is not UUID",
 			options: infra.ClaimSandboxOptions{
-				User:     user,
-				Template: existTemplate,
+				User:      user,
+				Template:  existTemplate,
+				AgentName: "test-agent",
 				InitRuntime: &config.InitRuntimeOptions{
 					AccessToken: "some-token",
 				},
@@ -4258,8 +4371,9 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 		{
 			name: "security token is issued even when InitRuntime is nil",
 			options: infra.ClaimSandboxOptions{
-				User:     user,
-				Template: existTemplate,
+				User:      user,
+				Template:  existTemplate,
+				AgentName: "test-agent",
 			},
 			mockProvider: &mockIdentityProvider{
 				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
@@ -4275,14 +4389,44 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 			},
 		},
 		{
-			// Verifies the IsIDTokenRequested opt-in gate — when the
-			// sandbox does NOT carry the security.agents.kruise.io/agent-name
-			// annotation, the entire identity provider branch must be skipped: neither
-			// IssueToken nor PropagateSecurityToken may run, no TokenRefreshStatus
-			// annotation may be persisted, and metrics.SecurityToken must remain
-			// zero. This is the dedicated opt-in regression test for the
-			// IsIDTokenRequested predicate.
-			name: "skips security token issuance when agent-name annotation is absent",
+			// Verifies the IsIDTokenRequested opt-in gate: when the claim requests
+			// no agent name, the entire identity provider branch must be skipped —
+			// neither IssueToken nor PropagateSecurityToken may run, no
+			// TokenRefreshStatus annotation may be persisted, and
+			// metrics.SecurityToken must remain zero.
+			name: "skips security token issuance when no agent name is requested",
+			options: infra.ClaimSandboxOptions{
+				User:     user,
+				Template: existTemplate,
+				InitRuntime: &config.InitRuntimeOptions{
+					AccessToken: "original-uuid-token",
+				},
+			},
+			mockProvider: &mockIdentityProvider{
+				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
+					t.Fatalf("IssueToken must not be called when no agent name is requested")
+					return nil, nil
+				},
+				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
+					t.Fatalf("PropagateSecurityToken must not be called when no agent name is requested")
+					return nil
+				},
+			},
+			postCheck: func(t *testing.T, sbx infra.Sandbox, metrics infra.ClaimMetrics) {
+				annotations := sbx.GetAnnotations()
+				assert.Empty(t, annotations[identity.AgentKeyTokenRefreshStatus],
+					"TokenRefreshStatus annotation must NOT be written when the provider branch is skipped")
+				assert.Equal(t, time.Duration(0), metrics.SecurityToken,
+					"SecurityToken metric must remain zero when the provider branch is skipped")
+			},
+		},
+		{
+			// A pooled sandbox may still carry the agent-name metadata a previous
+			// claim left behind (the recycle flow does not reset it yet). The claim
+			// flow converges the key against the requested value, so an unrequested
+			// agent name must be stripped before the opt-in gate runs and must
+			// never issue a token bound to the previous claimer's identity.
+			name: "residual agent-name metadata does not opt the claim in",
 			options: infra.ClaimSandboxOptions{
 				User:     user,
 				Template: existTemplate,
@@ -4291,23 +4435,20 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 				},
 			},
 			preModifier: func(sbx *v1alpha1.Sandbox) {
-				// Strip the opt-in annotation so IsIDTokenRequested returns false.
-				delete(sbx.Annotations, identity.AnnotationAgentName)
+				sbx.Labels[identity.AnnotationAgentName] = "previous-agent"
+				sbx.Annotations[identity.AnnotationAgentName] = "previous-agent"
 			},
 			mockProvider: &mockIdentityProvider{
 				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
-					t.Fatalf("IssueToken must not be called when agent-name annotation is absent")
+					t.Fatalf("IssueToken must not be called for a residual agent name")
 					return nil, nil
-				},
-				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
-					t.Fatalf("PropagateSecurityToken must not be called when agent-name annotation is absent")
-					return nil
 				},
 			},
 			postCheck: func(t *testing.T, sbx infra.Sandbox, metrics infra.ClaimMetrics) {
-				annotations := sbx.GetAnnotations()
-				assert.Empty(t, annotations[identity.AgentKeyTokenRefreshStatus],
-					"TokenRefreshStatus annotation must NOT be written when the provider branch is skipped")
+				assert.NotContains(t, sbx.GetLabels(), identity.AnnotationAgentName,
+					"the residual label must be stripped by the claim")
+				assert.NotContains(t, sbx.GetAnnotations(), identity.AnnotationAgentName,
+					"the annotation form must never be persisted")
 				assert.Equal(t, time.Duration(0), metrics.SecurityToken,
 					"SecurityToken metric must remain zero when the provider branch is skipped")
 			},
@@ -4342,9 +4483,6 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 					CreationTimestamp: metav1.Now(),
 					Annotations: map[string]string{
 						v1alpha1.AnnotationRuntimeURL: server.URL,
-						// Opt the sandbox into the identity provider issuance path;
-						// the dedicated "absent" sub-test strips this annotation via preModifier.
-						identity.AnnotationAgentName: "test-agent",
 					},
 					OwnerReferences: GetSbsOwnerReference(),
 				},

--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -304,7 +304,21 @@ func prepareSandboxFromCheckpoint(ctx context.Context, opts infra.CloneSandboxOp
 	if opts.CSIMount != nil && opts.CSIMount.MountOptionListRaw != "" {
 		sbx.Annotations[v1alpha1.AnnotationCSIVolumeConfig] = opts.CSIMount.MountOptionListRaw
 	}
+	// Converge the agent-name labels on the cloned sandbox and its pod template,
+	// mirroring the claim flow (modifyPickedSandbox). The expected value comes
+	// from the clone request, falling back to the agent name persisted with the
+	// checkpoint so a snapshot keeps its identity binding. Running after
+	// RestoreAnnotationsFromCheckpoint and DefaultPostProcessClonedSandbox means
+	// a deployment-specific post-process hook that injects the annotation cannot
+	// leave the labels drifting from it. When neither source carries an agent
+	// name, the label inherited from the source sandbox's pod template is
+	// removed, so a clone never silently keeps the snapshot's identity. An
+	// invalid label value is a terminal user error: reject the clone instead of
+	// retrying a deterministic apiserver validation failure.
 	DefaultPostProcessClonedSandbox(sbx.Sandbox)
+	if err := reconcileAgentNameLabels(sbx.Sandbox, resolveCloneAgentName(opts, cp)); err != nil {
+		return nil, nil, managererrors.NewError(managererrors.ErrorBadRequest, "%s", err.Error())
+	}
 	return sbx, initRuntimeOpts, nil
 }
 

--- a/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -454,6 +455,116 @@ func TestPrepareSandboxFromCheckpoint_CSIMountConfigPrecedence(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, sbx)
 			assert.Equal(t, tt.expectCSIAnno, sbx.GetAnnotations()[v1alpha1.AnnotationCSIVolumeConfig])
+		})
+	}
+}
+
+// TestPrepareSandboxFromCheckpoint_AgentNameLabels verifies how a clone resolves
+// the agent name and converges it onto the cloned sandbox's labels and pod
+// template labels: the request value wins, the checkpoint value keeps a
+// snapshot's binding alive when the request is silent, an unbound clone has the
+// label inherited from the snapshot's pod template stripped, the annotation form
+// is never persisted, and a value violating Kubernetes label-value constraints
+// rejects the clone with a terminal ErrorBadRequest instead of retrying.
+func TestPrepareSandboxFromCheckpoint_AgentNameLabels(t *testing.T) {
+	newTemplate := func(labels map[string]string) *v1alpha1.SandboxTemplate {
+		return &v1alpha1.SandboxTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: "cp-agent", Namespace: "default"},
+			Spec: v1alpha1.SandboxTemplateSpec{
+				Template: &corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: labels},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "main", Image: "test-image"}},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		requestAgentName string                  // agent name carried by the clone request
+		checkpointAgent  string                  // checkpoint's agent-name annotation; "" means absent
+		templateLabels   map[string]string       // pod template labels inherited from the snapshot
+		expectErrCode    managererrors.ErrorCode // empty means no error expected
+		wantLabel        string
+		reason           string
+	}{
+		{
+			name:             "request value is written to labels",
+			requestAgentName: "request-agent",
+			wantLabel:        "request-agent",
+			reason:           "a clone may bind a fresh identity without a snapshot carrying one",
+		},
+		{
+			name:            "checkpoint value applies when the request is silent",
+			checkpointAgent: "checkpoint-agent",
+			wantLabel:       "checkpoint-agent",
+			reason:          "a snapshot must keep its identity binding across a clone",
+		},
+		{
+			name:             "request value overrides the checkpoint value",
+			requestAgentName: "request-agent",
+			checkpointAgent:  "checkpoint-agent",
+			templateLabels:   map[string]string{identity.AnnotationAgentName: "checkpoint-agent"},
+			wantLabel:        "request-agent",
+			reason:           "the caller must be able to rebind the clone",
+		},
+		{
+			name:   "no agent name anywhere leaves the clone unbound",
+			reason: "clones of non-identity snapshots must stay inert",
+		},
+		{
+			name:           "inherited pod template label is stripped when unbound",
+			templateLabels: map[string]string{identity.AnnotationAgentName: "snapshot-agent"},
+			reason:         "an unbound clone must not silently keep the snapshot's identity",
+		},
+		{
+			name:            "invalid agent name from the checkpoint rejects the clone",
+			checkpointAgent: strings.Repeat("a", 64),
+			expectErrCode:   managererrors.ErrorBadRequest,
+			reason:          "a deterministic apiserver validation failure must not be retried",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cp := &v1alpha1.Checkpoint{
+				ObjectMeta: metav1.ObjectMeta{Name: "cp-agent", Namespace: "default"},
+			}
+			if tt.checkpointAgent != "" {
+				cp.Annotations = map[string]string{
+					identity.AnnotationAgentName: tt.checkpointAgent,
+				}
+			}
+
+			opts := infra.CloneSandboxOptions{
+				User:         "test-user",
+				CheckPointID: "cp-agent",
+				AgentName:    tt.requestAgentName,
+			}
+
+			sbx, _, err := prepareSandboxFromCheckpoint(t.Context(), opts, newTemplate(tt.templateLabels), cp, nil)
+
+			if tt.expectErrCode != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectErrCode, managererrors.GetErrCode(err), tt.reason)
+				return
+			}
+
+			require.NoError(t, err, tt.reason)
+			require.NotNil(t, sbx)
+			if tt.wantLabel != "" {
+				assert.Equal(t, tt.wantLabel, sbx.GetLabels()[identity.AnnotationAgentName],
+					"sandbox label must carry the resolved agent name")
+				assert.Equal(t, tt.wantLabel, sbx.GetPodLabels()[identity.AnnotationAgentName],
+					"pod template label must carry the resolved agent name")
+			} else {
+				assert.NotContains(t, sbx.GetLabels(), identity.AnnotationAgentName, tt.reason)
+				assert.NotContains(t, sbx.GetPodLabels(), identity.AnnotationAgentName, tt.reason)
+			}
+			assert.NotContains(t, sbx.GetAnnotations(), identity.AnnotationAgentName,
+				"the annotation restored from the checkpoint must not be persisted")
 		})
 	}
 }
@@ -2247,7 +2358,7 @@ func TestCloneSandbox_SecurityToken(t *testing.T) {
 	tests := []struct {
 		name         string
 		mockProvider *mockIdentityProvider
-		addAgentName bool
+		agentName    string // agent name requested by the clone; "" means not opted in
 		expectError  string
 		postCheck    func(t *testing.T, sbx infra.Sandbox, metrics infra.CloneMetrics)
 	}{
@@ -2261,7 +2372,7 @@ func TestCloneSandbox_SecurityToken(t *testing.T) {
 					return nil
 				},
 			},
-			addAgentName: true,
+			agentName: "test-agent",
 			postCheck: func(t *testing.T, sbx infra.Sandbox, metrics infra.CloneMetrics) {
 				annotations := sbx.GetAnnotations()
 				// SecurityToken metrics should be recorded
@@ -2271,6 +2382,9 @@ func TestCloneSandbox_SecurityToken(t *testing.T) {
 				assert.NotEmpty(t, raw)
 				var decoded identity.TokenRefreshStatus
 				require.NoError(t, json.Unmarshal([]byte(raw), &decoded))
+				assert.Equal(t, "test-agent", sbx.GetLabels()[identity.AnnotationAgentName],
+					"the agent name must be carried by the label, not the annotation")
+				assert.NotContains(t, annotations, identity.AnnotationAgentName)
 			},
 		},
 		{
@@ -2284,8 +2398,8 @@ func TestCloneSandbox_SecurityToken(t *testing.T) {
 					return nil
 				},
 			},
-			addAgentName: true,
-			expectError:  "failed to issue security token",
+			agentName:   "test-agent",
+			expectError: "failed to issue security token",
 		},
 		{
 			name: "propagate security token failure returns retriable error",
@@ -2297,22 +2411,21 @@ func TestCloneSandbox_SecurityToken(t *testing.T) {
 					return fmt.Errorf("propagation failed")
 				},
 			},
-			addAgentName: true,
-			expectError:  "propagation failed",
+			agentName:   "test-agent",
+			expectError: "propagation failed",
 		},
 		{
-			name: "skips security token issuance when agent-name annotation is absent",
+			name: "skips security token issuance when no agent name is requested",
 			mockProvider: &mockIdentityProvider{
 				issueTokenFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error) {
-					t.Fatalf("IssueToken must not be called when agent-name annotation is absent")
+					t.Fatalf("IssueToken must not be called when no agent name is requested")
 					return nil, nil
 				},
 				propagateFunc: func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
-					t.Fatalf("PropagateSecurityToken must not be called when agent-name annotation is absent")
+					t.Fatalf("PropagateSecurityToken must not be called when no agent name is requested")
 					return nil
 				},
 			},
-			addAgentName: false,
 			postCheck: func(t *testing.T, sbx infra.Sandbox, metrics infra.CloneMetrics) {
 				annotations := sbx.GetAnnotations()
 				assert.Empty(t, annotations[identity.AgentKeyTokenRefreshStatus],
@@ -2378,17 +2491,15 @@ func TestCloneSandbox_SecurityToken(t *testing.T) {
 				return err == nil
 			}, time.Second, 10*time.Millisecond)
 
-			// Decorator: DefaultCreateSandbox - set sandbox ready after creation and
-			// optionally add the agent-name annotation to opt into the identity provider path.
+			// Decorator: DefaultCreateSandbox - set sandbox ready after creation.
+			// The agent name is requested through the clone options instead, so the
+			// convergence in prepareSandboxFromCheckpoint is what opts the sandbox in.
 			origCreateSandbox := DefaultCreateSandbox
 			DefaultCreateSandbox = func(ctx context.Context, sbx *v1alpha1.Sandbox, c client.Client) (*v1alpha1.Sandbox, error) {
 				if sbx.Annotations == nil {
 					sbx.Annotations = map[string]string{}
 				}
 				sbx.Annotations[v1alpha1.AnnotationRuntimeURL] = server.URL
-				if tt.addAgentName {
-					sbx.Annotations[identity.AnnotationAgentName] = "test-agent"
-				}
 				created, err := origCreateSandbox(ctx, sbx, c)
 				if err != nil {
 					return nil, err
@@ -2420,6 +2531,7 @@ func TestCloneSandbox_SecurityToken(t *testing.T) {
 				CheckPointID:     checkpointID,
 				WaitReadyTimeout: 30 * time.Second,
 				CloneTimeout:     500 * time.Millisecond,
+				AgentName:        tt.agentName,
 			}
 
 			ctx, cancel := context.WithTimeout(t.Context(), opts.CloneTimeout)

--- a/pkg/sandbox-manager/infra/types.go
+++ b/pkg/sandbox-manager/infra/types.go
@@ -83,6 +83,15 @@ type ClaimSandboxOptions struct {
 	// added during claim (from SandboxClaim.Spec or E2B request). Used by the
 	// cleanup flow to clean up user metadata when returning the sandbox to the pool.
 	UserMetadataKeys *v1alpha1.UpdatedMetadataInClaim `json:"-"`
+	// AgentName is the agent name requested for this claim, already resolved by
+	// the caller from its own protocol input (E2B request metadata, SandboxClaim
+	// spec). It is the single expected value the claim flow converges the
+	// identity.AnnotationAgentName labels to: a non-empty value is written to the
+	// sandbox and pod template labels, and an empty value removes any label a
+	// previous claim left behind on a pooled sandbox. Callers must not express
+	// the agent name through Modifier annotations instead; only this field is
+	// authoritative.
+	AgentName string `json:"agentName,omitempty"`
 	// Claim is the SandboxClaim that triggers this claim. May be nil for
 	// non-CRD paths such as the E2B API. IdentityProvider implementations must
 	// handle a nil Claim gracefully.
@@ -109,6 +118,11 @@ type CloneSandboxOptions struct {
 	// GenerateName sets ObjectMeta.GenerateName on the cloned sandbox (prefix).
 	// Mutually exclusive with Name.
 	GenerateName string `json:"generateName,omitempty"`
+	// AgentName is the agent name requested for this clone. See AgentName on
+	// ClaimSandboxOptions for the convergence contract. When empty, the clone
+	// flow falls back to the agent name persisted with the checkpoint, so a
+	// snapshot keeps its identity binding without the caller repeating it.
+	AgentName string `json:"agentName,omitempty"`
 }
 
 type CreateCheckpointOptions struct {

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -164,6 +164,7 @@ func (sc *Controller) createSandboxWithClaim(ctx context.Context, request models
 		ReserveFailedSandboxFor: request.Extensions.ReserveFailedSandboxFor,
 		CreateOnNoStock:         request.Extensions.CreateOnNoStock,
 		UserMetadataKeys:        sandboxcr.BuildUserMetadataKeys(request.Extensions.Labels, request.Metadata),
+		AgentName:               request.Extensions.AgentName,
 	}
 
 	if !request.Extensions.SkipInitRuntime {
@@ -254,6 +255,7 @@ func (sc *Controller) createSandboxWithClone(ctx context.Context, request models
 		ReserveFailedSandboxFor: request.Extensions.ReserveFailedSandboxFor,
 		Name:                    request.Extensions.Name,
 		GenerateName:            request.Extensions.GenerateName,
+		AgentName:               request.Extensions.AgentName,
 	}
 	infraOpts.WaitReadyTimeout = resolveServerTimeout(request.Extensions.WaitReadySeconds)
 

--- a/pkg/servers/e2b/list.go
+++ b/pkg/servers/e2b/list.go
@@ -205,8 +205,16 @@ func getListFilter(request ListSandboxesRequest) func(sbx infra.Sandbox) bool {
 			}
 		}
 		if len(request.Metadata) > 0 {
+			// Metadata is surfaced from both annotations and labels (see
+			// convertToE2BSandbox), so the filter must consult both. Keys stored
+			// only as a label — the agent name is one — would otherwise never
+			// match, even though a GET on the same sandbox reports them.
+			annotations, labels := sbx.GetAnnotations(), sbx.GetLabels()
 			for key, value := range request.Metadata {
-				if sbx.GetAnnotations()[key] != value {
+				if annotations[key] == value {
+					continue
+				}
+				if labels[key] != value {
 					return false
 				}
 			}

--- a/pkg/servers/e2b/list_test.go
+++ b/pkg/servers/e2b/list_test.go
@@ -26,6 +26,9 @@ import (
 
 	"github.com/google/uuid"
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/identity"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
@@ -35,6 +38,83 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
+
+// TestGetListFilter_MetadataSources verifies that the metadata filter matches
+// against both the sandbox annotations and its labels. Metadata is surfaced from
+// both sources by convertToE2BSandbox, so a key stored only as a label — the
+// agent name is one — must be filterable too, otherwise a GET would report a
+// value that LIST cannot find.
+func TestGetListFilter_MetadataSources(t *testing.T) {
+	tests := []struct {
+		name        string
+		labels      map[string]string
+		annotations map[string]string
+		metadata    map[string]string
+		want        bool
+		reason      string
+	}{
+		{
+			name:        "annotation match",
+			annotations: map[string]string{"testKey": "value1"},
+			metadata:    map[string]string{"testKey": "value1"},
+			want:        true,
+			reason:      "plain E2B metadata is stored as an annotation",
+		},
+		{
+			name:     "label-only match",
+			labels:   map[string]string{identity.AnnotationAgentName: "my-agent"},
+			metadata: map[string]string{identity.AnnotationAgentName: "my-agent"},
+			want:     true,
+			reason:   "the agent name is carried by labels only",
+		},
+		{
+			name:        "value mismatch in both sources",
+			labels:      map[string]string{identity.AnnotationAgentName: "other-agent"},
+			annotations: map[string]string{"testKey": "value2"},
+			metadata:    map[string]string{identity.AnnotationAgentName: "my-agent"},
+			reason:      "a filter that matches neither source must exclude the sandbox",
+		},
+		{
+			name:        "all requested keys must match",
+			labels:      map[string]string{identity.AnnotationAgentName: "my-agent"},
+			annotations: map[string]string{"testKey": "value2"},
+			metadata: map[string]string{
+				identity.AnnotationAgentName: "my-agent",
+				"testKey":                    "value1",
+			},
+			reason: "metadata filtering stays conjunctive across sources",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := sandboxcr.AsSandbox(&agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-sandbox",
+					Namespace:   "default",
+					Labels:      tt.labels,
+					Annotations: tt.annotations,
+				},
+				// A claimed, ready and running sandbox: the state filter must pass so
+				// the assertions below only reflect the metadata matching.
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+					Conditions: []metav1.Condition{{
+						Type:   string(agentsv1alpha1.SandboxConditionReady),
+						Status: metav1.ConditionTrue,
+					}},
+				},
+			}, nil)
+
+			filter := getListFilter(ListSandboxesRequest{
+				States:   []string{agentsv1alpha1.SandboxStateRunning},
+				Metadata: tt.metadata,
+			})
+			var asInfra infra.Sandbox = sbx
+			assert.Equal(t, tt.want, filter(asInfra), tt.reason)
+		})
+	}
+}
 
 func TestListSandboxes(t *testing.T) {
 	templateName := "test-template"

--- a/pkg/servers/e2b/models/extensions.go
+++ b/pkg/servers/e2b/models/extensions.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/distribution/reference"
+	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/pausedretention"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/utils/timeout"
@@ -137,6 +138,17 @@ func (r *NewSandboxRequest) parseCommonExtensions() error {
 	if err = r.parseExtensionLabels(); err != nil {
 		return err
 	}
+	// The agent name is stored on the sandbox and pod labels, so an invalid value
+	// would otherwise only surface as a terminal claim/clone failure after a
+	// sandbox has been picked. Reject it at parse time instead and resolve it
+	// into the extensions, so the claim and clone options can pass the expected
+	// value explicitly to the infra layer. The entry deliberately stays in
+	// Metadata: it keeps the E2B metadata round-trip intact for callers that
+	// re-send it, and the infra layer drops the annotation form anyway.
+	if err = identity.ValidateAgentName(r.Metadata[identity.AnnotationAgentName]); err != nil {
+		return err
+	}
+	r.Extensions.AgentName = r.Metadata[identity.AnnotationAgentName]
 	if err = r.parseExtensionSandboxNaming(); err != nil {
 		return err
 	}

--- a/pkg/servers/e2b/models/extensions_test.go
+++ b/pkg/servers/e2b/models/extensions_test.go
@@ -18,9 +18,11 @@ package models
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/utils/timeout"
 	"github.com/stretchr/testify/assert"
@@ -360,6 +362,22 @@ func TestParseExtensions(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "agent name exceeding 63 characters is rejected at parse time",
+			metadata: map[string]string{
+				identity.AnnotationAgentName: strings.Repeat("a", 64),
+			},
+			wantErr:     true,
+			errContains: "is not a valid label value",
+		},
+		{
+			name: "agent name with invalid characters is rejected at parse time",
+			metadata: map[string]string{
+				identity.AnnotationAgentName: "agent/with/slashes",
+			},
+			wantErr:     true,
+			errContains: "is not a valid label value",
+		},
+		{
 			name: "valid csi mount extension",
 			metadata: map[string]string{
 				ExtensionKeyClaimWithCSIMount_VolumeName: "test-volume",
@@ -464,6 +482,45 @@ func TestParseExtensions(t *testing.T) {
 				require.NoError(t, err)
 				assert.EqualValues(t, tt.expectExtension, req.Extensions)
 				assert.Empty(t, req.Metadata)
+			}
+		})
+	}
+}
+
+// TestParseExtensionsResolvesAgentName ensures a valid agent-name metadata entry
+// passes parse-time validation, is resolved into Extensions so the claim and
+// clone options can pass it explicitly to the infra layer, and — unlike
+// extension keys — survives in Metadata so the E2B metadata round-trip stays
+// intact. It cannot join the TestParseExtensions table, whose success branch
+// asserts Metadata ends up empty.
+func TestParseExtensionsResolvesAgentName(t *testing.T) {
+	tests := []struct {
+		name      string
+		metadata  map[string]string
+		wantAgent string
+		reason    string
+	}{
+		{
+			name:      "valid agent name is resolved and kept in metadata",
+			metadata:  map[string]string{identity.AnnotationAgentName: "my-agent"},
+			wantAgent: "my-agent",
+			reason:    "the infra layer needs the value as an explicit option",
+		},
+		{
+			name:     "absent agent name resolves to empty",
+			metadata: map[string]string{},
+			reason:   "an empty expected value strips residual labels during claim",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &NewSandboxRequest{Metadata: tt.metadata}
+			require.NoError(t, req.ParseExtensions())
+			assert.Equal(t, tt.wantAgent, req.Extensions.AgentName, tt.reason)
+			if tt.wantAgent != "" {
+				assert.Equal(t, tt.wantAgent, req.Metadata[identity.AnnotationAgentName],
+					"the entry must stay in Metadata for the E2B round-trip")
 			}
 		})
 	}

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -82,6 +82,12 @@ type NewSandboxRequestExtension struct {
 	Labels                       map[string]string
 	Name                         string
 	GenerateName                 string
+	// AgentName carries the security.agents.kruise.io/agent-name entry supplied
+	// through the request metadata. It is resolved here so the claim and clone
+	// options can pass the expected value explicitly to the infra layer, which
+	// stores the agent name on the sandbox and pod labels rather than on the
+	// annotations.
+	AgentName string
 }
 
 type InplaceUpdateExtension struct {


### PR DESCRIPTION
…ate labels

The security.agents.kruise.io/agent-name annotation remains the single source of truth and the only opt-in signal for token issuance, but label-based consumers need to observe the agent name on both the Sandbox and its Pod. Add identity.MirrorAgentNameToLabels to mirror the annotation value into the sandbox labels and the inline pod template labels under the same key, validating it against Kubernetes label-value constraints and rejecting invalid values before any apiserver write can fail.

Wire the mirror into both infra choke points so the E2B and SandboxClaim protocols are covered uniformly: modifyPickedSandbox on the claim path (after the request modifier injected the annotations) and prepareSandboxFromCheckpoint on the clone path (after RestoreAnnotationsFromCheckpoint and DefaultPostProcessClonedSandbox, so a post-process hook rewriting the annotation cannot leave the label drifting). An invalid value is classified as a terminal ErrorBadRequest, and TryClaimSandbox now lets already-classified manager errors pass through unwrapped so the retry loop stops and the HTTP layer maps them to 400 instead of retrying a deterministic validation failure.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

