### PR TITLE
fix(runtime): harden command RPC against lost grpc-status trailers

### DIFF
--- a/pkg/utils/runtime/command_transport.go
+++ b/pkg/utils/runtime/command_transport.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"connectrpc.com/connect"
+)
+
+// runtimeCommandHTTPClient is the HTTP client used by RunCommandWithRuntime for the
+// streaming Process/Start RPC.
+//
+// It deliberately does not use http.DefaultClient: the default client shares a
+// process-wide connection pool with every other net/http user in the binary, so a
+// long-lived streaming RPC whose result is carried in HTTP trailers becomes sensitive
+// to unrelated traffic and to stale pooled connections. DisableKeepAlives keeps each
+// command on its own connection, which makes a failure attributable to that single call.
+//
+// Intentionally no http.Client.Timeout is set: RunCommandWithRuntime wraps the caller's
+// context with args.Timeout, which stays the single source of truth for deadlines
+// (mirrors runtimeFilesHTTPClient).
+//
+// It is a variable so tests can substitute their own transport.
+var runtimeCommandHTTPClient = &http.Client{
+	Transport: newRuntimeCommandTransport(),
+}
+
+// newRuntimeCommandTransport builds the transport backing runtimeCommandHTTPClient.
+// The dialer and handshake timeouts mirror http.DefaultTransport so the only intentional
+// behavioral difference is connection reuse.
+func newRuntimeCommandTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		// gRPC carries the RPC status in HTTP trailers, which are the very last bytes of
+		// the response. Never hand a command RPC a connection that another request has
+		// already used (or that the peer may have half-closed while idle).
+		DisableKeepAlives:     true,
+		ForceAttemptHTTP2:     true,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
+
+// missingGRPCStatusTrailerMarker matches the message connect-go produces when a gRPC
+// response body ends cleanly but carries no grpc-status trailer
+// (connect's errTrailersWithoutGRPCStatus, see protocol_grpc.go). connect keeps that
+// sentinel unexported and does not wrap it in anything comparable, so message matching
+// is the only way to recognize it from the outside.
+const missingGRPCStatusTrailerMarker = "no Grpc-Status trailer"
+
+// IsMissingGRPCStatusTrailer reports whether err is the connect-go protocol error raised
+// when the server closed the response stream without sending a grpc-status trailer.
+//
+// Such an error says nothing about whether the remote work happened: the request was
+// accepted, the response was streamed and terminated gracefully, only the terminal status
+// metadata is absent. Callers that already learned the outcome from the stream payload
+// (for example a Process End event) can therefore treat it as non-fatal, while callers
+// with no payload to fall back on must keep treating it as a failure.
+//
+// connect reports it with code Internal when no trailer at all was received, and Unknown
+// when trailers arrived without grpc-status; both are accepted here.
+func IsMissingGRPCStatusTrailer(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch connect.CodeOf(err) {
+	case connect.CodeInternal, connect.CodeUnknown:
+	default:
+		return false
+	}
+	return strings.Contains(err.Error(), missingGRPCStatusTrailerMarker)
+}

