### PR TITLE
fix(controller): reject leftover pod from a previous same-name sandbox

### DIFF
--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -41,6 +41,10 @@ import (
 
 const CommonControlName = "common"
 
+// eventReasonPodOwnerMismatch is the event reason emitted when an existing
+// pod is owned by a previous sandbox generation with the same name.
+const eventReasonPodOwnerMismatch = "PodOwnerMismatch"
+
 // Container waiting reasons defined by kubelet (not exported as public constants in K8s API).
 const (
 	// WaitingReasonPodInitializing indicates init containers are still running.
@@ -116,6 +120,20 @@ func (r *commonControl) EnsureSandboxRunning(ctx context.Context, args EnsureFun
 		}
 		_, err := r.podControl.CreatePod(ctx, CreatePodArgs{Box: box, NewStatus: newStatus, AdvertiseRuntimeTLS: true})
 		return 0, err
+	}
+
+	// A pod owned by a previous sandbox generation with the same name must not
+	// be adopted (issue #756): stay Pending, surface an event, and wait for the
+	// GC controller to reclaim it. The pod watch retriggers the reconcile once
+	// it is gone, then a fresh pod is created.
+	if staleOwner, stale := StaleSandboxPodOwner(pod, box); stale {
+		klog.FromContext(ctx).Info("existing pod is owned by a previous sandbox generation, waiting for GC to delete it",
+			"sandbox", klog.KObj(box), "pod", klog.KObj(pod),
+			"podOwnerUID", string(staleOwner), "sandboxUID", string(box.UID))
+		r.recorder.Eventf(box, corev1.EventTypeWarning, eventReasonPodOwnerMismatch,
+			"pod %s is owned by sandbox uid %s, not the current sandbox uid %s; waiting for GC to delete it",
+			pod.Name, staleOwner, box.UID)
+		return 0, nil
 	}
 
 	// pod status running

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -139,6 +139,72 @@ func TestCommonControl_EnsureSandboxRunning(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "pod is running and owned by current sandbox",
+			args: EnsureFuncArgs{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-sandbox",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: agentsv1alpha1.SchemeGroupVersion.String(),
+								Kind:       "Sandbox",
+								Name:       "test-sandbox",
+								UID:        "current-uid",
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+				Box: &agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-sandbox",
+						Namespace: "default",
+						UID:       "current-uid",
+					},
+				},
+				NewStatus: &agentsv1alpha1.SandboxStatus{},
+			},
+			podExist: true,
+			wantErr:  false,
+		},
+		{
+			name: "pod is running but owned by previous sandbox generation, should stay pending",
+			args: EnsureFuncArgs{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-sandbox",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: agentsv1alpha1.SchemeGroupVersion.String(),
+								Kind:       "Sandbox",
+								Name:       "test-sandbox",
+								UID:        "old-uid",
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+				Box: &agentsv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-sandbox",
+						Namespace: "default",
+						UID:       "current-uid",
+					},
+				},
+				NewStatus: &agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxPending,
+				},
+			},
+			podExist: true,
+			wantErr:  false,
+		},
+		{
 			name:        "feature gate enabled, threshold exceeded, normal sandbox rate-limited",
 			featureGate: true,
 			setupRL: func(rl *RateLimiter) {
@@ -288,6 +354,13 @@ func TestCommonControl_EnsureSandboxRunning(t *testing.T) {
 
 			// If pod is running, verify status was updated
 			if tt.args.Pod != nil && tt.args.Pod.Status.Phase == corev1.PodRunning {
+				if _, stale := StaleSandboxPodOwner(tt.args.Pod, tt.args.Box); stale {
+					// A stale pod must not be adopted: phase stays Pending.
+					if tt.args.NewStatus.Phase != agentsv1alpha1.SandboxPending {
+						t.Errorf("Expected sandbox phase to stay Pending for stale pod, got %v", tt.args.NewStatus.Phase)
+					}
+					return
+				}
 				if tt.args.NewStatus.Phase != agentsv1alpha1.SandboxRunning {
 					t.Errorf("Expected sandbox phase to be Running, got %v", tt.args.NewStatus.Phase)
 				}

--- a/pkg/controller/sandbox/core/util.go
+++ b/pkg/controller/sandbox/core/util.go
@@ -78,3 +78,18 @@ func GeneratePVCName(templateName, sandboxName string) (string, error) {
 func GetControllerKey(obj client.Object) string {
 	return types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}.String()
 }
+
+// StaleSandboxPodOwner returns the UID of the Sandbox owner reference on pod
+// when it does not match the current sandbox, i.e. the pod is a leftover from
+// a previous sandbox generation with the same name (see issue #756).
+// Returns "", false when the pod is owned by the current sandbox or carries
+// no Sandbox owner reference.
+func StaleSandboxPodOwner(pod *corev1.Pod, box *agentsv1alpha1.Sandbox) (types.UID, bool) {
+	for i := range pod.OwnerReferences {
+		ref := &pod.OwnerReferences[i]
+		if ref.Kind == "Sandbox" && ref.APIVersion == agentsv1alpha1.SchemeGroupVersion.String() {
+			return ref.UID, ref.UID != box.UID
+		}
+	}
+	return "", false
+}

--- a/pkg/controller/sandbox/core/util.go
+++ b/pkg/controller/sandbox/core/util.go
@@ -88,7 +88,10 @@ func StaleSandboxPodOwner(pod *corev1.Pod, box *agentsv1alpha1.Sandbox) (types.U
 	for i := range pod.OwnerReferences {
 		ref := &pod.OwnerReferences[i]
 		if ref.Kind == "Sandbox" && ref.APIVersion == agentsv1alpha1.SchemeGroupVersion.String() {
-			return ref.UID, ref.UID != box.UID
+			if ref.UID == box.UID {
+				return "", false
+			}
+			return ref.UID, true
 		}
 	}
 	return "", false

--- a/pkg/controller/sandbox/core/util_test.go
+++ b/pkg/controller/sandbox/core/util_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -697,6 +698,112 @@ func TestGeneratePodFromSandbox(t *testing.T) {
 			}
 			if tt.checkPod != nil {
 				tt.checkPod(t, pod)
+			}
+		})
+	}
+}
+
+func TestStaleSandboxPodOwner(t *testing.T) {
+	sandboxRef := func(uid types.UID, apiVersion string) metav1.OwnerReference {
+		return metav1.OwnerReference{
+			APIVersion: apiVersion,
+			Kind:       "Sandbox",
+			Name:       "test-sandbox",
+			UID:        uid,
+		}
+	}
+
+	tests := []struct {
+		name      string
+		pod       *corev1.Pod
+		box       *agentsv1alpha1.Sandbox
+		wantUID   types.UID
+		wantStale bool
+	}{
+		{
+			name: "no owner references",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default"},
+			},
+			box:       &agentsv1alpha1.Sandbox{ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default", UID: "current-uid"}},
+			wantUID:   "",
+			wantStale: false,
+		},
+		{
+			name: "owned by another controller",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-sandbox", Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "rs-1", UID: "rs-uid"},
+					},
+				},
+			},
+			box:       &agentsv1alpha1.Sandbox{ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default", UID: "current-uid"}},
+			wantUID:   "",
+			wantStale: false,
+		},
+		{
+			name: "sandbox owner reference with matching uid",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-sandbox", Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{sandboxRef("current-uid", agentsv1alpha1.SchemeGroupVersion.String())},
+				},
+			},
+			box:       &agentsv1alpha1.Sandbox{ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default", UID: "current-uid"}},
+			wantUID:   "",
+			wantStale: false,
+		},
+		{
+			name: "sandbox owner reference with mismatched uid",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-sandbox", Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{sandboxRef("old-uid", agentsv1alpha1.SchemeGroupVersion.String())},
+				},
+			},
+			box:       &agentsv1alpha1.Sandbox{ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default", UID: "current-uid"}},
+			wantUID:   "old-uid",
+			wantStale: true,
+		},
+		{
+			name: "sandbox kind with mismatched api version",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-sandbox", Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{sandboxRef("old-uid", "agents.example.io/v1beta1")},
+				},
+			},
+			box:       &agentsv1alpha1.Sandbox{ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default", UID: "current-uid"}},
+			wantUID:   "",
+			wantStale: false,
+		},
+		{
+			name: "sandbox owner reference is not the first entry",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-sandbox", Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "rs-1", UID: "rs-uid"},
+						sandboxRef("old-uid", agentsv1alpha1.SchemeGroupVersion.String()),
+					},
+				},
+			},
+			box:       &agentsv1alpha1.Sandbox{ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default", UID: "current-uid"}},
+			wantUID:   "old-uid",
+			wantStale: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uid, stale := StaleSandboxPodOwner(tt.pod, tt.box)
+			if uid != tt.wantUID {
+				t.Errorf("StaleSandboxPodOwner() uid = %q, want %q", uid, tt.wantUID)
+			}
+			if stale != tt.wantStale {
+				t.Errorf("StaleSandboxPodOwner() stale = %v, want %v", stale, tt.wantStale)
 			}
 		})
 	}

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -521,6 +521,14 @@ func (r *SandboxReconciler) calculateStatus(ctx context.Context, args core.Ensur
 
 	switch newStatus.Phase {
 	case agentsv1alpha1.SandboxPending:
+		// A leftover pod from a previous sandbox generation with the same name
+		// (issue #756) must not drive status: treat it as absent so its terminal
+		// phase cannot complete the new sandbox.
+		if pod != nil {
+			if _, stale := core.StaleSandboxPodOwner(pod, box); stale {
+				pod = nil
+			}
+		}
 		updateStatusIfPodCompleted(pod, newStatus)
 		if isSandboxCompletedPhase(newStatus.Phase) {
 			return newStatus, true

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -3274,6 +3274,48 @@ func TestCalculateStatus(t *testing.T) {
 			expectedShouldReq: true,
 		},
 		{
+			name: "pending phase with terminal pod owned by previous sandbox generation should stay pending",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sandbox",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: agentsv1alpha1.SchemeGroupVersion.String(),
+							Kind:       "Sandbox",
+							Name:       "test-sandbox",
+							UID:        "old-uid",
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodFailed,
+				},
+			},
+			box: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-sandbox",
+					Namespace:  "default",
+					UID:        "current-uid",
+					Generation: 1,
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "test", Image: "nginx"}},
+							},
+						},
+					},
+				},
+			},
+			initStatus: &agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxPending,
+			},
+			expectedPhase:     agentsv1alpha1.SandboxPending,
+			expectedShouldReq: false,
+		},
+		{
 			name: "running phase with hash mismatch and recreate policy should transition to upgrading and remove upgrading condition",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/webhook/pod/validating/pod_delete.go
+++ b/pkg/webhook/pod/validating/pod_delete.go
@@ -121,6 +121,11 @@ func (h *PodValidatingHandler) Handle(ctx context.Context, req admission.Request
 		// Sandbox not found, allow deletion/eviction
 		return admission.Allowed("")
 	}
+	if sandbox.UID != *sandboxOwner {
+		// The pod belongs to a previous sandbox generation with the same name;
+		// allow deletion (typically by the GC controller) so it can be reclaimed.
+		return admission.Allowed("")
+	}
 	if sandbox.DeletionTimestamp.IsZero() {
 		// Sandbox exists and is not being deleted, deny pod deletion/eviction
 		return admission.Denied(fmt.Sprintf(

--- a/pkg/webhook/pod/validating/pod_delete_test.go
+++ b/pkg/webhook/pod/validating/pod_delete_test.go
@@ -238,6 +238,7 @@ func TestPodValidatingHandler_Handle(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "sandbox-pod",
 					Namespace:         "default",
+					UID:               "test-uid",
 					CreationTimestamp: now,
 					// DeletionTimestamp is nil, sandbox is not being deleted
 				},
@@ -248,6 +249,40 @@ func TestPodValidatingHandler_Handle(t *testing.T) {
 			operation:   admissionv1.Delete,
 			username:    "regular-user",
 			expectAllow: false,
+		},
+		{
+			name: "sandbox pod owned by previous sandbox generation - should allow",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sandbox-pod",
+					Namespace: "default",
+					Labels: map[string]string{
+						utils.PodLabelCreatedBy: utils.CreatedBySandbox,
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: agentsv1alpha1.SchemeGroupVersion.String(),
+							Kind:       "Sandbox",
+							Name:       "sandbox-pod",
+							UID:        "old-sandbox-uid",
+						},
+					},
+				},
+			},
+			sandbox: &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "sandbox-pod",
+					Namespace:         "default",
+					UID:               "new-sandbox-uid",
+					CreationTimestamp: now,
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+				},
+			},
+			operation:   admissionv1.Delete,
+			username:    "regular-user",
+			expectAllow: true,
 		},
 		{
 			name: "sandbox pod with sandbox exists and deleting - should allow",
@@ -351,6 +386,7 @@ func TestPodValidatingHandler_Handle(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "sandbox-pod",
 					Namespace:         "default",
+					UID:               "test-uid",
 					CreationTimestamp: now,
 				},
 				Status: agentsv1alpha1.SandboxStatus{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The sandbox controller fetches the pod purely by the sandbox's NamespacedName
and never verifies the pod's owner reference. When a Sandbox is deleted and
recreated with the same name (new UID) — commonly hit in the snapshot workflow
(snapshot -> delete -> recreate) — a leftover pod from the previous generation
can still exist, and its ownerReference UID points to the old Sandbox.
`EnsureSandboxRunning` then adopts it: the new Sandbox transitions to Running
with the previous generation's pod (stale workload state, PodIP, PodUID).

This PR adds an ownership guard:

- `EnsureSandboxRunning` no longer adopts a pod whose Sandbox ownerRef UID
  differs from the current sandbox. It stays Pending, emits a
  `Warning/PodOwnerMismatch` event, and waits for the GC controller to reclaim
  the pod; the pod watch retriggers the reconcile afterwards, then a fresh pod
  is created.
- `calculateStatus` treats such a stale pod as absent in the Pending phase, so
  a terminal-phase leftover pod cannot complete the new sandbox.
- The pod-delete validating webhook now allows deletion/eviction when the
  pod's Sandbox ownerRef UID differs from the same-named existing Sandbox.
  Without this, the GC is denied forever and the leftover pod is never
  reclaimed.

### Ⅱ. Does this pull request fix one issue?

fixes #756

### Ⅲ. Describe how to verify it

1. Unit tests: `go test ./pkg/controller/sandbox/... ./pkg/webhook/pod/... -count=1`
2. New table cases: a running pod owned by a different sandbox UID keeps the
   sandbox Pending (with event); a pending sandbox with a terminal stale pod
   stays Pending; the webhook allows deleting a pod whose Sandbox ownerRef UID
   mismatches the same-named sandbox.
3. Manual: delete a sandbox and recreate one with the same name while the old
   pod still exists — the new sandbox stays Pending until GC removes the old
   pod, then creates its own.

### Ⅳ. Special notes for reviews

- The controller intentionally does not delete the stale pod itself: it stays
  Pending and relies on the GC, keeping deletion authority in one place. The
  webhook change is required for this to converge, because the webhook
  previously denied GC deletions whenever a same-named sandbox exists (only
  the sandbox controller's service account is exempted).
- Pods without any Sandbox owner reference keep the previous behavior (no
  mismatch check), so pods owned by other controllers are untouched.
- Related background: PR #646 (lazy finalizer) moved Running-sandbox pod
  cleanup from the controller's synchronous termination path to async
  owner-reference GC, which widened this race window.
