### PR TITLE
feat(checkpoint): mirror checkpoint ID into a selectable label

### DIFF
--- a/api/v1alpha1/checkpoint_types.go
+++ b/api/v1alpha1/checkpoint_types.go
@@ -31,6 +31,9 @@ const (
 	// CheckpointLabelType is the checkpoint type label key
 	CheckpointLabelType = InternalPrefix + "checkpoint-type"
 
+	// CheckpointLabelID is the checkpoint ID label key
+	CheckpointLabelID = InternalPrefix + "checkpoint-id"
+
 	// CheckpointTypePodInfo indicates this checkpoint stores pod info delta
 	CheckpointTypePodInfo = "pod-info"
 

--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -510,8 +510,22 @@ func CreateCheckpoint(ctx context.Context, sbx *v1alpha1.Sandbox, cache infracac
 		log.Error(err, "failed to refresh checkpoint after wait")
 		return "", fmt.Errorf("failed to refresh checkpoint: %w", err)
 	}
-	log.Info("checkpoint ready")
-	return fresh.Status.CheckpointId, nil
+	checkpointID := fresh.Status.CheckpointId
+	// Mirror the status-only ID into metadata so operators can find the
+	// Checkpoint with a kubectl label selector. Best-effort: the checkpoint is
+	// already usable, so a label failure must not fail the whole operation.
+	base := fresh.DeepCopy()
+	if fresh.Labels == nil {
+		fresh.Labels = make(map[string]string)
+	}
+	fresh.Labels[v1alpha1.CheckpointLabelID] = checkpointID
+	if err = retry.OnError(retry.DefaultBackoff, utils.RetryIfContextNotCanceled(ctx), func() error {
+		return cache.GetClient().Patch(ctx, fresh, client.MergeFrom(base))
+	}); err != nil {
+		log.Error(err, "failed to patch checkpoint ID label, continuing", "checkpointID", checkpointID)
+	}
+	log.Info("checkpoint ready", "checkpointID", checkpointID)
+	return checkpointID, nil
 }
 
 func AsCheckpointInfo(cp *v1alpha1.Checkpoint) infra.CheckpointInfo {

--- a/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
@@ -1804,6 +1804,7 @@ func TestCreateCheckPoint(t *testing.T) {
 				assert.Equal(t, "tmpl-1", cp.Name)
 				assert.Equal(t, "test-sandbox-1", *cp.Spec.PodName)
 				assert.Empty(t, cp.OwnerReferences, "checkpoint should have no owner references")
+				assert.Equal(t, "cp-id-123", cp.Labels[v1alpha1.CheckpointLabelID])
 				var tmpl v1alpha1.SandboxTemplate
 				require.NoError(t, c.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "tmpl-1"}, &tmpl))
 				require.Len(t, tmpl.OwnerReferences, 1)


### PR DESCRIPTION
## Summary
- Add `agents.kruise.io/checkpoint-id` (`CheckpointLabelID`) so succeeded Checkpoints can be selected with `kubectl` without scraping `status.checkpointId`.
- After `CreateCheckpoint` reaches Succeeded, best-effort MergeFrom-patch the ID onto metadata; label failure is logged and does not fail the API return.
- Cover the happy path in the existing CreateCheckpoint unit test.

## Test plan
- [ ] `go test ./pkg/sandbox-manager/infra/sandboxcr/ -run TestCreateCheckPoint -count=1`
- [ ] Create a checkpoint via sandbox-manager and confirm `kubectl get checkpoint -l agents.kruise.io/checkpoint-id=<id>` finds it
- [ ] Confirm a simulated label-patch failure still returns the checkpoint ID (best-effort behavior)