### PR TITLE
fix: increase timing margin in flaky TestSandbox_Resume_ContextExpiredAfterWait

### DIFF
--- a/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go
@@ -248,11 +248,14 @@ func TestSandbox_Resume_ContextExpiredAfterWait(t *testing.T) {
 	mockMgr := cache.GetMockManager()
 	mockMgr.AddWaitReconcileKey(sandbox)
 
-	// Use a very short timeout (200ms) and update sandbox at 190ms
-	// This simulates the scenario where wait succeeds right at the deadline boundary
+	// Use a short timeout (500ms) and update sandbox at 300ms.
+	// The 200ms window gives the informer cache enough time to propagate the
+	// status update before the context deadline fires the double-check, while
+	// still being tight enough that the context expires during or right after
+	// the wait — exercising the fresh-context fallback in Resume.
 	modified := s.Sandbox.DeepCopy()
 	mergeFrom := ctrl.MergeFrom(s.Sandbox)
-	time.AfterFunc(190*time.Millisecond, func() {
+	time.AfterFunc(300*time.Millisecond, func() {
 		modified.Status.Phase = v1alpha1.SandboxRunning
 		modified.Status.Conditions = []metav1.Condition{
 			{Type: string(v1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Resume"},
@@ -262,7 +265,7 @@ func TestSandbox_Resume_ContextExpiredAfterWait(t *testing.T) {
 
 	// Context timeout is slightly longer than the update delay, but short enough
 	// that context may expire during the wait's double-check phase
-	resumeCtx, resumeCancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	resumeCtx, resumeCancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 	defer resumeCancel()
 
 	err = s.Resume(resumeCtx, infra.ResumeOptions{})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Fixes a flaky timing-based test `TestSandbox_Resume_ContextExpiredAfterWait` in `pkg/sandbox-manager/infra/sandboxcr/pause_resume_test.go`.

The test used a 10ms window (190ms status update vs 200ms context timeout) to simulate the scenario where the context expires during the wait's double-check phase. This window was too tight for CI environments — the informer cache often hadn't propagated the status update by the time the context deadline fired the double-check, causing intermittent `object is not satisfied during double check` failures.

Increased the timing to a 200ms window (300ms update vs 500ms timeout), giving the cache enough time to propagate while still exercising the fresh-context fallback in `Resume`.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. Describe how to verify it

1. Run the test repeatedly: `go test -run TestSandbox_Resume_ContextExpiredAfterWait ./pkg/sandbox-manager/infra/sandboxcr/... -count=5 -v`
2. Verify no `object is not satisfied during double check` failures

### Ⅳ. Special notes for reviews

- The test intent (context expires during/after wait, exercising fresh-context fallback) is preserved
- The 200ms window is 20x larger than the original 10ms, which should be robust enough for CI load variations
