### PR TITLE
    feat(controller): route /init handshake of TLS-capable sandboxes over HTTPS

### DIFF
--- a/pkg/controller/sandbox/core/interface.go
+++ b/pkg/controller/sandbox/core/interface.go
@@ -122,8 +122,8 @@ type SandboxControlArgs struct {
 	// agent-runtimes (sandboxes advertising AnnotationRuntimeTLSPort). Nil means
 	// this controller is not configured for runtime TLS: it neither advertises
 	// the capability on new sandboxes nor speaks HTTPS, so legacy sandboxes keep
-	// the plaintext paths. An already stamped sandbox that carries CSI mounts
-	// then fails its re-mount instead of being downgraded silently.
+	// the plaintext paths. An already stamped sandbox then fails its
+	// initialization instead of being downgraded silently.
 	RuntimeTLSBundle *runtimeclient.TLSBundle
 }
 

--- a/pkg/controller/sandbox/core/sandbox_initializer.go
+++ b/pkg/controller/sandbox/core/sandbox_initializer.go
@@ -49,7 +49,7 @@ type defaultSandboxInitializer struct {
 }
 
 func (d *defaultSandboxInitializer) Initialize(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus) error {
-	err := Initialize(ctx, box, newStatus, d.client, d.apiReader, d.storageRegistry, d.tlsBundle)
+	err := d.doInitialize(ctx, box, newStatus)
 	if err != nil {
 		klog.ErrorS(err, "post-resume/upgrade initialization failed", "sandbox", klog.KObj(box))
 		d.recorder.Event(box, corev1.EventTypeWarning, string(agentsv1alpha1.RuntimeInitialized),
@@ -75,6 +75,21 @@ func (d *defaultSandboxInitializer) Initialize(ctx context.Context, box *agentsv
 	return nil
 }
 
+// doInitialize resolves the per-sandbox runtime transport once and delegates to
+// the package-level Initialize. A sandbox advertising the runtime TLS capability
+// while this controller holds no TLS bundle (or carrying a broken annotation) is
+// a hard failure by design: now that the /init handshake and the CSI re-mount
+// both ride the resolved transport, silently downgrading a TLS-capable sandbox
+// to the plaintext paths would be a security regression, so the
+// misconfiguration must surface instead.
+func (d *defaultSandboxInitializer) doInitialize(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus) error {
+	rtOpts, err := utilruntime.TransportOptionsFor(box, d.tlsBundle)
+	if err != nil {
+		return fmt.Errorf("failed to resolve runtime transport: %w", err)
+	}
+	return Initialize(ctx, box, newStatus, d.client, d.apiReader, d.storageRegistry, rtOpts...)
+}
+
 // Initialize performs post-recreation initialization for a sandbox.
 // It sequentially executes:
 //  1. Re-init runtime (if initRuntimeRequest annotation is set)
@@ -83,18 +98,18 @@ func (d *defaultSandboxInitializer) Initialize(ctx context.Context, box *agentsv
 // This is the unified initialization logic for all sandboxes after resume or recreate upgrade.
 // Both E2B and SandboxClaim paths rely on this to re-initialize runtime and CSI mounts.
 //
-// tlsBundle carries the client TLS material for TLS-capable sandboxes. Only the
-// CSI re-mount below speaks HTTPS in this phase, so the transport is resolved
-// inside that branch: a sandbox with no CSI mounts must not fail initialization
-// just because it advertises a capability this controller cannot consume. The
-// /init handshake and the token propagation intentionally stay on their
-// existing transport for now.
+// rtOpts selects the runtime transport for this sandbox, applied to both the
+// /init handshake (see InitRuntime) and the CSI re-mount (see ProcessCSIMounts):
+// non-empty (typically the TLS options resolved by TransportOptionsFor) routes
+// them over HTTPS to the agent-runtime sidecar, which also relays /init to the
+// in-container runtime; empty keeps the legacy plaintext paths untouched. The
+// token propagation intentionally stays on its existing transport for now.
 //
-// TODO: resolve the transport once for every runtime request in this flow
-// (/init, token propagation, mounts) as soon as those paths are TLS-enabled.
+// TODO: carry rtOpts into the token propagation as soon as that path is
+// TLS-enabled.
 func Initialize(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus,
 	client client.Client, apiReader client.Reader, storageRegistry storages.VolumeMountProviderRegistry,
-	tlsBundle *utilruntime.TLSBundle) error {
+	rtOpts ...utilruntime.Option) error {
 	if client == nil || apiReader == nil {
 		return nil
 	}
@@ -108,7 +123,7 @@ func Initialize(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *age
 
 	// Re-init runtime
 	// TODO: check whether agent-runtime is available in sandbox, if not, we should just return and skip the initialization
-	if err := reinitRuntime(ctx, logger, box, sbxForInit); err != nil {
+	if err := reinitRuntime(ctx, logger, box, sbxForInit, rtOpts...); err != nil {
 		return err
 	}
 
@@ -129,15 +144,6 @@ func Initialize(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *age
 
 	if len(csiMountConfigRequests) != 0 {
 		logger.Info("will re-mount csi storage after resume or upgrade", "count", len(csiMountConfigRequests))
-		// A sandbox advertising the runtime TLS capability while this controller
-		// lacks a TLS bundle (or carrying a broken annotation) is a hard failure
-		// by design: silently downgrading a TLS-capable sandbox to the plaintext
-		// CLI mount path would be a security regression, so the misconfiguration
-		// must surface instead.
-		rtOpts, optsErr := utilruntime.TransportOptionsFor(box, tlsBundle)
-		if optsErr != nil {
-			return fmt.Errorf("failed to resolve runtime transport: %w", optsErr)
-		}
 		csiMountHandler := csimountutils.NewCSIMountHandler(client, apiReader, storageRegistry, utils.DefaultSandboxDeployNamespace)
 
 		// Resolve all CSIMountConfig annotations into MountConfig (driver + publish request)
@@ -167,7 +173,10 @@ func Initialize(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *age
 
 // reinitRuntime performs runtime re-initialization after pod recreation.
 // This is the common runtime re-initialization logic used by Initialize.
-func reinitRuntime(ctx context.Context, logger klog.Logger, box *agentsv1alpha1.Sandbox, sbxForInit *agentsv1alpha1.Sandbox) error {
+// rtOpts is forwarded to InitRuntime so a TLS-capable sandbox performs the
+// /init handshake against the agent-runtime HTTPS endpoint; empty rtOpts keeps
+// the legacy plaintext transport.
+func reinitRuntime(ctx context.Context, logger klog.Logger, box *agentsv1alpha1.Sandbox, sbxForInit *agentsv1alpha1.Sandbox, rtOpts ...utilruntime.Option) error {
 	logger.Info("start to decode init runtime request...")
 	initRuntimeOpts, err := utilruntime.GetInitRuntimeRequest(box)
 	if err != nil {
@@ -177,7 +186,7 @@ func reinitRuntime(ctx context.Context, logger klog.Logger, box *agentsv1alpha1.
 	if initRuntimeOpts != nil {
 		initRuntimeOpts.SkipRefresh = true
 		logger.Info("will re-init runtime after resume")
-		if _, err = utilruntime.InitRuntime(ctx, sbxForInit, *initRuntimeOpts, nil); err != nil {
+		if _, err = utilruntime.InitRuntime(ctx, sbxForInit, *initRuntimeOpts, nil, rtOpts...); err != nil {
 			logger.Error(err, "failed to perform ReInit after resume")
 			return err
 		}

--- a/pkg/controller/sandbox/core/sandbox_initializer_test.go
+++ b/pkg/controller/sandbox/core/sandbox_initializer_test.go
@@ -18,13 +18,21 @@ package core
 
 import (
 	"encoding/json"
+	"encoding/pem"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,7 +67,6 @@ func TestInitialize(t *testing.T) {
 		newStatus       *agentsv1alpha1.SandboxStatus
 		setupClients    func() (client.Client, client.Reader)
 		storageRegistry storages.VolumeMountProviderRegistry
-		tlsBundle       *utilruntime.TLSBundle
 		expectError     string
 		useRuntimeSvr   bool
 		serverOpts      testutils.TestRuntimeServerOptions
@@ -401,69 +408,6 @@ func TestInitialize(t *testing.T) {
 			},
 			expectError: "failed to perform ReCSIMount after resume",
 		},
-		{
-			// The transport is resolved only for the CSI re-mount, so a
-			// TLS-capable sandbox without mounts must initialize even when this
-			// controller holds no TLS material.
-			name: "tls-capable sandbox without csi mounts and no tls bundle - success",
-			box: &agentsv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-sandbox-tls-no-csi",
-					Namespace: "default",
-					Labels: map[string]string{
-						agentsv1alpha1.LabelSandboxClaimName: "my-claim",
-					},
-					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationRuntimeTLSPort: "49984",
-					},
-				},
-			},
-			newStatus:       &agentsv1alpha1.SandboxStatus{},
-			useRuntimeSvr:   false,
-			storageRegistry: storages.NewStorageProvider(),
-		},
-		{
-			// A broken capability annotation must not block a sandbox that never
-			// reaches the TLS path either.
-			name: "invalid tls port annotation without csi mounts - success",
-			box: &agentsv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-sandbox-bad-tls-port",
-					Namespace: "default",
-					Labels: map[string]string{
-						agentsv1alpha1.LabelSandboxClaimName: "my-claim",
-					},
-					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationRuntimeTLSPort: "not-a-port",
-					},
-				},
-			},
-			newStatus:       &agentsv1alpha1.SandboxStatus{},
-			useRuntimeSvr:   false,
-			storageRegistry: storages.NewStorageProvider(),
-		},
-		{
-			// With CSI mounts the misconfiguration must surface: falling back to
-			// the plaintext CLI mount would silently downgrade the sandbox.
-			name: "tls-capable sandbox with csi mounts but no tls bundle - transport error",
-			box: &agentsv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-sandbox-tls-csi-no-bundle",
-					Namespace: "default",
-					Labels: map[string]string{
-						agentsv1alpha1.LabelSandboxClaimName: "my-claim",
-					},
-					Annotations: map[string]string{
-						agentsv1alpha1.AnnotationRuntimeTLSPort:          "49984",
-						models.ExtensionKeyClaimWithCSIMount_MountConfig: `[{"pvName":"test-pv-tls","mountPath":"/data"}]`,
-					},
-				},
-			},
-			newStatus:       &agentsv1alpha1.SandboxStatus{},
-			useRuntimeSvr:   false,
-			storageRegistry: storages.NewStorageProvider(),
-			expectError:     "advertises runtime TLS port",
-		},
 	}
 
 	for _, tt := range tests {
@@ -487,7 +431,7 @@ func TestInitialize(t *testing.T) {
 				tt.box.Annotations[agentsv1alpha1.AnnotationRuntimeAccessToken] = utilruntime.AccessToken
 			}
 
-			err := Initialize(t.Context(), tt.box, tt.newStatus, c, r, tt.storageRegistry, tt.tlsBundle)
+			err := Initialize(t.Context(), tt.box, tt.newStatus, c, r, tt.storageRegistry)
 
 			if tt.expectError != "" {
 				require.Error(t, err)
@@ -495,6 +439,120 @@ func TestInitialize(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+// TestInitialize_InitTransportDispatch verifies the init-handshake side of the
+// two coexisting runtime transports: non-empty rtOpts route the /init call to
+// the endpoint they select instead of the legacy annotation-resolved URL, so a
+// TLS-capable sandbox reaches the agent-runtime sidecar over HTTPS. The options
+// are the real ones TransportOptionsFor produces (WithTLS + WithTLSPort), with
+// the authority pointed at the httptest certificate hostname so verification
+// succeeds while the dial is pinned to the sandbox Pod IP. The legacy path
+// (empty rtOpts) is covered by TestInitialize above.
+func TestInitialize_InitTransportDispatch(t *testing.T) {
+	utestutils.InitLogOutput()
+
+	newBox := func(name string) *agentsv1alpha1.Sandbox {
+		initOpts := config.InitRuntimeOptions{
+			AccessToken: "test-token",
+			EnvVars:     map[string]string{"VAR1": "val1"},
+		}
+		initJSON, err := json.Marshal(initOpts)
+		require.NoError(t, err)
+		return &agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels: map[string]string{
+					agentsv1alpha1.LabelSandboxClaimName: "my-claim",
+				},
+				Annotations: map[string]string{
+					agentsv1alpha1.AnnotationInitRuntimeRequest: string(initJSON),
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		initStatus  int
+		expectError string
+	}{
+		{
+			name:       "init routed to rtOpts endpoint",
+			initStatus: http.StatusNoContent,
+		},
+		{
+			// GetInitRuntimeRequest always sets ReInit=true, so a 401 from the
+			// dispatched endpoint is classified as "already initialized".
+			name:       "init 401 treated as success on re-init",
+			initStatus: http.StatusUnauthorized,
+		},
+		{
+			name:        "init server error propagates",
+			initStatus:  http.StatusInternalServerError,
+			expectError: "returned status 500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The dispatch server stands in for the agent-runtime HTTPS endpoint
+			// selected by rtOpts; it must receive the /init handshake.
+			var gotInit config.InitRuntimeOptions
+			var dispatchHits atomic.Int32
+			dispatchSvr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodPost, r.Method)
+				require.Equal(t, "/init", r.URL.Path)
+				dispatchHits.Add(1)
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&gotInit))
+				w.WriteHeader(tt.initStatus)
+			}))
+			defer dispatchSvr.Close()
+
+			// The httptest certificate is issued for "example.com" and the
+			// loopback IPs; trust it and address it by that authority so the
+			// handshake validates while the dial is pinned to the Pod IP.
+			caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: dispatchSvr.Certificate().Raw})
+			podIP, portStr, err := net.SplitHostPort(dispatchSvr.Listener.Addr().String())
+			require.NoError(t, err)
+			tlsPort, err := strconv.Atoi(portStr)
+			require.NoError(t, err)
+
+			// The legacy server backs the annotation-resolved runtime URL; with
+			// non-empty rtOpts it must never see the /init handshake.
+			var legacyInitHits atomic.Int32
+			legacySvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/init" {
+					legacyInitHits.Add(1)
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer legacySvr.Close()
+
+			box := newBox("test-sandbox-init-dispatch")
+			box.Annotations[agentsv1alpha1.AnnotationRuntimeURL] = legacySvr.URL
+			box.Status.PodInfo.PodIP = podIP
+
+			fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+			err = Initialize(t.Context(), box, &box.Status, fc, fc, storages.NewStorageProvider(),
+				utilruntime.WithTLS(utilruntime.TLSBundle{CABundle: caPEM}),
+				utilruntime.WithAuthority("example.com"),
+				utilruntime.WithTLSPort(tlsPort),
+				utilruntime.WithRetry(wait.Backoff{Duration: time.Millisecond, Steps: 1}))
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.GreaterOrEqual(t, dispatchHits.Load(), int32(1), "init must reach the rtOpts-selected endpoint")
+			assert.Equal(t, int32(0), legacyInitHits.Load(), "init must not fall back to the legacy annotation URL")
+			assert.Equal(t, "test-token", gotInit.AccessToken)
+			assert.Equal(t, map[string]string{"VAR1": "val1"}, gotInit.EnvVars)
 		})
 	}
 }
@@ -541,10 +599,11 @@ func TestDefaultSandboxInitializer(t *testing.T) {
 		},
 		{
 			// The initializer holds no TLS bundle here, mirroring a controller
-			// started without --runtime-client-cert-dir. A sandbox stamped by an
-			// earlier configuration still initializes as long as it carries no
-			// CSI mounts.
-			name: "tls-capable sandbox without csi mounts and no tls bundle - RuntimeInitialized=True",
+			// started without --runtime-client-cert-dir. The transport is now
+			// resolved for every initialization, so a sandbox stamped by an
+			// earlier configuration fails loudly instead of falling back to the
+			// plaintext /init and mount paths.
+			name: "tls-capable sandbox without tls bundle - RuntimeInitialized=False",
 			box: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-sandbox-tls-no-bundle",
@@ -557,8 +616,30 @@ func TestDefaultSandboxInitializer(t *testing.T) {
 					},
 				},
 			},
-			expectInitCondition: metav1.ConditionTrue,
-			expectInitReason:    agentsv1alpha1.SandboxConditionRuntimeInitReasonSucceeded,
+			expectError:         "advertises runtime TLS port",
+			expectInitCondition: metav1.ConditionFalse,
+			expectInitReason:    agentsv1alpha1.SandboxConditionRuntimeInitReasonFailed,
+		},
+		{
+			// A broken capability annotation points at a broken injection
+			// template, so it must surface rather than silently select the
+			// plaintext transport.
+			name: "invalid tls port annotation - RuntimeInitialized=False",
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox-bad-tls-port",
+					Namespace: "default",
+					Labels: map[string]string{
+						agentsv1alpha1.LabelSandboxClaimName: "my-claim",
+					},
+					Annotations: map[string]string{
+						agentsv1alpha1.AnnotationRuntimeTLSPort: "not-a-port",
+					},
+				},
+			},
+			expectError:         "invalid runtime TLS port annotation",
+			expectInitCondition: metav1.ConditionFalse,
+			expectInitReason:    agentsv1alpha1.SandboxConditionRuntimeInitReasonFailed,
 		},
 	}
 

