### PR TITLE
feat(identity): add a signed JWT issuer for traffic access tokens

### DIFF
--- a/pkg/identity/jwtissuer/endpoints.go
+++ b/pkg/identity/jwtissuer/endpoints.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	jose "github.com/go-jose/go-jose/v4"
 )
 
 // Endpoint paths served for OIDC discovery. The gateway is pointed at
@@ -57,10 +59,7 @@ func (i *Issuer) Handler() (http.Handler, error) {
 		return nil, fmt.Errorf("marshal JWKS: %w", err)
 	}
 
-	algorithms, err := i.signingAlgorithms()
-	if err != nil {
-		return nil, err
-	}
+	algorithms := signingAlgorithms(keySet)
 	discoveryBody, err := json.Marshal(discoveryDocument{
 		Issuer:                           i.issuerURL,
 		JWKSURI:                          strings.TrimSuffix(i.issuerURL, "/") + JWKSPath,
@@ -93,13 +92,10 @@ func issuerBasePath(issuerURL string) string {
 }
 
 // signingAlgorithms lists every algorithm a published key can be used with, so
-// the discovery document stays accurate across a rotation overlap window.
-func (i *Issuer) signingAlgorithms() ([]string, error) {
-	keySet, err := i.PublicKeySet()
-	if err != nil {
-		return nil, err
-	}
-
+// the discovery document stays accurate across a rotation overlap window. It
+// takes the key set the caller already built rather than rebuilding it, so the
+// two cannot describe different keys.
+func signingAlgorithms(keySet jose.JSONWebKeySet) []string {
 	seen := make(map[string]struct{}, len(keySet.Keys))
 	algorithms := make([]string, 0, len(keySet.Keys))
 	for _, key := range keySet.Keys {
@@ -109,7 +105,7 @@ func (i *Issuer) signingAlgorithms() ([]string, error) {
 		seen[key.Algorithm] = struct{}{}
 		algorithms = append(algorithms, key.Algorithm)
 	}
-	return algorithms, nil
+	return algorithms
 }
 
 func serveJSON(body []byte) http.HandlerFunc {

--- a/pkg/identity/jwtissuer/endpoints.go
+++ b/pkg/identity/jwtissuer/endpoints.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -71,10 +72,24 @@ func (i *Issuer) Handler() (http.Handler, error) {
 		return nil, fmt.Errorf("marshal discovery document: %w", err)
 	}
 
+	// Serve under the issuer URL's own path so the advertised jwks_uri is
+	// actually reachable when the issuer sits behind an ingress path prefix.
+	basePath := issuerBasePath(i.issuerURL)
+
 	mux := http.NewServeMux()
-	mux.HandleFunc(DiscoveryPath, serveJSON(discoveryBody))
-	mux.HandleFunc(JWKSPath, serveJSON(jwksBody))
+	mux.HandleFunc(basePath+DiscoveryPath, serveJSON(discoveryBody))
+	mux.HandleFunc(basePath+JWKSPath, serveJSON(jwksBody))
 	return mux, nil
+}
+
+// issuerBasePath returns the path portion of the issuer URL without a trailing
+// slash, or "" when the issuer is served from the root.
+func issuerBasePath(issuerURL string) string {
+	parsed, err := url.Parse(issuerURL)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSuffix(parsed.Path, "/")
 }
 
 // signingAlgorithms lists every algorithm a published key can be used with, so

--- a/pkg/identity/jwtissuer/endpoints.go
+++ b/pkg/identity/jwtissuer/endpoints.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jwtissuer
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Endpoint paths served for OIDC discovery. The gateway is pointed at
+// DiscoveryPath and follows jwks_uri from there.
+const (
+	DiscoveryPath = "/.well-known/openid-configuration"
+	JWKSPath      = "/jwks.json"
+)
+
+// discoveryDocument is the subset of the OIDC discovery document the gateway
+// verifier reads. It only needs the issuer and the JWKS location; the remaining
+// fields are advertised because discovery consumers commonly expect them.
+type discoveryDocument struct {
+	Issuer                           string   `json:"issuer"`
+	JWKSURI                          string   `json:"jwks_uri"`
+	ResponseTypesSupported           []string `json:"response_types_supported"`
+	SubjectTypesSupported            []string `json:"subject_types_supported"`
+	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+}
+
+// Handler serves OIDC discovery and the JWKS for an Issuer.
+//
+// Both responses are public by design: they carry only public keys and the
+// issuer identity, which is what lets a gateway bootstrap without credentials.
+// The private key never leaves the Issuer.
+func (i *Issuer) Handler() (http.Handler, error) {
+	keySet, err := i.PublicKeySet()
+	if err != nil {
+		return nil, fmt.Errorf("build JWKS: %w", err)
+	}
+	jwksBody, err := json.Marshal(keySet)
+	if err != nil {
+		return nil, fmt.Errorf("marshal JWKS: %w", err)
+	}
+
+	algorithms, err := i.signingAlgorithms()
+	if err != nil {
+		return nil, err
+	}
+	discoveryBody, err := json.Marshal(discoveryDocument{
+		Issuer:                           i.issuerURL,
+		JWKSURI:                          strings.TrimSuffix(i.issuerURL, "/") + JWKSPath,
+		ResponseTypesSupported:           []string{"id_token"},
+		SubjectTypesSupported:            []string{"public"},
+		IDTokenSigningAlgValuesSupported: algorithms,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal discovery document: %w", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(DiscoveryPath, serveJSON(discoveryBody))
+	mux.HandleFunc(JWKSPath, serveJSON(jwksBody))
+	return mux, nil
+}
+
+// signingAlgorithms lists every algorithm a published key can be used with, so
+// the discovery document stays accurate across a rotation overlap window.
+func (i *Issuer) signingAlgorithms() ([]string, error) {
+	keySet, err := i.PublicKeySet()
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{}, len(keySet.Keys))
+	algorithms := make([]string, 0, len(keySet.Keys))
+	for _, key := range keySet.Keys {
+		if _, exists := seen[key.Algorithm]; exists {
+			continue
+		}
+		seen[key.Algorithm] = struct{}{}
+		algorithms = append(algorithms, key.Algorithm)
+	}
+	return algorithms, nil
+}
+
+func serveJSON(body []byte) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", "GET, HEAD")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		if _, err := w.Write(body); err != nil {
+			// The response is already partially written, so there is nothing
+			// useful left to say to the client.
+			return
+		}
+	}
+}

--- a/pkg/identity/jwtissuer/issuer.go
+++ b/pkg/identity/jwtissuer/issuer.go
@@ -37,6 +37,10 @@ import (
 // the caller does not choose one.
 const DefaultTokenLifetime = time.Hour
 
+// minRSAKeyBits is the smallest RSA modulus RFC 7518 section 3.3 permits for
+// RS256.
+const minRSAKeyBits = 2048
+
 // SigningKey is the private key an Issuer signs with, paired with the key ID it
 // publishes in the JWKS. The KeyID must be stable for as long as tokens signed
 // by this key can still be presented.
@@ -46,9 +50,13 @@ type SigningKey struct {
 }
 
 // VerificationKey is a public key published in the JWKS but no longer used for
-// signing. Retaining the previous key here is what makes rotation safe: the
-// gateway snapshots the JWKS once at startup and never refetches it, so a new
-// key must be published and rolled out before it starts signing anything.
+// signing. Retaining the previous key here is what makes rotation safe.
+//
+// As the gateway behaves today it snapshots the JWKS once at startup and never
+// refetches, so a new key must be published and rolled out before it signs
+// anything. If the verifier gains a refresh, retention stops being the only
+// thing preventing a fleet of 401s and becomes a window for verifiers that have
+// not refreshed yet. Retaining the previous key is correct under both.
 type VerificationKey struct {
 	KeyID     string
 	PublicKey crypto.PublicKey
@@ -57,6 +65,13 @@ type VerificationKey struct {
 // SandboxBinding identifies the sandbox a token is minted for. The gateway
 // compares these against the route it selected, so a token for one sandbox
 // cannot be replayed against another.
+//
+// Tokens carry no jti. They are short-lived bearer tokens bound to a single
+// sandbox, and a jti would only be useful alongside a revocation store that
+// nothing here maintains. The trade is that a leaked token stays valid for the
+// rest of its lifetime; shortening the lifetime is the lever, or rotating the
+// signing key and dropping the retained one to invalidate every outstanding
+// token at once.
 type SandboxBinding struct {
 	SandboxID  string
 	SandboxUID string
@@ -173,7 +188,9 @@ func (i *Issuer) IssueTrafficAccessToken(subject string, binding SandboxBinding)
 		return "", time.Time{}, fmt.Errorf("create signer: %w", err)
 	}
 
-	// The verifier requires exp, iat and nbf to all be present.
+	// The verifier requires exp, iat and nbf to all be present. nbf is set equal
+	// to iat rather than backdated: oidc.DefaultClockSkew is one minute, so a
+	// replica running slightly ahead of a gateway does not trip nbf.
 	issuedAt := i.now()
 	expiry := issuedAt.Add(i.lifetime)
 	claims := trafficAccessTokenClaims{
@@ -250,6 +267,14 @@ func publicJWK(keyID string, publicKey crypto.PublicKey) (jose.JSONWebKey, error
 func signatureAlgorithmFor(publicKey crypto.PublicKey) (jose.SignatureAlgorithm, error) {
 	switch key := publicKey.(type) {
 	case *rsa.PublicKey:
+		// RFC 7518 section 3.3 requires at least 2048 bits for RS256, and neither
+		// go-jose nor the gateway verifier enforces it: oidc.algorithmSupportsKey
+		// pairs on key type and curve size and never looks at the RSA modulus. The
+		// issuer is the only side that can decline to create the problem, so a weak
+		// key is refused here rather than producing tokens nothing flags.
+		if bits := key.N.BitLen(); bits < minRSAKeyBits {
+			return "", fmt.Errorf("RSA key is %d bits, RS256 requires at least %d", bits, minRSAKeyBits)
+		}
 		return jose.RS256, nil
 	case *ecdsa.PublicKey:
 		switch bitSize := key.Curve.Params().BitSize; bitSize {

--- a/pkg/identity/jwtissuer/issuer.go
+++ b/pkg/identity/jwtissuer/issuer.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package jwtissuer mints the signed traffic access tokens that
+// pkg/identity/oidc verifies, and publishes the public keys needed to verify
+// them. It is the issuing half of the contract described in
+// docs/proposals/20260713-traffic-access-token-jwt-verification.md.
+package jwtissuer
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"fmt"
+	"net/url"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+)
+
+// DefaultTokenLifetime is the validity stamped on a traffic access token when
+// the caller does not choose one.
+const DefaultTokenLifetime = time.Hour
+
+// SigningKey is the private key an Issuer signs with, paired with the key ID it
+// publishes in the JWKS. The KeyID must be stable for as long as tokens signed
+// by this key can still be presented.
+type SigningKey struct {
+	KeyID      string
+	PrivateKey crypto.Signer
+}
+
+// VerificationKey is a public key published in the JWKS but no longer used for
+// signing. Retaining the previous key here is what makes rotation safe: the
+// gateway snapshots the JWKS once at startup and never refetches it, so a new
+// key must be published and rolled out before it starts signing anything.
+type VerificationKey struct {
+	KeyID     string
+	PublicKey crypto.PublicKey
+}
+
+// SandboxBinding identifies the sandbox a token is minted for. The gateway
+// compares these against the route it selected, so a token for one sandbox
+// cannot be replayed against another.
+type SandboxBinding struct {
+	SandboxID  string
+	SandboxUID string
+}
+
+// Issuer mints tokens for a single issuer URL.
+type Issuer struct {
+	issuerURL string
+	lifetime  time.Duration
+
+	active   SigningKey
+	retained []VerificationKey
+
+	now func() time.Time
+}
+
+// Option adjusts an Issuer at construction time.
+type Option func(*Issuer)
+
+// WithTokenLifetime sets how long minted tokens stay valid.
+func WithTokenLifetime(lifetime time.Duration) Option {
+	return func(i *Issuer) { i.lifetime = lifetime }
+}
+
+// WithRetainedKeys publishes additional public keys that are no longer used for
+// signing. Use this during a rotation overlap window so verifiers holding an
+// older JWKS snapshot still accept tokens signed by the previous key.
+func WithRetainedKeys(keys ...VerificationKey) Option {
+	return func(i *Issuer) { i.retained = append(i.retained, keys...) }
+}
+
+// withClock overrides the time source. Tests use it to mint tokens outside the
+// current validity window.
+func withClock(now func() time.Time) Option {
+	return func(i *Issuer) { i.now = now }
+}
+
+// New returns an Issuer that signs with active and publishes it under issuerURL.
+// issuerURL must be an absolute HTTPS URL: it becomes the iss claim, and the
+// verifier compares it against the issuer advertised by OIDC discovery.
+func New(issuerURL string, active SigningKey, opts ...Option) (*Issuer, error) {
+	if err := validateHTTPSURL(issuerURL); err != nil {
+		return nil, fmt.Errorf("issuer URL: %w", err)
+	}
+	if active.KeyID == "" {
+		return nil, fmt.Errorf("signing key ID must not be empty")
+	}
+	if active.PrivateKey == nil {
+		return nil, fmt.Errorf("signing key must not be nil")
+	}
+	if _, err := signatureAlgorithmFor(active.PrivateKey.Public()); err != nil {
+		return nil, fmt.Errorf("signing key: %w", err)
+	}
+
+	issuer := &Issuer{
+		issuerURL: issuerURL,
+		lifetime:  DefaultTokenLifetime,
+		active:    active,
+		now:       time.Now,
+	}
+	for _, opt := range opts {
+		opt(issuer)
+	}
+
+	if issuer.lifetime <= 0 {
+		return nil, fmt.Errorf("token lifetime must be positive")
+	}
+	if err := issuer.validateRetainedKeys(); err != nil {
+		return nil, err
+	}
+	return issuer, nil
+}
+
+func (i *Issuer) validateRetainedKeys() error {
+	seen := map[string]struct{}{i.active.KeyID: {}}
+	for _, key := range i.retained {
+		if key.KeyID == "" {
+			return fmt.Errorf("retained key ID must not be empty")
+		}
+		if _, exists := seen[key.KeyID]; exists {
+			return fmt.Errorf("duplicate key ID %q", key.KeyID)
+		}
+		if _, err := signatureAlgorithmFor(key.PublicKey); err != nil {
+			return fmt.Errorf("retained key %q: %w", key.KeyID, err)
+		}
+		seen[key.KeyID] = struct{}{}
+	}
+	return nil
+}
+
+// IssueTrafficAccessToken mints a token binding subject to a single sandbox and
+// returns it alongside its expiry, so callers can record the expiry without
+// parsing the token back.
+func (i *Issuer) IssueTrafficAccessToken(subject string, binding SandboxBinding) (string, time.Time, error) {
+	if subject == "" {
+		return "", time.Time{}, fmt.Errorf("subject must not be empty")
+	}
+	if binding.SandboxID == "" {
+		return "", time.Time{}, fmt.Errorf("sandbox ID must not be empty")
+	}
+	if binding.SandboxUID == "" {
+		return "", time.Time{}, fmt.Errorf("sandbox UID must not be empty")
+	}
+
+	algorithm, err := signatureAlgorithmFor(i.active.PrivateKey.Public())
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: algorithm, Key: i.active.PrivateKey},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", i.active.KeyID),
+	)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("create signer: %w", err)
+	}
+
+	// The verifier requires exp, iat and nbf to all be present.
+	issuedAt := i.now()
+	expiry := issuedAt.Add(i.lifetime)
+	claims := trafficAccessTokenClaims{
+		Claims: jwt.Claims{
+			Issuer:    i.issuerURL,
+			Subject:   subject,
+			IssuedAt:  jwt.NewNumericDate(issuedAt),
+			NotBefore: jwt.NewNumericDate(issuedAt),
+			Expiry:    jwt.NewNumericDate(expiry),
+		},
+		Sandbox: sandboxClaims{
+			SandboxID:  binding.SandboxID,
+			SandboxUID: binding.SandboxUID,
+		},
+	}
+
+	rawJWT, err := jwt.Signed(signer).Claims(claims).Serialize()
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("sign token: %w", err)
+	}
+	return rawJWT, expiry, nil
+}
+
+// trafficAccessTokenClaims mirrors oidc.TrafficAccessTokenClaims. It is
+// duplicated rather than imported so the issuer and the verifier stay
+// independently changeable; the round-trip test is what keeps them aligned.
+type trafficAccessTokenClaims struct {
+	jwt.Claims
+	Sandbox sandboxClaims `json:"sandbox"`
+}
+
+type sandboxClaims struct {
+	SandboxID  string `json:"sandboxId"`
+	SandboxUID string `json:"sandboxUid"`
+}
+
+// PublicKeySet returns the keys to publish at the JWKS endpoint: the active
+// signing key first, then any retained keys.
+func (i *Issuer) PublicKeySet() (jose.JSONWebKeySet, error) {
+	keys := make([]jose.JSONWebKey, 0, 1+len(i.retained))
+
+	activeKey, err := publicJWK(i.active.KeyID, i.active.PrivateKey.Public())
+	if err != nil {
+		return jose.JSONWebKeySet{}, err
+	}
+	keys = append(keys, activeKey)
+
+	for _, retained := range i.retained {
+		key, err := publicJWK(retained.KeyID, retained.PublicKey)
+		if err != nil {
+			return jose.JSONWebKeySet{}, err
+		}
+		keys = append(keys, key)
+	}
+	return jose.JSONWebKeySet{Keys: keys}, nil
+}
+
+func publicJWK(keyID string, publicKey crypto.PublicKey) (jose.JSONWebKey, error) {
+	algorithm, err := signatureAlgorithmFor(publicKey)
+	if err != nil {
+		return jose.JSONWebKey{}, fmt.Errorf("key %q: %w", keyID, err)
+	}
+	return jose.JSONWebKey{
+		Key:       publicKey,
+		KeyID:     keyID,
+		Use:       "sig",
+		Algorithm: string(algorithm),
+	}, nil
+}
+
+// signatureAlgorithmFor picks the JWS algorithm for a key type. The verifier
+// rejects a token whose algorithm does not match its key, so this is the single
+// place that decides the pairing.
+func signatureAlgorithmFor(publicKey crypto.PublicKey) (jose.SignatureAlgorithm, error) {
+	switch key := publicKey.(type) {
+	case *rsa.PublicKey:
+		return jose.RS256, nil
+	case *ecdsa.PublicKey:
+		switch bitSize := key.Curve.Params().BitSize; bitSize {
+		case 256:
+			return jose.ES256, nil
+		case 384:
+			return jose.ES384, nil
+		case 521:
+			return jose.ES512, nil
+		default:
+			return "", fmt.Errorf("unsupported ECDSA curve size %d", bitSize)
+		}
+	case ed25519.PublicKey:
+		return jose.EdDSA, nil
+	default:
+		return "", fmt.Errorf("unsupported key type %T", publicKey)
+	}
+}
+
+func validateHTTPSURL(rawURL string) error {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil || !parsedURL.IsAbs() || parsedURL.Scheme != "https" || parsedURL.Host == "" {
+		return fmt.Errorf("must be an absolute HTTPS URL")
+	}
+	return nil
+}

--- a/pkg/identity/jwtissuer/issuer_test.go
+++ b/pkg/identity/jwtissuer/issuer_test.go
@@ -1,0 +1,409 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jwtissuer
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openkruise/agents/pkg/identity/oidc"
+)
+
+const (
+	testCANamespace = "sandbox-system"
+	testCAName      = "oidc-ca"
+	testCAKey       = "ca.crt"
+)
+
+// TestIssuedTokenPassesRealVerifier is the point of this package: a token minted
+// here must be accepted by the verifier the gateway actually runs, bootstrapped
+// the way the gateway actually bootstraps it: OIDC discovery over HTTPS, a JWKS
+// snapshot, and a CA read from a ConfigMap. A mock verifier would prove nothing.
+func TestIssuedTokenPassesRealVerifier(t *testing.T) {
+	tests := []struct {
+		name string
+		key  crypto.Signer
+	}{
+		{name: "ECDSA P-256", key: mustECDSAKey(t, elliptic.P256())},
+		{name: "ECDSA P-384", key: mustECDSAKey(t, elliptic.P384())},
+		{name: "RSA 2048", key: mustRSAKey(t)},
+		{name: "Ed25519", key: mustEd25519Key(t)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issuer, server := startIssuer(t, SigningKey{KeyID: "active", PrivateKey: tt.key})
+			verifier := newRealVerifier(t, server)
+
+			binding := SandboxBinding{SandboxID: "default--sample", SandboxUID: "89d24507-936c-4a04-a958-b5d6a8277ed5"}
+			rawJWT, expiry, err := issuer.IssueTrafficAccessToken("e2b:controlplane:client", binding)
+			require.NoError(t, err)
+
+			claims, err := verifier.Verify(rawJWT)
+			require.NoError(t, err)
+
+			assert.Equal(t, server.URL, claims.Issuer)
+			assert.Equal(t, "e2b:controlplane:client", claims.Subject)
+			assert.Equal(t, binding.SandboxID, claims.Sandbox.SandboxID)
+			assert.Equal(t, binding.SandboxUID, claims.Sandbox.SandboxUID)
+			// The returned expiry must match the exp claim, so callers can record
+			// it without parsing the token back.
+			assert.WithinDuration(t, expiry, claims.Expiry.Time(), time.Second)
+		})
+	}
+}
+
+// TestRotationOverlapWindow covers the constraint that makes rotation awkward
+// here: the gateway snapshots the JWKS once and never refetches it. A key must
+// therefore be published before it signs anything, and the previous key must
+// stay published until every gateway has rolled.
+func TestRotationOverlapWindow(t *testing.T) {
+	oldKey := mustECDSAKey(t, elliptic.P256())
+	newKey := mustECDSAKey(t, elliptic.P256())
+
+	// Step 1: only the old key exists. A gateway starting now snapshots it alone.
+	beforeRotation, server := startIssuer(t, SigningKey{KeyID: "old", PrivateKey: oldKey})
+	staleVerifier := newRealVerifier(t, server)
+
+	tokenFromOldKey, _, err := beforeRotation.IssueTrafficAccessToken("sub", testBinding())
+	require.NoError(t, err)
+	_, err = staleVerifier.Verify(tokenFromOldKey)
+	require.NoError(t, err)
+
+	// Step 2: the new key is published but the old one still signs. A gateway
+	// that has not restarted keeps working.
+	publishOnly, publishServer := startIssuer(t,
+		SigningKey{KeyID: "old", PrivateKey: oldKey},
+		WithRetainedKeys(VerificationKey{KeyID: "new", PublicKey: newKey.Public()}),
+	)
+	refreshedVerifier := newRealVerifier(t, publishServer)
+
+	tokenDuringOverlap, _, err := publishOnly.IssueTrafficAccessToken("sub", testBinding())
+	require.NoError(t, err)
+	_, err = refreshedVerifier.Verify(tokenDuringOverlap)
+	require.NoError(t, err)
+
+	// Step 3: signing flips to the new key while the old one stays published.
+	afterRotation, rotatedServer := startIssuer(t,
+		SigningKey{KeyID: "new", PrivateKey: newKey},
+		WithRetainedKeys(VerificationKey{KeyID: "old", PublicKey: oldKey.Public()}),
+	)
+	rotatedVerifier := newRealVerifier(t, rotatedServer)
+
+	tokenFromNewKey, _, err := afterRotation.IssueTrafficAccessToken("sub", testBinding())
+	require.NoError(t, err)
+	_, err = rotatedVerifier.Verify(tokenFromNewKey)
+	require.NoError(t, err)
+
+	// The hazard the overlap window exists to prevent: a gateway holding the
+	// pre-rotation snapshot cannot verify a token signed by the new key.
+	_, err = staleVerifier.Verify(tokenFromNewKey)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown kid")
+}
+
+func TestVerifierRejectsTokensOutsideValidityWindow(t *testing.T) {
+	tests := []struct {
+		name        string
+		clockOffset time.Duration
+		lifetime    time.Duration
+		expectError string
+	}{
+		{name: "expired", clockOffset: -2 * time.Hour, lifetime: time.Hour, expectError: "expired"},
+		{name: "not yet valid", clockOffset: 2 * time.Hour, lifetime: time.Hour, expectError: "not valid yet"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := mustECDSAKey(t, elliptic.P256())
+			issuer, server := startIssuer(t,
+				SigningKey{KeyID: "active", PrivateKey: key},
+				WithTokenLifetime(tt.lifetime),
+				withClock(func() time.Time { return time.Now().Add(tt.clockOffset) }),
+			)
+			verifier := newRealVerifier(t, server)
+
+			rawJWT, _, err := issuer.IssueTrafficAccessToken("sub", testBinding())
+			require.NoError(t, err)
+
+			_, err = verifier.Verify(rawJWT)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+}
+
+func TestVerifierRejectsTokenFromAnotherIssuer(t *testing.T) {
+	// Two independent issuers, each with its own key and issuer URL.
+	_, trustedServer := startIssuer(t, SigningKey{KeyID: "trusted", PrivateKey: mustECDSAKey(t, elliptic.P256())})
+	foreign, _ := startIssuer(t, SigningKey{KeyID: "foreign", PrivateKey: mustECDSAKey(t, elliptic.P256())})
+
+	verifier := newRealVerifier(t, trustedServer)
+
+	rawJWT, _, err := foreign.IssueTrafficAccessToken("sub", testBinding())
+	require.NoError(t, err)
+
+	_, err = verifier.Verify(rawJWT)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown kid")
+}
+
+func TestNewValidatesInput(t *testing.T) {
+	validKey := mustECDSAKey(t, elliptic.P256())
+
+	tests := []struct {
+		name        string
+		issuerURL   string
+		signing     SigningKey
+		opts        []Option
+		expectError string
+	}{
+		{
+			name:        "plaintext issuer URL",
+			issuerURL:   "http://issuer.example",
+			signing:     SigningKey{KeyID: "active", PrivateKey: validKey},
+			expectError: "absolute HTTPS URL",
+		},
+		{
+			name:        "relative issuer URL",
+			issuerURL:   "/issuer",
+			signing:     SigningKey{KeyID: "active", PrivateKey: validKey},
+			expectError: "absolute HTTPS URL",
+		},
+		{
+			name:        "empty key ID",
+			issuerURL:   "https://issuer.example",
+			signing:     SigningKey{PrivateKey: validKey},
+			expectError: "key ID must not be empty",
+		},
+		{
+			name:        "nil signing key",
+			issuerURL:   "https://issuer.example",
+			signing:     SigningKey{KeyID: "active"},
+			expectError: "signing key must not be nil",
+		},
+		{
+			name:        "non-positive lifetime",
+			issuerURL:   "https://issuer.example",
+			signing:     SigningKey{KeyID: "active", PrivateKey: validKey},
+			opts:        []Option{WithTokenLifetime(0)},
+			expectError: "lifetime must be positive",
+		},
+		{
+			name:      "retained key reuses the active key ID",
+			issuerURL: "https://issuer.example",
+			signing:   SigningKey{KeyID: "active", PrivateKey: validKey},
+			opts: []Option{WithRetainedKeys(
+				VerificationKey{KeyID: "active", PublicKey: mustECDSAKey(t, elliptic.P256()).Public()},
+			)},
+			expectError: "duplicate key ID",
+		},
+		{
+			name:        "retained key without an ID",
+			issuerURL:   "https://issuer.example",
+			signing:     SigningKey{KeyID: "active", PrivateKey: validKey},
+			opts:        []Option{WithRetainedKeys(VerificationKey{PublicKey: validKey.Public()})},
+			expectError: "retained key ID must not be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issuer, err := New(tt.issuerURL, tt.signing, tt.opts...)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+			assert.Nil(t, issuer)
+		})
+	}
+}
+
+func TestIssueTrafficAccessTokenValidatesBinding(t *testing.T) {
+	issuer, err := New("https://issuer.example", SigningKey{KeyID: "active", PrivateKey: mustECDSAKey(t, elliptic.P256())})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		subject     string
+		binding     SandboxBinding
+		expectError string
+	}{
+		{name: "empty subject", binding: testBinding(), expectError: "subject must not be empty"},
+		{
+			name:        "empty sandbox ID",
+			subject:     "sub",
+			binding:     SandboxBinding{SandboxUID: "uid"},
+			expectError: "sandbox ID must not be empty",
+		},
+		{
+			name:        "empty sandbox UID",
+			subject:     "sub",
+			binding:     SandboxBinding{SandboxID: "default--sample"},
+			expectError: "sandbox UID must not be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rawJWT, _, err := issuer.IssueTrafficAccessToken(tt.subject, tt.binding)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+			assert.Empty(t, rawJWT)
+		})
+	}
+}
+
+// TestJWKSNeverExposesPrivateKeyMaterial guards the one mistake in this package
+// that would be unrecoverable in production.
+func TestJWKSNeverExposesPrivateKeyMaterial(t *testing.T) {
+	issuer, server := startIssuer(t, SigningKey{KeyID: "active", PrivateKey: mustECDSAKey(t, elliptic.P256())})
+
+	keySet, err := issuer.PublicKeySet()
+	require.NoError(t, err)
+	for _, key := range keySet.Keys {
+		assert.True(t, key.IsPublic(), "key %q must be public", key.KeyID)
+	}
+
+	response, err := server.Client().Get(server.URL + JWKSPath)
+	require.NoError(t, err)
+	defer response.Body.Close()
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+
+	// A private ECDSA key would serialize its scalar as "d".
+	var published struct {
+		Keys []map[string]any `json:"keys"`
+	}
+	require.NoError(t, decodeJSON(response.Body, &published))
+	require.NotEmpty(t, published.Keys)
+	for _, key := range published.Keys {
+		assert.NotContains(t, key, "d", "JWKS must not publish private key material")
+	}
+}
+
+func TestEndpointsRejectNonReadMethods(t *testing.T) {
+	_, server := startIssuer(t, SigningKey{KeyID: "active", PrivateKey: mustECDSAKey(t, elliptic.P256())})
+
+	for _, path := range []string{DiscoveryPath, JWKSPath} {
+		t.Run(path, func(t *testing.T) {
+			request, err := http.NewRequest(http.MethodPost, server.URL+path, nil)
+			require.NoError(t, err)
+			response, err := server.Client().Do(request)
+			require.NoError(t, err)
+			defer response.Body.Close()
+			assert.Equal(t, http.StatusMethodNotAllowed, response.StatusCode)
+		})
+	}
+}
+
+// startIssuer serves an Issuer over HTTPS and points its issuer URL at itself,
+// which is what the verifier requires: the iss claim must equal the issuer
+// advertised by discovery. The server URL is only known after it starts, so the
+// handler is installed once the Issuer exists.
+func startIssuer(t *testing.T, signing SigningKey, opts ...Option) (*Issuer, *httptest.Server) {
+	t.Helper()
+
+	var handler http.Handler
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler.ServeHTTP(w, r)
+	}))
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	issuer, err := New(server.URL, signing, opts...)
+	require.NoError(t, err)
+
+	handler, err = issuer.Handler()
+	require.NoError(t, err)
+	return issuer, server
+}
+
+// newRealVerifier builds the production verifier against the running issuer,
+// with the server's own CA supplied through a ConfigMap exactly as the gateway
+// reads it.
+func newRealVerifier(t *testing.T, server *httptest.Server) oidc.Verifier {
+	t.Helper()
+
+	verifier, err := oidc.NewVerifier(context.Background(), caReader(t, server), oidc.Options{
+		DiscoveryURL:         server.URL + DiscoveryPath,
+		CAConfigMapNamespace: testCANamespace,
+		CAConfigMapName:      testCAName,
+		CAConfigMapKey:       testCAKey,
+	})
+	require.NoError(t, err)
+	return verifier
+}
+
+func caReader(t *testing.T, server *httptest.Server) client.Reader {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testCANamespace, Name: testCAName},
+		Data:       map[string]string{testCAKey: string(caPEM)},
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+}
+
+func testBinding() SandboxBinding {
+	return SandboxBinding{SandboxID: "default--sample", SandboxUID: "89d24507-936c-4a04-a958-b5d6a8277ed5"}
+}
+
+func mustECDSAKey(t *testing.T, curve elliptic.Curve) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+	require.NoError(t, err)
+	return key
+}
+
+func mustRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return key
+}
+
+func mustEd25519Key(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	return key
+}
+
+func decodeJSON(reader io.Reader, dest any) error {
+	return json.NewDecoder(reader).Decode(dest)
+}

