### PR TITLE
fix(e2b): accept sandbox hosts without a port prefix

### DIFF
--- a/pkg/servers/e2b/adapters/native_e2b.go
+++ b/pkg/servers/e2b/adapters/native_e2b.go
@@ -21,6 +21,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/openkruise/agents/pkg/utils"
 )
 
 const (
@@ -42,7 +44,14 @@ type NativeE2BAdapter struct {
 	DefaultPort       int
 }
 
-var hostRegex = regexp.MustCompile(`^(\d+)-([a-zA-Z0-9\-]+)\.`)
+var (
+	hostRegex = regexp.MustCompile(`^(\d+)-([a-zA-Z0-9\-]+)\.`)
+	// e2b SDK >= 2.20 builds sandbox URLs as {sandboxID}.{domain}, dropping the
+	// {port}- prefix. Without that prefix there is nothing marking the host as a
+	// sandbox, so require the reserved "--" separator of a sandbox ID. Otherwise
+	// an ordinary host such as "some-gateway.internal" would parse as a sandbox.
+	hostRegexNoPort = regexp.MustCompile(`^([a-zA-Z0-9\-]+--[a-zA-Z0-9\-]+)\.`)
+)
 
 func (a *NativeE2BAdapter) getSandboxIDHeader() string {
 	if a.SandboxIDHeader != "" {
@@ -70,7 +79,9 @@ func (a *NativeE2BAdapter) getHostHeader() string {
 //     the port header (or DefaultPort when port header is absent).
 //  2. If sandbox ID header is not found, fall back to hostname parsing from authority or a custom
 //     host header. Parse the hostname format: {port}-{namespace}--{name}.{domain}.
-//  3. If neither yields a result, return error.
+//  3. Accept {namespace}--{name}.{domain} as well, the form e2b SDK >= 2.20 sends, and resolve
+//     the port from DefaultPort.
+//  4. If none yields a result, return error.
 func (a *NativeE2BAdapter) Map(req *ParsedRequest) (
 	sandboxID string, sandboxPort int, extraHeaders map[string]string, err error) {
 	authority := req.Authority
@@ -113,6 +124,18 @@ func (a *NativeE2BAdapter) Map(req *ParsedRequest) (
 			return // impossible
 		}
 		sandboxID = matches[2]
+		return
+	}
+
+	// Step 3: Hostname without a port prefix (SDK >= 2.20). The SDK omits the
+	// port when it talks to the runtime, so use the configured default port.
+	matches = hostRegexNoPort.FindStringSubmatch(resolvedAuthority)
+	if len(matches) == 2 {
+		sandboxID = matches[1]
+		sandboxPort = a.DefaultPort
+		if sandboxPort == 0 {
+			sandboxPort = utils.RuntimePort
+		}
 		return
 	}
 

--- a/pkg/servers/e2b/adapters/unified_e2b_test.go
+++ b/pkg/servers/e2b/adapters/unified_e2b_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -476,6 +477,45 @@ func TestNativeE2BAdapterHeaderBasedMap(t *testing.T) {
 			headers:           map[string]string{"x-custom-host": "8080-ns--sandbox2.example.com"},
 			expectSandboxID:   "ns--sandbox2",
 			expectSandboxPort: 8080,
+		},
+		{
+			name:              "hostname without port prefix: e2b SDK >= 2.20 falls back to the runtime port",
+			adapter:           &NativeE2BAdapter{},
+			authority:         "ns--sandbox1.example.com",
+			headers:           map[string]string{},
+			expectSandboxID:   "ns--sandbox1",
+			expectSandboxPort: utils.RuntimePort,
+		},
+		{
+			name:              "hostname without port prefix: configured default port wins",
+			adapter:           &NativeE2BAdapter{DefaultPort: 8888},
+			authority:         "ns--sandbox1.example.com",
+			headers:           map[string]string{},
+			expectSandboxID:   "ns--sandbox1",
+			expectSandboxPort: 8888,
+		},
+		{
+			name:              "hostname without port prefix: port prefix still wins when present",
+			adapter:           &NativeE2BAdapter{DefaultPort: 8888},
+			authority:         "3000-ns--sandbox1.example.com",
+			headers:           map[string]string{},
+			expectSandboxID:   "ns--sandbox1",
+			expectSandboxPort: 3000,
+		},
+		{
+			name:              "hostname without port prefix: reached through a custom host header",
+			adapter:           &NativeE2BAdapter{HostHeader: "x-custom-host"},
+			authority:         "some-api-gateway.internal",
+			headers:           map[string]string{"x-custom-host": "ns--sandbox2.example.com"},
+			expectSandboxID:   "ns--sandbox2",
+			expectSandboxPort: utils.RuntimePort,
+		},
+		{
+			name:      "hostname without port prefix: host without the -- separator is not a sandbox",
+			adapter:   &NativeE2BAdapter{},
+			authority: "grafana.example.com",
+			headers:   map[string]string{},
+			expectErr: true,
 		},
 		{
 			name:      "custom host header: custom header not present, authority doesn't match",


### PR DESCRIPTION
### I. Describe what this PR does

`hostRegex` in the native adapter only matches `{port}-{sandboxID}.{domain}`. e2b SDK >= 2.20 dropped the port prefix and sends `{sandboxID}.{domain}`, so `Map` could not extract the sandbox and every connection failed. `pip install e2b` gets that version, so this hits anyone following the docs.

Added a second pattern for the portless form. The port comes from `DefaultPort`, already wired to 49983 by the gateway config, and falls back to `utils.RuntimePort` for the sandbox-manager adapter, which does not set one.

The new pattern requires the `--` separator instead of matching any subdomain. Without the `{port}-` prefix there is nothing else marking the host as a sandbox, and a permissive pattern would swallow ordinary hosts like `grafana.example.com` that currently produce a clear error. The `{port}-` form is still tried first, so nothing about existing URLs changes.

### II. Does this pull request fix one issue?

fixes #253

### III. Describe how to verify it

`go test ./pkg/servers/e2b/adapters/ -count=1`

New cases in `TestNativeE2BAdapter_Map` cover the portless host, the configured default port winning over the runtime port, the port prefix still winning when present, the custom host header path, and a non-sandbox host still erroring.

### IV. Special notes for reviews

Rebased onto master now that #686 has landed, which answers the question I left here originally.

Short IDs are 13 characters with no `--` in them, so the portless pattern will not match one. That combination is not reachable by default, since `--enable-short-sandbox-id` is off and the `{port}-` form is still matched first, so this is missing coverage rather than a regression. Covering it needs a way to tell a bare short ID apart from an ordinary subdomain, and `--short-sandbox-id-prefix` looks like the intended hook. Happy to extend this PR if you want that now, but it seemed like a separate decision rather than something to guess at here.

I did not touch `GetSandboxAddress`, which still hands out the `{port}-{id}.{domain}` form. That URL keeps working, so this is only about accepting what newer SDKs send.
