### PR TITLE
fix(controller): requeue SandboxUpdateOps blocked by an active ops

### DIFF
--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,6 +45,13 @@ import (
 )
 
 const finalizerName = "agents.kruise.io/sandboxupdateops-protection"
+
+// blockedRequeueInterval is how long to wait before re-evaluating a
+// SandboxUpdateOps that has been skipped because another ops in the same
+// namespace is updating. No watch enqueues the skipped ops when the active one
+// reaches a terminal phase, so without this requeue it would stall until the
+// next full resync.
+const blockedRequeueInterval = 5 * time.Second
 
 var (
 	concurrentReconciles        = 1
@@ -107,24 +115,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// 2. Check if another SandboxUpdateOps in the same namespace is already Updating
-	// TODO: This is a short-term solution to prevent concurrent ops in the same namespace.
-	//  A more robust approach would be using a webhook to reject creation when an active ops exists,
-	//  or implementing a queue/priority-based scheduling mechanism.
-	opsList := &agentsv1alpha1.SandboxUpdateOpsList{}
-	if err := r.List(ctx, opsList, client.InNamespace(ops.Namespace), client.UnsafeDisableDeepCopy); err != nil {
-		return ctrl.Result{}, err
-	}
-	for i := range opsList.Items {
-		other := &opsList.Items[i]
-		if other.Name != ops.Name && other.Status.Phase == agentsv1alpha1.SandboxUpdateOpsUpdating {
-			klog.InfoS("Another SandboxUpdateOps is already updating, skipping this one",
-				"current", klog.KObj(ops), "active", klog.KObj(other))
-			return ctrl.Result{}, nil
-		}
-	}
-
-	// 3. Handle deletion: clean up sandbox labels
+	// 2. Handle deletion: clean up sandbox labels. Deletion must be handled
+	// before the concurrency check below, so that removing an ops is never
+	// blocked by another ops updating in the same namespace.
 	if !ops.DeletionTimestamp.IsZero() {
 		return r.handleDeletion(ctx, ops)
 	}
@@ -143,13 +136,29 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	// 3. Convert selector to labels.Selector
+	// 5. Check if another SandboxUpdateOps in the same namespace is already Updating
+	// TODO: This is a short-term solution to prevent concurrent ops in the same namespace.
+	//  A more robust approach would be using a webhook to reject creation when an active ops exists,
+	//  or implementing a queue/priority-based scheduling mechanism.
+	active, err := r.findActiveOps(ctx, ops)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if active != nil {
+		klog.InfoS("Another SandboxUpdateOps is already updating, skipping this one",
+			"current", klog.KObj(ops), "active", klog.KObj(active), "requeueAfter", blockedRequeueInterval)
+		// Nothing enqueues this ops when the active one leaves the Updating
+		// phase, so requeue explicitly to avoid stalling until the next resync.
+		return ctrl.Result{RequeueAfter: blockedRequeueInterval}, nil
+	}
+
+	// 6. Convert selector to labels.Selector
 	selector, err := metav1.LabelSelectorAsSelector(ops.Spec.Selector)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	// 4. List matching sandboxes in the same namespace (exclude sandboxes controlled by SandboxSet)
+	// 7. List matching sandboxes in the same namespace (exclude sandboxes controlled by SandboxSet)
 	sandboxList := &agentsv1alpha1.SandboxList{}
 	if err := r.List(ctx, sandboxList,
 		client.InNamespace(ops.Namespace),
@@ -158,7 +167,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	// 5. Classify sandbox states
+	// 8. Classify sandbox states
 	updated, failed, updating, candidates, resumeSucceedCandidates, requeueResult := r.classifySandboxes(ctx, sandboxList, ops)
 	if requeueResult != nil {
 		return *requeueResult, nil
@@ -177,7 +186,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return candidates[i].Name < candidates[j].Name
 	})
 
-	// 6. Phase state machine
+	// 9. Phase state machine
 	switch {
 	case ops.Status.Phase == "" || ops.Status.Phase == agentsv1alpha1.SandboxUpdateOpsPending:
 		newStatus.Phase = agentsv1alpha1.SandboxUpdateOpsUpdating
@@ -223,7 +232,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	// 7. Update status first, then return patch error for requeue
+	// 10. Update status first, then return patch error for requeue
 	if err := r.updateStatus(ctx, ops, newStatus); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -231,6 +240,22 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, patchErr
 	}
 	return ctrl.Result{}, nil
+}
+
+// findActiveOps returns another SandboxUpdateOps in the same namespace that is
+// currently Updating, or nil when no other ops holds the namespace.
+func (r *Reconciler) findActiveOps(ctx context.Context, ops *agentsv1alpha1.SandboxUpdateOps) (*agentsv1alpha1.SandboxUpdateOps, error) {
+	opsList := &agentsv1alpha1.SandboxUpdateOpsList{}
+	if err := r.List(ctx, opsList, client.InNamespace(ops.Namespace), client.UnsafeDisableDeepCopy); err != nil {
+		return nil, err
+	}
+	for i := range opsList.Items {
+		other := &opsList.Items[i]
+		if other.Name != ops.Name && other.Status.Phase == agentsv1alpha1.SandboxUpdateOpsUpdating {
+			return other, nil
+		}
+	}
+	return nil, nil
 }
 
 // patchResumeSucceedSandboxes applies template patches (phase 2) to sandboxes