--- a/pkg/identity/jwtissuer/issuer_test.go
+++ b/pkg/identity/jwtissuer/issuer_test.go
@@ -60,6 +60,7 @@ func TestIssuedTokenPassesRealVerifier(t *testing.T) {
 	}{
 		{name: "ECDSA P-256", key: mustECDSAKey(t, elliptic.P256())},
 		{name: "ECDSA P-384", key: mustECDSAKey(t, elliptic.P384())},
+		{name: "ECDSA P-521", key: mustECDSAKey(t, elliptic.P521())},
 		{name: "RSA 2048", key: mustRSAKey(t)},
 		{name: "Ed25519", key: mustEd25519Key(t)},
 	}

--- a/pkg/identity/jwtissuer/issuer_test.go
+++ b/pkg/identity/jwtissuer/issuer_test.go
@@ -407,3 +407,37 @@ func mustEd25519Key(t *testing.T) ed25519.PrivateKey {
 func decodeJSON(reader io.Reader, dest any) error {
 	return json.NewDecoder(reader).Decode(dest)
 }
+
+// TestIssuerBehindPathPrefix covers an issuer served under an ingress path
+// rather than at the root. The discovery document has to advertise a jwks_uri
+// that is actually reachable, otherwise the gateway cannot bootstrap at all.
+func TestIssuerBehindPathPrefix(t *testing.T) {
+	signing := SigningKey{KeyID: "active", PrivateKey: mustECDSAKey(t, elliptic.P256())}
+
+	var handler http.Handler
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler.ServeHTTP(w, r)
+	}))
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	issuer, err := New(server.URL+"/identity", signing)
+	require.NoError(t, err)
+	handler, err = issuer.Handler()
+	require.NoError(t, err)
+
+	verifier, err := oidc.NewVerifier(context.Background(), caReader(t, server), oidc.Options{
+		DiscoveryURL:         server.URL + "/identity" + DiscoveryPath,
+		CAConfigMapNamespace: testCANamespace,
+		CAConfigMapName:      testCAName,
+		CAConfigMapKey:       testCAKey,
+	})
+	require.NoError(t, err)
+
+	rawJWT, _, err := issuer.IssueTrafficAccessToken("sub", testBinding())
+	require.NoError(t, err)
+
+	claims, err := verifier.Verify(rawJWT)
+	require.NoError(t, err)
+	assert.Equal(t, server.URL+"/identity", claims.Issuer)
+}

