### PR TITLE
feat(runtime): log the resolved transport on every runtime API call

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.20.2
 )
 
-require go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
+require go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
 
 require (
 	cel.dev/expr v0.24.0 // indirect

--- a/pkg/utils/runtime/client.go
+++ b/pkg/utils/runtime/client.go
@@ -22,7 +22,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -320,6 +322,52 @@ func (r *runtimeClient) dialIPFor(sbx *agentsv1alpha1.Sandbox) string {
 	return sbx.Status.PodInfo.PodIP
 }
 
+// transportLogValues describes the transport this client speaks to sbx as
+// structured log key-values, so a capability group can state in its own logs
+// whether the call goes over HTTPS (with forced resolution) or plaintext HTTP
+// without raising the verbosity of the whole call path.
+//
+// The values reflect the construction-time transport decision, not readiness:
+// in TLS mode the endpoint is the fixed authority URL, while dialTarget is
+// derived from the Pod IP of the given sandbox and may still be empty before a
+// refresh resolves it.
+func (r *runtimeClient) transportLogValues(sbx *agentsv1alpha1.Sandbox) []any {
+	if !r.tlsEnabled {
+		// Plain HTTP addresses the runtime by the URL host itself, so there is
+		// nothing to force-resolve.
+		return []any{
+			"transport", "http",
+			"endpoint", GetRuntimeURL(sbx),
+			"forcedResolution", false,
+		}
+	}
+	var caBundleBytes int
+	if r.tlsBundle != nil {
+		caBundleBytes = len(r.tlsBundle.CABundle)
+	}
+	var dialTarget string
+	if ip := r.dialIPFor(sbx); ip != "" {
+		dialTarget = net.JoinHostPort(ip, strconv.Itoa(r.tlsPort))
+	}
+	return []any{
+		"transport", "https",
+		"endpoint", fmt.Sprintf("https://%s:%d", r.authority, r.tlsPort),
+		// forcedResolution reports the `curl --resolve` behaviour: the dial goes
+		// to dialTarget (the sandbox Pod IP) while SNI and certificate
+		// verification stay on the endpoint authority. An empty dialTarget means
+		// the Pod IP is not resolved yet, i.e. the call cannot be addressed.
+		"forcedResolution", dialTarget != "",
+		"dialTarget", dialTarget,
+		"authority", r.authority,
+		"tlsPort", r.tlsPort,
+		// A client certificate is optional: its presence is what upgrades the
+		// connection from server-authenticated TLS to mutual TLS.
+		"mutualTLS", r.tlsClientConfig != nil && len(r.tlsClientConfig.Certificates) > 0,
+		"caBundleBytes", caBundleBytes,
+		"tlsConfigErr", r.tlsConfigErr,
+	}
+}
+
 // APIError describes a non-2xx response from the runtime. It preserves the HTTP
 // status code and the server-provided message so callers can both surface a
 // clean reason and decide whether to retry (see IsClientError).
@@ -369,8 +417,17 @@ func (e *APIError) IsClientError() bool {
 // user credential is opt-in via WithAuthUser: control-plane calls send none by
 // default, and callers whose capability resolves an OS user supply it at
 // construction time.
+//
+// Logging: the per-attempt request/response pair stays at V(DebugLogLevel)
+// because every capability group funnels through here, while a failed attempt is
+// reported at the default verbosity — retry.OnError discards every intermediate
+// error, so an attempt that is retried away would otherwise leave no trace. Both
+// carry the resolved transport (scheme, forced resolution, dial target, mutual
+// TLS) so a connectivity failure can be attributed to the protocol and
+// addressing actually used.
 func (r *runtimeClient) call(ctx context.Context, method, path string, reqBody, respOut any) error {
-	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(r.sbx)).V(utils.DebugLogLevel)
+	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(r.sbx))
+	debugLog := log.V(utils.DebugLogLevel)
 
 	// A TLS-config construction failure is a permanent, non-retryable error:
 	// surface it before entering the retry loop.
@@ -436,8 +493,13 @@ func (r *runtimeClient) call(ctx context.Context, method, path string, reqBody, 
 			req.Header.Set("Authorization", basicAuthHeader(r.authUser))
 		}
 
+		// attemptValues records what this attempt puts on the wire: the resolved
+		// transport of the (possibly refreshed) sandbox plus the full request URL.
+		attemptValues := append(r.transportLogValues(sbx),
+			"method", method, "requestURL", endpoint, "attempt", attempt)
+
 		start := time.Now()
-		log.Info("sending runtime request", "method", method, "endpoint", endpoint, "attempt", attempt)
+		debugLog.Info("sending runtime request", attemptValues...)
 
 		resp, err := httpClient.Do(req)
 		if err != nil {
@@ -481,12 +543,24 @@ func (r *runtimeClient) call(ctx context.Context, method, path string, reqBody, 
 			}
 		}
 
-		log.Info("runtime request completed", "method", method, "endpoint", endpoint,
-			"statusCode", resp.StatusCode, "cost", time.Since(start), "attempt", attempt)
+		debugLog.Info("runtime request completed",
+			append(attemptValues, "statusCode", resp.StatusCode, "cost", time.Since(start))...)
 		return nil
 	}
 
