### PR TITLE
docs(proposal): add agent identity proposals for sandbox ingress authn and outb…

### DIFF
--- a/docs/proposals/20260725-sandbox-ingress-authn.md
+++ b/docs/proposals/20260725-sandbox-ingress-authn.md
@@ -1,0 +1,1042 @@
+---
+title: Sandbox Ingress (envd) Token Authentication and aud Authorization
+authors:
+  - "@DahuK"
+reviewers:
+  - "@TBD"
+creation-date: 2026-07-25
+last-updated: 2026-07-25
+status: provisional
+see-also:
+  - "/docs/proposals/20260727-agent-dynamic-identity-spiffe-token-exchange.md"
+---
+
+# Sandbox Ingress (envd) Token Authentication and aud Authorization
+
+> Feature gate: `SandboxIngressJWTAuth` (gateway + manager, Alpha, disabled by default).
+
+## Table of Contents
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+- [Glossary](#glossary)
+- [Baseline (Current State)](#baseline-current-state)
+- [Proposal](#proposal)
+    - [Architecture: three planes](#architecture-three-planes)
+    - [Identity and aud semantics (SPIFFE)](#identity-and-aud-semantics-spiffe)
+    - [Token structure](#token-structure)
+    - [Issuance flow (sandbox-manager + identity)](#issuance-flow-sandbox-manager--identity)
+        - [Issuance credential: reuse the existing Team API Key](#issuance-credential-reuse-the-existing-team-api-key)
+        - [Issuer-side authorization: CanRequestToken (Decision A)](#issuer-side-authorization-canrequesttoken-decision-a)
+        - [Pluggable Signer detailed design](#pluggable-signer-detailed-design)
+        - [Issuer-side SDK design (extending the E2B SDK)](#issuer-side-sdk-design-extending-the-e2b-sdk)
+    - [Verification flow (sandbox-gateway filter)](#verification-flow-sandbox-gateway-filter)
+        - [JWKS retrieval and caching](#jwks-retrieval-and-caching)
+        - [Verification chain: authentication + authorization](#verification-chain-authentication--authorization)
+    - [Admin authorization: SandboxIngressPolicy CRD](#admin-authorization-sandboxingresspolicy-crd)
+    - [Two-sided enforcement and consistency](#two-sided-enforcement-and-consistency)
+    - [Revocation and key rotation](#revocation-and-key-rotation)
+    - [End-to-end sequence](#end-to-end-sequence)
+- [User Stories](#user-stories)
+- [Requirements](#requirements)
+- [Risks and Mitigations](#risks-and-mitigations)
+- [Alternatives](#alternatives)
+- [Upgrade Strategy](#upgrade-strategy)
+- [Test Plan](#test-plan)
+- [Implementation History](#implementation-history)
+
+## Summary
+
+This proposal introduces JWT-based authentication and **audience (aud)
+authorization** for the **ingress direction** of a sandbox (client →
+sandbox-gateway → envd/agent-runtime). Only a token whose `aud` explicitly
+contains the target sandbox's SPIFFE ID — and that passes signature, expiry,
+and admin policy checks — may reach that sandbox's envd ingress interfaces.
+
+Three parts:
+
+1. **Issuance plane** (sandbox-manager + `pkg/identity`): exchange an existing
+   Team API Key for a short-lived JWT carrying `aud`.
+2. **Authorization control plane**: a new namespaced CRD `SandboxIngressPolicy`
+   (symmetric to the egress `SecurityProfile`).
+3. **Verification data plane** (sandbox-gateway): upgrade the current static
+   `x-access-token` comparison into a tiered verification chain.
+
+envd itself is unchanged. The whole feature is guarded by the
+`SandboxIngressJWTAuth` feature gate (gateway + manager, Alpha, **disabled by
+default**); when disabled, the gateway reverts to the current static-token
+behavior and the `SandboxIngressPolicy` CRD is inert. It is fully backward
+compatible (`TokenClass=Opaque` preserves the legacy path). See
+[Upgrade Strategy](#upgrade-strategy) for rollout and rollback.
+
+## Motivation
+
+Today ingress auth is only a static `x-access-token` constant-time comparison
+per sandbox in the gateway. Problems:
+
+- **No audience isolation**: the token is a per-sandbox shared secret; a leak
+  cannot be scoped.
+- **No fine-grained authorization**: cannot restrict a caller to a subset of
+  envd interfaces.
+- **No standard lifecycle**: no `exp`, no stable subject, not revocable, no audit.
+
+This maps to roadmap → Runtime → *more secure access token and auditing*.
+
+### Goals
+
+- envd ingress accepts only tokens whose **aud contains the target sandbox
+  SPIFFE ID**; a missing aud yields 403.
+- Admins authorize "subject × sandbox × interface/capability" declaratively.
+- Short TTL (5min default) JWT + local signature verification; key rotation.
+- Reuse the existing Team API Key as the issuance credential, the
+  `SecurityProfile` authorization paradigm, and the gateway filter architecture.
+- Off by default, backward compatible, gradual rollout.
+
+### Non-Goals / Future Work
+
+- No authorization inside envd (Future).
+- No proof-of-possession / DPoP (strong non-transferability → X.509 + mTLS, Future).
+- **The first version performs only ownership checks on the issuer side
+  (Decision A)**; all fine-grained scope/interface authorization is enforced by
+  the gateway.
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| ingress | client → sandbox-gateway → envd/agent-runtime direction |
+| envd | agent-runtime sidecar inside a sandbox pod exposing E2B-compatible APIs |
+| **sandbox SPIFFE ID** | `spiffe://<trust-domain>/ns/{namespace}/sandbox/{name}` — the aud value |
+| **caller SPIFFE ID (sub)** | `spiffe://<trust-domain>/principal/apikey/{user.ID}` — derived from the Team API Key |
+| aud | JWT audience; the target sandbox SPIFFE ID |
+| scope | envd interface-level capability, e.g. `envd:fs:read` |
+| TokenClass | token format: `JWT` (new) or `Opaque` (legacy static token) |
+| Role A / Role B | A = issuance credential (Team API Key, admission ticket); B = ingress token (newly issued JWT) |
+
+## Baseline (Current State)
+
+> All facts are from the current codebase.
+
+| Aspect | Current implementation | Location |
+|--------|------------------------|----------|
+| Ingress auth | static `x-access-token` constant-time compare, `EnableAuth` defaults false | `pkg/sandbox-gateway/filter/filter.go:116` |
+| Route carrier | `Route{IP,ID,UID,Owner,State,ResourceVersion,AccessToken}`, `AccessToken` from annotation `agents.kruise.io/runtime-access-token` | `pkg/utils/proxyutils/route.go:39,45` |
+| Sandbox lookup | `adapter.Map` derives sandboxID, port from authority/path | `filter.go:74` |
+| Issuance credential | Team API Key (`X-API-Key`) → `CheckApiKey` → `*models.CreatedTeamAPIKey` (has `ID`, `Team.Name`) | `pkg/servers/e2b/routes.go:100`, `models/api_key.go` |
+| Identity granularity | team name → namespace (`getNamespaceOfUser`), admin team is cluster-scoped | `pkg/servers/e2b/routes.go:207` |
+| Token issuance API | `IdentityProvider.IssueToken(ctx,sbx,claim)→TokenResponse{AccessToken}`, `TokenType`=Agent/Principal | `pkg/identity/{interface,types}.go` |
+| Enterprise transport | `identityProviderClient.Invoke(action,req,resp)` generic action router, `ValidateToken/RevokeToken` reserved | `pkg/identity/inner/security_provider.go:513,86` |
+| Material distribution template | `GetProxyCABundle` action + `CABundleSpec` registry + lazy provider three-state layering | `pkg/identity/inner/proxy_ca_bundle.go` |
+| Egress authorization paradigm | `SecurityProfile` CRD: Selector + ordered Rules + Accepted/Programmed | `api/v1alpha1/securityprofile_types.go` |
+
+## Proposal
+
+### Architecture: three planes
+
+```
+                 ┌────────────── Control plane (admin) ──────────────┐
+                 │  kubectl apply SandboxIngressPolicy (new CRD)      │
+                 │        │ watch                                     │
+                 │        ▼                                           │
+                 │  ingresspolicy-controller ─► compile ─► gateway registry
+                 └───────────────────────┬────────────────────────────┘
+                                         │ policy + JWKS
+ [Issuance]                              ▼
+ caller ─POST /v1/ingress-tokens(X-API-Key)─► sandbox-manager
+              │ CanRequestToken(Decision A: aud exists + team→namespace ownership)
+              ▼
+        identity.IssueToken → Signer signs JWT(aud=spiffe://.../sandbox/A, exp=5m)
+              │
+ [Data plane]  ▼ Authorization: Bearer <jwt>
+ caller ───────────► sandbox-gateway.filter.DecodeHeaders
+                        1. adapter.Map resolves sandboxID (existing)
+                        --- authentication ---
+                        2. JWKS verify (kid, RS256/ES256)
+                        3. exp/iat/nbf + iss
+                        4. aud ∋ sandbox SPIFFE ID       ◄── core
+                        --- authorization ---
+                        5. SandboxIngressPolicy(sub/path/method/scope)
+                        6. allow → forward to envd ; else 401/403
+```
+
+```mermaid
+flowchart TB
+    subgraph CtrlPlane[Control plane · admin]
+        SIP[SandboxIngressPolicy CRD]
+        IPC[ingresspolicy controller]
+        SIP -->|watch| IPC
+    end
+
+    subgraph IssuePlane[Issuance plane · sandbox-manager]
+        ISSUE[POST /v1/ingress-tokens]
+        AUTHZ["CanRequestToken<br/>Decision A: aud exists + team→namespace ownership"]
+        SIGNER[Signer signs JWT]
+        ISSUE --> AUTHZ --> SIGNER
+    end
+
+    subgraph DataPlane[Data plane · sandbox-gateway]
+        FILTER[filter.DecodeHeaders]
+        AUTHN["authentication<br/>verify · exp/iss · aud ∋ sandbox SPIFFE ID"]
+        AZ["authorization<br/>policy.Evaluate sub/path/method/scope"]
+        FILTER --> AUTHN --> AZ
+    end
+
+    Caller((caller))
+    ENVD[[envd / agent-runtime]]
+
+    Caller -->|1. X-API-Key| ISSUE
+    SIGNER -->|JWT aud=spiffe://.../sandbox/A, exp=5m| Caller
+    Caller -->|2. Bearer JWT| FILTER
+    IPC -->|compiled decision table| DataPlane
+    IssuePlane -.JWKS /.well-known/jwks.json.-> DataPlane
+    AZ -->|allow| ENVD
+    AZ -.deny.-> Reject[401 / 403]
+```
+
+**Important boundary**: **issuance happens in sandbox-manager, verification in
+the gateway. The gateway never issues.** "Two-sided enforcement" means the same
+`SandboxIngressPolicy` is evaluated once on each side (see
+[Two-sided enforcement](#two-sided-enforcement-and-consistency)); in the first
+version the issuer side only does ownership checks (Decision A).
+
+### Identity and aud semantics (SPIFFE)
+
+**Decision: `aud` = the target sandbox's SPIFFE ID.** Rationale:
+
+1. Minimal leak surface: a stolen token can only hit sandboxes in its aud.
+2. Natural boundary: the envd ingress trust boundary is exactly "a sandbox",
+   which maps directly to the "specific aud range" requirement.
+3. SPIFFE naming is readable, cross-cluster unique, and aligns with a standard
+   zero-trust identity model.
+
+```
+spiffe://agents.kruise.io/ns/{namespace}/sandbox/{sandboxName}
+```
+
+`aud` is an array, supporting one token that accesses a small set of sandboxes
+(e.g. sandboxes from the same batch SandboxClaim).
+
+**Caller subject `sub` = `spiffe://agents.kruise.io/principal/apikey/{user.ID}`**
+(key-granularity, derived from `CreatedTeamAPIKey.ID`, zero data-model change).
+
+### Token structure
+
+```jsonc
+{
+  "iss": "https://identity.agents.kruise.io",                  // trusted issuer
+  "sub": "spiffe://agents.kruise.io/principal/apikey/8f3c...",  // caller, key-granularity
+  "aud": ["spiffe://agents.kruise.io/ns/default/sandbox/sbx-abc"],
+  "exp": 1750000300,                                           // 5min default
+  "iat": 1750000000,
+  "nbf": 1750000000,
+  "jti": "req-uuid",                                           // revocation / audit
+  "scope": ["envd:fs:read", "envd:cmd:exec"]                   // optional
+}
+```
+
+Signing algorithm restricted to `RS256` / `ES256` (asymmetric; verifiers need
+only the public key).
+
+### Issuance flow (sandbox-manager + identity)
+
+#### Issuance credential: reuse the existing Team API Key
+
+The issuance endpoint introduces **no new credential**. Callers present the
+existing Team API Key (`X-API-Key`) and reuse the existing `CheckApiKey`
+middleware. The API Key plays only the "admission ticket (Role A)" role — it is
+exchanged for the ingress JWT and is never used to access envd directly.
+
+> **Why the API Key is not the ingress token (Role B)**: the API Key is a
+> team-granularity, long-lived, opaque shared pass — no `aud` (cannot be scoped
+> to a single sandbox), no `exp` (unbounded leak window), granularity only at
+> team level, and verification requires a KeyStorage lookup (undesirable in the
+> gateway data plane). So the API Key only "admits", and the short-lived JWT
+> "travels".
+
+Backward-compatible extensions to `TokenRequest` / `TokenResponse`:
+
+```go
+type TokenRequest struct {
+    TokenType TokenType         `json:"tokenType"`
+    Principal *PrincipalInfo    `json:"principal,omitempty"`
+    Sandbox   *SandboxInfo      `json:"sandbox,omitempty"`
+    Metadata  map[string]string `json:"metadata,omitempty"`
+    RequestedAudience []string  `json:"requestedAudience,omitempty"` // new: sandbox SPIFFE IDs
+    Scope             []string  `json:"scope,omitempty"`             // new: requested capabilities
+}
+
+type TokenResponse struct {
+    RequestID             string `json:"requestId"`
+    AccessToken           string `json:"accessToken"`
+    SandboxClientID       string `json:"sandboxClientId,omitempty"`
+    AccessTokenExpiration string `json:"accessTokenExpiration,omitempty"`
+    Audience   []string `json:"audience,omitempty"`   // new: granted aud
+    TokenClass string   `json:"tokenClass,omitempty"` // new: JWT|Opaque
+    KeyID      string   `json:"kid,omitempty"`        // new: JWT signing kid
+}
+```
+
+Issuance API:
+
+```
+POST /v1/ingress-tokens
+X-API-Key: <existing Team API Key>       // Role A: admission ticket
+{
+  "audience":   ["spiffe://agents.kruise.io/ns/default/sandbox/sbx-abc"],
+  "scope":      ["envd:fs:read"],
+  "ttlSeconds": 300
+}
+──►
+200 {
+  "accessToken": "<jwt>",                // Role B: sub = principal/apikey/{user.ID}
+  "audience":    ["...sbx-abc"],
+  "expiresAt":   "2026-07-25T12:05:00Z",
+  "tokenClass":  "JWT"
+}
+```
+
+#### Issuer-side authorization: CanRequestToken (Decision A)
+
+**Core question**: the API Key only carries team identity (→namespace); how does
+it decide whether a given aud/scope may be issued? Answer — **the API Key alone
+cannot decide it; it provides "who you are", and the decision is a joint lookup
+of that identity against the admin-declared policy.**
+
+**Decision A**: the first version does **only the first two steps** (ownership
+checks) on the issuer side; all fine-grained scope/interface authorization is
+delegated to the gateway.
+
+```go
+// pkg/servers/e2b/... new handler (pseudocode)
+func (h *IngressTokenHandler) Issue(ctx, req) (*identity.TokenResponse, *web.ApiError) {
+    user := userFromContext(ctx)                                    // injected by CheckApiKey
+    subject := fmt.Sprintf("spiffe://agents.kruise.io/principal/apikey/%s", user.ID)
+
+    for _, aud := range req.Audience {
+        ns, name, ok := parseSandboxSpiffeID(aud)                   // spiffe://.../ns/{ns}/sandbox/{name}
+        if !ok { return nil, badRequest("invalid audience: "+aud) }
+
+        // Step 1: aud → sandbox existence
+        if !h.sandboxExists(ctx, ns, name) {
+            return nil, forbidden("sandbox not found for audience: "+aud)
+        }
+        // Step 2: ownership check (pure API Key identity; admin exempt).
+        //   A non-admin caller's requested aud namespace must equal the
+        //   namespace mapped from its team. This is the strongest first gate,
+        //   reusing existing multi-tenant isolation, reading no policy.
+        if user.Team.Name != models.AdminTeamName && ns != h.sc.getNamespaceOfUser(user) {
+            return nil, forbidden("audience outside caller namespace: "+aud)
+        }
+        // Decision A: the issuer side stops here. scope/interface authorization
+        // is left to the gateway (policy.Evaluate).
+    }
+
+    return identity.IssueToken(ctx, nil, nil, identity.TokenRequest{
+        TokenType:         identity.TokenTypePrincipal,
+        Principal:         &identity.PrincipalInfo{PrincipalName: subject},
+        RequestedAudience: req.Audience,
+        Scope:             req.Scope,   // signed as-is; interface narrowing done by gateway
+    })
+}
+```
+
+**This answers the core question**:
+- **Ownership (whether an aud may be issued to you)** is fully decided by the
+  API Key's `team → namespace`: alice's key belongs to `team-a`, so she can
+  never mint a token for a `team-b` sandbox (namespace mismatch). Zero extra
+  policy.
+- **Fine granularity (scope/interface)** cannot come from the API Key and would
+  otherwise require `SandboxIngressPolicy`; **under Decision A the first version
+  does not do it on the issuer side** — it is delegated to the gateway, keeping
+  the issuer side simple and low-risk.
+
+#### Pluggable Signer detailed design
+
+> **Aligned with the existing `GetProxyCABundle` pattern**
+> (`pkg/identity/inner/proxy_ca_bundle.go`): same `identityProviderClient.Invoke`
+> transport, same "community baseline / enterprise secure / failing" three-state
+> layering, same lazy provider singleton. The signing-key Secret reuses the
+> gateway Secret naming family.
+
+**(1) Signer abstraction (`pkg/identity/signer.go`)**
+
+```go
+type Claims struct {
+    Issuer    string
+    Subject   string    // spiffe://.../principal/apikey/{user.ID}
+    Audience  []string  // sandbox SPIFFE IDs
+    Scope     []string
+    IssuedAt  time.Time
+    ExpiresAt time.Time
+    JWTID     string
+}
+type Signer interface {
+    Sign(ctx context.Context, c Claims) (token, kid string, err error)
+    Algorithm() string   // RS256 / ES256
+}
+func RegisterSigner(s Signer)   // mirrors RegisterProvider init registration
+func getSigner() Signer         // unset → failingSigner (mirrors failingProvider)
+```
+
+`TokenClass=Opaque` (legacy) does not go through the Signer.
+
+**(2) Community default: sandbox-manager local self-signing**
+
+- Signing-key Secret `sandbox-ingress-jwt-signer` (gateway Secret naming family,
+  in `sandbox-system`):
+  ```
+  data:
+    <kid>.key    # PEM private key (current signing key)
+    <kid>.pub    # PEM public key
+    active-kid   # current signing kid
+  ```
+  `kid` = public-key fingerprint (SHA-256 prefix), one-to-one with the key and
+  naturally distinct across rotations.
+- `localSigner` reads the private key from the Secret and signs by `active-kid`.
+- The manager exposes `GET /.well-known/jwks.json` with all non-expired public
+  keys (current + grace-period old kids).
+- **Multi-replica consistency**: replicas share one Secret; key material uses
+  LoadOrCreate + informer sync (mirroring the `secretKeyStorage` semantics in
+  the keys package); **no leader election required**.
+
+**(3) Enterprise deployment: remote Signer**
+
+- New inner actions `ActionSignJWT` / `ActionGetJWKS` reuse
+  `identityProviderClient.Invoke` (same endpoint/mTLS/timeout as
+  `ActionIssueToken`, `ActionGetProxyCABundle`).
+- `enterpriseSigner` sends `Claims` to the identity provider for signing; the
+  private key never leaves that service.
+
+**(4) Three-state layering (mirrors GetProxyCABundle)**
+
+| Mode | Signer | JWKS source | Failure semantics |
+|------|--------|-------------|-------------------|
+| Community baseline | `localSigner` | manager `/.well-known/jwks.json` | key Secret unavailable → fail-closed, 5xx on issuance |
+| Enterprise (configured) | `enterpriseSigner` | provider JWKS / manager proxy | provider unreachable → error, no degradation |
+| Enterprise (misconfigured) | `failingSigner` | — | surfaces the construction error every call, never silently degrades |
+| legacy opaque | none | none | backward compat, **no aud** |
+
+**(5) Key rotation**
+
+1. Append a new key pair `<kid2>` to the Secret without switching `active-kid`.
+2. After the gateway JWKS refreshes, kid2 can **verify** but does not yet **sign**.
+3. Switch `active-kid=kid2`; new tokens use kid2; existing kid1 tokens (≤5min)
+   still verify.
+4. After one TTL grace period, delete `<kid1>`; JWKS drops kid1; old tokens fail.
+
+Short TTL keeps the rotation window tiny — no online revocation needed. All
+three modes are transparent to the gateway/CRD; the gateway only knows
+`kid → public key`.
+
+#### Issuer-side SDK design (extending the E2B SDK)
+
+> **Aligned with the existing SDK convention**: the repo's
+> `sdk/customized_e2b/kruise_agents` extends the official e2b SDK via
+> **monkey-patching** (`patch_e2b`) and already ships `keys.py` (API-key encoding,
+> kept in sync with `keys/compat.go` constants). The ingress-token issuance/rotation
+> extension **follows the same pattern**: a new `kruise_agents/ingress_token.py`,
+> no fork of e2b, no change to existing behavior of official classes — only new
+> capabilities are attached.
+
+**(1) Principles**
+
+- **Reuse E2B auth and connection config**: the SDK uses the existing
+  `E2B_API_KEY` (Role A) as the issuance credential and the existing `E2B_DOMAIN`
+    + kruise private protocol (`/kruise/api`) as the endpoint — the user configures
+      nothing new.
+- **Non-invasive**: issuance is a *new* capability on a new `IngressTokenClient`;
+  it may *optionally* auto-inject the signed token into `Sandbox` requests (see (4))
+  for a zero-touch experience.
+- **Sync/async parity**: provide `IngressTokenClient` / `AsyncIngressTokenClient`,
+  matching e2b.
+
+**(2) Public API (`kruise_agents/ingress_token.py`)**
+
+```python
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+@dataclass
+class IngressToken:
+    access_token: str          # JWT
+    audience: list[str]        # granted aud, SPIFFE IDs
+    expires_at: datetime       # expiry (UTC)
+    token_class: str = "JWT"   # JWT | Opaque
+
+    @property
+    def is_expired(self) -> bool:
+        return datetime.now(timezone.utc) >= self.expires_at
+
+    def expires_within(self, seconds: float) -> bool:
+        """Whether it expires within `seconds` — used for rotation decisions."""
+        return (self.expires_at - datetime.now(timezone.utc)).total_seconds() <= seconds
+
+
+class IngressTokenClient:
+    """Ingress-token issuance/rotation client. Reuses E2B api_key and domain."""
+
+    def __init__(self, api_key: str | None = None, domain: str | None = None,
+                 https: bool = True):
+        # Defaults from E2B_API_KEY / E2B_DOMAIN, consistent with patch_e2b.
+        ...
+
+    def issue(self, audience: list[str], scope: list[str] | None = None,
+              ttl_seconds: int = 300) -> IngressToken:
+        """POST /v1/ingress-tokens. `audience` is a list of sandbox SPIFFE IDs
+        (spiffe://.../ns/{ns}/sandbox/{name}).
+
+        Maps to backend CanRequestToken (Decision A): the issuer side only
+        checks aud existence + team→namespace ownership; ownership failure
+        raises IngressAuthzError(403).
+        """
+
+    def refresh(self, token: IngressToken) -> IngressToken:
+        """Rotation: re-issue a fresh token using the original audience/scope.
+
+        Semantics = issue again with the same request params (the backend is
+        stateless; under the short-TTL model 'refresh' == 're-sign'). Does not
+        depend on the backend storing old-token state.
+        """
+        return self.issue(audience=token.audience, scope=token.scope,
+                          ttl_seconds=token.default_ttl)
+
+    def auto_refresh(self, audience: list[str], scope: list[str] | None = None,
+                     ttl_seconds: int = 300,
+                     refresh_margin: float = 60) -> "TokenProvider":
+        """Return a lazy TokenProvider that re-signs on access when the token
+        will expire within `refresh_margin` seconds. Consumed by Sandbox on
+        connect to always carry a fresh token."""
+```
+
+**(3) Rotation semantics (key point)**
+
+Because ingress tokens are **short-lived, stateless** JWTs, the SDK's `refresh`
+does **not** renew an existing token on the backend; it **re-issues with the same
+audience/scope** (`POST /v1/ingress-tokens` is side-effect-free and repeatable).
+This matches the backend: revocation is "stop refreshing + natural expiry", not
+mutating a single token's state. Three rotation styles:
+
+- **Manual**: `token = client.refresh(token)`.
+- **Expiry check**: `token.expires_within(60)` lets the caller decide when to re-sign.
+- **Auto/lazy**: `provider = client.auto_refresh(aud, ...)`; each `provider.get()`
+  re-signs near expiry, thread-safe (internal lock + singleflight to avoid
+  concurrent duplicate issuance).
+
+**(4) Integration with Sandbox (optional, zero-touch)**
+
+An `attach_ingress_token` patch auto-injects the token into the sandbox's ingress
+request headers (`Authorization: Bearer <jwt>`), so the `Sandbox` the user holds
+is authenticated transparently:
+
+```python
+from kruise_agents.patch_e2b import patch_e2b
+from kruise_agents.ingress_token import IngressTokenClient, attach_ingress_token
+from e2b_code_interpreter import Sandbox
+
+patch_e2b(https=False)
+client = IngressTokenClient()
+
+sbx = Sandbox.create(template="code-interpreter")
+# Issue an ingress token for this sandbox and auto-inject into its requests (with auto-rotation)
+attach_ingress_token(sbx, client, scope=["envd:fs:read", "envd:cmd:exec"])
+
+sbx.run_code("print('hello')")   # requests carry a valid JWT, auto re-signed near expiry
+```
+
+Internally `attach_ingress_token`:
+1. Derives the audience from `sbx.sandbox_id` (SPIFFE ID
+   `spiffe://.../ns/{ns}/sandbox/{name}`, consistent with the backend).
+2. Builds a lazy provider via `client.auto_refresh(...)`.
+3. Monkey-patches this sandbox instance's request origin (mirroring how
+   `patch_e2b` patches `get_host`), injecting `provider.get().access_token` before
+   each ingress request.
+
+**(5) Error model**
+
+Aligned with e2b's exception hierarchy:
+
+```python
+class IngressAuthzError(Exception):   # 403: ownership/authorization failure (backend CanRequestToken deny)
+    ...
+class IngressTokenError(Exception):   # other issuance failures (4xx/5xx, network, JWKS, ...)
+    ...
+```
+
+**(6) Constant sync with the backend contract**
+
+`ingress_token.py` defines shared constants at the top (endpoint path
+`/v1/ingress-tokens`, header names, default TTL, audience format), each annotated
+with the corresponding backend source file, following the "SDK constants stay in
+sync with the backend" convention already established by `keys.py`, to avoid
+protocol drift.
+
+**(7) Resolving the audience from a sandbox ID (SPIFFE-specific)**
+
+The SPIFFE aud is `spiffe://<trust-domain>/ns/{namespace}/sandbox/{name}`, so the
+SDK needs three pieces: **trust-domain**, **namespace**, **name**. Only the
+sandbox ID is guaranteed on the client. How much of the aud the SDK can derive
+locally depends on the ID form:
+
+- **kruise / customized-E2B deployment (SDK can derive locally)**: the e2b
+  `sandbox_id` equals the backend `GetSandboxID` = `{namespace}--{name}`
+  (`--` separator, see `pkg/utils/utils.go:289`; it is also the ID embedded in
+  the private-protocol URL `/kruise/{sandbox_id}/{port}` that `patch_e2b`
+  produces). The SDK can split on the first `--` to obtain `namespace` and
+  `name`, then format the SPIFFE aud with a configured trust-domain. **No extra
+  round-trip.**
+- **native-E2B-style / opaque ID (SDK cannot derive locally)**: when the ID is
+  an opaque token (e.g. native e2b `i37sc83s...`), `{namespace}--{name}` cannot
+  be recovered from the string. The SDK must obtain the namespace another way
+  (below).
+
+Because the client cannot assume which form it holds, the SDK resolves the
+audience through a **tiered strategy**, failing closed if none succeeds:
+
+```python
+class AudienceResolver:
+    """Resolve a SPIFFE audience for a sandbox_id, most-local-first."""
+
+    def __init__(self, trust_domain: str, namespace: str | None = None):
+        self._trust_domain = trust_domain     # e.g. "agents.kruise.io"
+        self._namespace = namespace           # optional explicit override
+
+    def resolve(self, sandbox_id: str, client: "IngressTokenClient") -> str:
+        ns, name = self._resolve_ns_name(sandbox_id, client)
+        return f"spiffe://{self._trust_domain}/ns/{ns}/sandbox/{name}"
+
+    def _resolve_ns_name(self, sandbox_id, client) -> tuple[str, str]:
+        # 1. explicit namespace supplied by the caller (highest precedence)
+        if self._namespace:
+            return self._namespace, sandbox_id
+        # 2. kruise ID form: split "{namespace}--{name}" locally, no round-trip
+        if "--" in sandbox_id:
+            ns, name = sandbox_id.split("--", 1)
+            return ns, name
+        # 3. opaque ID: ask the backend once (GET sandbox detail returns
+        #    namespace + the canonical aud); cached per sandbox_id
+        detail = client.get_sandbox_identity(sandbox_id)   # -> {namespace, name, audience}
+        return detail.namespace, detail.name
+```
+
+Strategy precedence and rationale:
+
+1. **Explicit `namespace`** — caller passes it (e.g. from their team config); zero
+   ambiguity, zero round-trip. Recommended when the app already knows its namespace.
+2. **Local split of `{namespace}--{name}`** — the common kruise/customized case;
+   no round-trip. This mirrors the backend `GetSandboxID` contract exactly.
+3. **Backend lookup** — for opaque IDs, one authenticated call (reusing the same
+   `E2B_API_KEY`) to a small identity endpoint that returns the sandbox's
+   `namespace` (and ideally the canonical `audience` string, so the SDK does not
+   re-derive it). The result is cached per `sandbox_id` for the process lifetime,
+   so the cost is one lookup per sandbox, not per token issuance.
+
+To make strategy 3 robust and avoid the SDK guessing the aud format at all, the
+**recommended backend enhancement** is: have `POST /v1/ingress-tokens` **accept a
+raw `sandbox_id` in addition to a fully-formed `audience`**, and let the backend
+(which authoritatively knows the sandbox's namespace) expand it into the
+canonical SPIFFE aud and echo the granted `audience` back in the response. Then
+the SDK's default path becomes "send `sandbox_id`, read back `audience`", and the
+client never needs to know the trust-domain or namespace at all:
+
+```python
+# Preferred: let the backend expand sandbox_id -> canonical SPIFFE aud
+token = client.issue(sandbox_ids=[sbx.sandbox_id], scope=["envd:fs:read"])
+# token.audience is the canonical aud echoed by the backend
+```
+
+`attach_ingress_token` uses this `sandbox_ids` form by default (fully backend-
+authoritative, no client-side SPIFFE assembly), and falls back to the local
+`AudienceResolver` only when the caller explicitly opts into client-side
+resolution (e.g. air-gapped or latency-sensitive paths that want to avoid the
+extra lookup).
+
+> **Note for the internal-product variant**: the internal product uses
+> `{namespace}--{name}` as the aud directly, which is exactly the `sandbox_id`,
+> so strategies 2 always applies and no lookup is ever needed. The tiered
+> resolver and the `sandbox_ids` backend expansion above are only necessary for
+> the community SPIFFE format when opaque IDs are in play.
+
+### Verification flow (sandbox-gateway filter)
+
+#### Route extension (`pkg/utils/proxyutils/route.go`)
+
+```go
+type Route struct {
+    // ... existing fields ...
+    AccessToken string `json:"accessToken,omitempty"` // kept: Opaque compat
+    TokenClass  string `json:"tokenClass,omitempty"`  // new: JWT|Opaque
+    SpiffeID    string `json:"spiffeId,omitempty"`    // new: this sandbox's aud SPIFFE ID
+}
+```
+
+`SpiffeID` is derived from `ns/name`. `Route.String()` already masks
+`AccessToken`; new sensitive fields must be masked too.
+
+#### JWKS retrieval and caching
+
+The gateway needs a local `kid → public key` view behind one `JWKSProvider`
+interface (source differences are encapsulated inside the implementation):
+
+```go
+type JWKSProvider interface {
+    KeyByID(ctx context.Context, kid string) (crypto.PublicKey, error)
+}
+```
+
+**Source** (gateway config `jwksSource`):
+- Community `manager`: HTTP fetch of sandbox-manager `/.well-known/jwks.json`
+  (in-cluster Service).
+- Enterprise `provider`: `identityProviderClient.Invoke` `ActionGetJWKS` direct;
+  or still via manager proxy to reduce the gateway's direct dependency.
+
+**Caching and refresh**:
+- In-memory `map[kid]publicKey` + background periodic refresh (5min default).
+- **On-demand refresh**: an unknown kid (typically freshly rotated) triggers a
+  throttled forced refresh (singleflight to avoid thundering herd), then one
+  retry; only a still-miss is rejected.
+- **Stale-while-error**: on refresh failure keep the old cache serving, expose
+  `ingress_jwks_refresh_failed_total` + alert; fail-closed only when the cache
+  was never established. This keeps manager/provider blips from 401-ing all
+  ingress.
+- Accept only JWKS keys declared `RS256`/`ES256`, `use=sig`.
+
+#### Verification chain: authentication + authorization
+
+The gateway verification decision flow (any failing step fails closed):
+
+```mermaid
+flowchart TD
+    Start([ingress request]) --> Enable{EnableAuth?}
+    Enable -->|false| Fwd[forward to envd]
+    Enable -->|true| Class{TokenClass}
+    Class -->|Opaque| Cmp{static token match?}
+    Cmp -->|no| R401a[401]
+    Cmp -->|yes| Fwd
+    Class -->|JWT| K{kid→JWKS key found?}
+    K -->|no| R401b[401 unknown key]
+    K -->|yes| Sig{verify sig + exp/iat/nbf?}
+    Sig -->|fail| R401c[401 invalid/expired]
+    Sig -->|pass| Iss{iss trusted?}
+    Iss -->|no| R403a[403 untrusted issuer]
+    Iss -->|yes| Aud{"aud ∋ this sandbox<br/>SPIFFE ID?"}
+    Aud -->|no| R403b[403 aud mismatch]
+    Aud -->|yes| Pol{"policy.Evaluate<br/>sub/path/method/scope allow?"}
+    Pol -->|no| R403c[403 endpoint not authorized]
+    Pol -->|yes| Fwd
+
+    subgraph authentication
+        K
+        Sig
+        Iss
+        Aud
+    end
+    subgraph authorization
+        Pol
+    end
+```
+
+The existing route-resolution logic (`filter.go:74-112`) is unchanged; the
+static comparison is replaced:
+
+```go
+if f.config.EnableAuth {
+    switch route.TokenClass {
+    case "JWT", "":
+        if st := f.authenticateAndAuthorize(header, sandboxID, route); st != api.Continue {
+            return st                     // already 401/403 inside
+        }
+    case "Opaque":                        // backward-compatible legacy path
+        requestToken, _ := header.Get(accessTokenHeader)
+        if subtle.ConstantTimeCompare([]byte(requestToken), []byte(route.AccessToken)) != 1 {
+            return f.reply(401, "unauthorized")
+        }
+    }
+}
+```
+
+`authenticateAndAuthorize`, two phases (any failure rejects, fail-closed):
+
+```go
+func (f *sandboxFilter) authenticateAndAuthorize(header api.RequestHeaderMap, sandboxID string, route Route) api.StatusType {
+    // ===== authentication: is the token real, and is it for THIS sandbox =====
+    raw := bearer(header)
+    if raw == "" { return f.reply(401, "missing token") }
+    parsed, _ := jwt.ParseUnverified(raw)
+    key, err := f.jwks.KeyByID(ctx, parsed.Header["kid"])
+    if err != nil { return f.reply(401, "unknown signing key") }
+    claims, err := jwt.Verify(raw, key, jwt.WithValidMethods([]string{"RS256", "ES256"}))
+    if err != nil { return f.reply(401, "invalid signature or expired") }
+    if !f.policy.TrustedIssuer(sandboxID, claims.Issuer) { return f.reply(403, "untrusted issuer") }
+    // ★ core: aud must contain this sandbox's SPIFFE ID ★
+    if !contains(claims.Audience, route.SpiffeID) {
+        return f.reply(403, "token audience does not include this sandbox")
+    }
+
+    // ===== authorization: may this token hit this endpoint now (the sole
+    // fine-grained enforcement point under Decision A) =====
+    d := ingressauthz.Evaluate(f.policy.Snapshot(sandboxID), ingressauthz.Input{
+        Subject: claims.Subject,
+        Scope:   claims.Scope,
+        Path:    reqPath(header),      // request-time attribute, gateway-only
+        Method:  reqMethod(header),
+    })
+    if !d.Allow { return f.reply(403, "not authorized for endpoint: "+d.Reason) }
+
+    header.Set("x-agents-principal", claims.Subject)  // propagate subject for envd audit
+    return api.Continue
+}
+```
+
+**Step 4 (aud check) is the enforcement point for "envd ingress only allows a
+specific aud"**; **the authorization phase is the only place scope/interface
+limits are enforced under Decision A** (the issuer side does not).
+
+### Admin authorization: SandboxIngressPolicy CRD
+
+Symmetric to `SecurityProfile` (egress), a new namespaced CRD for ingress. Under
+Decision A it is consumed mainly by the **gateway** (the issuer side only does
+ownership checks).
+
+```go
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Namespaced,shortName=sip
+type SandboxIngressPolicy struct {
+    metav1.TypeMeta   `json:",inline"`
+    metav1.ObjectMeta `json:"metadata,omitempty"`
+    Spec   SandboxIngressPolicySpec   `json:"spec,omitempty"`
+    Status SandboxIngressPolicyStatus `json:"status,omitempty"`
+}
+
+type SandboxIngressPolicySpec struct {
+    // Selector chooses target sandboxes. Empty selector = all in the namespace
+    // (consistent with SecurityProfile).
+    Selector metav1.LabelSelector `json:"selector"`
+    // Issuers trusted iss values. The gateway only accepts tokens from these.
+    // +kubebuilder:validation:MinItems=1
+    Issuers []string `json:"issuers"`
+    // Rules ordered chain. Default Deny (whitelist).
+    // +optional
+    // +listType=map
+    // +listMapKey=name
+    Rules []IngressRule `json:"rules,omitempty"`
+    // DefaultAction when no rule matches. Default Deny.
+    // +kubebuilder:validation:Enum=Allow;Deny
+    // +kubebuilder:default:=Deny
+    DefaultAction string `json:"defaultAction,omitempty"`
+}
+
+type IngressRule struct {
+    Name string `json:"name"`
+    // Subjects allowed caller subjects (token sub, SPIFFE ID). Empty = any verified sub.
+    // +optional
+    Subjects []SubjectMatch `json:"subjects,omitempty"`
+    // Paths/Methods restrict envd interfaces (reuse SecurityProfile PathMatch).
+    // +optional
+    Paths []PathMatch `json:"paths,omitempty"`
+    // +optional
+    Methods []string `json:"methods,omitempty"`
+    // RequiredScopes token.scope must include these.
+    // +optional
+    RequiredScopes []string `json:"requiredScopes,omitempty"`
+    // +kubebuilder:validation:Enum=Allow;Deny
+    Action string `json:"action"`
+}
+
+type SubjectMatch struct {
+    // +kubebuilder:validation:Enum=Exact;SpiffePrefix
+    // +kubebuilder:default:=Exact
+    Type  string `json:"type,omitempty"`
+    // e.g. spiffe://agents.kruise.io/principal/team-fraud/*
+    Value string `json:"value"`
+}
+```
+
+Example (allow the `team-fraud` principals read-only file access to `app=analyzer` sandboxes):
+
+```yaml
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxIngressPolicy
+metadata:
+  name: analyzer-readonly
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: analyzer
+  issuers: ["https://identity.agents.kruise.io"]
+  defaultAction: Deny
+  rules:
+    - name: fraud-team-read-files
+      subjects:
+        - {type: SpiffePrefix, value: "spiffe://agents.kruise.io/principal/team-fraud/"}
+      paths:
+        - {type: Prefix, value: /files}
+      methods: [GET, HEAD]
+      requiredScopes: [envd:fs:read]
+      action: Allow
+```
+
+**Controller `pkg/controller/ingresspolicy`**: watch CRD → validate → set
+`Accepted` → compile into a compact decision table pushed to the gateway
+registry (same mechanism as existing Route push) → set `Programmed`.
+
+### Two-sided enforcement and consistency
+
+**Boundary restated: issuance is in sandbox-manager, verification in the
+gateway; the gateway never issues.**
+
+| | Issuer side (sandbox-manager) | Verifier side (sandbox-gateway) |
+|---|---|---|
+| Trigger | before signing in `POST /v1/ingress-tokens` | every ingress request |
+| Credential | Team API Key (Role A) | issued JWT |
+| **Under Decision A** | ownership only (aud exists + team→namespace) | authentication (verify/aud) **+ all fine-grained authorization** (sub/path/method/scope) |
+| Reads policy | no (not in v1) | yes (`SandboxIngressPolicy`) |
+
+Under Decision A this is not strict "two-sided", but a split: **coarse on the
+issuer side (ownership) + fine on the gateway (policy)**:
+- The issuer side blocks cross-tenant escalation via the API Key's
+  team→namespace — simple and reliable.
+- The gateway is the sole arbiter of scope/interface authorization and the final
+  runtime gate.
+
+**Reserved for future full two-sided enforcement**: the authorization core is a
+pure-function library `pkg/identity/ingressauthz` (no K8s dependency: input a
+compiled policy + request attributes, output allow/deny + reason). Only the
+gateway calls it today; if fine-grained authorization is later added to the
+issuer side (upgrading to full two-sided), the issuer side simply calls the same
+function with empty `Path/Method` (wildcard) — inherently consistent, no drift.
+
+```go
+package ingressauthz
+type Input struct { Subject string; Scope []string; Path string; Method string }
+type Decision struct { Allow bool; Reason string }
+func Evaluate(policies []CompiledPolicy, in Input) Decision   // pure, deterministic, centrally tested
+```
+
+### Revocation and key rotation
+
+- Short TTL (5min) primary: revocation via "stop refreshing + natural expiry".
+- Key rotation per [Signer (5)]; rotation + short TTL rotate keys without online
+  revocation.
+- Active revocation (Future): reuse the reserved `RevokeToken` + a gateway `jti`
+  short-lived blacklist for emergencies.
+
+### End-to-end sequence
+
+```mermaid
+sequenceDiagram
+    actor Admin
+    participant Caller
+    participant Mgr as sandbox-manager
+    participant Signer as identity / Signer
+    participant GW as sandbox-gateway
+    participant Envd as envd
+
+    Note over Admin,GW: Control plane: policy rollout
+    Admin->>Mgr: kubectl apply SandboxIngressPolicy
+    Mgr-->>GW: ingresspolicy-controller compiles & pushes decision table
+
+    Note over Caller,Signer: Issuance: exchange API Key for JWT (Decision A)
+    Caller->>Mgr: POST /v1/ingress-tokens (X-API-Key)<br/>aud=[spiffe://.../sandbox/A]
+    Mgr->>Mgr: CanRequestToken<br/>1. aud→sandbox exists? 2. team→namespace ownership?
+    alt ownership fails
+        Mgr-->>Caller: 403 audience outside caller namespace
+    else pass
+        Mgr->>Signer: Sign(Claims sub=principal/apikey/{id})
+        Signer-->>Mgr: JWT (kid)
+        Mgr-->>Caller: 200 JWT (aud=spiffe://.../sandbox/A, exp=5m)
+    end
+
+    Note over Caller,Envd: Data plane: gateway verification (authn + authz)
+    Caller->>GW: GET /files  Authorization: Bearer JWT
+    GW->>GW: authn: JWKS verify / exp / iss
+    GW->>GW: aud ∋ spiffe://.../sandbox/A ?
+    GW->>GW: authz: policy.Evaluate(sub/path/method/scope)
+    alt authn or authz fails
+        GW-->>Caller: 401 / 403
+    else pass
+        GW->>Envd: forward GET /files (x-agents-principal)
+        Envd-->>Caller: 200 response
+    end
+```
+
+## User Stories
+
+- **Audience isolation**: alice holds a token with `aud=[.../sandbox/sbx-abc]`
+  and mistakenly uses it against `sbx-def`; the gateway 403s at the aud check.
+- **Interface least-privilege**: policy allows only `GET /files`; even with a
+  valid token and correct aud, `POST /process` is 403'd by the gateway
+  authorization phase.
+- **Cross-tenant block**: a team-a API Key requests a token for a team-b
+  sandbox; the issuer-side ownership check rejects it.
+
+## Requirements
+
+- **FR1 (MUST)**: gateway verifies JWT, checks exp/iat/nbf/iss/aud; missing aud → 403.
+- **FR2 (MUST)**: issuer side authorizes via the Team API Key; v1 does aud
+  existence + team→namespace ownership (Decision A).
+- **FR3 (MUST)**: `SandboxIngressPolicy` CRD supports selector + ordered rules +
+  Default Deny; consumed by the gateway.
+- **FR4 (SHOULD)**: scope expresses envd interface capabilities; local
+  self-signing Signer + JWKS rotation.
+- **FR5 (COULD)**: `RevokeToken` + jti blacklist; issuer-side fine-grained
+  authorization (upgrade to full two-sided).
+
+### Non-Functional
+
+- **NFR1 performance**: gateway verification uses in-memory public keys +
+  compiled decision table; per-request auth P99 < 1ms, no synchronous outbound call.
+- **NFR2 compatibility**: `EnableAuth=false` unchanged; `TokenClass=Opaque` legacy path kept.
+- **NFR3 security**: fail-closed; asymmetric algorithms only; sensitive fields masked.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| gateway cannot fetch JWKS (manager/provider blip) | local cache + stale-while-error; fail-closed only if never established; metric alert |
+| misconfigured `DefaultAction: Allow` | CRD defaults Deny; webhook validation; docs stress whitelist |
+| `alg:none` / algorithm confusion | explicit `WithValidMethods([RS256,ES256])` |
+| bearer token replay outside cluster | short TTL + aud narrowing; strong need → X.509+mTLS (Future) |
+| Decision A: issuer does not gate scope, more useless tokens | gateway is the final arbiter; useless tokens still fail runtime authorization |
+
+## Alternatives
+
+- **Full two-sided (issuer also reads policy)**: stronger defense-in-depth but
+  the issuer side must add policy watch/cache. Decision A defers this;
+  `ingressauthz` reserves the upgrade path.
+- **Authorization inside envd**: stronger isolation but requires runtime changes
+  and per-sandbox JWKS/policy distribution; Future.
+- **aud = team / capability group**: larger leak surface or a mapping table;
+  rejected in favor of per-sandbox aud.
+- **Keep static opaque token**: no exp/sub/revocation/audit; does not meet goals.
+
+## Upgrade Strategy
+
+- feature gate `SandboxIngressJWTAuth` (gateway + manager), off by default.
+- Per-sandbox opt-in: only sandboxes annotated `TokenClass=JWT` take the new
+  path; others keep Opaque.
+- Rollout: push CRD + enable gate in a test namespace, watch reject/verify-failure
+  rates, then expand.
+- Rollback: disabling the gate reverts to static-token behavior; the CRD is inert.
+
+## Test Plan
+
+- **Unit**: `ingressauthz` table-driven (sub/path/method/scope × allow/deny ×
+  default); JWKS refresh/rotation/miss/stale; filter authn and authz failure
+  branches; issuer-side ownership checks (same/cross namespace, admin). Follow
+  AGENTS.md: table-driven, `expectError string`, changed packages only.
+- **E2E (Ginkgo)**: issue→carry→allow/deny full path; aud mismatch 403;
+  cross-tenant issuance rejection.
+- **Compatibility**: `EnableAuth=false` and `TokenClass=Opaque` regression.
+
+## Implementation History
+
+- [ ] 2026-07-25: First draft (community design, Decision A)
+- [ ] TBD: `api/v1alpha1` + `make generate manifests`
+- [ ] TBD: `ingressauthz` pure-function library + unit tests
+- [ ] TBD: local self-signing Signer + `/.well-known/jwks.json`
+- [ ] TBD: sandbox-manager issuance API + ownership checks
+- [ ] TBD: gateway filter authn+authz phases + JWKS
+- [ ] TBD: ingresspolicy-controller
+- [ ] TBD: E2E + gradual rollout

--- a/docs/proposals/20260725-sandbox-ingress-authn.md
+++ b/docs/proposals/20260725-sandbox-ingress-authn.md
@@ -185,10 +185,10 @@ flowchart TB
     ENVD[[envd / agent-runtime]]
 
     Caller -->|1. X-API-Key| ISSUE
-    SIGNER -->|JWT aud=spiffe://.../sandbox/A, exp=5m| Caller
+    SIGNER -->|"JWT aud=spiffe://.../sandbox/A, exp=5m"| Caller
     Caller -->|2. Bearer JWT| FILTER
     IPC -->|compiled decision table| DataPlane
-    IssuePlane -.JWKS /.well-known/jwks.json.-> DataPlane
+    IssuePlane -. "JWKS /.well-known/jwks.json" .-> DataPlane
     AZ -->|allow| ENVD
     AZ -.deny.-> Reject[401 / 403]
 ```
@@ -970,6 +970,40 @@ sequenceDiagram
   authorization phase.
 - **Cross-tenant block**: a team-a API Key requests a token for a team-b
   sandbox; the issuer-side ownership check rejects it.
+- **Short-window containment after a leak**: an ingress token is accidentally
+  captured in a log and leaked. Because the default TTL is only 5 minutes and
+  the caller stops refreshing, the token expires on its own within minutes with
+  no online revocation needed; even during that window it can only hit the one
+  sandbox in its `aud` (the leak surface is already narrowed by aud).
+- **Zero-downtime key rotation**: an operator appends a new key pair `kid2` to
+  the signer Secret — first letting the gateway JWKS *verify* with it but not
+  yet *sign* — then switches `active-kid=kid2`. During the switch, in-flight
+  tokens signed with `kid1` (≤5min) still verify, new tokens use `kid2`; after
+  one TTL grace period `kid1` is deleted. The whole process is transparent to
+  callers and the gateway, with no 401 flapping.
+- **Fine-grained per-interface authorization of envd in multi-tenant
+  scenarios**: in enterprise multi-tenant settings, admins and operators may
+  need different levels of envd-interface access; `SandboxIngressPolicy` enables
+  interface-dimension fine-grained authorization.
+- **Decoupling ingress-token issuance**: today ingress-token issuance is bound
+  to the sandbox creation flow; by implementing the issuance and rotation
+  interfaces, ingress-token issuance can be removed from the sandbox creation
+  flow and used flexibly on the client side.
+- **Single token for a batch of sandboxes**: a caller requests, in one shot, a
+  token whose `aud` is an array covering several sandboxes from the same
+  SandboxClaim batch (`aud=[.../sandbox/A, .../sandbox/B]`), and uses that one
+  token to reach any sandbox in the group, while sandboxes outside the group
+  still return 403.
+- **Zero-touch auth and auto-rotation via the SDK**: a developer calls
+  `attach_ingress_token(sbx, client)` to bind an ingress token to a `Sandbox`
+  instance; thereafter every request such as `sbx.run_code(...)` automatically
+  carries a valid JWT, lazily re-signed by the SDK near expiry, with no manual
+  token-lifecycle management.
+- **Auditability**: after a request passes authentication, the gateway
+  propagates the verified `sub`
+  (`spiffe://.../principal/apikey/{user.ID}`) to envd via the
+  `x-agents-principal` header, so runtime audit logs can trace "which principal
+  accessed which interface of this sandbox".
 
 ## Requirements
 

--- a/docs/proposals/20260725-sandbox-ingress-authn.md
+++ b/docs/proposals/20260725-sandbox-ingress-authn.md
@@ -106,9 +106,10 @@ This maps to roadmap → Runtime → *more secure access token and auditing*.
 |------|---------|
 | ingress | client → sandbox-gateway → envd/agent-runtime direction |
 | envd | agent-runtime sidecar inside a sandbox pod exposing E2B-compatible APIs |
-| **sandbox SPIFFE ID** | `spiffe://<trust-domain>/ns/{namespace}/sandbox/{name}` — the aud value |
+| **sandbox binding claim** | custom `sandbox` claim `{sandboxId, sandboxUid}` — the **primary** authorization anchor, aligned with the merged verifier and #772 |
+| **sandbox SPIFFE ID** | `spiffe://<trust-domain>/ns/{namespace}/sandbox/{name}` — a readable identity label; also usable as `aud` for defense-in-depth |
 | **caller SPIFFE ID (sub)** | `spiffe://<trust-domain>/principal/apikey/{user.ID}` — derived from the Team API Key |
-| aud | JWT audience; the target sandbox SPIFFE ID |
+| aud | JWT audience (RFC 7519 §4.1.3): the intended recipient. **Optional, defense-in-depth only** — sandbox scoping is done by the `sandbox` claim, not `aud` |
 | scope | envd interface-level capability, e.g. `envd:fs:read` |
 | TokenClass | token format: `JWT` (new) or `Opaque` (legacy static token) |
 | Role A / Role B | A = issuance credential (Team API Key, admission ticket); B = ingress token (newly issued JWT) |
@@ -153,7 +154,9 @@ This maps to roadmap → Runtime → *more secure access token and auditing*.
                         --- authentication ---
                         2. JWKS verify (kid, RS256/ES256)
                         3. exp/iat/nbf + iss
-                        4. aud ∋ sandbox SPIFFE ID       ◄── core
+                        4. sandbox.sandboxId == route.ID
+                           && sandbox.sandboxUid == route.UID   ◄── core (aligned with #772 / merged verifier)
+                        4b. (optional) aud ∋ sandbox SPIFFE ID  ── defense-in-depth
                         --- authorization ---
                         5. SandboxIngressPolicy(sub/path/method/scope)
                         6. allow → forward to envd ; else 401/403
@@ -176,7 +179,7 @@ flowchart TB
 
     subgraph DataPlane[Data plane · sandbox-gateway]
         FILTER[filter.DecodeHeaders]
-        AUTHN["authentication<br/>verify · exp/iss · aud ∋ sandbox SPIFFE ID"]
+        AUTHN["authentication<br/>verify · exp/iss · sandbox claim (id+uid) matches route · (aud optional)"]
         AZ["authorization<br/>policy.Evaluate sub/path/method/scope"]
         FILTER --> AUTHN --> AZ
     end
@@ -199,21 +202,49 @@ the gateway. The gateway never issues.** "Two-sided enforcement" means the same
 [Two-sided enforcement](#two-sided-enforcement-and-consistency)); in the first
 version the issuer side only does ownership checks (Decision A).
 
-### Identity and aud semantics (SPIFFE)
+### Identity and sandbox-binding semantics (SPIFFE)
 
-**Decision: `aud` = the target sandbox's SPIFFE ID.** Rationale:
+**Decision: the primary sandbox binding is a custom `sandbox` claim
+(`{sandboxId, sandboxUid}`), not `aud`.** `aud` retains its RFC 7519 meaning
+(the intended recipient) and is an **optional defense-in-depth** signal only.
 
-1. Minimal leak surface: a stolen token can only hit sandboxes in its aud.
-2. Natural boundary: the envd ingress trust boundary is exactly "a sandbox",
-   which maps directly to the "specific aud range" requirement.
-3. SPIFFE naming is readable, cross-cluster unique, and aligns with a standard
-   zero-trust identity model.
+> **Why the `sandbox` claim, not `aud`.** Per [RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3),
+> `aud` "identifies the recipients that the JWT is intended for" — each principal
+> processing the token must identify itself in `aud`. Using `aud` to name the
+> *target sandbox* conflates "who receives the token" with "what the token is
+> scoped to access". More importantly, the companion outbound proposal
+> ([`20260727-agent-dynamic-identity-spiffe-token-exchange.md`](./20260727-agent-dynamic-identity-spiffe-token-exchange.md))
+> uses `aud` for the **external service** the agent calls — the opposite
+> direction. A single claim cannot mean "the target sandbox" here and "the
+> external API" there. So sandbox scoping moves to a dedicated claim, and `aud`
+> keeps one consistent meaning (recipient) across both documents.
 
+This also aligns with what the merged data plane already does. The
+`sandbox-gateway` binds on the `sandbox` claim and compares both `sandboxId`
+and `sandboxUid` against the selected route (`filter.go`), and the traffic
+access token issuer in [#772](https://github.com/openkruise/agents/pull/772)
+mints exactly this shape (`iss/sub/exp/iat/nbf` + `sandbox{sandboxId,
+sandboxUid}`, no `aud`). Keeping this proposal on the same claim removes a
+second, competing mechanism.
+
+**Binding claim:**
+
+```jsonc
+"sandbox": {
+  "sandboxId":  "default/sbx-abc",   // namespace/name, human-readable
+  "sandboxUid": "8f3c9e2a-..."        // Kubernetes object UID, the strong key
+}
 ```
-spiffe://agents.kruise.io/ns/{namespace}/sandbox/{sandboxName}
-```
 
-`aud` is an array, supporting one token that accesses a small set of sandboxes
+The gateway authorizes a request only when **both** `sandboxId` and
+`sandboxUid` match the route it selected, so a token minted for one sandbox
+cannot be replayed against another — including a same-name sandbox in another
+cluster (see [Multi-cluster considerations](#multi-cluster-considerations)).
+
+**Sandbox SPIFFE ID (`spiffe://<trust-domain>/ns/{namespace}/sandbox/{name}`)**
+remains as a readable identity label and MAY be populated into `aud` as a
+defense-in-depth layer; it is never the sole authorization key. When present,
+`aud` is an array, supporting one token that names a small set of recipients
 (e.g. sandboxes from the same batch SandboxClaim).
 
 **Caller subject `sub` = `spiffe://agents.kruise.io/principal/apikey/{user.ID}`**
@@ -223,9 +254,13 @@ spiffe://agents.kruise.io/ns/{namespace}/sandbox/{sandboxName}
 
 ```jsonc
 {
-  "iss": "https://identity.agents.kruise.io",                  // trusted issuer
-  "sub": "spiffe://agents.kruise.io/principal/apikey/8f3c...",  // caller, key-granularity
-  "aud": ["spiffe://agents.kruise.io/ns/default/sandbox/sbx-abc"],
+  "iss": "https://identity.<cluster-id>.agents.kruise.io",     // trusted issuer, per-cluster
+  "sub": "spiffe://<cluster-id>.agents.kruise.io/principal/apikey/8f3c...", // caller
+  "sandbox": {                                                 // PRIMARY binding (aligned with #772 / merged verifier)
+    "sandboxId":  "default/sbx-abc",                           //   namespace/name
+    "sandboxUid": "8f3c9e2a-..."                               //   K8s object UID — the strong key
+  },
+  "aud": ["spiffe://<cluster-id>.agents.kruise.io/ns/default/sandbox/sbx-abc"], // OPTIONAL, defense-in-depth
   "exp": 1750000300,                                           // 5min default
   "iat": 1750000000,
   "nbf": 1750000000,
@@ -233,6 +268,10 @@ spiffe://agents.kruise.io/ns/{namespace}/sandbox/{sandboxName}
   "scope": ["envd:fs:read", "envd:cmd:exec"]                   // optional
 }
 ```
+
+> **Authorization rests on the `sandbox` claim** (`sandboxId` + `sandboxUid`
+> both matched against the route). `aud`, when present, is an additional check,
+> not the primary gate. This matches the merged verifier and #772.
 
 Signing algorithm restricted to `RS256` / `ES256` (asymmetric; verifiers need
 only the public key).
@@ -253,24 +292,45 @@ exchanged for the ingress JWT and is never used to access envd directly.
 > gateway data plane). So the API Key only "admits", and the short-lived JWT
 > "travels".
 
-Backward-compatible extensions to `TokenRequest` / `TokenResponse`:
+**Issuance API — extend `TokenOptions`, do not reintroduce `TokenRequest`.**
+
+The merged `IssueToken` signature is `IssueToken(ctx, sbx *Sandbox, kind
+TokenKind)`; the pre-built `TokenRequest` parameter was deliberately removed
+(#632) so that each provider derives the wire request from `sbx` itself.
+[#742](https://github.com/openkruise/agents/pull/742) is replacing the `kind`
+parameter with a `TokenOptions{Kind, RequestedValidity}` struct, where
+sandbox-manager normalizes caller-requested values before use.
+`RequestedAudience` and `Scope` are the same kind of value — caller-requested,
+issuer-normalized — so this proposal **adds them to `TokenOptions`** rather
+than introducing a second request shape:
 
 ```go
-type TokenRequest struct {
-    TokenType TokenType         `json:"tokenType"`
-    Principal *PrincipalInfo    `json:"principal,omitempty"`
-    Sandbox   *SandboxInfo      `json:"sandbox,omitempty"`
-    Metadata  map[string]string `json:"metadata,omitempty"`
-    RequestedAudience []string  `json:"requestedAudience,omitempty"` // new: sandbox SPIFFE IDs
-    Scope             []string  `json:"scope,omitempty"`             // new: requested capabilities
+// Extends #742's TokenOptions; caller-requested, issuer-normalized.
+type TokenOptions struct {
+    Kind              TokenKind
+    RequestedValidity time.Duration // from #742
+    RequestedAudience []string      // new: optional defense-in-depth recipients (sandbox SPIFFE IDs)
+    Scope             []string      // new: requested envd capabilities
 }
 
+// Usage: providers still derive the sandbox binding (sandboxId/sandboxUid)
+// directly from sbx; TokenOptions only carries what the caller may request.
+IssueToken(ctx, sbx, TokenOptions{
+    Kind:              TokenKindAccessToken,
+    RequestedValidity: 5 * time.Minute,
+    Scope:             []string{"envd:fs:read"},
+})
+```
+
+`TokenResponse` extensions remain backward-compatible:
+
+```go
 type TokenResponse struct {
     RequestID             string `json:"requestId"`
     AccessToken           string `json:"accessToken"`
     SandboxClientID       string `json:"sandboxClientId,omitempty"`
     AccessTokenExpiration string `json:"accessTokenExpiration,omitempty"`
-    Audience   []string `json:"audience,omitempty"`   // new: granted aud
+    Audience   []string `json:"audience,omitempty"`   // new: granted aud (defense-in-depth, optional)
     TokenClass string   `json:"tokenClass,omitempty"` // new: JWT|Opaque
     KeyID      string   `json:"kid,omitempty"`        // new: JWT signing kid
 }
@@ -1041,9 +1101,32 @@ sequenceDiagram
   `ingressauthz` reserves the upgrade path.
 - **Authorization inside envd**: stronger isolation but requires runtime changes
   and per-sandbox JWKS/policy distribution; Future.
-- **aud = team / capability group**: larger leak surface or a mapping table;
-  rejected in favor of per-sandbox aud.
+- **`aud` = target sandbox as the primary binding**: rejected. It conflicts
+  with RFC 7519 (`aud` = recipient), collides with the outbound proposal's use
+  of `aud` for the external service, and duplicates the merged `sandbox`-claim
+  mechanism. Sandbox binding uses the `sandbox` claim; `aud` is optional
+  defense-in-depth only.
 - **Keep static opaque token**: no exp/sub/revocation/audit; does not meet goals.
+
+## Multi-cluster considerations
+
+The `sandbox` SPIFFE ID alone is **not** globally unique across clusters if the
+trust domain names the product (e.g. `agents.kruise.io`): two clusters both
+running `default/my-sandbox` would produce identical SPIFFE IDs, so a token
+minted for one could be accepted by the other. Uniqueness must not rest on any
+single mechanism. This proposal uses **two independent layers** (defense in
+depth):
+
+1. **Per-cluster trust domain (hard requirement).** Each installation MUST use
+   a distinct trust domain, e.g. `spiffe://<cluster-id>.agents.kruise.io/...`,
+   where `<cluster-id>` is unique per cluster. The product name alone
+   (`agents.kruise.io`) MUST NOT be used as a shared trust domain across
+   clusters. This scopes issuer (`iss`), `sub`, and any `aud` to one cluster.
+
+2. **`sandboxUid` in the `sandbox` claim (primary binding).** The gateway
+   compares `sandbox.sandboxUid` (the Kubernetes object UID) against the route
+   it selected. Even if namespace and name collide across clusters, the UID
+   comparison fails for a replayed token.
 
 ## Upgrade Strategy
 

--- a/docs/proposals/20260727-agent-dynamic-identity-spiffe-token-exchange.md
+++ b/docs/proposals/20260727-agent-dynamic-identity-spiffe-token-exchange.md
@@ -61,7 +61,7 @@ The existing `IdentityProvider` interface (`pkg/identity/interface.go`) has only
 1. Provides **cryptographic workload identity** (the current UUID token can be copied and replayed).
 2. Enables **delegated access to third-party APIs** (Agents cannot call GitHub/cloud APIs on behalf of users).
 3. Supports **revocable, time-bounded, scope-limited** credentials.
-4. Aligns with **community standards** (SPIFFE, OAuth 2.0, OIDC) used by AWS, Azure, and GCP.
+4. Aligns with **community standards** (SPIFFE, OAuth 2.0, OIDC).
 
 ### Goals
 

--- a/docs/proposals/20260727-agent-dynamic-identity-spiffe-token-exchange.md
+++ b/docs/proposals/20260727-agent-dynamic-identity-spiffe-token-exchange.md
@@ -196,6 +196,48 @@ flowchart TB
 | Discovery | OIDC Discovery | [OpenID Connect](https://openid.net/specs/openid-connect-discovery-1_0.html) | JWKS endpoint discovery |
 | Workload Identity (IETF) | WIMSE | [IETF WIMSE WG](https://datatracker.ietf.org/group/wimse/about/) | Workload Identity in Multi-System Environments |
 
+#### `aud` semantics (outbound / egress — standards-first)
+
+**This document is about the agent's *outbound* (egress) token identity — the
+token the agent presents to third-party / external services — not the inbound
+client token that reaches envd** (that is the companion ingress proposal,
+[`20260725-sandbox-ingress-authn.md`](./20260725-sandbox-ingress-authn.md)).
+Because these tokens leave the cluster and are validated by **external
+authorization systems** we do not control, this direction follows the OAuth /
+OIDC standards to the letter, so `aud` interoperates with any standard resource
+server or IdP.
+
+Per [RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3),
+`aud` names the **intended recipient** of a token, and per
+[RFC 8707 (Resource Indicators)](https://datatracker.ietf.org/doc/html/rfc8707)
+the audience identifies the **target resource server**. On the outbound path
+`aud` is therefore authoritative and takes priority — it is exactly what the
+external verifier checks:
+
+| Token (this document, outbound) | `aud` = recipient (authoritative) | Acting party |
+|---|---|---|
+| Stage-1 intermediate token | the **sandbox's own SPIFFE ID** (only that sandbox may present it), derived from the verified SVID subject — not caller-chosen | — |
+| Stage-2 final token | the **external target API** (the resource server that validates it, RFC 8707) | sandbox appears as `azp` / authorized-party (RFC 8693) |
+
+Key point for the outbound direction: **`aud` is the primary, standards-defined
+audience so the token interoperates with external authorization systems; the
+sandbox is carried as `azp` (the authorized party performing the exchange),
+following RFC 8693, rather than by overloading `aud`.**
+
+> **Relationship to the ingress proposal.** The two documents address opposite
+> directions and are intentionally scoped differently:
+> - **Outbound (this doc):** `aud` = the external service, standards-first, so
+>   the token is accepted by external IdPs/resource servers unchanged.
+> - **Inbound (ingress doc):** the recipient is the sandbox itself; the primary
+>   authorization anchor is the internal `sandbox` claim (`sandboxId`+`sandboxUid`,
+>   aligned with the merged verifier and #772), with `aud` available as an
+>   optional defense-in-depth signal.
+>
+> The invariant that keeps them consistent: **`aud` always names who is expected
+> to accept the token** — the external service on egress, the sandbox on ingress
+> — and is never overloaded to mean something else. This resolves the earlier
+> inconsistency where `aud` appeared to point in opposite directions.
+
 ### Implementation Details
 
 #### Core Components
@@ -581,7 +623,25 @@ func init() {
 }
 ```
 
-Existing call sites (`identity.IssueToken()`, `identity.PropagateSecurityToken()`) work without modification.
+Existing call sites compile and are invoked without signature changes:
+
+- **`identity.IssueToken()`** — used as-is; the SPIFFE provider builds its wire
+  request from `sbx` like any other provider.
+- **`identity.PropagateSecurityToken()`** — the *call site* is unchanged, but
+  note that in community mode `defaultTokenProvider.PropagateSecurityToken` is a
+  **no-op** and no propagator is registered, so a token issued by a registered
+  SPIFFE provider does **not** reach the sandbox on its own. Delivering the
+  token to the workload is a required, separate piece — it is **not** implied by
+  "works without modification".
+
+  **Design principle: the credential must not land inside the untrusted
+  sandbox as a long-lived secret.** Propagation is therefore intentionally left
+  to the forthcoming envd architecture split (a trusted in-pod component that
+  brokers short-lived tokens to the agent process), rather than writing the
+  credential into the sandbox filesystem/environment. Work on this propagation
+  path is already in progress — see
+  [#787](https://github.com/openkruise/agents/pull/787) — and this proposal
+  simply notes it as related work rather than claiming the path already exists.
 
 ### Deployment Modes
 

--- a/docs/proposals/20260727-agent-dynamic-identity-spiffe-token-exchange.md
+++ b/docs/proposals/20260727-agent-dynamic-identity-spiffe-token-exchange.md
@@ -1,0 +1,678 @@
+---
+title: "Agent Dynamic Identity: SPIFFE Workload Identity and OAuth 2.0 Token Exchange"
+authors:
+  - "@DahuK"
+reviewers:
+  - "@TBD"
+creation-date: 2026-07-27
+last-updated: 2026-07-27
+status: provisional
+see-also:
+  - "/docs/proposals/20260427-security-identity-provider.md"
+  - "/docs/proposals/20260725-sandbox-ingress-authn.md"
+---
+
+# Agent Dynamic Identity: SPIFFE Workload Identity and OAuth 2.0 Token Exchange
+
+> Feature gate: `SecurityIdentityProvider` (Alpha, disabled by default).
+
+## Table of Contents
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals/Future Work](#non-goalsfuture-work)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+  - [Architecture Overview](#architecture-overview)
+  - [Protocol Standards](#protocol-standards)
+  - [Implementation Details](#implementation-details)
+    - [Core Components](#core-components)
+    - [SPIFFE Client](#spiffe-client)
+    - [Token Exchanger (RFC 8693)](#token-exchanger-rfc-8693)
+    - [Trusted Principal Derivation](#trusted-principal-derivation)
+    - [Two-Stage Token Exchange](#two-stage-token-exchange)
+    - [Outbound Credential Flows (2LO / 3LO / OBO)](#outbound-credential-flows-2lo--3lo--obo)
+    - [Delegation Store (Encrypted Vault)](#delegation-store-encrypted-vault)
+    - [Inbound Validator](#inbound-validator)
+    - [Keycloak SPIFFE SPI](#keycloak-spiffe-spi)
+  - [Integration with Existing Identity Framework](#integration-with-existing-identity-framework)
+  - [Deployment Modes](#deployment-modes)
+  - [Sandbox Annotations](#sandbox-annotations)
+  - [Security Model](#security-model)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Alternatives](#alternatives)
+- [Test Plan](#test-plan)
+- [Implementation History](#implementation-history)
+
+## Summary
+
+This proposal introduces a concrete `IdentityProvider` implementation that enables Sandbox Agents to securely call third-party APIs (e.g., GitHub, cloud services) on behalf of users. It builds on the pluggable identity framework defined in [20260427-security-identity-provider.md](./20260427-security-identity-provider.md) and implements it using two industry-standard protocols:
+
+1. **SPIFFE/SPIRE** (CNCF Graduated) for cryptographic workload identity -- proving which specific Pod is making a request.
+2. **RFC 8693 OAuth 2.0 Token Exchange** for delegated credential acquisition -- converting a user-authorized refresh token into a short-lived third-party access token.
+
+The combination provides a complete inbound/outbound credential flow: the Agent proves its identity via a SPIFFE JWT-SVID, then exchanges a user-delegated refresh token for a scoped third-party access token through an OAuth 2.0 Authorization Server (e.g., Keycloak).
+
+## Motivation
+
+The existing `IdentityProvider` interface (`pkg/identity/interface.go`) has only a default UUID-based implementation. While the framework supports pluggable providers via `RegisterProvider()`, there is no open-source implementation that:
+
+1. Provides **cryptographic workload identity** (the current UUID token can be copied and replayed).
+2. Enables **delegated access to third-party APIs** (Agents cannot call GitHub/cloud APIs on behalf of users).
+3. Supports **revocable, time-bounded, scope-limited** credentials.
+4. Aligns with **community standards** (SPIFFE, OAuth 2.0, OIDC) used by AWS, Azure, and GCP.
+
+### Goals
+
+- Implement a `SpiffeTokenExchangeProvider` that satisfies the `IdentityProvider` interface.
+- Support both SPIFFE mode (production, with SPIRE DaemonSet) and client-secret mode (serverless/dev fallback).
+- Enable Agents to obtain delegated third-party API tokens via standard RFC 8693 Token Exchange.
+- Provide inbound JWT-SVID validation for verifying caller identity at the gateway.
+- Maintain backward compatibility: disabled by default behind `SecurityIdentityProviderGate`.
+- Provide a reference Authorization Server integration using Keycloak with custom SPIs.
+
+### Non-Goals/Future Work
+
+- Defining a new Agent identity protocol (we adopt existing standards: SPIFFE + OAuth 2.0).
+- Replacing the existing gateway UUID auth mechanism (JWT gateway auth is covered by PR #648).
+- Multi-tenancy across trust domains (future SPIFFE Federation work).
+- Automatic key rotation for mTLS certificates (requires separate proposal).
+- User-facing Portal UI for delegation management (application-layer concern).
+
+## Proposal
+
+### User Stories
+
+#### Story 1: Agent Calls GitHub on Behalf of User
+
+A developer deploys a coding Agent in a Sandbox. The Agent needs to create PRs on the user's GitHub repositories. The user pre-authorizes the Agent via an OAuth consent flow. At runtime, the Agent obtains a short-lived GitHub token scoped to `repo` and bound to its specific SPIFFE identity, then creates the PR. The token expires in 8 hours and is automatically refreshed by the token refresh controller.
+
+#### Story 2: Revoking Agent Access
+
+A user decides to revoke an Agent's access to their GitHub account. They do so through the authorization portal. The next time the Agent attempts a Token Exchange, the Authorization Server rejects the request because the delegation grant is revoked. The Agent receives a clear error and stops attempting API calls.
+
+#### Story 3: Multi-Agent Isolation
+
+Two Agents (research-agent and writer-agent) run in the same namespace but with different ServiceAccounts. Each has a distinct SPIFFE ID. Even if research-agent's refresh token is accidentally exposed to writer-agent, the Token Exchange fails because the delegation scope is bound to research-agent's exact SPIFFE ID.
+
+### Architecture Overview
+
+```
+                        +-----------------------+
+                        |   User (Principal)    |
+                        +-----------+-----------+
+                                    |
+                     Phase 1: OAuth consent + delegation scope
+                                    |
+                                    v
++----------------+     +------------------------+     +------------------+
+|   Portal       |---->|  Authorization Server  |---->|  Third-party IdP |
+| (consent flow) |     |  (Keycloak + SPIs)     |     |  (GitHub, etc.)  |
++----------------+     +--------+---+-----------+     +------------------+
+                                |   ^
+          Phase 2: Token Exchange   |   JWKS verification
+          (refresh_token + JWT-SVID)|   |
+                                |   |
+                                v   |
++-------------------------------+---+----------------------------------+
+|                         Kubernetes Cluster                            |
+|                                                                      |
+|  +------------------+    +-------------+    +-----------+            |
+|  | SPIRE Server     |    | SPIRE Agent |    | CSI Driver|            |
+|  | (trust bundle,   |    | (DaemonSet, |    | (mounts   |            |
+|  |  SVID signing)   |    |  attestation|    |  workload |            |
+|  +--------+---------+    +------+------+    |  API sock)|            |
+|           |                     |           +-----------+            |
+|           | JWKS                | Workload API                       |
+|           v                     v                                    |
+|  +--------+---------------------+--------+                          |
+|  |          Agent Sandbox Pod            |                          |
+|  |                                       |                          |
+|  |  [SpiffeTokenExchangeProvider]        |                          |
+|  |    1. FetchJWTSVID() from SPIRE       |                          |
+|  |    2. Read refresh_token from Secret  |                          |
+|  |    3. Token Exchange with AuthZ Server|                          |
+|  |    4. Cache + return access_token     |                          |
+|  |                                       |    Phase 3: API call     |
+|  |  [Agent workload] ------------------->+---> Third-party API      |
+|  +---------------------------------------+                          |
++----------------------------------------------------------------------+
+```
+
+#### Architecture (rendered)
+
+```mermaid
+flowchart TB
+    User["User (Principal)<br/>browser"]
+
+    subgraph IS["Identity Service (trusted, key-holder), self-hostable"]
+        IDP["Identity Provider<br/>(issues Agent/Principal JWT)"]
+        CPS["Credential Provider Server<br/>(outbound credential API)"]
+        AS["Authorization Server<br/>(Keycloak + SPIFFE SPIs)"]
+        Vault[("Encrypted Vault<br/>refresh_token ciphertext<br/>decrypt key: Identity Service only")]
+    end
+
+    subgraph K8S["Kubernetes Cluster"]
+        subgraph SPIRE["SPIRE (workload identity)"]
+            SS["SPIRE Server<br/>trust bundle / JWKS"]
+            SA["SPIRE Agent + CSI<br/>Workload API socket"]
+        end
+        subgraph POD["Agent Sandbox Pod (untrusted)"]
+            PROV["SpiffeTokenExchangeProvider"]
+            AGENT["Agent workload"]
+        end
+    end
+
+    IDP3P["Third-party IdP<br/>(GitHub, Google, Entra...)"]
+    API["Third-party API"]
+
+    User -->|"one-time OAuth consent (3LO)"| AS
+    AS -->|"federates"| IDP3P
+    SS -->|"JWKS (verify SVID)"| AS
+    SA -->|"JWT-SVID via Workload API"| PROV
+    SS -.->|"signs SVID"| SA
+    PROV -->|"authenticated API<br/>(short-lived token only)"| CPS
+    CPS <-->|"decrypt / refresh"| Vault
+    CPS -->|"token exchange / refresh / client_credentials"| AS
+    AGENT -->|"Bearer access_token"| API
+
+    style IS fill:#eef6ff
+    style POD fill:#fff0f0
+    style SPIRE fill:#f0fff0
+```
+
+### Protocol Standards
+
+| Layer | Standard | RFC/Spec | Purpose |
+|-------|----------|----------|---------|
+| Workload Identity | SPIFFE | [spiffe.io](https://spiffe.io) | Cryptographic Pod identity |
+| Identity Document | JWT-SVID | [SPIFFE JWT-SVID](https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md) | Short-lived signed identity assertion |
+| Client Authentication | RFC 7523 | [JWT Bearer Assertion](https://datatracker.ietf.org/doc/html/rfc7523) | JWT-SVID as `client_assertion` |
+| Token Exchange | RFC 8693 | [OAuth 2.0 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693) | OBO: exchange a verified user token for a third-party token |
+| Authorization Code + PKCE | RFC 6749 §4.1 / RFC 7636 | [OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc6749) / [PKCE](https://datatracker.ietf.org/doc/html/rfc7636) | 3LO: user consent → code → access + refresh token |
+| Client Credentials | RFC 6749 §4.4 | [OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc6749) | 2LO: service-to-service token (no user, no refresh token) |
+| Resource Indicators | RFC 8707 | [Resource Indicators](https://datatracker.ietf.org/doc/html/rfc8707) | Target audience specification |
+| Discovery | OIDC Discovery | [OpenID Connect](https://openid.net/specs/openid-connect-discovery-1_0.html) | JWKS endpoint discovery |
+| Workload Identity (IETF) | WIMSE | [IETF WIMSE WG](https://datatracker.ietf.org/group/wimse/about/) | Workload Identity in Multi-System Environments |
+
+### Implementation Details
+
+#### Core Components
+
+```
+pkg/identity/
+├── spiffe/                         # New package
+│   ├── provider.go                 # SpiffeTokenExchangeProvider
+│   ├── provider_options.go         # Functional options
+│   ├── spiffe_client.go            # SPIRE Workload API client
+│   ├── token_exchanger.go          # RFC 8693 Token Exchange client
+│   ├── delegation_store.go         # K8s Secret reader for refresh tokens
+│   ├── token_cache.go              # TTL-based token cache
+│   ├── inbound_validator.go        # Inbound JWT-SVID verification
+│   └── spiffe_test.go              # Unit tests
+│
+├── propagator/                     # New package
+│   ├── credential_file.go          # Write token to sandbox filesystem
+│   └── env_injector.go             # Inject token into Pod env
+```
+
+#### SPIFFE Client
+
+The SPIFFE Client wraps the SPIRE Workload API to fetch JWT-SVIDs:
+
+```go
+type SpiffeClient struct {
+    socketPath string         // unix:///run/spire/sockets/agent.sock
+    authMode   ClientAuthMode // "spiffe" or "client_secret"
+}
+
+type ClientAuthMode string
+const (
+    AuthModeSpiffe       ClientAuthMode = "spiffe"
+    AuthModeClientSecret ClientAuthMode = "client_secret"
+)
+
+// FetchJWTSVID obtains a JWT-SVID from SPIRE Agent with the given audience.
+// The audience MUST be the Authorization Server's realm issuer URL.
+func (c *SpiffeClient) FetchJWTSVID(ctx context.Context, audience string) (*JWTSVID, error)
+```
+
+The SPIFFE ID format follows the SPIRE Kubernetes attestation template:
+```
+spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>
+```
+
+#### Token Exchanger (RFC 8693)
+
+The Token Exchanger performs the standard OAuth 2.0 Token Exchange:
+
+```
+POST /realms/{realm}/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+&subject_token={user_refresh_token}
+&subject_token_type=urn:ietf:params:oauth:token-type:refresh_token
+&requested_token_type=urn:ietf:params:oauth:token-type:access_token
+&requested_issuer={target_idp}      (e.g., "github")
+&scope={requested_scope}            (e.g., "repo")
+&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer
+&client_assertion={JWT-SVID}
+```
+
+Response:
+```json
+{
+  "access_token": "<third-party-access-token>",
+  "token_type": "Bearer",
+  "expires_in": 28800,
+  "scope": "repo"
+}
+```
+
+#### Trusted Principal Derivation
+
+> **Threat model note.** The `PrincipalInfo.PrincipalName` field on `TokenRequest` MUST NOT be treated as a trusted input. A user identity that a caller can freely populate is an *assertion*, not an *authentication*: any component able to invoke `IssueToken()` could otherwise claim to act on behalf of an arbitrary user and obtain that user's delegated third-party credentials. The user identity that seeds a delegation exchange MUST be **derived from a cryptographically verified inbound credential**, never from a caller-supplied string.
+
+**Rule: the `Principal` is derived, not passed.** The `IdentityProvider` accepts a principal value only after the caller has been authenticated at an inbound boundary, and the principal value MUST equal the `sub` claim of the verified inbound credential.
+
+Trust sources for the two identities that participate in a delegated exchange:
+
+| Identity | Trusted source | How it is verified | Never |
+|----------|----------------|--------------------|-------|
+| **User (Principal)** | Inbound OIDC/OAuth access token presented by the user | JWKS signature + `iss` + `aud` + `exp`; `Principal` = verified `sub` | A raw `PrincipalName` string set by the caller/SDK/sandbox |
+| **Workload (Sandbox/Agent)** | SPIFFE JWT-SVID from SPIRE Workload API | SPIRE trust-bundle signature + `sub` (SPIFFE ID) + trust-domain match | A `sandboxId` value chosen by the request |
+
+**Who is allowed to set the Principal.** Only the trusted Identity Service (the component that holds the signing/decryption keys — a self-hosted Deployment, not a cloud-managed control plane) may bind a principal, and only after it has itself validated the inbound OIDC token:
+
+```go
+// TRUSTED: the gateway validated the inbound OIDC token first, and the
+// principal is the verified subject of that token — not a request field.
+claims, err := inboundValidator.VerifyOIDC(ctx, inboundBearerToken) // JWKS + iss/aud/exp
+if err != nil {
+    return nil, fmt.Errorf("inbound authentication failed: %w", err)
+}
+req := TokenRequest{
+    TokenType: TokenTypePrincipal,
+    Principal: &PrincipalInfo{PrincipalName: claims.Subject}, // == verified `sub`
+    Sandbox:   sbxInfo,
+}
+resp, err := provider.IssueToken(ctx, sbx, TokenKindIDToken /* principal-bound */)
+```
+
+```go
+// UNTRUSTED (rejected): principal taken directly from an unauthenticated field.
+// The provider MUST reject a principal that is not backed by a verified inbound
+// credential in the current call context.
+req := TokenRequest{ Principal: &PrincipalInfo{PrincipalName: userInput} } // ✗ forgeable
+```
+
+**Enforcement points.**
+
+1. `IssueToken()` with `TokenType == Principal` MUST fail closed when no verified inbound credential is present in the call context (no silent fallback to a passed-in name).
+2. The delegation grant stored for a user (see [Delegation Store](#delegation-store)) is bound to a specific SPIFFE ID via the `delegation:<spiffe-id>` scope; the Authorization Server performs an **exact match** at exchange time, so even a correctly-named principal cannot be exercised by the wrong workload.
+3. The intermediate-token audience in the two-stage flow is **derived from the verified Sandbox SVID subject**, never from a request parameter, so one sandbox cannot mint a delegation token scoped to another sandbox.
+
+**Design invariant (aligned with established delegation practice).**
+
+- The user identity always originates from an **inbound OIDC/JWT login that is verified** (signature via JWKS, issuer, and audience) before it is used; the verified token — never an application-level field — becomes the `subject_token` for the exchange.
+- The workload identity is a **SPIFFE JWT-SVID verified against the SPIRE trust bundle**.
+- The design **does not** hand the sandbox the user's raw OIDC token, and **does not** let the caller request an arbitrary intermediate audience: the intermediate audience is derived from the verified workload SVID subject so a workload cannot mint a token scoped to another identity.
+
+Invariant: **user identity = a verified inbound credential's subject; workload identity = a verified SVID's subject; the exchange audience is derived from the verified workload identity.**
+
+#### Two-Stage Token Exchange
+
+To keep user-delegated credentials out of the (untrusted) sandbox while still producing a token that carries *both* the user subject and the sandbox as authorized party, the exchange is split into two stages across the trust boundary.
+
+```
+                    ┌──────────────── TRUST BOUNDARY ────────────────┐
+  User (OIDC)       │  Identity Service (trusted, key-holder)        │   Sandbox (untrusted)
+      │             │                                               │
+      │ inbound OIDC │  ① VerifyOIDC(inbound token)  ── JWKS/iss/aud │
+      └─────────────┼─► Principal = verified `sub`                   │
+                    │                                               │
+                    │  ② verify Sandbox SVID (SPIRE JWKS,           │◄── SVID (SPIFFE Workload API)
+                    │     trust-domain match)                       │
+                    │                                               │
+                    │  ③ STAGE 1 exchange (RFC 8693):               │
+                    │     subject_token   = verified user token     │
+                    │     client_assertion= GATEWAY JWT-SVID        │
+                    │     audience        = <derived from verified  │
+                    │                        Sandbox SVID subject>  │
+                    │            │                                  │
+                    │            ▼                                  │
+                    │     intermediate token (aud = sandbox SPIFFE) ├──► returned to sandbox
+                    │                                               │
+                    └───────────────────────────────────────────────┘
+                                                                    │  ④ STAGE 2 exchange (RFC 8693):
+                                                                    │     subject_token   = intermediate token
+                                                                    │     client_assertion= SANDBOX JWT-SVID
+                                                                    │     audience/scope  = target API
+                                                                    │            │
+                                                                    │            ▼
+                                                                    │     final token
+                                                                    │     (sub = user, azp = sandbox SPIFFE)
+                                                                    │  ⑤ inject Authorization: Bearer → target API
+```
+
+**Why two stages (and why the user token never enters the sandbox):**
+
+- The **user's delegated credential is held encrypted (envelope encryption), and the decryption key is held only by the trusted Identity Service**, which is the only component that decrypts-and-uses it as `subject_token` inside Stage 1. The sandbox never sees the refresh token — it only receives short-lived tokens through an authenticated API (see [Delegation Store](#delegation-store-encrypted-vault)). This closes the risk of a user `refresh_token` being readable inside the sandbox, and note the guarantee comes from **decryption-key custody, not namespace placement or any cloud-managed control plane** (the vault Secret may share the sandbox's namespace, and the Identity Service is a self-hostable workload).
+- Stage 1 produces an **intermediate token whose audience is the sandbox's own SPIFFE ID**, so it is only usable by that specific sandbox. The audience is derived from the *verified* SVID subject (enforcement point 3 above), not chosen by the caller.
+- Stage 2 is a **standard RFC 8693 exchange performed by the sandbox** using its own SVID as `client_assertion` and the intermediate token as `subject_token`, yielding a final token where `sub` = user and `azp`/authorized-party = sandbox SPIFFE ID.
+
+**Deployment variant — bind-at-injection (single runtime hop).** Because openkruise/agents injects the outbound `IDToken` into the sandbox from a trusted operator/Identity Service (written into the runtime, kept off the CR), Stage 1 MAY be performed at **injection time** by that trusted component after it has verified the user's inbound OIDC identity. In that variant the sandbox receives an already-user-bound `IDToken` and only performs the single Stage-2 exchange at runtime. Security is equivalent to the two-hop flow — the user credential still never enters the sandbox and the binding is still done by a trusted key-holding component that verified the user identity — while avoiding a per-request round-trip. The choice between "runtime two-hop" and "bind-at-injection one-hop" is a deployment-mode decision, not a change to the trust model.
+
+> **Guardrail for the injection variant:** the component that *triggers* injection MUST itself have verified the user's inbound OIDC identity before requesting a principal-bound `IDToken`; otherwise the forgery risk simply moves from the `Principal` field to the injection trigger.
+
+#### Outbound Credential Flows (2LO / 3LO / OBO)
+
+The system exposes three OAuth 2.0 grant flows for agents to obtain third-party credentials. They differ in **who the token represents** and **whether a refresh token is involved**.
+
+| Flow | Grant | Represents | User interaction | Refresh token | On expiry |
+|------|-------|-----------|------------------|---------------|-----------|
+| **2LO** | `client_credentials` | the service itself | none | **not used** | re-fetch with client secret (stateless) |
+| **3LO** | `authorization_code` (+ PKCE) | the **user** (delegated) | one-time browser consent | **required** (with `offline_access`) | silent refresh; fall back to re-consent |
+| **OBO** | RFC 8693 token-exchange | **user + agent** (combined) | none (uses inbound token) | not pre-stored | re-exchange from the inbound `subject_token` |
+
+In all flows: the agent authenticates to the Credential Provider Server with its Agent JWT (`Authorization: Bearer`), is authorized by AgentRole/AgentRoleBinding, and receives **only a short-lived access token** — long-lived material (client secret, refresh token) is held encrypted by the Identity Service (see [Delegation Store](#delegation-store-encrypted-vault)).
+
+##### 2LO — Client Credentials (no refresh token)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Agent as Agent sandbox
+    participant CPS as Credential Provider Server
+    participant Vault as Encrypted Vault
+    participant IdP as Third-party IdP
+
+    Note over Agent,IdP: 2LO - represents the service itself, no refresh token
+
+    Agent->>CPS: GetResourceOAuth2Token credentialProviderName<br/>Authorization Bearer agent-jwt
+    CPS->>CPS: verify agent-jwt plus AgentRole authorization
+    CPS->>Vault: lookup cached or stored access token
+    alt hit and not near expiry
+        Vault-->>CPS: access token valid
+    else miss or expired or near expiry
+        CPS->>IdP: grant_type=client_credentials<br/>client_id plus client_secret plus scope
+        IdP-->>CPS: access_token, NO refresh_token
+        CPS->>Vault: store access token, RefreshToken empty
+    end
+    CPS-->>Agent: accessToken, tokenType, expiresAt
+    Note over CPS,IdP: on expiry, re-run client_credentials, no refresh token needed
+    Agent->>IdP: call third-party API with accessToken
+```
+
+##### 3LO — Authorization Code + PKCE (refresh token required)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User as User browser
+    participant Agent as Agent sandbox
+    participant CPS as Credential Provider Server
+    participant Vault as Encrypted Vault
+    participant IdP as Third-party IdP
+
+    Note over User,IdP: 3LO - represents the user, depends on refresh token
+
+    rect rgb(235,245,255)
+    Note over Agent,IdP: One-time authorization, user must be present
+    Agent->>CPS: GetResourceOAuth2Token credentialProviderName
+    CPS->>Vault: any stored credential for workload+user+scope
+    alt exists and refreshable
+        Note over CPS: go to silent-refresh phase
+    else none, initiate authorization
+        CPS-->>Agent: authorizationUrl, sessionId, sessionStatus Pending
+        Agent->>User: open authorizationUrl
+        User->>IdP: login plus consent
+        IdP->>CPS: callback with authorization code
+        CPS->>IdP: grant_type=authorization_code plus PKCE
+        IdP-->>CPS: access_token plus refresh_token, with offline_access
+        CPS->>Vault: store access_token plus refresh_token, encrypted
+        Agent->>CPS: CompleteResourceOAuth2Auth sessionId
+        Agent->>CPS: GetResourceOAuth2Token sessionId, poll
+        CPS-->>Agent: accessToken, expiresAt
+    end
+    end
+
+    rect rgb(240,255,240)
+    Note over Agent,IdP: Silent refresh, user may be offline
+    Agent->>CPS: GetResourceOAuth2Token credentialProviderName
+    CPS->>Vault: read encrypted entry with refresh_token
+    alt access token not near expiry
+        Vault-->>CPS: access token valid
+        CPS-->>Agent: accessToken
+    else near expiry, less than refreshBeforeExpiry default 5m
+        CPS->>IdP: grant_type=refresh_token plus refresh_token
+        alt refresh ok
+            IdP-->>CPS: new access_token, maybe new refresh_token
+            CPS->>Vault: update encrypted entry
+            CPS-->>Agent: accessToken
+        else invalid_grant, revoked or expired
+            CPS-->>Agent: re-authorization required, forceAuthentication
+        end
+    end
+    end
+    Agent->>IdP: call third-party API with accessToken
+```
+
+##### OBO — On-Behalf-Of Token Exchange (RFC 8693, combined identity)
+
+This is the [Two-Stage Token Exchange](#two-stage-token-exchange) flow, shown here in the same notation for comparison. It carries **user + agent** identity in the final token without any pre-stored refresh token.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Agent as Agent sandbox
+    participant CPS as Identity Service
+    participant SW as SPIFFE Workload API
+    participant IdP as Third-party IdP
+
+    Note over Agent,IdP: OBO - represents user plus agent, no pre-stored refresh token
+
+    Agent->>SW: fetch JWT-SVID
+    SW-->>Agent: sandbox JWT-SVID
+    Agent->>CPS: GetResourceOAuth2Token, subjectToken=verified user token<br/>Authorization Bearer agent-jwt
+    Note over CPS: Stage 1 - verify inbound user token plus sandbox SVID<br/>exchange using Identity Service SVID as client_assertion<br/>audience = sandbox SPIFFE ID, derived not caller-chosen
+    CPS->>IdP: RFC 8693 exchange, subject=user token, client_assertion=Identity Service SVID
+    IdP-->>CPS: intermediate token, aud = sandbox SPIFFE ID
+    CPS-->>Agent: intermediate token
+    Note over Agent: Stage 2 - exchange with own SVID as client_assertion
+    Agent->>IdP: RFC 8693 exchange, subject=intermediate, client_assertion=sandbox SVID, audience=target API
+    IdP-->>Agent: final token, sub = user, azp = sandbox SPIFFE ID
+    Agent->>IdP: call third-party API with final token
+```
+
+**Choosing a flow:** use **2LO** when the agent acts as itself (service-to-service, no user); use **3LO** when the agent must act for a user who authorizes once and may then go offline (background/long-running work — the refresh token in the vault keeps it going); use **OBO** when a verified user token is already present in the request and the downstream service must see both the user (`sub`) and the acting agent (`azp`) in one token.
+
+#### Delegation Store (Encrypted Vault)
+
+User-delegated refresh tokens are **long-lived credentials** and MUST NOT be readable by the (untrusted) sandbox. The trust boundary here is **not** drawn on the Kubernetes namespace, and it does **not** depend on any cloud-managed control plane — it is drawn on **who holds the decryption key**. The store is an envelope-encrypted abstraction ("vault") backed by Kubernetes Secrets.
+
+> **Terminology.** In this document the key-holding trusted component is called the **Identity Service** — the workload(s) that hold the signing/decryption keys and expose the credential API (in the reference implementation, the identity-provider and credential-provider servers). It is an ordinary, **self-hostable Kubernetes Deployment**; the term does not imply a cloud vendor's managed control plane. The security properties below follow from *key custody by this component*, wherever it runs.
+
+**Storage model (as implemented in the reference Identity Service):**
+
+1. **Envelope encryption before write.** The refresh token is encrypted with an asymmetric key pair before it is written into a Secret. The Secret therefore contains ciphertext, never a base64 plaintext token.
+
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     # Name derived from a vault key that binds workload + user + scope, e.g.
+     #   SHA256(namespace, credentialProvider, grantType, workloadHash, userHash, scopeHash)
+     name: <vault-name-prefix>-<hash>
+     # Namespace follows the CredentialProvider CR's namespace (typically the
+     # user/business namespace) — it is NOT a dedicated/privileged namespace.
+     namespace: <credentialprovider-cr-namespace>
+     ownerReferences:
+       - kind: CredentialProvider
+         name: <cr-name>            # GC-bound to the CR
+   type: agentidentity.alibabacloud.com/oauth2-vault-entry
+   data:
+     payload: <envelope-encrypted-refresh-token-and-metadata>   # ciphertext
+   ```
+
+2. **Decryption key lives only in the Identity Service.** The encryption key pair is loaded from files mounted only into the Identity Service workloads (identity/credential provider servers), e.g. `/etc/agent-identity/token/token-encrypt-key.pem` (private) and `token-encrypt-pub-key.pem` (public). **No sandbox/agent code path loads the private key.** Even if a sandbox shares the CR's namespace and can `get secret` the vault entry, it retrieves only ciphertext it cannot decrypt. (The key is a file mount, so the private key can be sourced from an RBAC-restricted Secret, a CSI secret driver, or a KMS/HSM — none of which require a cloud-managed control plane.)
+
+3. **The agent never touches the refresh token.** The sandbox obtains outbound credentials exclusively through an authenticated HTTP API on the Identity Service (`POST /api/v1/credentials` with `x-api-action-name: GetResourceOAuth2Token` and `Authorization: Bearer <agent-jwt>`). The service authenticates the caller, decrypts the vault entry, performs the refresh/exchange, and returns **only a short-lived access token** (the response view never includes the refresh token). Refresh tokens are never present in API responses, logs, or metrics.
+
+4. **Silent refresh by the Identity Service.** When an access token nears expiry (`RefreshBeforeExpiry`), the Identity Service uses the stored refresh token to obtain a new access token (concurrency-collapsed via singleflight). This is what enables the offline-delegation scenario (see below): the user can be offline while the agent keeps operating, because the long-lived credential and its refresh cycle live entirely inside the Identity Service.
+
+**Binding.** The refresh token carries a `delegation:<spiffe-id>` scope, enforced by the Authorization Server via **exact match** at exchange time; additionally the vault key itself binds the entry to `(workload, user, scope)`, so a leaked ciphertext is useless to a different workload even before decryption is attempted.
+
+> **Correct security statement (do not paraphrase as "stored in a control-plane namespace" or "secured by the cloud control plane"):** the refresh token is stored as **envelope-encrypted ciphertext in a Kubernetes Secret (namespace follows the CredentialProvider CR)**; the **decryption key is held only by the trusted Identity Service (a self-hostable workload)**; and the **agent can only obtain a short-lived access token through an authenticated API and never sees the refresh token**. Security derives from **decryption-key custody + encryption + API-only access** — not from namespace isolation and not from any cloud-vendor-managed control plane.
+
+**Delegation models (two complementary paradigms).** This design supports both:
+
+| Model | When user is | Credential | How |
+|-------|--------------|------------|-----|
+| **Online / request-time (OBO)** | Present (token in request) | Verified inbound user token used as `subject_token` at request time | RFC 8693 token exchange, nothing pre-stored |
+| **Offline / pre-stored delegation** | Absent (offline) | Long-lived refresh token pre-authorized once (3LO consent + `offline_access`), stored encrypted in vault | Identity Service silently refreshes; agent gets short-lived tokens on demand |
+
+The **offline model** lets an agent act on a user's behalf while the user is offline (Story 1's auto-refreshing GitHub token; long-running background agents), which a purely request-time (online) model cannot do. The cost is a long-lived credential, which is precisely why it is held encrypted under a key custodied by the Identity Service, never in the sandbox.
+
+#### Inbound Validator
+
+For verifying incoming requests at the gateway/traffic-extension level:
+
+1. Parse JWT header, extract `kid`
+2. Fetch public key from SPIRE Server JWKS endpoint (cached)
+3. Verify RSA/ECDSA signature
+4. Validate `sub` (SPIFFE ID) matches allowed patterns
+5. Validate `aud` includes the target service
+6. Check `exp` for token expiration
+
+#### Keycloak SPIFFE SPI
+
+The Authorization Server requires custom extensions to bridge SPIFFE and standard OAuth 2.0. For Keycloak, this involves three custom SPIs:
+
+| SPI                           | Purpose                                                                                                            | Gap Addressed                                            |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
+| `SpiffeClientAuthenticator`   | Validates JWT-SVID as `client_assertion`; maps SPIFFE ID to Keycloak client via `spiffe.id.pattern` attribute      | Gap 1: SVID format differs from standard JWT client auth |
+| `SpiffeIdDelegationValidator` | Extracts `delegation:<spiffe-id>` scope from subject_token; performs **exact match** against requester's SPIFFE ID | Gap 5: Delegation scope SPIFFE ID validation             |
+| `AudienceEnforcerMapper`      | Injects `audience` into token `aud` claim (workaround until Keycloak 26.8 implements RFC 8707)                     | Gap 4: Missing Resource Indicators                       |
+
+Additional operational configurations:
+- **Gap 2** (SPIFFE ID to Client mapping): Solved by storing `spiffe.id.pattern` glob in Keycloak client attributes.
+- **Gap 3** (SPIRE Trust Bundle sync): Solved by configuring Keycloak's JWKS URL to point to SPIRE Server's `/keys` endpoint.
+- **Gap 6** (Token revocation): Optional `TokenRevocationMapper` blocks token issuance for revoked delegation grants.
+
+### Integration with Existing Identity Framework
+
+The implementation integrates with zero changes to existing callers:
+
+```go
+// Registration at startup (gated by SecurityIdentityProviderGate)
+func init() {
+    if features.DefaultFeatureGate.Enabled(features.SecurityIdentityProviderGate) {
+        provider, _ := spiffe.NewSpiffeTokenExchangeProvider(
+            spiffe.WithTokenEndpoint(os.Getenv("TOKEN_EXCHANGE_ENDPOINT")),
+            spiffe.WithRealmIssuer(os.Getenv("REALM_ISSUER")),
+            spiffe.WithSpireSocketPath(os.Getenv("SPIFFE_ENDPOINT_SOCKET")),
+            spiffe.WithAuthMode(spiffe.ClientAuthMode(os.Getenv("CLIENT_AUTH_MODE"))),
+        )
+        identity.RegisterProvider(provider)
+    }
+}
+```
+
+Existing call sites (`identity.IssueToken()`, `identity.PropagateSecurityToken()`) work without modification.
+
+### Deployment Modes
+
+| Mode | SPIRE Required | Client Authentication | Use Case |
+|------|----------------|----------------------|----------|
+| `spiffe` (default) | Yes (DaemonSet + CSI) | JWT-SVID from SPIRE Workload API | Production Kubernetes |
+| `client_secret` | No | `client_id` + `client_secret` from K8s Secret | ACK Serverless (ECI), dev, CI |
+
+### Sandbox Annotations
+
+```yaml
+metadata:
+  annotations:
+    security.agents.kruise.io/delegation-secret: "user-alice-delegation"
+    security.agents.kruise.io/target-issuer: "github"
+    security.agents.kruise.io/target-scope: "repo"
+    security.agents.kruise.io/auth-mode: "spiffe"
+```
+
+### Security Model
+
+| Property | Mechanism |
+|----------|-----------|
+| **User identity unforgeable** | `Principal` is derived from a verified inbound OIDC token's `sub` claim (JWKS + `iss`/`aud`/`exp`), never from a caller-supplied field (see [Trusted Principal Derivation](#trusted-principal-derivation)) |
+| **User credential never enters sandbox** | User token stays inside the trusted Identity Service (key-holder) and is used only as Stage-1 `subject_token`; the sandbox only ever holds a sandbox-scoped intermediate/ID token (see [Two-Stage Token Exchange](#two-stage-token-exchange)) |
+| **Intermediate audience non-forgeable** | Stage-1 intermediate audience is derived from the *verified* Sandbox SVID subject, not from a request parameter, so a sandbox cannot mint a delegation token for another sandbox |
+| **Workload identity unforgeable** | SPIFFE JWT-SVID issued by SPIRE via kernel-level Pod attestation (k8s_psat) |
+| **Delegation binding** | `delegation:<spiffe-id>` scope in refresh_token; Authorization Server performs **exact match** (not glob) |
+| **Cross-agent isolation** | SPIFFE ID encodes `ns/{namespace}/sa/{serviceAccount}`; different Agents have different IDs |
+| **Least privilege** | Scope downgrading enforced; Agent cannot request broader scope than user authorized |
+| **Revocable** | User revokes delegation -> Authorization Server rejects subsequent Token Exchange |
+| **Audit trail** | Exchanged token contains `act.sub` claim recording which Agent acted on behalf of user |
+| **Time-bounded** | Short-lived tokens (default 8h); automatic refresh via `securitytokenrefresh` controller |
+| **Fail-closed** | Missing SPIRE socket, missing Secret, unverified inbound identity, or failed Token Exchange -> error propagated, no silent fallback |
+
+### Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| **Forged `Principal` (user impersonation)** | A caller sets an arbitrary `PrincipalName` and obtains another user's delegated credentials | `Principal` MUST be derived from a verified inbound OIDC token's `sub`; `IssueToken(TokenType=Principal)` fails closed if no verified inbound credential is in the call context; only the trusted Identity Service (post inbound verification) may bind a principal — see [Trusted Principal Derivation](#trusted-principal-derivation) |
+| **Intermediate-token audience forgery** | A sandbox requests an intermediate token scoped to a *different* sandbox | Stage-1 audience is derived from the verified Sandbox SVID subject, not from any request field; Stage-2 verifies the intermediate token's audience matches its own SVID |
+| SPIRE Server unavailable | Agent cannot obtain JWT-SVID; token issuance fails | Retry with backoff; client_secret fallback mode for non-DaemonSet environments |
+| Vault Secret read by a co-located sandbox (same namespace) | Sandbox could try to read the stored refresh token | Vault entries are **envelope-encrypted**; the **decryption key is mounted only into the Identity Service workloads** (no sandbox code path loads the private key), so a co-located sandbox reads only ciphertext. Agents obtain credentials only via an authenticated API that returns short-lived access tokens; the refresh token never appears in responses/logs/metrics (see [Delegation Store](#delegation-store-encrypted-vault)). Guarantee is from **key custody**, not namespace isolation. |
+| Decryption key compromise | Attacker could decrypt all vault entries | Private key mounted only to the Identity Service pods via file (`/etc/agent-identity/token/token-encrypt-key.pem`), restricted by pod/Secret RBAC; the key source is pluggable (RBAC-restricted Secret, CSI secret driver, or KMS/HSM) and self-hostable; future: KMS/HSM-backed key, rotation |
+| Authorization Server unavailable | Token Exchange fails | Cached tokens remain valid until expiry; retry with backoff |
+| JWKS key rotation | Inbound validator rejects new tokens | Lazy refresh on unknown `kid`; configurable JWKS cache TTL |
+| Long-lived refresh_token in Secret | Exposure window if Secret compromised | Future: integrate with external secret stores (Vault, ESO); short TTL + rotation |
+
+## Alternatives
+
+| Alternative                      | Why Not Chosen                                                                               |
+| -------------------------------- | -------------------------------------------------------------------------------------------- |
+| **AgentID (agentscope-ai)**      | Agent self-manages private keys; no workload attestation; no delegation mechanism            |
+| **Pure K8s SA Token projection** | No third-party API delegation; limited to GCP/AWS federation only                            |
+| **E2B-style API Key per team**   | No per-user delegation; no workload identity; no revocation                                  |
+| **Custom proprietary protocol**  | Not interoperable; community standards preferred                                             |
+| **Direct GitHub OAuth in Agent** | Agent holds long-lived user credentials; violates least-privilege; no centralized revocation |
+
+## Test Plan
+
+### Unit Tests
+- `SpiffeClient`: Mock SPIRE Workload API; verify JWT-SVID fetch and caching.
+- `TokenExchanger`: Mock HTTP server; verify RFC 8693 request format and response parsing.
+- `DelegationStore`: Mock K8s client; verify Secret reading and error handling.
+- `TokenCache`: Verify TTL expiration, sandbox isolation, and eviction.
+- `InboundValidator`: Verify signature validation, audience check, expiration check, and SPIFFE ID pattern matching.
+
+### Integration Tests (E2E)
+
+| Phase | Scenarios | What is Validated |
+|-------|-----------|-------------------|
+| Phase 1 (Pre-auth) | User consent flow, delegation scope issuance, refresh_token storage | OIDC flow correctness, scope binding |
+| Phase 2 (Token Exchange) | SPIFFE auth, Token Exchange, third-party token acquisition | RFC 8693 compliance, delegation validation |
+| Failure scenarios | Invalid refresh_token, revoked delegation, SPIFFE ID mismatch, Authorization Server unavailable | Error handling, fail-closed behavior |
+| Security scenarios | Cross-agent token reuse attempt, scope escalation attempt | Isolation and least-privilege enforcement |
+| Principal trust scenarios | Forged/caller-supplied `Principal` with no inbound token, `Principal` mismatching the verified inbound `sub`, sandbox requesting an intermediate token for another sandbox's audience, user token absent from sandbox filesystem after two-stage exchange | Trusted principal derivation, fail-closed on unverified inbound identity, intermediate-audience binding, user-credential confinement |
+| Outbound flow coverage | 2LO client_credentials re-fetch on expiry (no refresh token); 3LO consent → code → refresh, silent refresh before expiry, re-consent on `invalid_grant`; OBO two-stage exchange | Correct grant per flow, refresh-token presence only in 3LO, short-lived-token-only to agent |
+
+### E2E Infrastructure
+- Docker-compose environment: Keycloak + PostgreSQL + SPIRE Server/Agent + Mock third-party IdP
+- Python pytest framework for flow validation
+- Mock third-party server simulating OAuth authorization code flow and API authentication
+
+## Implementation History
+
+- 2026-07-25: Initial proposal drafted
+- 2026-07-25: Added Trusted Principal Derivation and Two-Stage Token Exchange sections — established that `Principal` must be derived from a verified inbound OIDC credential (not a caller-supplied field), that the user credential stays inside the trusted Identity Service and never enters the untrusted sandbox, and that the Stage-1 intermediate audience is derived from the verified Sandbox SVID. Added the bind-at-injection single-hop deployment variant.
+- 2026-07-25: Corrected the Delegation Store security model to match the verified reference implementation — the refresh token is **envelope-encrypted ciphertext in a K8s Secret whose namespace follows the CredentialProvider CR (may co-locate with the sandbox)**, and the trust guarantee comes from **decryption-key custody by the Identity Service + API-only access returning short-lived tokens**, NOT from namespace isolation. Added the two complementary delegation models (online/OBO request pass-through vs offline/pre-stored vault refresh).
+- 2026-07-25: Terminology — replaced "control plane" with **Identity Service** (a self-hostable, key-holding Kubernetes Deployment) throughout, to make explicit that the refresh-token security model depends on **decryption-key custody**, not on any cloud-vendor-managed control plane. Clarified the private-key source is pluggable (RBAC-restricted Secret / CSI / KMS / HSM).
+- 2026-07-27: Added a rendered Mermaid **architecture diagram** and a new **Outbound Credential Flows (2LO / 3LO / OBO)** section with three Mermaid sequence diagrams and a flow-comparison table. Clarified that **refresh tokens are used only in 3LO** (2LO re-fetches via client_credentials; OBO re-exchanges the inbound subject token). Added `authorization_code`+PKCE and `client_credentials` to Protocol Standards and an outbound-flow-coverage row to the E2E test plan.
+- [Pending]: Community review
+- [Pending]: Implementation of `pkg/identity/spiffe/` package
+- [Pending]: Keycloak SPI reference implementation
+- [Pending]: E2E test suite


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds two design proposals under `docs/proposals/` that together cover
**bidirectional identity** for sandbox agents — inbound authentication into a
sandbox, and outbound delegated credential acquisition from a sandbox. Both are
documentation-only, gated behind feature gates that are **off by default**, and
fully backward compatible.

### 1. `20260725-sandbox-ingress-authn.md` — Sandbox Ingress (envd) Token Authentication and aud Authorization

Introduces JWT-based authentication and **audience (aud) authorization** for the
**ingress direction** (client → sandbox-gateway → envd/agent-runtime). Only a
token whose `aud` explicitly contains the target sandbox's SPIFFE ID — and that
passes signature, expiry, and admin-policy checks — may reach that sandbox's
envd interfaces.

- **Issuance plane** (`sandbox-manager` + `pkg/identity`): exchange the existing
  Team API Key for a short-lived JWT carrying `aud`.
- **Authorization control plane**: a new namespaced CRD `SandboxIngressPolicy`
  (symmetric to the egress `SecurityProfile`).
- **Verification data plane** (`sandbox-gateway`): upgrade the current static
  `x-access-token` comparison into a tiered verification chain.
- Guarded by the `SandboxIngressJWTAuth` feature gate (gateway + manager, Alpha,
  disabled by default); `TokenClass=Opaque` preserves the legacy path.

### 2. `20260727-agent-dynamic-identity-spiffe-token-exchange.md` — Agent Dynamic Identity: SPIFFE Workload Identity and OAuth 2.0 Token Exchange

Introduces SPIFFE workload identity + OAuth 2.0 Token Exchange (RFC 8693) for the
**outbound direction**, so an agent can call third-party APIs on behalf of a user
without ever holding long-lived secrets.

- **Trusted Principal Derivation**: the user identity is derived from a verified
  inbound OIDC credential, never from a caller-supplied field.
- **Two-Stage Token Exchange**: keeps the user credential inside the trusted
  Identity Service (never in the untrusted sandbox) while producing a final token
  carrying both the user subject and the sandbox as authorized party; the
  intermediate audience is derived from the verified sandbox SVID.
- **Delegation Store (encrypted vault)**: refresh tokens are stored as
  envelope-encrypted ciphertext; the decryption key is held only by the Identity
  Service; the agent obtains only short-lived access tokens via an authenticated API.
- Supports 2LO / 3LO / OBO outbound flows with sequence diagrams.
- Guarded by the `SecurityIdentityProvider` feature gate (Alpha, disabled by default).

## Which issue(s) this PR fixes

<!-- Fixes #xxxx (fill in if there is a tracking issue) -->
Relates to roadmap → Runtime → *more secure access token and auditing*.

## Special notes for your reviewer

- **Docs only** — no code, no CRD wiring, no behavior change in this PR.
- Both features are **off by default** and backward compatible.
- The two proposals are complementary (ingress vs egress) and cross-reference
  each other via `see-also` front matter.
- Reviewers for the `reviewers:` front matter field are still `@TBD` — please
  suggest owners.

## Does this PR introduce a user-facing change?

NONE