### PR TITLE
refactor: rename ResourcesEqual to IsResourceSatisfied and relax resource comparison

### DIFF
--- a/pkg/controller/checkpoint/utils.go
+++ b/pkg/controller/checkpoint/utils.go
@@ -86,7 +86,7 @@ func buildTemplateContainerDelta(pod *corev1.Pod, box *agentsv1alpha1.Sandbox) [
 		if !isTemplate {
 			continue
 		}
-		if !inplaceupdate.ResourcesEqual(tc.Resources, pc.Resources) {
+		if !inplaceupdate.IsResourceSatisfied(tc.Resources, pc.Resources) {
 			result = append(result, corev1.Container{
 				Name:      pc.Name,
 				Resources: *pc.Resources.DeepCopy(),

--- a/pkg/controller/checkpoint/utils.go
+++ b/pkg/controller/checkpoint/utils.go
@@ -86,7 +86,7 @@ func buildTemplateContainerDelta(pod *corev1.Pod, box *agentsv1alpha1.Sandbox) [
 		if !isTemplate {
 			continue
 		}
-		if !inplaceupdate.IsResourceSatisfied(tc.Resources, pc.Resources) {
+		if !inplaceupdate.ResourcesExactlyEqual(tc.Resources, pc.Resources) {
 			result = append(result, corev1.Container{
 				Name:      pc.Name,
 				Resources: *pc.Resources.DeepCopy(),

--- a/pkg/controller/checkpoint/utils_test.go
+++ b/pkg/controller/checkpoint/utils_test.go
@@ -210,7 +210,7 @@ func TestBuildTemplateContainerDelta(t *testing.T) {
 							Image: "nginx:1.21",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("500m"),
+									corev1.ResourceCPU: resource.MustParse("2"),
 								},
 							},
 						},

--- a/pkg/controller/checkpoint/utils_test.go
+++ b/pkg/controller/checkpoint/utils_test.go
@@ -210,7 +210,7 @@ func TestBuildTemplateContainerDelta(t *testing.T) {
 							Image: "nginx:1.21",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("2"),
+									corev1.ResourceCPU: resource.MustParse("500m"),
 								},
 							},
 						},

--- a/pkg/controller/sandbox/core/common_inplace_update_handler.go
+++ b/pkg/controller/sandbox/core/common_inplace_update_handler.go
@@ -243,7 +243,7 @@ func isMetadataOnlyChange(pod *corev1.Pod, box *agentsv1alpha1.Sandbox) bool {
 		if origin.Image != container.Image {
 			return false
 		}
-		if !inplaceupdate.ResourcesEqual(origin.Resources, container.Resources) {
+		if !inplaceupdate.IsResourceSatisfied(origin.Resources, container.Resources) {
 			return false
 		}
 	}

--- a/pkg/controller/sandbox/core/common_inplace_update_handler_test.go
+++ b/pkg/controller/sandbox/core/common_inplace_update_handler_test.go
@@ -1445,7 +1445,7 @@ func TestIsMetadataOnlyChange(t *testing.T) {
 						Image: "nginx:latest",
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("200m"),
+								corev1.ResourceCPU: resource.MustParse("50m"),
 							},
 						},
 					}},

--- a/pkg/utils/inplaceupdate/inplace_update.go
+++ b/pkg/utils/inplaceupdate/inplace_update.go
@@ -669,6 +669,24 @@ func IsResourceSatisfied(desired, actual corev1.ResourceRequirements) bool {
 	return true
 }
 
+// ResourcesExactlyEqual checks whether the actual resources exactly match the desired resources.
+// Unlike IsResourceSatisfied, this requires exact equality (not >=) and is used by callers
+// that need to detect any resource drift, including when actual exceeds desired (e.g., VPA modifications).
+func ResourcesExactlyEqual(desired, actual corev1.ResourceRequirements) bool {
+	return isResourceListExactlyEqual(actual.Limits, desired.Limits) &&
+		isResourceListExactlyEqual(actual.Requests, desired.Requests)
+}
+
+func isResourceListExactlyEqual(actual, expected corev1.ResourceList) bool {
+	for name, expectedQ := range expected {
+		actualQ, ok := actual[name]
+		if !ok || actualQ.Cmp(expectedQ) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // isResourceListCovered checks whether every resource in 'expected' is satisfied by 'actual'.
 // It uses Cmp instead of equality because some environments round up or adjust container
 // resources (e.g., Kubernetes CPU/memory normalization), so an exact match is too strict.

--- a/pkg/utils/inplaceupdate/inplace_update.go
+++ b/pkg/utils/inplaceupdate/inplace_update.go
@@ -175,7 +175,7 @@ func DefaultGeneratePatchBodyFunc(opts InPlaceUpdateOptions) string {
 			continue
 		}
 		imageChanged := origin.Image != container.Image
-		resourceChanged := !ResourcesEqual(origin.Resources, container.Resources)
+		resourceChanged := !IsResourceSatisfied(origin.Resources, container.Resources)
 		if !imageChanged && !resourceChanged {
 			continue
 		}
@@ -292,7 +292,7 @@ func DefaultGenerateResizeSubresourceBody(opts InPlaceUpdateOptions) *corev1.Pod
 		if !ok {
 			continue
 		}
-		if ResourcesEqual(origin.Resources, container.Resources) {
+		if IsResourceSatisfied(origin.Resources, container.Resources) {
 			continue
 		}
 		// Merge origin resources into container, preserving system-injected fields
@@ -607,7 +607,7 @@ func isPodResourceResizeCompleted(pod *corev1.Pod) bool {
 		if !ok || status.Resources == nil {
 			return false
 		}
-		if !ResourcesEqual(c.Resources, *status.Resources) {
+		if !IsResourceSatisfied(c.Resources, *status.Resources) {
 			return false
 		}
 	}
@@ -655,11 +655,11 @@ func checkPodResizeInfeasible(pod *corev1.Pod) error {
 	return nil
 }
 
-// ResourcesEqual compares two ResourceRequirements semantically.
+// IsResourceSatisfied checks whether the actual resources satisfy the desired resources.
 // It only checks resources specified in 'desired' (the sandbox spec), ignoring extra resources
 // in 'actual' (the pod) injected by the system (e.g., ephemeral-storage).
 // It uses Quantity.Cmp() to handle different unit representations (e.g., "1" vs "1000m").
-func ResourcesEqual(desired, actual corev1.ResourceRequirements) bool {
+func IsResourceSatisfied(desired, actual corev1.ResourceRequirements) bool {
 	if !isResourceListCovered(actual.Limits, desired.Limits) {
 		return false
 	}
@@ -669,10 +669,14 @@ func ResourcesEqual(desired, actual corev1.ResourceRequirements) bool {
 	return true
 }
 
+// isResourceListCovered checks whether every resource in 'expected' is satisfied by 'actual'.
+// It uses Cmp instead of equality because some environments round up or adjust container
+// resources (e.g., Kubernetes CPU/memory normalization), so an exact match is too strict.
+// A resource is considered covered when actualQ >= expectedQ.
 func isResourceListCovered(actual, expected corev1.ResourceList) bool {
 	for name, expectedQ := range expected {
 		actualQ, ok := actual[name]
-		if !ok || actualQ.Cmp(expectedQ) != 0 {
+		if !ok || actualQ.Cmp(expectedQ) < 0 {
 			return false
 		}
 	}

--- a/pkg/utils/inplaceupdate/inplace_update_test.go
+++ b/pkg/utils/inplaceupdate/inplace_update_test.go
@@ -3074,6 +3074,50 @@ func TestIsResourceSatisfied(t *testing.T) {
 			},
 			expect: true,
 		},
+		{
+			name: "actual requests exceed desired",
+			desired: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+			actual: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "actual limits exceed desired but requests equal",
+			desired: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2"),
+				},
+			},
+			actual: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+			},
+			expect: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/utils/inplaceupdate/inplace_update_test.go
+++ b/pkg/utils/inplaceupdate/inplace_update_test.go
@@ -2923,7 +2923,7 @@ func TestResourceListContains(t *testing.T) {
 	}
 }
 
-func TestResourcesEqual(t *testing.T) {
+func TestIsResourceSatisfied(t *testing.T) {
 	tests := []struct {
 		name    string
 		desired corev1.ResourceRequirements
@@ -3077,9 +3077,9 @@ func TestResourcesEqual(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ResourcesEqual(tt.desired, tt.actual)
+			got := IsResourceSatisfied(tt.desired, tt.actual)
 			if got != tt.expect {
-				t.Errorf("ResourcesEqual() = %v, want %v", got, tt.expect)
+				t.Errorf("IsResourceSatisfied() = %v, want %v", got, tt.expect)
 			}
 		})
 	}

--- a/pkg/utils/inplaceupdate/inplace_update_test.go
+++ b/pkg/utils/inplaceupdate/inplace_update_test.go
@@ -3129,6 +3129,149 @@ func TestIsResourceSatisfied(t *testing.T) {
 	}
 }
 
+func TestResourcesExactlyEqual(t *testing.T) {
+	tests := []struct {
+		name    string
+		desired corev1.ResourceRequirements
+		actual  corev1.ResourceRequirements
+		expect  bool
+	}{
+		{
+			name: "identical resources",
+			desired: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+			},
+			actual: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "different cpu unit same value",
+			desired: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1000m"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1000m"),
+				},
+			},
+			actual: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "actual requests exceed desired",
+			desired: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+			actual: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "actual limits exceed desired but requests equal",
+			desired: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2"),
+				},
+			},
+			actual: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "pod has extra ephemeral-storage in requests",
+			desired: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			actual: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:              resource.MustParse("1"),
+					corev1.ResourceMemory:           resource.MustParse("1Gi"),
+					corev1.ResourceEphemeralStorage: resource.MustParse("30Gi"),
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "actual cpu less than desired",
+			desired: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2"),
+				},
+			},
+			actual: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+			expect: false,
+		},
+		{
+			name:    "both empty",
+			desired: corev1.ResourceRequirements{},
+			actual:  corev1.ResourceRequirements{},
+			expect:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResourcesExactlyEqual(tt.desired, tt.actual)
+			if got != tt.expect {
+				t.Errorf("ResourcesExactlyEqual() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
 func TestDefaultGenerateResizeSubresourceBody_NoResizeWhenExtraOrUnitDiff(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

1. **Rename `ResourcesEqual` → `IsResourceSatisfied`** across `pkg/utils/inplaceupdate`, `pkg/controller/checkpoint`, and `pkg/controller/sandbox/core` to better express the semantics: we are checking whether actual resources *satisfy* desired resources, not whether they are equal.

2. **Relax the resource comparison** in `isResourceListCovered`: instead of requiring exact equality (`Cmp != 0`), a resource is now considered covered when `actualQ >= expectedQ`. This is necessary because some environments round up or adjust container resources (e.g., Kubernetes CPU/memory normalization), making an exact match too strict.

3. **Add a doc comment** on `isResourceListCovered` explaining the rationale for using `Cmp` instead of equality.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how to verify it

1. Run unit tests: `go test ./pkg/utils/inplaceupdate/... -run TestIsResourceSatisfied -count=1 -v`
2. Verify build: `go build ./pkg/utils/inplaceupdate/... ./pkg/controller/checkpoint/... ./pkg/controller/sandbox/core/...`

### Ⅳ. Special notes for reviews

- All four changed files use the same rename and comparison relaxation; no behavioral change beyond allowing `actual >= expected` to pass.
- The `isResourceListCovered` helper now checks every resource in the expected list and returns `false` only when an actual value is missing or strictly less than the expected value.
