### PR TITLE
    feat(identity): deliver security tokens over the resolved runtime transport

### DIFF
--- a/pkg/controller/controllers.go
+++ b/pkg/controller/controllers.go
@@ -51,7 +51,7 @@ func SetupWithManager(m manager.Manager, deps Deps) error {
 	if err := sandboxupdateops.Add(m); err != nil {
 		return err
 	}
-	if err := securitytokenrefresh.Add(m); err != nil {
+	if err := securitytokenrefresh.Add(m, deps.RuntimeTLSBundle); err != nil {
 		return err
 	}
 	if err := commit.Add(m); err != nil {

--- a/pkg/controller/sandbox/core/lifecycle_handler.go
+++ b/pkg/controller/sandbox/core/lifecycle_handler.go
@@ -32,6 +32,21 @@ type LifecycleHookFunc func(ctx context.Context, box *agentsv1alpha1.Sandbox, ac
 
 // ExecuteLifecycleHook executes an upgrade action inside the sandbox pod via envd.
 // It uses the shared RunCommandWithRuntime from pkg/utils/runtime.
+//
+// It is currently the one controller path that still reaches the runtime over
+// plaintext HTTP: it forwards no runtime.Option, so even a sandbox advertising
+// the runtime TLS capability is contacted on the plain runtime port, while the
+// initializer paths (/init handshake, CSI re-mount, security token) already ride
+// the transport resolved for the sandbox.
+//
+// TODO: resolve the sandbox transport via runtime.TransportOptionsFor once the
+// upgrade/recycle flows carry the runtime TLS bundle, mirroring the
+// claim/clone/post-resume flows (see PR #734). The bundle already reaches this
+// package as SandboxControlArgs.RuntimeTLSBundle, so the missing piece is
+// threading it through LifecycleHookFunc. The runtime URL gate below must be
+// revisited together with it: it is a plaintext-only readiness signal, whereas
+// the TLS transport addresses the runtime by its certificate hostname and dials
+// the sandbox Pod IP.
 func ExecuteLifecycleHook(ctx context.Context, box *agentsv1alpha1.Sandbox, action *agentsv1alpha1.UpgradeAction) (exitCode int32, stdout, stderr string, err error) {
 	if action == nil || action.Exec == nil || len(action.Exec.Command) == 0 {
 		return 0, "", "", nil

--- a/pkg/controller/sandbox/core/recycle_test.go
+++ b/pkg/controller/sandbox/core/recycle_test.go
@@ -1058,7 +1058,8 @@ func TestEnsureSandboxRecycled(t *testing.T) {
 			})
 			csiResetSignalRetryInterval = time.Millisecond
 			var csiWriteCalls int
-			writeRuntimeFileFunc = func(_ context.Context, _ agentsruntime.WriteFileArgs) (agentsruntime.WriteFileResult, error) {
+			writeRuntimeFileFunc = func(_ context.Context, _ agentsruntime.WriteFileArgs,
+				_ ...agentsruntime.Option) (agentsruntime.WriteFileResult, error) {
 				csiWriteCalls++
 				if tt.csiWriteErr != nil {
 					return agentsruntime.WriteFileResult{}, tt.csiWriteErr
@@ -2129,7 +2130,8 @@ func TestEnsureCSIResetSignal(t *testing.T) {
 			var calls int
 			var gotPath string
 			var gotContent []byte
-			writeRuntimeFileFunc = func(_ context.Context, args agentsruntime.WriteFileArgs) (agentsruntime.WriteFileResult, error) {
+			writeRuntimeFileFunc = func(_ context.Context, args agentsruntime.WriteFileArgs,
+				_ ...agentsruntime.Option) (agentsruntime.WriteFileResult, error) {
 				calls++
 				gotPath = args.FilePath
 				gotContent = args.Content

--- a/pkg/controller/sandbox/core/sandbox_initializer.go
+++ b/pkg/controller/sandbox/core/sandbox_initializer.go
@@ -98,15 +98,12 @@ func (d *defaultSandboxInitializer) doInitialize(ctx context.Context, box *agent
 // This is the unified initialization logic for all sandboxes after resume or recreate upgrade.
 // Both E2B and SandboxClaim paths rely on this to re-initialize runtime and CSI mounts.
 //
-// rtOpts selects the runtime transport for this sandbox, applied to both the
-// /init handshake (see InitRuntime) and the CSI re-mount (see ProcessCSIMounts):
+// rtOpts selects the runtime transport for this sandbox, applied uniformly to
+// the /init handshake (see InitRuntime), the security-token propagation (see
+// identity.ProcessSandboxToken) and the CSI re-mount (see ProcessCSIMounts):
 // non-empty (typically the TLS options resolved by TransportOptionsFor) routes
 // them over HTTPS to the agent-runtime sidecar, which also relays /init to the
-// in-container runtime; empty keeps the legacy plaintext paths untouched. The
-// token propagation intentionally stays on its existing transport for now.
-//
-// TODO: carry rtOpts into the token propagation as soon as that path is
-// TLS-enabled.
+// in-container runtime; empty keeps the legacy plaintext paths untouched.
 func Initialize(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus,
 	client client.Client, apiReader client.Reader, storageRegistry storages.VolumeMountProviderRegistry,
 	rtOpts ...utilruntime.Option) error {
@@ -131,7 +128,7 @@ func Initialize(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *age
 	// Ordering mirrors the claim flow (InitRuntime -> SecurityToken -> CSIMount):
 	// the freshly recreated runtime holds no token, so the credential must be
 	// delivered before agent-identity CSI mounts below rely on it.
-	if err := reinitSecurityToken(ctx, client, sbxForInit); err != nil {
+	if err := reinitSecurityToken(ctx, client, sbxForInit, rtOpts...); err != nil {
 		return err
 	}
 
@@ -215,12 +212,17 @@ func reinitRuntime(ctx context.Context, logger klog.Logger, box *agentsv1alpha1.
 // sharing the original sandbox ObjectMeta (annotations, name), so the opt-in
 // gate and the annotation patch behave identically to operating on the original
 // sandbox.
-func reinitSecurityToken(ctx context.Context, c client.Client, sbxForInit *agentsv1alpha1.Sandbox) error {
+//
+// rtOpts is forwarded to ProcessSandboxToken so the credential travels over the
+// transport resolved for this sandbox, exactly like the /init handshake and the
+// CSI re-mount.
+func reinitSecurityToken(ctx context.Context, c client.Client, sbxForInit *agentsv1alpha1.Sandbox,
+	rtOpts ...utilruntime.Option) error {
 	if !identity.IsIDTokenRequested(sbxForInit) {
 		return nil
 	}
 	logger := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbxForInit))
-	if _, err := identity.ProcessSandboxToken(ctx, c, sbxForInit); err != nil {
+	if _, err := identity.ProcessSandboxToken(ctx, c, sbxForInit, rtOpts...); err != nil {
 		return fmt.Errorf("failed to reinitialize security token after resume: %w", err)
 	}
 	logger.Info("security token re-issued after resume or upgrade")

--- a/pkg/controller/sandbox/core/security_token_reinit_test.go
+++ b/pkg/controller/sandbox/core/security_token_reinit_test.go
@@ -32,6 +32,7 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/agent-runtime/storages"
 	"github.com/openkruise/agents/pkg/identity"
+	utilruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 // fakeReinitProvider is a test IdentityProvider that records issue/propagate
@@ -54,7 +55,8 @@ func (f *fakeReinitProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.San
 	return f.resp, nil
 }
 
-func (f *fakeReinitProvider) PropagateSecurityToken(_ context.Context, sbx *agentsv1alpha1.Sandbox, _ *identity.TokenResponse) error {
+func (f *fakeReinitProvider) PropagateSecurityToken(_ context.Context, sbx *agentsv1alpha1.Sandbox, _ *identity.TokenResponse,
+	_ ...utilruntime.Option) error {
 	f.propagateCalls++
 	f.gotPropSbx = sbx
 	return f.propagateErr

--- a/pkg/controller/securitytokenrefresh/core/refresher.go
+++ b/pkg/controller/securitytokenrefresh/core/refresher.go
@@ -29,13 +29,15 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/identity"
+	utilruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 // Refresher performs the actual security-token refresh on a single sandbox.
 //
 // Implementations must guarantee the following ordering invariants:
 //  1. Issue a new token via identity.IssueSandboxToken.
-//  2. Propagate the new token to the runtime via identity.PropagateSandboxToken.
+//  2. Propagate the new token to the runtime via identity.PropagateSandboxToken,
+//     over the transport resolved for the sandbox.
 //  3. Only after a successful propagation, patch the sandbox annotation
 //     identity.AgentKeyTokenRefreshStatus with the new expiration.
 //
@@ -52,13 +54,21 @@ type Refresher interface {
 // It is the production implementation used by the security-token-refresh controller.
 type defaultRefresher struct {
 	client client.Client
+	// tlsBundle is the client TLS bundle used to reach TLS-capable sandboxes.
+	// Nil means this process holds no runtime certificates, which is only
+	// compatible with sandboxes that do not advertise the TLS capability.
+	tlsBundle *utilruntime.TLSBundle
 }
 
 // NewDefaultRefresher constructs the production Refresher backed by the given
 // controller-runtime client. The client is used to patch the sandbox annotation
 // once the new token has been propagated successfully.
-func NewDefaultRefresher(c client.Client) Refresher {
-	return &defaultRefresher{client: c}
+//
+// tlsBundle carries the runtime client certificates so a refreshed token is
+// delivered over the same transport the claim and post-resume flows use. It may
+// be nil when runtime TLS is not configured for this process.
+func NewDefaultRefresher(c client.Client, tlsBundle *utilruntime.TLSBundle) Refresher {
+	return &defaultRefresher{client: c, tlsBundle: tlsBundle}
 }
 
 // Refresh executes the issue → propagate → patch sequence described on Refresher.
@@ -68,12 +78,23 @@ func NewDefaultRefresher(c client.Client) Refresher {
 func (r *defaultRefresher) Refresh(ctx context.Context, sbx *agentsv1alpha1.Sandbox) (*identity.TokenResponse, error) {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx))
 
+	// Resolve the transport before spending an issuance call: a sandbox that
+	// advertises the TLS capability while this controller holds no bundle is a
+	// configuration error, and delivering the credential in plaintext instead
+	// would be a security regression. Resolving per refresh (rather than once at
+	// startup) is required because the Pod IP and the advertised capability can
+	// change across pause/resume cycles.
+	rtOpts, err := utilruntime.TransportOptionsFor(sbx, r.tlsBundle)
+	if err != nil {
+		return nil, fmt.Errorf("resolve runtime transport: %w", err)
+	}
+
 	tokenResp, err := identity.IssueSandboxToken(ctx, sbx)
 	if err != nil {
 		return nil, fmt.Errorf("issue token: %w", err)
 	}
 
-	if err := identity.PropagateSandboxToken(ctx, sbx, tokenResp); err != nil {
+	if err := identity.PropagateSandboxToken(ctx, sbx, tokenResp, rtOpts...); err != nil {
 		return nil, fmt.Errorf("propagate token: %w", err)
 	}
 

--- a/pkg/controller/securitytokenrefresh/core/refresher_test.go
+++ b/pkg/controller/securitytokenrefresh/core/refresher_test.go
@@ -31,6 +31,7 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/identity"
+	utilruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 // stubIdentityProvider is a hand-rolled IdentityProvider that returns the configured
@@ -42,6 +43,10 @@ type stubIdentityProvider struct {
 	propagateErr   error
 	propagateCalls int
 	issueCalls     int
+	// gotPropOpts records how many transport options the propagation phase
+	// received, which is how the tests observe that the refresher forwards the
+	// resolved transport instead of silently delivering the token in plaintext.
+	gotPropOpts int
 }
 
 func (s *stubIdentityProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ identity.TokenKind) (*identity.TokenResponse, error) {
@@ -52,8 +57,10 @@ func (s *stubIdentityProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.S
 	return s.resp, nil
 }
 
-func (s *stubIdentityProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *identity.TokenResponse) error {
+func (s *stubIdentityProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *identity.TokenResponse,
+	rtOpts ...utilruntime.Option) error {
 	s.propagateCalls++
+	s.gotPropOpts = len(rtOpts)
 	return s.propagateErr
 }
 
@@ -94,8 +101,19 @@ func TestDefaultRefresher_Refresh(t *testing.T) {
 		name string
 		// stub configures the global identity provider for the duration of the case.
 		stub *stubIdentityProvider
+		// tlsPortAnnotation, when set, makes the sandbox advertise the runtime TLS
+		// capability so the transport resolution branch is exercised.
+		tlsPortAnnotation string
+		// tlsBundle is the client certificate material handed to the refresher.
+		tlsBundle *utilruntime.TLSBundle
 		// expectErr is the substring expected in the returned error (empty == no error).
 		expectErr string
+		// expectNoIssue asserts the failure happened before any token was minted,
+		// so a misconfiguration never burns an identity-provider issuance call.
+		expectNoIssue bool
+		// expectPropOpts is the number of transport options the propagation phase
+		// must receive. Zero means the legacy plaintext path.
+		expectPropOpts int
 		// expectAnnotation is the value the sandbox annotation should have AFTER Refresh.
 		// Empty means "annotation must remain unchanged".
 		expectAnnotation string
@@ -128,6 +146,32 @@ func TestDefaultRefresher_Refresh(t *testing.T) {
 			},
 			expectErr: "propagate token",
 		},
+		{
+			// A sandbox advertising the TLS capability while this controller holds
+			// no certificates must fail loudly: refreshing over plaintext instead
+			// would hand the credential to the network in clear text. The failure
+			// has to precede issuance so the misconfiguration costs nothing.
+			name: "TLS-capable sandbox without a bundle -> transport error before issuance",
+			stub: &stubIdentityProvider{
+				resp: &identity.TokenResponse{AccessToken: "fresh", AccessTokenExpiration: newExpire},
+			},
+			tlsPortAnnotation: "49984",
+			expectErr:         "resolve runtime transport",
+			expectNoIssue:     true,
+		},
+		{
+			// The resolved TLS options (WithTLS + WithTLSPort) must reach the
+			// propagator so the refreshed credential rides the same HTTPS
+			// transport as the claim and post-resume flows.
+			name: "TLS-capable sandbox with a bundle -> propagation receives the TLS options",
+			stub: &stubIdentityProvider{
+				resp: &identity.TokenResponse{AccessToken: "fresh", AccessTokenExpiration: newExpire},
+			},
+			tlsPortAnnotation: "49984",
+			tlsBundle:         &utilruntime.TLSBundle{CABundle: []byte("pem")},
+			expectPropOpts:    2,
+			expectAnnotation:  `{"accessTokenExpiration":"` + newExpire + `"}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -135,8 +179,11 @@ func TestDefaultRefresher_Refresh(t *testing.T) {
 			withProvider(t, tt.stub)
 
 			sbx := newSandbox("sbx-1")
+			if tt.tlsPortAnnotation != "" {
+				sbx.Annotations[agentsv1alpha1.AnnotationRuntimeTLSPort] = tt.tlsPortAnnotation
+			}
 			c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(sbx).Build()
-			r := NewDefaultRefresher(c)
+			r := NewDefaultRefresher(c, tt.tlsBundle)
 
 			_, err := r.Refresh(context.Background(), sbx.DeepCopy())
 			if tt.expectErr == "" {
@@ -150,11 +197,17 @@ func TestDefaultRefresher_Refresh(t *testing.T) {
 			require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "sbx-1", Namespace: "default"}, got))
 
 			if tt.expectErr != "" {
+				if tt.expectNoIssue {
+					assert.Zero(t, tt.stub.issueCalls, "no token may be minted when the transport cannot be resolved")
+					assert.Zero(t, tt.stub.propagateCalls, "propagation must not run when the transport cannot be resolved")
+				}
 				assert.Equal(t, sbx.Annotations[identity.AgentKeyTokenRefreshStatus],
 					got.Annotations[identity.AgentKeyTokenRefreshStatus],
 					"annotation must NOT change when an upstream step fails")
 				return
 			}
+			assert.Equal(t, tt.expectPropOpts, tt.stub.gotPropOpts,
+				"the propagation phase must receive exactly the transport resolved for the sandbox")
 			if tt.expectAnnotation != "" {
 				assert.Equal(t, tt.expectAnnotation, got.Annotations[identity.AgentKeyTokenRefreshStatus])
 			}
@@ -177,7 +230,7 @@ func TestDefaultRefresher_PatchAnnotation_NilAnnotations(t *testing.T) {
 	sbx.Annotations = nil
 
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(sbx).Build()
-	r := NewDefaultRefresher(c)
+	r := NewDefaultRefresher(c, nil)
 
 	_, err := r.Refresh(context.Background(), sbx.DeepCopy())
 	require.NoError(t, err)

--- a/pkg/controller/securitytokenrefresh/token_refresh_controller.go
+++ b/pkg/controller/securitytokenrefresh/token_refresh_controller.go
@@ -50,6 +50,7 @@ import (
 	"github.com/openkruise/agents/pkg/features"
 	"github.com/openkruise/agents/pkg/identity"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
+	utilruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 const (
@@ -149,7 +150,10 @@ func runSetupHooks(mgr manager.Manager) error {
 	return nil
 }
 
-func Add(mgr manager.Manager) error {
+// Add registers the security-token-refresh controller. runtimeTLSBundle is the
+// client TLS bundle used to deliver a refreshed token to TLS-capable sandboxes;
+// nil means runtime TLS is not configured for this process.
+func Add(mgr manager.Manager, runtimeTLSBundle *utilruntime.TLSBundle) error {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.SecurityIdentityProviderGate) ||
 		!discovery.DiscoverGVK(securityTokenRefreshControllerKind) {
 		return nil
@@ -159,7 +163,7 @@ func Add(mgr manager.Manager) error {
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
 		Recorder:  mgr.GetEventRecorderFor(controllerName),
-		refresher: core.NewDefaultRefresher(mgr.GetClient()),
+		refresher: core.NewDefaultRefresher(mgr.GetClient(), runtimeTLSBundle),
 		now:       time.Now,
 		// rand.Float64 returns [0,1); centred to [-1,1) below for symmetric jitter.
 		randFloat: rand.Float64,

--- a/pkg/controller/securitytokenrefresh/token_refresh_controller_test.go
+++ b/pkg/controller/securitytokenrefresh/token_refresh_controller_test.go
@@ -885,7 +885,7 @@ func TestAdd_FeatureGateDisabled(t *testing.T) {
 	})
 
 	mgr := &fakeManager{t: t}
-	err := Add(mgr)
+	err := Add(mgr, nil)
 	assert.NoError(t, err, "Add must return nil when the feature gate is disabled")
 	assert.False(t, called, "setup hooks must not run when the feature gate is disabled")
 }

--- a/pkg/identity/common_provider.go
+++ b/pkg/identity/common_provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/uuid"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	agentsruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 // defaultAccessTokenLifetime is the lifetime the community default provider
@@ -62,7 +63,9 @@ func (u *defaultTokenProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.S
 }
 
 // PropagateSecurityToken is a no-op for the default provider.
-// Community mode has no propagators registered.
-func (u *defaultTokenProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse) error {
+// Community mode has no propagators registered, so it never reaches the sandbox
+// runtime and the resolved transport in rtOpts is irrelevant here.
+func (u *defaultTokenProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse,
+	_ ...agentsruntime.Option) error {
 	return nil
 }

--- a/pkg/identity/default_provider.go
+++ b/pkg/identity/default_provider.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	agentsruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 // provider is the global IdentityProvider instance.
@@ -54,6 +55,9 @@ func IssueToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, kind TokenKind
 
 // PropagateSecurityToken delegates to the registered provider to execute
 // post-token processing (e.g., writing credentials into the sandbox runtime).
-func PropagateSecurityToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tokenResp *TokenResponse) error {
-	return provider.PropagateSecurityToken(ctx, sbx, tokenResp)
+// rtOpts is forwarded verbatim so the provider reaches the sandbox over the
+// transport the caller resolved.
+func PropagateSecurityToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tokenResp *TokenResponse,
+	rtOpts ...agentsruntime.Option) error {
+	return provider.PropagateSecurityToken(ctx, sbx, tokenResp, rtOpts...)
 }

--- a/pkg/identity/interface.go
+++ b/pkg/identity/interface.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	agentsruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 // IdentityProvider is the unified interface for sandbox identity management.
@@ -53,5 +54,15 @@ type IdentityProvider interface {
 
 	// PropagateSecurityToken executes post-token processing after a token is issued,
 	// such as writing credentials into the sandbox runtime.
-	PropagateSecurityToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tokenResp *TokenResponse) error
+	//
+	// rtOpts carries the transport the caller resolved for this sandbox (see
+	// runtime.TransportOptionsFor): non-empty means the sandbox is reached over
+	// HTTPS with forced resolution, empty means the legacy plaintext runtime URL.
+	// Implementations that touch the sandbox runtime MUST forward it to the
+	// runtime client so propagation rides the same transport as the rest of the
+	// flow; implementations that never reach the runtime ignore it. This package
+	// only carries the value — it never resolves or overrides the transport
+	// itself, keeping the TLS decision at the caller's boundary.
+	PropagateSecurityToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tokenResp *TokenResponse,
+		rtOpts ...agentsruntime.Option) error
 }

--- a/pkg/identity/process_sandbox_token_test.go
+++ b/pkg/identity/process_sandbox_token_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	agentsruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 // fakeProcessProvider is an IdentityProvider stub that records issue/propagate
@@ -43,6 +44,10 @@ type fakeProcessProvider struct {
 	resp           *TokenResponse
 	issueErr       error
 	propagateErr   error
+	// gotPropOpts records how many transport options reached the propagation
+	// phase, so the tests can assert that ProcessSandboxToken forwards the
+	// caller-resolved transport verbatim instead of dropping it.
+	gotPropOpts int
 }
 
 func (f *fakeProcessProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ TokenKind) (*TokenResponse, error) {
@@ -53,8 +58,10 @@ func (f *fakeProcessProvider) IssueToken(_ context.Context, _ *agentsv1alpha1.Sa
 	return f.resp, nil
 }
 
-func (f *fakeProcessProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse) error {
+func (f *fakeProcessProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse,
+	rtOpts ...agentsruntime.Option) error {
 	f.propagateCalls++
+	f.gotPropOpts = len(rtOpts)
 	return f.propagateErr
 }
 
@@ -74,14 +81,18 @@ func TestProcessSandboxToken(t *testing.T) {
 	const expiration = "2030-01-01T00:00:00Z"
 
 	tests := []struct {
-		name            string
-		agentName       string // sets the agent-name annotation to mimic an opted-in sandbox
-		issueErr        error
-		propagateErr    error
-		patchFails      bool
+		name         string
+		agentName    string // sets the agent-name annotation to mimic an opted-in sandbox
+		issueErr     error
+		propagateErr error
+		patchFails   bool
+		// rtOpts is the transport the caller resolved for the sandbox; it must
+		// reach the propagator unchanged.
+		rtOpts          []agentsruntime.Option
 		expectError     string
 		expectIssue     int
 		expectPropagate int
+		expectPropOpts  int
 		expectAnnotated bool // whether the token-status annotation should be persisted
 	}{
 		{
@@ -89,6 +100,18 @@ func TestProcessSandboxToken(t *testing.T) {
 			agentName:       "my-agent",
 			expectIssue:     1,
 			expectPropagate: 1,
+			expectAnnotated: true,
+		},
+		{
+			// The claim/clone/post-resume callers hand the resolved TLS transport
+			// down; without this forwarding an enterprise propagator would deliver
+			// the credential over plaintext to a TLS-capable sandbox.
+			name:            "success - resolved transport is forwarded to the propagator",
+			agentName:       "my-agent",
+			rtOpts:          []agentsruntime.Option{agentsruntime.WithTLSPort(49984), agentsruntime.WithAuthority("runtime.example")},
+			expectIssue:     1,
+			expectPropagate: 1,
+			expectPropOpts:  2,
 			expectAnnotated: true,
 		},
 		{
@@ -153,7 +176,7 @@ func TestProcessSandboxToken(t *testing.T) {
 			}
 			c := builder.Build()
 
-			cost, err := ProcessSandboxToken(context.Background(), c, sbx)
+			cost, err := ProcessSandboxToken(context.Background(), c, sbx, tt.rtOpts...)
 
 			if tt.expectError != "" {
 				require.Error(t, err)
@@ -164,6 +187,8 @@ func TestProcessSandboxToken(t *testing.T) {
 			}
 			assert.Equal(t, tt.expectIssue, fp.issueCalls, "unexpected IssueToken call count")
 			assert.Equal(t, tt.expectPropagate, fp.propagateCalls, "unexpected PropagateSecurityToken call count")
+			assert.Equal(t, tt.expectPropOpts, fp.gotPropOpts,
+				"the propagator must receive exactly the transport options the caller passed in")
 
 			// In-memory annotation mirroring: only present on a fully successful run.
 			raw, present := sbx.GetAnnotations()[AgentKeyTokenRefreshStatus]

--- a/pkg/identity/sandbox_token_helper.go
+++ b/pkg/identity/sandbox_token_helper.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	agentsruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 // IsIDTokenRequested reports whether the sandbox opts into the ID token
@@ -182,11 +183,17 @@ func validateAccessTokenResponse(resp *TokenResponse) error {
 // The error returned by the underlying provider is surfaced verbatim so
 // callers can decide their own retry / event semantics; this function never
 // wraps or rewrites it.
-func PropagateSandboxToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tokenResp *TokenResponse) error {
+//
+// rtOpts is the transport the caller resolved for this sandbox and is forwarded
+// verbatim to the propagators. This function neither resolves nor inspects it:
+// the TLS decision belongs to the caller (see runtime.TransportOptionsFor), so
+// this package stays transport-neutral.
+func PropagateSandboxToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tokenResp *TokenResponse,
+	rtOpts ...agentsruntime.Option) error {
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx), "action", "PropagateSandboxToken")
 	start := time.Now()
 	log.Info("propagating sandbox security token", "propagatorCount", SecurityTokenPropagatorCount())
-	if err := PropagateSecurityToken(ctx, sbx, tokenResp); err != nil {
+	if err := PropagateSecurityToken(ctx, sbx, tokenResp, rtOpts...); err != nil {
 		log.Error(err, "failed to propagate sandbox security token", "cost", time.Since(start))
 		return err
 	}
@@ -217,7 +224,15 @@ func PropagateSandboxToken(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tok
 // (issue + propagate + record) is returned so callers can record metrics; on
 // failure the returned cost still reflects the elapsed time up to the failing
 // phase.
-func ProcessSandboxToken(ctx context.Context, c client.Client, sbx *agentsv1alpha1.Sandbox) (time.Duration, error) {
+//
+// rtOpts is the transport the caller resolved for this sandbox (typically via
+// runtime.TransportOptionsFor) and is forwarded to the propagation phase, so a
+// TLS-capable sandbox receives its credential over the same transport the
+// /init handshake and the CSI mounts use. Issuance and the annotation patch are
+// unaffected: they talk to the identity provider and the apiserver, not to the
+// sandbox runtime.
+func ProcessSandboxToken(ctx context.Context, c client.Client, sbx *agentsv1alpha1.Sandbox,
+	rtOpts ...agentsruntime.Option) (time.Duration, error) {
 	// Measure the whole issue -> propagate -> record lifecycle so callers record
 	// the total cost of the security-token step, not just token issuance.
 	start := time.Now()
@@ -229,7 +244,7 @@ func ProcessSandboxToken(ctx context.Context, c client.Client, sbx *agentsv1alph
 		return time.Since(start), err
 	}
 
-	if err := PropagateSandboxToken(ctx, sbx, tokenResp); err != nil {
+	if err := PropagateSandboxToken(ctx, sbx, tokenResp, rtOpts...); err != nil {
 		return time.Since(start), fmt.Errorf("failed to propagate security token: %w", err)
 	}
 

--- a/pkg/identity/sandbox_token_helper_test.go
+++ b/pkg/identity/sandbox_token_helper_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	agentsruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 // fakeIdentityProvider is a minimal IdentityProvider stub used to capture the
@@ -47,7 +48,8 @@ func (f *fakeIdentityProvider) IssueToken(_ context.Context, sbx *agentsv1alpha1
 	return f.resp, f.err
 }
 
-func (f *fakeIdentityProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse) error {
+func (f *fakeIdentityProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse,
+	_ ...agentsruntime.Option) error {
 	return nil
 }
 
@@ -111,7 +113,8 @@ func (p *kindCapturingProvider) IssueToken(_ context.Context, sbx *agentsv1alpha
 	return p.resp, p.err
 }
 
-func (p *kindCapturingProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse) error {
+func (p *kindCapturingProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse,
+	_ ...agentsruntime.Option) error {
 	return nil
 }
 
@@ -373,7 +376,8 @@ func (p *annotationReadingProvider) IssueToken(_ context.Context, sbx *agentsv1a
 	return &TokenResponse{AccessToken: "tok"}, nil
 }
 
-func (p *annotationReadingProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse) error {
+func (p *annotationReadingProvider) PropagateSecurityToken(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse,
+	_ ...agentsruntime.Option) error {
 	return nil
 }
 
@@ -513,7 +517,8 @@ func (p *propagatingFakeProvider) IssueToken(_ context.Context, _ *agentsv1alpha
 	return nil, nil
 }
 
-func (p *propagatingFakeProvider) PropagateSecurityToken(_ context.Context, sbx *agentsv1alpha1.Sandbox, resp *TokenResponse) error {
+func (p *propagatingFakeProvider) PropagateSecurityToken(_ context.Context, sbx *agentsv1alpha1.Sandbox, resp *TokenResponse,
+	_ ...agentsruntime.Option) error {
 	p.calls++
 	p.gotSandbox = sbx
 	p.gotResp = resp

--- a/pkg/identity/security_token_propagator.go
+++ b/pkg/identity/security_token_propagator.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/klog/v2"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	agentsruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 // SecurityTokenPropagator is a function that propagates an issued security token
@@ -32,11 +33,18 @@ import (
 //   - ctx: The context carrying logging and cancellation.
 //   - sbx: The claimed sandbox Kubernetes object (used to derive runtime URL, access token, etc.).
 //   - tokenResp: The issued token response to be written into the sandbox runtime.
+//   - rtOpts: The transport the caller resolved for this sandbox (see
+//     runtime.TransportOptionsFor). A propagator that reaches the sandbox runtime
+//     must forward it to the runtime client (e.g. as the trailing argument of
+//     WriteFileWithRuntime or ChmodFileOnRuntime) so the credential is delivered
+//     over the same transport the rest of the flow uses; an empty slice keeps the
+//     legacy plaintext path.
 //
 // Community default: No propagators registered — this is a no-op.
 // Enterprise deployment: Register propagators via RegisterSecurityTokenPropagator() to inject
 // tokens into the sandbox runtime (e.g., write credential files via RunCommand).
-type SecurityTokenPropagator func(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tokenResp *TokenResponse) error
+type SecurityTokenPropagator func(ctx context.Context, sbx *agentsv1alpha1.Sandbox, tokenResp *TokenResponse,
+	rtOpts ...agentsruntime.Option) error
 
 // securityTokenPropagators holds all registered propagator functions.
 // Enterprise packages register handlers here during init() via RegisterSecurityTokenPropagator().

--- a/pkg/identity/security_token_propagator_test.go
+++ b/pkg/identity/security_token_propagator_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	agentsruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 func TestRegisterSecurityTokenPropagator(t *testing.T) {
@@ -35,13 +36,15 @@ func TestRegisterSecurityTokenPropagator(t *testing.T) {
 	assert.Equal(t, 0, SecurityTokenPropagatorCount())
 
 	// Register first propagator.
-	RegisterSecurityTokenPropagator(func(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse) error {
+	RegisterSecurityTokenPropagator(func(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse,
+		_ ...agentsruntime.Option) error {
 		return nil
 	})
 	assert.Equal(t, 1, SecurityTokenPropagatorCount())
 
 	// Register second propagator.
-	RegisterSecurityTokenPropagator(func(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse) error {
+	RegisterSecurityTokenPropagator(func(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *TokenResponse,
+		_ ...agentsruntime.Option) error {
 		return fmt.Errorf("err")
 	})
 	assert.Equal(t, 2, SecurityTokenPropagatorCount())

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -373,7 +373,9 @@ func runClaimPostProcesses(ctx context.Context, sbx *Sandbox, lockType infra.Loc
 	// injected by modifyPickedSandbox.
 	if identity.IsIDTokenRequested(sbx.Sandbox) {
 		var err error
-		metrics.SecurityToken, err = identity.ProcessSandboxToken(ctx, cache.GetClient(), sbx.Sandbox)
+		// rtOpts rides along so the credential is delivered over the same transport
+		// the /init handshake and the CSI mounts use.
+		metrics.SecurityToken, err = identity.ProcessSandboxToken(ctx, cache.GetClient(), sbx.Sandbox, rtOpts...)
 		if err != nil {
 			return retriableError{Message: fmt.Sprintf("failed to process security token: %s", err)}
 		}

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -4161,7 +4161,8 @@ func (m *mockIdentityProvider) IssueToken(ctx context.Context, sbx *v1alpha1.San
 	return &identity.TokenResponse{AccessToken: uuid.NewString()}, nil
 }
 
-func (m *mockIdentityProvider) PropagateSecurityToken(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse) error {
+func (m *mockIdentityProvider) PropagateSecurityToken(ctx context.Context, sbx *v1alpha1.Sandbox, tokenResp *identity.TokenResponse,
+	_ ...runtime.Option) error {
 	if m.propagateFunc != nil {
 		return m.propagateFunc(ctx, sbx, tokenResp)
 	}

--- a/pkg/sandbox-manager/infra/sandboxcr/clone.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/clone.go
@@ -193,8 +193,10 @@ func CloneSandbox(ctx context.Context, opts infra.CloneSandboxOptions, cache inf
 	// Step 6: process security token
 	// Issue and propagate the identity-provider security token before performing
 	// access-token issuance and CSI mounts, mirroring the claim flow ordering.
+	// rtOpts rides along so the credential is delivered over the same transport
+	// as the re-init handshake.
 	if identity.IsIDTokenRequested(sbx.Sandbox) {
-		metrics.SecurityToken, err = identity.ProcessSandboxToken(ctx, cache.GetClient(), sbx.Sandbox)
+		metrics.SecurityToken, err = identity.ProcessSandboxToken(ctx, cache.GetClient(), sbx.Sandbox, rtOpts...)
 		if err != nil {
 			if !wait.Interrupted(err) {
 				err = retriableError{Message: fmt.Sprintf("security token processing failed: %s", err)}

--- a/pkg/utils/runtime/client.go
+++ b/pkg/utils/runtime/client.go
@@ -91,6 +91,12 @@ type Runtime interface {
 	// Init returns the initialization capability group, backed by the runtime
 	// /init handshake endpoint.
 	Init() InitAPI
+	// Filesystem returns the filesystem capability group, backed by the
+	// E2B-compatible multipart /files route and the envd Filesystem service.
+	Filesystem() FilesystemAPI
+	// Process returns the process capability group, backed by the envd Process
+	// service.
+	Process() ProcessAPI
 }
 
 // Option customizes a Runtime constructed by NewRuntime.
@@ -245,6 +251,47 @@ func (r *runtimeClient) Init() InitAPI {
 	return &initAPI{r: r}
 }
 
+// Filesystem returns the filesystem capability group for the bound sandbox.
+func (r *runtimeClient) Filesystem() FilesystemAPI {
+	return &filesystemAPI{r: r}
+}
+
+// Process returns the process capability group for the bound sandbox.
+func (r *runtimeClient) Process() ProcessAPI {
+	return &processAPI{r: r}
+}
+
+// resolveTransport resolves the endpoint and the HTTP client for a single call
+// against sbx, and is the single place where the plain-HTTP/TLS decision is
+// applied. Every capability group routes through it, so the JSON, multipart and
+// connect-gRPC protocols cannot drift apart on addressing or TLS.
+//
+// plainClient is the client used when TLS is off. It is a parameter rather than
+// r.client because each protocol keeps its own plaintext client (the shared
+// JSON one, runtimeFilesHTTPClient, runtimeGRPCHTTPClient), which tests
+// substitute independently; passing it in preserves that seam untouched.
+//
+// In TLS mode the returned client carries a per-call pinned transport: the
+// request is addressed by authority (so the certificate validates) while the
+// connection goes to the sandbox Pod IP. The transport is rebuilt per call
+// because a refresh may change the Pod IP between attempts.
+func (r *runtimeClient) resolveTransport(sbx *agentsv1alpha1.Sandbox, plainClient *http.Client) (string, *http.Client, error) {
+	// A TLS-config construction failure is permanent: report it before spending
+	// an attempt on a client that cannot handshake.
+	if r.tlsEnabled && r.tlsConfigErr != nil {
+		return "", nil, fmt.Errorf("invalid runtime TLS configuration: %w", r.tlsConfigErr)
+	}
+	base := r.resolveBaseURL(sbx)
+	if base == "" {
+		return "", nil, fmt.Errorf("runtime url not found on sandbox")
+	}
+	client := plainClient
+	if dialIP := r.dialIPFor(sbx); dialIP != "" {
+		client = &http.Client{Transport: newPinnedTransport(dialIP, r.tlsPort, r.tlsClientConfig.Clone())}
+	}
+	return base, client, nil
+}
+
 // resolveBaseURL resolves the runtime endpoint for the given sandbox. In TLS
 // mode (see WithTLS) it returns the HTTPS authority URL
 // (https://<authority>:<tlsPort>) so net/http derives the Host header and TLS
@@ -358,9 +405,12 @@ func (r *runtimeClient) call(ctx context.Context, method, path string, reqBody, 
 			}
 		}
 
-		base := r.resolveBaseURL(sbx)
-		if base == "" {
-			return fmt.Errorf("runtime url not found on sandbox")
+		// The endpoint and the client are resolved together so this JSON path
+		// applies exactly the same TLS decision as the multipart and connect-gRPC
+		// capability groups (see resolveTransport).
+		base, httpClient, err := r.resolveTransport(sbx, r.client)
+		if err != nil {
+			return err
 		}
 		endpoint := strings.TrimRight(base, "/") + path
 
@@ -384,17 +434,6 @@ func (r *runtimeClient) call(ctx context.Context, method, path string, reqBody, 
 		// Basic user credential is caller-supplied (WithAuthUser); absent by default.
 		if r.authUser != "" {
 			req.Header.Set("Authorization", basicAuthHeader(r.authUser))
-		}
-
-		// In automatic TLS mode dial the sandbox Pod IP while verifying the server
-		// certificate against the authority hostname (curl --resolve). The pinned
-		// transport is built per attempt because WithRefresh may change the Pod IP
-		// between retries; it disables keep-alives so the discarded transport does
-		// not strand an idle TLS connection (see newPinnedTransport). Otherwise use
-		// the shared plain-HTTP client.
-		httpClient := r.client
-		if dialIP := r.dialIPFor(sbx); dialIP != "" {
-			httpClient = &http.Client{Transport: newPinnedTransport(dialIP, r.tlsPort, r.tlsClientConfig.Clone())}
 		}
 
 		start := time.Now()

--- a/pkg/utils/runtime/filesystem.go
+++ b/pkg/utils/runtime/filesystem.go
@@ -42,6 +42,89 @@ import (
 	"github.com/openkruise/agents/proto/envd/filesystem/filesystemconnect"
 )
 
+// FilesystemAPI is the runtime filesystem capability group. It covers the
+// E2B-compatible multipart /files route (Write) and the envd Filesystem service
+// (ListDir, Remove).
+//
+// Every method is addressed through the transport resolved by the owning
+// runtimeClient, so a TLS-capable sandbox is reached over HTTPS with the same
+// forced resolution the JSON routes use, while a legacy sandbox keeps the
+// plaintext runtime URL. The group is bound to one sandbox at construction
+// time, so no method takes a *Sandbox argument.
+type FilesystemAPI interface {
+	// Write pushes a single file into the sandbox, unconditionally overwriting
+	// any pre-existing file at the same path.
+	Write(ctx context.Context, req WriteFileRequest) (WriteFileResult, error)
+	// ListDir lists the entries of a directory inside the sandbox.
+	ListDir(ctx context.Context, req ListDirRequest) ([]*filesystem.EntryInfo, error)
+	// Remove deletes a file or directory inside the sandbox. Directory removal is
+	// recursive.
+	Remove(ctx context.Context, req RemovePathRequest) error
+}
+
+// WriteFileRequest describes a single file write. It is WriteFileArgs without
+// the sandbox, which the capability group already carries.
+type WriteFileRequest struct {
+	// FilePath is the absolute file path inside the sandbox runtime where Content
+	// will be materialized. The parent directory must already exist on the
+	// runtime side.
+	FilePath string
+	// Content is the raw file body, uploaded as-is via multipart/form-data.
+	Content []byte
+	// Username is the OS user the runtime should use when writing the file.
+	// Defaults to defaultRuntimeFilesUsername ("root") when empty.
+	Username string
+	// AuthUser is the user identity sent as an HTTP Basic Authorization header
+	// (empty password). Empty means no Authorization header is sent.
+	AuthUser string
+	// Timeout bounds the duration of a single HTTP write request. Defaults to
+	// defaultRuntimeWriteTimeout when zero or negative.
+	Timeout time.Duration
+	// Permissions is the intended UNIX file mode of the written file. It is
+	// currently NOT transmitted: the runtime applies its default permissions
+	// (typically 0644 derived from umask), and a caller that needs an exact mode
+	// must follow the write with ProcessAPI.Chmod. The field is retained because
+	// it records the caller's intent and becomes effective without a call-site
+	// change once the runtime honors an explicit file-mode header.
+	Permissions os.FileMode
+}
+
+// ListDirRequest describes a directory listing. It is ListDirArgs without the
+// sandbox, which the capability group already carries.
+type ListDirRequest struct {
+	// Path is the directory to list inside the sandbox.
+	Path string
+	// Depth bounds how deep the listing descends. Zero means the runtime default
+	// of 1, i.e. the direct children of Path.
+	Depth uint32
+	// AuthUser is the user identity sent as an HTTP Basic Authorization header
+	// (empty password). It is required: the Filesystem service resolves every
+	// path relative to an authenticated user and rejects requests without one.
+	AuthUser string
+	// Timeout bounds the RPC. Defaults to defaultRuntimeFilesystemTimeout when
+	// zero or negative.
+	Timeout time.Duration
+}
+
+// RemovePathRequest describes a removal. It is RemovePathArgs without the
+// sandbox, which the capability group already carries.
+type RemovePathRequest struct {
+	// Path is the file or directory to remove inside the sandbox.
+	Path string
+	// AuthUser is the user identity sent as an HTTP Basic Authorization header
+	// (empty password), required for the same reason as in ListDirRequest.
+	AuthUser string
+	// Timeout bounds the RPC. Defaults to defaultRuntimeFilesystemTimeout when
+	// zero or negative.
+	Timeout time.Duration
+}
+
+// filesystemAPI is the default FilesystemAPI implementation. It delegates
+// transport to the owning runtimeClient and carries no domain logic of its own.
+type filesystemAPI struct {
+	r *runtimeClient
+}
+
 // WriteFileArgs are the arguments accepted by WriteFileWithRuntime.
 type WriteFileArgs struct {
 	// Sbx is the target sandbox. Its annotations supply the runtime URL and access token,
@@ -64,10 +147,10 @@ type WriteFileArgs struct {
 	// Timeout bounds the duration of a single HTTP write request. Defaults to
 	// defaultRuntimeWriteTimeout when zero or negative.
 	Timeout time.Duration
-	// Permissions is the UNIX file mode applied to the written file by the runtime after
-	// creation (e.g. 0600 for credential files, 0644 for non-sensitive files). When zero,
-	// the runtime applies its default permissions (typically 0644 derived from umask).
-	// Transmitted to the agent-runtime via the X-File-Mode HTTP header as an octal string.
+	// Permissions is the intended UNIX file mode of the written file (e.g. 0600
+	// for credential files). See WriteFileRequest.Permissions: the mode is not
+	// transmitted today, so a caller needing an exact mode must follow the write
+	// with ChmodFileOnRuntime.
 	Permissions os.FileMode
 }
 
@@ -114,58 +197,83 @@ var runtimeFilesHTTPClient = &http.Client{}
 // This function is intended as the standard counterpart to RunCommandWithRuntime: any
 // caller that needs to push a file into the sandbox runtime should use it instead of
 // rolling its own HTTP client.
-func WriteFileWithRuntime(ctx context.Context, args WriteFileArgs) (WriteFileResult, error) {
-	sbx := args.Sbx
-	if sbx == nil {
+//
+// rtOpts selects the transport for this sandbox: non-empty (typically the TLS
+// options resolved by TransportOptionsFor) routes the write over HTTPS to the
+// agent-runtime, empty keeps the legacy plaintext runtime URL. The call is
+// delegated to FilesystemAPI.Write, which owns the implementation.
+func WriteFileWithRuntime(ctx context.Context, args WriteFileArgs, rtOpts ...Option) (WriteFileResult, error) {
+	// Keep the nil-sandbox guard here: NewRuntime binds the sandbox at
+	// construction time, so a nil one would otherwise surface later as an
+	// unresolved endpoint instead of naming the actual programming error.
+	if args.Sbx == nil {
 		return WriteFileResult{}, fmt.Errorf("sandbox is nil")
 	}
-	if args.FilePath == "" {
+	return NewRuntime(args.Sbx, rtOpts...).Filesystem().Write(ctx, WriteFileRequest{
+		FilePath:    args.FilePath,
+		Content:     args.Content,
+		Username:    args.Username,
+		AuthUser:    args.AuthUser,
+		Timeout:     args.Timeout,
+		Permissions: args.Permissions,
+	})
+}
+
+// Write implements FilesystemAPI by posting the file content to the runtime
+// files API. It is the single implementation of the write path, shared by the
+// capability group and the WriteFileWithRuntime convenience wrapper.
+func (f *filesystemAPI) Write(ctx context.Context, req WriteFileRequest) (WriteFileResult, error) {
+	if req.FilePath == "" {
 		return WriteFileResult{}, fmt.Errorf("filePath is required")
 	}
+	sbx := f.r.sbx
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx)).V(utils.DebugLogLevel)
 
-	rtURL := GetRuntimeURL(sbx)
-	if rtURL == "" {
-		return WriteFileResult{}, fmt.Errorf("runtime url not found on sandbox")
-	}
-
-	username := args.Username
-	if username == "" {
-		username = defaultRuntimeFilesUsername
-	}
-	timeout := args.Timeout
-	if timeout <= 0 {
-		timeout = defaultRuntimeWriteTimeout
-	}
-
-	body, contentType, err := buildRuntimeFilesMultipartBody(args.FilePath, args.Content)
+	// The multipart write shares the transport decision with every other
+	// capability group; runtimeFilesHTTPClient stays the plaintext client so the
+	// existing test seam keeps working.
+	base, httpClient, err := f.r.resolveTransport(sbx, runtimeFilesHTTPClient)
 	if err != nil {
 		return WriteFileResult{}, err
 	}
 
-	endpoint := buildRuntimeFilesEndpoint(rtURL, args.FilePath, username)
+	username := req.Username
+	if username == "" {
+		username = defaultRuntimeFilesUsername
+	}
+	timeout := req.Timeout
+	if timeout <= 0 {
+		timeout = defaultRuntimeWriteTimeout
+	}
+
+	body, contentType, err := buildRuntimeFilesMultipartBody(req.FilePath, req.Content)
+	if err != nil {
+		return WriteFileResult{}, err
+	}
+
+	endpoint := buildRuntimeFilesEndpoint(base, req.FilePath, username)
 	reqCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, endpoint, body)
+	httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, endpoint, body)
 	if err != nil {
 		return WriteFileResult{}, fmt.Errorf("failed to build runtime files write request: %w", err)
 	}
-	req.Header.Set("Content-Type", contentType)
+	httpReq.Header.Set("Content-Type", contentType)
 	if accessToken := utils.GetAccessToken(sbx); accessToken != "" {
-		req.Header.Set("X-Access-Token", accessToken)
+		httpReq.Header.Set(accessTokenHeader, accessToken)
 	}
 	// The Basic user credential is caller-supplied: it is sent only when
-	// args.AuthUser expresses a user identity for the runtime to resolve.
-	if args.AuthUser != "" {
-		req.Header.Set("Authorization", basicAuthHeader(args.AuthUser))
+	// req.AuthUser expresses a user identity for the runtime to resolve.
+	if req.AuthUser != "" {
+		httpReq.Header.Set("Authorization", basicAuthHeader(req.AuthUser))
 	}
 
 	start := time.Now()
 	log.Info("writing file to runtime via files API",
-		"filePath", args.FilePath,
+		"filePath", req.FilePath,
 		"endpoint", endpoint)
 
-	resp, err := runtimeFilesHTTPClient.Do(req)
+	resp, err := httpClient.Do(httpReq)
 	if err != nil {
 		return WriteFileResult{}, fmt.Errorf("failed to call runtime files API: %w", err)
 	}
@@ -190,7 +298,7 @@ func WriteFileWithRuntime(ctx context.Context, args WriteFileArgs) (WriteFileRes
 	}
 
 	log.Info("file written to runtime successfully (overwrite)",
-		"filePath", args.FilePath,
+		"filePath", req.FilePath,
 		"statusCode", resp.StatusCode,
 		"cost", time.Since(start))
 	return result, nil
@@ -280,26 +388,44 @@ type ListDirArgs struct {
 //     ErrRuntimeFilesystemUnsupported;
 //   - everything else (unauthenticated, path is not a directory, transport
 //     failure) is returned as a plain wrapped error.
-func ListDirWithRuntime(ctx context.Context, args ListDirArgs) ([]*filesystem.EntryInfo, error) {
-	client, callCtx, cancel, err := newFilesystemCall(ctx, args.Sbx, args.Path, args.AuthUser, args.Timeout)
+//
+// rtOpts selects the transport for this sandbox exactly as in
+// WriteFileWithRuntime. The call is delegated to FilesystemAPI.ListDir.
+func ListDirWithRuntime(ctx context.Context, args ListDirArgs, rtOpts ...Option) ([]*filesystem.EntryInfo, error) {
+	if args.Sbx == nil {
+		return nil, fmt.Errorf("sandbox is nil")
+	}
+	return NewRuntime(args.Sbx, rtOpts...).Filesystem().ListDir(ctx, ListDirRequest{
+		Path:     args.Path,
+		Depth:    args.Depth,
+		AuthUser: args.AuthUser,
+		Timeout:  args.Timeout,
+	})
+}
+
+// ListDir implements FilesystemAPI. It is the single implementation of the
+// listing path, shared by the capability group and the ListDirWithRuntime
+// convenience wrapper.
+func (f *filesystemAPI) ListDir(ctx context.Context, req ListDirRequest) ([]*filesystem.EntryInfo, error) {
+	client, callCtx, cancel, err := f.newCall(ctx, req.Path, req.AuthUser, req.Timeout)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
 
-	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(args.Sbx)).V(utils.DebugLogLevel)
+	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(f.r.sbx)).V(utils.DebugLogLevel)
 	start := time.Now()
 
 	resp, err := client.ListDir(callCtx, connect.NewRequest(&filesystem.ListDirRequest{
-		Path:  args.Path,
-		Depth: args.Depth,
+		Path:  req.Path,
+		Depth: req.Depth,
 	}))
 	if err != nil {
-		return nil, classifyFilesystemError("ListDir", args.Path, err)
+		return nil, classifyFilesystemError("ListDir", req.Path, err)
 	}
 
 	entries := resp.Msg.GetEntries()
-	log.Info("listed sandbox runtime directory", "path", args.Path,
+	log.Info("listed sandbox runtime directory", "path", req.Path,
 		"entries", len(entries), "cost", time.Since(start))
 	return entries, nil
 }
@@ -335,38 +461,54 @@ type RemovePathArgs struct {
 //     ErrRuntimeFilesystemUnsupported;
 //   - everything else (unauthenticated, transport failure) is returned as a
 //     plain wrapped error.
-func RemovePathWithRuntime(ctx context.Context, args RemovePathArgs) error {
-	client, callCtx, cancel, err := newFilesystemCall(ctx, args.Sbx, args.Path, args.AuthUser, args.Timeout)
+//
+// rtOpts selects the transport for this sandbox exactly as in
+// WriteFileWithRuntime. The call is delegated to FilesystemAPI.Remove.
+func RemovePathWithRuntime(ctx context.Context, args RemovePathArgs, rtOpts ...Option) error {
+	if args.Sbx == nil {
+		return fmt.Errorf("sandbox is nil")
+	}
+	return NewRuntime(args.Sbx, rtOpts...).Filesystem().Remove(ctx, RemovePathRequest{
+		Path:     args.Path,
+		AuthUser: args.AuthUser,
+		Timeout:  args.Timeout,
+	})
+}
+
+// Remove implements FilesystemAPI. It is the single implementation of the
+// removal path, shared by the capability group and the RemovePathWithRuntime
+// convenience wrapper.
+func (f *filesystemAPI) Remove(ctx context.Context, req RemovePathRequest) error {
+	client, callCtx, cancel, err := f.newCall(ctx, req.Path, req.AuthUser, req.Timeout)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(args.Sbx)).V(utils.DebugLogLevel)
+	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(f.r.sbx)).V(utils.DebugLogLevel)
 	start := time.Now()
 
 	if _, err := client.Remove(callCtx, connect.NewRequest(&filesystem.RemoveRequest{
-		Path: args.Path,
+		Path: req.Path,
 	})); err != nil {
-		return classifyFilesystemError("Remove", args.Path, err)
+		return classifyFilesystemError("Remove", req.Path, err)
 	}
 
-	log.Info("removed sandbox runtime path", "path", args.Path, "cost", time.Since(start))
+	log.Info("removed sandbox runtime path", "path", req.Path, "cost", time.Since(start))
 	return nil
 }
 
-// newFilesystemCall validates the shared arguments of the Filesystem helpers and
-// builds the connect client plus the per-call context carrying the timeout and
-// the authentication headers. The returned cancel func must always be called.
+// newCall validates the shared arguments of the Filesystem RPCs and builds the
+// connect client plus the per-call context carrying the timeout and the
+// authentication headers. The returned cancel func must always be called.
 //
-// It mirrors RunCommandWithRuntime's transport choices (connect over gRPC, the
-// X-Access-Token header, Basic user identity) so the process and filesystem
-// capabilities authenticate identically against the same runtime endpoint.
-func newFilesystemCall(ctx context.Context, sbx *agentsv1alpha1.Sandbox, path, authUser string,
+// It mirrors the Process capability group's transport choices (connect over
+// gRPC, the X-Access-Token header, Basic user identity) so the process and
+// filesystem capabilities authenticate identically against the same runtime
+// endpoint, and it resolves that endpoint through resolveTransport so a
+// TLS-capable sandbox is reached over HTTPS.
+func (f *filesystemAPI) newCall(ctx context.Context, path, authUser string,
 	timeout time.Duration) (filesystemconnect.FilesystemClient, context.Context, context.CancelFunc, error) {
-	if sbx == nil {
-		return nil, nil, nil, fmt.Errorf("sandbox is nil")
-	}
 	if path == "" {
 		return nil, nil, nil, fmt.Errorf("path is required")
 	}
@@ -376,15 +518,16 @@ func newFilesystemCall(ctx context.Context, sbx *agentsv1alpha1.Sandbox, path, a
 	if authUser == "" {
 		return nil, nil, nil, fmt.Errorf("authUser is required by the runtime filesystem service")
 	}
-	url := GetRuntimeURL(sbx)
-	if url == "" {
-		return nil, nil, nil, fmt.Errorf("runtime url not found on sandbox")
+	sbx := f.r.sbx
+	base, httpClient, err := f.r.resolveTransport(sbx, runtimeGRPCHTTPClient)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 	if timeout <= 0 {
 		timeout = defaultRuntimeFilesystemTimeout
 	}
 
-	client := filesystemconnect.NewFilesystemClient(runtimeGRPCHTTPClient, url, connect.WithGRPC())
+	client := filesystemconnect.NewFilesystemClient(httpClient, base, connect.WithGRPC())
 
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
 	callCtx, callInfo := connect.NewClientContext(ctxWithTimeout)

--- a/pkg/utils/runtime/process.go
+++ b/pkg/utils/runtime/process.go
@@ -72,36 +72,95 @@ type RunCmdFuncArgs struct {
 	AuthUser string
 }
 
-func RunCommandWithRuntime(ctx context.Context, args RunCmdFuncArgs) (RunCommandResult, error) {
-	sbx, processConfig, timeout := args.Sbx, args.ProcessConfig, args.Timeout
+// ProcessAPI is the runtime process capability group, backed by the envd Process
+// service. Like every other group it is addressed through the transport
+// resolved by the owning runtimeClient, so a TLS-capable sandbox is reached over
+// HTTPS with forced resolution while a legacy sandbox keeps the plaintext
+// runtime URL. The group is bound to one sandbox at construction time, so no
+// method takes a *Sandbox argument.
+type ProcessAPI interface {
+	// Run starts a process in the sandbox and consumes its event stream until the
+	// process exits, returning the collected output and exit status.
+	Run(ctx context.Context, req RunCommandRequest) (RunCommandResult, error)
+	// Chmod applies mode to filePath inside the sandbox by running chmod as root.
+	Chmod(ctx context.Context, filePath, mode string) error
+}
+
+// RunCommandRequest describes a single process execution. It is RunCmdFuncArgs
+// without the sandbox, which the capability group already carries.
+type RunCommandRequest struct {
+	// ProcessConfig is the command, arguments and environment to execute.
+	ProcessConfig *process.ProcessConfig
+	// Timeout bounds the whole execution, including consuming the event stream.
+	Timeout time.Duration
+	// AuthUser is the user identity sent as an HTTP Basic Authorization header
+	// (empty password). Empty means no Authorization header is sent.
+	AuthUser string
+}
+
+// processAPI is the default ProcessAPI implementation. It delegates transport to
+// the owning runtimeClient and carries no domain logic of its own.
+type processAPI struct {
+	r *runtimeClient
+}
+
+// RunCommandWithRuntime starts a process in the sandbox runtime and waits for it
+// to exit.
+//
+// rtOpts selects the transport for this sandbox: non-empty (typically the TLS
+// options resolved by TransportOptionsFor) routes the call over HTTPS to the
+// agent-runtime, empty keeps the legacy plaintext runtime URL. The call is
+// delegated to ProcessAPI.Run, which owns the implementation.
+func RunCommandWithRuntime(ctx context.Context, args RunCmdFuncArgs, rtOpts ...Option) (RunCommandResult, error) {
+	// Keep the nil-sandbox guard here: NewRuntime binds the sandbox at
+	// construction time, so a nil one would otherwise surface later as an
+	// unresolved endpoint instead of naming the actual programming error.
+	if args.Sbx == nil {
+		return RunCommandResult{}, fmt.Errorf("sandbox is nil")
+	}
+	return NewRuntime(args.Sbx, rtOpts...).Process().Run(ctx, RunCommandRequest{
+		ProcessConfig: args.ProcessConfig,
+		Timeout:       args.Timeout,
+		AuthUser:      args.AuthUser,
+	})
+}
+
+// Run implements ProcessAPI. It is the single implementation of the process
+// execution path, shared by the capability group and the RunCommandWithRuntime
+// convenience wrapper.
+func (p *processAPI) Run(ctx context.Context, req RunCommandRequest) (RunCommandResult, error) {
+	sbx, processConfig, timeout := p.r.sbx, req.ProcessConfig, req.Timeout
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx)).V(utils.DebugLogLevel)
-	url := GetRuntimeURL(sbx)
-	if url == "" {
-		return RunCommandResult{}, fmt.Errorf("runtime url not found on sandbox")
+	// The process RPC shares the transport decision with every other capability
+	// group; runtimeGRPCHTTPClient stays the plaintext client so the existing
+	// test seam keeps working.
+	base, httpClient, err := p.r.resolveTransport(sbx, runtimeGRPCHTTPClient)
+	if err != nil {
+		return RunCommandResult{}, err
 	}
 	client := processconnect.NewProcessClient(
-		runtimeGRPCHTTPClient,
-		url,
+		httpClient,
+		base,
 		connect.WithGRPC(),
 	)
 
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	clientContext, callInfo := connect.NewClientContext(ctxWithTimeout)
-	callInfo.RequestHeader().Set("X-Access-Token", utils.GetAccessToken(sbx))
+	callInfo.RequestHeader().Set(accessTokenHeader, utils.GetAccessToken(sbx))
 	// The Basic user credential is caller-supplied: it is sent only when
-	// args.AuthUser expresses a user identity for the runtime to resolve.
-	if args.AuthUser != "" {
-		callInfo.RequestHeader().Set("Authorization", basicAuthHeader(args.AuthUser))
+	// req.AuthUser expresses a user identity for the runtime to resolve.
+	if req.AuthUser != "" {
+		callInfo.RequestHeader().Set("Authorization", basicAuthHeader(req.AuthUser))
 	}
 
-	req := connect.NewRequest(&process.StartRequest{
+	startReq := connect.NewRequest(&process.StartRequest{
 		Process: processConfig,
 		Tag:     nil,
 		Pty:     nil,
 		Stdin:   nil,
 	})
-	stream, err := client.Start(clientContext, req)
+	stream, err := client.Start(clientContext, startReq)
 	if err != nil {
 		return RunCommandResult{}, err
 	}
@@ -146,11 +205,23 @@ func RunCommandWithRuntime(ctx context.Context, args RunCmdFuncArgs) (RunCommand
 }
 
 // ChmodFileOnRuntime executes `chmod <mode> <filePath>` inside the sandbox runtime
-// via RunCommandWithRuntime. This is a temporary measure to enforce file permissions
-// until the agent-runtime (envd) natively honors the X-File-Mode header.
-func ChmodFileOnRuntime(ctx context.Context, sbx *agentsv1alpha1.Sandbox, filePath, mode string) error {
-	result, err := RunCommandWithRuntime(ctx, RunCmdFuncArgs{
-		Sbx: sbx,
+// via the process capability group. This is a temporary measure to enforce file
+// permissions until the agent-runtime (envd) natively honors the X-File-Mode header.
+//
+// rtOpts selects the transport for this sandbox exactly as in
+// RunCommandWithRuntime. The call is delegated to ProcessAPI.Chmod.
+func ChmodFileOnRuntime(ctx context.Context, sbx *agentsv1alpha1.Sandbox, filePath, mode string, rtOpts ...Option) error {
+	if sbx == nil {
+		return fmt.Errorf("sandbox is nil")
+	}
+	return NewRuntime(sbx, rtOpts...).Process().Chmod(ctx, filePath, mode)
+}
+
+// Chmod implements ProcessAPI. It is the single implementation of the chmod
+// path, shared by the capability group and the ChmodFileOnRuntime convenience
+// wrapper.
+func (p *processAPI) Chmod(ctx context.Context, filePath, mode string) error {
+	result, err := p.Run(ctx, RunCommandRequest{
 		ProcessConfig: &process.ProcessConfig{
 			Cmd:  "chmod",
 			Args: []string{mode, filePath},

--- a/pkg/utils/runtime/transport_test.go
+++ b/pkg/utils/runtime/transport_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -41,6 +42,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/proto/envd/filesystem/filesystemconnect"
+	"github.com/openkruise/agents/proto/envd/process"
+	"github.com/openkruise/agents/proto/envd/process/processconnect"
 )
 
 // sandboxWithPodIP returns a sandbox whose Pod IP is set (but with no runtime
@@ -455,6 +459,224 @@ func TestNewTLSBundleFromSecret(t *testing.T) {
 				assert.Empty(t, m.ClientCertPEM)
 				assert.Empty(t, m.ClientKeyPEM)
 			}
+		})
+	}
+}
+
+// TestTLSMode_EveryCapabilityGroupRidesTheResolvedTransport is the regression
+// test for the invariant that made the security-token propagation reachable over
+// TLS: all three wire protocols spoken to the runtime (JSON for storage,
+// multipart for the files route, connect-gRPC for the filesystem and process
+// services) must resolve their endpoint through the same transport decision.
+//
+// Before the capability groups existed, only the JSON path honoured WithTLS
+// while the multipart and connect paths hard-coded the plaintext runtime URL, so
+// a TLS-capable sandbox silently received its credential in clear text. Each
+// case therefore asserts two things: the call reaches the HTTPS server at all
+// (proving the pinned TLS transport is used), and the request is addressed by
+// the certificate authority hostname rather than the dialed Pod IP.
+func TestTLSMode_EveryCapabilityGroupRidesTheResolvedTransport(t *testing.T) {
+	const authority = "example.com"
+
+	fsHandler := &mockFilesystemHandler{}
+	procHandler := &mockProcessHandler{
+		startFn: func(_ context.Context, _ *connect.Request[process.StartRequest],
+			stream *connect.ServerStream[process.StartResponse]) error {
+			// A single End event is enough: Run only has to observe the process
+			// exiting to return, and the transport is what this test exercises.
+			return stream.Send(&process.StartResponse{Event: &process.ProcessEvent{
+				Event: &process.ProcessEvent_End{End: &process.ProcessEvent_EndEvent{ExitCode: 0, Exited: true}},
+			}})
+		},
+	}
+
+	mux := http.NewServeMux()
+	var filesCalls int
+	mux.HandleFunc("/files", func(w http.ResponseWriter, _ *http.Request) {
+		filesCalls++
+		w.WriteHeader(http.StatusOK)
+	})
+	fsPath, fsHTTP := filesystemconnect.NewFilesystemHandler(fsHandler)
+	mux.Handle(fsPath, fsHTTP)
+	procPath, procHTTP := processconnect.NewProcessHandler(procHandler)
+	mux.Handle(procPath, procHTTP)
+
+	// Record the Host of every request ahead of the routing so the connect
+	// handlers (which never expose it) are covered just like the plain routes.
+	var mu sync.Mutex
+	var gotHosts []string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotHosts = append(gotHosts, r.Host)
+		mu.Unlock()
+		mux.ServeHTTP(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	host, portStr, err := net.SplitHostPort(server.Listener.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	newTLSRuntime := func() Runtime {
+		return NewRuntime(
+			sandboxWithPodIP(host), // Pod IP == loopback the TLS server listens on
+			WithRetry(wait.Backoff{Steps: 1}),
+			WithTLS(TLSBundle{CABundle: caPEM}),
+			WithAuthority(authority),
+			WithTLSPort(port),
+		)
+	}
+
+	tests := []struct {
+		name string
+		// invoke performs one capability call against the TLS runtime. A nil
+		// error means the call completed over HTTPS.
+		invoke func(ctx context.Context, rt Runtime) error
+		// verify asserts the server side observed the call.
+		verify func(t *testing.T)
+	}{
+		{
+			name: "filesystem write over the multipart files route",
+			invoke: func(ctx context.Context, rt Runtime) error {
+				_, err := rt.Filesystem().Write(ctx, WriteFileRequest{
+					FilePath: "/var/opt/token", Content: []byte("credential"), AuthUser: "root",
+				})
+				return err
+			},
+			verify: func(t *testing.T) {
+				assert.Equal(t, 1, filesCalls, "the files route must be reached over TLS")
+			},
+		},
+		{
+			name: "filesystem listdir over connect-gRPC",
+			invoke: func(ctx context.Context, rt Runtime) error {
+				_, err := rt.Filesystem().ListDir(ctx, ListDirRequest{Path: "/var/opt", AuthUser: "root"})
+				return err
+			},
+			verify: func(t *testing.T) {
+				assert.Equal(t, basicAuthHeader("root"), fsHandler.gotAuth,
+					"the Filesystem service must be reached over TLS with the user identity")
+			},
+		},
+		{
+			name: "filesystem remove over connect-gRPC",
+			invoke: func(ctx context.Context, rt Runtime) error {
+				return rt.Filesystem().Remove(ctx, RemovePathRequest{Path: "/var/opt/token", AuthUser: "root"})
+			},
+			verify: func(t *testing.T) {
+				assert.Equal(t, basicAuthHeader("root"), fsHandler.gotAuth)
+			},
+		},
+		{
+			name: "process run over connect-gRPC",
+			invoke: func(ctx context.Context, rt Runtime) error {
+				res, err := rt.Process().Run(ctx, RunCommandRequest{
+					ProcessConfig: &process.ProcessConfig{Cmd: "true"},
+					Timeout:       5 * time.Second,
+					AuthUser:      "root",
+				})
+				if err == nil {
+					assert.True(t, res.Exited, "the End event must be observed over TLS")
+				}
+				return err
+			},
+		},
+		{
+			// Chmod is the follow-up a credential writer needs to tighten the
+			// file mode, so it has to be TLS-capable together with Write.
+			name: "process chmod over connect-gRPC",
+			invoke: func(ctx context.Context, rt Runtime) error {
+				return rt.Process().Chmod(ctx, "/var/opt/token", "0600")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mu.Lock()
+			gotHosts = nil
+			mu.Unlock()
+
+			require.NoError(t, tt.invoke(context.Background(), newTLSRuntime()))
+			if tt.verify != nil {
+				tt.verify(t)
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			require.NotEmpty(t, gotHosts, "the call must reach the HTTPS server")
+			for _, h := range gotHosts {
+				// Addressed by certificate hostname even though the connection
+				// was pinned to the Pod IP.
+				assert.Contains(t, h, authority)
+			}
+		})
+	}
+}
+
+// TestTLSMode_CapabilityGroupsRejectInvalidBundle verifies that an unusable TLS
+// bundle is reported by the multipart and connect capability groups too, instead
+// of silently falling back to the plaintext runtime URL. Without this, a broken
+// certificate mount would downgrade credential delivery to clear text.
+func TestTLSMode_CapabilityGroupsRejectInvalidBundle(t *testing.T) {
+	rt := NewRuntime(
+		sandboxWithPodIP("10.0.0.1"),
+		WithRetry(wait.Backoff{Steps: 1}),
+		WithTLS(TLSBundle{CABundle: []byte("not a pem")}),
+	)
+
+	tests := []struct {
+		name   string
+		invoke func(ctx context.Context) error
+	}{
+		{
+			name: "filesystem write",
+			invoke: func(ctx context.Context) error {
+				_, err := rt.Filesystem().Write(ctx, WriteFileRequest{FilePath: "/tmp/f", AuthUser: "root"})
+				return err
+			},
+		},
+		{
+			name: "filesystem listdir",
+			invoke: func(ctx context.Context) error {
+				_, err := rt.Filesystem().ListDir(ctx, ListDirRequest{Path: "/tmp", AuthUser: "root"})
+				return err
+			},
+		},
+		{
+			// Remove deletes recursively, so a broken bundle must stop the call
+			// outright rather than replay it over plaintext.
+			name: "filesystem remove",
+			invoke: func(ctx context.Context) error {
+				return rt.Filesystem().Remove(ctx, RemovePathRequest{Path: "/tmp/f", AuthUser: "root"})
+			},
+		},
+		{
+			name: "process run",
+			invoke: func(ctx context.Context) error {
+				_, err := rt.Process().Run(ctx, RunCommandRequest{
+					ProcessConfig: &process.ProcessConfig{Cmd: "true"}, Timeout: time.Second,
+				})
+				return err
+			},
+		},
+		{
+			// Chmod wraps Run, so the case also pins that the wrapping keeps the
+			// TLS configuration failure visible instead of masking it as a chmod
+			// exit status.
+			name: "process chmod",
+			invoke: func(ctx context.Context) error {
+				return rt.Process().Chmod(ctx, "/tmp/f", "0600")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.invoke(context.Background())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid runtime TLS configuration")
 		})
 	}
 }


### PR DESCRIPTION
…nsport

The claim, clone and post-resume flows already resolved a per-sandbox transport with TransportOptionsFor and applied it to the /init handshake and the CSI mounts, but the security-token step stayed on the plaintext runtime URL, so a TLS-capable sandbox received its identity-provider credential in clear text. Forwarding the transport alone would not have helped: only the JSON capability group understood WithTLS, while the multipart /files route and the connect-gRPC Filesystem and Process services resolved GetRuntimeURL directly, which is why Initialize still carried a TODO for this step.

- runtime: add Filesystem() (Write/ListDir/Remove) and Process() (Run/Chmod) capability groups to the Runtime interface and move the existing helper implementations into them. All three wire protocols (JSON, multipart, connect-gRPC) now resolve their endpoint and HTTP client through a single resolveTransport, so no path can drift back to plaintext unnoticed. TLS keeps HTTP/1.1, matching the protocol the plaintext connect path already uses. The former free functions remain as thin wrappers that accept rtOpts, leaving their call sites and the recycle test seam untouched.
- identity: thread rtOpts through SecurityTokenPropagator, IdentityProvider.PropagateSecurityToken, PropagateSandboxToken and ProcessSandboxToken. The package only carries the value and never resolves or overrides it, so the TLS decision stays at the caller's boundary and identity remains transport-neutral.
- claim / clone / post-resume: pass the already resolved rtOpts into ProcessSandboxToken, which retires the TODO in Initialize.
- securitytokenrefresh: plumb the runtime TLS bundle from Deps into NewDefaultRefresher and resolve the transport per refresh, because the Pod IP and the advertised capability change across pause/resume cycles. The resolution runs before issuance, so a sandbox advertising TLS while the controller holds no bundle fails without burning an issuance call rather than downgrading the delivery to plaintext.
- WriteFileArgs.Permissions: correct the comment, which claimed the mode travels in an X-File-Mode header that is never set. Behaviour is unchanged; ChmodFileOnRuntime stays the way to enforce a mode until the runtime honours the header natively.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

