### PR TITLE
fix: requeue SandboxUpdateOps when skipped due to concurrent ops

### DIFF
--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,7 +121,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if other.Name != ops.Name && other.Status.Phase == agentsv1alpha1.SandboxUpdateOpsUpdating {
 			klog.InfoS("Another SandboxUpdateOps is already updating, skipping this one",
 				"current", klog.KObj(ops), "active", klog.KObj(other))
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 	}
 

--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
@@ -1334,7 +1334,7 @@ func TestReconcile_ConcurrentOpsInNamespace(t *testing.T) {
 		NamespacedName: types.NamespacedName{Name: "ops-pending", Namespace: "default"},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, ctrl.Result{}, result)
+	assert.Equal(t, ctrl.Result{RequeueAfter: 5 * time.Second}, result)
 
 	// Verify ops-pending was NOT transitioned (still Pending, no status update)
 	updatedOps := &agentsv1alpha1.SandboxUpdateOps{}


### PR DESCRIPTION

**PR Description:**

**Context:**
Fixes #759. 
When creating a new `SandboxUpdateOps` in a namespace where another `SandboxUpdateOps` is currently in the `Updating` phase, the controller skipped the new ops but returned an empty result `ctrl.Result{}, nil`. Without a `RequeueAfter` value, the event was dropped and the new ops stalled indefinitely until an external trigger caused a reconciliation.

**Changes:**
- Updated `pkg/controller/sandboxupdateops/sandboxupdateops_controller.go` to return `ctrl.Result{RequeueAfter: 5 * time.Second}` when skipping a concurrent `SandboxUpdateOps`.
- Updated `pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go` to assert the correct `RequeueAfter` result.

**Verification:**
- Ran the unit tests for the `sandboxupdateops` package, which passed successfully.

**PR Checklist:**
- [x] I have read the [Contributing Guidelines](https://github.com/openkruise/agents/blob/master/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked that all new and existing tests pass.
- [x] My code follows the code style of this project.
