### PR TITLE
feat: rename dynamic storage to on-demand mount

### DIFF
--- a/api/v1alpha1/sandboxclaim_types.go
+++ b/api/v1alpha1/sandboxclaim_types.go
@@ -80,13 +80,24 @@ type SandboxClaimSpec struct {
 	// +optional
 	InplaceUpdate *SandboxClaimInplaceUpdateOptions `json:"inplaceUpdate,omitempty"`
 
-	// DynamicVolumesMount specifies the dynamic volumes to be mounted into the sandbox
+	// OnDemandMounts specifies the volumes to be mounted into the sandbox on demand,
+	// at claim time, via CSI NodePublishVolume.
 	// +optional
 	// +patchMergeKey=mountPath
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=mountPath
-	DynamicVolumesMount []CSIMountConfig `json:"dynamicVolumesMount" patchMergeKey:"mountPath" patchStrategy:"merge"`
+	OnDemandMounts []CSIMountConfig `json:"onDemandMounts,omitempty" patchMergeKey:"mountPath" patchStrategy:"merge"`
+
+	// DynamicVolumesMount specifies the dynamic volumes to be mounted into the sandbox.
+	// If both are set, OnDemandMounts takes precedence.
+	// +optional
+	// +patchMergeKey=mountPath
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=mountPath
+	// Deprecated: use OnDemandMounts instead. Will be removed in v1beta1.
+	DynamicVolumesMount []CSIMountConfig `json:"dynamicVolumesMount,omitempty" patchMergeKey:"mountPath" patchStrategy:"merge"`
 
 	// Runtimes - Runtime configuration for sandbox object
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1547,6 +1547,13 @@ func (in *SandboxClaimSpec) DeepCopyInto(out *SandboxClaimSpec) {
 		*out = new(SandboxClaimInplaceUpdateOptions)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.OnDemandMounts != nil {
+		in, out := &in.OnDemandMounts, &out.OnDemandMounts
+		*out = make([]CSIMountConfig, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.DynamicVolumesMount != nil {
 		in, out := &in.DynamicVolumesMount, &out.DynamicVolumesMount
 		*out = make([]CSIMountConfig, len(*in))

--- a/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
@@ -81,8 +81,10 @@ spec:
                   available
                 type: boolean
               dynamicVolumesMount:
-                description: DynamicVolumesMount specifies the dynamic volumes to
-                  be mounted into the sandbox
+                description: |-
+                  DynamicVolumesMount specifies the dynamic volumes to be mounted into the sandbox.
+                  If both are set, OnDemandMounts takes precedence.
+                  Deprecated: use OnDemandMounts instead. Will be removed in v1beta1.
                 items:
                   properties:
                     attributes:
@@ -170,6 +172,34 @@ spec:
                   to claimed Sandbox resources and synced to sandbox template labels.
                 type: object
                 x-kubernetes-map-type: granular
+              onDemandMounts:
+                description: |-
+                  OnDemandMounts specifies the volumes to be mounted into the sandbox on demand,
+                  at claim time, via CSI NodePublishVolume.
+                items:
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    mountID:
+                      type: string
+                    mountPath:
+                      type: string
+                    pvName:
+                      type: string
+                    readOnly:
+                      type: boolean
+                    subPath:
+                      type: string
+                  required:
+                  - mountPath
+                  - pvName
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - mountPath
+                x-kubernetes-list-type: map
               replicas:
                 default: 1
                 description: |-

--- a/pkg/agent-runtime/common/types.go
+++ b/pkg/agent-runtime/common/types.go
@@ -18,6 +18,10 @@ package common
 
 const (
 	// this is a env var for supported storage driver names
+	ENV_ON_DEMAND_MOUNT_DRIVER_LIST = "ON_DEMAND_MOUNT_DRIVER_LIST"
+
+	// Deprecated: use ENV_ON_DEMAND_MOUNT_DRIVER_LIST instead. Still read when the
+	// current name is unset, so existing deployments keep working.
 	ENV_DYNAMIC_STORAGE_DRIVER_LIST = "DYNAMIC_STORAGE_DRIVER_LIST"
 
 	// RuntimeInitContainerName is the name of the runtime init container.

--- a/pkg/agent-runtime/storages/config.go
+++ b/pkg/agent-runtime/storages/config.go
@@ -30,9 +30,27 @@ var (
 	driversConfig           = map[string]string{}
 )
 
+// driverListFromEnv reads the configured CSI driver names.
+// ENV_DYNAMIC_STORAGE_DRIVER_LIST is the deprecated spelling of
+// ENV_ON_DEMAND_MOUNT_DRIVER_LIST, so it is only read when the current name is unset.
+// Empty entries are dropped; an unset variable configures no drivers at all.
+func driverListFromEnv() []string {
+	list := os.Getenv(common.ENV_ON_DEMAND_MOUNT_DRIVER_LIST)
+	if list == "" {
+		list = os.Getenv(common.ENV_DYNAMIC_STORAGE_DRIVER_LIST)
+	}
+
+	var drivers []string
+	for _, name := range strings.Split(list, ",") {
+		if name = strings.TrimSpace(name); name != "" {
+			drivers = append(drivers, name)
+		}
+	}
+	return drivers
+}
+
 func init() {
-	dynamicDriverList := strings.Split(os.Getenv(common.ENV_DYNAMIC_STORAGE_DRIVER_LIST), ",")
-	for _, driverName := range dynamicDriverList {
+	for _, driverName := range driverListFromEnv() {
 		initializeProviderFuncs = append(initializeProviderFuncs,
 			func(sp *StorageProvider) {
 				sp.RegisterProvider(driverName, &MountProvider{})

--- a/pkg/agent-runtime/storages/config_test.go
+++ b/pkg/agent-runtime/storages/config_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openkruise/agents/pkg/agent-runtime/common"
 )
 
@@ -93,4 +95,48 @@ func TestInitFunction(t *testing.T) {
 // resetInitializeProviderFuncs resets the global initializeProviderFuncs slice for testing
 func resetInitializeProviderFuncs() {
 	initializeProviderFuncs = []initProviderFunc{}
+}
+
+func TestDriverListFromEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		onDemandEnv string
+		dynamicEnv  string
+		expect      []string
+	}{
+		{
+			name:        "current env var",
+			onDemandEnv: "driver1,driver2",
+			expect:      []string{"driver1", "driver2"},
+		},
+		{
+			name:       "deprecated env var is still honoured",
+			dynamicEnv: "driver1,driver2",
+			expect:     []string{"driver1", "driver2"},
+		},
+		{
+			name:        "current env var wins when both are set",
+			onDemandEnv: "new-driver",
+			dynamicEnv:  "old-driver",
+			expect:      []string{"new-driver"},
+		},
+		{
+			name:   "neither set configures no drivers",
+			expect: nil,
+		},
+		{
+			name:        "blank entries are dropped",
+			onDemandEnv: "driver1,, driver2 ,",
+			expect:      []string{"driver1", "driver2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(common.ENV_ON_DEMAND_MOUNT_DRIVER_LIST, tt.onDemandEnv)
+			t.Setenv(common.ENV_DYNAMIC_STORAGE_DRIVER_LIST, tt.dynamicEnv)
+
+			assert.Equal(t, tt.expect, driverListFromEnv())
+		})
+	}
 }

--- a/pkg/controller/sandbox/core/interface.go
+++ b/pkg/controller/sandbox/core/interface.go
@@ -134,7 +134,7 @@ func NewSandboxControl(args SandboxControlArgs) map[string]SandboxControl {
 }
 
 // SandboxInitializer handles sandbox post-recreation initialization after resume or recreate upgrade.
-// When a sandbox pod becomes available again, runtime and dynamic CSI mounts need to be re-initialized.
+// When a sandbox pod becomes available again, runtime and on-demand CSI mounts need to be re-initialized.
 type SandboxInitializer interface {
 	Initialize(ctx context.Context, box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus) error
 }

--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -414,9 +414,9 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 	if err := c.applyInitRuntimeOptions(ctx, &opts, claim, sandboxSet); err != nil {
 		return opts, err
 	}
-	if len(claim.Spec.DynamicVolumesMount) > 0 {
+	if mounts := onDemandMountsOf(claim); len(mounts) > 0 {
 		var err error
-		opts.CSIMount, storageAuthKey, storageAuthValue, err = c.buildCSIMountOptions(ctx, claim.Spec.DynamicVolumesMount)
+		opts.CSIMount, storageAuthKey, storageAuthValue, err = c.buildCSIMountOptions(ctx, mounts)
 		if err != nil {
 			return opts, err
 		}
@@ -476,6 +476,16 @@ func (c *commonControl) applyInitRuntimeOptions(ctx context.Context, opts *infra
 			"sandboxSet", klog.KObj(sandboxSet), "claim", klog.KObj(claim))
 	}
 	return nil
+}
+
+// onDemandMountsOf returns the mounts to apply for a claim. DynamicVolumesMount is
+// the deprecated spelling of OnDemandMounts, so it is only read when the new field
+// is empty. Claims written against either field keep working.
+func onDemandMountsOf(claim *agentsv1alpha1.SandboxClaim) []agentsv1alpha1.CSIMountConfig {
+	if len(claim.Spec.OnDemandMounts) > 0 {
+		return claim.Spec.OnDemandMounts
+	}
+	return claim.Spec.DynamicVolumesMount
 }
 
 // buildCSIMountOptions generates CSI mount options and storage-auth annotation

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -2277,7 +2277,9 @@ func TestBuildClaimOptions_CSIMount_ConfigValidation(t *testing.T) {
 				},
 				Spec: agentsv1alpha1.SandboxClaimSpec{
 					TemplateName: "test-template",
-					DynamicVolumesMount: []agentsv1alpha1.CSIMountConfig{
+					// Uses the current field name; the cases below still cover the
+					// deprecated DynamicVolumesMount spelling.
+					OnDemandMounts: []agentsv1alpha1.CSIMountConfig{
 						{
 							PvName:    "test-pv-nas",
 							MountPath: "/data",
@@ -3381,6 +3383,66 @@ func TestBuildClaimOptions_CSIMount_Test(t *testing.T) {
 			if tt.validate != nil {
 				tt.validate(t, opts)
 			}
+		})
+	}
+}
+
+func TestOnDemandMountsOf(t *testing.T) {
+	newMounts := []agentsv1alpha1.CSIMountConfig{{PvName: "pv-new", MountPath: "/new"}}
+	deprecatedMounts := []agentsv1alpha1.CSIMountConfig{{PvName: "pv-old", MountPath: "/old"}}
+
+	tests := []struct {
+		name       string
+		spec       agentsv1alpha1.SandboxClaimSpec
+		expectPVs  []string
+		expectNone bool
+	}{
+		{
+			name:      "current field is used",
+			spec:      agentsv1alpha1.SandboxClaimSpec{OnDemandMounts: newMounts},
+			expectPVs: []string{"pv-new"},
+		},
+		{
+			name:      "deprecated field is still honoured",
+			spec:      agentsv1alpha1.SandboxClaimSpec{DynamicVolumesMount: deprecatedMounts},
+			expectPVs: []string{"pv-old"},
+		},
+		{
+			name: "current field wins when both are set",
+			spec: agentsv1alpha1.SandboxClaimSpec{
+				OnDemandMounts:      newMounts,
+				DynamicVolumesMount: deprecatedMounts,
+			},
+			expectPVs: []string{"pv-new"},
+		},
+		{
+			name: "empty current field falls back to the deprecated one",
+			spec: agentsv1alpha1.SandboxClaimSpec{
+				OnDemandMounts:      []agentsv1alpha1.CSIMountConfig{},
+				DynamicVolumesMount: deprecatedMounts,
+			},
+			expectPVs: []string{"pv-old"},
+		},
+		{
+			name:       "neither field set",
+			spec:       agentsv1alpha1.SandboxClaimSpec{},
+			expectNone: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mounts := onDemandMountsOf(&agentsv1alpha1.SandboxClaim{Spec: tt.spec})
+			if tt.expectNone {
+				assert.Empty(t, mounts)
+				return
+			}
+
+			pvNames := make([]string, 0, len(mounts))
+			for _, mount := range mounts {
+				pvNames = append(pvNames, mount.PvName)
+			}
+			assert.Equal(t, tt.expectPVs, pvNames)
 		})
 	}
 }

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -678,7 +678,7 @@ func (s *Sandbox) GetClaimTime() (time.Time, error) {
 	return time.Parse(time.RFC3339, claimTimestamp)
 }
 
-// CSIMount creates a dynamic mount point in Sandbox with `sandbox-storage` cli.
+// CSIMount creates an on-demand mount point in Sandbox with `sandbox-storage` cli.
 // It delegates to the runtime package's CSIMount function to avoid circular dependencies.
 func (s *Sandbox) CSIMount(ctx context.Context, driver string, request string) error {
 	return runtime.CSIMount(ctx, s.Sandbox, driver, request)

--- a/pkg/utils/runtime/csi.go
+++ b/pkg/utils/runtime/csi.go
@@ -44,7 +44,7 @@ import (
 
 var MountCommand = "/mnt/envd/sandbox-runtime-storage"
 
-// CSIMount creates a dynamic mount point in Sandbox with `sandbox-storage` cli.
+// CSIMount creates an on-demand mount point in Sandbox with `sandbox-storage` cli.
 // It accepts the raw Sandbox API object to avoid circular dependency on the sandboxcr package.
 //
 // NOTE: `sandbox-storage` cli should be injected with `sandbox-runtime` and will be replaced by a built-in service of


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Implements the rename from the issue, Phase 1 (introduce), using the recommended Option A: controller-level fallback, no new webhook.

- `SandboxClaimSpec.OnDemandMounts` added; `DynamicVolumesMount` kept and marked deprecated.
- `ON_DEMAND_MOUNT_DRIVER_LIST` added; `DYNAMIC_STORAGE_DRIVER_LIST` kept.
- The deprecated field and env var are only read when the current one is unset, so existing claims and deployments keep working with no action.
- Comment-only updates in `csi.go`, `sandbox.go` and `sandbox/core/interface.go`.
- `zz_generated.deepcopy.go` and the sandboxclaims CRD regenerated.

Two small deviations from the issue text, both easy to revert if you'd rather I didn't:

The fallback is a small `onDemandMountsOf` helper rather than inlined in `buildClaimOptions`, so the precedence rule is testable on its own.

I left most existing tests on `DynamicVolumesMount` instead of converting all ~20 references. Converting them would have moved every case onto the new field and left the deprecated path with no coverage at all, which seemed like the wrong trade for a compatibility shim. One case now uses `OnDemandMounts` so the new field is exercised end to end through `buildClaimOptions`, and `TestOnDemandMountsOf` covers precedence directly.

I also gave the deprecated field `omitempty`, matching the snippet in the issue. It previously serialized as `dynamicVolumesMount: null` on every claim; without this, every object would carry both fields as null.

While extracting `driverListFromEnv` I noticed the old `init()` fed `strings.Split("", ",")` straight into the loop, which returns `[""]` and registers a provider under an empty driver name whenever the env var is unset. The new helper drops blank entries, as the issue's Layer 4 snippet does. `TestInitFunction` did not catch this because it reimplements the parsing logic locally rather than calling the real code. The new test calls `driverListFromEnv` directly.

Not in this PR, per the phased plan in the issue: deprecation warnings and doc updates (Phase 2), removal (Phase 3).

### Ⅱ. Does this pull request fix one issue?

fixes #481

### Ⅲ. Describe how to verify it

`go test ./pkg/agent-runtime/storages/ ./pkg/controller/sandboxclaim/... -count=1`

For the generated files I ran the `make generate` / `make manifests` commands directly with controller-gen v0.18.0, the version pinned in the Makefile. `make` is not available on my machine, and controller-gen would not expand the `./api/...` and `./pkg/...` patterns there, so I ran it against `./api/v1alpha1` with only the `crd` generator. Regenerating touched only `agents.kruise.io_sandboxclaims.yaml`, so nothing else drifted, but please confirm CI's `make generate manifests` produces the same bytes.

### Ⅳ. Special notes for reviews

Existing test failures on master, unrelated to this change and present on a clean checkout: `TestSetupRegistryAuth_StatError`, `TestPrepareToWrite`, `TestProcessCSIMounts/empty_mount_list_returns_immediately`, and flaky subtests in `pkg/sandbox-manager/infra/sandboxcr` (`TestInfra_ClaimSandbox`, `TestTryClaimSandbox_SecurityToken`, where the failing subtest changes between runs).

The issue lists `client/` as needing regeneration. Nothing under `client/` references the field by name, so no clientset change was required.