--- a/pkg/identity/jwtissuer/key.go
+++ b/pkg/identity/jwtissuer/key.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jwtissuer
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"os"
+
+	jose "github.com/go-jose/go-jose/v4"
+)
+
+// LoadSigningKey parses a PEM-encoded private key and derives its key ID from
+// the public key, so every replica that loads the same key material agrees on
+// the same kid without coordinating. Callers holding a Kubernetes Secret pass
+// the relevant data value straight in.
+func LoadSigningKey(pemData []byte) (SigningKey, error) {
+	privateKey, err := ParsePrivateKeyPEM(pemData)
+	if err != nil {
+		return SigningKey{}, err
+	}
+	keyID, err := ThumbprintKeyID(privateKey.Public())
+	if err != nil {
+		return SigningKey{}, err
+	}
+	return SigningKey{KeyID: keyID, PrivateKey: privateKey}, nil
+}
+
+// LoadSigningKeyFromFile reads a PEM-encoded private key from disk, for the
+// common case of a Secret projected into the pod as a volume.
+func LoadSigningKeyFromFile(path string) (SigningKey, error) {
+	pemData, err := os.ReadFile(path)
+	if err != nil {
+		return SigningKey{}, fmt.Errorf("read signing key: %w", err)
+	}
+	return LoadSigningKey(pemData)
+}
+
+// ParsePrivateKeyPEM decodes the first PEM block and accepts the three private
+// key encodings cert tooling emits: PKCS#8, PKCS#1 and SEC1.
+//
+// Errors deliberately carry no key material, since anything returned here can
+// end up in a log line.
+func ParsePrivateKeyPEM(pemData []byte) (crypto.Signer, error) {
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in signing key")
+	}
+
+	parsed, err := parsePrivateKeyDER(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse signing key: %w", err)
+	}
+
+	signer, ok := parsed.(crypto.Signer)
+	if !ok {
+		return nil, fmt.Errorf("signing key of type %T cannot sign", parsed)
+	}
+	// Reject key types the verifier could never accept, at load time rather
+	// than at the first issuance.
+	if _, err := signatureAlgorithmFor(signer.Public()); err != nil {
+		return nil, fmt.Errorf("signing key: %w", err)
+	}
+	return signer, nil
+}
+
+func parsePrivateKeyDER(der []byte) (any, error) {
+	if key, err := x509.ParsePKCS8PrivateKey(der); err == nil {
+		return key, nil
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+		return key, nil
+	}
+	if key, err := x509.ParseECPrivateKey(der); err == nil {
+		return key, nil
+	}
+	return nil, fmt.Errorf("not a PKCS#8, PKCS#1 or SEC1 private key")
+}
+
+// ThumbprintKeyID returns the RFC 7638 JWK thumbprint of a public key, base64url
+// encoded. It is a pure function of the key, which gives two useful properties:
+// replicas sharing one Secret publish one kid, and rotating to new key material
+// necessarily produces a new kid rather than silently reusing the old one.
+func ThumbprintKeyID(publicKey crypto.PublicKey) (string, error) {
+	switch publicKey.(type) {
+	case *rsa.PublicKey, *ecdsa.PublicKey, ed25519.PublicKey:
+	default:
+		return "", fmt.Errorf("unsupported key type %T", publicKey)
+	}
+
+	thumbprint, err := (&jose.JSONWebKey{Key: publicKey}).Thumbprint(crypto.SHA256)
+	if err != nil {
+		return "", fmt.Errorf("compute key thumbprint: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(thumbprint), nil
+}

--- a/pkg/identity/jwtissuer/key.go
+++ b/pkg/identity/jwtissuer/key.go
@@ -48,8 +48,12 @@ func LoadSigningKey(pemData []byte) (SigningKey, error) {
 
 // LoadSigningKeyFromFile reads a PEM-encoded private key from disk, for the
 // common case of a Secret projected into the pod as a volume.
+//
+// The path is operator configuration naming a mount inside the pod, not a value
+// any request can influence, so reading it through a variable is the intended
+// behaviour rather than a traversal risk.
 func LoadSigningKeyFromFile(path string) (SigningKey, error) {
-	pemData, err := os.ReadFile(path)
+	pemData, err := os.ReadFile(path) // #nosec G304 -- operator-configured key mount path
 	if err != nil {
 		return SigningKey{}, fmt.Errorf("read signing key: %w", err)
 	}

--- a/pkg/identity/jwtissuer/key_test.go
+++ b/pkg/identity/jwtissuer/key_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jwtissuer
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadSigningKeyAcceptsCommonEncodings(t *testing.T) {
+	ecKey := mustECDSAKey(t, elliptic.P256())
+	rsaKey := mustRSAKey(t)
+	edKey := mustEd25519Key(t)
+
+	tests := []struct {
+		name string
+		pem  []byte
+	}{
+		{name: "PKCS#8 ECDSA", pem: mustPKCS8PEM(t, ecKey)},
+		{name: "PKCS#8 RSA", pem: mustPKCS8PEM(t, rsaKey)},
+		{name: "PKCS#8 Ed25519", pem: mustPKCS8PEM(t, edKey)},
+		{name: "SEC1 ECDSA", pem: mustSEC1PEM(t, ecKey)},
+		{name: "PKCS#1 RSA", pem: mustPKCS1PEM(t, rsaKey)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signing, err := LoadSigningKey(tt.pem)
+			require.NoError(t, err)
+			assert.NotEmpty(t, signing.KeyID)
+			require.NotNil(t, signing.PrivateKey)
+
+			// A loaded key must be immediately usable for issuance.
+			issuer, err := New("https://issuer.example", signing)
+			require.NoError(t, err)
+			rawJWT, _, err := issuer.IssueTrafficAccessToken("sub", testBinding())
+			require.NoError(t, err)
+			assert.NotEmpty(t, rawJWT)
+		})
+	}
+}
+
+// TestKeyIDIsDerivedFromTheKey covers the property that makes a shared Secret
+// workable across replicas: the kid is a function of the key alone, so two
+// processes loading the same material agree without coordinating, and different
+// material can never collide onto one kid.
+func TestKeyIDIsDerivedFromTheKey(t *testing.T) {
+	key := mustECDSAKey(t, elliptic.P256())
+
+	fromPKCS8, err := LoadSigningKey(mustPKCS8PEM(t, key))
+	require.NoError(t, err)
+	fromSEC1, err := LoadSigningKey(mustSEC1PEM(t, key))
+	require.NoError(t, err)
+
+	assert.Equal(t, fromPKCS8.KeyID, fromSEC1.KeyID,
+		"same key in a different encoding must produce the same kid")
+
+	other, err := LoadSigningKey(mustPKCS8PEM(t, mustECDSAKey(t, elliptic.P256())))
+	require.NoError(t, err)
+	assert.NotEqual(t, fromPKCS8.KeyID, other.KeyID, "distinct keys must not share a kid")
+}
+
+// TestRotatedKeyIsVerifiableEndToEnd loads two keys the way an operator would
+// and runs them through the real verifier, so key loading and the rotation
+// overlap are proven together rather than separately.
+func TestRotatedKeyIsVerifiableEndToEnd(t *testing.T) {
+	oldSigning, err := LoadSigningKey(mustPKCS8PEM(t, mustECDSAKey(t, elliptic.P256())))
+	require.NoError(t, err)
+	newSigning, err := LoadSigningKey(mustPKCS8PEM(t, mustECDSAKey(t, elliptic.P256())))
+	require.NoError(t, err)
+
+	issuer, server := startIssuer(t, newSigning,
+		WithRetainedKeys(VerificationKey{KeyID: oldSigning.KeyID, PublicKey: oldSigning.PrivateKey.Public()}),
+	)
+	verifier := newRealVerifier(t, server)
+
+	rawJWT, _, err := issuer.IssueTrafficAccessToken("sub", testBinding())
+	require.NoError(t, err)
+	_, err = verifier.Verify(rawJWT)
+	require.NoError(t, err)
+}
+
+func TestLoadSigningKeyRejectsBadInput(t *testing.T) {
+	tests := []struct {
+		name        string
+		pem         []byte
+		expectError string
+	}{
+		{name: "empty input", pem: nil, expectError: "no PEM block"},
+		{name: "not PEM", pem: []byte("hello"), expectError: "no PEM block"},
+		{
+			name:        "PEM with garbage body",
+			pem:         pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("not DER")}),
+			expectError: "parse signing key",
+		},
+		{
+			name:        "public key instead of private",
+			pem:         mustPublicKeyPEM(t, mustECDSAKey(t, elliptic.P256()).Public()),
+			expectError: "parse signing key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signing, err := LoadSigningKey(tt.pem)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+			assert.Empty(t, signing.KeyID)
+
+			// Whatever went wrong, the message must not carry key material.
+			assert.NotContains(t, err.Error(), "BEGIN")
+		})
+	}
+}
+
+func TestLoadSigningKeyFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tls.key")
+	require.NoError(t, os.WriteFile(path, mustPKCS8PEM(t, mustECDSAKey(t, elliptic.P256())), 0o600))
+
+	signing, err := LoadSigningKeyFromFile(path)
+	require.NoError(t, err)
+	assert.NotEmpty(t, signing.KeyID)
+
+	_, err = LoadSigningKeyFromFile(filepath.Join(dir, "absent.key"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read signing key")
+}
+
+func mustPKCS8PEM(t *testing.T, key crypto.Signer) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}
+
+func mustSEC1PEM(t *testing.T, key *ecdsa.PrivateKey) []byte {
+	t.Helper()
+	der, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
+}
+
+func mustPKCS1PEM(t *testing.T, key *rsa.PrivateKey) []byte {
+	t.Helper()
+	der := x509.MarshalPKCS1PrivateKey(key)
+	return pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der})
+}
+
+func mustPublicKeyPEM(t *testing.T, key crypto.PublicKey) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+}

