### PR TITLE
feat(checkpoint): add selection labels and clone context

### DIFF
--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -77,7 +77,7 @@ func ValidateAndInitCheckpointOptions(opts infra.CreateCheckpointOptions) infra.
 }
 
 func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache infracache.Provider) (cloned infra.Sandbox, metrics infra.CloneMetrics, err error) {
-	log := klog.FromContext(ctx).WithValues("checkpoint", opts.CheckPointID)
+	log := klog.FromContext(ctx).WithValues("checkpointID", opts.CheckPointID)
 	opts.LockString = chooseLockString(opts.Admission, opts.LockString)
 	admitted := false
 
@@ -93,6 +93,7 @@ func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache inf
 	if err != nil {
 		return nil, metrics, err
 	}
+	log = log.WithValues("template", klog.KObj(tmpl), "checkpoint", klog.KObj(cp))
 
 	// Step 2: block on the create rate limiter so a single Infra.createLimiter
 	// gates both claim and clone create traffic. Unlike newSandboxFromSandboxSet
@@ -205,7 +206,7 @@ func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache inf
 
 // findCheckpointAndTemplateById gets checkpoint and template from cache, fallback to API server if not found
 func findCheckpointAndTemplateById(ctx context.Context, opts infra.CloneSandboxOptions, cache infracache.Provider, metrics infra.CloneMetrics) (*v1alpha1.SandboxTemplate, *v1alpha1.Checkpoint, infra.CloneMetrics, error) {
-	log := klog.FromContext(ctx).WithValues("checkpoint", opts.CheckPointID, "step", "1.findCheckpointAndTemplate")
+	log := klog.FromContext(ctx).WithValues("checkpointID", opts.CheckPointID, "step", "1.findCheckpointAndTemplate")
 	start := time.Now()
 
 	// Try to get checkpoint from cache first
@@ -238,7 +239,7 @@ func findCheckpointAndTemplateById(ctx context.Context, opts infra.CloneSandboxO
 
 	metrics.GetTemplate = time.Since(start)
 	metrics.Total += metrics.GetTemplate
-	log.Info("checkpoint and template found", "cost", metrics.GetTemplate)
+	log.Info("checkpoint and template found", "cost", metrics.GetTemplate, "template", klog.KObj(template), "checkpoint", klog.KObj(checkpoint))
 	return template, checkpoint, metrics, nil
 }
 
@@ -252,7 +253,7 @@ func waitCloneCreateLimiter(ctx context.Context, opts infra.CloneSandboxOptions,
 	if opts.CreateLimiter == nil {
 		return metrics, nil
 	}
-	log := klog.FromContext(ctx).WithValues("checkpoint", opts.CheckPointID, "step", "2.waitCreateLimiter")
+	log := klog.FromContext(ctx).WithValues("checkpointID", opts.CheckPointID, "step", "2.waitCreateLimiter")
 	log.Info("waiting for create sandbox limiter")
 	start := time.Now()
 	waitErr := opts.CreateLimiter.Wait(ctx)
@@ -283,7 +284,7 @@ func waitCloneCreateLimiter(ctx context.Context, opts infra.CloneSandboxOptions,
 }
 
 func prepareSandboxFromCheckpoint(ctx context.Context, opts infra.CloneSandboxOptions, tmpl *v1alpha1.SandboxTemplate, cp *v1alpha1.Checkpoint, cache infracache.Provider) (*Sandbox, *config.InitRuntimeOptions, error) {
-	log := klog.FromContext(ctx).WithValues("checkpoint", opts.CheckPointID, "step", "3.prepareSandboxFromCheckpoint")
+	log := klog.FromContext(ctx).WithValues("checkpointID", opts.CheckPointID, "step", "3.prepareSandboxFromCheckpoint")
 	initRuntimeOpts, err := runtime.GetInitRuntimeRequest(cp)
 	if err != nil {
 		log.Error(err, "failed to get init runtime request")
@@ -309,7 +310,7 @@ func prepareSandboxFromCheckpoint(ctx context.Context, opts infra.CloneSandboxOp
 }
 
 func createPreparedSandbox(ctx context.Context, opts infra.CloneSandboxOptions, sbx *Sandbox, cache infracache.Provider, metrics infra.CloneMetrics) (*Sandbox, infra.CloneMetrics, error) {
-	log := klog.FromContext(ctx).WithValues("checkpoint", opts.CheckPointID, "step", "3.createSandboxFromCheckpoint")
+	log := klog.FromContext(ctx).WithValues("checkpointID", opts.CheckPointID, "step", "3.createSandboxFromCheckpoint")
 	start := time.Now()
 	log.Info("creating new sandbox from checkpoint")
 	created, err := DefaultCreateSandbox(ctx, sbx.Sandbox, cache.GetClient())
@@ -327,7 +328,7 @@ func createPreparedSandbox(ctx context.Context, opts infra.CloneSandboxOptions, 
 
 // cloneWaitSandboxReady waits for the sandbox to be ready
 func cloneWaitSandboxReady(ctx context.Context, sbx *Sandbox, opts infra.CloneSandboxOptions, cache infracache.Provider, metrics infra.CloneMetrics) (infra.CloneMetrics, error) {
-	log := klog.FromContext(ctx).WithValues("checkpoint", opts.CheckPointID, "step", "4.waitSandboxReady")
+	log := klog.FromContext(ctx).WithValues("checkpointID", opts.CheckPointID, "step", "4.waitSandboxReady")
 	var err error
 	metrics.WaitReady, err = waitForSandboxReady(ctx, sbx, infra.ClaimSandboxOptions{
 		WaitReadyTimeout: opts.WaitReadyTimeout,
@@ -342,7 +343,7 @@ func cloneWaitSandboxReady(ctx context.Context, sbx *Sandbox, opts infra.CloneSa
 
 // cloneReInitRuntime re-initializes the runtime if needed
 func cloneReInitRuntime(ctx context.Context, sbx *Sandbox, opts infra.CloneSandboxOptions, initRuntimeOpts *config.InitRuntimeOptions, metrics infra.CloneMetrics) (infra.CloneMetrics, error) {
-	log := klog.FromContext(ctx).WithValues("checkpoint", opts.CheckPointID, "step", "5.reInitRuntime")
+	log := klog.FromContext(ctx).WithValues("checkpointID", opts.CheckPointID, "step", "5.reInitRuntime")
 	if initRuntimeOpts == nil {
 		return metrics, nil
 	}
@@ -433,6 +434,11 @@ func CreateCheckpoint(ctx context.Context, sbx *v1alpha1.Sandbox, cache infracac
 				v1alpha1.AnnotationInitRuntimeRequest: sbx.Annotations[v1alpha1.AnnotationInitRuntimeRequest],
 				v1alpha1.AnnotationOwner:              sbx.Annotations[v1alpha1.AnnotationOwner],
 				v1alpha1.AnnotationSandboxID:          utils.GetSandboxID(sbx),
+			},
+			// Labels are for manual selection by users with kubectl.
+			Labels: map[string]string{
+				v1alpha1.AnnotationOwner:  sbx.Annotations[v1alpha1.AnnotationOwner],
+				v1alpha1.LabelSandboxName: sbx.Name,
 			},
 		},
 		Spec: v1alpha1.CheckpointSpec{


### PR DESCRIPTION
## What changed

- Label newly created Checkpoints with the owner and source Sandbox name for manual `kubectl` selection.
- Use `checkpointID` for the external checkpoint identifier in clone logs.
- Attach structured SandboxTemplate and Checkpoint object context after lookup.

## Why

These changes were left uncommitted when #712 was merged. The merged change added the Checkpoint ID label, but omitted the user-facing selection labels and the related structured clone log context.

## Impact

Users can select Checkpoints by owner or source Sandbox name, while clone logs distinguish the external checkpoint ID from Kubernetes object identity.

## Validation

```text
GOFLAGS=-mod=readonly GOCACHE=/private/tmp/go-build-cache go test ./pkg/sandbox-manager/infra/sandboxcr -run '^TestCreateCheckPoint$' -count=1
```
