### PR TITLE
fix(sandbox-manager): issue traffic tokens for cloned sandboxes

### DIFF
--- a/pkg/identity/sandbox_token_helper.go
+++ b/pkg/identity/sandbox_token_helper.go
@@ -148,8 +148,25 @@ func IssueSandboxAccessToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (
 		log.Error(err, "failed to issue sandbox access token", "cost", cost)
 		return nil, fmt.Errorf("failed to issue access token: %w", err)
 	}
+	if err = validateAccessTokenResponse(accessResp); err != nil {
+		log.Error(err, "identity provider returned an invalid sandbox access token", "cost", cost)
+		return nil, fmt.Errorf("invalid access token response: %w", err)
+	}
 	log.Info("sandbox access token issued", "cost", cost)
 	return accessResp, nil
+}
+
+func validateAccessTokenResponse(resp *TokenResponse) error {
+	if resp == nil {
+		return fmt.Errorf("identity provider returned an empty access token response")
+	}
+	if resp.AccessToken == "" {
+		return fmt.Errorf("identity provider returned an empty access token")
+	}
+	if _, err := time.Parse(time.RFC3339, resp.AccessTokenExpiration); err != nil {
+		return fmt.Errorf("identity provider returned an invalid access token expiration: %w", err)
+	}
+	return nil
 }
 
 // PropagateSandboxToken propagates the freshly issued security token to the

--- a/pkg/identity/sandbox_token_helper_test.go
+++ b/pkg/identity/sandbox_token_helper_test.go
@@ -123,7 +123,8 @@ var _ IdentityProvider = (*kindCapturingProvider)(nil)
 // distinct "failed to issue access token" prefix while preserving the cause via
 // errors.Is. Like its twin, it must forward the sandbox pointer unchanged, call
 // the provider exactly once, return the response as-is on success, and return a
-// nil response on error so callers never persist a zero-value token.
+// nil response on provider or contract-validation errors so callers never
+// persist a zero-value token.
 func TestIssueSandboxAccessToken(t *testing.T) {
 	wantResp := &TokenResponse{
 		RequestID:             "req-access",
@@ -151,6 +152,26 @@ func TestIssueSandboxAccessToken(t *testing.T) {
 			expectError: "failed to issue access token",
 			wantCause:   rootErr,
 		},
+		{
+			name:        "nil response is rejected",
+			fake:        &kindCapturingProvider{},
+			expectError: "empty access token response",
+		},
+		{
+			name: "empty token is rejected",
+			fake: &kindCapturingProvider{resp: &TokenResponse{
+				AccessTokenExpiration: "2099-01-01T00:00:00Z",
+			}},
+			expectError: "empty access token",
+		},
+		{
+			name: "invalid expiration is rejected",
+			fake: &kindCapturingProvider{resp: &TokenResponse{
+				AccessToken:           "access-tok",
+				AccessTokenExpiration: "not-a-time",
+			}},
+			expectError: "invalid access token expiration",
+		},
 	}
 
 	for _, tt := range tests {
@@ -174,8 +195,10 @@ func TestIssueSandboxAccessToken(t *testing.T) {
 				assert.Nil(t, gotResp, "response must be nil on error to prevent persisting a zero-value token")
 				assert.Contains(t, err.Error(), tt.expectError,
 					"wrap message must remain stable for downstream phase classification")
-				assert.True(t, errors.Is(err, tt.wantCause),
-					"wrapped error must preserve the original cause via errors.Is")
+				if tt.wantCause != nil {
+					assert.True(t, errors.Is(err, tt.wantCause),
+						"wrapped error must preserve the original cause via errors.Is")
+				}
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, gotResp)

--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -60,9 +60,9 @@ const (
 	// AnnotationEnableJwtAuth is the sandbox Annotation Key whose value "true"
 	// opts the sandbox into the JWT traffic-token issuance path. Unlike
 	// AnnotationAgentName (which carries a meaningful agent name), this is a pure
-	// boolean toggle: the traffic token is minted during claim only when this
-	// annotation equals exactly "true". Any other value (including "1" or "True")
-	// leaves the sandbox out of the issuance path.
+	// boolean toggle: the traffic token is minted during claim or clone only when
+	// this annotation equals exactly "true". Any other value (including "1" or
+	// "True") leaves the sandbox out of the issuance path.
 	AnnotationEnableJwtAuth = SecurityMetadataPrefix + "enable-jwt-auth"
 )
 

--- a/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils.go
@@ -86,17 +86,3 @@ func RestoreAnnotationsFromCheckpoint(cp *v1alpha1.Checkpoint, sbx *v1alpha1.San
 	}
 	sbx.SetAnnotations(copyPreservedAnnotations(cpAnnotations, sbx.GetAnnotations()))
 }
-
-// restoreAnnotationsFromCheckpointForClone applies generic checkpoint
-// restoration plus clone request precedence for JWT authentication. An
-// explicitly provided request value overrides the restored checkpoint value;
-// an absent request inherits the checkpoint unchanged.
-func restoreAnnotationsFromCheckpointForClone(cp *v1alpha1.Checkpoint, sbx *v1alpha1.Sandbox) {
-	requestValue, requestProvided := sbx.GetAnnotations()[identity.AnnotationEnableJwtAuth]
-	RestoreAnnotationsFromCheckpoint(cp, sbx)
-	if requestProvided {
-		annotations := sbx.GetAnnotations()
-		annotations[identity.AnnotationEnableJwtAuth] = requestValue
-		sbx.SetAnnotations(annotations)
-	}
-}

--- a/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils.go
@@ -17,19 +17,10 @@ limitations under the License.
 package sandboxcr
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/identity"
-)
-
-type jwtAuthSetting int
-
-const (
-	jwtAuthUnset jwtAuthSetting = iota
-	jwtAuthDisabled
-	jwtAuthEnabled
 )
 
 // necessaryAnnotationKeys defines the exact annotation keys that need to be
@@ -97,41 +88,15 @@ func RestoreAnnotationsFromCheckpoint(cp *v1alpha1.Checkpoint, sbx *v1alpha1.San
 }
 
 // restoreAnnotationsFromCheckpointForClone applies generic checkpoint