-	return retry.OnError(r.backoff, retriableRuntimeError(ctx), do)
+	// Report every failed attempt with its transport: the retry loop swallows all
+	// but the last error, and a 4xx that a capability group later reclassifies as
+	// success (e.g. init's 401 on re-init) must not surface as an ERROR entry, so
+	// the error travels as a log value instead of via Error().
+	return retry.OnError(r.backoff, retriableRuntimeError(ctx), func() error {
+		err := do()
+		if err != nil {
+			log.Info("runtime request attempt failed",
+				append(r.transportLogValues(sbx), "method", method, "path", path,
+					"attempt", attempt, "err", err.Error())...)
+		}
+		return err
+	})
 }
 
 // retriableRuntimeError builds the retry predicate for call. It stops retrying

--- a/pkg/utils/runtime/init.go
+++ b/pkg/utils/runtime/init.go
@@ -63,7 +63,17 @@ type initAPI struct {
 // Init implements InitAPI by posting the init options to the runtime init
 // endpoint through the shared call transport (retry, refresh and optional
 // TLS/pinned addressing included).
+//
+// The handshake runs once per sandbox lifecycle, so the resolved transport is
+// logged at the default verbosity: it is the cheapest way to tell whether init
+// reached the runtime over HTTPS/mTLS or plaintext HTTP, without turning on the
+// V(DebugLogLevel) per-attempt logs of the shared transport.
 func (i *initAPI) Init(ctx context.Context, opts config.InitRuntimeOptions) error {
+	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(i.r.sbx))
+	transport := i.r.transportLogValues(i.r.sbx)
+	log.Info("init runtime starting", append(transport, "reInit", opts.ReInit)...)
+
+	start := time.Now()
 	err := i.r.call(ctx, http.MethodPost, initPath, opts, nil)
 	// The runtime rejects an init whose body token is absent or no longer
 	// matches its stored token with 401. On a re-init (resume/recreate) that
@@ -71,11 +81,19 @@ func (i *initAPI) Init(ctx context.Context, opts config.InitRuntimeOptions) erro
 	// call never retries a 4xx, so this classification happens exactly once.
 	var apiErr *APIError
 	if opts.ReInit && errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusUnauthorized {
-		klog.FromContext(ctx).Info("init runtime returned 401, treated as success because ReInit is true",
-			"sandbox", klog.KObj(i.r.sbx))
+		log.Info("init runtime returned 401, treated as success because ReInit is true",
+			append(transport, "cost", time.Since(start))...)
 		return nil
 	}
-	return err
+	if err != nil {
+		// Logged here (in addition to the caller's own error handling) because
+		// this is the only layer that knows which transport was actually used,
+		// which is the first thing to check on a runtime connectivity failure.
+		log.Error(err, "init runtime failed", append(transport, "cost", time.Since(start))...)
+		return err
+	}
+	log.Info("init runtime completed", append(transport, "cost", time.Since(start))...)
+	return nil
 }
 
 // GetInitRuntimeRequest parses init runtime configuration from object annotations.


### PR DESCRIPTION
Attribute a connectivity failure to the protocol and addressing actually used, instead of guessing from a bare dial error:

- add transportLogValues, which renders the transport decision as structured key-values: transport (http/https), endpoint, forcedResolution, dialTarget, authority, tlsPort, mutualTLS, caBundleBytes and tlsConfigErr;
- log the request/response pair of every attempt at V(DebugLogLevel) with method, requestURL and attempt — every capability group funnels through call(), so this stays off by default;
- log a failed attempt at the default verbosity: retry.OnError discards all but the last error, so an attempt that is retried away would otherwise leave no trace at all;
- wire init.go through the same values.

Conflict resolution: the cherry-picked commit predates the resolveTransport refactor, so its copy of the per-attempt pinned-transport construction (httpClient := r.client + newPinnedTransport) is dropped. resolveTransport is now the single place that decision is made; keeping the block would redeclare the httpClient already returned there and fail to compile, besides building the transport twice. The rationale carried by the dropped comment is not lost: why the transport is rebuilt per call (a refresh may change the Pod IP) is documented on resolveTransport, and why keep-alives are disabled (a discarded one-shot transport would strand an idle TLS connection) on newPinnedTransport.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

