### PR TITLE
fix(servers/e2b): temporarily disable Volume management endpoints

### DIFF
--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -67,10 +67,11 @@ func (sc *Controller) registerRoutes() {
 	RegisterE2BRoute(sc.mux, http.MethodGet, "/debug", sc.Debug, sc.CheckApiKey)
 
 	// Volume management endpoints
-	RegisterE2BRoute(sc.mux, http.MethodPost, "/volumes", sc.CreateVolume, sc.CheckApiKey)
-	RegisterE2BRoute(sc.mux, http.MethodGet, "/volumes", sc.ListVolumes, sc.CheckApiKey)
-	RegisterE2BRoute(sc.mux, http.MethodGet, "/volumes/{volumeID}", sc.GetVolume, sc.CheckApiKey)
-	RegisterE2BRoute(sc.mux, http.MethodDelete, "/volumes/{volumeID}", sc.DeleteVolume, sc.CheckApiKey)
+	// Temporarily disabled.
+	// RegisterE2BRoute(sc.mux, http.MethodPost, "/volumes", sc.CreateVolume, sc.CheckApiKey)
+	// RegisterE2BRoute(sc.mux, http.MethodGet, "/volumes", sc.ListVolumes, sc.CheckApiKey)
+	// RegisterE2BRoute(sc.mux, http.MethodGet, "/volumes/{volumeID}", sc.GetVolume, sc.CheckApiKey)
+	// RegisterE2BRoute(sc.mux, http.MethodDelete, "/volumes/{volumeID}", sc.DeleteVolume, sc.CheckApiKey)
 
 	// API Keys management endpoints
 	if sc.keyCfg != nil {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Comment out E2B Volume management endpoint registration in `pkg/servers/e2b/routes.go` so the following APIs are temporarily not exposed:

- `POST /volumes`
- `GET /volumes`
- `GET /volumes/{volumeID}`
- `DELETE /volumes/{volumeID}`

Handler implementations and unit tests are left unchanged.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Inspect `pkg/servers/e2b/routes.go` and confirm the Volume management `RegisterE2BRoute` calls are commented out.
2. Start sandbox-manager / E2B API server and confirm `/volumes` routes return 404 (native and customized prefix).

### Ⅳ. Special notes for reviews

This is an intentional temporary disable of route exposure only; volume handler code remains in the tree for later re-enable.