-// restoration plus the clone-specific JWT inheritance rule: an explicit
-// request may enable inherited JWT auth, but cannot disable it.
-func restoreAnnotationsFromCheckpointForClone(cp *v1alpha1.Checkpoint, sbx *v1alpha1.Sandbox) error {
-	checkpointSetting := parseJWTAuthSetting(cp.GetAnnotations())
-	requestSetting := parseJWTAuthSetting(sbx.GetAnnotations())
-
-	if checkpointSetting == jwtAuthEnabled && requestSetting == jwtAuthDisabled {
-		return fmt.Errorf("cannot disable JWT authentication inherited from checkpoint")
-	}
-
+// restoration plus clone request precedence for JWT authentication. An
+// explicitly provided request value overrides the restored checkpoint value;
+// an absent request inherits the checkpoint unchanged.
+func restoreAnnotationsFromCheckpointForClone(cp *v1alpha1.Checkpoint, sbx *v1alpha1.Sandbox) {
+	requestValue, requestProvided := sbx.GetAnnotations()[identity.AnnotationEnableJwtAuth]
 	RestoreAnnotationsFromCheckpoint(cp, sbx)
-	finalSetting := checkpointSetting
-	if requestSetting == jwtAuthEnabled || checkpointSetting == jwtAuthUnset {
-		finalSetting = requestSetting
+	if requestProvided {
+		annotations := sbx.GetAnnotations()
+		annotations[identity.AnnotationEnableJwtAuth] = requestValue
+		sbx.SetAnnotations(annotations)
 	}
-	annotations := sbx.GetAnnotations()
-	switch finalSetting {
-	case jwtAuthEnabled:
-		annotations[identity.AnnotationEnableJwtAuth] = v1alpha1.True
-	case jwtAuthDisabled:
-		annotations[identity.AnnotationEnableJwtAuth] = v1alpha1.False
-	default:
-		delete(annotations, identity.AnnotationEnableJwtAuth)
-	}
-	sbx.SetAnnotations(annotations)
-	return nil
-}
-
-func parseJWTAuthSetting(annotations map[string]string) jwtAuthSetting {
-	value, present := annotations[identity.AnnotationEnableJwtAuth]
-	if !present {
-		return jwtAuthUnset
-	}
-	if value == v1alpha1.True {
-		return jwtAuthEnabled
-	}
-	return jwtAuthDisabled
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils.go
@@ -17,10 +17,19 @@ limitations under the License.
 package sandboxcr
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/identity"
+)
+
+type jwtAuthSetting int
+
+const (
+	jwtAuthUnset jwtAuthSetting = iota
+	jwtAuthDisabled
+	jwtAuthEnabled
 )
 
 // necessaryAnnotationKeys defines the exact annotation keys that need to be
@@ -85,4 +94,54 @@ func RestoreAnnotationsFromCheckpoint(cp *v1alpha1.Checkpoint, sbx *v1alpha1.San
 		return
 	}
 	sbx.SetAnnotations(copyPreservedAnnotations(cpAnnotations, sbx.GetAnnotations()))
+}
+
+// restoreAnnotationsFromCheckpointForClone applies generic checkpoint
+// restoration plus the clone-specific JWT inheritance rule: an explicit
+// request may enable inherited JWT auth, but cannot disable it.
+func restoreAnnotationsFromCheckpointForClone(cp *v1alpha1.Checkpoint, sbx *v1alpha1.Sandbox) error {
+	checkpointSetting, err := parseJWTAuthSetting(cp.GetAnnotations())
+	if err != nil {
+		return fmt.Errorf("invalid checkpoint JWT authentication setting: %w", err)
+	}
+	requestSetting, err := parseJWTAuthSetting(sbx.GetAnnotations())
+	if err != nil {
+		return fmt.Errorf("invalid clone JWT authentication setting: %w", err)
+	}
+
+	if checkpointSetting == jwtAuthEnabled && requestSetting == jwtAuthDisabled {
+		return fmt.Errorf("cannot disable JWT authentication inherited from checkpoint")
+	}
+
+	RestoreAnnotationsFromCheckpoint(cp, sbx)
+	finalSetting := checkpointSetting
+	if requestSetting == jwtAuthEnabled || checkpointSetting == jwtAuthUnset {
+		finalSetting = requestSetting
+	}
+	annotations := sbx.GetAnnotations()
+	switch finalSetting {
+	case jwtAuthEnabled:
+		annotations[identity.AnnotationEnableJwtAuth] = v1alpha1.True
+	case jwtAuthDisabled:
+		annotations[identity.AnnotationEnableJwtAuth] = v1alpha1.False
+	default:
+		delete(annotations, identity.AnnotationEnableJwtAuth)
+	}
+	sbx.SetAnnotations(annotations)
+	return nil
+}
+
+func parseJWTAuthSetting(annotations map[string]string) (jwtAuthSetting, error) {
+	value, present := annotations[identity.AnnotationEnableJwtAuth]
+	if !present {
+		return jwtAuthUnset, nil
+	}
+	switch value {
+	case v1alpha1.True:
+		return jwtAuthEnabled, nil
+	case v1alpha1.False:
+		return jwtAuthDisabled, nil
+	default:
+		return jwtAuthUnset, fmt.Errorf("%s must be %q or %q", identity.AnnotationEnableJwtAuth, v1alpha1.True, v1alpha1.False)
+	}
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/checkpoint_utils.go
@@ -100,14 +100,8 @@ func RestoreAnnotationsFromCheckpoint(cp *v1alpha1.Checkpoint, sbx *v1alpha1.San
 // restoration plus the clone-specific JWT inheritance rule: an explicit
 // request may enable inherited JWT auth, but cannot disable it.
 func restoreAnnotationsFromCheckpointForClone(cp *v1alpha1.Checkpoint, sbx *v1alpha1.Sandbox) error {
-	checkpointSetting, err := parseJWTAuthSetting(cp.GetAnnotations())
-	if err != nil {
-		return fmt.Errorf("invalid checkpoint JWT authentication setting: %w", err)
-	}
-	requestSetting, err := parseJWTAuthSetting(sbx.GetAnnotations())
-	if err != nil {
-		return fmt.Errorf("invalid clone JWT authentication setting: %w", err)
-	}
+	checkpointSetting := parseJWTAuthSetting(cp.GetAnnotations())
+	requestSetting := parseJWTAuthSetting(sbx.GetAnnotations())
 
 	if checkpointSetting == jwtAuthEnabled && requestSetting == jwtAuthDisabled {
 		return fmt.Errorf("cannot disable JWT authentication inherited from checkpoint")
@@ -131,17 +125,13 @@ func restoreAnnotationsFromCheckpointForClone(cp *v1alpha1.Checkpoint, sbx *v1al
 	return nil
 }
 
-func parseJWTAuthSetting(annotations map[string]string) (jwtAuthSetting, error) {
+func parseJWTAuthSetting(annotations map[string]string) jwtAuthSetting {
 	value, present := annotations[identity.AnnotationEnableJwtAuth]
 	if !present {
-		return jwtAuthUnset, nil
+		return jwtAuthUnset
 	}
-	switch value {
-	case v1alpha1.True:
-		return jwtAuthEnabled, nil
-	case v1alpha1.False:
-		return jwtAuthDisabled, nil
-	default:
-		return jwtAuthUnset, fmt.Errorf("%s must be %q or %q", identity.AnnotationEnableJwtAuth, v1alpha1.True, v1alpha1.False)
+	if value == v1alpha1.True {
+		return jwtAuthEnabled
 	}
+	return jwtAuthDisabled
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -4146,11 +4146,15 @@ func TestNewSandboxFromSandboxSet_TemplateRef(t *testing.T) {
 
 // mockIdentityProvider is a configurable mock for testing TryClaimSandbox security token flows.
 type mockIdentityProvider struct {
-	issueTokenFunc func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error)
-	propagateFunc  func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error
+	issueTokenFunc         func(ctx context.Context, sbx *v1alpha1.Sandbox) (*identity.TokenResponse, error)
+	issueTokenWithKindFunc func(ctx context.Context, sbx *v1alpha1.Sandbox, kind identity.TokenKind) (*identity.TokenResponse, error)
+	propagateFunc          func(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error
 }
 
-func (m *mockIdentityProvider) IssueToken(ctx context.Context, sbx *v1alpha1.Sandbox, _ identity.TokenKind) (*identity.TokenResponse, error) {
+func (m *mockIdentityProvider) IssueToken(ctx context.Context, sbx *v1alpha1.Sandbox, kind identity.TokenKind) (*identity.TokenResponse, error) {
+	if m.issueTokenWithKindFunc != nil {
+		return m.issueTokenWithKindFunc(ctx, sbx, kind)
+	}
 	if m.issueTokenFunc != nil {
 		return m.issueTokenFunc(ctx, sbx)
 	}

--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -179,7 +179,7 @@ func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache inf
 
 	// Step 6: process security token
 	// Issue and propagate the identity-provider security token before performing
-	// CSI mounts, mirroring the claim flow ordering.
+	// access-token issuance and CSI mounts, mirroring the claim flow ordering.
 	if identity.IsIDTokenRequested(sbx.Sandbox) {
 		metrics.SecurityToken, err = identity.ProcessSandboxToken(ctx, cache.GetClient(), sbx.Sandbox)
 		if err != nil {
@@ -189,6 +189,25 @@ func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache inf
 			return
 		}
 		metrics.Total += metrics.SecurityToken
+	}
+
+	// Mint a new traffic access token for the cloned sandbox. The token is bound
+	// to the clone's identity and stays only on the transient wrapper returned to
+	// the API layer; it is never persisted to the Sandbox or Checkpoint.
+	if identity.IsAccessTokenRequested(sbx.Sandbox) {
+		start := time.Now()
+		accessResp, issueErr := identity.IssueSandboxAccessToken(ctx, sbx.Sandbox)
+		metrics.TrafficToken = time.Since(start)
+		metrics.Total += metrics.TrafficToken
+		if issueErr != nil {
+			err = retriableError{Message: issueErr.Error()}
+			return
+		}
+		if validationErr := validateTrafficTokenResponse(accessResp); validationErr != nil {
+			err = retriableError{Message: validationErr.Error()}
+			return
+		}
+		sbx.trafficToken = accessResp
 	}
 
 	// Step 7: csi mount
@@ -215,6 +234,19 @@ func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache inf
 
 	cloned = sbx
 	return
+}
+
+func validateTrafficTokenResponse(resp *identity.TokenResponse) error {
+	if resp == nil {
+		return fmt.Errorf("identity provider returned an empty access token response")
+	}
+	if resp.AccessToken == "" {
+		return fmt.Errorf("identity provider returned an empty access token")
+	}
+	if _, err := time.Parse(time.RFC3339, resp.AccessTokenExpiration); err != nil {
+		return fmt.Errorf("identity provider returned an invalid access token expiration: %w", err)
+	}
+	return nil
 }
 
 // findCheckpointAndTemplateById gets checkpoint and template from cache, fallback to API server if not found
@@ -309,7 +341,9 @@ func prepareSandboxFromCheckpoint(ctx context.Context, opts infra.CloneSandboxOp
 		sbx.Annotations[v1alpha1.AnnotationInitRuntimeRequest] = cp.Annotations[v1alpha1.AnnotationInitRuntimeRequest]
 	}
 	// e.g., copy csi mount config from checkpoint to sandbox obj
-	RestoreAnnotationsFromCheckpoint(cp, sbx.Sandbox)
+	if err := restoreAnnotationsFromCheckpointForClone(cp, sbx.Sandbox); err != nil {
+		return nil, nil, managererrors.NewError(managererrors.ErrorBadRequest, "%v", err)
+	}
 	// When the clone request explicitly provides CSI mount configs, they take
 	// precedence over the csi-volume-config restored from the checkpoint. This
 	// keeps the persisted annotation consistent with the mount performed in the

--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -327,8 +327,12 @@ func prepareSandboxFromCheckpoint(ctx context.Context, opts infra.CloneSandboxOp
 		sbx.Annotations[v1alpha1.AnnotationRuntimeAccessToken] = initRuntimeOpts.AccessToken
 		sbx.Annotations[v1alpha1.AnnotationInitRuntimeRequest] = cp.Annotations[v1alpha1.AnnotationInitRuntimeRequest]
 	}
-	// e.g., copy csi mount config from checkpoint to sandbox obj
-	restoreAnnotationsFromCheckpointForClone(cp, sbx.Sandbox)
+	requestJWTAuth, requestJWTAuthProvided := sbx.Annotations[identity.AnnotationEnableJwtAuth]
+	RestoreAnnotationsFromCheckpoint(cp, sbx.Sandbox)
+	// Explicit clone settings take precedence over values restored from the checkpoint.
+	if requestJWTAuthProvided {
+		sbx.Annotations[identity.AnnotationEnableJwtAuth] = requestJWTAuth
+	}
 	// When the clone request explicitly provides CSI mount configs, they take
 	// precedence over the csi-volume-config restored from the checkpoint. This
 	// keeps the persisted annotation consistent with the mount performed in the

--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -191,6 +191,7 @@ func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache inf
 		metrics.Total += metrics.SecurityToken
 	}
 
+	// Step 7: issue traffic access token
 	// Mint a new traffic access token for the cloned sandbox. The token is bound
 	// to the clone's identity and stays only on the transient wrapper returned to
 	// the API layer; it is never persisted to the Sandbox or Checkpoint.
@@ -200,17 +201,16 @@ func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache inf
 		metrics.TrafficToken = time.Since(start)
 		metrics.Total += metrics.TrafficToken
 		if issueErr != nil {
-			err = retriableError{Message: issueErr.Error()}
-			return
-		}
-		if validationErr := validateTrafficTokenResponse(accessResp); validationErr != nil {
-			err = retriableError{Message: validationErr.Error()}
+			err = issueErr
+			if !wait.Interrupted(err) {
+				err = retriableError{Message: issueErr.Error()}
+			}
 			return
 		}
 		sbx.trafficToken = accessResp
 	}
 
-	// Step 7: csi mount
+	// Step 8: csi mount
 	// If opts.CSIMount is not provided from request, try to resolve mount options from sandbox annotation.
 	if opts.CSIMount == nil {
 		var resolveErr error
@@ -234,19 +234,6 @@ func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache inf
 
 	cloned = sbx
 	return
-}
-
-func validateTrafficTokenResponse(resp *identity.TokenResponse) error {
-	if resp == nil {
-		return fmt.Errorf("identity provider returned an empty access token response")
-	}
-	if resp.AccessToken == "" {
-		return fmt.Errorf("identity provider returned an empty access token")
-	}
-	if _, err := time.Parse(time.RFC3339, resp.AccessTokenExpiration); err != nil {
-		return fmt.Errorf("identity provider returned an invalid access token expiration: %w", err)
-	}
-	return nil
 }
 
 // findCheckpointAndTemplateById gets checkpoint and template from cache, fallback to API server if not found

--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -328,9 +328,7 @@ func prepareSandboxFromCheckpoint(ctx context.Context, opts infra.CloneSandboxOp
 		sbx.Annotations[v1alpha1.AnnotationInitRuntimeRequest] = cp.Annotations[v1alpha1.AnnotationInitRuntimeRequest]
 	}
 	// e.g., copy csi mount config from checkpoint to sandbox obj
-	if err := restoreAnnotationsFromCheckpointForClone(cp, sbx.Sandbox); err != nil {
-		return nil, nil, managererrors.NewError(managererrors.ErrorBadRequest, "%v", err)
-	}
+	restoreAnnotationsFromCheckpointForClone(cp, sbx.Sandbox)
 	// When the clone request explicitly provides CSI mount configs, they take
 	// precedence over the csi-volume-config restored from the checkpoint. This
 	// keeps the persisted annotation consistent with the mount performed in the

--- a/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
@@ -484,6 +484,9 @@ func TestPrepareSandboxFromCheckpoint_JWTAuthMerge(t *testing.T) {
 		{name: "inherits enabled checkpoint", checkpointSetting: ptr.To(v1alpha1.True), expectSetting: ptr.To(v1alpha1.True)},
 		{name: "request keeps enabled checkpoint", checkpointSetting: ptr.To(v1alpha1.True), requestSetting: ptr.To(v1alpha1.True), expectSetting: ptr.To(v1alpha1.True)},
 		{name: "request cannot weaken enabled checkpoint", checkpointSetting: ptr.To(v1alpha1.True), requestSetting: ptr.To(v1alpha1.False), expectError: "cannot disable JWT authentication inherited from checkpoint"},
+		{name: "non-standard request value disables", requestSetting: ptr.To("True"), expectSetting: ptr.To(v1alpha1.False)},
+		{name: "non-standard checkpoint value is disabled", checkpointSetting: ptr.To("1"), expectSetting: ptr.To(v1alpha1.False)},
+		{name: "non-standard request cannot weaken enabled checkpoint", checkpointSetting: ptr.To(v1alpha1.True), requestSetting: ptr.To("True"), expectError: "cannot disable JWT authentication inherited from checkpoint"},
 	}
 
 	for _, tt := range tests {
@@ -2517,6 +2520,7 @@ func TestCloneSandbox_TrafficAccessToken(t *testing.T) {
 		providerError     error
 		expectError       string
 		expectToken       bool
+		expectInterrupted bool
 	}{
 		{
 			name:              "issues token for cloned sandbox identity",
@@ -2533,6 +2537,13 @@ func TestCloneSandbox_TrafficAccessToken(t *testing.T) {
 			checkpointSetting: v1alpha1.True,
 			providerError:     errors.New("traffic token provider unavailable"),
 			expectError:       "traffic token provider unavailable",
+		},
+		{
+			name:              "context cancellation is preserved",
+			checkpointSetting: v1alpha1.True,
+			providerError:     context.Canceled,
+			expectError:       context.Canceled.Error(),
+			expectInterrupted: true,
 		},
 		{
 			name:              "empty token fails clone",
@@ -2602,7 +2613,12 @@ func TestCloneSandbox_TrafficAccessToken(t *testing.T) {
 				assert.Nil(t, sbx)
 				assert.True(t, providerCalled)
 				var retryErr retriableError
-				assert.True(t, errors.As(cloneErr, &retryErr))
+				if tt.expectInterrupted {
+					assert.ErrorIs(t, cloneErr, context.Canceled)
+					assert.False(t, errors.As(cloneErr, &retryErr))
+				} else {
+					assert.True(t, errors.As(cloneErr, &retryErr))
+				}
 				stored := &v1alpha1.Sandbox{}
 				deleteErr := fc.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: sandboxName}, stored)
 				assert.True(t, apierrors.IsNotFound(deleteErr), "failed clone must clean up the new sandbox")

--- a/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
@@ -474,7 +474,6 @@ func TestPrepareSandboxFromCheckpoint_JWTAuthMerge(t *testing.T) {
 		checkpointSetting *string
 		requestSetting    *string
 		expectSetting     *string
-		expectError       string
 	}{
 		{name: "both unset"},
 		{name: "request explicitly disables", requestSetting: ptr.To(v1alpha1.False), expectSetting: ptr.To(v1alpha1.False)},
@@ -483,10 +482,10 @@ func TestPrepareSandboxFromCheckpoint_JWTAuthMerge(t *testing.T) {
 		{name: "request strengthens disabled checkpoint", checkpointSetting: ptr.To(v1alpha1.False), requestSetting: ptr.To(v1alpha1.True), expectSetting: ptr.To(v1alpha1.True)},
 		{name: "inherits enabled checkpoint", checkpointSetting: ptr.To(v1alpha1.True), expectSetting: ptr.To(v1alpha1.True)},
 		{name: "request keeps enabled checkpoint", checkpointSetting: ptr.To(v1alpha1.True), requestSetting: ptr.To(v1alpha1.True), expectSetting: ptr.To(v1alpha1.True)},
-		{name: "request cannot weaken enabled checkpoint", checkpointSetting: ptr.To(v1alpha1.True), requestSetting: ptr.To(v1alpha1.False), expectError: "cannot disable JWT authentication inherited from checkpoint"},
-		{name: "non-standard request value disables", requestSetting: ptr.To("True"), expectSetting: ptr.To(v1alpha1.False)},
-		{name: "non-standard checkpoint value is disabled", checkpointSetting: ptr.To("1"), expectSetting: ptr.To(v1alpha1.False)},
-		{name: "non-standard request cannot weaken enabled checkpoint", checkpointSetting: ptr.To(v1alpha1.True), requestSetting: ptr.To("True"), expectError: "cannot disable JWT authentication inherited from checkpoint"},
+		{name: "request disables enabled checkpoint", checkpointSetting: ptr.To(v1alpha1.True), requestSetting: ptr.To(v1alpha1.False), expectSetting: ptr.To(v1alpha1.False)},
+		{name: "non-standard request value is preserved", requestSetting: ptr.To("True"), expectSetting: ptr.To("True")},
+		{name: "non-standard checkpoint value is inherited", checkpointSetting: ptr.To("1"), expectSetting: ptr.To("1")},
+		{name: "non-standard request overrides enabled checkpoint", checkpointSetting: ptr.To(v1alpha1.True), requestSetting: ptr.To("True"), expectSetting: ptr.To("True")},
 	}
 
 	for _, tt := range tests {
@@ -505,12 +504,6 @@ func TestPrepareSandboxFromCheckpoint_JWTAuthMerge(t *testing.T) {
 			}
 
 			sbx, _, err := prepareSandboxFromCheckpoint(t.Context(), opts, tmpl, cp, nil)
-			if tt.expectError != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.expectError)
-				assert.Equal(t, managererrors.ErrorBadRequest, managererrors.GetErrCode(err))
-				return
-			}
 			require.NoError(t, err)
 			value, present := sbx.GetAnnotations()[identity.AnnotationEnableJwtAuth]
 			if tt.expectSetting == nil {

--- a/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone_test.go
@@ -459,6 +459,67 @@ func TestPrepareSandboxFromCheckpoint_CSIMountConfigPrecedence(t *testing.T) {
 	}
 }
 
+func TestPrepareSandboxFromCheckpoint_JWTAuthMerge(t *testing.T) {
+	tmpl := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "cp-jwt", Namespace: "default"},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "test-image"}}},
+			},
+		},
+	}
+
+	tests := []struct {
+		name              string
+		checkpointSetting *string
+		requestSetting    *string
+		expectSetting     *string
+		expectError       string
+	}{
+		{name: "both unset"},
+		{name: "request explicitly disables", requestSetting: ptr.To(v1alpha1.False), expectSetting: ptr.To(v1alpha1.False)},
+		{name: "request enables", requestSetting: ptr.To(v1alpha1.True), expectSetting: ptr.To(v1alpha1.True)},
+		{name: "checkpoint disables", checkpointSetting: ptr.To(v1alpha1.False), expectSetting: ptr.To(v1alpha1.False)},
+		{name: "request strengthens disabled checkpoint", checkpointSetting: ptr.To(v1alpha1.False), requestSetting: ptr.To(v1alpha1.True), expectSetting: ptr.To(v1alpha1.True)},
+		{name: "inherits enabled checkpoint", checkpointSetting: ptr.To(v1alpha1.True), expectSetting: ptr.To(v1alpha1.True)},
+		{name: "request keeps enabled checkpoint", checkpointSetting: ptr.To(v1alpha1.True), requestSetting: ptr.To(v1alpha1.True), expectSetting: ptr.To(v1alpha1.True)},
+		{name: "request cannot weaken enabled checkpoint", checkpointSetting: ptr.To(v1alpha1.True), requestSetting: ptr.To(v1alpha1.False), expectError: "cannot disable JWT authentication inherited from checkpoint"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cp := &v1alpha1.Checkpoint{ObjectMeta: metav1.ObjectMeta{Name: "cp-jwt", Namespace: "default"}}
+			if tt.checkpointSetting != nil {
+				cp.Annotations = map[string]string{identity.AnnotationEnableJwtAuth: *tt.checkpointSetting}
+			}
+			opts := infra.CloneSandboxOptions{User: "test-user", CheckPointID: "cp-jwt"}
+			if tt.requestSetting != nil {
+				opts.Modifier = func(sbx infra.Sandbox) {
+					annotations := sbx.GetAnnotations()
+					annotations[identity.AnnotationEnableJwtAuth] = *tt.requestSetting
+					sbx.SetAnnotations(annotations)
+				}
+			}
+
+			sbx, _, err := prepareSandboxFromCheckpoint(t.Context(), opts, tmpl, cp, nil)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				assert.Equal(t, managererrors.ErrorBadRequest, managererrors.GetErrCode(err))
+				return
+			}
+			require.NoError(t, err)
+			value, present := sbx.GetAnnotations()[identity.AnnotationEnableJwtAuth]
+			if tt.expectSetting == nil {
+				assert.False(t, present)
+				return
+			}
+			assert.True(t, present)
+			assert.Equal(t, *tt.expectSetting, value)
+		})
+	}
+}
+
 func TestFindCheckpointAndTemplateById_NamespaceScoped(t *testing.T) {
 	objects := []client.Object{
 		&v1alpha1.SandboxTemplate{
@@ -2441,6 +2502,130 @@ func TestCloneSandbox_SecurityToken(t *testing.T) {
 
 			if tt.postCheck != nil {
 				tt.postCheck(t, sbx, metrics)
+			}
+		})
+	}
+}
+
+func TestCloneSandbox_TrafficAccessToken(t *testing.T) {
+	const expiration = "2099-01-01T00:00:00Z"
+
+	tests := []struct {
+		name              string
+		checkpointSetting string
+		providerResponse  *identity.TokenResponse
+		providerError     error
+		expectError       string
+		expectToken       bool
+	}{
+		{
+			name:              "issues token for cloned sandbox identity",
+			checkpointSetting: v1alpha1.True,
+			providerResponse:  &identity.TokenResponse{AccessToken: "clone-traffic-token", AccessTokenExpiration: expiration},
+			expectToken:       true,
+		},
+		{
+			name:              "skips issuance when JWT auth is disabled",
+			checkpointSetting: v1alpha1.False,
+		},
+		{
+			name:              "provider error fails clone",
+			checkpointSetting: v1alpha1.True,
+			providerError:     errors.New("traffic token provider unavailable"),
+			expectError:       "traffic token provider unavailable",
+		},
+		{
+			name:              "empty token fails clone",
+			checkpointSetting: v1alpha1.True,
+			providerResponse:  &identity.TokenResponse{AccessTokenExpiration: expiration},
+			expectError:       "empty access token",
+		},
+		{
+			name:              "invalid expiration fails clone",
+			checkpointSetting: v1alpha1.True,
+			providerResponse:  &identity.TokenResponse{AccessToken: "clone-traffic-token", AccessTokenExpiration: "not-a-time"},
+			expectError:       "invalid access token expiration",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache, fc, err := cachetest.NewTestCache(t)
+			require.NoError(t, err)
+			require.NoError(t, cache.Run(t.Context()))
+			defer cache.Stop(t.Context())
+
+			checkpointID := fmt.Sprintf("clone-traffic-token-%d", i)
+			createCloneTestCheckpoint(t, fc, cache, checkpointID)
+			cp := &v1alpha1.Checkpoint{}
+			require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: checkpointID}, cp))
+			cp.Annotations = map[string]string{identity.AnnotationEnableJwtAuth: tt.checkpointSetting}
+			require.NoError(t, fc.Update(t.Context(), cp))
+
+			sandboxName := fmt.Sprintf("cloned-traffic-token-%d", i)
+			sandboxUID := types.UID(fmt.Sprintf("cloned-uid-%d", i))
+			providerCalled := false
+			identity.RegisterProvider(&mockIdentityProvider{
+				issueTokenWithKindFunc: func(_ context.Context, sbx *v1alpha1.Sandbox, kind identity.TokenKind) (*identity.TokenResponse, error) {
+					providerCalled = true
+					assert.Equal(t, identity.TokenKindAccessToken, kind)
+					assert.Equal(t, sandboxName, sbx.Name)
+					assert.Equal(t, sandboxUID, sbx.UID)
+					return tt.providerResponse, tt.providerError
+				},
+			})
+			t.Cleanup(func() { identity.RegisterProvider(identity.NewDefaultIdentityProvider()) })
+
+			origCreateSandbox := DefaultCreateSandbox
+			DefaultCreateSandbox = func(ctx context.Context, sbx *v1alpha1.Sandbox, c client.Client) (*v1alpha1.Sandbox, error) {
+				sbx.Name = sandboxName
+				sbx.UID = sandboxUID
+				created, createErr := origCreateSandbox(ctx, sbx, c)
+				if createErr != nil {
+					return nil, createErr
+				}
+				markSandboxReadyForTest(t, ctx, c, created, "1.2.3.4")
+				return created, nil
+			}
+			t.Cleanup(func() { DefaultCreateSandbox = origCreateSandbox })
+
+			sbx, metrics, cloneErr := CloneSandbox(t.Context(), infra.CloneSandboxOptions{
+				User:                    "test-user",
+				CheckPointID:            checkpointID,
+				WaitReadyTimeout:        time.Second,
+				ReserveFailedSandboxFor: ptr.To(consts.ReserveFailedSandboxNever),
+			}, cache)
+
+			if tt.expectError != "" {
+				require.Error(t, cloneErr)
+				assert.Contains(t, cloneErr.Error(), tt.expectError)
+				assert.Nil(t, sbx)
+				assert.True(t, providerCalled)
+				var retryErr retriableError
+				assert.True(t, errors.As(cloneErr, &retryErr))
+				stored := &v1alpha1.Sandbox{}
+				deleteErr := fc.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: sandboxName}, stored)
+				assert.True(t, apierrors.IsNotFound(deleteErr), "failed clone must clean up the new sandbox")
+				return
+			}
+
+			require.NoError(t, cloneErr)
+			require.NotNil(t, sbx)
+			assert.Equal(t, tt.expectToken, providerCalled)
+			if tt.expectToken {
+				assert.Equal(t, "clone-traffic-token", sbx.GetTrafficAccessToken())
+				assert.Equal(t, expiration, sbx.GetTrafficAccessTokenExpiration())
+				assert.Greater(t, metrics.TrafficToken, time.Duration(0))
+			} else {
+				assert.Empty(t, sbx.GetTrafficAccessToken())
+				assert.Empty(t, sbx.GetTrafficAccessTokenExpiration())
+				assert.Zero(t, metrics.TrafficToken)
+			}
+			stored := &v1alpha1.Sandbox{}
+			require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: sandboxName}, stored))
+			for _, value := range stored.Annotations {
+				assert.NotEqual(t, sbx.GetTrafficAccessToken(), value)
+				assert.NotEqual(t, sbx.GetTrafficAccessTokenExpiration(), value)
 			}
 		})
 	}