--- a/pkg/identity/jwtissuer/key_test.go
+++ b/pkg/identity/jwtissuer/key_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
@@ -176,4 +177,35 @@ func mustPublicKeyPEM(t *testing.T, key crypto.PublicKey) []byte {
 	der, err := x509.MarshalPKIXPublicKey(key)
 	require.NoError(t, err)
 	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+}
+
+// TestRejectsUndersizedRSAKey pins the RFC 7518 section 3.3 floor for RS256.
+// Neither go-jose nor the gateway verifier checks the modulus, so an operator
+// pointing this at a weak Secret would otherwise get signed tokens that nothing
+// in the chain flags.
+func TestRejectsUndersizedRSAKey(t *testing.T) {
+	tests := []struct {
+		name   string
+		bits   int
+		accept bool
+	}{
+		{name: "1024 is refused", bits: 1024},
+		{name: "2048 is accepted", bits: 2048, accept: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, err := rsa.GenerateKey(rand.Reader, tt.bits)
+			require.NoError(t, err)
+
+			signing, err := LoadSigningKey(mustPKCS8PEM(t, key))
+			if tt.accept {
+				require.NoError(t, err)
+				assert.NotEmpty(t, signing.KeyID)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "at least 2048")
+		})
+	}
 }


### PR DESCRIPTION
Opening this as a draft against #659. It is deliberately only the first piece, and it stops short of the parts that depend on decisions the mentors haven't made yet.