--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
@@ -1653,32 +1653,100 @@ func TestReconcile_DeletionTimestamp_CallsHandleDeletion(t *testing.T) {
 }
 
 func TestReconcile_ConcurrentOpsInNamespace(t *testing.T) {
-	// First ops is actively Updating
-	ops1 := newSandboxUpdateOps("ops-active", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil)
-	// Second ops is Pending (should be blocked)
-	ops2 := newSandboxUpdateOps("ops-pending", "default", agentsv1alpha1.SandboxUpdateOpsPending, false, nil)
-	sbx := newSandbox("sbx-1", "default", "", agentsv1alpha1.SandboxRunning, nil)
+	const (
+		otherOpsName  = "ops-other"
+		targetOpsName = "ops-target"
+	)
 
-	r := newTestReconciler(ops1, ops2, sbx)
+	tests := []struct {
+		name string
+		// phase of the other ops sharing the namespace
+		otherPhase agentsv1alpha1.SandboxUpdateOpsPhase
+		// phase of the ops being reconciled
+		targetPhase     agentsv1alpha1.SandboxUpdateOpsPhase
+		targetDeleting  bool
+		sandboxOpsLabel string
+		wantResult      ctrl.Result
+		wantPhase       agentsv1alpha1.SandboxUpdateOpsPhase
+		wantOpsGone     bool
+		wantSandboxOps  string
+	}{
+		{
+			name:        "blocked while another ops is updating",
+			otherPhase:  agentsv1alpha1.SandboxUpdateOpsUpdating,
+			targetPhase: agentsv1alpha1.SandboxUpdateOpsPending,
+			// Requeued so the ops resumes once the active one finishes,
+			// instead of stalling until the next resync.
+			wantResult: ctrl.Result{RequeueAfter: blockedRequeueInterval},
+			wantPhase:  agentsv1alpha1.SandboxUpdateOpsPending,
+		},
+		{
+			name:           "proceeds once the other ops completes",
+			otherPhase:     agentsv1alpha1.SandboxUpdateOpsCompleted,
+			targetPhase:    agentsv1alpha1.SandboxUpdateOpsPending,
+			wantResult:     ctrl.Result{},
+			wantPhase:      agentsv1alpha1.SandboxUpdateOpsUpdating,
+			wantSandboxOps: targetOpsName,
+		},
+		{
+			name:        "terminal ops is not requeued while another ops updates",
+			otherPhase:  agentsv1alpha1.SandboxUpdateOpsUpdating,
+			targetPhase: agentsv1alpha1.SandboxUpdateOpsCompleted,
+			wantResult:  ctrl.Result{},
+			wantPhase:   agentsv1alpha1.SandboxUpdateOpsCompleted,
+		},
+		{
+			name:            "deletion is not blocked by another updating ops",
+			otherPhase:      agentsv1alpha1.SandboxUpdateOpsUpdating,
+			targetPhase:     agentsv1alpha1.SandboxUpdateOpsUpdating,
+			targetDeleting:  true,
+			sandboxOpsLabel: targetOpsName,
+			wantResult:      ctrl.Result{},
+			wantOpsGone:     true,
+		},
+	}
 
-	// Reconcile the second ops
-	result, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "ops-pending", Namespace: "default"},
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, ctrl.Result{}, result)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			other := newSandboxUpdateOps(otherOpsName, "default", tt.otherPhase, false, nil)
+			target := newSandboxUpdateOps(targetOpsName, "default", tt.targetPhase, false, nil)
+			target.Spec.Patch = mustMarshalPatch(corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "busybox:2.0"}},
+				},
+			})
+			target.Finalizers = []string{finalizerName}
+			sbx := newSandbox("sbx-1", "default", tt.sandboxOpsLabel, agentsv1alpha1.SandboxRunning, nil)
 