--- a/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
@@ -1248,7 +1248,7 @@ func TestInfra_CloneSandboxDoesNotRetryCreateFailure(t *testing.T) {
 
 func assertCloneMetricsTotalConsistent(t *testing.T, metrics infra.CloneMetrics) {
 	t.Helper()
-	expectedTotal := metrics.Wait + metrics.GetTemplate + metrics.CreateSandbox + metrics.WaitReady + metrics.InitRuntime + metrics.SecurityToken + metrics.CSIMount
+	expectedTotal := metrics.Wait + metrics.GetTemplate + metrics.CreateSandbox + metrics.WaitReady + metrics.InitRuntime + metrics.SecurityToken + metrics.TrafficToken + metrics.CSIMount
 	assert.Equal(t, expectedTotal, metrics.Total)
 }
 

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -55,8 +55,8 @@ type Sandbox struct {
 	Cache           cache.Provider
 	storageRegistry storages.VolumeMountProviderRegistry
 	// trafficToken holds the access token response minted for accessing this
-	// sandbox through the sandbox gateway. It is transient and per-claim: set in
-	// memory during runClaimPostProcesses and never persisted to the CR, so
+	// sandbox through the sandbox gateway. It is transient and per-operation: set
+	// in memory during claim or clone and never persisted to the CR, so
 	// InplaceRefresh / retryUpdate reassigning s.Sandbox do not clear it.
 	trafficToken *identity.TokenResponse
 }
@@ -201,7 +201,7 @@ func (s *Sandbox) GetSandboxID() string {
 	return utils.GetSandboxID(s.Sandbox)
 }
 
-// GetTrafficAccessToken returns the transient access token minted during claim
+// GetTrafficAccessToken returns the transient access token minted during claim or clone
 // for accessing this sandbox through the sandbox gateway. It is empty unless
 // the sandbox opted in via AnnotationEnableJwtAuth.
 func (s *Sandbox) GetTrafficAccessToken() string {
@@ -212,7 +212,7 @@ func (s *Sandbox) GetTrafficAccessToken() string {
 }
 
 // GetTrafficAccessTokenExpiration returns the expiration time (RFC3339) of the
-// transient traffic token minted during claim. It is empty unless the sandbox
+// transient traffic token minted during claim or clone. It is empty unless the sandbox
 // opted in via AnnotationEnableJwtAuth.
 func (s *Sandbox) GetTrafficAccessTokenExpiration() string {
 	if s.trafficToken == nil {

--- a/pkg/sandbox-manager/infra/types.go
+++ b/pkg/sandbox-manager/infra/types.go
@@ -219,6 +219,7 @@ type CloneMetrics struct {
 	WaitReady     time.Duration
 	InitRuntime   time.Duration
 	SecurityToken time.Duration
+	TrafficToken  time.Duration
 	CSIMount      time.Duration
 	Total         time.Duration
 	LastError     error
@@ -229,8 +230,8 @@ func (m *CloneMetrics) String() string {
 	if m.LastError != nil {
 		lastErrStr = sanitizeErrorMessage(m.LastError)
 	}
-	return fmt.Sprintf("CloneMetrics{Retries: %d, Wait: %v, GetTemplate: %v, CreateSandbox: %v, WaitReady: %v, InitRuntime: %v, SecurityToken: %v, CSIMount: %v, Total: %v, LastError: %v}",
-		m.Retries, m.Wait, m.GetTemplate, m.CreateSandbox, m.WaitReady, m.InitRuntime, m.SecurityToken, m.CSIMount, m.Total, lastErrStr)
+	return fmt.Sprintf("CloneMetrics{Retries: %d, Wait: %v, GetTemplate: %v, CreateSandbox: %v, WaitReady: %v, InitRuntime: %v, SecurityToken: %v, TrafficToken: %v, CSIMount: %v, Total: %v, LastError: %v}",
+		m.Retries, m.Wait, m.GetTemplate, m.CreateSandbox, m.WaitReady, m.InitRuntime, m.SecurityToken, m.TrafficToken, m.CSIMount, m.Total, lastErrStr)
 }
 
 // Merge accumulates per-attempt durations from src into m. Retries and
@@ -243,6 +244,7 @@ func (m *CloneMetrics) Merge(src CloneMetrics) {
 	m.WaitReady += src.WaitReady
 	m.InitRuntime += src.InitRuntime
 	m.SecurityToken += src.SecurityToken
+	m.TrafficToken += src.TrafficToken
 	m.CSIMount += src.CSIMount
 	m.Total += src.Total
 }

--- a/pkg/sandbox-manager/infra/types_test.go
+++ b/pkg/sandbox-manager/infra/types_test.go
@@ -449,8 +449,9 @@ func TestCloneMetrics_String(t *testing.T) {
 				CreateSandbox: 3 * time.Second,
 				WaitReady:     4 * time.Second,
 				InitRuntime:   5 * time.Second,
-				CSIMount:      6 * time.Second,
-				Total:         21 * time.Second,
+				TrafficToken:  6 * time.Second,
+				CSIMount:      7 * time.Second,
+				Total:         28 * time.Second,
 			},
 			wantContains: []string{
 				"Retries: 2",
@@ -459,8 +460,9 @@ func TestCloneMetrics_String(t *testing.T) {
 				"CreateSandbox: 3s",
 				"WaitReady: 4s",
 				"InitRuntime: 5s",
-				"CSIMount: 6s",
-				"Total: 21s",
+				"TrafficToken: 6s",
+				"CSIMount: 7s",
+				"Total: 28s",
 			},
 		},
 		{
@@ -519,8 +521,9 @@ func TestCloneMetrics_Merge(t *testing.T) {
 				CreateSandbox: 3 * time.Second,
 				WaitReady:     4 * time.Second,
 				InitRuntime:   5 * time.Second,
-				CSIMount:      6 * time.Second,
-				Total:         21 * time.Second,
+				TrafficToken:  6 * time.Second,
+				CSIMount:      7 * time.Second,
+				Total:         28 * time.Second,
 				LastError:     errors.New("outer retry error"),
 			},
 			src: CloneMetrics{
@@ -530,8 +533,9 @@ func TestCloneMetrics_Merge(t *testing.T) {
 				CreateSandbox: 30 * time.Millisecond,
 				WaitReady:     40 * time.Millisecond,
 				InitRuntime:   50 * time.Millisecond,
-				CSIMount:      60 * time.Millisecond,
-				Total:         210 * time.Millisecond,
+				TrafficToken:  60 * time.Millisecond,
+				CSIMount:      70 * time.Millisecond,
+				Total:         280 * time.Millisecond,
 				LastError:     errors.New("per-attempt error"),
 			},
 			expected: CloneMetrics{
@@ -541,8 +545,9 @@ func TestCloneMetrics_Merge(t *testing.T) {
 				CreateSandbox: 3*time.Second + 30*time.Millisecond,
 				WaitReady:     4*time.Second + 40*time.Millisecond,
 				InitRuntime:   5*time.Second + 50*time.Millisecond,
-				CSIMount:      6*time.Second + 60*time.Millisecond,
-				Total:         21*time.Second + 210*time.Millisecond,
+				TrafficToken:  6*time.Second + 60*time.Millisecond,
+				CSIMount:      7*time.Second + 70*time.Millisecond,
+				Total:         28*time.Second + 280*time.Millisecond,
 				LastError:     errors.New("outer retry error"),
 			},
 		},
@@ -580,6 +585,9 @@ func TestCloneMetrics_Merge(t *testing.T) {
 			}
 			if tt.initial.InitRuntime != tt.expected.InitRuntime {
 				t.Fatalf("InitRuntime = %v, want %v", tt.initial.InitRuntime, tt.expected.InitRuntime)
+			}
+			if tt.initial.TrafficToken != tt.expected.TrafficToken {
+				t.Fatalf("TrafficToken = %v, want %v", tt.initial.TrafficToken, tt.expected.TrafficToken)
 			}
 			if tt.initial.CSIMount != tt.expected.CSIMount {
 				t.Fatalf("CSIMount = %v, want %v", tt.initial.CSIMount, tt.expected.CSIMount)

--- a/pkg/servers/e2b/sandbox.go
+++ b/pkg/servers/e2b/sandbox.go
@@ -108,9 +108,9 @@ func (sc *Controller) convertToE2BSandbox(sbx infra.Sandbox, accessToken, domain
 		Domain:          domain,
 		EnvdVersion:     "0.2.10",
 		EnvdAccessToken: accessToken,
-		// TrafficAccessToken is the transient access token minted during claim; it
-		// is empty unless the sandbox opted into access-token issuance, so omitempty
-		// hides it on paths (list, etc.) that carry no token.
+		// TrafficAccessToken is the transient access token minted during claim or
+		// clone; it is empty unless the sandbox opted into access-token issuance, so
+		// omitempty hides it on paths (list, etc.) that carry no token.
 		TrafficAccessToken:           sbx.GetTrafficAccessToken(),
 		TrafficAccessTokenExpiration: sbx.GetTrafficAccessTokenExpiration(),
 	}

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -1289,13 +1289,13 @@ func TestCloneSandbox(t *testing.T) {
 			},
 		},
 		{
-			name: "clone success returns transient JWT traffic token",
+			name: "clone inherits JWT auth and returns transient traffic token",
 			request: models.NewSandboxRequest{
 				TemplateID: checkpointID,
 				Timeout:    300,
-				Metadata: map[string]string{
-					identity.AnnotationEnableJwtAuth: v1alpha1.True,
-				},
+			},
+			checkpointAnnotations: map[string]string{
+				identity.AnnotationEnableJwtAuth: v1alpha1.True,
 			},
 			setup: func(t *testing.T, _ *Controller, _ ctrlclient.Client) {
 				identity.RegisterProvider(identity.NewDefaultIdentityProvider())

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -1320,7 +1320,7 @@ func TestCloneSandbox(t *testing.T) {
 			},
 		},
 		{
-			name: "clone rejects disabling inherited JWT auth",
+			name: "clone request disables inherited JWT auth",
 			request: models.NewSandboxRequest{
 				TemplateID: checkpointID,
 				Timeout:    300,
@@ -1331,9 +1331,9 @@ func TestCloneSandbox(t *testing.T) {
 			checkpointAnnotations: map[string]string{
 				identity.AnnotationEnableJwtAuth: v1alpha1.True,
 			},
-			expectError: &web.ApiError{
-				Code:    http.StatusBadRequest,
-				Message: "cannot disable JWT authentication inherited from checkpoint",
+			postCheck: func(t *testing.T, resp *models.Sandbox, _ *Controller) {
+				assert.Empty(t, resp.TrafficAccessToken)
+				assert.Empty(t, resp.TrafficAccessTokenExpiration)
 			},
 		},
 		{

--- a/pkg/servers/e2b/services_test.go
+++ b/pkg/servers/e2b/services_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/agent-runtime/storages"
 	"github.com/openkruise/agents/pkg/cache"
+	"github.com/openkruise/agents/pkg/identity"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/sandbox-manager/quota"
@@ -1251,11 +1252,12 @@ func TestCloneSandbox(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		request     models.NewSandboxRequest
-		expectError *web.ApiError
-		postCheck   func(t *testing.T, resp *models.Sandbox, controller *Controller)
-		setup       func(t *testing.T, controller *Controller, fc ctrlclient.Client)
+		name                  string
+		request               models.NewSandboxRequest
+		checkpointAnnotations map[string]string
+		expectError           *web.ApiError
+		postCheck             func(t *testing.T, resp *models.Sandbox, controller *Controller)
+		setup                 func(t *testing.T, controller *Controller, fc ctrlclient.Client)
 	}{
 		{
 			name: "clone success",
@@ -1284,6 +1286,54 @@ func TestCloneSandbox(t *testing.T) {
 			request: models.NewSandboxRequest{
 				TemplateID: checkpointID,
 				Timeout:    1200,
+			},
+		},
+		{
+			name: "clone success returns transient JWT traffic token",
+			request: models.NewSandboxRequest{
+				TemplateID: checkpointID,
+				Timeout:    300,
+				Metadata: map[string]string{
+					identity.AnnotationEnableJwtAuth: v1alpha1.True,
+				},
+			},
+			setup: func(t *testing.T, _ *Controller, _ ctrlclient.Client) {
+				identity.RegisterProvider(identity.NewDefaultIdentityProvider())
+				t.Cleanup(func() { identity.RegisterProvider(identity.NewDefaultIdentityProvider()) })
+			},
+			postCheck: func(t *testing.T, resp *models.Sandbox, controller *Controller) {
+				require.NotEmpty(t, resp.TrafficAccessToken)
+				require.NotEmpty(t, resp.TrafficAccessTokenExpiration)
+				_, err := time.Parse(time.RFC3339, resp.TrafficAccessTokenExpiration)
+				require.NoError(t, err)
+
+				persisted, err := controller.manager.GetSandbox(t.Context(), keys.AdminKeyID.String(), []string{v1alpha1.SandboxStateRunning}, infra.GetSandboxOptions{
+					SandboxID: resp.SandboxID,
+				})
+				require.NoError(t, err)
+				assert.Empty(t, persisted.GetTrafficAccessToken())
+				assert.Empty(t, persisted.GetTrafficAccessTokenExpiration())
+				for _, value := range persisted.GetAnnotations() {
+					assert.NotEqual(t, resp.TrafficAccessToken, value)
+					assert.NotEqual(t, resp.TrafficAccessTokenExpiration, value)
+				}
+			},
+		},
+		{
+			name: "clone rejects disabling inherited JWT auth",
+			request: models.NewSandboxRequest{
+				TemplateID: checkpointID,
+				Timeout:    300,
+				Metadata: map[string]string{
+					identity.AnnotationEnableJwtAuth: v1alpha1.False,
+				},
+			},
+			checkpointAnnotations: map[string]string{
+				identity.AnnotationEnableJwtAuth: v1alpha1.True,
+			},
+			expectError: &web.ApiError{
+				Code:    http.StatusBadRequest,
+				Message: "cannot disable JWT authentication inherited from checkpoint",
 			},
 		},
 		{
@@ -1449,7 +1499,12 @@ func TestCloneSandbox(t *testing.T) {
 			if tt.setup != nil {
 				tt.setup(t, controller, fc)
 			}
-			cleanup := CreateCheckpointAndTemplate(t, controller, checkpointID)
+			var cleanup func()
+			if tt.checkpointAnnotations != nil {
+				cleanup = CreateCheckpointAndTemplateWithAnnotations(t, controller, checkpointID, tt.checkpointAnnotations)
+			} else {
+				cleanup = CreateCheckpointAndTemplate(t, controller, checkpointID)
+			}
 			defer cleanup()
 
 			now := time.Now()


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

- Applies explicit three-state JWT auth merging during clone: an explicitly provided request value overrides the checkpoint value, while an absent request inherits the checkpoint unchanged.
- Issues a fresh traffic access token for the cloned Sandbox identity, validates the token and RFC3339 expiration, and keeps both values only on the transient response wrapper.
- Fails and cleans up clones when token issuance or response validation fails, and records clone traffic-token latency.
- Adds table-driven merge coverage plus clone lifecycle and E2B response tests.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

```bash
go test ./pkg/identity -count=1
go test ./pkg/sandbox-manager/infra/sandboxcr -count=1
go test ./pkg/sandbox-manager/infra -count=1
go test ./pkg/servers/e2b -run "^TestCloneSandbox$|^TestConvertToE2BSandbox" -count=1
```

### Ⅳ. Special notes for reviews

- Traffic tokens and expirations are never persisted to Sandbox or Checkpoint metadata.
- This PR intentionally excludes token-validity configuration, refresh APIs, SDK refresh behavior, and Gateway/JWKS changes.