--- a/pkg/utils/runtime/command_transport_test.go
+++ b/pkg/utils/runtime/command_transport_test.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2026.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/proto/envd/process"
+	"github.com/openkruise/agents/proto/envd/process/processconnect"
+)
+
+func TestIsMissingGRPCStatusTrailer(t *testing.T) {
+	missingTrailer := func(code connect.Code) error {
+		return connect.NewError(code, errors.New("protocol error: no Grpc-Status trailer: unexpected EOF"))
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "unrelated plain error",
+			err:  errors.New("mount failed"),
+			want: false,
+		},
+		{
+			name: "no trailer at all is reported as internal",
+			err:  missingTrailer(connect.CodeInternal),
+			want: true,
+		},
+		{
+			name: "trailers without grpc-status are reported as unknown",
+			err:  missingTrailer(connect.CodeUnknown),
+			want: true,
+		},
+		{
+			name: "same message under an unrelated code is not a trailer problem",
+			err:  missingTrailer(connect.CodeUnavailable),
+			want: false,
+		},
+		{
+			name: "wrapped with %w",
+			err:  fmt.Errorf("failed to run command: %w", missingTrailer(connect.CodeInternal)),
+			want: true,
+		},
+		{
+			name: "joined the way RunCommandWithRuntime joins its errors",
+			err:  errors.Join(nil, missingTrailer(connect.CodeInternal)),
+			want: true,
+		},
+		{
+			name: "real server error keeps failing the call",
+			err:  connect.NewError(connect.CodeInternal, errors.New("internal server error")),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsMissingGRPCStatusTrailer(tt.err))
+		})
+	}
+}
+
+// newTrailerStrippingRuntimeServer serves the Process handler behind a middleware that
+// drops the gRPC trailers connect-go staged for the response, reproducing a peer (or an
+// intermediate hop) that terminates the response body cleanly but never delivers
+// grpc-status. It returns a Sandbox pointing at that server.
+func newTrailerStrippingRuntimeServer(t *testing.T, handler *mockProcessHandler) *agentsv1alpha1.Sandbox {
+	t.Helper()
+	_, processHandler := processconnect.NewProcessHandler(handler)
+	stripped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		processHandler.ServeHTTP(w, r)
+		// connect stages gRPC trailers as http.TrailerPrefix-prefixed header keys, and
+		// net/http only serializes them once the handler has returned. Deleting them here
+		// is exactly what a trailer-unaware hop does to the wire.
+		for key := range w.Header() {
+			if strings.HasPrefix(key, http.TrailerPrefix) {
+				w.Header().Del(key)
+			}
+		}
+	})
+	server := httptest.NewServer(stripped)
+	t.Cleanup(server.Close)
+	return newTestSandboxWithURL(server.URL)
+}
+
+func TestRunCommandWithRuntime_MissingGRPCStatusTrailer(t *testing.T) {
+	sendStart := func(stream *connect.ServerStream[process.StartResponse], pid uint32) error {
+		return stream.Send(&process.StartResponse{Event: &process.ProcessEvent{
+			Event: &process.ProcessEvent_Start{Start: &process.ProcessEvent_StartEvent{Pid: pid}},
+		}})
+	}
+	sendEnd := func(stream *connect.ServerStream[process.StartResponse], end *process.ProcessEvent_EndEvent) error {
+		return stream.Send(&process.StartResponse{Event: &process.ProcessEvent{
+			Event: &process.ProcessEvent_End{End: end},
+		}})
+	}
+
+	tests := []struct {
+		name            string
+		startFn         func(ctx context.Context, req *connect.Request[process.StartRequest], stream *connect.ServerStream[process.StartResponse]) error
+		wantErr         bool
+		errContains     string
+		errNotContains  string
+		wantEndReceived bool
+		wantExitCode    int32
+	}{
+		{
+			name: "end event received: the lost trailer is tolerated",
+			startFn: func(_ context.Context, _ *connect.Request[process.StartRequest], stream *connect.ServerStream[process.StartResponse]) error {
+				if err := sendStart(stream, 42); err != nil {
+					return err
+				}
+				return sendEnd(stream, &process.ProcessEvent_EndEvent{ExitCode: 0, Exited: true})
+			},
+			wantEndReceived: true,
+		},
+		{
+			name: "end event with non-zero exit code is preserved for the caller to judge",
+			startFn: func(_ context.Context, _ *connect.Request[process.StartRequest], stream *connect.ServerStream[process.StartResponse]) error {
+				if err := sendStart(stream, 43); err != nil {
+					return err
+				}
+				return sendEnd(stream, &process.ProcessEvent_EndEvent{ExitCode: 2, Exited: true})
+			},
+			wantEndReceived: true,
+			wantExitCode:    2,
+		},
+		{
+			name: "process error from the end event still fails the call",
+			startFn: func(_ context.Context, _ *connect.Request[process.StartRequest], stream *connect.ServerStream[process.StartResponse]) error {
+				if err := sendStart(stream, 44); err != nil {
+					return err
+				}
+				return sendEnd(stream, &process.ProcessEvent_EndEvent{
+					ExitCode: 1, Exited: true, Error: ptr.To("segmentation fault"),
+				})
+			},
+			wantErr:         true,
+			errContains:     "segmentation fault",
+			errNotContains:  missingGRPCStatusTrailerMarker,
+			wantEndReceived: true,
+			wantExitCode:    1,
+		},
+		{
+			name: "no end event: the protocol error must surface",
+			startFn: func(_ context.Context, _ *connect.Request[process.StartRequest], stream *connect.ServerStream[process.StartResponse]) error {
+				return sendStart(stream, 45)
+			},
+			wantErr:     true,
+			errContains: missingGRPCStatusTrailerMarker,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := newTrailerStrippingRuntimeServer(t, &mockProcessHandler{startFn: tt.startFn})
+
+			result, err := RunCommandWithRuntime(context.Background(), RunCmdFuncArgs{
+				Sbx:           sbx,
+				ProcessConfig: &process.ProcessConfig{Cmd: "echo"},
+				Timeout:       5 * time.Second,
+			})
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				if tt.errNotContains != "" {
+					assert.NotContains(t, err.Error(), tt.errNotContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantEndReceived, result.EndReceived)
+			assert.Equal(t, tt.wantExitCode, result.ExitCode)
+		})
+	}
+}
+
+func TestRunCommandWithRuntime_DoesNotReuseConnections(t *testing.T) {
+	handler := &mockProcessHandler{
+		startFn: func(_ context.Context, _ *connect.Request[process.StartRequest], stream *connect.ServerStream[process.StartResponse]) error {
+			return stream.Send(&process.StartResponse{Event: &process.ProcessEvent{
+				Event: &process.ProcessEvent_End{End: &process.ProcessEvent_EndEvent{ExitCode: 0, Exited: true}},
+			}})
+		},
+	}
+	_, processHandler := processconnect.NewProcessHandler(handler)
+	server := httptest.NewUnstartedServer(processHandler)
+	var acceptedConns int32
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			atomic.AddInt32(&acceptedConns, 1)
+		}
+	}
+	server.Start()
+	t.Cleanup(server.Close)
+
+	sbx := newTestSandboxWithURL(server.URL)
+	const calls = 2
+	for i := 0; i < calls; i++ {
+		result, err := RunCommandWithRuntime(context.Background(), RunCmdFuncArgs{
+			Sbx:           sbx,
+			ProcessConfig: &process.ProcessConfig{Cmd: "echo"},
+			Timeout:       5 * time.Second,
+		})
+		require.NoError(t, err)
+		require.True(t, result.EndReceived)
+	}
+
+	assert.Equal(t, int32(calls), atomic.LoadInt32(&acceptedConns),
+		"each command RPC must run on its own connection so a pooled peer cannot truncate its trailers")
+}
+
+func TestRuntimeCommandHTTPClient_Configuration(t *testing.T) {
+	assert.NotSame(t, http.DefaultClient, runtimeCommandHTTPClient,
+		"command RPCs must not share the process-wide default connection pool")
+	assert.Zero(t, runtimeCommandHTTPClient.Timeout,
+		"deadlines come from the per-call context, not from the client")
+
+	transport := newRuntimeCommandTransport()
+	assert.True(t, transport.DisableKeepAlives)
+	assert.True(t, transport.ForceAttemptHTTP2)
+}

