### PR TITLE
feat(manager): wire TLS runtime client with Secret-based material into claim/clone paths

### DIFF
--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net/http"         // Added for pprof server
@@ -30,6 +31,7 @@ import (
 	zapRaw "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/klog/v2"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/openkruise/agents/pkg/sandbox-manager/clients"
@@ -40,6 +42,7 @@ import (
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/utils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
+	utilruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 const (
@@ -96,6 +99,7 @@ func main() {
 	var quotaRedisBreakerD time.Duration
 	var quotaAntiDriftInterval time.Duration
 	var quotaAntiDriftGrace time.Duration
+	var runtimeClientCertSecret string
 
 	utilfeature.DefaultMutableFeatureGate.AddFlag(pflag.CommandLine)
 
@@ -137,6 +141,8 @@ func main() {
 	pflag.DurationVar(&quotaRedisBreakerD, "quota-redis-breaker-open-duration", consts.DefaultQuotaRedisBreakerD, "How long the Redis quota fail-open breaker stays open before probing again.")
 	pflag.DurationVar(&quotaAntiDriftInterval, "quota-anti-drift-interval", consts.DefaultQuotaAntiDriftInterval, "Interval for quota anti-drift reconciliation.")
 	pflag.DurationVar(&quotaAntiDriftGrace, "quota-anti-drift-grace", consts.DefaultQuotaAntiDriftGrace, "Grace period before periodic quota anti-drift releases suspected leaked entries.")
+	pflag.StringVar(&runtimeClientCertSecret, "runtime-client-cert-secret", "",
+		"namespace/name of the Secret holding the agent-runtime client TLS bundle. Leave it empty to disable the runtime mTLS.")
 
 	opts := zap.Options{
 		Development: false,
@@ -247,6 +253,31 @@ func main() {
 		klog.Fatalf("Failed to initialize Kubernetes client: %v", err)
 	}
 
+	// Load the runtime client TLS bundle. The certificate Secret is fetched once
+	// at startup (fail fast on a broken reference) and held for the lifetime of
+	// the process: the material is long-lived and static, so a replacement is
+	// picked up by the next restart.
+	var runtimeTLSBundle *utilruntime.TLSBundle
+	if runtimeClientCertSecret != "" {
+		secretNamespace, secretName, found := strings.Cut(runtimeClientCertSecret, "/")
+		if !found || secretNamespace == "" || secretName == "" {
+			klog.Fatalf("--runtime-client-cert-secret must be in namespace/name form, got %q", runtimeClientCertSecret)
+		}
+		secretReader, err := ctrlclient.New(clientConfig, ctrlclient.Options{})
+		if err != nil {
+			klog.Fatalf("Failed to create client for the runtime client TLS bundle: %v", err)
+		}
+		loadCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		runtimeTLSBundle, err = utilruntime.NewTLSBundleFromSecret(loadCtx, secretReader, secretNamespace, secretName)
+		cancel()
+		if err != nil {
+			klog.Fatalf("Failed to load the runtime client TLS bundle: %v", err)
+		}
+		klog.InfoS("runtime client TLS enabled", "secret", runtimeClientCertSecret)
+	} else {
+		klog.InfoS("runtime client TLS disabled, using the legacy plaintext runtime paths")
+	}
+
 	var keyCfg *keys.Config
 	if e2bEnableAuth {
 		keyCfg = &keys.Config{
@@ -259,8 +290,26 @@ func main() {
 		}
 	}
 
-	sandboxController := e2b.NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSelector, e2bMaxTimeout, e2bMinResumeTimeout, maxClaimWorkers, maxCreateQPS, uint32(extProcMaxConcurrency),
-		port, memberlistBindPort, keyCfg, clientConfig, quotaOpts)
+	sandboxController := e2b.NewController(e2b.ControllerOptions{
+		Domain:           domain,
+		Port:             port,
+		MaxTimeout:       e2bMaxTimeout,
+		MinResumeTimeout: e2bMinResumeTimeout,
+		KeyConfig:        keyCfg,
+		Manager: config.SandboxManagerOptions{
+			SystemNamespace:       sysNs,
+			PeerSelector:          peerSelector,
+			SandboxNamespace:      sandboxNamespace,
+			SandboxLabelSelector:  sandboxLabelSelector,
+			MaxClaimWorkers:       maxClaimWorkers,
+			MaxCreateQPS:          maxCreateQPS,
+			ExtProcMaxConcurrency: uint32(extProcMaxConcurrency),
+			MemberlistBindPort:    memberlistBindPort,
+			RestConfig:            clientConfig,
+			Quota:                 quotaOpts,
+		},
+		RuntimeTLSBundle: runtimeTLSBundle,
+	})
 
 	if err := sandboxController.Init(); err != nil {
 		klog.Fatalf("Failed to initialize sandbox controller: %v", err)

--- a/pkg/sandbox-manager/core.go
+++ b/pkg/sandbox-manager/core.go
@@ -36,6 +36,7 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/sandbox-manager/quota"
 	quotaspec "github.com/openkruise/agents/pkg/sandbox-manager/quota/spec"
+	"github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 // QuotaEnforcer is the minimal surface sandbox-manager needs for admission, delete release, and cleanup.
@@ -63,6 +64,12 @@ type SandboxManagerBuilder struct {
 	buildInfraFunc GetInfraBuilderFunc
 	getPeersFunc   GetPeersFunc
 	requestAdapter proxy.RequestAdapter
+	// runtimeTLSBundle is the client TLS bundle for reaching TLS-capable
+	// agent-runtimes. It is carried on the builder rather than on
+	// config.SandboxManagerOptions (which the cache layer imports) and handed to
+	// the sandbox infra so claim/clone post-processing can resolve the
+	// per-sandbox runtime transport. Nil disables runtime TLS.
+	runtimeTLSBundle *runtime.TLSBundle
 }
 
 func NewSandboxManagerBuilder(opts config.SandboxManagerOptions) *SandboxManagerBuilder {
@@ -90,8 +97,18 @@ func (b *SandboxManagerBuilder) WithSandboxInfra() *SandboxManagerBuilder {
 		return sandboxcr.NewInfraBuilder(b.opts).
 			WithCache(cache).
 			WithProxy(b.instance.proxy).
-			WithAPIReader(mgr.GetAPIReader()), nil
+			WithAPIReader(mgr.GetAPIReader()).
+			WithRuntimeTLSBundle(b.runtimeTLSBundle), nil
 	}
+	return b
+}
+
+// WithRuntimeTLSBundle supplies the client TLS bundle used to reach TLS-capable
+// agent-runtimes. It may be called in any order relative to WithSandboxInfra
+// because the infra builder is materialized lazily at Build time. A nil bundle
+// (the default) keeps every runtime call on the legacy plaintext paths.
+func (b *SandboxManagerBuilder) WithRuntimeTLSBundle(bundle *runtime.TLSBundle) *SandboxManagerBuilder {
+	b.runtimeTLSBundle = bundle
 	return b
 }
 

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -321,10 +321,23 @@ func runClaimPostProcesses(ctx context.Context, sbx *Sandbox, lockType infra.Loc
 		log.Info("sandbox is ready", "cost", metrics.WaitReady)
 	}
 
+	// Resolve the per-sandbox runtime transport once for both runtime calls
+	// below (init handshake and CSI mounts). This runs after the wait-ready
+	// gate so the sandbox already advertises the capabilities of the pod that
+	// actually runs it. A resolution failure means the sandbox declares the TLS
+	// capability while this manager cannot honor it, which is a configuration
+	// error: return it as non-retriable rather than silently downgrading to
+	// plaintext.
+	rtOpts, err := runtime.TransportOptionsFor(sbx.Sandbox, opts.RuntimeTLSBundle)
+	if err != nil {
+		log.Error(err, "failed to resolve runtime transport")
+		return err
+	}
+
 	if opts.InitRuntime != nil {
 		log.Info("starting to init runtime", "opts", opts.InitRuntime)
 		var err error
-		metrics.InitRuntime, err = runtime.InitRuntime(ctx, sbx.Sandbox, *opts.InitRuntime, sbx.refreshFunc())
+		metrics.InitRuntime, err = runtime.InitRuntime(ctx, sbx.Sandbox, *opts.InitRuntime, sbx.refreshFunc(), rtOpts...)
 		if err != nil {
 			log.Error(err, "failed to init runtime")
 			return retriableError{Message: fmt.Sprintf("failed to init runtime: %s", err)}
@@ -373,7 +386,7 @@ func runClaimPostProcesses(ctx context.Context, sbx *Sandbox, lockType infra.Loc
 	if opts.CSIMount != nil {
 		log.Info("starting to perform csi mount")
 		var err error
-		metrics.CSIMount, err = runtime.ProcessCSIMounts(ctx, sbx.Sandbox, *opts.CSIMount)
+		metrics.CSIMount, err = runtime.ProcessCSIMounts(ctx, sbx.Sandbox, *opts.CSIMount, rtOpts...)
 		if err != nil {
 			log.Error(err, "failed to perform csi mount")
 			return fmt.Errorf("failed to perform csi mount: %s", err)

--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -156,8 +156,21 @@ func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache inf
 		return
 	}
 
+	// Resolve the per-sandbox runtime transport once for the runtime calls below
+	// (re-init handshake and CSI mounts). This runs after the wait-ready gate so
+	// the cloned sandbox already advertises the capabilities of the pod that
+	// actually runs it. A resolution failure means the sandbox declares the TLS
+	// capability while this manager cannot honor it, which is a configuration
+	// error: surface it instead of silently downgrading to plaintext.
+	rtOpts, rtErr := runtime.TransportOptionsFor(sbx.Sandbox, opts.RuntimeTLSBundle)
+	if rtErr != nil {
+		log.Error(rtErr, "failed to resolve runtime transport")
+		err = rtErr
+		return
+	}
+
 	// Step 5: re-init runtime
-	if metrics, err = cloneReInitRuntime(ctx, sbx, opts, initRuntimeOpts, metrics); err != nil {
+	if metrics, err = cloneReInitRuntime(ctx, sbx, opts, initRuntimeOpts, metrics, rtOpts...); err != nil {
 		if !wait.Interrupted(err) {
 			err = retriableError{Message: fmt.Sprintf("failed to init runtime: %s", err)}
 		}
@@ -190,7 +203,7 @@ func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache inf
 	}
 	if opts.CSIMount != nil {
 		log.Info("starting to perform csi mount")
-		metrics.CSIMount, err = runtime.ProcessCSIMounts(ctx, sbx.Sandbox, *opts.CSIMount)
+		metrics.CSIMount, err = runtime.ProcessCSIMounts(ctx, sbx.Sandbox, *opts.CSIMount, rtOpts...)
 		metrics.Total += metrics.CSIMount
 		if err != nil {
 			log.Error(err, "failed to perform csi mount")
@@ -341,8 +354,10 @@ func cloneWaitSandboxReady(ctx context.Context, sbx *Sandbox, opts infra.CloneSa
 	return metrics, nil
 }
 
-// cloneReInitRuntime re-initializes the runtime if needed
-func cloneReInitRuntime(ctx context.Context, sbx *Sandbox, opts infra.CloneSandboxOptions, initRuntimeOpts *config.InitRuntimeOptions, metrics infra.CloneMetrics) (infra.CloneMetrics, error) {
+// cloneReInitRuntime re-initializes the runtime if needed. rtOpts is forwarded
+// to InitRuntime so a TLS-capable sandbox performs the re-init handshake against
+// the agent-runtime HTTPS endpoint; empty rtOpts keeps the plaintext transport.
+func cloneReInitRuntime(ctx context.Context, sbx *Sandbox, opts infra.CloneSandboxOptions, initRuntimeOpts *config.InitRuntimeOptions, metrics infra.CloneMetrics, rtOpts ...runtime.Option) (infra.CloneMetrics, error) {
 	log := klog.FromContext(ctx).WithValues("checkpointID", opts.CheckPointID, "step", "5.reInitRuntime")
 	if initRuntimeOpts == nil {
 		return metrics, nil
@@ -350,7 +365,7 @@ func cloneReInitRuntime(ctx context.Context, sbx *Sandbox, opts infra.CloneSandb
 	initRuntimeOpts.ReInit = true
 	log.Info("re-init runtime")
 	var err error
-	metrics.InitRuntime, err = runtime.InitRuntime(ctx, sbx.Sandbox, *initRuntimeOpts, sbx.refreshFunc())
+	metrics.InitRuntime, err = runtime.InitRuntime(ctx, sbx.Sandbox, *initRuntimeOpts, sbx.refreshFunc(), rtOpts...)
 	metrics.Total += metrics.InitRuntime
 	if err != nil {
 		log.Error(err, "failed to init runtime")

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -42,6 +42,7 @@ import (
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
 	"github.com/openkruise/agents/pkg/utils/proxyutils"
+	"github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 var DefaultDeleteSandboxTemplate = deleteSandboxTemplate
@@ -89,6 +90,14 @@ func (b *InfraBuilder) WithProxy(proxy *proxy.Server) *InfraBuilder {
 	return b
 }
 
+// WithRuntimeTLSBundle supplies the client TLS bundle used to reach TLS-capable
+// agent-runtimes during claim/clone post-processing. A nil bundle (the default)
+// keeps every runtime call on the legacy plaintext paths.
+func (b *InfraBuilder) WithRuntimeTLSBundle(bundle *runtime.TLSBundle) *InfraBuilder {
+	b.instance.RuntimeTLSBundle = bundle
+	return b
+}
+
 func (b *InfraBuilder) Build() infra.Infrastructure {
 	i := b.instance
 	if c, ok := i.Cache.(*cache.Cache); ok {
@@ -104,6 +113,11 @@ type Infra struct {
 	Cache     cache.Provider
 	APIReader client.Reader
 	Proxy     *proxy.Server
+
+	// RuntimeTLSBundle is the client TLS bundle for reaching TLS-capable
+	// agent-runtimes; nil disables runtime TLS for this manager, so every
+	// sandbox is served over the legacy plaintext paths.
+	RuntimeTLSBundle *runtime.TLSBundle
 
 	// For claiming sandbox
 	pickCache        sync.Map
@@ -144,6 +158,9 @@ func (i *Infra) ClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions
 		log.Error(err, "invalid claim options")
 		return nil, metrics, err
 	}
+	// Inject the Infra-owned runtime TLS bundle so claim post-processing can
+	// resolve the per-sandbox transport; API callers never set this field.
+	opts.RuntimeTLSBundle = i.RuntimeTLSBundle
 
 	claimCtx, cancel := context.WithTimeout(ctx, opts.ClaimTimeout)
 	defer cancel()
@@ -235,6 +252,8 @@ func (i *Infra) CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions
 	// limiting at the same gate as ClaimSandbox (see newSandboxFromSandboxSet).
 	attemptOpts := opts
 	attemptOpts.CreateLimiter = i.createLimiter
+	// Inject the Infra-owned runtime TLS bundle, mirroring the claim path.
+	attemptOpts.RuntimeTLSBundle = i.RuntimeTLSBundle
 
 	metrics.Retries = -1 // starts from 0
 	var clonedSandbox infra.Sandbox

--- a/pkg/sandbox-manager/infra/types.go
+++ b/pkg/sandbox-manager/infra/types.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+	"github.com/openkruise/agents/pkg/utils/runtime"
 	"github.com/openkruise/agents/pkg/utils/timeout"
 )
 
@@ -87,6 +88,12 @@ type ClaimSandboxOptions struct {
 	// non-CRD paths such as the E2B API. IdentityProvider implementations must
 	// handle a nil Claim gracefully.
 	Claim *v1alpha1.SandboxClaim `json:"-"`
+	// RuntimeTLSBundle is the client TLS bundle used to reach a TLS-capable
+	// agent-runtime during claim post-processing (init handshake and CSI
+	// mounts). It is injected by the Infrastructure implementation, never by
+	// API callers, mirroring how CloneSandboxOptions.CreateLimiter is injected.
+	// Nil means this process is not configured for runtime TLS.
+	RuntimeTLSBundle *runtime.TLSBundle `json:"-"`
 }
 
 type CloneSandboxOptions struct {
@@ -109,6 +116,11 @@ type CloneSandboxOptions struct {
 	// GenerateName sets ObjectMeta.GenerateName on the cloned sandbox (prefix).
 	// Mutually exclusive with Name.
 	GenerateName string `json:"generateName,omitempty"`
+	// RuntimeTLSBundle is the client TLS bundle used to reach a TLS-capable
+	// agent-runtime during clone post-processing (re-init handshake and CSI
+	// mounts). Injected by the Infrastructure implementation like
+	// CreateLimiter; nil means this process is not configured for runtime TLS.
+	RuntimeTLSBundle *runtime.TLSBundle `json:"-"`
 }
 
 type CreateCheckpointOptions struct {

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -26,7 +26,6 @@ import (
 	"syscall"
 	"time"
 
-	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
 	"github.com/openkruise/agents/pkg/agent-runtime/storages"
@@ -37,25 +36,25 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/logs"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
+	utilruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 // Controller handles sandbox-related operations
 type Controller struct {
-	port                  int
+	// E2B API surface
 	maxTimeout            int
 	minResumeTimeoutValue int
-
-	// manager params
-	systemNamespace       string // the namespace where the sandbox manager is running
-	peerSelector          string
-	maxClaimWorkers       int
-	maxCreateQPS          int
-	extProcMaxConcurrency uint32
-	sandboxLabelSelector  string
-	sandboxNamespace      string
-	memberlistBindPort    int
+	domain                string
 	keyCfg                *keys.Config
-	quotaOpts             config.QuotaOptions
+
+	// mgrOpts is handed to the sandbox-manager builder unchanged. It also carries
+	// the system namespace the API handlers fall back to, so it is the single
+	// place a manager-level knob has to be threaded through.
+	mgrOpts config.SandboxManagerOptions
+	// runtimeTLSBundle is the client TLS bundle for reaching TLS-capable
+	// agent-runtimes; nil disables runtime TLS for this manager, so every
+	// sandbox is served over the legacy plaintext paths.
+	runtimeTLSBundle *utilruntime.TLSBundle
 
 	// fields
 	mux             *http.ServeMux
@@ -63,37 +62,51 @@ type Controller struct {
 	stop            chan os.Signal
 	cache           cache.Provider
 	storageRegistry storages.VolumeMountProviderRegistry
-	clientConfig    *rest.Config
-	domain          string
 	adapter         *adapters.E2BAdapter
 	manager         *sandboxmanager.SandboxManager
 	keys            keys.KeyStorage
 }
 
-// NewController creates a new E2B Controller
-func NewController(domain, sysNs, peerSelector, sandboxNamespace, sandboxLabelSelector string, maxTimeout, minResumeTimeout, maxClaimWorkers, maxCreateQPS int, extProcMaxConcurrency uint32, port, memberlistBindPort int, keyCfg *keys.Config, clientConfig *rest.Config, quotaOpts config.QuotaOptions) *Controller {
+// ControllerOptions carries everything NewController needs. Passing a struct
+// instead of a long positional parameter list keeps every value named at the
+// call site, so adding a knob cannot silently shift an argument.
+type ControllerOptions struct {
+	// Domain is the static E2B domain. When empty the domain is resolved per
+	// request from the HTTP Host header.
+	Domain string
+	// Port is the port the E2B HTTP server listens on.
+	Port int
+	// MaxTimeout is the E2B maximum sandbox timeout in seconds.
+	MaxTimeout int
+	// MinResumeTimeout is the floor, in seconds, applied to the timeout carried
+	// by the E2B connect API.
+	MinResumeTimeout int
+	// KeyConfig configures API key storage. Nil disables E2B authentication.
+	KeyConfig *keys.Config
+
+	// Manager is passed to the sandbox-manager builder unchanged.
+	Manager config.SandboxManagerOptions
+	// RuntimeTLSBundle is the client TLS bundle used to reach TLS-capable
+	// agent-runtimes during claim and clone post-processing. Nil keeps every
+	// runtime call on the legacy plaintext paths.
+	RuntimeTLSBundle *utilruntime.TLSBundle
+}
+
+// NewController creates a new E2B Controller from opts.
+func NewController(opts ControllerOptions) *Controller {
 	sc := &Controller{
 		mux:                   http.NewServeMux(),
-		domain:                domain,
-		adapter:               adapters.DefaultAdapterFactory(port),
-		clientConfig:          clientConfig,
-		port:                  port,
-		maxTimeout:            maxTimeout,
-		minResumeTimeoutValue: minResumeTimeout,
-		systemNamespace:       sysNs, // the namespace where the sandbox manager is running
-		peerSelector:          peerSelector,
-		sandboxNamespace:      sandboxNamespace,
-		sandboxLabelSelector:  sandboxLabelSelector,
-		maxClaimWorkers:       maxClaimWorkers,
-		maxCreateQPS:          maxCreateQPS,
-		extProcMaxConcurrency: extProcMaxConcurrency,
-		memberlistBindPort:    memberlistBindPort,
-		keyCfg:                keyCfg,
-		quotaOpts:             quotaOpts,
+		domain:                opts.Domain,
+		adapter:               adapters.DefaultAdapterFactory(opts.Port),
+		maxTimeout:            opts.MaxTimeout,
+		minResumeTimeoutValue: opts.MinResumeTimeout,
+		keyCfg:                opts.KeyConfig,
+		mgrOpts:               opts.Manager,
+		runtimeTLSBundle:      opts.RuntimeTLSBundle,
 	}
 
 	sc.server = &http.Server{
-		Addr:              fmt.Sprintf(":%d", port),
+		Addr:              fmt.Sprintf(":%d", opts.Port),
 		Handler:           sc.mux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
@@ -106,10 +119,11 @@ func (sc *Controller) Init() error {
 	log := klog.FromContext(ctx)
 	log.Info("init controller")
 
-	sandboxManager, err := sandboxmanager.NewSandboxManagerBuilder(sc.sandboxManagerOptions()).
+	sandboxManager, err := sandboxmanager.NewSandboxManagerBuilder(sc.mgrOpts).
 		WithSandboxInfra().
 		WithMemberlistPeers().
 		WithRequestAdapter(sc.adapter).
+		WithRuntimeTLSBundle(sc.runtimeTLSBundle).
 		Build()
 
 	if err != nil {
@@ -128,7 +142,7 @@ func (sc *Controller) Init() error {
 	// Initialize quota through the sandbox-manager, which owns the runtime lifecycle.
 	if sc.keys != nil {
 		log.Info("will init quota management with quota options")
-		if err := sc.manager.InitQuota(ctx, sc.quotaOpts, keys.NewQuotaSubjectLister(sc.keys)); err != nil {
+		if err := sc.manager.InitQuota(ctx, sc.mgrOpts.Quota, keys.NewQuotaSubjectLister(sc.keys)); err != nil {
 			return err
 		}
 	} else {
@@ -138,21 +152,6 @@ func (sc *Controller) Init() error {
 		}
 	}
 	return nil
-}
-
-func (sc *Controller) sandboxManagerOptions() config.SandboxManagerOptions {
-	return config.SandboxManagerOptions{
-		SystemNamespace:       sc.systemNamespace,
-		PeerSelector:          sc.peerSelector,
-		SandboxNamespace:      sc.sandboxNamespace,
-		SandboxLabelSelector:  sc.sandboxLabelSelector,
-		MaxClaimWorkers:       sc.maxClaimWorkers,
-		ExtProcMaxConcurrency: sc.extProcMaxConcurrency,
-		MaxCreateQPS:          sc.maxCreateQPS,
-		MemberlistBindPort:    sc.memberlistBindPort,
-		RestConfig:            sc.clientConfig,
-		Quota:                 sc.quotaOpts,
-	}
 }
 
 func (sc *Controller) initKeyStorage(ctx context.Context) error {

--- a/pkg/servers/e2b/core_test.go
+++ b/pkg/servers/e2b/core_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	utilruntime "github.com/openkruise/agents/pkg/utils/runtime"
 	"github.com/openkruise/agents/pkg/utils/testutils"
 )
 
@@ -85,6 +86,68 @@ func refreshKeyStorageForTest(t *testing.T, controller *Controller) {
 	require.NoError(t, controller.keys.Init(t.Context()))
 }
 
+// TestNewController pins the ControllerOptions -> Controller mapping so a field
+// cannot be silently dropped by the constructor, and so the manager options
+// reach the sandbox-manager builder verbatim.
+func TestNewController(t *testing.T) {
+	keyCfg := &keys.Config{Mode: keys.StorageModeSecret, Namespace: "sandbox-system"}
+	bundle := &utilruntime.TLSBundle{CABundle: []byte("pem")}
+	mgrOpts := config.SandboxManagerOptions{
+		SystemNamespace:       "sandbox-system",
+		PeerSelector:          "component=sandbox-manager",
+		SandboxNamespace:      "sandboxes",
+		SandboxLabelSelector:  "app=sandbox",
+		MaxClaimWorkers:       7,
+		MaxCreateQPS:          11,
+		ExtProcMaxConcurrency: 13,
+		MemberlistBindPort:    config.DefaultMemberlistBindPort,
+		Quota:                 config.QuotaOptions{RedisAddr: "127.0.0.1:6379"},
+	}
+
+	tests := []struct {
+		name string
+		opts ControllerOptions
+	}{
+		{
+			name: "fully populated options",
+			opts: ControllerOptions{
+				Domain:           "example.com",
+				Port:             8080,
+				MaxTimeout:       3600,
+				MinResumeTimeout: 30,
+				KeyConfig:        keyCfg,
+				Manager:          mgrOpts,
+				RuntimeTLSBundle: bundle,
+			},
+		},
+		{
+			name: "zero options leave auth and runtime TLS disabled",
+			opts: ControllerOptions{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := NewController(tt.opts)
+			require.NotNil(t, sc)
+
+			assert.Equal(t, tt.opts.Domain, sc.domain)
+			assert.Equal(t, tt.opts.MaxTimeout, sc.maxTimeout)
+			assert.Equal(t, tt.opts.MinResumeTimeout, sc.minResumeTimeoutValue)
+			assert.Equal(t, tt.opts.KeyConfig, sc.keyCfg)
+			assert.Equal(t, tt.opts.RuntimeTLSBundle, sc.runtimeTLSBundle)
+			// The manager options are handed to the sandbox-manager builder
+			// unchanged, so they must survive the constructor verbatim.
+			assert.Equal(t, tt.opts.Manager, sc.mgrOpts)
+
+			// Port is not retained as a field; it only shapes the server address.
+			require.NotNil(t, sc.server)
+			assert.Equal(t, fmt.Sprintf(":%d", tt.opts.Port), sc.server.Addr)
+			assert.NotNil(t, sc.mux)
+			assert.NotNil(t, sc.adapter)
+		})
+	}
+}
+
 func SetupWithMinResumeTimeout(t *testing.T, minResumeTimeout int) (*Controller, ctrlclient.Client, func()) {
 	return setupWithMinResumeTimeoutAndQuota(t, minResumeTimeout, nil)
 }
@@ -102,14 +165,24 @@ func setupWithMinResumeTimeoutAndQuota(t *testing.T, minResumeTimeout int, quota
 	})
 	cache, fc, cacheErr := cachetest.NewTestCache(t)
 	require.NoError(t, cacheErr)
-	controller := NewController("example.com", namespace, "component=sandbox-manager", "", "", models.DefaultMaxTimeout, minResumeTimeout, 10,
-		0, 0, TestServerPort, config.DefaultMemberlistBindPort, &keys.Config{
+	// The controller gets its own copy so the peer selector it advertises does not
+	// leak into the proxy/infra built from opts below.
+	ctrlMgrOpts := opts
+	ctrlMgrOpts.PeerSelector = "component=sandbox-manager"
+	controller := NewController(ControllerOptions{
+		Domain:           "example.com",
+		Port:             TestServerPort,
+		MaxTimeout:       models.DefaultMaxTimeout,
+		MinResumeTimeout: minResumeTimeout,
+		KeyConfig: &keys.Config{
 			Mode:      keys.StorageModeSecret,
 			Namespace: namespace,
 			AdminKey:  InitKey,
 			Client:    fc,
 			APIReader: fc,
-		}, nil, config.QuotaOptions{})
+		},
+		Manager: ctrlMgrOpts,
+	})
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -140,7 +140,7 @@ func (sc *Controller) CheckApiKey(ctx context.Context, r *http.Request) (context
 		middleWareLog = middleWareLog.WithValues("volumeID", volumeID)
 		namespace := sc.getNamespaceOfUser(user)
 		if namespace == "" {
-			namespace = sc.systemNamespace
+			namespace = sc.mgrOpts.SystemNamespace
 		}
 		owner, ok := sc.manager.GetOwnerOfVolume(ctx, namespace, volumeID)
 		if !ok {

--- a/pkg/servers/e2b/volume.go
+++ b/pkg/servers/e2b/volume.go
@@ -55,7 +55,7 @@ func (sc *Controller) CreateVolume(r *http.Request) (web.ApiResponse[*models.Vol
 	}
 	namespace := sc.getNamespaceOfUser(user)
 	if namespace == "" {
-		namespace = sc.systemNamespace
+		namespace = sc.mgrOpts.SystemNamespace
 	}
 
 	// Parse request body and headers
@@ -187,7 +187,7 @@ func (sc *Controller) ListVolumes(r *http.Request) (web.ApiResponse[[]*models.Vo
 	}
 	namespace := sc.getNamespaceOfUser(user)
 	if namespace == "" {
-		namespace = sc.systemNamespace
+		namespace = sc.mgrOpts.SystemNamespace
 	}
 
 	volumes, err := sc.manager.GetInfra().ListVolumes(ctx, infra.ListVolumesOptions{
@@ -230,7 +230,7 @@ func (sc *Controller) GetVolume(r *http.Request) (web.ApiResponse[*models.Volume
 	}
 	namespace := sc.getNamespaceOfUser(user)
 	if namespace == "" {
-		namespace = sc.systemNamespace
+		namespace = sc.mgrOpts.SystemNamespace
 	}
 
 	volumeID := r.PathValue("volumeID")
@@ -283,7 +283,7 @@ func (sc *Controller) DeleteVolume(r *http.Request) (web.ApiResponse[struct{}], 
 	}
 	namespace := sc.getNamespaceOfUser(user)
 	if namespace == "" {
-		namespace = sc.systemNamespace
+		namespace = sc.mgrOpts.SystemNamespace
 	}
 
 	volumeID := r.PathValue("volumeID")

--- a/pkg/utils/runtime/transport.go
+++ b/pkg/utils/runtime/transport.go
@@ -25,6 +25,10 @@ import (
 	"strconv"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 )
 
@@ -46,9 +50,10 @@ const (
 	// pinnedDialTimeout bounds a single TCP dial to the sandbox Pod IP.
 	pinnedDialTimeout = 5 * time.Second
 
-	// Well-known file names inside a runtime client certificate directory, as
-	// laid out by the client certificate Secret mounted into control-plane
-	// components (see NewTLSBundle).
+	// Well-known names of the runtime client certificate material. They are
+	// both the file names inside a mounted certificate directory (see
+	// NewTLSBundle) and the data keys of the certificate Secret itself (see
+	// NewTLSBundleFromSecret).
 	clientCAFile   = "ca.crt"
 	clientCertFile = "client.crt"
 	clientKeyFile  = "client.key"
@@ -71,15 +76,29 @@ type TLSBundle struct {
 	ClientCertPEM []byte
 	// ClientKeyPEM is the optional PEM-encoded client private key for mutual TLS.
 	ClientKeyPEM []byte
+
+	// parsed caches the decoded form of the PEM blocks above. It is populated by
+	// the loaders (NewTLSBundle, NewTLSBundleFromSecret), which must decode the
+	// material anyway to fail fast on a broken bundle, so every runtime client
+	// then only assembles a tls.Config around it instead of re-parsing the PEM.
+	// A zero-valued TLSBundle (built directly by a caller) leaves it nil and is
+	// decoded on demand.
+	parsed *parsedTLSBundle
 }
 
-// buildClientTLSConfig assembles the *tls.Config used by the runtime client.
-//
-// serverName pins the SNI and certificate-verification hostname (typically
-// RuntimeServerSNI) so verification succeeds against the wildcard SAN even
-// though the underlying connection dials a bare Pod IP. A client certificate is
-// attached only when both PEM blocks are supplied.
-func buildClientTLSConfig(m TLSBundle, serverName string) (*tls.Config, error) {
+// parsedTLSBundle holds the decoded, authority-independent part of a TLSBundle.
+// Only tls.Config.ServerName varies between clients (see WithAuthority), so the
+// trust anchors and the client certificate can be decoded once and shared; both
+// are read-only afterwards and safe for concurrent use.
+type parsedTLSBundle struct {
+	rootCAs *x509.CertPool
+	// clientCert is nil unless the bundle carries a client certificate/key pair.
+	clientCert *tls.Certificate
+}
+
+// parseTLSBundle decodes the PEM blocks of m, rejecting a bundle that cannot
+// produce a usable TLS configuration.
+func parseTLSBundle(m TLSBundle) (*parsedTLSBundle, error) {
 	if len(m.CABundle) == 0 {
 		return nil, fmt.Errorf("runtime TLS CA bundle is required")
 	}
@@ -87,18 +106,40 @@ func buildClientTLSConfig(m TLSBundle, serverName string) (*tls.Config, error) {
 	if !pool.AppendCertsFromPEM(m.CABundle) {
 		return nil, fmt.Errorf("failed to parse runtime TLS CA bundle")
 	}
-	cfg := &tls.Config{
-		RootCAs:    pool,
-		ServerName: serverName,
-		MinVersion: tls.VersionTLS12,
-	}
+	parsed := &parsedTLSBundle{rootCAs: pool}
 	// Client certificate is optional (server uses VerifyClientCertIfGiven).
 	if len(m.ClientCertPEM) > 0 || len(m.ClientKeyPEM) > 0 {
 		cert, err := tls.X509KeyPair(m.ClientCertPEM, m.ClientKeyPEM)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load runtime client certificate/key pair: %w", err)
 		}
-		cfg.Certificates = []tls.Certificate{cert}
+		parsed.clientCert = &cert
+	}
+	return parsed, nil
+}
+
+// buildClientTLSConfig assembles the *tls.Config used by the runtime client.
+//
+// serverName pins the SNI and certificate-verification hostname (typically
+// RuntimeServerSNI) so verification succeeds against the wildcard SAN even
+// though the underlying connection dials a bare Pod IP. The decoded material is
+// reused from m when a loader already cached it, and decoded on demand
+// otherwise; only serverName differs per client, so nothing else is rebuilt.
+func buildClientTLSConfig(m TLSBundle, serverName string) (*tls.Config, error) {
+	parsed := m.parsed
+	if parsed == nil {
+		var err error
+		if parsed, err = parseTLSBundle(m); err != nil {
+			return nil, err
+		}
+	}
+	cfg := &tls.Config{
+		RootCAs:    parsed.rootCAs,
+		ServerName: serverName,
+		MinVersion: tls.VersionTLS12,
+	}
+	if parsed.clientCert != nil {
+		cfg.Certificates = []tls.Certificate{*parsed.clientCert}
 	}
 	return cfg, nil
 }
@@ -145,11 +186,62 @@ func NewTLSBundle(dir string) (*TLSBundle, error) {
 	}
 
 	m := &TLSBundle{CABundle: caBundle, ClientCertPEM: certPEM, ClientKeyPEM: keyPEM}
-	// Validate the bundle eagerly so a broken mount fails fast at startup
-	// instead of on the first runtime call.
-	if _, err := buildClientTLSConfig(*m, RuntimeServerSNI); err != nil {
+	// Decode eagerly so a broken mount fails fast at startup instead of on the
+	// first runtime call, and keep the result so runtime clients reuse it.
+	parsed, err := parseTLSBundle(*m)
+	if err != nil {
 		return nil, fmt.Errorf("invalid runtime client TLS bundle in %s: %w", dir, err)
 	}
+	m.parsed = parsed
+	return m, nil
+}
+
+// NewTLSBundleFromSecret loads the client TLS bundle from the Kubernetes Secret
+// namespace/name through reader. It is the Secret-backed counterpart of
+// NewTLSBundle for components that cannot volume-mount the certificate Secret —
+// e.g. the sandbox-manager, whose certificate Secret lives in a namespace it
+// does not mount — and reads the very same ca.crt / client.crt / client.key
+// keys.
+//
+// Semantics mirror NewTLSBundle: an empty name means TLS is not configured and
+// yields (nil, nil), while a non-empty name declares the intent to speak TLS,
+// so any problem (missing Secret, missing ca.crt, unparsable material, an
+// unpaired client certificate) is an error the caller should surface at startup
+// instead of silently degrading to plain HTTP.
+//
+// The returned bundle is likewise a snapshot: the caller reads it once during
+// startup and holds the value, so replacing the certificate material requires
+// restarting the process.
+func NewTLSBundleFromSecret(ctx context.Context, reader ctrlclient.Reader, namespace, name string) (*TLSBundle, error) {
+	if name == "" {
+		return nil, nil
+	}
+	secret := &corev1.Secret{}
+	if err := reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, secret); err != nil {
+		return nil, fmt.Errorf("failed to get runtime client certificate secret %s/%s: %w", namespace, name, err)
+	}
+
+	caBundle := secret.Data[clientCAFile]
+	if len(caBundle) == 0 {
+		return nil, fmt.Errorf("runtime client certificate secret %s/%s is missing the %q data key", namespace, name, clientCAFile)
+	}
+	// Unlike the directory layout, a Secret cannot distinguish "absent" from
+	// "empty", so an unpaired client certificate is rejected explicitly rather
+	// than silently downgraded to server-authenticated TLS.
+	certPEM, keyPEM := secret.Data[clientCertFile], secret.Data[clientKeyFile]
+	if (len(certPEM) == 0) != (len(keyPEM) == 0) {
+		return nil, fmt.Errorf("runtime client certificate secret %s/%s carries an unpaired %q/%q data key (set both or neither)",
+			namespace, name, clientCertFile, clientKeyFile)
+	}
+
+	m := &TLSBundle{CABundle: caBundle, ClientCertPEM: certPEM, ClientKeyPEM: keyPEM}
+	// Decode eagerly so a broken Secret fails fast at startup instead of on the
+	// first runtime call, and keep the result so runtime clients reuse it.
+	parsed, err := parseTLSBundle(*m)
+	if err != nil {
+		return nil, fmt.Errorf("invalid runtime client TLS bundle in secret %s/%s: %w", namespace, name, err)
+	}
+	m.parsed = parsed
 	return m, nil
 }
 

--- a/pkg/utils/runtime/transport_test.go
+++ b/pkg/utils/runtime/transport_test.go
@@ -34,8 +34,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 )
@@ -166,6 +169,14 @@ func TestBuildClientTLSConfig(t *testing.T) {
 	t.Cleanup(server.Close)
 	validCA := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
 
+	// preParsed mimics a bundle returned by a loader: the PEM is already decoded
+	// and cached, so buildClientTLSConfig must reuse it and still apply the
+	// caller's serverName.
+	preParsed := TLSBundle{CABundle: validCA}
+	cached, err := parseTLSBundle(preParsed)
+	require.NoError(t, err)
+	preParsed.parsed = cached
+
 	tests := []struct {
 		name    string
 		bundle  TLSBundle
@@ -175,6 +186,7 @@ func TestBuildClientTLSConfig(t *testing.T) {
 		{name: "invalid CA", bundle: TLSBundle{CABundle: []byte("garbage")}, wantErr: true},
 		{name: "valid CA only", bundle: TLSBundle{CABundle: validCA}, wantErr: false},
 		{name: "invalid client cert", bundle: TLSBundle{CABundle: validCA, ClientCertPEM: []byte("x"), ClientKeyPEM: []byte("y")}, wantErr: true},
+		{name: "cached parse is reused", bundle: preParsed, wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -338,6 +350,104 @@ func TestNewTLSBundle(t *testing.T) {
 			}
 			require.NotNil(t, m)
 			assert.NotEmpty(t, m.CABundle)
+			// The loader has to decode the bundle to fail fast, so the result
+			// must be cached rather than thrown away.
+			assert.NotNil(t, m.parsed)
+			if tt.wantClient {
+				assert.NotEmpty(t, m.ClientCertPEM)
+				assert.NotEmpty(t, m.ClientKeyPEM)
+			} else {
+				assert.Empty(t, m.ClientCertPEM)
+				assert.Empty(t, m.ClientKeyPEM)
+			}
+		})
+	}
+}
+
+// TestNewTLSBundleFromSecret covers the Secret-backed loader, whose semantics
+// mirror TestNewTLSBundle: an empty name disables TLS, while a named Secret must
+// yield a fully valid bundle read from the same ca.crt/client.crt/client.key
+// keys.
+func TestNewTLSBundleFromSecret(t *testing.T) {
+	caPEM, _ := genSelfSignedPEM(t)
+	clientCert, clientKey := genSelfSignedPEM(t)
+
+	// readerWith returns a client serving a single secret with the given data.
+	readerWith := func(data map[string][]byte) ctrlclient.Reader {
+		return fake.NewClientBuilder().WithObjects(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "runtime-client-cert", Namespace: "certs"},
+			Data:       data,
+		}).Build()
+	}
+
+	tests := []struct {
+		name       string
+		reader     ctrlclient.Reader
+		secretName string
+		wantNil    bool
+		wantErr    bool
+		wantClient bool
+	}{
+		{
+			name:       "empty name disables TLS",
+			reader:     fake.NewClientBuilder().Build(),
+			secretName: "",
+			wantNil:    true,
+		},
+		{
+			name:       "missing secret is an error",
+			reader:     fake.NewClientBuilder().Build(),
+			secretName: "runtime-client-cert",
+			wantErr:    true,
+		},
+		{
+			name:       "ca only yields server-authenticated bundle",
+			reader:     readerWith(map[string][]byte{"ca.crt": caPEM}),
+			secretName: "runtime-client-cert",
+		},
+		{
+			name:       "full set yields mutual TLS bundle",
+			reader:     readerWith(map[string][]byte{"ca.crt": caPEM, "client.crt": clientCert, "client.key": clientKey}),
+			secretName: "runtime-client-cert",
+			wantClient: true,
+		},
+		{
+			name:       "client cert without key is an error",
+			reader:     readerWith(map[string][]byte{"ca.crt": caPEM, "client.crt": clientCert}),
+			secretName: "runtime-client-cert",
+			wantErr:    true,
+		},
+		{
+			name:       "missing ca key is an error",
+			reader:     readerWith(map[string][]byte{"client.crt": clientCert, "client.key": clientKey}),
+			secretName: "runtime-client-cert",
+			wantErr:    true,
+		},
+		{
+			name:       "unparsable ca is an error",
+			reader:     readerWith(map[string][]byte{"ca.crt": []byte("not a pem")}),
+			secretName: "runtime-client-cert",
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := NewTLSBundleFromSecret(context.Background(), tt.reader, "certs", tt.secretName)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, m)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantNil {
+				assert.Nil(t, m)
+				return
+			}
+			require.NotNil(t, m)
+			assert.NotEmpty(t, m.CABundle)
+			// The loader has to decode the bundle to fail fast, so the result
+			// must be cached rather than thrown away.
+			assert.NotNil(t, m.parsed)
 			if tt.wantClient {
 				assert.NotEmpty(t, m.ClientCertPEM)
 				assert.NotEmpty(t, m.ClientKeyPEM)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

    Add LoadTLSMaterialFromSecret to read mTLS certificates from a cross-namespace Secret via the in-cluster client, and thread TLSMaterialProvider through SandboxManagerOptions, InfraBuilder and Claim/CloneSandboxOptions so InitRuntime and ProcessCSIMounts reach TLS-capable sandboxes over HTTPS.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

