### PR TITLE
fix(e2e): add readiness probe and health check to TLS registry setup

### DIFF
--- a/hack/setup-local-registry.sh
+++ b/hack/setup-local-registry.sh
@@ -16,9 +16,11 @@
 # Deploy a self-signed TLS registry in the kind cluster for e2e tests.
 # This creates:
 #   1. A self-signed CA + server certificate
-#   2. A registry:2 Deployment with TLS enabled (port 5443)
+#   2. A registry:2 Deployment with TLS enabled (port 5443) and a TCP readiness
+#      probe so kubectl wait only returns once the registry is actually listening
 #   3. Configures kind nodes with certs.d so containerd/nerdctl trusts the CA
 #   4. Adds /etc/hosts entries on kind nodes for hostNetwork pod DNS resolution
+#   5. Verifies end-to-end reachability (DNS + TLS + HTTP) from a kind node
 
 set -o errexit
 set -o pipefail
@@ -97,6 +99,18 @@ spec:
           value: "/certs/tls.crt"
         - name: REGISTRY_HTTP_TLS_KEY
           value: "/certs/tls.key"
+        # Without a readiness probe the pod is marked Ready as soon as the
+        # container starts, but the registry:2 process needs a brief moment
+        # to open the listening socket. kubectl wait --for=condition=available
+        # would return before the port is actually accepting connections, causing
+        # an intermittent race with the commit e2e test that pushes to this
+        # registry. The TCP probe gates availability on the port being open.
+        readinessProbe:
+          tcpSocket:
+            port: ${REGISTRY_PORT}
+          initialDelaySeconds: 2
+          periodSeconds: 3
+          failureThreshold: 20
         volumeMounts:
         - name: certs
           mountPath: /certs
@@ -151,5 +165,24 @@ CLUSTER_IP=$(kubectl get svc "${REGISTRY_NAME}" -n "${REGISTRY_NS}" -o jsonpath=
 for node in $(${KIND} get nodes --name "${KIND_CLUSTER}" 2>/dev/null); do
   docker exec "${node}" bash -c "echo '${CLUSTER_IP} ${REGISTRY_HOST}' >> /etc/hosts"
 done
+
+# End-to-end verification: confirm the registry is reachable from a kind
+# node with DNS resolution (/etc/hosts), TLS trust (CA via certs.d), and a
+# valid HTTP response. This catches transient startup races and misconfigured
+# node plumbing that a Deployment condition alone cannot detect.
+echo "==> Verifying TLS registry reachability from kind nodes..."
+VERIFIED=false
+for node in $(${KIND} get nodes --name "${KIND_CLUSTER}" 2>/dev/null); do
+  if docker exec "${node}" curl -sf --cacert "${CERTS_DIR}/ca.crt" \
+      "https://${REGISTRY_HOST}:${REGISTRY_PORT}/v2/" 2>/dev/null; then
+    VERIFIED=true
+    break
+  fi
+done
+if [ "${VERIFIED}" != "true" ]; then
+  echo "ERROR: TLS registry is not reachable from any kind node" >&2
+  echo "       Check /etc/hosts, certs.d CA, and the registry pod logs" >&2
+  exit 1
+fi
 
 echo "==> TLS registry is ready at ${REGISTRY_HOST}:${REGISTRY_PORT}"


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines; https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

The TLS registry Deployment deployed by `hack/setup-local-registry.sh` had no readiness probe. Without one, `kubectl wait --for=condition=available` returned as soon as the container process started — before the `registry:2` process opened its listening socket. The commit e2e test (`Commit to TLS registry`) then raced the startup and intermittently timed out (180s) waiting for `CommitPhase=Succeeded`, causing CI failures like the one in [PR #700's e2e run](https://github.com/openkruise/agents/actions/runs/30742415236/job/91482055892).

This PR adds two layers of protection:

1. **TCPSocket readiness probe** on port 5443 — gates the Deployment's `Available` condition on the port actually accepting connections, so `kubectl wait` only returns once the registry is listening.

2. **End-to-end post-setup verification** — after all node plumbing (certs.d CA, `/etc/hosts`) is in place, runs `curl --cacert <ca.crt> https://<fqdn>:5443/v2/` from a kind node. This validates DNS resolution, TLS trust, and HTTP serving in one shot. If it fails, the `Setup TLS Registry` CI step fails with a clear message instead of letting the commit test fail mysteriously minutes later.

### Ⅱ. Does this pull request fix one issue?

Fixes the intermittent e2e failure observed in PR #700 CI run (run 30742415236, job 91482055892).

### Ⅲ. Describe how to verify it

Run the e2e-1.32 CI workflow. The `Setup TLS Registry` step should:
- Wait for the registry pod's TCP readiness probe before proceeding
- Print `==> Verifying TLS registry reachability from kind nodes...` and succeed
- Print `==> TLS registry is ready at tls-registry.e2e-registry.svc.cluster.local:5443`

If the registry is unhealthy, the step fails immediately with a diagnostic message rather than causing a 180s timeout in the commit test.

### Ⅳ. Special notes for reviews

- Only `hack/setup-local-registry.sh` is modified — no production code or test code changes.
- The readiness probe uses `failureThreshold: 20` with `periodSeconds: 3` (up to 60s of retry) to accommodate slow `registry:2` image pulls on first CI run.
- The `curl` verification relies on the CA cert already installed in `/etc/containerd/certs.d/` by the preceding loop, and the `/etc/hosts` entry added by the immediately preceding step.