### PR TITLE
docs: add gVisor example and runtime compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ To interact with the OpenKruise Agents programmatically, you can use the E2B SDK
 - [Running E2B Desktop Sandbox](examples/desktop/README.md)
 - [Running OpenClaw](examples/openclaw/README.md)
 - [Running Claude Code](examples/claude-code/README.md)
+- [Running E2B Code Interpreter Sandbox with gVisor](examples/gvisor/README.md)
+
+For guidance on which container runtimes (runc, gVisor, Kata) are supported and which features work under each, see [Runtime Compatibility](docs/runtime-compatibility.md).
 
 ## Roadmap
 

--- a/docs/runtime-compatibility.md
+++ b/docs/runtime-compatibility.md
@@ -1,0 +1,103 @@
+# Container Runtime Compatibility
+
+OpenKruise Agents manages sandboxes as Kubernetes Pods. Because
+`spec.template` is a standard `PodTemplateSpec`, users can set
+`runtimeClassName` to select an alternative OCI runtime for stronger workload
+isolation.
+
+This page documents which OpenKruise Agents features have been validated under
+each runtime. The table reflects the current state of testing and known
+architectural constraints; entries marked **Untested** mean the feature has not
+been explicitly verified but no known blocker exists.
+
+## Compatibility Matrix
+
+| Feature | runc (default) | gVisor (`runsc`) | Kata Containers |
+|---|---|---|---|
+| Sandbox lifecycle (create, delete, timeout) | ✅ Validated | ✅ Validated | ✅ Expected |
+| SandboxSet pre-warming pools | ✅ Validated | ✅ Validated | ✅ Expected |
+| SandboxClaim (session binding) | ✅ Validated | ✅ Expected | ✅ Expected |
+| Agent-runtime sidecar (envd, file ops, code exec) | ✅ Validated | ✅ Validated | ✅ Expected |
+| E2B SDK compatibility | ✅ Validated | ✅ Expected | ✅ Expected |
+| In-place image upgrade | ✅ Validated | ❓ Untested | ❓ Untested |
+| Pause / Resume | ✅ Validated | ❌ Not supported — gVisor does not support CRIU | ❓ Untested |
+| Checkpoint / Fork | ✅ Validated | ❌ Not supported — requires CRIU | ❓ Untested |
+| On-Demand CSI Volume Mount | ✅ Validated | ❌ **Incompatible** — see below | ✅ Expected |
+| Sandbox Gateway (traffic routing) | ✅ Validated | ✅ Expected | ✅ Expected |
+
+### Legend
+
+- **✅ Validated** — tested and confirmed working.
+- **✅ Expected** — no known blocker; uses standard Kubernetes or OCI
+  primitives that the runtime supports, but not yet explicitly tested by the
+  project.
+- **❓ Untested** — not tested; may or may not work. Contributions welcome.
+- **❌ Incompatible / Not supported** — known architectural limitation;
+  see the notes below.
+
+## Known Incompatibilities
+
+### gVisor + On-Demand CSI Volume Mount
+
+**Status:** Incompatible — architectural limitation of gVisor.
+
+The On-Demand CSI Volume Mount feature
+([proposal](proposals/20260608-dynamic-csi-mount.md)) relies on
+`mountPropagation: Bidirectional` on a privileged `csi-sidecar` container
+(§5.4 of the proposal). This maps to the Linux `rshared` mount option, which
+requires the kernel's mount-namespace propagation mechanism.
+
+gVisor is a userspace kernel that does not implement mount-namespace
+propagation. It explicitly rejects `rshared` and only permits `private` or
+`slave` root mount propagation. When a Pod with `runtimeClassName: gvisor`
+contains a container with `mountPropagation: Bidirectional`, the pod sandbox
+creation fails with:
+
+```
+OCI runtime create failed: root mount propagation option must specify
+private or slave: "rshared"
+```
+
+This is not a configuration issue — it is a fundamental design constraint of
+gVisor's architecture. See [#698](https://github.com/openkruise/agents/issues/698)
+for the original bug report and reproduction steps.
+
+**Workaround:** If you need both strong isolation and on-demand CSI mounts,
+use Kata Containers (`runtimeClassName: kata`) instead. Kata runs a real Linux
+kernel inside a lightweight VM and fully supports bidirectional mount
+propagation.
+
+**Using gVisor without CSI mount:** gVisor works well for sandboxes that do
+not require on-demand storage attachment. See the
+[gVisor example](../examples/gvisor/) for a working SandboxSet configuration.
+
+### gVisor + Pause / Resume (CRIU)
+
+**Status:** Not supported.
+
+Pause/Resume with memory-state preservation depends on
+[CRIU](https://criu.org/) (Checkpoint/Restore In Userspace), which operates on
+real Linux kernel data structures. gVisor's userspace kernel does not expose
+the interfaces that CRIU requires. Pausing a gVisor sandbox will fall back to
+container stop/start without memory-state preservation.
+
+## Choosing a Runtime
+
+| Priority | Recommended Runtime |
+|---|---|
+| Maximum compatibility (all features) | `runc` (default) |
+| Strong isolation + on-demand CSI mounts | Kata Containers |
+| Strong isolation, no CSI mount needed | gVisor |
+| GPU workloads | `runc` (gVisor GPU support is limited) |
+
+## Examples
+
+- [gVisor code-interpreter example](../examples/gvisor/) — SandboxSet with
+  `runtimeClassName: gvisor`, demonstrating basic lifecycle and E2B SDK usage
+  without CSI sidecar.
+
+## Contributing
+
+If you have validated a feature under a runtime marked **❓ Untested** or
+**✅ Expected**, please open a PR updating this table. Testing reports for
+Kata Containers and Kuasar are especially welcome.

--- a/examples/gvisor/README.md
+++ b/examples/gvisor/README.md
@@ -1,0 +1,84 @@
+# Running Code Interpreter Under gVisor
+
+This example deploys the E2B code-interpreter sandbox with
+[gVisor](https://gvisor.dev/) (`runsc`) as the container runtime, providing
+stronger workload isolation than the default `runc` runtime.
+
+For basic concepts (Sandbox, SandboxSet, sandbox-manager, agent-runtime), see
+[Running E2B Code Interpreter Sandbox](../code_interpreter/README.md).
+
+## Prerequisites
+
+1. **gVisor installed on every node.** The `runsc` binary and
+   `containerd-shim-runsc-v1` must be present and containerd must register a
+   runtime handler named **`runsc`** (matching the `RuntimeClass` handler below).
+   See the [gVisor containerd quick-start](https://gvisor.dev/docs/user_guide/containerd/quick_start/).
+   The relevant section of `/etc/containerd/config.toml`:
+
+   ```toml
+   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
+     runtime_type = "io.containerd.runsc.v1"
+     [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc.options]
+       BinaryName = "/usr/local/bin/runsc"
+   ```
+
+2. **A Kubernetes `RuntimeClass` for gVisor:**
+
+   ```shell
+   kubectl apply -f - <<EOF
+   apiVersion: node.k8s.io/v1
+   kind: RuntimeClass
+   metadata:
+     name: gvisor
+   handler: runsc
+   EOF
+   ```
+
+3. **OpenKruise Agents deployed** (controller + sandbox-manager).
+
+## 1. Deploying the Pre-Warmed Pool
+
+Apply the SandboxSet that uses `runtimeClassName: gvisor`:
+
+```shell
+kubectl apply -f examples/gvisor/sandboxset.yaml
+```
+
+Verify the sandboxes start under gVisor:
+
+```shell
+kubectl get sandbox -n default
+kubectl exec <pod-name> -- dmesg | head -5   # should show "Starting gVisor"
+```
+
+## 2. Using the Sandbox via E2B SDK
+
+```python
+from e2b_code_interpreter import Sandbox
+
+# The template name must match the SandboxSet name
+sbx = Sandbox.create(template="code-interpreter-gvisor", timeout=300)
+print(f"sandbox id: {sbx.sandbox_id}")
+
+sbx.run_code("import platform; print(platform.platform())")
+
+sbx.kill()
+```
+
+## Feature Compatibility Under gVisor
+
+Not all OpenKruise Agents features work under gVisor. See
+[Runtime Compatibility](../../docs/runtime-compatibility.md) for the full
+matrix. The key limitation:
+
+> **On-Demand CSI Volume Mount is incompatible with gVisor.** gVisor rejects
+> `mountPropagation: Bidirectional` (the `rshared` mount option) because it is
+> a userspace kernel and does not implement Linux mount-namespace propagation.
+> This is an architectural limitation of gVisor, not a configuration issue.
+> See [#698](https://github.com/openkruise/agents/issues/698) for details.
+
+This example therefore does **not** include CSI sidecar containers. If you need
+both strong isolation and on-demand storage, consider using
+[Kata Containers](https://katacontainers.io/) instead (`runtimeClassName: kata`),
+which runs a real Linux kernel inside a lightweight VM and fully supports
+bidirectional mount propagation.

--- a/examples/gvisor/sandboxset.yaml
+++ b/examples/gvisor/sandboxset.yaml
@@ -1,0 +1,69 @@
+# Note: Currently, OpenKruise Agent Runtime is not yet released. To use E2B related features, you need to manually inject
+# the E2B envd component into the sandbox container for now:
+# 1. Inject envd through the preview agent-runtime image and an emptyDir volume mount.
+# 2. Start envd through the sandbox container's postStart hook.
+#
+# This template uses runtimeClassName: gvisor for stronger workload isolation.
+# On-Demand CSI Volume Mount is incompatible with gVisor. See docs/runtime-compatibility.md.
+apiVersion: agents.kruise.io/v1alpha1
+kind: SandboxSet
+metadata:
+  name: code-interpreter-gvisor
+  namespace: default
+  annotations:
+    e2b.agents.kruise.io/should-init-envd: "true"
+spec:
+  replicas: 2
+  template:
+    spec:
+      runtimeClassName: gvisor
+      initContainers:
+        - name: init
+          image: openkruise/agent-runtime:preview-v0.0.2
+          volumeMounts:
+            - name: envd-volume
+              mountPath: /mnt/envd
+          env:
+            - name: ENVD_DIR
+              value: /mnt/envd
+          restartPolicy: Always
+      containers:
+        - name: sandbox
+          image: e2bdev/code-interpreter:latest
+          resources:
+            requests:
+              cpu: 1
+              memory: 1Gi
+            limits:
+              cpu: 1
+              memory: 1Gi
+          env:
+            - name: PORT
+              value: "49999"
+            - name: ENVD_DIR
+              value: /mnt/envd
+          volumeMounts:
+            - name: envd-volume
+              mountPath: /mnt/envd
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - bash
+                  - /mnt/envd/envd-run.sh
+          startupProbe:
+            failureThreshold: 20
+            httpGet:
+              path: /health
+              port: 49999
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            timeoutSeconds: 1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: true
+      terminationGracePeriodSeconds: 1
+      volumes:
+        - name: envd-volume
+          emptyDir: { }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

This PR adds complete documentation, usage examples, and a container runtime compatibility matrix for running OpenKruise Agents sandboxes under gVisor (runsc).

Specifically, it includes:

**gVisor Example (examples/gvisor/):**
sandboxset.yaml: A ready-to-deploy SandboxSet configured with runtimeClassName: gvisor and securityContext: runAsUser: 0 (required for envd initialization inside gVisor).

**README.md:** 
Prerequisites, RuntimeClass setup manifest, containerd configuration guidelines, and SDK usage steps.

**Runtime Compatibility Matrix (docs/runtime-compatibility.md):**
Detailed feature compatibility matrix across runc, gVisor, and Kata Containers.

**Architectural documentation explaining why gVisor is incompatible with mountPropagation:** 
Bidirectional (On-Demand CSI Mounts) and CRIU (Pause/Resume).

**Repository README update:**
Linked the new example and compatibility doc under the main Examples list.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #733

### Ⅲ. Describe how to verify it
Follow the step-by-step verification guide in 

[examples/gvisor/README.md](https://github.com/anshikasharmaa1517/agents/blob/5f71da297c1f575656d227ffdc4661b60c7d1d0b/examples/gvisor/README.md)


```

# 1. Apply gVisor SandboxSet
kubectl apply -f examples/gvisor/sandboxset.yaml

# 2. Confirm gVisor execution via dmesg
POD_NAME=$(kubectl get pods -n default --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}')
kubectl exec $POD_NAME -c sandbox -n default -- dmesg | head -5

```
Expected Output:


`[    0.000000] Starting gVisor...`


### Ⅳ. Special notes for reviews