-	// Verify ops-pending was NOT transitioned (still Pending, no status update)
-	updatedOps := &agentsv1alpha1.SandboxUpdateOps{}
-	err = r.Get(context.Background(), types.NamespacedName{Name: "ops-pending", Namespace: "default"}, updatedOps)
-	assert.NoError(t, err)
-	assert.Equal(t, agentsv1alpha1.SandboxUpdateOpsPending, updatedOps.Status.Phase)
+			r := newTestReconciler(other, target, sbx)
 
-	// Verify sandbox was not patched
-	updatedSbx := &agentsv1alpha1.Sandbox{}
-	err = r.Get(context.Background(), types.NamespacedName{Name: "sbx-1", Namespace: "default"}, updatedSbx)
-	assert.NoError(t, err)
-	assert.Empty(t, updatedSbx.Labels[agentsv1alpha1.LabelSandboxUpdateOps])
+			if tt.targetDeleting {
+				// The fake client only sets DeletionTimestamp because the
+				// finalizer keeps the object around.
+				assert.NoError(t, r.Delete(context.Background(), target))
+			}
+
+			result, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: targetOpsName, Namespace: "default"},
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantResult, result)
+
+			updatedOps := &agentsv1alpha1.SandboxUpdateOps{}
+			err = r.Get(context.Background(), types.NamespacedName{Name: targetOpsName, Namespace: "default"}, updatedOps)
+			if tt.wantOpsGone {
+				assert.True(t, errors.IsNotFound(err), "ops should be gone after finalizer removal")
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantPhase, updatedOps.Status.Phase)
+			}
+
+			updatedSbx := &agentsv1alpha1.Sandbox{}
+			err = r.Get(context.Background(), types.NamespacedName{Name: "sbx-1", Namespace: "default"}, updatedSbx)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantSandboxOps, updatedSbx.Labels[agentsv1alpha1.LabelSandboxUpdateOps])
+		})
+	}
 }
 
 func TestSandboxUpdateStateString_Unknown(t *testing.T) {


### PR DESCRIPTION
## What this PR does

Fixes #759.

`SandboxUpdateOps` reconciliation skips an ops when another ops in the same namespace is `Updating`, but it returned `ctrl.Result{}` with no requeue. Nothing enqueues the skipped ops when the active one reaches a terminal phase (the only extra watch is on `Sandbox`, and it enqueues by the sandbox's ops label), so the blocked ops stalled until the next full resync or a controller restart.

Changes:

1. **Requeue when blocked.** Skipping now returns `ctrl.Result{RequeueAfter: blockedRequeueInterval}` (5s), so the ops starts as soon as the namespace is free. The list/scan is extracted into `findActiveOps` to keep `Reconcile` readable.

2. **Never block deletion on another ops.** The concurrency check ran before deletion handling, so a `SandboxUpdateOps` under deletion kept its finalizer — and its sandboxes kept the `agents.kruise.io/sandbox-update-ops` tracking label — for as long as another ops was updating. The check now runs after deletion handling, finalizer setup, and the terminal-phase short-circuit, which also avoids requeueing `Completed`/`Failed` ops for no reason.

The validating webhook already rejects creating a second active ops in a namespace; this controller-side check stays as defense in depth (webhooks can be disabled or bypassed), so it must not deadlock when it does trigger. The existing `TODO` about a queue/priority-based mechanism is preserved.

## Testing

`TestReconcile_ConcurrentOpsInNamespace` is now table-driven and covers:

- blocked while another ops is updating → `RequeueAfter` set, phase unchanged, sandbox untouched
- other ops completed → the blocked ops proceeds to `Updating` and patches its sandbox
- terminal ops while another updates → no requeue
- deletion while another ops updates → finalizer removed, sandbox label cleaned up

```
go test ./pkg/controller/sandboxupdateops/ -count=1 -race   # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)