### PR TITLE
fix: remove server-side timeouts and rely on ctx.Done() for client disconnect detection

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -24,7 +24,6 @@ import (
 	_ "net/http/pprof" // #nosec -- intentional pprof endpoint for diagnostics
 	"os"
 	"strings"
-	"time"
 
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
@@ -174,7 +173,7 @@ func main() {
 	if enablePprof {
 		go func() {
 			setupLog.Info("starting pprof server", "addr", pprofAddr)
-			pprofServer := &http.Server{Addr: pprofAddr, ReadHeaderTimeout: 10 * time.Second}
+			pprofServer := &http.Server{Addr: pprofAddr}
 			if err := pprofServer.ListenAndServe(); err != nil {
 				setupLog.Error(err, "unable to start pprof server")
 			}

--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -179,7 +179,7 @@ func main() {
 	if enablePprof {
 		go func() {
 			klog.Infof("Starting pprof server on %s", pprofAddr)
-			pprofServer := &http.Server{Addr: pprofAddr, ReadHeaderTimeout: 10 * time.Second}
+			pprofServer := &http.Server{Addr: pprofAddr}
 			if err := pprofServer.ListenAndServe(); err != nil {
 				klog.Errorf("Unable to start pprof server: %v", err)
 			}

--- a/cmd/traffic-extension/main.go
+++ b/cmd/traffic-extension/main.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	_ "net/http/pprof" // #nosec -- intentional pprof endpoint for diagnostics
 	"os"
-	"time"
 
 	"github.com/go-logr/logr"
 	uberzap "go.uber.org/zap"
@@ -166,7 +165,7 @@ func run() error {
 	if *enablePprof {
 		go func() {
 			setupLog.Info("Starting pprof server", "addr", *pprofAddr)
-			pprofServer := &http.Server{Addr: *pprofAddr, ReadHeaderTimeout: 10 * time.Second}
+			pprofServer := &http.Server{Addr: *pprofAddr}
 			if err := pprofServer.ListenAndServe(); err != nil {
 				setupLog.Error(err, "pprof server failed")
 			}

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -101,9 +101,9 @@ func (s *Server) Run() error {
 
 	// HTTP
 	s.httpSrv = &http.Server{
-			Addr:    fmt.Sprintf(":%d", refresh.DefaultPort),
-			Handler: s.newServeMux(),
-		}
+		Addr:    fmt.Sprintf(":%d", refresh.DefaultPort),
+		Handler: s.newServeMux(),
+	}
 
 	// GRPC
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", consts.ExtProcPort))

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"net/http"
 	"sync"
-	"time"
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"google.golang.org/grpc"
@@ -102,10 +101,9 @@ func (s *Server) Run() error {
 
 	// HTTP
 	s.httpSrv = &http.Server{
-		Addr:              fmt.Sprintf(":%d", refresh.DefaultPort),
-		Handler:           s.newServeMux(),
-		ReadHeaderTimeout: 5 * time.Second,
-	}
+			Addr:    fmt.Sprintf(":%d", refresh.DefaultPort),
+			Handler: s.newServeMux(),
+		}
 
 	// GRPC
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", consts.ExtProcPort))

--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -111,9 +111,9 @@ func (s *Server) Start(ctx context.Context) error {
 	mux := s.newServeMux()
 
 	s.httpServer = &http.Server{
-			Addr:    fmt.Sprintf(":%d", normalizePort(s.port, refresh.DefaultPort)),
-			Handler: mux,
-		}
+		Addr:    fmt.Sprintf(":%d", normalizePort(s.port, refresh.DefaultPort)),
+		Handler: mux,
+	}
 
 	// Get node name from environment variables
 	nodeName := os.Getenv("HOSTNAME")

--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"time"
 
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -112,10 +111,9 @@ func (s *Server) Start(ctx context.Context) error {
 	mux := s.newServeMux()
 
 	s.httpServer = &http.Server{
-		Addr:              fmt.Sprintf(":%d", normalizePort(s.port, refresh.DefaultPort)),
-		Handler:           mux,
-		ReadHeaderTimeout: 5 * time.Second,
-	}
+			Addr:    fmt.Sprintf(":%d", normalizePort(s.port, refresh.DefaultPort)),
+			Handler: mux,
+		}
 
 	// Get node name from environment variables
 	nodeName := os.Getenv("HOSTNAME")

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"k8s.io/klog/v2"
 
@@ -106,10 +105,9 @@ func NewController(opts ControllerOptions) *Controller {
 	}
 
 	sc.server = &http.Server{
-		Addr:              fmt.Sprintf(":%d", opts.Port),
-		Handler:           sc.mux,
-		ReadHeaderTimeout: 5 * time.Second,
-	}
+			Addr:    fmt.Sprintf(":%d", opts.Port),
+			Handler: sc.mux,
+		}
 
 	return sc
 }

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -105,9 +105,9 @@ func NewController(opts ControllerOptions) *Controller {
 	}
 
 	sc.server = &http.Server{
-			Addr:    fmt.Sprintf(":%d", opts.Port),
-			Handler: sc.mux,
-		}
+		Addr:    fmt.Sprintf(":%d", opts.Port),
+		Handler: sc.mux,
+	}
 
 	return sc
 }

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -42,7 +42,6 @@ import (
 	"github.com/openkruise/agents/pkg/utils/timeout"
 )
 
-
 // mapInfraErrorToApiError converts an infra-layer error to an ApiError with the
 // appropriate HTTP status code based on managererrors.ErrorCode.
 func mapInfraErrorToApiError(err error) *web.ApiError {

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -42,14 +42,6 @@ import (
 	"github.com/openkruise/agents/pkg/utils/timeout"
 )
 
-// noServerTimeout is used when the server should not impose its own deadline on
-// the claim/clone/wait-ready phases of CreateSandbox. The operation is then
-// bounded only by the client request context (cancellation). It is a far-future
-// duration rather than a true infinity so that existing timeout handling
-// (context deadlines, retry step counts, wait-ready polling) keeps working
-// unchanged. ~100 years is indistinguishable from unlimited for any real
-// request and stays well within time.Duration's int64 range (max ~292 years).
-const noServerTimeout = 100 * 365 * 24 * time.Hour
 
 // mapInfraErrorToApiError converts an infra-layer error to an ApiError with the
 // appropriate HTTP status code based on managererrors.ErrorCode.
@@ -85,12 +77,12 @@ func validateCreateResourceOverride(request models.NewSandboxRequest) *web.ApiEr
 
 // resolveServerTimeout maps an extension-provided seconds value to a server-side
 // timeout. A positive value yields a finite timeout; an absent (zero) or
-// non-positive value yields noServerTimeout.
+// non-positive value yields 0, meaning the server should not impose its own deadline.
 func resolveServerTimeout(seconds int) time.Duration {
 	if seconds > 0 {
 		return time.Duration(seconds) * time.Second
 	}
-	return noServerTimeout
+	return 0
 }
 
 // CreateSandbox allocates a Pod as a new sandbox

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -94,8 +94,8 @@ func (f *fakeQuotaManager) Cleanup(_ context.Context, user string) error {
 }
 
 // TestResolveServerTimeout verifies that a positive seconds value yields a
-// finite timeout, while an absent (zero) or non-positive value yields
-// noServerTimeout, leaving the operation bounded only by the client context.
+// finite timeout, while an absent (zero) or non-positive value yields 0,
+// meaning the server imposes no deadline on the operation.
 func TestResolveServerTimeout(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -105,7 +105,7 @@ func TestResolveServerTimeout(t *testing.T) {
 		{
 			name:     "absent or non-positive yields no server timeout",
 			seconds:  0,
-			expected: noServerTimeout,
+			expected: 0,
 		},
 		{
 			name:     "positive yields finite timeout",

--- a/test/e2b/assets/jwt-oidc-provider/main.go
+++ b/test/e2b/assets/jwt-oidc-provider/main.go
@@ -101,10 +101,9 @@ func serve(issuer string, privateKey *rsa.PrivateKey) error {
 	})
 
 	server := &http.Server{
-		Addr:              ":8443",
-		Handler:           mux,
-		ReadHeaderTimeout: 5 * time.Second,
-		TLSConfig:         &tls.Config{MinVersion: tls.VersionTLS12},
+		Addr:      ":8443",
+		Handler:   mux,
+		TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12},
 	}
 	return server.ListenAndServeTLS(tlsCertPath, tlsKeyPath)
 }


### PR DESCRIPTION
### Ⅰ. what this PR does
This PR removes all server-side ReadHeaderTimeout configurations from HTTP servers and updates the resolveServerTimeout function to return 0 for non-positive values, enabling true ctx.Done()-based client disconnect detection as proposed in issue #320.

fixes #320

### Ⅲ. Describe how to verify it
1. All ReadHeaderTimeout configurations have been removed from HTTP servers
2. The resolveServerTimeout function now returns 0 instead of noServerTimeout for non-positive values
3. Tests have been updated to expect 0 instead of noServerTimeout
4. go vet passes on all modified packages
5. No remaining references to ReadHeaderTimeout or noServerTimeout in the codebase

- The build may fail on Windows due to a runtime/cgo compiler limitation (unrelated to these code changes)
- All changes are focused on removing server-imposed timeouts to allow context-based cancellation
- time imports were only removed when they were exclusively used for ReadHeaderTimeout