### PR TITLE
test: add ReadHeaderTimeout to runtime-mtls-server HTTP servers

### DIFF
--- a/test/e2b/assets/runtime-mtls-server/main.go
+++ b/test/e2b/assets/runtime-mtls-server/main.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 )
 
 func main() {
@@ -37,7 +38,8 @@ func main() {
 
 	go func() {
 		plaintextServer := &http.Server{
-			Addr: ":8080",
+			Addr:              ":8080",
+			ReadHeaderTimeout: 5 * time.Second,
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				if _, err := fmt.Fprint(w, "runtime-plaintext-ok"); err != nil {
 					log.Printf("write plaintext response: %v", err)
@@ -48,7 +50,8 @@ func main() {
 	}()
 
 	server := &http.Server{
-		Addr: ":49983",
+		Addr:              ":49983",
+		ReadHeaderTimeout: 5 * time.Second,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			if _, err := fmt.Fprint(w, "runtime-mtls-ok"); err != nil {
 				log.Printf("write mTLS response: %v", err)


### PR DESCRIPTION
### Ⅰ. what this PR does

Sets a `ReadHeaderTimeout` on the two `http.Server` instances in the E2E test asset `test/e2b/assets/runtime-mtls-server/main.go` (plaintext `:8080` and mTLS `:49983`). Without a read-header timeout these servers are exposed to Slowloris-style denial-of-service attacks: an attacker can hold connections open by sending HTTP request bytes very slowly, eventually exhausting the listener.

This matches the convention already used in the sibling test asset `test/e2b/assets/jwt-oidc-provider/main.go` and in the production HTTP servers (`pkg/servers/e2b`, `pkg/proxy`, `pkg/sandbox-gateway`, and the pprof servers in `cmd/*`), all of which already set `ReadHeaderTimeout`.

### Ⅱ. Does this pull request fix one issue?

Fixes #346.

### Ⅲ.  how to verify it

- `gofmt -w test/e2b/assets/runtime-mtls-server/main.go` (no diff after running).
- `go vet ./test/e2b/assets/runtime-mtls-server/...` passes.
- `go build ./test/e2b/assets/runtime-mtls-server/...` passes.
- Manual Slowloris smoke: open a TCP connection to `:8080` and slowly drip bytes (one byte every few seconds) for more than 5 seconds; the server should drop the connection instead of holding it open indefinitely.


- Only test-asset code is changed. A repo-wide audit confirmed every production `http.Server` already had `ReadHeaderTimeout`.
- Chose `5 * time.Second` to mirror `test/e2b/assets/jwt-oidc-provider/main.go`; pprof servers in `cmd/*` use `10s` because they are debug-only.
- `pkg/servers/e2b/core_test.go` also creates an `http.Server` but it runs inside the Go test harness with no external network exposure, so it is intentionally left untouched.