### PR TITLE
fix(e2b): correct malformed klog structured logging in csiMountOptionsConfigRecord

### DIFF
--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -469,7 +469,7 @@ func (sc *Controller) csiMountOptionsConfigRecord(ctx context.Context, sbx infra
 	// marshal the csi mount confit to json
 	csiMountConfigRaw, err := json.Marshal(request.Extensions.CSIMount.MountConfigs)
 	if err != nil {
-		log.Info("failed to marshal csi mount config", err)
+		log.Error(err, "failed to marshal csi mount config")
 		return
 	}
 	annotations := sbx.GetAnnotations()

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -42,6 +42,8 @@ import (
 	"github.com/openkruise/agents/pkg/utils/timeout"
 )
 
+var jsonMarshal = json.Marshal
+
 // noServerTimeout is used when the server should not impose its own deadline on
 // the claim/clone/wait-ready phases of CreateSandbox. The operation is then
 // bounded only by the client request context (cancellation). It is a far-future
@@ -467,7 +469,7 @@ func (sc *Controller) csiMountOptionsConfigRecord(ctx context.Context, sbx infra
 		return
 	}
 	// marshal the csi mount confit to json
-	csiMountConfigRaw, err := json.Marshal(request.Extensions.CSIMount.MountConfigs)
+	csiMountConfigRaw, err := jsonMarshal(request.Extensions.CSIMount.MountConfigs)
 	if err != nil {
 		log.Error(err, "failed to marshal csi mount config")
 		return

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -281,6 +281,42 @@ func TestCsiMountOptionsConfigRecord(t *testing.T) {
 	}
 }
 
+func TestCsiMountOptionsConfigRecord_MarshalError(t *testing.T) {
+	oldMarshal := jsonMarshal
+	defer func() { jsonMarshal = oldMarshal }()
+	jsonMarshal = func(v any) ([]byte, error) {
+		return nil, fmt.Errorf("mock marshal error")
+	}
+
+	ctrl := &Controller{}
+	ctx := context.Background()
+	mockSbx := &sandboxcr.Sandbox{
+		Sandbox: &agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-sandbox",
+				Namespace:   "default",
+			},
+		},
+	}
+	request := models.NewSandboxRequest{
+		Extensions: models.NewSandboxRequestExtension{
+			CSIMount: models.CSIMountExtension{
+				MountConfigs: []v1alpha1.CSIMountConfig{
+					{MountPath: "/data"},
+				},
+			},
+		},
+	}
+	
+	// Ensure this doesn't panic and handles the error path
+	ctrl.csiMountOptionsConfigRecord(ctx, mockSbx, request)
+
+	// Annotation should not be set because marshal failed
+	if val, exists := mockSbx.GetAnnotations()[models.ExtensionKeyClaimWithCSIMount_MountConfig]; exists {
+		t.Errorf("expected no annotation, got %q", val)
+	}
+}
+
 func TestCreateSandboxWithClaim_CSIMount(t *testing.T) {
 	tests := []struct {
 		name               string


### PR DESCRIPTION

### Ⅰ. Describe what this PR does

This PR fixes a bug in `pkg/servers/e2b/create.go` where a `log.Info` call inside the `csiMountOptionsConfigRecord` function was provided with an odd number of arguments for its key-value pairs (`log.Info("failed to marshal csi mount config", err)`). This broke the structured logging, producing malformed output when trying to log an error.

The PR changes `log.Info` to `log.Error(err, "failed to marshal csi mount config")`, ensuring that the error is correctly handled and logged in the expected structured format.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #758

### Ⅲ. Describe how to verify it

This can be verified by running the unit tests for the `pkg/servers/e2b` package:
```bash
make test
# OR
go test ./pkg/servers/e2b/...
```
And manually reviewing the code change to ensure the `log.Error` signature conforms to the expected standard.

### Ⅳ. Special notes for reviews

```
NONE

```