### Ⅰ. Describe what this PR does

`pkg/identity/oidc` is a complete verifier with nothing in tree on the other side of it. `defaultTokenProvider.IssueToken` returns `uuid.NewString()` for both token kinds, so there is no way to produce a token that verifier would accept.

This adds `pkg/identity/jwtissuer`:

- signs traffic access tokens with the claim shape from `20260713-traffic-access-token-jwt-verification.md`: `iss`, `sub`, `exp`, `iat`, `nbf`, and the `sandbox` claim carrying `sandboxId`/`sandboxUid`
- serves `/.well-known/openid-configuration` and `/jwks.json`, so a community deployment can bootstrap the gateway without an external IdP
- supports RSA, ECDSA P-256/384/521 and Ed25519, picking the algorithm from the key type, since the verifier rejects a token whose `alg` doesn't match its key
- publishes retained public keys alongside the active signing key, for rotation

Nothing is wired into the provider, the manager, or any server yet. This package alone is not user-visible.

### Ⅱ. Does this pull request fix one issue?

Refs #659. First step only, not the whole issue.

### Ⅲ. Describe how to verify it

`go test ./pkg/identity/jwtissuer/ -count=1 -race`

The tests don't mock the verifier. They stand up an HTTPS test server, publish real discovery and JWKS documents from it, hand `oidc.NewVerifier` the server's CA through a fake-client ConfigMap, and let it perform discovery exactly as the gateway does. What gets asserted is that the production verifier accepts the token. The claim shape and the JWKS rules it enforces (unique non-empty `kid`, public keys only, `alg` matching key type) are checked by the real consumer rather than by my reading of it.

