### PR TITLE
[BUG] Unclosed http.Response Body in BrowserUse Endpoint Handler Causes Socket Leak

### DIFF
--- a/pkg/servers/e2b/services.go
+++ b/pkg/servers/e2b/services.go
@@ -165,6 +165,7 @@ func (sc *Controller) BrowserUse(r *http.Request) (web.ApiResponse[*browserHandS
 			Message: fmt.Sprintf("Failed to proxy request to sandbox port %d: %v", cdpPort, err),
 		}
 	}
+	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return web.ApiResponse[*browserHandShake]{}, &web.ApiError{

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -2460,6 +2460,16 @@ func TestSandboxNamespaceIsolationWithSameName(t *testing.T) {
 	})
 }
 
+type trackedReadCloser struct {
+	io.Reader
+	closed *bool
+}
+
+func (t *trackedReadCloser) Close() error {
+	*t.closed = true
+	return nil
+}
+
 func TestBrowserUse(t *testing.T) {
 	controller, _, teardown := Setup(t)
 	defer teardown()
@@ -2504,12 +2514,16 @@ func TestBrowserUse(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				bodyClosed := false
 				proxyutils.DefaultRequestFunc = func(ctx context.Context, sbx *v1alpha1.Sandbox, method, path string, port int, body io.Reader) (*http.Response, error) {
 					assert.Equal(t, "/json/version", path)
 					assert.Equal(t, tt.expectedPort, port)
 					return &http.Response{
 						StatusCode: http.StatusOK,
-						Body:       io.NopCloser(strings.NewReader(expectedBody)),
+						Body: &trackedReadCloser{
+							Reader: strings.NewReader(expectedBody),
+							closed: &bodyClosed,
+						},
 					}, nil
 				}
 
@@ -2524,6 +2538,7 @@ func TestBrowserUse(t *testing.T) {
 
 				require.Nil(t, apiErr)
 				require.NotNil(t, resp.Body)
+				assert.True(t, bodyClosed, "response body should be closed by BrowserUse")
 				assert.Equal(t, http.StatusOK, resp.Code)
 				assert.Equal(t, "Chrome", resp.Body.Browser)
 				assert.Contains(t, resp.Body.WebSocketDebuggerURL,


### PR DESCRIPTION


**What happened**:

In `pkg/servers/e2b/services.go`, the `BrowserUse` endpoint handler (`GET /browser/{sandboxID}/json/version`) proxies Chrome DevTools Protocol (CDP) version requests to the target sandbox via `sbx.Request(...)`. While it reads the response body using `io.ReadAll(resp.Body)`, it never closes `resp.Body` (missing `defer resp.Body.Close()`). 

Consequently, the underlying HTTP connection and TCP socket file descriptor remain open indefinitely after every call to `/browser/{sandboxID}/json/version`, causing file descriptor and network socket leaks under load.

**What you expected to happen**:

`resp.Body.Close()` should be deferred immediately after verifying that `sbx.Request` returned a non-nil response without error, ensuring the response body is always closed and connection reuse is enabled.

**How to reproduce it (as minimally and precisely as possible)**:

1. Inspect `pkg/servers/e2b/services.go:162-180`:
```go
	resp, err := sbx.Request(r.Context(), r.Method, "/json/version", cdpPort, r.Body)
	if err != nil {
		return web.ApiResponse[*browserHandShake]{}, &web.ApiError{
			Message: fmt.Sprintf("Failed to proxy request to sandbox port %d: %v", cdpPort, err),
		}
	}
	body, err := io.ReadAll(resp.Body)