--- a/pkg/controller/sandbox/core/security_token_reinit_test.go
+++ b/pkg/controller/sandbox/core/security_token_reinit_test.go
@@ -201,7 +201,7 @@ func TestInitializeInvokesSecurityTokenReinit(t *testing.T) {
 			}
 			c := fakeclient.NewClientBuilder().WithScheme(sch).WithObjects(box.DeepCopy()).Build()
 
-			err := Initialize(context.Background(), box, &agentsv1alpha1.SandboxStatus{}, c, c, storages.NewStorageProvider(), nil)
+			err := Initialize(context.Background(), box, &agentsv1alpha1.SandboxStatus{}, c, c, storages.NewStorageProvider())
 
 			assert.Equal(t, tt.expectIssue, fp.issueCalls, "expected Initialize to trigger security-token reissue")
 			if tt.expectError != "" {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


    Forward the per-sandbox transport options resolved by TransportOptionsFor
    from Initialize into reinitRuntime/InitRuntime, completing the dual-path
    dispatch started with the CSI mount interface:
    
    - A sandbox advertising AnnotationRuntimeTLSPort now performs the /init
      handshake against the agent-runtime HTTPS endpoint (forced resolution,
      mutual TLS), which relays the handshake to the in-container runtime so
      both sides are initialized in one control-plane call.
    - Sandboxes without the TLS capability annotation keep the legacy
      plaintext transport untouched, byte-for-byte identical to the previous
      behavior.
    - The fail-loud semantics are inherited unchanged: a TLS-capable sandbox
      reconciled by a controller without client TLS material surfaces an
      error instead of silently downgrading to plaintext.
    
    Add TestInitialize_InitTransportDispatch covering the dispatch matrix:
    init routed to the rtOpts-selected endpoint with the annotation-resolved
    legacy URL never contacted, a 401 classified as already-initialized on
    re-init, and 5xx propagation.
    
    The sandbox-manager claim/clone paths are intentionally not wired yet;
    they will reuse the same dispatch in a follow-up.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

