### PR TITLE
feat(utils): add atomic max and generic concurrent map helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,17 +152,26 @@ docker-buildx-manager: ## Build multi-platform docker image for sandbox-manager.
 docker-pushx-manager: ## Build and push multi-platform docker image for sandbox-manager.
 	docker buildx build --platform=$(PLATFORMS) -f dockerfiles/sandbox-manager.Dockerfile -t ${MANAGER_IMG} --push .
 
+# RUNTIME_VERSION stamps the agent-runtime binary with the revision it was built
+# from (nearest agent-runtime tag + commit + dirty marker), falling back to the
+# bare commit when no such tag exists and to "dev" outside a git tree. The tag
+# filter matters: this repo tags several components, so an unfiltered
+# `git describe` would label agent-runtime with an unrelated component's tag.
+# .dockerignore excludes .git from the build context, so the value must be
+# resolved here and handed to the image build as the VERSION build-arg.
+RUNTIME_VERSION ?= $(shell git describe --tags --always --dirty --match 'agent-runtime-v*' 2>/dev/null || echo "dev")
+
 .PHONY: docker-build-runtime
 docker-build-runtime: ## Build docker image for agent-runtime.
-	docker build -f dockerfiles/agent-runtime.Dockerfile -t ${RUNTIME_IMG} .
+	docker build --build-arg VERSION=$(RUNTIME_VERSION) -f dockerfiles/agent-runtime.Dockerfile -t ${RUNTIME_IMG} .
 
 .PHONY: docker-buildx-runtime
 docker-buildx-runtime: ## Build multi-platform docker image for agent-runtime.
-	docker buildx build --platform=$(PLATFORMS) -f dockerfiles/agent-runtime.Dockerfile -t ${RUNTIME_IMG} .
+	docker buildx build --platform=$(PLATFORMS) --build-arg VERSION=$(RUNTIME_VERSION) -f dockerfiles/agent-runtime.Dockerfile -t ${RUNTIME_IMG} .
 
 .PHONY: docker-pushx-runtime
 docker-pushx-runtime: ## Build and push multi-platform docker image for agent-runtime.
-	docker buildx build --platform=$(PLATFORMS) -f dockerfiles/agent-runtime.Dockerfile -t ${RUNTIME_IMG} --push .
+	docker buildx build --platform=$(PLATFORMS) --build-arg VERSION=$(RUNTIME_VERSION) -f dockerfiles/agent-runtime.Dockerfile -t ${RUNTIME_IMG} --push .
 
 .PHONY: build-sandbox-gateway
 build-sandbox-gateway: $(LOCALBIN) ## Build sandbox-gateway plugin binary.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openkruise/agents
 
