### PR TITLE
fix(proxy): add nil checks for HttpHeaders in ext_proc header helpers

### DIFF
--- a/pkg/proxy/ext_proc.go
+++ b/pkg/proxy/ext_proc.go
@@ -65,6 +65,11 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 			return status.Errorf(codes.Unknown, "cannot receive stream request: %v", err)
 		}
 
+		if req == nil || req.Request == nil {
+			log.Info("empty stream request received")
+			continue
+		}
+
 		// build response based on request type
 		resp := &extProcPb.ProcessingResponse{
 			Response: &extProcPb.ProcessingResponse_RequestHeaders{
@@ -95,6 +100,9 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 var OrigDstHeader = "x-envoy-original-dst-host"
 
 func (s *Server) handleRequestHeaders(requestHeaders *extProcPb.ProcessingRequest_RequestHeaders, log logr.Logger) *extProcPb.ProcessingResponse {
+	if requestHeaders == nil {
+		return s.logAndCreateErrorResponse(http.StatusBadRequest, "nil request headers", log)
+	}
 	// Step 1: Convert ext_proc headers to flat map[string]string
 	headers := extProcHeadersToMap(requestHeaders.RequestHeaders)
 	// Step 2: Use adapter.ParseRequest to normalize the request
@@ -189,18 +197,27 @@ func (s *Server) logAndCreateErrorResponse(statusCode int, message string, log l
 // preserving pseudo-headers (:scheme, :authority, :path) so that adapter.ParseRequest
 // can normalize them uniformly.
 func extProcHeadersToMap(httpHeaders *extProcPb.HttpHeaders) map[string]string {
-	headers := make(map[string]string, len(httpHeaders.Headers.Headers))
-	for _, header := range httpHeaders.Headers.Headers {
-		headers[header.Key] = string(header.RawValue)
+	if httpHeaders == nil || httpHeaders.GetHeaders() == nil {
+		return map[string]string{}
+	}
+	rawHeaders := httpHeaders.GetHeaders().GetHeaders()
+	headers := make(map[string]string, len(rawHeaders))
+	for _, header := range rawHeaders {
+		if header != nil {
+			headers[header.Key] = string(header.RawValue)
+		}
 	}
 	return headers
 }
 
 func headerModifiers(key string, in *extProcPb.HttpHeaders, log logr.Logger) []*configPb.HeaderValueOption {
 	var modifiers []*configPb.HeaderValueOption
+	if in == nil || in.GetHeaders() == nil {
+		return modifiers
+	}
 	value := ""
-	for _, header := range in.Headers.Headers {
-		if header.Key == key {
+	for _, header := range in.GetHeaders().GetHeaders() {
+		if header != nil && header.Key == key {
 			value = string(header.RawValue)
 			break
 		}

--- a/pkg/proxy/ext_proc_test.go
+++ b/pkg/proxy/ext_proc_test.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
@@ -644,4 +645,56 @@ func TestServer_Run_Stop(t *testing.T) {
 
 	// Stop server
 	server.Stop(t.Context())
+}
+
+func TestExtProcHeadersToMap_NilHandling(t *testing.T) {
+	t.Run("nil HttpHeaders", func(t *testing.T) {
+		res := extProcHeadersToMap(nil)
+		assert.NotNil(t, res)
+		assert.Empty(t, res)
+	})
+
+	t.Run("nil Headers inside HttpHeaders", func(t *testing.T) {
+		res := extProcHeadersToMap(&extProcPb.HttpHeaders{Headers: nil})
+		assert.NotNil(t, res)
+		assert.Empty(t, res)
+	})
+
+	t.Run("nil element inside Headers slice", func(t *testing.T) {
+		res := extProcHeadersToMap(&extProcPb.HttpHeaders{
+			Headers: &corev3.HeaderMap{
+				Headers: []*corev3.HeaderValue{nil},
+			},
+		})
+		assert.NotNil(t, res)
+		assert.Empty(t, res)
+	})
+}
+
+func TestHeaderModifiers_NilHandling(t *testing.T) {
+	t.Run("nil HttpHeaders", func(t *testing.T) {
+		res := headerModifiers("test-key", nil, klog.Background())
+		assert.Nil(t, res)
+	})
+
+	t.Run("nil Headers inside HttpHeaders", func(t *testing.T) {
+		res := headerModifiers("test-key", &extProcPb.HttpHeaders{Headers: nil}, klog.Background())
+		assert.Nil(t, res)
+	})
+
+	t.Run("nil element inside Headers slice", func(t *testing.T) {
+		res := headerModifiers("test-key", &extProcPb.HttpHeaders{
+			Headers: &corev3.HeaderMap{
+				Headers: []*corev3.HeaderValue{nil},
+			},
+		}, klog.Background())
+		assert.Nil(t, res)
+	})
+}
+
+func TestHandleRequestHeaders_NilHandling(t *testing.T) {
+	s := &Server{}
+	res := s.handleRequestHeaders(nil, klog.Background())
+	assert.NotNil(t, res)
+	assert.IsType(t, &extProcPb.ProcessingResponse_ImmediateResponse{}, res.Response)
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR fixes a potential runtime nil pointer dereference panic in `pkg/proxy/ext_proc.go`. 

Specifically:
- Added `nil` checks for `httpHeaders == nil || httpHeaders.Headers == nil` in `extProcHeadersToMap` and `headerModifiers`.
- Prevents the proxy server stream handler from panicking when processing gRPC requests sent by Envoy containing empty or `nil` header maps.
- Added unit tests `TestExtProcHeadersToMap_NilHandling` and `TestHeaderModifiers_NilHandling` in `ext_proc_test.go`.

### Ⅱ. Does this pull request fix one issue?

fixes #703

### Ⅲ. Describe how to verify it

Run the unit tests in `pkg/proxy`:
```bash
go test -v ./pkg/proxy/...