--- a/pkg/utils/runtime/csi.go
+++ b/pkg/utils/runtime/csi.go
@@ -73,7 +73,12 @@ func CSIMount(ctx context.Context, sbx *agentsv1alpha1.Sandbox, driver string, r
 		AuthUser: "root",
 	})
 	if err != nil {
-		log.Error(err, "failed to run command", "stdout", result.Stdout, "stderr", result.Stderr)
+		// Log the process-level outcome alongside the error: a transport failure and a
+		// command that really failed look identical in the logs otherwise, and the two
+		// need very different follow-up.
+		log.Error(err, "failed to run command", "stdout", result.Stdout, "stderr", result.Stderr,
+			"pid", result.PID, "endReceived", result.EndReceived, "exitCode", result.ExitCode,
+			"exited", result.Exited)
 		return err
 	}
 	if result.ExitCode != 0 {

--- a/pkg/utils/runtime/process.go
+++ b/pkg/utils/runtime/process.go
@@ -36,16 +36,16 @@ import (
 
 var AccessToken = "access-token"
 
-// runtimeGRPCHTTPClient is the package-level HTTP client shared by the connect
-// (gRPC) callers of the runtime: the Process service here and the Filesystem
-// service in filesystem.go. It deliberately does not use http.DefaultClient so
-// tests can substitute their own transport without monkey-patching the global,
-// mirroring runtimeFilesHTTPClient which backs the multipart /files path.
+// runtimeGRPCHTTPClient is the package-level HTTP client used by the connect (gRPC)
+// callers whose result does not ride in HTTP trailers — today the Filesystem service
+// in filesystem.go. It deliberately does not use http.DefaultClient so tests can
+// substitute their own transport without monkey-patching the global, mirroring
+// runtimeFilesHTTPClient which backs the multipart /files path.
 //
-// The two capabilities speak the same connect-over-gRPC protocol against the
-// same runtime endpoint, so they must not diverge on transport. Keeping a
-// single variable makes any future transport tuning (for example the pending
-// migration to the pinned TLS transport) apply to both at once.
+// The Process/Start RPC deliberately does NOT use it: its outcome arrives in the
+// grpc-status trailer, i.e. the very last bytes of the response, so it gets
+// runtimeCommandHTTPClient with keep-alives disabled instead (see
+// command_transport.go).
 //
 // Intentionally no http.Client.Timeout is set: every caller wraps the context
 // with context.WithTimeout, which stays the single source of truth for the RPC
@@ -59,6 +59,11 @@ type RunCommandResult struct {
 	ExitCode int32
 	Exited   bool
 	Error    error
+	// EndReceived reports whether the runtime delivered a Process End event, i.e. whether
+	// ExitCode and Exited describe an actually observed process termination rather than
+	// their zero values. Callers must consult it before trusting ExitCode == 0 on a call
+	// that also returned an error.
+	EndReceived bool
 }
 
 type RunCmdFuncArgs struct {
@@ -70,17 +75,27 @@ type RunCmdFuncArgs struct {
 	// that need the runtime to resolve a user identity (e.g. "root") must set
 	// it explicitly.
 	AuthUser string
+	// HTTPClient overrides the client used for the Process/Start RPC. It exists for tests
+	// and for ad-hoc transport experiments (for example forcing cleartext HTTP/2 while
+	// diagnosing trailer delivery); production callers leave it nil and get
+	// runtimeCommandHTTPClient.
+	HTTPClient *http.Client
 }
 
 func RunCommandWithRuntime(ctx context.Context, args RunCmdFuncArgs) (RunCommandResult, error) {
 	sbx, processConfig, timeout := args.Sbx, args.ProcessConfig, args.Timeout
-	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx)).V(utils.DebugLogLevel)
+	baseLog := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
+	log := baseLog.V(utils.DebugLogLevel)
 	url := GetRuntimeURL(sbx)
 	if url == "" {
 		return RunCommandResult{}, fmt.Errorf("runtime url not found on sandbox")
 	}
+	httpClient := args.HTTPClient
+	if httpClient == nil {
+		httpClient = runtimeCommandHTTPClient
+	}
 	client := processconnect.NewProcessClient(
-		runtimeGRPCHTTPClient,
+		httpClient,
 		url,
 		connect.WithGRPC(),
 	)
@@ -131,6 +146,7 @@ func RunCommandWithRuntime(ctx context.Context, args RunCmdFuncArgs) (RunCommand
 			}
 
 		case *process.ProcessEvent_End:
+			result.EndReceived = true
 			result.ExitCode = evt.End.ExitCode
 			result.Exited = evt.End.Exited
 			if evt.End.Error != nil {
@@ -141,8 +157,20 @@ func RunCommandWithRuntime(ctx context.Context, args RunCmdFuncArgs) (RunCommand
 			continue
 		}
 	}
+	streamErr := stream.Err()
 	log.Info("all messages are received", "cost", time.Since(start), "result", result)
-	return result, errors.Join(result.Error, stream.Err())
+	// A missing grpc-status trailer only means the terminal status metadata was lost; the
+	// End event already told us how the process finished, so the command result stands and
+	// the caller must not be forced to redo work that demonstrably ran. Log it at default
+	// verbosity: it still points at a transport or runtime defect worth chasing.
+	if streamErr != nil && result.EndReceived && IsMissingGRPCStatusTrailer(streamErr) {
+		baseLog.Info("tolerating missing grpc-status trailer because the process end event was received",
+			"cmd", processConfig.GetCmd(), "pid", result.PID, "exitCode", result.ExitCode,
+			"exited", result.Exited, "cost", time.Since(start),
+			"responseTrailer", stream.ResponseTrailer(), "protocolError", streamErr.Error())
+		streamErr = nil
+	}
+	return result, errors.Join(result.Error, streamErr)
 }
 
 // ChmodFileOnRuntime executes `chmod <mode> <filePath>` inside the sandbox runtime


### PR DESCRIPTION
A CSI mount claim failed with "internal: protocol error: no Grpc-Status trailer: unexpected EOF" although the mount command had run to completion and NodePublishVolume had succeeded: the gRPC response stream ended cleanly but carried no grpc-status, so the claim was failed and the sandbox was reserved for debugging instead of being handed out.

- Give the Process/Start RPC its own http.Client with DisableKeepAlives instead of sharing runtimeGRPCHTTPClient, so a command RPC never inherits a pooled or half-closed connection whose tail bytes carry the RPC status. RunCmdFuncArgs.HTTPClient allows overriding it per call for tests and transport experiments.
- Record whether a Process End event arrived and, when it did, tolerate the missing-trailer protocol error: the exit status is already known, so the caller decides based on ExitCode. Calls without an End event keep failing, because then ExitCode == 0 only means "never observed".
- Log pid/exitCode/exited/endReceived on command failure so a transport problem is distinguishable from a command that really failed.

runtimeGRPCHTTPClient now backs only the Filesystem service, and its comment records why the Process path deliberately diverges on transport. The Filesystem RPCs carry their result in trailers too, so they may want the same treatment later; that is left out here to keep this fix scoped to the failure actually observed.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

