### PR TITLE
fix(sandboxset): only emit success event when dead sandbox deletion succeeds

### DIFF
--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -426,11 +426,17 @@ func (r *Reconciler) deleteDeadSandboxes(ctx context.Context, dead []*agentsv1al
 			continue
 		}
 		if err := r.Delete(ctx, sbx); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
 			log.Error(err, "failed to delete sandbox")
+			r.Recorder.Eventf(sbx, corev1.EventTypeWarning, EventFailedSandboxDeleted,
+				"Failed to delete sandbox %s: %v", klog.KObj(sbx), err)
 			failNum++
+		} else {
+			log.Info("sandbox deleted", "sandbox", klog.KObj(sbx))
+			r.Recorder.Eventf(sbx, corev1.EventTypeNormal, EventFailedSandboxDeleted, "Sandbox %s deleted", klog.KObj(sbx))
 		}
-		log.Info("sandbox deleted", "sandbox", klog.KObj(sbx))
-		r.Recorder.Eventf(sbx, corev1.EventTypeNormal, EventFailedSandboxDeleted, "Sandbox %s deleted", klog.KObj(sbx))
 	}
 	if failNum > 0 {
 		return fmt.Errorf("failed to delete %d sandboxes", failNum)

--- a/pkg/controller/sandboxset/sandboxset_controller_test.go
+++ b/pkg/controller/sandboxset/sandboxset_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,6 +37,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
@@ -325,6 +327,62 @@ func TestReconcile_DeleteDead(t *testing.T) {
 				tt.checkFunc(t, k8sClient, sbs)
 			}
 			CheckAllEvents(t, eventRecorder, tt.expectEvents)
+		})
+	}
+}
+
+func TestDeleteDeadSandboxes_DeleteFailure(t *testing.T) {
+	utestutils.InitLogOutput()
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		injectErr  error
+		expectErr  bool
+		expectWarn bool
+	}{
+		{
+			name:       "delete returns generic error",
+			injectErr:  fmt.Errorf("etcd timeout"),
+			expectErr:  true,
+			expectWarn: true,
+		},
+		{
+			name:      "delete returns NotFound",
+			injectErr: apierrors.NewNotFound(v1alpha1.Resource("sandboxes"), "failed-0"),
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := getBaseSandbox(0, "failed-", "rev-1")
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(sbx).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+						return tt.injectErr
+					},
+				}).
+				Build()
+
+			eventRecorder := record.NewFakeRecorder(10)
+			r := &Reconciler{Client: k8sClient, Scheme: testScheme, Recorder: eventRecorder}
+
+			err := r.deleteDeadSandboxes(ctx, []*v1alpha1.Sandbox{sbx})
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to delete 1 sandboxes")
+				CheckEvent(t, eventRecorder, corev1.EventTypeWarning, EventFailedSandboxDeleted)
+			} else {
+				require.NoError(t, err)
+			}
+			select {
+			case extra := <-eventRecorder.Events:
+				t.Errorf("unexpected event on failure path: %s", extra)
+			default:
+			}
 		})
 	}
 }
@@ -860,7 +918,7 @@ func TestCompareScaleDownPriority(t *testing.T) {
 		}
 		return &v1alpha1.Sandbox{
 			Status: v1alpha1.SandboxStatus{
-				Phase:        phase,
+				Phase:         phase,
 				RecycledCount: recycledCount,
 				Conditions: []metav1.Condition{
 					{Type: string(v1alpha1.SandboxConditionReady), Status: readyStatus},


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

`deleteDeadSandboxes` in `pkg/controller/sandboxset/sandboxset_controller.go` recorded a `Normal` `"Sandbox X deleted"` event and a success log even when `r.Delete` returned an error, because those statements sat outside the error branch with no `else`.

This PR:

1. Wraps the success log and event in an `else` branch so the two paths are mutually exclusive.
2. Records a `Warning` event with the error detail on failure, matching the existing `createSandbox` failure pattern (lines 376, 387).
3. Reuses the existing `FailedSandboxDeleted` reason for both severities to avoid changing user-visible event reasons that dashboards/alerts may match on.

---

### Ⅱ. Does this pull request fix one issue?

Fixes #722

---

### Ⅲ. Describe how to verify it

```bash
go test ./pkg/controller/sandboxset/ -run 'TestDeleteDeadSandboxes_DeleteFailure|TestReconcile_DeleteDead|TestReconcile_BasicScale' -count=1
go test ./pkg/controller/sandboxset/ -count=1
go vet ./pkg/controller/sandboxset/...
```

---

### Ⅳ. Special notes for reviews

- Production change is ~6 lines in one function; no new constants or imports.
- New `TestDeleteDeadSandboxes_DeleteFailure` injects a `Delete` error via `interceptor.Funcs` and asserts a `Warning` event is emitted with no `Normal` event on the failure path.
- Existing GC-event tests are unchanged.