### PR TITLE
fix(e2b): restrict /debug control-plane info to admin keys

### DIFF
--- a/pkg/sandbox-manager/api_test.go
+++ b/pkg/sandbox-manager/api_test.go
@@ -937,7 +937,38 @@ func (c *erroringClaimedSandboxCache) GetClaimedSandbox(context.Context, infraca
 
 func TestSandboxManager_Debug(t *testing.T) {
 	manager, _ := setupTestManager(t)
-	manager.GetDebugInfo()
+	manager.GetDebugInfo(DebugScope{IncludeControlPlane: true})
+}
+
+// TestSandboxManager_GetDebugInfoScope covers the control-plane gate. Peers
+// carries sandbox-manager pod IPs, so a caller that is not an admin must not
+// receive it.
+func TestSandboxManager_GetDebugInfoScope(t *testing.T) {
+	manager, _ := setupTestManager(t)
+
+	tests := []struct {
+		name                string
+		includeControlPlane bool
+		expectControlPlane  bool
+	}{
+		{name: "admin sees the control plane", includeControlPlane: true, expectControlPlane: true},
+		{name: "non-admin does not", includeControlPlane: false, expectControlPlane: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := manager.GetDebugInfo(DebugScope{IncludeControlPlane: tt.includeControlPlane})
+			if tt.expectControlPlane {
+				// Peers is empty in this fixture, so Pools is what distinguishes
+				// "reported" from "withheld" here.
+				assert.Equal(t, manager.infra.LoadDebugInfo(), info.Pools)
+				assert.NotNil(t, info.Pools)
+				return
+			}
+			assert.Nil(t, info.Peers)
+			assert.Nil(t, info.Pools)
+		})
+	}
 }
 
 func TestSandboxManager_PauseSandbox(t *testing.T) {

--- a/pkg/sandbox-manager/debug.go
+++ b/pkg/sandbox-manager/debug.go
@@ -25,9 +25,19 @@ type DebugInfo struct {
 	Pools map[string]any
 }
 
-func (m *SandboxManager) GetDebugInfo() DebugInfo {
-	return DebugInfo{
-		Peers: m.proxy.ListPeers(),
-		Pools: m.infra.LoadDebugInfo(),
+// DebugScope limits what GetDebugInfo reports. The caller decides what the
+// requester is allowed to see; this package only applies the filter.
+type DebugScope struct {
+	// IncludeControlPlane adds Peers and Pools. Both describe the
+	// sandbox-manager deployment rather than any caller's own sandboxes.
+	IncludeControlPlane bool
+}
+
+func (m *SandboxManager) GetDebugInfo(scope DebugScope) DebugInfo {
+	info := DebugInfo{}
+	if scope.IncludeControlPlane {
+		info.Peers = m.proxy.ListPeers()
+		info.Pools = m.infra.LoadDebugInfo()
 	}
+	return info
 }

--- a/pkg/servers/e2b/services.go
+++ b/pkg/servers/e2b/services.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog/v2"
 
 	sandboxmanager "github.com/openkruise/agents/pkg/sandbox-manager"
+	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
 	"github.com/openkruise/agents/pkg/utils"
@@ -207,8 +208,24 @@ func parseCDPPort(r *http.Request) (int, *web.ApiError) {
 	return port, nil
 }
 
-func (sc *Controller) Debug(_ *http.Request) (web.ApiResponse[sandboxmanager.DebugInfo], *web.ApiError) {
+// Debug reports proxy state for troubleshooting. A route carries the sandbox ID,
+// pod IP and owner of a sandbox, so callers outside the admin team only see the
+// routes they own, the same visibility rule ListSandboxes applies. Peers and
+// Pools describe the control plane and stay admin-only.
+func (sc *Controller) Debug(r *http.Request) (web.ApiResponse[sandboxmanager.DebugInfo], *web.ApiError) {
+	user := GetUserFromContext(r.Context())
+	if user == nil {
+		return web.ApiResponse[sandboxmanager.DebugInfo]{}, &web.ApiError{
+			Code:    http.StatusUnauthorized,
+			Message: "User not found",
+		}
+	}
+
+	scope := sandboxmanager.DebugScope{
+		IncludeControlPlane: keys.TeamForKey(user).Name == models.AdminTeamName,
+	}
+
 	return web.ApiResponse[sandboxmanager.DebugInfo]{
-		Body: sc.manager.GetDebugInfo(),
+		Body: sc.manager.GetDebugInfo(scope),
 	}, nil
 }


### PR DESCRIPTION
### I. Describe what this PR does

Rebased onto master, and the scope has shrunk since I opened this.

#686 removed `Routes` from `DebugInfo`, which takes the cross-tenant sandbox enumeration in #694 with it. So the route scoping this PR originally did is no longer needed and is gone.

What remains is the other half of the issue. `/debug` is registered with only `CheckApiKey`, and `CheckApiKey` enforces ownership just for paths carrying `{sandboxID}` or `{volumeID}`. `/debug` has neither, so any valid key still reaches it, and `Peers` carries sandbox-manager pod IPs and names. An ordinary tenant key learns the control-plane layout from it.

`Peers` and `Pools` are now reported only to keys in the admin team. The admin check stays in the API layer next to the rest of the auth code; the manager takes a neutral `DebugScope` and applies it.

Nothing changes for admin keys, or for installs with auth disabled, since the anonymous caller is in the admin team.

### II. Does this pull request fix one issue?

fixes #694

### III. Describe how to verify it

`go test ./pkg/sandbox-manager/ -run Debug -count=1`

`TestSandboxManager_GetDebugInfoScope` covers both sides of the gate. `Peers` is empty in that fixture, so the assertion keys on `Pools`, which is what distinguishes reported from withheld there.

### IV. Special notes for reviews

If you would rather `/debug` were admin-only outright now that it carries nothing tenant-scoped, say so and I will make it a 403 for non-admins instead. That is arguably cleaner than returning an empty body, and it is the other option #694 lists.