-go 1.25.0
+go 1.25.9
 
 require (
 	connectrpc.com/connect v1.19.1

--- a/pkg/traffic-extension/handlers/audit_test.go
+++ b/pkg/traffic-extension/handlers/audit_test.go
@@ -21,8 +21,8 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	v1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/traffic-extension/model"

--- a/pkg/traffic-extension/util/matcher/matcher_test.go
+++ b/pkg/traffic-extension/util/matcher/matcher_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestParseRequestInfo(t *testing.T) {
 	h1 := map[string]string{":authority": "api.openai.com", ":path": "/v1/chat", ":method": "POST"}
-	info1 := ParseRequestInfo(context.Background(),h1)
+	info1 := ParseRequestInfo(context.Background(), h1)
 	if info1.Host != "api.openai.com" {
 		t.Errorf("expected host 'api.openai.com', got %q", info1.Host)
 	}
@@ -35,7 +35,7 @@ func TestParseRequestInfo(t *testing.T) {
 	}
 
 	h2 := map[string]string{"host": "example.com", ":path": "/api"}
-	info2 := ParseRequestInfo(context.Background(),h2)
+	info2 := ParseRequestInfo(context.Background(), h2)
 	if info2.Host != "example.com" {
 		t.Errorf("expected host 'example.com', got %q", info2.Host)
 	}
@@ -97,7 +97,7 @@ func TestSplitPathAndQuery(t *testing.T) {
 // TestParseRequestInfo_SplitsHostAndPath verifies the front-door parser splits
 // ":authority" into Host+Port and ":path" into Path+Query.
 func TestParseRequestInfo_SplitsHostAndPath(t *testing.T) {
-	info := ParseRequestInfo(context.Background(),map[string]string{
+	info := ParseRequestInfo(context.Background(), map[string]string{
 		":authority": "api.example.com:8443",
 		":path":      "/v1/chat?x=1&y=2",
 		":method":    "POST",
@@ -116,7 +116,7 @@ func TestParseRequestInfo_SplitsHostAndPath(t *testing.T) {
 	}
 
 	// Falls back to "host" header when :authority is absent.
-	info2 := ParseRequestInfo(context.Background(),map[string]string{
+	info2 := ParseRequestInfo(context.Background(), map[string]string{
 		"host":    "fallback.example.com:1234",
 		":path":   "/p",
 		":method": "GET",
@@ -129,7 +129,7 @@ func TestParseRequestInfo_SplitsHostAndPath(t *testing.T) {
 	}
 
 	// Empty headers map yields zero RequestInfo (with non-nil Headers map).
-	info3 := ParseRequestInfo(context.Background(),map[string]string{})
+	info3 := ParseRequestInfo(context.Background(), map[string]string{})
 	if info3.Host != "" || info3.Path != "" || info3.Method != "" || info3.Port != 0 {
 		t.Errorf("expected empty info, got %+v", info3)
 	}
@@ -175,7 +175,7 @@ func TestParseRequestInfo_InfersPortFromScheme(t *testing.T) {
 			if tt.scheme != "" {
 				h[":scheme"] = tt.scheme
 			}
-			info := ParseRequestInfo(context.Background(),h)
+			info := ParseRequestInfo(context.Background(), h)
 			if info.Port != tt.wantPort {
 				t.Errorf("got Port=%d, want %d", info.Port, tt.wantPort)
 			}

--- a/pkg/utils/atomic/atomic_max.go
+++ b/pkg/utils/atomic/atomic_max.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 The OpenKruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package atomic provides simple atomic primitives that are not covered by
+// the standard library. Aligned with community envd's internal utilities so
+// that idempotent gates (e.g. /init Timestamp guard) behave identically.
+package atomic
+
+import "sync"
+
+// AtomicMax tracks a monotonically non-decreasing int64 value.
+// Concurrent callers compete via SetToGreater; only the writer that observes
+// a strictly newer value wins.
+type AtomicMax struct {
+	val int64
+	mu  sync.Mutex
+}
+
+// NewAtomicMax returns a zero-initialised AtomicMax.
+func NewAtomicMax() *AtomicMax {
+	return &AtomicMax{}
+}
+
+// SetToGreater sets the stored value to newValue iff newValue is greater than
+// or equal to the current value, and returns true on success. A strictly
+// smaller newValue is rejected and false is returned.
+//
+// This is the core primitive used to gate idempotent writes against replayed
+// or out-of-order requests: callers should treat false as "skip side effects".
+func (a *AtomicMax) SetToGreater(newValue int64) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.val > newValue {
+		return false
+	}
+
+	a.val = newValue
+
+	return true
+}

--- a/pkg/utils/atomic/atomic_max_test.go
+++ b/pkg/utils/atomic/atomic_max_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2024 The OpenKruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package atomic
+
+import (
+	"math"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AtomicMax exposes no reader, so the stored value can only be observed through
+// what a later SetToGreater accepts or rejects. probeAtOrAbove reports whether
+// the stored value is at least want, by offering want-1: a rejection means the
+// stored value is strictly greater than want-1, i.e. at least want.
+//
+// On the expected path — the stored value really is at least want — the offer is
+// rejected and nothing is written, so probing is side-effect free. An offer that
+// gets accepted means the assertion has already failed. want must be above
+// MinInt64, since want-1 would otherwise underflow.
+func probeAtOrAbove(t *testing.T, m *AtomicMax, want int64) bool {
+	t.Helper()
+
+	return !m.SetToGreater(want - 1)
+}
+
+func TestAtomicMax_SetToGreater(t *testing.T) {
+	tests := []struct {
+		name string
+		// seed is applied in order before the assertion, so the max under test
+		// starts from a known high-water mark.
+		seed  []int64
+		value int64
+		want  bool
+	}{
+		{
+			name:  "first write above the zero value is accepted",
+			value: 1,
+			want:  true,
+		},
+		{
+			// A fresh max holds 0, and 0 is not smaller than 0, so re-writing the
+			// initial value counts as accepted rather than as a stale replay.
+			name:  "zero on a fresh max is accepted",
+			value: 0,
+			want:  true,
+		},
+		{
+			// The zero value doubles as the low-water mark, so a negative value can
+			// never be stored — not even as the very first write.
+			name:  "negative on a fresh max is rejected",
+			value: -1,
+			want:  false,
+		},
+		{
+			name:  "greater than the current value is accepted",
+			seed:  []int64{5},
+			value: 6,
+			want:  true,
+		},
+		{
+			// Equal is accepted: the guard rejects only a strictly smaller value.
+			// A caller that needs "a replay of the same timestamp must be skipped"
+			// does not get it from this primitive.
+			name:  "equal to the current value is accepted",
+			seed:  []int64{5},
+			value: 5,
+			want:  true,
+		},
+		{
+			name:  "smaller than the current value is rejected",
+			seed:  []int64{5},
+			value: 4,
+			want:  false,
+		},
+		{
+			name:  "the highest seed wins regardless of the order it arrived in",
+			seed:  []int64{1, 9, 3},
+			value: 8,
+			want:  false,
+		},
+		{
+			name:  "MaxInt64 is accepted",
+			seed:  []int64{5},
+			value: math.MaxInt64,
+			want:  true,
+		},
+		{
+			name:  "MinInt64 is rejected",
+			seed:  []int64{5},
+			value: math.MinInt64,
+			want:  false,
+		},
+		{
+			// Nothing is greater than MaxInt64, so the max saturates: once there,
+			// only MaxInt64 itself is still accepted (by the equal-is-accepted rule).
+			name:  "MaxInt64 saturates the max",
+			seed:  []int64{math.MaxInt64},
+			value: math.MaxInt64,
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewAtomicMax()
+			for _, seed := range tt.seed {
+				_ = m.SetToGreater(seed)
+			}
+
+			assert.Equal(t, tt.want, m.SetToGreater(tt.value))
+		})
+	}
+}
+
+// TestAtomicMax_RejectedWriteLeavesValueIntact pins down the property the guard
+// exists for: a rejected write must not move the high-water mark, or a stale
+// request would lower the bar for the next one.
+func TestAtomicMax_RejectedWriteLeavesValueIntact(t *testing.T) {
+	m := NewAtomicMax()
+	require.True(t, m.SetToGreater(10))
+
+	require.False(t, m.SetToGreater(5), "a stale value must be rejected")
+
+	// Had the rejected 5 been stored, 9 would now be accepted.
+	assert.False(t, m.SetToGreater(9), "the rejected write must not have lowered the max")
+	assert.True(t, probeAtOrAbove(t, m, 10), "the max must still hold 10")
+}
+
+// TestAtomicMax_ZeroValueIsUsable asserts the constructor is a convenience, not
+// a requirement: an embedded or declared AtomicMax works without it.
+func TestAtomicMax_ZeroValueIsUsable(t *testing.T) {
+	var m AtomicMax
+
+	assert.True(t, m.SetToGreater(7))
+	assert.False(t, m.SetToGreater(6))
+	assert.True(t, probeAtOrAbove(t, &m, 7))
+}
+
+// TestAtomicMax_MonotonicSequence walks a mixed sequence and asserts the max
+// never decreases: every value at or above the running high-water mark is
+// accepted, every value below it is rejected.
+func TestAtomicMax_MonotonicSequence(t *testing.T) {
+	m := NewAtomicMax()
+
+	sequence := []struct {
+		value int64
+		want  bool
+	}{
+		{value: 3, want: true},
+		{value: 3, want: true},  // equal, still accepted
+		{value: 2, want: false}, // below the mark
+		{value: 4, want: true},
+		{value: 1, want: false},
+		{value: 100, want: true},
+		{value: 99, want: false},
+	}
+
+	for _, step := range sequence {
+		assert.Equal(t, step.want, m.SetToGreater(step.value), "value %d", step.value)
+	}
+
+	assert.True(t, probeAtOrAbove(t, m, 100), "the highest accepted value must be the one retained")
+}
+
+// TestAtomicMax_ConcurrentSetToGreater is the reason the type carries a mutex:
+// competing writers must not corrupt the value or race. Under -race this is what
+// surfaces an unsynchronised read-modify-write.
+func TestAtomicMax_ConcurrentSetToGreater(t *testing.T) {
+	const (
+		writers   = 8
+		perWriter = 100
+	)
+
+	m := NewAtomicMax()
+
+	var wg sync.WaitGroup
+	for writer := range writers {
+		wg.Add(1)
+		go func(writer int) {
+			defer wg.Done()
+
+			// Interleave ascending and descending offers so both branches of the
+			// guard run concurrently.
+			for i := range perWriter {
+				_ = m.SetToGreater(int64(writer*perWriter + i))
+				_ = m.SetToGreater(int64(perWriter - i))
+			}
+		}(writer)
+	}
+	wg.Wait()
+
+	// The largest value ever offered is (writers-1)*perWriter + perWriter-1.
+	highest := int64((writers-1)*perWriter + perWriter - 1)
+	assert.True(t, probeAtOrAbove(t, m, highest), "the max must retain the highest offered value")
+	assert.False(t, m.SetToGreater(highest-1), "nothing below the high-water mark may be accepted")
+}

--- a/pkg/utils/runtime/client.go
+++ b/pkg/utils/runtime/client.go
@@ -140,8 +140,11 @@ func WithRefresh(fn RefreshFunc) Option {
 // on RuntimeTLSPort while verifying the server certificate against
 // RuntimeServerSNI (overridable via
 // WithAuthority), reproducing `curl --resolve`. CABundle is required to verify
-// the server; a client certificate is optional (the runtime server uses
-// VerifyClientCertIfGiven). An invalid bundle is reported by the first call.
+// the server; a client certificate is required as well against any runtime
+// started with -tls-ca-cert-file, which demands one
+// (tls.RequireAndVerifyClientCert) and additionally may allow-list the
+// certificate identity via -allowed-client-cns. An invalid bundle is reported by
+// the first call.
 func WithTLS(m TLSBundle) Option {
 	return func(rc *runtimeClient) {
 		rc.tlsEnabled = true

--- a/pkg/utils/runtime/transport.go
+++ b/pkg/utils/runtime/transport.go
@@ -62,12 +62,13 @@ const (
 // TLSBundle carries the client-side certificate material used to speak
 // HTTPS/mTLS to the agent-runtime.
 //
-// Only CABundle is required: it verifies the server certificate presented by
-// the runtime. ClientCertPEM/ClientKeyPEM are optional because the runtime
-// server is configured with tls.VerifyClientCertIfGiven — presenting a client
-// certificate upgrades the connection to mutual TLS, but omitting it still
-// yields a valid server-authenticated TLS connection. Provide both the client
-// certificate and key together, or neither.
+// CABundle is always required: it verifies the server certificate presented by
+// the runtime. ClientCertPEM/ClientKeyPEM are structurally optional — a bundle
+// without them still yields a valid server-authenticated TLS connection — but a
+// runtime started with -tls-ca-cert-file demands a client certificate
+// (tls.RequireAndVerifyClientCert) and will fail such a handshake with "client
+// didn't provide a certificate". Omit them only against a runtime that runs
+// without a client CA. Provide the certificate and key together, or neither.
 type TLSBundle struct {
 	// CABundle is the PEM-encoded CA certificate(s) that issued the runtime
 	// server certificate. Required.
@@ -107,7 +108,9 @@ func parseTLSBundle(m TLSBundle) (*parsedTLSBundle, error) {
 		return nil, fmt.Errorf("failed to parse runtime TLS CA bundle")
 	}
 	parsed := &parsedTLSBundle{rootCAs: pool}
-	// Client certificate is optional (server uses VerifyClientCertIfGiven).
+	// Structurally optional: a runtime configured without a client CA serves
+	// server-authenticated TLS. One configured with a client CA requires the
+	// certificate, so a bundle that omits it fails at the handshake, not here.
 	if len(m.ClientCertPEM) > 0 || len(m.ClientKeyPEM) > 0 {
 		cert, err := tls.X509KeyPair(m.ClientCertPEM, m.ClientKeyPEM)
 		if err != nil {
@@ -176,8 +179,9 @@ func NewTLSBundle(dir string) (*TLSBundle, error) {
 	certMissing, keyMissing := os.IsNotExist(certErr), os.IsNotExist(keyErr)
 	switch {
 	case certMissing && keyMissing:
-		// Server-authenticated TLS only; the runtime server accepts it
-		// (VerifyClientCertIfGiven).
+		// Server-authenticated TLS only. Accepted just by a runtime that runs
+		// without -tls-ca-cert-file; one that has a client CA requires the
+		// certificate and rejects this bundle at the handshake.
 		certPEM, keyPEM = nil, nil
 	case certErr != nil:
 		return nil, fmt.Errorf("failed to read runtime client certificate %s: %w", filepath.Join(dir, clientCertFile), certErr)


### PR DESCRIPTION
Add three small, dependency-light building blocks under pkg/utils:

- pkg/utils/atomic: AtomicMax tracks a monotonically non-decreasing int64 and exposes SetToGreater, the primitive used to gate idempotent writes against replayed or out-of-order requests.
- pkg/utils/map: type-safe generic wrapper over sync.Map that removes the per-call type assertions at the call sites.
- pkg/utils/smap: string-keyed generic map backed by github.com/orcaman/concurrent-map/v2, for sharded concurrent access with callback-based upsert/remove.

Also included:

- Makefile: stamp the agent-runtime image with RUNTIME_VERSION, derived from the nearest agent-runtime-v* tag, and hand it to the build as the VERSION build-arg. The tag filter avoids labelling agent-runtime with another component's tag, and the value must be resolved outside the image because .dockerignore excludes .git from the build context.
- pkg/utils/runtime: correct the TLSBundle documentation. A runtime started with -tls-ca-cert-file uses RequireAndVerifyClientCert, so a bundle without a client certificate fails at the handshake rather than yielding a server-authenticated connection; the client certificate is only structurally optional.
- go.mod: require github.com/orcaman/concurrent-map/v2 v2.0.1 and raise the go directive to 1.25.9.
- pkg/traffic-extension/util/matcher: gofmt the ParseRequestInfo test call sites.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

