### PR TITLE
fix(cache): skip TrafficPolicy cache setup when the CRD is absent

### DIFF
--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -34,6 +34,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	agentsclient "github.com/openkruise/agents/client"
 	"github.com/openkruise/agents/pkg/sandbox-manager/clients"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
@@ -270,6 +271,13 @@ func main() {
 			klog.Errorf("Failed to shutdown tracing: %v", err)
 		}
 	}()
+
+	// Initialize the generic client registry so CRD discovery
+	// (discovery.DiscoverGVK) works; the shared cache uses it to skip
+	// optional CRD-dependent setup when a CRD is not installed.
+	if err := agentsclient.NewRegistry(clientConfig); err != nil {
+		klog.Fatalf("Failed to initialize generic client registry: %v", err)
+	}
 
 	// Load the runtime client TLS bundle. The certificate Secret is fetched once
 	// at startup (fail fast on a broken reference) and held for the lifetime of

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -125,6 +125,7 @@ type Cache struct {
 // A — Custom resources (sandbox namespace + optional label selector):
 //
 //	Sandbox, SandboxSet, Checkpoint, SandboxTemplate, TrafficPolicy
+//	(TrafficPolicy only when its CRD is installed)
 //
 // B — System namespace resources (requires opts.SystemNamespace to be set):
 //
@@ -163,7 +164,12 @@ func BuildCacheConfig(opts config.SandboxManagerOptions) (map[ctrlclient.Object]
 	byObject[&agentsv1alpha1.SandboxSet{}] = customObjConfig
 	byObject[&agentsv1alpha1.Checkpoint{}] = customObjConfig
 	byObject[&agentsv1alpha1.SandboxTemplate{}] = customObjConfig
-	byObject[&agentsv1alpha1.TrafficPolicy{}] = customObjConfig
+	// The TrafficPolicy CRD is optional: skip its informer when the CRD is
+	// not discovered on the API server, otherwise the cache fails to resolve
+	// the GVK and crashes the process at startup.
+	if discoverGVK(trafficPolicyKind) {
+		byObject[&agentsv1alpha1.TrafficPolicy{}] = customObjConfig
+	}
 
 	// System namespace resources
 	if opts.SystemNamespace != "" {

--- a/pkg/cache/index.go
+++ b/pkg/cache/index.go
@@ -21,10 +21,13 @@ import (
 
 	"github.com/openkruise/agents/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/discovery"
 )
 
 // Index name constants (consistent with sandboxcr/index.go values)
@@ -36,13 +39,24 @@ var (
 	IndexCheckpointID           = "checkpointID"
 	IndexVolumeName             = "volumeName"
 	IndexTrafficPolicySandboxID = "trafficPolicySandboxID"
+
+	trafficPolicyKind = agentsv1alpha1.GroupVersion.WithKind("TrafficPolicy")
 )
+
+// discoverGVK is indirected through a variable so tests can simulate an
+// absent CRD without a live API server. Callers must ensure the generic
+// client registry is initialized (client.NewRegistry) before relying on it.
+var discoverGVK = discovery.DiscoverGVK
 
 // IndexFunc defines a field index function for a specific resource type.
 type IndexFunc struct {
 	Obj       client.Object
 	FieldName string
 	Extract   func(obj client.Object) []string
+	// OptionalGVK marks the index as optional: when set, registration is
+	// skipped if the GVK is reliably absent from API server discovery (e.g.
+	// the corresponding CRD is not installed).
+	OptionalGVK schema.GroupVersionKind
 }
 
 // GetIndexFuncs returns all field index functions used by the cache.
@@ -165,8 +179,9 @@ func GetIndexFuncs() []IndexFunc {
 			},
 		},
 		{
-			Obj:       &agentsv1alpha1.TrafficPolicy{},
-			FieldName: IndexTrafficPolicySandboxID,
+			Obj:         &agentsv1alpha1.TrafficPolicy{},
+			FieldName:   IndexTrafficPolicySandboxID,
+			OptionalGVK: trafficPolicyKind,
 			Extract: func(obj client.Object) []string {
 				tp, ok := obj.(*agentsv1alpha1.TrafficPolicy)
 				if !ok {
@@ -182,11 +197,17 @@ func GetIndexFuncs() []IndexFunc {
 }
 
 // AddIndexesToCache registers all required field indexes on the controller-runtime cache.
+// Indexes whose OptionalGVK is reliably absent from API server discovery (e.g. the
+// corresponding CRD is not installed) are skipped instead of failing the startup.
 func AddIndexesToCache(c ctrlcache.Cache) error {
 	if c == nil {
 		return nil
 	}
 	for _, idx := range GetIndexFuncs() {
+		if !idx.OptionalGVK.Empty() && !discoverGVK(idx.OptionalGVK) {
+			klog.InfoS("Skipping field index for absent CRD", "field", idx.FieldName, "gvk", idx.OptionalGVK.String())
+			continue
+		}
 		if err := c.IndexField(context.Background(), idx.Obj, idx.FieldName, idx.Extract); err != nil {
 			return err
 		}

--- a/pkg/cache/index_test.go
+++ b/pkg/cache/index_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+)
+
+// recordingCache records IndexField calls; any other ctrlcache.Cache method
+// falls through to the embedded nil interface and panics, which is the
+// desired loud-failure behavior for paths the tests should not reach.
+type recordingCache struct {
+	ctrlcache.Cache
+	fields []string
+}
+
+func (r *recordingCache) IndexField(_ context.Context, _ client.Object, field string, _ client.IndexerFunc) error {
+	r.fields = append(r.fields, field)
+	return nil
+}
+
+func containsField(fields []string, field string) bool {
+	for _, f := range fields {
+		if f == field {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGetIndexFuncs_OptionalGVK(t *testing.T) {
+	for _, idx := range GetIndexFuncs() {
+		_, isTrafficPolicy := idx.Obj.(*agentsv1alpha1.TrafficPolicy)
+		wantGVK := schema.GroupVersionKind{}
+		if isTrafficPolicy {
+			wantGVK = trafficPolicyKind
+		}
+		if idx.OptionalGVK != wantGVK {
+			t.Errorf("index %q OptionalGVK = %v, want %v", idx.FieldName, idx.OptionalGVK, wantGVK)
+		}
+	}
+}
+
+func TestAddIndexesToCache(t *testing.T) {
+	allFields := make([]string, 0)
+	for _, idx := range GetIndexFuncs() {
+		allFields = append(allFields, idx.FieldName)
+	}
+	withoutTrafficPolicy := make([]string, 0, len(allFields)-1)
+	for _, f := range allFields {
+		if f != IndexTrafficPolicySandboxID {
+			withoutTrafficPolicy = append(withoutTrafficPolicy, f)
+		}
+	}
+
+	tests := []struct {
+		name       string
+		absent     bool
+		wantFields []string
+	}{
+		{
+			name:       "TrafficPolicy CRD present registers every index",
+			absent:     false,
+			wantFields: allFields,
+		},
+		{
+			name:       "TrafficPolicy CRD absent skips its index",
+			absent:     true,
+			wantFields: withoutTrafficPolicy,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			old := discoverGVK
+			discoverGVK = func(gvk schema.GroupVersionKind) bool {
+				return !(tt.absent && gvk == trafficPolicyKind)
+			}
+			t.Cleanup(func() { discoverGVK = old })
+
+			c := &recordingCache{}
+			if err := AddIndexesToCache(c); err != nil {
+				t.Fatalf("AddIndexesToCache() error = %v", err)
+			}
+			if len(c.fields) != len(tt.wantFields) {
+				t.Fatalf("registered fields = %v, want %v", c.fields, tt.wantFields)
+			}
+			for _, want := range tt.wantFields {
+				if !containsField(c.fields, want) {
+					t.Errorf("registered fields = %v, missing %q", c.fields, want)
+				}
+			}
+		})
+	}
+}
+
+func TestAddIndexesToCache_NilCache(t *testing.T) {
+	if err := AddIndexesToCache(nil); err != nil {
+		t.Errorf("AddIndexesToCache(nil) error = %v, want nil", err)
+	}
+}
+
+func TestBuildCacheConfig_SkipsTrafficPolicyWhenCRDAbsent(t *testing.T) {
+	tests := []struct {
+		name              string
+		absent            bool
+		wantTrafficPolicy bool
+	}{
+		{
+			name:              "TrafficPolicy CRD present keeps informer config",
+			absent:            false,
+			wantTrafficPolicy: true,
+		},
+		{
+			name:              "TrafficPolicy CRD absent skips informer config",
+			absent:            true,
+			wantTrafficPolicy: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			old := discoverGVK
+			discoverGVK = func(gvk schema.GroupVersionKind) bool {
+				return !(tt.absent && gvk == trafficPolicyKind)
+			}
+			t.Cleanup(func() { discoverGVK = old })
+
+			byObject, err := BuildCacheConfig(config.SandboxManagerOptions{})
+			if err != nil {
+				t.Fatalf("BuildCacheConfig() error = %v", err)
+			}
+			var ok bool
+			for obj := range byObject {
+				if _, isTrafficPolicy := obj.(*agentsv1alpha1.TrafficPolicy); isTrafficPolicy {
+					ok = true
+					break
+				}
+			}
+			if ok != tt.wantTrafficPolicy {
+				t.Errorf("TrafficPolicy in byObject = %v, want %v", ok, tt.wantTrafficPolicy)
+			}
+		})
+	}
+}

--- a/pkg/cache/main_test.go
+++ b/pkg/cache/main_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/client"
+)
+
+// TestMain initializes the generic client registry against a fake discovery
+// server that reports all agents.kruise.io kinds as installed. Production
+// code paths under test (BuildCacheConfig, AddIndexesToCache) use
+// discovery.DiscoverGVK, which treats an uninitialized registry as "CRD
+// absent"; seeding the registry keeps the default test environment in the
+// "CRD installed" state. Tests that need an absent CRD stub discoverGVK.
+func TestMain(m *testing.M) {
+	kinds := []string{"Sandbox", "SandboxSet", "SandboxTemplate", "SandboxClaim",
+		"Checkpoint", "Commit", "SandboxUpdateOps", "TrafficPolicy", "GlobalTrafficPolicy"}
+	resources := make([]metav1.APIResource, 0, len(kinds))
+	for _, kind := range kinds {
+		resources = append(resources, metav1.APIResource{Name: kind, Kind: kind})
+	}
+	list := metav1.APIResourceList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "APIResourceList",
+			APIVersion: "v1",
+		},
+		GroupVersion: v1alpha1.GroupVersion.String(),
+		APIResources: resources,
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&list)
+	}))
+	defer server.Close()
+
+	if err := client.NewRegistry(&rest.Config{Host: server.URL}); err != nil {
+		panic("failed to initialize generic client registry for tests: " + err.Error())
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

When the `TrafficPolicy` CRD is not installed, `agent-sandbox-controller` crashes at startup:

```
ERROR setup unable to setup controllers {"error": "failed to create cache: failed to add indexes to cache: no matches for kind \"TrafficPolicy\" in version \"agents.kruise.io/v1alpha1\""}
```

The failure path is `sandboxclaim.Add` -> `cache.NewCache` -> `AddIndexesToCache`, which unconditionally registers a field index for `TrafficPolicy`; `BuildCacheConfig` also unconditionally registers its informer.

This PR makes TrafficPolicy cache setup optional by detecting the CRD through the existing `discovery.DiscoverGVK` helper (the same pattern used by other controllers/webhooks):

- `pkg/cache/index.go`: `IndexFunc` gains an `OptionalGVK` field; `AddIndexesToCache` skips (with a log line) indexes whose GVK is not discovered.
- `pkg/cache/cache.go`: `BuildCacheConfig` only registers the TrafficPolicy informer when the GVK is discovered.
- `cmd/sandbox-manager/main.go`: initialize the generic client registry (`client.NewRegistry`) — previously only the controller binary did this, and `DiscoverGVK` returns false with an uninitialized registry, which would wrongly skip TrafficPolicy even when the CRD exists.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Unit tests: `go test ./pkg/cache/... ./cmd/sandbox-manager/... ./pkg/controller/sandboxclaim/...`
2. Deploy `agent-sandbox-controller` to a cluster **without** the TrafficPolicy CRD: it now starts successfully and logs `Skipping field index for absent CRD`.
3. Deploy to a cluster **with** the CRD: behavior is unchanged (index and informer registered as before).

### Ⅳ. Special notes for reviews

- `DiscoverGVK` treats discovery errors conservatively as "present" (existing behavior), so a flaky API server never disables the feature; skipping only happens when discovery definitively reports the kind absent.
- The sandbox-manager registry initialization is required for the direct `DiscoverGVK` check to distinguish "CRD absent" from "client not initialized" in that binary.
- When the CRD is genuinely absent, the first `DiscoverGVK` call pays its existing retry backoff (~15s) at startup — same cost as the pre-existing `fieldindex.RegisterFieldIndexes` pattern.
