### PR TITLE
fix: prevent SandboxUpdateOps from permanently hanging when skipped due to concurrent active ops

### DIFF
--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,7 +121,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if other.Name != ops.Name && other.Status.Phase == agentsv1alpha1.SandboxUpdateOpsUpdating {
 			klog.InfoS("Another SandboxUpdateOps is already updating, skipping this one",
 				"current", klog.KObj(ops), "active", klog.KObj(other))
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 	}
 

--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
@@ -1334,7 +1334,7 @@ func TestReconcile_ConcurrentOpsInNamespace(t *testing.T) {
 		NamespacedName: types.NamespacedName{Name: "ops-pending", Namespace: "default"},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, ctrl.Result{}, result)
+	assert.Equal(t, ctrl.Result{RequeueAfter: 5 * time.Second}, result)
 
 	// Verify ops-pending was NOT transitioned (still Pending, no status update)
 	updatedOps := &agentsv1alpha1.SandboxUpdateOps{}


### PR DESCRIPTION

### Ⅰ. Describe what this PR does
This PR fixes a bug where a `SandboxUpdateOps` operation would hang permanently if it was reconciled while another `SandboxUpdateOps` in the same namespace was in the `Updating` phase.

Currently, the controller returns `ctrl.Result{}, nil` when skipping to prevent concurrent operations, causing the reconciliation loop for the skipped operation to stop entirely without waking up when the active operation finishes. This PR changes the return result to `ctrl.Result{RequeueAfter: 5 * time.Second}, nil` to ensure the skipped operation periodically retries until it is unblocked.

### Ⅱ. Does this pull request fix one issue?
fixes #770

### Ⅲ. Describe how to verify it
1. Create a `SandboxUpdateOps` (Ops A) that begins updating.
2. Quickly create a second `SandboxUpdateOps` (Ops B) in the same namespace.
3. Observe that Ops B is skipped but its logs will show it periodically requeues.
4. Wait for Ops A to successfully complete (transitions to `Completed`).
5. Observe that Ops B is subsequently picked up by the reconciler and begins processing successfully instead of staying permanently stuck.

### Ⅳ. Special notes for reviews
The `TestReconcile_ConcurrentOpsInNamespace` test was also updated to expect the correct `RequeueAfter` value.

### PR Checklist
- [x] I have analyzed the codebase and root cause correctly.
- [x] The fix aligns with standard Kubernetes controller patterns.
- [x] Tests have been updated and run successfully via `go test ./pkg/controller/sandboxupdateops/...`.
- [x] Unnecessary files were not modified and the patch is minimal.


