### PR TITLE
docs, api, e2b: clarify pause/resume pod delete/recreate semantics

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -148,12 +148,14 @@ type SandboxUpgradePolicy struct {
 }
 
 // PauseStrategyType enumerates the supported pause strategies.
-// +kubebuilder:validation:Enum=Stop;Hibernate
+// Currently, pause/resume maps onto Pod delete/recreate (Stop strategy).
+// +kubebuilder:validation:Enum=Stop
 type PauseStrategyType string
 
 const (
-	// PauseStrategyStop deletes the Pod immediately.
+	// PauseStrategyStop deletes the Pod immediately. Upon resume, the Pod is recreated.
 	// Only PVC-backed data survives; rootfs and in-memory state are lost.
+	// Resuming incurs a pod recreation cold start latency.
 	PauseStrategyStop PauseStrategyType = "Stop"
 	// PauseStrategyHibernate preserves sandbox state (e.g., rootfs and memory,
 	// as defined by persistentContents) before deleting the Pod.

--- a/config/crd/bases/agents.kruise.io_sandboxes.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxes.yaml
@@ -145,7 +145,6 @@ spec:
                     description: Type selects the pause mechanism.
                     enum:
                     - Stop
-                    - Hibernate
                     type: string
                 type: object
               pauseTime:

--- a/pkg/sandbox-manager/infra/sandboxcr/network_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/network_test.go
@@ -380,7 +380,7 @@ func TestUpdateSelectNetworkPolicy_RoundTrip(t *testing.T) {
 	assert.Nil(t, result.DenyOut)
 
 	// Simulate a legacy policy so the update verifies priority migration too.
-	sandboxID := utils.GetSandboxID(sbx)
+	sandboxID := sandboxid.Resolve(sbx)
 	tpList := &agentsv1alpha1.TrafficPolicyList{}
 	require.NoError(t, fc.List(t.Context(), tpList,
 		ctrlclient.InNamespace(sbx.Namespace),

--- a/pkg/servers/e2b/AGENTS.md
+++ b/pkg/servers/e2b/AGENTS.md
@@ -32,8 +32,11 @@ behavior and delegates protocol-independent use cases to Manager.
 - List visibility and delete authorization must remain consistent for
   sandboxes, snapshots, templates, and API keys.
 
-## Timeout Behavior
+## Timeout And Pause Behavior
 
+- Pause uses the Stop strategy (Pod delete/recreate); `PauseSandbox` returns
+  `x-e2b-kruise-pause-strategy: Stop` in the response header so clients can
+  detect the applied strategy. Resuming incurs a pod recreation cold start.
 - An absent paused-retention value uses the API default of `"forever"`;
   accepted writes may persist the resolved value.
 - Keep lifecycle deadlines, paused retention, and synchronous operation

--- a/pkg/servers/e2b/models/extensions.go
+++ b/pkg/servers/e2b/models/extensions.go
@@ -81,6 +81,7 @@ const (
 	ExtensionHeaderVolumeAccessMode             = ExtensionHeaderPrefix + "volume-access-mode"
 	ExtensionHeaderVolumeWaitSuccessSeconds     = ExtensionHeaderPrefix + "volume-wait-success-seconds"
 	ExtensionHeaderReservePausedSandboxDuration = ExtensionHeaderPrefix + "reserve-paused-sandbox-duration"
+	ExtensionHeaderPauseStrategy                = ExtensionHeaderPrefix + "pause-strategy"
 )
 
 const sandboxGenerateNameValidationSuffix = "abcde"

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -70,6 +70,9 @@ func (sc *Controller) PauseSandbox(r *http.Request) (web.ApiResponse[struct{}], 
 	log.Info("sandbox paused", "timeout", sbx.GetTimeout())
 	return web.ApiResponse[struct{}]{
 		Code: http.StatusNoContent,
+		Headers: map[string]string{
+			models.ExtensionHeaderPauseStrategy: string(v1alpha1.PauseStrategyStop),
+		},
 	}, nil
 }
 

--- a/pkg/servers/e2b/pause_resume_test.go
+++ b/pkg/servers/e2b/pause_resume_test.go
@@ -73,6 +73,7 @@ func TestPauseSandbox(t *testing.T) {
 	describeResp, err := controller.DescribeSandbox(req)
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusNoContent, pauseResp.Code)
+	assert.Equal(t, string(agentsv1alpha1.PauseStrategyStop), pauseResp.Headers[models.ExtensionHeaderPauseStrategy])
 	assert.Equal(t, models.SandboxStatePaused, describeResp.Body.State)
 
 	// pause again — should be idempotent (sandbox already paused)


### PR DESCRIPTION
### What issue(s) this PR fixes

Fixes #732

### What this PR does / why we need it

Currently, the `pause/resume` mechanism operates via a Pod delete/recreate process (`Stop` strategy). However, `Hibernate` was previously present in the CRD `PauseStrategyType` validation enum, allowing `kubectl apply` with `Hibernate` to succeed while causing controller reconciliation to stall with an error. Additionally, clients calling the E2B `/pause` endpoint had no programmatic way to detect which pause strategy was applied.

This PR makes the `pause/resume` semantics transparent to users:
1. **CRD Enum Validation**: Removed `Hibernate` from `PauseStrategyType` enum validation (`+kubebuilder:validation:Enum=Stop`) so invalid configurations fail fast at API server admission.
2. **E2B API Header**: Added `x-e2b-kruise-pause-strategy: Stop` to `PauseSandbox` HTTP response (`204 No Content`) headers so callers can programmatically inspect the applied pause strategy.
3. **Documentation**: Clarified in Go docstrings and `pkg/servers/e2b/AGENTS.md` that pause/resume currently maps onto Pod delete/recreate and incurs cold-start latency on resume.

### Step to verify

1. Build & update manifests: `make generate manifests`
2. Run unit tests:
   ```bash
   go test -v -count=1 ./pkg/servers/e2b/... ./pkg/controller/sandbox/core/...
