### PR TITLE
fix(sandbox-manager): correct E2B traffic policy precedence

### DIFF
--- a/pkg/sandbox-manager/infra/sandboxcr/network.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/network.go
@@ -30,6 +30,10 @@ import (
 	"github.com/openkruise/agents/pkg/utils/network"
 )
 
+// E2B global fallback policies must use a priority greater than this value.
+// TrafficPolicy priorities are evaluated in ascending order.
+const e2bPerSandboxTrafficPolicyPriority int32 = 100
+
 // sandboxOwnerRef returns an OwnerReference that points to the given Sandbox CR.
 // Setting this on TrafficPolicy CRs ensures they are garbage-collected
 // when the owning Sandbox is deleted (including timeout-driven deletion by the controller).
@@ -102,7 +106,7 @@ func buildTrafficPolicy(allowOutCIDRs, allowOutDomains, denyOut []string, namesp
 			OwnerReferences: []metav1.OwnerReference{sandboxOwnerRef(sandbox)},
 		},
 		Spec: agentsv1alpha1.TrafficPolicySpec{
-			Priority: 1000,
+			Priority: e2bPerSandboxTrafficPolicyPriority,
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					agentsv1alpha1.LabelSandboxName: sandbox.Name,

--- a/pkg/sandbox-manager/infra/sandboxcr/network_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/network_test.go
@@ -235,7 +235,7 @@ func TestBuildTrafficPolicy(t *testing.T) {
 			assert.Equal(t, "tp-", tp.GenerateName)
 			assert.Equal(t, "default", tp.Namespace)
 			assert.Equal(t, "test-sandbox", tp.Spec.Selector.MatchLabels[agentsv1alpha1.LabelSandboxName])
-			assert.Equal(t, int32(1000), tp.Spec.Priority)
+			assert.Equal(t, e2bPerSandboxTrafficPolicyPriority, tp.Spec.Priority)
 			// Verify OwnerReference is set
 			require.Len(t, tp.OwnerReferences, 1)
 			assert.Equal(t, "Sandbox", tp.OwnerReferences[0].Kind)
@@ -379,11 +379,43 @@ func TestUpdateSelectNetworkPolicy_RoundTrip(t *testing.T) {
 	assert.Equal(t, []string{"1.2.3.4/32"}, result.AllowOut)
 	assert.Nil(t, result.DenyOut)
 
+	// Simulate a legacy policy so the update verifies priority migration too.
+	sandboxID := utils.GetSandboxID(sbx)
+	tpList := &agentsv1alpha1.TrafficPolicyList{}
+	require.NoError(t, fc.List(t.Context(), tpList,
+		ctrlclient.InNamespace(sbx.Namespace),
+		ctrlclient.MatchingFields{cache.IndexTrafficPolicySandboxID: sandboxID},
+	))
+	require.Len(t, tpList.Items, 1)
+	legacyPolicy := &tpList.Items[0]
+	legacyPolicy.Spec.Priority = 1000
+	require.NoError(t, fc.Update(t.Context(), legacyPolicy))
+
 	// Step 2: Update to allowOut + denyOut (whitelist mode with deny)
 	require.NoError(t, sandbox.UpdateNetworkPolicy(t.Context(), infra.SandboxNetworkConfig{
 		AllowOut: []string{"1.2.3.4"},
 		DenyOut:  []string{"10.0.0.0/8"},
 	}))
+
+	tpList = &agentsv1alpha1.TrafficPolicyList{}
+	require.NoError(t, fc.List(t.Context(), tpList,
+		ctrlclient.InNamespace(sbx.Namespace),
+		ctrlclient.MatchingFields{cache.IndexTrafficPolicySandboxID: sandboxID},
+	))
+	require.Len(t, tpList.Items, 1)
+	updatedPolicy := &tpList.Items[0]
+	assert.Equal(t, e2bPerSandboxTrafficPolicyPriority, updatedPolicy.Spec.Priority)
+	require.NotNil(t, updatedPolicy.Spec.Egress)
+	assert.Equal(t, []agentsv1alpha1.TrafficPolicyRule{
+		{
+			Action: agentsv1alpha1.RuleActionAllow,
+			To:     []agentsv1alpha1.TrafficPolicyPeer{{CIDR: "1.2.3.4/32"}},
+		},
+		{
+			Action: agentsv1alpha1.RuleActionReject,
+			To:     []agentsv1alpha1.TrafficPolicyPeer{{CIDR: "10.0.0.0/8"}},
+		},
+	}, updatedPolicy.Spec.Egress.Rules)
 
 	result, err = sandbox.SelectNetworkPolicy(t.Context())
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

- Changes per-Sandbox E2B TrafficPolicy priority from 1000 to 100.
- Ensures per-Sandbox allow/deny rules are evaluated before matching E2B global fallback policies.
- Adds coverage for newly created policies and runtime updates that migrate a legacy priority-1000 policy to priority 100.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

Run:

```bash
go test ./pkg/sandbox-manager/infra/sandboxcr -count=1
go test ./pkg/servers/e2b -run TestUpdateSandboxNetwork_Success -count=1
```

Verify that newly created TrafficPolicies use priority 100 and updating an existing priority-1000 policy changes it to priority 100 without changing its rules.

### Ⅳ. Special notes for reviews

This quick fix intentionally changes only the per-Sandbox priority. E2B global fallback policies are deployment prerequisites and must use a priority greater than 100. Their concrete priority is operator-defined; 900 is a recommended value, not a code dependency.

For narrow-deny semantics, an internet-enabled sandbox is expected to match a global allow fallback. For internet-disabled semantics, it is expected to match a global deny fallback. Runtime mutation of `allow_internet_access` remains outside this PR.