I checked the tests aren't vacuous: dropping `nbf` from the minted claims fails `TestIssuedTokenPassesRealVerifier` with `token is missing nbf claim`.

`TestRotationOverlapWindow` walks the three rotation steps and ends by asserting the hazard is real: a gateway holding a pre-rotation JWKS snapshot rejects a token signed by the new key with `unknown kid`.

### Ⅳ. Special notes for reviews

**Why this stops here.** @PRAteek-singHWY raised six design questions on #659 that are still open, and several of them change what comes next: whether access tokens get a re-issue path, whether `sub` carries the authenticated principal from the claiming API key or stays a fixed control-plane subject, and which runtime channel carries the ID token. I didn't want to guess at those, so I built the layer that is the same under every answer. Once the issuer exists, the provider wiring is small.

**Rotation.** The proposal states a published verifier is never replaced for the process lifetime, so rotation can only mean an overlap window: publish the new key, roll the gateways, then flip signing. `WithRetainedKeys` is what makes that expressible. Re-fetching JWKS on an unknown `kid` would put network I/O back on the request path and contradict the offline-after-initialization goal, so I've assumed that needs its own proposal.

**Claim struct duplication.** `trafficAccessTokenClaims` mirrors `oidc.TrafficAccessTokenClaims` rather than importing it. Importing would make the round-trip test tautological, since both sides would share one definition and a wrong JSON tag would still pass. The duplication is what gives the test something to catch. Happy to import it instead if you'd rather have the compile-time link.

**Not in scope here:** loading keys from a Secret, ID token issuance, `PropagateSecurityToken`, and the `IdentityProvider` implementation itself.

If the direction is wrong I would rather find out now than after building on top of it. I'm also happy to write this up under `docs/proposals/` first. Reading the two existing proposals together, the issuance side is the piece with no design doc yet.

