### PR TITLE
fix(controller): supply runtime TLS bundle on the SandboxClaim claim path

### DIFF
--- a/pkg/controller/controllers.go
+++ b/pkg/controller/controllers.go
@@ -45,7 +45,7 @@ func SetupWithManager(m manager.Manager, deps Deps) error {
 	if err := sandboxset.Add(m); err != nil {
 		return err
 	}
-	if err := sandboxclaim.Add(m); err != nil {
+	if err := sandboxclaim.Add(m, deps.RuntimeTLSBundle); err != nil {
 		return err
 	}
 	if err := sandboxupdateops.Add(m); err != nil {

--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -44,6 +44,7 @@ import (
 	annotationutils "github.com/openkruise/agents/pkg/utils/annotations"
 	"github.com/openkruise/agents/pkg/utils/csiutils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
+	runtimeclient "github.com/openkruise/agents/pkg/utils/runtime"
 	"github.com/openkruise/agents/pkg/utils/timeout"
 )
 
@@ -53,18 +54,26 @@ type commonControl struct {
 	cache           cache.Provider
 	storageRegistry storages.VolumeMountProviderRegistry
 	pickCache       sync.Map
+	// runtimeTLSBundle is the client TLS bundle for reaching TLS-capable
+	// agent-runtimes during claim post-processing. Nil means this controller is
+	// not configured for runtime TLS, in which case claiming a sandbox that
+	// already advertises the capability fails instead of downgrading to
+	// plaintext (see runtime.TransportOptionsFor).
+	runtimeTLSBundle *runtimeclient.TLSBundle
 }
 
-func NewCommonControl(c client.Client, recorder record.EventRecorder, cache cache.Provider) ClaimControl {
+func NewCommonControl(c client.Client, recorder record.EventRecorder, cache cache.Provider,
+	runtimeTLSBundle *runtimeclient.TLSBundle) ClaimControl {
 	// Note: sandboxClient and cache can be nil for unit tests
 	// In production, SetupWithManager always provides these dependencies
 
 	control := &commonControl{
-		Client:          c,
-		recorder:        recorder,
-		cache:           cache,
-		storageRegistry: storages.NewStorageProvider(),
-		pickCache:       sync.Map{},
+		Client:           c,
+		recorder:         recorder,
+		cache:            cache,
+		storageRegistry:  storages.NewStorageProvider(),
+		pickCache:        sync.Map{},
+		runtimeTLSBundle: runtimeTLSBundle,
 	}
 
 	return control
@@ -333,6 +342,9 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 		CreateOnNoStock:         claim.Spec.CreateOnNoStock,
 		UserMetadataKeys:        sandboxcr.BuildUserMetadataKeys(claim.Spec.Labels, claim.Spec.Annotations),
 		Claim:                   claim,
+		// Set here because this control bypasses Infrastructure.ClaimSandbox
+		// (see the runtimeTLSBundle field doc).
+		RuntimeTLSBundle: c.runtimeTLSBundle,
 	}
 
 	if claim.Spec.InplaceUpdate != nil {

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/utils/csiutils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
+	runtimeclient "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 func TestNewCommonControl(t *testing.T) {
@@ -55,7 +56,7 @@ func TestNewCommonControl(t *testing.T) {
 	fakeRecorder := record.NewFakeRecorder(10)
 
 	// NewCommonControl should handle nil cache/client gracefully
-	control := NewCommonControl(fakeClient, fakeRecorder, nil)
+	control := NewCommonControl(fakeClient, fakeRecorder, nil, nil)
 
 	require.NotNil(t, control, "NewCommonControl() returned nil")
 
@@ -122,7 +123,7 @@ func TestNewClaimControl(t *testing.T) {
 
 	fakeRecorder := record.NewFakeRecorder(10)
 
-	controls := NewClaimControl(fakeClient, fakeRecorder, nil)
+	controls := NewClaimControl(fakeClient, fakeRecorder, nil, nil)
 
 	require.NotNil(t, controls, "NewClaimControl() returned nil")
 
@@ -133,6 +134,29 @@ func TestNewClaimControl(t *testing.T) {
 
 	// Verify it implements the interface
 	var _ ClaimControl = commonControl
+}
+
+// TestNewClaimControl_ForwardsRuntimeTLSBundle pins the bundle handoff from
+// NewClaimControl down to the concrete control. commonControl is the only place
+// that can supply the bundle to TryClaimSandbox, so a dropped argument here
+// would silently reintroduce failing claims for TLS-capable sandboxes.
+func TestNewClaimControl_ForwardsRuntimeTLSBundle(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	bundle := &runtimeclient.TLSBundle{CABundle: []byte("test-ca")}
+
+	controls := NewClaimControl(fakeClient, record.NewFakeRecorder(10), nil, bundle)
+
+	control, exists := controls[CommonControlName]
+	require.True(t, exists, "NewClaimControl() missing CommonControlName key")
+	cc, ok := control.(*commonControl)
+	require.True(t, ok, "CommonControlName should map to *commonControl")
+	assert.Same(t, bundle, cc.runtimeTLSBundle, "runtime TLS bundle must be forwarded to commonControl")
 }
 
 func TestCommonControl_EnsureClaimClaiming(t *testing.T) {
@@ -419,7 +443,7 @@ func TestCommonControl_EnsureClaimClaiming(t *testing.T) {
 
 			fakeRecorder := record.NewFakeRecorder(100)
 
-			control := NewCommonControl(fakeClient, fakeRecorder, cache)
+			control := NewCommonControl(fakeClient, fakeRecorder, cache, nil)
 
 			args := ClaimArgs{
 				Claim:      tt.claim,
@@ -522,7 +546,7 @@ func TestCommonControl_EnsureClaimClaiming_ClaimedGreaterThanZero(t *testing.T) 
 
 	ctx := context.Background()
 	fakeRecorder := record.NewFakeRecorder(100)
-	control := NewCommonControl(fakeClient, fakeRecorder, cache)
+	control := NewCommonControl(fakeClient, fakeRecorder, cache, nil)
 
 	newStatus := &agentsv1alpha1.SandboxClaimStatus{
 		Phase:           agentsv1alpha1.SandboxClaimPhaseClaiming,
@@ -595,7 +619,7 @@ func TestCommonControl_EnsureClaimClaiming_CPUResizeFeatureGatePrecondition(t *t
 			Phase: agentsv1alpha1.SandboxClaimPhaseClaiming,
 		}
 
-		control := NewCommonControl(fakeClient, record.NewFakeRecorder(10), cache)
+		control := NewCommonControl(fakeClient, record.NewFakeRecorder(10), cache, nil)
 
 		strategy, err := control.EnsureClaimClaiming(t.Context(), ClaimArgs{
 			Claim:      claim,
@@ -626,7 +650,7 @@ func TestCommonControl_EnsureClaimClaiming_CPUResizeFeatureGatePrecondition(t *t
 			Phase: agentsv1alpha1.SandboxClaimPhaseClaiming,
 		}
 
-		control := NewCommonControl(fakeClient, record.NewFakeRecorder(10), cache)
+		control := NewCommonControl(fakeClient, record.NewFakeRecorder(10), cache, nil)
 
 		strategy, err := control.EnsureClaimClaiming(t.Context(), ClaimArgs{
 			Claim:      claim,
@@ -771,7 +795,7 @@ func TestCommonControl_EnsureClaimCompleted(t *testing.T) {
 
 			fakeRecorder := record.NewFakeRecorder(10)
 
-			control := NewCommonControl(fakeClient, fakeRecorder, nil)
+			control := NewCommonControl(fakeClient, fakeRecorder, nil, nil)
 
 			args := ClaimArgs{
 				Claim:     tt.claim,
@@ -833,7 +857,10 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 		sandboxSet  *agentsv1alpha1.SandboxSet
 		initObjs    []client.Object
 		expectError bool
-		validate    func(t *testing.T, opts infra.ClaimSandboxOptions)
+		// runtimeTLSBundle is the bundle handed to NewCommonControl; nil keeps
+		// the control on the legacy plaintext runtime paths.
+		runtimeTLSBundle *runtimeclient.TLSBundle
+		validate         func(t *testing.T, opts infra.ClaimSandboxOptions)
 	}{
 		{
 			name: "basic claim without optional fields",
@@ -1613,6 +1640,62 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			// The control calls sandboxcr.TryClaimSandbox directly and thus
+			// bypasses the Infra-level bundle injection, so the configured
+			// bundle must reach the options or claiming a TLS-capable sandbox
+			// fails in runtime.TransportOptionsFor.
+			name: "runtime TLS bundle is propagated to claim options",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim-tls",
+					Namespace: "default",
+					UID:       "test-uid-tls",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "test-template",
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-template",
+					Namespace: "default",
+				},
+			},
+			// A syntactically invalid CABundle is fine here: buildClaimOptions
+			// only forwards the pointer and never decodes the PEM. Tests that
+			// actually dial the runtime need a real bundle instead.
+			runtimeTLSBundle: &runtimeclient.TLSBundle{CABundle: []byte("test-ca")},
+			expectError:      false,
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				require.NotNil(t, opts.RuntimeTLSBundle, "RuntimeTLSBundle should be propagated from the control")
+				assert.Equal(t, []byte("test-ca"), opts.RuntimeTLSBundle.CABundle, "RuntimeTLSBundle.CABundle mismatch")
+			},
+		},
+		{
+			name: "nil runtime TLS bundle leaves claim options without a bundle",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim-no-tls",
+					Namespace: "default",
+					UID:       "test-uid-no-tls",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "test-template",
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-template",
+					Namespace: "default",
+				},
+			},
+			runtimeTLSBundle: nil,
+			expectError:      false,
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				assert.Nil(t, opts.RuntimeTLSBundle, "RuntimeTLSBundle should stay nil when the control is not configured for runtime TLS")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1623,7 +1706,7 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 			} else {
 				testClient = fakeClient
 			}
-			testControl := NewCommonControl(testClient, fakeRecorder, nil).(*commonControl)
+			testControl := NewCommonControl(testClient, fakeRecorder, nil, tt.runtimeTLSBundle).(*commonControl)
 			opts, err := testControl.buildClaimOptions(ctx, tt.claim, tt.sandboxSet)
 			if (err != nil) != tt.expectError {
 				t.Errorf("buildClaimOptions() error = %v, expectError %v", err, tt.expectError)
@@ -1701,7 +1784,7 @@ func TestBuildClaimOptions_CSIMount_ConfigValidation(t *testing.T) {
 	storageRegistry.RegisterProvider("nasplugin.csi.alibabacloud.com", &storages.MountProvider{})
 	storageRegistry.RegisterProvider("ossplugin.csi.alibabacloud.com", &storages.MountProvider{})
 
-	control := NewCommonControl(fakeClient, fakeRecorder, cache)
+	control := NewCommonControl(fakeClient, fakeRecorder, cache, nil)
 	// Inject the storage registry into the control
 	commonControl := control.(*commonControl)
 	commonControl.storageRegistry = storageRegistry
@@ -2125,7 +2208,7 @@ func TestBuildClaimOptions_CSIMount_Test(t *testing.T) {
 	storageRegistry.RegisterProvider("nasplugin.csi.alibabacloud.com", &storages.MountProvider{})
 	storageRegistry.RegisterProvider("ossplugin.csi.alibabacloud.com", &storages.MountProvider{})
 
-	control := NewCommonControl(fakeClient, fakeRecorder, cache)
+	control := NewCommonControl(fakeClient, fakeRecorder, cache, nil)
 	// Inject the storage registry into the control
 	commonControl := control.(*commonControl)
 	commonControl.storageRegistry = storageRegistry

--- a/pkg/controller/sandboxclaim/core/interface.go
+++ b/pkg/controller/sandboxclaim/core/interface.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/controller/sandbox/core"
 	"github.com/openkruise/agents/pkg/utils/expectations"
+	runtimeclient "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 var (
@@ -75,9 +76,12 @@ type ClaimControl interface {
 	EnsureClaimCompleted(ctx context.Context, args ClaimArgs) (RequeueStrategy, error)
 }
 
-// NewClaimControl creates a map of claim controls
-func NewClaimControl(c client.Client, recorder record.EventRecorder, cache cache.Provider) map[string]ClaimControl {
+// NewClaimControl creates a map of claim controls. runtimeTLSBundle is the
+// client TLS bundle for reaching TLS-capable agent-runtimes; nil disables
+// runtime TLS for the claim path.
+func NewClaimControl(c client.Client, recorder record.EventRecorder, cache cache.Provider,
+	runtimeTLSBundle *runtimeclient.TLSBundle) map[string]ClaimControl {
 	controls := map[string]ClaimControl{}
-	controls[core.CommonControlName] = NewCommonControl(c, recorder, cache)
+	controls[core.CommonControlName] = NewCommonControl(c, recorder, cache, runtimeTLSBundle)
 	return controls
 }

--- a/pkg/controller/sandboxclaim/core/metrics_test.go
+++ b/pkg/controller/sandboxclaim/core/metrics_test.go
@@ -122,7 +122,7 @@ func TestSandboxSetClaimsTotal_Success(t *testing.T) {
 			}
 
 			fakeRecorder := record.NewFakeRecorder(100)
-			control := NewCommonControl(fakeClient, fakeRecorder, cache)
+			control := NewCommonControl(fakeClient, fakeRecorder, cache, nil)
 
 			newStatus := &agentsv1alpha1.SandboxClaimStatus{
 				Phase:           agentsv1alpha1.SandboxClaimPhaseClaiming,
@@ -210,7 +210,7 @@ func TestSandboxSetClaimsTotal_Failed(t *testing.T) {
 			require.NoError(t, err)
 
 			fakeRecorder := record.NewFakeRecorder(100)
-			control := NewCommonControl(fake.NewClientBuilder().WithScheme(scheme).Build(), fakeRecorder, cache)
+			control := NewCommonControl(fake.NewClientBuilder().WithScheme(scheme).Build(), fakeRecorder, cache, nil)
 
 			newStatus := &agentsv1alpha1.SandboxClaimStatus{
 				Phase:           agentsv1alpha1.SandboxClaimPhaseClaiming,
@@ -296,7 +296,7 @@ func TestSandboxClaimExpiredTotal(t *testing.T) {
 				Build()
 
 			fakeRecorder := record.NewFakeRecorder(10)
-			control := NewCommonControl(fakeClient, fakeRecorder, nil)
+			control := NewCommonControl(fakeClient, fakeRecorder, nil, nil)
 
 			newStatus := &agentsv1alpha1.SandboxClaimStatus{
 				Phase:          agentsv1alpha1.SandboxClaimPhaseCompleted,

--- a/pkg/controller/sandboxclaim/sandboxclaim_controller.go
+++ b/pkg/controller/sandboxclaim/sandboxclaim_controller.go
@@ -48,6 +48,7 @@ import (
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
+	runtimeclient "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 func init() {
@@ -61,7 +62,11 @@ var (
 	controllerKind       = agentsv1alpha1.GroupVersion.WithKind("SandboxClaim")
 )
 
-func Add(mgr manager.Manager) error {
+// Add registers the SandboxClaim controller. runtimeTLSBundle is the client TLS
+// bundle for reaching TLS-capable agent-runtimes during claim post-processing;
+// nil disables runtime TLS, so claiming a sandbox that already advertises the
+// capability fails rather than downgrading to plaintext.
+func Add(mgr manager.Manager, runtimeTLSBundle *runtimeclient.TLSBundle) error {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.SandboxClaimGate) || !discovery.DiscoverGVK(controllerKind) {
 		return nil
 	}
@@ -77,7 +82,7 @@ func Add(mgr manager.Manager) error {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		recorder: recorder,
-		controls: core.NewClaimControl(mgr.GetClient(), recorder, cache),
+		controls: core.NewClaimControl(mgr.GetClient(), recorder, cache, runtimeTLSBundle),
 	}).SetupWithManager(mgr)
 	if err != nil {
 		return err

--- a/pkg/controller/sandboxclaim/sandboxclaim_controller_test.go
+++ b/pkg/controller/sandboxclaim/sandboxclaim_controller_test.go
@@ -107,7 +107,7 @@ func TestReconciler_Reconcile_BasicFlow(t *testing.T) {
 			reconciler := &Reconciler{
 				Client:   fakeClient,
 				Scheme:   scheme,
-				controls: core.NewClaimControl(fakeClient, fakeRecorder, nil),
+				controls: core.NewClaimControl(fakeClient, fakeRecorder, nil, nil),
 				recorder: fakeRecorder,
 			}
 
@@ -261,7 +261,7 @@ func TestReconciler_Reconcile_Claiming(t *testing.T) {
 	reconciler := &Reconciler{
 		Client:   testClient,
 		Scheme:   testClient.Scheme(),
-		controls: core.NewClaimControl(testClient, fakeRecorder, cache),
+		controls: core.NewClaimControl(testClient, fakeRecorder, cache, nil),
 		recorder: fakeRecorder,
 	}
 
@@ -400,7 +400,7 @@ func TestReconciler_Reconcile_Timeout(t *testing.T) {
 	reconciler := &Reconciler{
 		Client:   fakeClient,
 		Scheme:   scheme,
-		controls: core.NewClaimControl(fakeClient, fakeRecorder, nil),
+		controls: core.NewClaimControl(fakeClient, fakeRecorder, nil, nil),
 		recorder: fakeRecorder,
 	}
 
@@ -455,7 +455,7 @@ func TestReconciler_GetControl(t *testing.T) {
 	reconciler := &Reconciler{
 		Client:   fakeClient,
 		Scheme:   scheme,
-		controls: core.NewClaimControl(fakeClient, fakeRecorder, nil),
+		controls: core.NewClaimControl(fakeClient, fakeRecorder, nil, nil),
 		recorder: fakeRecorder,
 	}
 

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -4416,3 +4416,93 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 		})
 	}
 }
+
+// TestRunClaimPostProcesses_RuntimeTransport pins the claim-level behaviour of
+// the runtime transport gate. runtime.TestTransportOptionsFor already covers the
+// resolution matrix itself; what this test adds is how claim post-processing
+// reacts to it:
+//
+//   - a sandbox advertising the runtime TLS capability while the caller holds no
+//     bundle fails the claim instead of falling back to plaintext;
+//   - the gate runs ahead of the InitRuntime and CSIMount branches, so it fails
+//     even when the claim would make no runtime call at all — every case below
+//     leaves both options nil, so moving the resolution inside either branch
+//     would regress silently;
+//   - that failure stays non-retriable, since retrying cannot conjure
+//     certificate material;
+//   - a legacy sandbox carrying no capability annotation keeps working
+//     unchanged once the manager is configured with a bundle.
+func TestRunClaimPostProcesses_RuntimeTransport(t *testing.T) {
+	bundle := &runtime.TLSBundle{CABundle: []byte("pem")}
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		bundle      *runtime.TLSBundle
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "tls-capable sandbox without bundle fails the claim",
+			annotations: map[string]string{agentsv1alpha1.AnnotationRuntimeTLSPort: "49984"},
+			wantErr:     true,
+			errContains: "no client TLS bundle is configured",
+		},
+		{
+			name:        "tls-capable sandbox with bundle passes the transport gate",
+			annotations: map[string]string{agentsv1alpha1.AnnotationRuntimeTLSPort: "49984"},
+			bundle:      bundle,
+		},
+		{
+			// The direct evidence that enabling runtime TLS leaves already
+			// running sandboxes alone: they carry no capability annotation, so
+			// they stay on the plaintext paths even though a bundle is present.
+			name:   "legacy sandbox is unaffected once runtime TLS is enabled",
+			bundle: bundle,
+		},
+		{
+			name: "legacy sandbox stays on the plaintext path without a bundle",
+		},
+		{
+			// A present but unparsable annotation means a broken injection
+			// template, which must not be papered over either.
+			name:        "unparsable capability annotation fails the claim",
+			annotations: map[string]string{agentsv1alpha1.AnnotationRuntimeTLSPort: "not-a-port"},
+			bundle:      bundle,
+			wantErr:     true,
+			errContains: "invalid runtime TLS port annotation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := &Sandbox{Sandbox: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-sandbox",
+					Namespace:   "default",
+					Annotations: tt.annotations,
+				},
+			}}
+			// LockTypeUpdate without InplaceUpdate skips the wait-ready gate, and
+			// nil InitRuntime/CSIMount skip every runtime call, leaving the
+			// transport gate as the only step exercised here. The sandbox also
+			// carries no identity annotations, so both token steps are skipped
+			// and the nil cache is never dereferenced.
+			opts := infra.ClaimSandboxOptions{RuntimeTLSBundle: tt.bundle}
+
+			err := runClaimPostProcesses(t.Context(), sbx, infra.LockTypeUpdate, opts, nil, &infra.ClaimMetrics{})
+
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errContains)
+			// Missing or broken certificate material is a configuration error:
+			// classifying it as retriable would make ClaimSandbox burn its retry
+			// budget on an outcome that cannot change.
+			var retryErr retriableError
+			assert.False(t, errors.As(err, &retryErr), "transport resolution failure must not be retriable")
+		})
+	}
+}

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -158,8 +158,9 @@ func (i *Infra) ClaimSandbox(ctx context.Context, opts infra.ClaimSandboxOptions
 		log.Error(err, "invalid claim options")
 		return nil, metrics, err
 	}
-	// Inject the Infra-owned runtime TLS bundle so claim post-processing can
-	// resolve the per-sandbox transport; API callers never set this field.
+	// Overwrite with the Infra-owned runtime TLS bundle so claim
+	// post-processing can resolve the per-sandbox transport; the field is
+	// Infra-owned, see ClaimSandboxOptions.RuntimeTLSBundle.
 	opts.RuntimeTLSBundle = i.RuntimeTLSBundle
 
 	claimCtx, cancel := context.WithTimeout(ctx, opts.ClaimTimeout)
@@ -252,7 +253,7 @@ func (i *Infra) CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions
 	// limiting at the same gate as ClaimSandbox (see newSandboxFromSandboxSet).
 	attemptOpts := opts
 	attemptOpts.CreateLimiter = i.createLimiter
-	// Inject the Infra-owned runtime TLS bundle, mirroring the claim path.
+	// Overwrite with the Infra-owned runtime TLS bundle, mirroring the claim path.
 	attemptOpts.RuntimeTLSBundle = i.RuntimeTLSBundle
 
 	metrics.Retries = -1 // starts from 0

--- a/pkg/sandbox-manager/infra/types.go
+++ b/pkg/sandbox-manager/infra/types.go
@@ -90,9 +90,17 @@ type ClaimSandboxOptions struct {
 	Claim *v1alpha1.SandboxClaim `json:"-"`
 	// RuntimeTLSBundle is the client TLS bundle used to reach a TLS-capable
 	// agent-runtime during claim post-processing (init handshake and CSI
-	// mounts). It is injected by the Infrastructure implementation, never by
-	// API callers, mirroring how CloneSandboxOptions.CreateLimiter is injected.
-	// Nil means this process is not configured for runtime TLS.
+	// mounts). Nil means the caller is not configured for runtime TLS, so a
+	// sandbox that already advertises the capability fails the claim instead of
+	// being downgraded to plaintext (see runtime.TransportOptionsFor).
+	//
+	// The field belongs to whoever drives the claim, never to API callers:
+	//   - through Infrastructure.ClaimSandbox it is unconditionally overwritten
+	//     with the Infra-owned bundle, so a value set by an API caller is
+	//     discarded (same contract as CloneSandboxOptions.CreateLimiter);
+	//   - callers invoking sandboxcr.TryClaimSandbox directly — currently the
+	//     SandboxClaim controller — bypass that overwrite and must set it
+	//     themselves.
 	RuntimeTLSBundle *runtime.TLSBundle `json:"-"`
 }
 
@@ -118,8 +126,9 @@ type CloneSandboxOptions struct {
 	GenerateName string `json:"generateName,omitempty"`
 	// RuntimeTLSBundle is the client TLS bundle used to reach a TLS-capable
 	// agent-runtime during clone post-processing (re-init handshake and CSI
-	// mounts). Injected by the Infrastructure implementation like
-	// CreateLimiter; nil means this process is not configured for runtime TLS.
+	// mounts). Unconditionally overwritten by the Infrastructure implementation
+	// like CreateLimiter, so a value set by an API caller is discarded; nil
+	// means this process is not configured for runtime TLS.
 	RuntimeTLSBundle *runtime.TLSBundle `json:"-"`
 }
 


### PR DESCRIPTION
…path

The SandboxClaim controller calls sandboxcr.TryClaimSandbox directly and so bypasses Infrastructure.ClaimSandbox, the only place that fills ClaimSandboxOptions.RuntimeTLSBundle. Claim post-processing then resolved its transport with a nil bundle, so runClaimPostProcesses failed for every sandbox advertising AnnotationRuntimeTLSPort: TransportOptionsFor reports the missing bundle instead of silently downgrading to plaintext, and it runs before the InitRuntime and CSIMount branches, so even a claim that needs neither fails.

Since the same process stamps that annotation once --runtime-client-cert-dir is configured, enabling runtime TLS made the controller advertise a capability its own claim path could not consume, and the stamp is write-once with no self-healing.

Thread the bundle already loaded by agent-sandbox-controller from controller.Deps through sandboxclaim.Add, NewClaimControl and NewCommonControl into buildClaimOptions. A nil bundle preserves the previous plaintext behaviour.

Also correct the RuntimeTLSBundle field docs: ClaimSandbox and CloneSandbox overwrite the field unconditionally, so a value set by an API caller is discarded rather than merely unexpected.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

