### PR TITLE
feat(controller): refactor pause strategy to support Stop, Snapshot and CloudDisk

### DIFF
--- a/.github/workflows/e2e-e2b-latest.yaml
+++ b/.github/workflows/e2e-e2b-latest.yaml
@@ -236,4 +236,7 @@ jobs:
           if [ "${{ matrix.quota_profile }}" != "none" ]; then
             export QUOTA_E2E_PROFILE="${{ matrix.quota_profile }}"
           fi
-          bash hack/run-e2b-e2e-test.sh "${args[@]}" --pytest-extra-args "-s -x"
+          # Temporarily pinned: e2b 2.38.0 removed the http2 kwarg of
+          # get_transport() that e2b-code-interpreter 2.9.0 still passes.
+          # 2.37.1 + 2.9.0 is the last verified working combination.
+          bash hack/run-e2b-e2e-test.sh "${args[@]}" --e2b-version 2.37.1 --sdk-version 2.9.0 --pytest-extra-args "-s -x"

--- a/.github/workflows/e2e-e2b-mysql-latest.yaml
+++ b/.github/workflows/e2e-e2b-mysql-latest.yaml
@@ -222,10 +222,14 @@ jobs:
           export E2B_API_KEY=some-api-key
           export INPLACE_UPDATE_IMAGE="${INPLACE_UPDATE_IMG}"
           export QUOTA_E2E_PROFILE=redis
+          # Temporarily pinned: e2b 2.38.0 removed the http2 kwarg of
+          # get_transport() that e2b-code-interpreter 2.9.0 still passes.
+          # 2.37.1 + 2.9.0 is the last verified working combination.
           if [ "${{ matrix.with_gateway }}" = "true" ]; then
             bash hack/run-e2b-e2e-test.sh --with-gateway \
+              --e2b-version 2.37.1 --sdk-version 2.9.0 \
               -m "not gateway_routing and not gateway_uuid_auth and not jwt_auth and not runtime_mtls" \
               --pytest-extra-args "-s -x"
           else
-            bash hack/run-e2b-e2e-test.sh --pytest-extra-args "-s -x"
+            bash hack/run-e2b-e2e-test.sh --e2b-version 2.37.1 --sdk-version 2.9.0 --pytest-extra-args "-s -x"
           fi

--- a/.github/workflows/e2e-sandbox-gateway-security.yaml
+++ b/.github/workflows/e2e-sandbox-gateway-security.yaml
@@ -263,9 +263,13 @@ jobs:
             export TRAFFIC_ACCESS_TOKEN_JWT_E2E=true
             export JWT_E2E_TOKEN_COMMAND="kubectl exec -n sandbox-system deployment/jwt-e2e-oidc-provider -- /jwt-oidc-provider issue"
           fi
+          # Temporarily pinned: e2b 2.38.0 removed the http2 kwarg of
+          # get_transport() that e2b-code-interpreter 2.9.0 still passes.
+          # 2.37.1 + 2.9.0 is the last verified working combination.
           bash hack/run-e2b-e2e-test.sh \
             --with-gateway \
             --auth-disabled \
+            --e2b-version 2.37.1 --sdk-version 2.9.0 \
             --test-file "${{ matrix.test_file }}" \
             -m "${{ matrix.marker }}" \
             --pytest-extra-args "-s -x"

--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,5 @@ REVIEW.md
 .superpowers
 *.tar
 analysis/
+
+.gocache/

--- a/api/v1alpha1/checkpoint_types.go
+++ b/api/v1alpha1/checkpoint_types.go
@@ -34,15 +34,88 @@ const (
 	// CheckpointLabelID is the checkpoint ID label key
 	CheckpointLabelID = InternalPrefix + "checkpoint-id"
 
-	// CheckpointTypePodInfo indicates this checkpoint stores pod info delta
-	CheckpointTypePodInfo = "pod-info"
-
-	// CheckpointTypeUpgrade indicates this checkpoint is created for sandbox upgrade
-	CheckpointTypeUpgrade = "upgrade"
-
+	CheckpointPersistentContentPodInfo    = "podInfo"
 	CheckpointPersistentContentMemory     = "memory"
 	CheckpointPersistentContentFilesystem = "filesystem"
 )
+
+// Legacy checkpoint type label values used by v0.5.22 and earlier.
+// These exist solely for backward compatibility during controller upgrade:
+// the old controller used "pod-info" (with hyphen) and "upgrade" as label
+// values, while the new controller derives labels from PersistentContents
+// ("podInfo", "filesystem").
+// TODO(legacy-compat): remove once all v0.5.22 checkpoints are garbage collected.
+const (
+	LegacyCheckpointTypePodInfo = "pod-info"
+	LegacyCheckpointTypeUpgrade = "upgrade"
+)
+
+// IsPodInfoOnly returns true when PersistentContents contains only podInfo,
+// meaning the checkpoint records pod template delta without dumping any
+// container state. Such checkpoints skip the finalizer and succeed
+// immediately in the checkpoint controller.
+func IsPodInfoOnly(contents []string) bool {
+	if len(contents) != 1 {
+		return false
+	}
+	return contents[0] == CheckpointPersistentContentPodInfo
+}
+
+// ContainsPodInfo returns true when PersistentContents includes podInfo,
+// meaning the checkpoint records (or will record) pod template delta.
+func ContainsPodInfo(contents []string) bool {
+	for _, c := range contents {
+		if c == CheckpointPersistentContentPodInfo {
+			return true
+		}
+	}
+	return false
+}
+
+// LegacyCheckpointLabel returns the v0.5.22 label value for the given new
+// checkpoint type label, or empty if there is no legacy equivalent. Used
+// during controller upgrade to find existing checkpoints created by the old
+// controller before falling back to creating a new one.
+// TODO(legacy-compat): remove once all v0.5.22 checkpoints are garbage collected.
+func LegacyCheckpointLabel(label string) string {
+	switch label {
+	case CheckpointPersistentContentPodInfo:
+		return LegacyCheckpointTypePodInfo
+	case CheckpointPersistentContentFilesystem:
+		return LegacyCheckpointTypeUpgrade
+	}
+	return ""
+}
+
+// IsPodInfoOnlyCheckpoint returns true for a checkpoint that only records pod
+// template delta (no container state dump). This includes new checkpoints with
+// PersistentContents=["podInfo"], and legacy v0.5.22 pod-info checkpoints that
+// carry the old "pod-info" label and have no PersistentContents set.
+// TODO(legacy-compat): remove legacy branch after v0.5.22 checkpoints are GC'd.
+func IsPodInfoOnlyCheckpoint(cp *Checkpoint) bool {
+	if IsPodInfoOnly(cp.Spec.PersistentContents) {
+		return true
+	}
+	// Legacy: v0.5.22 pod-info checkpoints have no PersistentContents
+	// and carry the old "pod-info" label.
+	return len(cp.Spec.PersistentContents) == 0 &&
+		cp.Labels[CheckpointLabelType] == LegacyCheckpointTypePodInfo
+}
+
+// IsPodInfoCheckpoint returns true for any checkpoint that records pod
+// template delta, including legacy v0.5.22 pod-info checkpoints. Unlike
+// IsPodInfoOnlyCheckpoint, this also matches checkpoints whose contents
+// combine podInfo with other contents.
+// TODO(legacy-compat): remove legacy branch after v0.5.22 checkpoints are GC'd.
+func IsPodInfoCheckpoint(cp *Checkpoint) bool {
+	if ContainsPodInfo(cp.Spec.PersistentContents) {
+		return true
+	}
+	// Legacy: v0.5.22 pod-info checkpoints have no PersistentContents
+	// and carry the old "pod-info" label.
+	return len(cp.Spec.PersistentContents) == 0 &&
+		cp.Labels[CheckpointLabelType] == LegacyCheckpointTypePodInfo
+}
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
@@ -67,7 +140,7 @@ type CheckpointSpec struct {
 	// +kubebuilder:validation:Optional
 	KeepRunning *bool `json:"keepRunning,omitempty"`
 
-	// PersistentContents indicates resume pod with persistent content, Enum: memory, filesystem
+	// PersistentContents indicates resume pod with persistent content, Enum: podInfo, memory, filesystem
 	// +kubebuilder:validation:Optional
 	// +listType=atomic
 	PersistentContents []string `json:"persistentContents,omitempty"`

--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -175,7 +175,7 @@ const (
 	PauseStrategyStop PauseStrategyType = "Stop"
 	// PauseStrategyHibernate preserves sandbox state (e.g., rootfs and memory,
 	// as defined by persistentContents) before deleting the Pod.
-	// The storage medium is configured by hibernateStrategy (checkpoint).
+	// The storage medium is configured by hibernateStrategy (snapshot).
 	PauseStrategyHibernate PauseStrategyType = "Hibernate"
 )
 
@@ -183,8 +183,8 @@ const (
 type HibernateStrategyType string
 
 const (
-	// HibernateStrategyCheckpoint stores hibernate state in a checkpoint.
-	HibernateStrategyCheckpoint HibernateStrategyType = "Checkpoint"
+	// HibernateStrategySnapshot stores hibernate state in a snapshot.
+	HibernateStrategySnapshot HibernateStrategyType = "Snapshot"
 )
 
 // PauseStrategy configures how a sandbox is paused when spec.paused is true.
@@ -394,14 +394,13 @@ const (
 	SandboxUpgradingReasonSucceeded         = "Succeeded"
 
 	// SandboxConditionPaused Reason
-	SandboxPausedReasonPausing             = "Pausing"
-	SandboxPausedReasonImageChanged        = "ImageChanged"
-	SandboxPausedReasonCheckpointCreating  = "CheckpointCreating"
-	SandboxPausedReasonCheckpointSucceeded = "CheckpointSucceeded"
-	SandboxPausedReasonCheckpointFailed    = "CheckpointFailed"
-	SandboxPausedReasonSetPause            = "SetPause"
-	SandboxPausedReasonPausedSucceed       = "PauseSucceed"
-	SandboxPausedReasonDeletePod           = "DeletePod"
+	SandboxPausedReasonPending              = "Pending"
+	SandboxPausedReasonImageChanged         = "ImageChanged"
+	SandboxPausedReasonCheckpointCreating   = "CheckpointCreating"
+	SandboxPausedReasonCheckpointSucceeded  = "CheckpointSucceeded"
+	SandboxPausedReasonCheckpointFailed     = "CheckpointFailed"
+	SandboxPausedReasonSnapshotPauseSucceed = "SnapshotPauseSucceed"
+	SandboxPausedReasonStopPauseSucceed     = "StopPauseSucceed"
 
 	// SandboxConditionResume Reason
 	SandboxResumeReasonCreatePod = "CreatePod"

--- a/config/crd/bases/agents.kruise.io_checkpoints.yaml
+++ b/config/crd/bases/agents.kruise.io_checkpoints.yaml
@@ -55,7 +55,7 @@ spec:
                 type: boolean
               persistentContents:
                 description: 'PersistentContents indicates resume pod with persistent
-                  content, Enum: memory, filesystem'
+                  content, Enum: podInfo, memory, filesystem'
                 items:
                   type: string
                 type: array

--- a/pkg/controller/checkpoint/utils.go
+++ b/pkg/controller/checkpoint/utils.go
@@ -21,12 +21,10 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
-	"github.com/openkruise/agents/pkg/utils/configuration"
 	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
 )
 
@@ -42,33 +40,6 @@ func getTemplateInitContainers(box *agentsv1alpha1.Sandbox) []corev1.Container {
 		return box.Spec.Template.Spec.InitContainers
 	}
 	return nil
-}
-
-func buildMetadataDelta(pod *corev1.Pod) metav1.ObjectMeta {
-	content := configuration.GetSandboxResumePodPersistentContent()
-	if content == nil {
-		return metav1.ObjectMeta{}
-	}
-	return metav1.ObjectMeta{
-		Labels:      filterMapByKeys(pod.Labels, content.LabelKeys),
-		Annotations: filterMapByKeys(pod.Annotations, content.AnnotationKeys),
-	}
-}
-
-func filterMapByKeys(source map[string]string, keys []string) map[string]string {
-	if len(keys) == 0 {
-		return nil
-	}
-	result := map[string]string{}
-	for _, key := range keys {
-		if v, ok := source[key]; ok && v != "" {
-			result[key] = v
-		}
-	}
-	if len(result) == 0 {
-		return nil
-	}
-	return result
 }
 
 // buildTemplateContainerDelta returns template-defined containers whose resources
@@ -138,50 +109,42 @@ func buildContainerNameOrder(cs []corev1.Container) []map[string]string {
 	return out
 }
 
-// BuildPodTemplateDelta assembles a Strategic Merge Patch from three
-// independent delta components captured at pause time:
-//  1. Metadata: whitelisted labels/annotations
-//  2. Template containers: resource changes (e.g. VPA)
-//  3. Injected containers: runtime-injected and webhook-injected containers
+// BuildPodTemplateDelta assembles a Strategic Merge Patch from the
+// spec-level delta components captured at pause time:
+//  1. Template containers: resource changes (e.g. VPA)
+//  2. Injected containers: runtime-injected and webhook-injected containers
+//
+// Pod metadata (whitelisted labels/annotations) is deliberately excluded:
+// the same whitelist is already carried by Sandbox Status.PodInfo and
+// injected via InjectResumedPod on resume paths that need it, while a
+// pause-time metadata snapshot would replay stale runtime-binding
+// annotations (e.g. instance-id) onto a Pod whose underlying instance was
+// released with the checkpoint, permanently sticking the resume in Pending.
 func BuildPodTemplateDelta(pod *corev1.Pod, box *agentsv1alpha1.Sandbox) (runtime.RawExtension, error) {
-	meta := buildMetadataDelta(pod)
 	containers := buildTemplateContainerDelta(pod, box)
 	injected, injectedInit := buildInjectedContainerDelta(pod, box)
 	containers = append(containers, injected...)
 
-	if meta.Labels == nil && meta.Annotations == nil &&
-		len(containers) == 0 && len(injectedInit) == 0 {
+	if len(containers) == 0 && len(injectedInit) == 0 {
 		return runtime.RawExtension{}, nil
 	}
 
 	patch := map[string]any{}
-	if meta.Labels != nil || meta.Annotations != nil {
-		metadata := map[string]any{}
-		if meta.Labels != nil {
-			metadata["labels"] = meta.Labels
-		}
-		if meta.Annotations != nil {
-			metadata["annotations"] = meta.Annotations
-		}
-		patch["metadata"] = metadata
+	spec := map[string]any{}
+	if len(containers) > 0 {
+		spec["containers"] = containers
+		// Force resumed Pod's container order to match the live Pod at
+		// pause time. Without this directive Strategic Merge Patch keeps
+		// the base Pod's order, so a wrong injection order during
+		// resume (e.g. agent-runtime before csi-mount) would not be
+		// corrected.
+		spec["$setElementOrder/containers"] = buildContainerNameOrder(pod.Spec.Containers)
 	}
-	if len(containers) > 0 || len(injectedInit) > 0 {
-		spec := map[string]any{}
-		if len(containers) > 0 {
-			spec["containers"] = containers
-			// Force resumed Pod's container order to match the live Pod at
-			// pause time. Without this directive Strategic Merge Patch keeps
-			// the base Pod's order, so a wrong injection order during
-			// resume (e.g. agent-runtime before csi-mount) would not be
-			// corrected.
-			spec["$setElementOrder/containers"] = buildContainerNameOrder(pod.Spec.Containers)
-		}
-		if len(injectedInit) > 0 {
-			spec["initContainers"] = injectedInit
-			spec["$setElementOrder/initContainers"] = buildContainerNameOrder(pod.Spec.InitContainers)
-		}
-		patch["spec"] = spec
+	if len(injectedInit) > 0 {
+		spec["initContainers"] = injectedInit
+		spec["$setElementOrder/initContainers"] = buildContainerNameOrder(pod.Spec.InitContainers)
 	}
+	patch["spec"] = spec
 
 	patchBytes, err := json.Marshal(patch)
 	if err != nil {

--- a/pkg/controller/checkpoint/utils_test.go
+++ b/pkg/controller/checkpoint/utils_test.go
@@ -136,63 +136,6 @@ func TestGetTemplateInitContainers(t *testing.T) {
 	}
 }
 
-func TestBuildMetadataDelta(t *testing.T) {
-	tests := []struct {
-		name      string
-		pod       *corev1.Pod
-		whitelist *configuration.SandboxResumePodPersistentContent
-		checkFn   func(t *testing.T, meta metav1.ObjectMeta)
-	}{
-		{
-			name: "whitelisted labels and annotations extracted",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"topology.kubernetes.io/zone": "cn-hangzhou-b",
-						"app":                         "test",
-					},
-					Annotations: map[string]string{
-						"scheduling.k8s.io/group-name": "pool-a",
-						"non-whitelisted":              "ignored",
-					},
-				},
-			},
-			whitelist: &configuration.SandboxResumePodPersistentContent{
-				LabelKeys:      []string{"topology.kubernetes.io/zone"},
-				AnnotationKeys: []string{"scheduling.k8s.io/group-name"},
-			},
-			checkFn: func(t *testing.T, meta metav1.ObjectMeta) {
-				assert.Equal(t, map[string]string{"topology.kubernetes.io/zone": "cn-hangzhou-b"}, meta.Labels)
-				assert.Equal(t, map[string]string{"scheduling.k8s.io/group-name": "pool-a"}, meta.Annotations)
-			},
-		},
-		{
-			name: "nil whitelist - empty metadata",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{"app": "test"},
-					Annotations: map[string]string{"key": "val"},
-				},
-			},
-			whitelist: nil,
-			checkFn: func(t *testing.T, meta metav1.ObjectMeta) {
-				assert.Nil(t, meta.Labels)
-				assert.Nil(t, meta.Annotations)
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			configuration.SetSandboxResumePodPersistentContentForTest(tt.whitelist)
-			defer configuration.SetSandboxResumePodPersistentContentForTest(nil)
-
-			meta := buildMetadataDelta(tt.pod)
-			tt.checkFn(t, meta)
-		})
-	}
-}
-
 func TestBuildTemplateContainerDelta(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -553,7 +496,7 @@ func TestBuildPodTemplateDelta(t *testing.T) {
 			},
 		},
 		{
-			name: "annotation drift captured with whitelist",
+			name: "whitelisted metadata excluded from delta",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -573,17 +516,10 @@ func TestBuildPodTemplateDelta(t *testing.T) {
 			},
 			expectError: "",
 			checkFn: func(t *testing.T, delta runtime.RawExtension) {
-				assert.NotNil(t, delta.Raw)
-				var patch map[string]any
-				err := json.Unmarshal(delta.Raw, &patch)
-				assert.NoError(t, err)
-				metadata, ok := patch["metadata"].(map[string]any)
-				assert.True(t, ok, "delta should contain metadata")
-				annotations, ok := metadata["annotations"].(map[string]any)
-				assert.True(t, ok, "metadata should contain annotations")
-				assert.Equal(t, "sandbox-pool-a", annotations["scheduling.k8s.io/group-name"])
-				_, exists := annotations["non-whitelisted"]
-				assert.False(t, exists)
+				// Metadata is carried by Sandbox Status.PodInfo and injected
+				// via InjectResumedPod, never replayed through the delta; with
+				// no spec drift the delta must stay empty.
+				assert.Nil(t, delta.Raw)
 			},
 		},
 	}
@@ -797,8 +733,10 @@ func TestBuildAndApplyPodTemplateDeltaRoundTrip(t *testing.T) {
 	err = ApplyPodTemplateDelta(resumeBasePod, delta)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "sandbox-pool-a", resumeBasePod.Annotations["scheduling.k8s.io/group-name"])
-	assert.Equal(t, "cn-hangzhou-b", resumeBasePod.Labels["topology.kubernetes.io/zone"])
+	// Whitelisted metadata is deliberately excluded from the delta; it is
+	// carried by Sandbox Status.PodInfo and injected separately on resume.
+	assert.NotContains(t, resumeBasePod.Annotations, "scheduling.k8s.io/group-name")
+	assert.NotContains(t, resumeBasePod.Labels, "topology.kubernetes.io/zone")
 
 	mainContainer := resumeBasePod.Spec.Containers[0]
 	assert.Equal(t, "main", mainContainer.Name)
@@ -916,12 +854,14 @@ func TestBuildAndApplyPodTemplateDeltaRoundTripWithTemplateLabels(t *testing.T) 
 	assert.NoError(t, err)
 
 	assert.Equal(t, "sandbox-foo", resumeBasePod.Labels["app"])
-	assert.Equal(t, "cn-hangzhou-b", resumeBasePod.Labels["topology.kubernetes.io/zone"])
+	// Whitelisted metadata is deliberately excluded from the delta; it is
+	// carried by Sandbox Status.PodInfo and injected separately on resume.
+	assert.NotContains(t, resumeBasePod.Labels, "topology.kubernetes.io/zone")
+	assert.NotContains(t, resumeBasePod.Annotations, "scheduling.k8s.io/group-name")
 	_, hasControllerUID := resumeBasePod.Labels["controller-uid"]
 	assert.False(t, hasControllerUID, "non-whitelisted label should not appear")
 
 	assert.Equal(t, "v1", resumeBasePod.Annotations["agents.kruise.io/sandbox-version"])
-	assert.Equal(t, "sandbox-pool-a", resumeBasePod.Annotations["scheduling.k8s.io/group-name"])
 	_, hasLastApplied := resumeBasePod.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
 	assert.False(t, hasLastApplied, "non-whitelisted annotation should not appear")
 

--- a/pkg/controller/sandbox/core/checkpoint.go
+++ b/pkg/controller/sandbox/core/checkpoint.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -30,11 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
-	"github.com/openkruise/agents/pkg/features"
 	"github.com/openkruise/agents/pkg/tracing"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
-	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 	"github.com/openkruise/agents/pkg/utils/fieldindex"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -57,20 +56,66 @@ func NewCheckpointControl(cli client.Client, recorder record.EventRecorder) *Che
 	return &CheckpointControl{Client: cli, recorder: recorder}
 }
 
+// CheckpointScope parameterizes the checkpoint behavior for different pause
+// strategies. The scope is driven by PersistentContents: the derived label
+// determines which existing checkpoints are queried, and the contents are
+// passed to the checkpoint controller to decide what state to persist.
+type CheckpointScope struct {
+	// PersistentContents is the list of contents to persist (e.g. "podInfo",
+	// "filesystem"). The checkpoint label is derived from the sorted contents.
+	PersistentContents []string
+	// ValidateImages controls whether container images are compared against
+	// the sandbox template before allowing the pause to proceed.
+	ValidateImages bool
+}
+
+// checkpointContentsForPause derives the checkpoint persistent contents for
+// the pause flow from sandbox.spec.persistentContents: requested dump contents
+// (filesystem/memory) are passed through as-is and podInfo is used only when
+// no dump content is requested. Dump contents are never combined with podInfo
+// because a dump checkpoint already carries the pod info needed to rebuild the
+// pod template delta on resume. Without dump contents the result is a
+// pod-info-only checkpoint carrying no dump data.
+func checkpointContentsForPause(box *agentsv1alpha1.Sandbox) []string {
+	var contents []string
+	for _, c := range box.Spec.PersistentContents {
+		switch c {
+		case agentsv1alpha1.PersistentContentFilesystem:
+			contents = append(contents, agentsv1alpha1.CheckpointPersistentContentFilesystem)
+		case agentsv1alpha1.PersistentContentMemory:
+			contents = append(contents, agentsv1alpha1.CheckpointPersistentContentMemory)
+		}
+	}
+	if len(contents) == 0 {
+		return []string{agentsv1alpha1.CheckpointPersistentContentPodInfo}
+	}
+	return contents
+}
+
+// checkpointLabelForContents derives the checkpoint type label from the sorted
+// PersistentContents. For a single content the label is the content itself
+// (e.g. "podInfo", "filesystem"); for multiple contents they are joined with
+// a hyphen in sorted order (e.g. "filesystem-memory").
+func checkpointLabelForContents(contents []string) string {
+	if len(contents) == 0 {
+		return ""
+	}
+	sorted := make([]string, len(contents))
+	copy(sorted, contents)
+	sort.Strings(sorted)
+	return strings.Join(sorted, "-")
+}
+
 // AssumePodCheckpointed validates container images and manages the Checkpoint CR lifecycle.
 // Returns true if the pause flow should wait (checkpoint in progress or image rejected).
-func (c *CheckpointControl) AssumePodCheckpointed(ctx context.Context, pod *corev1.Pod, box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus, cond *metav1.Condition) bool {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.SandboxPauseCheckpointGate) {
-		cond.Reason = agentsv1alpha1.SandboxPausedReasonCheckpointSucceeded
-		return false
-	}
+func (c *CheckpointControl) AssumePodCheckpointed(ctx context.Context, pod *corev1.Pod, box *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus, cond *metav1.Condition, scope CheckpointScope) bool {
 	// Allow-list of paused reasons that should drive the checkpoint flow.
 	// Any other reason (e.g. CheckpointSucceeded already reached, or a reason
 	// introduced in the future) skips this flow on purpose; new reasons that
 	// need checkpointing must be added here explicitly.
 	switch cond.Reason {
 	case "",
-		agentsv1alpha1.SandboxPausedReasonPausing,
+		agentsv1alpha1.SandboxPausedReasonPending,
 		agentsv1alpha1.SandboxPausedReasonCheckpointCreating,
 		agentsv1alpha1.SandboxPausedReasonImageChanged,
 		agentsv1alpha1.SandboxPausedReasonCheckpointFailed:
@@ -79,42 +124,37 @@ func (c *CheckpointControl) AssumePodCheckpointed(ctx context.Context, pod *core
 		return false
 	}
 
-	if err := validateContainerImages(pod, box); err != nil {
-		cond.Status = metav1.ConditionFalse
-		cond.Reason = agentsv1alpha1.SandboxPausedReasonImageChanged
-		cond.Message = err.Error()
-		utils.SetSandboxCondition(newStatus, *cond)
-		c.recorder.Event(box, corev1.EventTypeWarning, agentsv1alpha1.SandboxPausedReasonImageChanged, err.Error())
-		klog.FromContext(ctx).Error(err, "Image validation failed, pause rejected", "sandbox", klog.KObj(box))
-		return true
+	if scope.ValidateImages {
+		if err := validateContainerImages(pod, box); err != nil {
+			cond.Status = metav1.ConditionFalse
+			cond.Reason = agentsv1alpha1.SandboxPausedReasonImageChanged
+			cond.Message = err.Error()
+			utils.SetSandboxCondition(newStatus, *cond)
+			c.recorder.Event(box, corev1.EventTypeWarning, agentsv1alpha1.SandboxPausedReasonImageChanged, err.Error())
+			klog.FromContext(ctx).Error(err, "Image validation failed, pause rejected", "sandbox", klog.KObj(box))
+			return true
+		}
 	}
-	if cond.Reason == "" || cond.Reason == agentsv1alpha1.SandboxPausedReasonPausing ||
-		cond.Reason == agentsv1alpha1.SandboxPausedReasonImageChanged {
+	if cond.Reason == "" || cond.Reason == agentsv1alpha1.SandboxPausedReasonPending {
 		cond.Reason = agentsv1alpha1.SandboxPausedReasonCheckpointCreating
 		cond.Message = "Checkpoint created, waiting for completion"
 		utils.SetSandboxCondition(newStatus, *cond)
 	}
 
-	cpList, err := listCheckpointsForSandbox(ctx, c.Client, box, agentsv1alpha1.CheckpointTypePodInfo)
+	cp, _, err := c.ensureCheckpointCR(ctx, box, scope.PersistentContents)
 	if err != nil {
-		klog.FromContext(ctx).Error(err, "Failed to list checkpoints", "sandbox", klog.KObj(box))
+		klog.FromContext(ctx).Error(err, "Failed to ensure checkpoint", "sandbox", klog.KObj(box))
 		cond.Reason = agentsv1alpha1.SandboxPausedReasonCheckpointFailed
-		cond.Message = fmt.Sprintf("Failed to list checkpoints: %v", err)
+		cond.Message = err.Error()
 		utils.SetSandboxCondition(newStatus, *cond)
 		c.recorder.Event(box, corev1.EventTypeWarning, agentsv1alpha1.SandboxPausedReasonCheckpointFailed, cond.Message)
 		return true
-	} else if len(cpList) == 0 {
-		if _, err := c.createCheckpoint(ctx, box, agentsv1alpha1.CheckpointTypePodInfo, nil); err != nil {
-			klog.FromContext(ctx).Error(err, "Failed to create checkpoint", "sandbox", klog.KObj(box))
-			cond.Reason = agentsv1alpha1.SandboxPausedReasonCheckpointFailed
-			cond.Message = fmt.Sprintf("Failed to create checkpoint: %v", err)
-			utils.SetSandboxCondition(newStatus, *cond)
-			c.recorder.Event(box, corev1.EventTypeWarning, agentsv1alpha1.SandboxPausedReasonCheckpointFailed, cond.Message)
-		}
+	}
+	if cp == nil {
+		// Checkpoint just created, wait for the checkpoint controller to process it.
 		return true
 	}
 
-	cp := &cpList[0]
 	switch cp.Status.Phase {
 	case agentsv1alpha1.CheckpointSucceeded:
 		cond.Reason = agentsv1alpha1.SandboxPausedReasonCheckpointSucceeded
@@ -138,30 +178,67 @@ func (c *CheckpointControl) AssumePodCheckpointed(ctx context.Context, pod *core
 	}
 }
 
-// GetPodTemplateDelta retrieves the pod template delta from the latest checkpoint for the given sandbox.
-func (c *CheckpointControl) GetPodTemplateDelta(ctx context.Context, box *agentsv1alpha1.Sandbox) *runtime.RawExtension {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.SandboxPauseCheckpointGate) {
-		return nil
+// ensureCheckpointCR finds an existing checkpoint for the sandbox matching the
+// given persistent contents, or creates a new one if none exists. It first
+// queries by the new content-derived label, then falls back to the legacy
+// v0.5.22 label for backward compatibility during controller upgrade.
+// Returns (nil, cpName, nil) when a new checkpoint was just created (caller
+// should wait). Returns a non-nil checkpoint when an existing one was found.
+// Returns (nil, "", err) when an error occurred.
+func (c *CheckpointControl) ensureCheckpointCR(ctx context.Context, box *agentsv1alpha1.Sandbox, persistentContents []string) (*agentsv1alpha1.Checkpoint, string, error) {
+	label := checkpointLabelForContents(persistentContents)
+	cpList, err := listCheckpointsForSandbox(ctx, c.Client, box, label)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to list checkpoints: %w", err)
 	}
-	cpList, cpErr := listCheckpointsForSandbox(ctx, c.Client, box, agentsv1alpha1.CheckpointTypePodInfo)
-	if cpErr != nil {
-		klog.FromContext(ctx).Error(cpErr, "Failed to list checkpoints for resume, proceeding without", "sandbox", klog.KObj(box))
-		return nil
-	}
-	// Normally the checkpoint list contains only one element
-	for i := range cpList {
-		if len(cpList[i].Status.PodTemplateDelta.Raw) > 0 {
-			return &cpList[i].Status.PodTemplateDelta
+	if len(cpList) == 0 {
+		// Fallback: try the legacy v0.5.22 label for backward compatibility.
+		// TODO(legacy-compat): remove once all v0.5.22 checkpoints are garbage collected.
+		if legacyLabel := agentsv1alpha1.LegacyCheckpointLabel(label); legacyLabel != "" {
+			cpList, err = listCheckpointsForSandbox(ctx, c.Client, box, legacyLabel)
+			if err != nil {
+				return nil, "", fmt.Errorf("failed to list legacy checkpoints: %w", err)
+			}
 		}
 	}
-	return nil
+	if len(cpList) == 0 {
+		cpName, err := c.createCheckpoint(ctx, box, persistentContents)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to create checkpoint: %w", err)
+		}
+		return nil, cpName, nil
+	}
+	return &cpList[0], cpList[0].Name, nil
 }
 
-// Cleanup deletes all pod-info Checkpoint CRs for the given sandbox.
-func (c *CheckpointControl) Cleanup(ctx context.Context, box *agentsv1alpha1.Sandbox) {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.SandboxPauseCheckpointGate) {
-		return
+// GetCheckpointResumeData retrieves the pod template delta and the checkpoint
+// ID from the sandbox's checkpoints in a single list operation. Both fields
+// come from the same checkpoint: the first one that recorded a non-empty pod
+// template delta. The delta rebuilds the pod on resume or a CheckpointRestore
+// upgrade, and the checkpoint ID restores the pod's writable layer. A sandbox
+// holds at most one active checkpoint at a time (created by the pause or the
+// upgrade flow and cleaned up afterwards), so both fields always belong to a
+// single checkpoint.
+//
+// Unlike the checkpoint creation path, reading here needs no feature gate
+// check: a checkpoint only exists if the creation path created it in the
+// first place.
+func (c *CheckpointControl) GetCheckpointResumeData(ctx context.Context, box *agentsv1alpha1.Sandbox) (*runtime.RawExtension, string) {
+	cpList, cpErr := listCheckpointsForSandbox(ctx, c.Client, box, "")
+	if cpErr != nil {
+		klog.FromContext(ctx).Error(cpErr, "Failed to list checkpoints for resume", "sandbox", klog.KObj(box))
+		return nil, ""
 	}
+	for i := range cpList {
+		if len(cpList[i].Status.PodTemplateDelta.Raw) > 0 {
+			return &cpList[i].Status.PodTemplateDelta, cpList[i].Status.CheckpointId
+		}
+	}
+	return nil, ""
+}
+
+// CleanupCheckpoints deletes all Checkpoint CRs for the given sandbox.
+func (c *CheckpointControl) CleanupCheckpoints(ctx context.Context, box *agentsv1alpha1.Sandbox) {
 	// Trace the cleanup so its latency is observable in Jaeger. Cleanup has
 	// several exit points, so the span is closed once from a deferred closure.
 	// Keep the closure: a direct defer tracing.EndSpan(ctx, span, err) would
@@ -171,7 +248,7 @@ func (c *CheckpointControl) Cleanup(ctx context.Context, box *agentsv1alpha1.San
 	ctx, span := tracing.StartControllerSpan(ctx, tracing.SpanControllerCheckpointCleanup)
 	var err error
 	defer func() { tracing.EndSpan(ctx, span, err) }()
-	cpList, cpErr := listCheckpointsForSandbox(ctx, c.Client, box, agentsv1alpha1.CheckpointTypePodInfo)
+	cpList, cpErr := listCheckpointsForSandbox(ctx, c.Client, box, "")
 	if cpErr != nil {
 		err = cpErr
 		klog.FromContext(ctx).Error(cpErr, "Failed to list checkpoints for cleanup", "sandbox", klog.KObj(box))
@@ -198,8 +275,8 @@ func (c *CheckpointControl) Cleanup(ctx context.Context, box *agentsv1alpha1.San
 // The name carries a random suffix so each invocation produces a distinct
 // checkpoint name. Idempotency within the same reconcile cycle is guaranteed
 // by the caller, which only invokes this function when no existing checkpoint
-// is found for the sandbox (see AssumePodCheckpointed).
-func (c *CheckpointControl) createCheckpoint(ctx context.Context, box *agentsv1alpha1.Sandbox, checkpointType string, persistentContents []string) (string, error) {
+// is found for the sandbox (see ensureCheckpointCR / AssumePodCheckpointed).
+func (c *CheckpointControl) createCheckpoint(ctx context.Context, box *agentsv1alpha1.Sandbox, persistentContents []string) (string, error) {
 	cpName := box.Name + "-" + utils.RandStringN(8)
 	cp := &agentsv1alpha1.Checkpoint{
 		ObjectMeta: metav1.ObjectMeta{
@@ -210,7 +287,7 @@ func (c *CheckpointControl) createCheckpoint(ctx context.Context, box *agentsv1a
 			},
 			Labels: map[string]string{
 				agentsv1alpha1.CheckpointLabelSandboxName: box.Name,
-				agentsv1alpha1.CheckpointLabelType:        checkpointType,
+				agentsv1alpha1.CheckpointLabelType:        checkpointLabelForContents(persistentContents),
 			},
 		},
 		Spec: agentsv1alpha1.CheckpointSpec{
@@ -258,20 +335,15 @@ func (c *CheckpointControl) EnsureCheckpointForUpgrade(ctx context.Context, box 
 		return true, "", nil
 	}
 
-	cpList, err := listCheckpointsForSandbox(ctx, c.Client, box, agentsv1alpha1.CheckpointTypeUpgrade)
+	contents := []string{agentsv1alpha1.CheckpointPersistentContentFilesystem}
+	cp, cpName, err := c.ensureCheckpointCR(ctx, box, contents)
 	if err != nil {
-		return false, "", fmt.Errorf("failed to list checkpoints for upgrade: %w", err)
+		return false, "", err
 	}
-
-	if len(cpList) == 0 {
-		cpName, err := c.createCheckpoint(ctx, box, agentsv1alpha1.CheckpointTypeUpgrade, []string{agentsv1alpha1.CheckpointPersistentContentFilesystem})
-		if err != nil {
-			return false, "", fmt.Errorf("failed to create checkpoint for upgrade: %w", err)
-		}
+	if cp == nil {
 		return false, cpName, nil
 	}
 
-	cp := &cpList[0]
 	switch cp.Status.Phase {
 	case agentsv1alpha1.CheckpointSucceeded:
 		c.recordCheckpointEvent(box, corev1.EventTypeNormal, EventCheckpointSucceeded,
@@ -288,50 +360,12 @@ func (c *CheckpointControl) EnsureCheckpointForUpgrade(ctx context.Context, box 
 	}
 }
 
-// GetCheckpointIDForUpgrade retrieves the checkpoint ID from the latest
-// checkpoint for upgrade purposes. The checkpoint ID is used to restore the
-// pod's writable layer when creating the new pod. Unlike GetPodTemplateDelta,
-// this does not check the SandboxPauseCheckpointGate feature gate because the
-// CheckpointRestore strategy is an explicit opt-in.
-func (c *CheckpointControl) GetCheckpointIDForUpgrade(ctx context.Context, box *agentsv1alpha1.Sandbox) string {
-	cpList, cpErr := listCheckpointsForSandbox(ctx, c.Client, box, agentsv1alpha1.CheckpointTypeUpgrade)
-	if cpErr != nil {
-		klog.ErrorS(cpErr, "Failed to list checkpoints for upgrade ID, proceeding without", "sandbox", klog.KObj(box))
-		return ""
-	}
-	for i := range cpList {
-		if cpList[i].Status.CheckpointId != "" {
-			return cpList[i].Status.CheckpointId
-		}
-	}
-	return ""
-}
-
-// CleanupForUpgrade deletes all upgrade Checkpoint CRs for the given sandbox
-// after a successful upgrade. Unlike Cleanup, this does not check the
-// SandboxPauseCheckpointGate feature gate.
-func (c *CheckpointControl) CleanupForUpgrade(ctx context.Context, box *agentsv1alpha1.Sandbox) {
-	cpList, cpErr := listCheckpointsForSandbox(ctx, c.Client, box, agentsv1alpha1.CheckpointTypeUpgrade)
-	if cpErr != nil {
-		klog.ErrorS(cpErr, "Failed to list checkpoints for upgrade cleanup", "sandbox", klog.KObj(box))
-		return
-	}
-	for i := range cpList {
-		ScaleExpectation.ExpectScale(GetControllerKey(box), expectations.Delete, cpList[i].Name)
-		if delErr := c.Delete(ctx, &cpList[i]); delErr != nil && !errors.IsNotFound(delErr) {
-			ScaleExpectation.ObserveScale(GetControllerKey(box), expectations.Delete, cpList[i].Name)
-			klog.ErrorS(delErr, "Failed to delete checkpoint after upgrade", "sandbox", klog.KObj(box), "checkpoint", cpList[i].Name)
-		} else {
-			klog.InfoS("Deleted checkpoint after successful upgrade", "sandbox", klog.KObj(box), "checkpoint", cpList[i].Name)
-		}
-	}
-}
-
 // validateContainerImages compares each user container's Image in the live Pod
 // against the Image defined in sandbox.spec.template. If any image differs,
-// the pause is rejected.
+// the pause is rejected. A nil pod carries nothing to compare (e.g. the pod
+// was already deleted), so validation trivially passes.
 func validateContainerImages(pod *corev1.Pod, box *agentsv1alpha1.Sandbox) error {
-	if box.Spec.Template == nil {
+	if pod == nil || box.Spec.Template == nil {
 		return nil
 	}
 	for _, tc := range box.Spec.Template.Spec.Containers {
@@ -357,15 +391,20 @@ func validateContainerImages(pod *corev1.Pod, box *agentsv1alpha1.Sandbox) error
 }
 
 // listCheckpointsForSandbox returns all Checkpoint CRs of the given type for the
-// given sandbox, sorted newest-first by creation timestamp.
+// given sandbox, sorted newest-first by creation timestamp. When
+// checkpointType is empty, all checkpoints for the sandbox are returned
+// regardless of their type label.
 func listCheckpointsForSandbox(ctx context.Context, cli client.Client, box *agentsv1alpha1.Sandbox, checkpointType string) ([]agentsv1alpha1.Checkpoint, error) {
 	cpList := &agentsv1alpha1.CheckpointList{}
-	err := cli.List(ctx, cpList,
+	listOpts := []client.ListOption{
 		client.InNamespace(box.Namespace),
 		client.MatchingFields{fieldindex.IndexNameForOwnerRefUID: string(box.UID)},
-		client.MatchingLabels{agentsv1alpha1.CheckpointLabelType: checkpointType},
 		client.UnsafeDisableDeepCopy,
-	)
+	}
+	if checkpointType != "" {
+		listOpts = append(listOpts, client.MatchingLabels{agentsv1alpha1.CheckpointLabelType: checkpointType})
+	}
+	err := cli.List(ctx, cpList, listOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/sandbox/core/checkpoint_test.go
+++ b/pkg/controller/sandbox/core/checkpoint_test.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
-	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 	"github.com/openkruise/agents/pkg/utils/fieldindex"
 )
 
@@ -283,7 +282,7 @@ func TestListCheckpointsForSandbox(t *testing.T) {
 						OwnerReferences:   []metav1.OwnerReference{ownerRef},
 						Labels: map[string]string{
 							agentsv1alpha1.CheckpointLabelSandboxName: "test-sandbox",
-							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointTypePodInfo,
+							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointPersistentContentPodInfo,
 						},
 					},
 					Status: agentsv1alpha1.CheckpointStatus{
@@ -308,7 +307,7 @@ func TestListCheckpointsForSandbox(t *testing.T) {
 						OwnerReferences:   []metav1.OwnerReference{ownerRef},
 						Labels: map[string]string{
 							agentsv1alpha1.CheckpointLabelSandboxName: "test-sandbox",
-							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointTypePodInfo,
+							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointPersistentContentPodInfo,
 						},
 					},
 				},
@@ -320,7 +319,7 @@ func TestListCheckpointsForSandbox(t *testing.T) {
 						OwnerReferences:   []metav1.OwnerReference{ownerRef},
 						Labels: map[string]string{
 							agentsv1alpha1.CheckpointLabelSandboxName: "test-sandbox",
-							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointTypePodInfo,
+							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointPersistentContentPodInfo,
 						},
 					},
 				},
@@ -349,7 +348,7 @@ func TestListCheckpointsForSandbox(t *testing.T) {
 						},
 						Labels: map[string]string{
 							agentsv1alpha1.CheckpointLabelSandboxName: "other-sandbox",
-							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointTypePodInfo,
+							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointPersistentContentPodInfo,
 						},
 					},
 				},
@@ -371,7 +370,7 @@ func TestListCheckpointsForSandbox(t *testing.T) {
 						OwnerReferences:   []metav1.OwnerReference{ownerRef},
 						Labels: map[string]string{
 							agentsv1alpha1.CheckpointLabelSandboxName: "test-sandbox",
-							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointTypePodInfo,
+							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointPersistentContentPodInfo,
 						},
 					},
 				},
@@ -393,7 +392,7 @@ func TestListCheckpointsForSandbox(t *testing.T) {
 						OwnerReferences:   []metav1.OwnerReference{ownerRef},
 						Labels: map[string]string{
 							agentsv1alpha1.CheckpointLabelSandboxName: "test-sandbox",
-							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointTypePodInfo,
+							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointPersistentContentPodInfo,
 						},
 					},
 				},
@@ -405,7 +404,7 @@ func TestListCheckpointsForSandbox(t *testing.T) {
 						OwnerReferences:   []metav1.OwnerReference{ownerRef},
 						Labels: map[string]string{
 							agentsv1alpha1.CheckpointLabelSandboxName: "test-sandbox",
-							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointTypePodInfo,
+							agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointPersistentContentPodInfo,
 						},
 					},
 				},
@@ -434,7 +433,7 @@ func TestListCheckpointsForSandbox(t *testing.T) {
 					UID:       tt.sandboxUID,
 				},
 			}
-			cpList, err := listCheckpointsForSandbox(context.TODO(), cli, box, agentsv1alpha1.CheckpointTypePodInfo)
+			cpList, err := listCheckpointsForSandbox(context.TODO(), cli, box, agentsv1alpha1.CheckpointPersistentContentPodInfo)
 			if tt.expectError == "" {
 				assert.NoError(t, err)
 			} else {
@@ -519,8 +518,11 @@ func newCheckpointTestCP(name string, box *agentsv1alpha1.Sandbox, phase agentsv
 			},
 			Labels: map[string]string{
 				agentsv1alpha1.CheckpointLabelSandboxName: box.Name,
-				agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointTypePodInfo,
+				agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointPersistentContentPodInfo,
 			},
+		},
+		Spec: agentsv1alpha1.CheckpointSpec{
+			PersistentContents: []string{agentsv1alpha1.CheckpointPersistentContentPodInfo},
 		},
 		Status: agentsv1alpha1.CheckpointStatus{
 			Phase: phase,
@@ -528,18 +530,112 @@ func newCheckpointTestCP(name string, box *agentsv1alpha1.Sandbox, phase agentsv
 	}
 }
 
-func enableCheckpointGate(t *testing.T) {
-	t.Helper()
-	_ = utilfeature.DefaultMutableFeatureGate.Set("SandboxPauseCheckpoint=true")
-	t.Cleanup(func() {
-		_ = utilfeature.DefaultMutableFeatureGate.Set("SandboxPauseCheckpoint=false")
-	})
+// testPodInfoScope is the default pause-flow checkpoint scope used in tests:
+// pod-info type with image validation.
+var testPodInfoScope = CheckpointScope{
+	PersistentContents: []string{agentsv1alpha1.CheckpointPersistentContentPodInfo},
+	ValidateImages:     true,
+}
+
+func TestCheckpointContentsForPause(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents []string
+		expected []string
+	}{
+		{
+			name:     "no persistent contents - podInfo only",
+			expected: []string{agentsv1alpha1.CheckpointPersistentContentPodInfo},
+		},
+		{
+			name:     "filesystem only - dump content carries pod info, not combined",
+			contents: []string{agentsv1alpha1.PersistentContentFilesystem},
+			expected: []string{agentsv1alpha1.CheckpointPersistentContentFilesystem},
+		},
+		{
+			name:     "filesystem and memory - dump contents only",
+			contents: []string{agentsv1alpha1.PersistentContentFilesystem, agentsv1alpha1.PersistentContentMemory},
+			expected: []string{
+				agentsv1alpha1.CheckpointPersistentContentFilesystem,
+				agentsv1alpha1.CheckpointPersistentContentMemory,
+			},
+		},
+		{
+			name:     "memory only - dump content carries pod info, not combined",
+			contents: []string{agentsv1alpha1.PersistentContentMemory},
+			expected: []string{agentsv1alpha1.CheckpointPersistentContentMemory},
+		},
+		{
+			name:     "ip only - not a checkpoint content, podInfo only",
+			contents: []string{agentsv1alpha1.PersistentContentIp},
+			expected: []string{agentsv1alpha1.CheckpointPersistentContentPodInfo},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			box := newCheckpointTestSandbox()
+			box.Spec.PersistentContents = tt.contents
+			assert.Equal(t, tt.expected, checkpointContentsForPause(box))
+		})
+	}
+}
+
+func TestCheckpointLabelForContents(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents []string
+		expected string
+	}{
+		{
+			name:     "empty contents - empty label",
+			contents: nil,
+			expected: "",
+		},
+		{
+			name:     "single podInfo",
+			contents: []string{agentsv1alpha1.CheckpointPersistentContentPodInfo},
+			expected: agentsv1alpha1.CheckpointPersistentContentPodInfo,
+		},
+		{
+			name:     "single filesystem",
+			contents: []string{agentsv1alpha1.CheckpointPersistentContentFilesystem},
+			expected: agentsv1alpha1.CheckpointPersistentContentFilesystem,
+		},
+		{
+			name: "podInfo and filesystem joined in sorted order",
+			contents: []string{
+				agentsv1alpha1.CheckpointPersistentContentPodInfo,
+				agentsv1alpha1.CheckpointPersistentContentFilesystem,
+			},
+			expected: agentsv1alpha1.CheckpointPersistentContentFilesystem + "-" + agentsv1alpha1.CheckpointPersistentContentPodInfo,
+		},
+		{
+			name: "three contents sorted regardless of input order",
+			contents: []string{
+				agentsv1alpha1.CheckpointPersistentContentPodInfo,
+				agentsv1alpha1.CheckpointPersistentContentMemory,
+				agentsv1alpha1.CheckpointPersistentContentFilesystem,
+			},
+			expected: agentsv1alpha1.CheckpointPersistentContentFilesystem + "-" +
+				agentsv1alpha1.CheckpointPersistentContentMemory + "-" +
+				agentsv1alpha1.CheckpointPersistentContentPodInfo,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := tt.contents
+			assert.Equal(t, tt.expected, checkpointLabelForContents(tt.contents))
+			// The input slice must not be mutated by the sort.
+			assert.Equal(t, before, tt.contents)
+		})
+	}
 }
 
 func TestAssumePodCheckpointed(t *testing.T) {
 	tests := []struct {
 		name         string
-		enableGate   bool
 		pod          *corev1.Pod
 		box          *agentsv1alpha1.Sandbox
 		existingCPs  []client.Object
@@ -548,24 +644,15 @@ func TestAssumePodCheckpointed(t *testing.T) {
 		expectReason string
 	}{
 		{
-			name:       "feature gate disabled - returns false immediately",
-			enableGate: false,
-			pod:        newCheckpointTestPod(),
-			box:        newCheckpointTestSandbox(),
-			expectWait: false,
-		},
-		{
 			name:         "non-checkpoint reason - returns false immediately",
-			enableGate:   true,
 			pod:          newCheckpointTestPod(),
 			box:          newCheckpointTestSandbox(),
-			condReason:   agentsv1alpha1.SandboxPausedReasonDeletePod,
+			condReason:   agentsv1alpha1.SandboxPausedReasonStopPauseSucceed,
 			expectWait:   false,
-			expectReason: agentsv1alpha1.SandboxPausedReasonDeletePod,
+			expectReason: agentsv1alpha1.SandboxPausedReasonStopPauseSucceed,
 		},
 		{
-			name:       "image changed - pause rejected",
-			enableGate: true,
+			name: "image changed - pause rejected",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default", UID: "pod-uid-001"},
 				Spec: corev1.PodSpec{
@@ -578,7 +665,6 @@ func TestAssumePodCheckpointed(t *testing.T) {
 		},
 		{
 			name:       "image changed retry from ImageChanged reason",
-			enableGate: true,
 			condReason: agentsv1alpha1.SandboxPausedReasonImageChanged,
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default", UID: "pod-uid-001"},
@@ -592,17 +678,15 @@ func TestAssumePodCheckpointed(t *testing.T) {
 		},
 		{
 			name:         "fresh pause - creates checkpoint",
-			enableGate:   true,
 			pod:          newCheckpointTestPod(),
 			box:          newCheckpointTestSandbox(),
 			expectWait:   true,
 			expectReason: agentsv1alpha1.SandboxPausedReasonCheckpointCreating,
 		},
 		{
-			name:       "checkpoint succeeded - returns false",
-			enableGate: true,
-			pod:        newCheckpointTestPod(),
-			box:        newCheckpointTestSandbox(),
+			name: "checkpoint succeeded - returns false",
+			pod:  newCheckpointTestPod(),
+			box:  newCheckpointTestSandbox(),
 			existingCPs: []client.Object{
 				newCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded),
 			},
@@ -611,10 +695,9 @@ func TestAssumePodCheckpointed(t *testing.T) {
 			expectReason: agentsv1alpha1.SandboxPausedReasonCheckpointSucceeded,
 		},
 		{
-			name:       "checkpoint failed - returns true",
-			enableGate: true,
-			pod:        newCheckpointTestPod(),
-			box:        newCheckpointTestSandbox(),
+			name: "checkpoint failed - returns true",
+			pod:  newCheckpointTestPod(),
+			box:  newCheckpointTestSandbox(),
 			existingCPs: []client.Object{
 				newCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointFailed),
 			},
@@ -624,7 +707,6 @@ func TestAssumePodCheckpointed(t *testing.T) {
 		},
 		{
 			name:         "checkpoint failed reason - retry creates checkpoint",
-			enableGate:   true,
 			pod:          newCheckpointTestPod(),
 			box:          newCheckpointTestSandbox(),
 			condReason:   agentsv1alpha1.SandboxPausedReasonCheckpointFailed,
@@ -632,10 +714,9 @@ func TestAssumePodCheckpointed(t *testing.T) {
 			expectReason: agentsv1alpha1.SandboxPausedReasonCheckpointFailed,
 		},
 		{
-			name:       "checkpoint in progress - waits",
-			enableGate: true,
-			pod:        newCheckpointTestPod(),
-			box:        newCheckpointTestSandbox(),
+			name: "checkpoint in progress - waits",
+			pod:  newCheckpointTestPod(),
+			box:  newCheckpointTestSandbox(),
 			existingCPs: []client.Object{
 				newCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointCreating),
 			},
@@ -644,10 +725,9 @@ func TestAssumePodCheckpointed(t *testing.T) {
 			expectReason: agentsv1alpha1.SandboxPausedReasonCheckpointCreating,
 		},
 		{
-			name:       "existing succeeded checkpoint with fresh entry - returns false",
-			enableGate: true,
-			pod:        newCheckpointTestPod(),
-			box:        newCheckpointTestSandbox(),
+			name: "existing succeeded checkpoint with fresh entry - returns false",
+			pod:  newCheckpointTestPod(),
+			box:  newCheckpointTestSandbox(),
 			existingCPs: []client.Object{
 				newCheckpointTestCP("test-sandbox-stale", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded),
 			},
@@ -658,9 +738,6 @@ func TestAssumePodCheckpointed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.enableGate {
-				enableCheckpointGate(t)
-			}
 			ctrl, _ := newCheckpointTestControl(tt.existingCPs...)
 			newStatus := &agentsv1alpha1.SandboxStatus{}
 			cond := &metav1.Condition{
@@ -670,7 +747,7 @@ func TestAssumePodCheckpointed(t *testing.T) {
 				LastTransitionTime: metav1.Now(),
 			}
 
-			wait := ctrl.AssumePodCheckpointed(context.TODO(), tt.pod, tt.box, newStatus, cond)
+			wait := ctrl.AssumePodCheckpointed(context.TODO(), tt.pod, tt.box, newStatus, cond, testPodInfoScope)
 			assert.Equal(t, tt.expectWait, wait)
 			if tt.expectReason != "" {
 				assert.Equal(t, tt.expectReason, cond.Reason)
@@ -679,90 +756,150 @@ func TestAssumePodCheckpointed(t *testing.T) {
 	}
 }
 
-func TestGetPodTemplateDelta(t *testing.T) {
+func TestGetCheckpointResumeData(t *testing.T) {
+	podInfoCPWithDelta := func() *agentsv1alpha1.Checkpoint {
+		cp := newCheckpointTestCP("test-sandbox-podinfo", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded)
+		cp.Status.PodTemplateDelta = runtime.RawExtension{Raw: []byte(`{"spec":{"containers":[]}}`)}
+		return cp
+	}
+	upgradeCPWithID := func() *agentsv1alpha1.Checkpoint {
+		cp := newUpgradeCheckpointTestCP("test-sandbox-upgrade", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded)
+		cp.Status.CheckpointId = "cp-id-123"
+		return cp
+	}
+
 	tests := []struct {
-		name       string
-		enableGate bool
-		existingCP *agentsv1alpha1.Checkpoint
-		expectNil  bool
+		name         string
+		existingCPs  []client.Object
+		interceptors interceptor.Funcs
+		expectNil    bool
+		expectID     string
 	}{
 		{
-			name:       "feature gate disabled - returns nil",
-			enableGate: false,
-			expectNil:  true,
-		},
-		{
-			name:       "no checkpoints - returns nil",
-			enableGate: true,
-			expectNil:  true,
-		},
-		{
-			name:       "checkpoint with delta - returns delta",
-			enableGate: true,
-			existingCP: func() *agentsv1alpha1.Checkpoint {
-				box := newCheckpointTestSandbox()
-				cp := newCheckpointTestCP("test-sandbox-cp1", box, agentsv1alpha1.CheckpointSucceeded)
-				cp.Status.PodTemplateDelta = runtime.RawExtension{Raw: []byte(`{"spec":{"containers":[]}}`)}
-				return cp
-			}(),
-			expectNil: false,
-		},
-		{
-			name:       "checkpoint with empty delta - returns nil",
-			enableGate: true,
-			existingCP: func() *agentsv1alpha1.Checkpoint {
-				box := newCheckpointTestSandbox()
-				return newCheckpointTestCP("test-sandbox-cp1", box, agentsv1alpha1.CheckpointSucceeded)
-			}(),
+			name:      "no checkpoints - returns nil delta and empty ID",
 			expectNil: true,
+			expectID:  "",
+		},
+		{
+			name:        "pod-info checkpoint with delta only",
+			existingCPs: []client.Object{podInfoCPWithDelta()},
+			expectNil:   false,
+			expectID:    "",
+		},
+		{
+			// Dump checkpoints record the pod template delta as well, so a
+			// filesystem-only checkpoint must also provide the delta.
+			name: "filesystem checkpoint with delta only",
+			existingCPs: []client.Object{
+				func() *agentsv1alpha1.Checkpoint {
+					cp := newUpgradeCheckpointTestCP("test-sandbox-fs", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded)
+					cp.Status.PodTemplateDelta = runtime.RawExtension{Raw: []byte(`{"spec":{"containers":[]}}`)}
+					return cp
+				}(),
+			},
+			expectNil: false,
+			expectID:  "",
+		},
+		{
+			// Without a recorded delta the checkpoint is not selected, even
+			// when it carries an ID.
+			name:        "upgrade checkpoint with ID only - not selected",
+			existingCPs: []client.Object{upgradeCPWithID()},
+			expectNil:   true,
+			expectID:    "",
+		},
+		{
+			name: "single checkpoint with both delta and ID",
+			existingCPs: []client.Object{
+				func() *agentsv1alpha1.Checkpoint {
+					cp := newCheckpointTestCP("test-sandbox-both", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded)
+					cp.Status.PodTemplateDelta = runtime.RawExtension{Raw: []byte(`{"spec":{"containers":[]}}`)}
+					cp.Status.CheckpointId = "cp-id-456"
+					return cp
+				}(),
+			},
+			expectNil: false,
+			expectID:  "cp-id-456",
+		},
+		{
+			// The delta and the ID always come from the same checkpoint: the
+			// first one with a non-empty delta wins, and the ID of a later
+			// checkpoint is not picked up.
+			name: "multiple checkpoints - delta and ID from the same checkpoint",
+			existingCPs: []client.Object{
+				func() *agentsv1alpha1.Checkpoint {
+					cp := newUpgradeCheckpointTestCP("test-sandbox-fs", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded)
+					cp.Status.PodTemplateDelta = runtime.RawExtension{Raw: []byte(`{"spec":{"containers":[]}}`)}
+					cp.Status.CheckpointId = "cp-id-first"
+					return cp
+				}(),
+				upgradeCPWithID(),
+			},
+			expectNil: false,
+			expectID:  "cp-id-first",
+		},
+		{
+			name:        "checkpoint with empty delta - returns nil",
+			existingCPs: []client.Object{newCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded)},
+			expectNil:   true,
+			expectID:    "",
+		},
+		{
+			name: "list error - returns nil delta and empty ID",
+			interceptors: interceptor.Funcs{List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return fmt.Errorf("list error")
+			}},
+			expectNil: true,
+			expectID:  "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.enableGate {
-				enableCheckpointGate(t)
+			scheme := runtime.NewScheme()
+			_ = clientgoscheme.AddToScheme(scheme)
+			_ = agentsv1alpha1.AddToScheme(scheme)
+			builder := fake.NewClientBuilder().WithScheme(scheme).
+				WithIndex(&agentsv1alpha1.Checkpoint{}, fieldindex.IndexNameForOwnerRefUID, fieldindex.OwnerIndexFunc)
+			if tt.interceptors.List != nil {
+				builder = builder.WithInterceptorFuncs(tt.interceptors)
 			}
-			var objs []client.Object
-			if tt.existingCP != nil {
-				objs = append(objs, tt.existingCP)
+			for _, o := range tt.existingCPs {
+				builder = builder.WithObjects(o)
 			}
-			ctrl, _ := newCheckpointTestControl(objs...)
+			cli := builder.Build()
+			ctrl := NewCheckpointControl(cli, record.NewFakeRecorder(10))
 			box := newCheckpointTestSandbox()
-			delta := ctrl.GetPodTemplateDelta(context.TODO(), box)
+
+			delta, id := ctrl.GetCheckpointResumeData(context.TODO(), box)
 			if tt.expectNil {
 				assert.Nil(t, delta)
 			} else {
 				assert.NotNil(t, delta)
 				assert.NotEmpty(t, delta.Raw)
 			}
+			assert.Equal(t, tt.expectID, id)
 		})
 	}
 }
 
 func TestCleanup(t *testing.T) {
 	tests := []struct {
-		name       string
-		enableGate bool
-		cpCount    int
+		name    string
+		cpCount int
 	}{
 		{
-			name:       "feature gate disabled - no deletion",
-			enableGate: false,
-			cpCount:    2,
+			name:    "single checkpoint - deletes all checkpoints",
+			cpCount: 1,
 		},
 		{
-			name:       "feature gate enabled - deletes all checkpoints",
-			enableGate: true,
-			cpCount:    2,
+			name:    "multiple checkpoints - deletes all checkpoints",
+			cpCount: 2,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.enableGate {
-				enableCheckpointGate(t)
-			}
 			box := newCheckpointTestSandbox()
 			var objs []client.Object
 			for i := 0; i < tt.cpCount; i++ {
@@ -772,25 +909,20 @@ func TestCleanup(t *testing.T) {
 			}
 			ctrl, cli := newCheckpointTestControl(objs...)
 
-			ctrl.Cleanup(context.TODO(), box)
+			ctrl.CleanupCheckpoints(context.TODO(), box)
 
 			remaining := &agentsv1alpha1.CheckpointList{}
 			_ = cli.List(context.TODO(), remaining, client.InNamespace(box.Namespace))
-			if tt.enableGate {
-				assert.Empty(t, remaining.Items)
-			} else {
-				assert.Len(t, remaining.Items, tt.cpCount)
-			}
+			assert.Empty(t, remaining.Items)
 		})
 	}
 }
 
 func TestCreateCheckpoint(t *testing.T) {
-	enableCheckpointGate(t)
 	box := newCheckpointTestSandbox()
 	ctrl, cli, recorder := newCheckpointTestControlWithRecorder()
 
-	name, err := ctrl.createCheckpoint(context.TODO(), box, agentsv1alpha1.CheckpointTypePodInfo, nil)
+	name, err := ctrl.createCheckpoint(context.TODO(), box, []string{agentsv1alpha1.CheckpointPersistentContentPodInfo})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, name)
 
@@ -803,7 +935,7 @@ func TestCreateCheckpoint(t *testing.T) {
 	assert.Equal(t, box.Name, *cp.Spec.SandboxName)
 	assert.Nil(t, cp.Spec.PodName)
 	assert.Equal(t, box.Name, cp.Labels[agentsv1alpha1.CheckpointLabelSandboxName])
-	assert.Equal(t, agentsv1alpha1.CheckpointTypePodInfo, cp.Labels[agentsv1alpha1.CheckpointLabelType])
+	assert.Equal(t, agentsv1alpha1.CheckpointPersistentContentPodInfo, cp.Labels[agentsv1alpha1.CheckpointLabelType])
 	assert.Len(t, cp.OwnerReferences, 1)
 	assert.Equal(t, box.Name, cp.OwnerReferences[0].Name)
 	assertCheckpointRecorderEvent(t, recorder, corev1.EventTypeNormal+" "+EventCheckpointStarted, "created, waiting for completion")
@@ -826,7 +958,6 @@ func TestAssumePodCheckpointedRecordsCheckpointSuccessEvent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			enableCheckpointGate(t)
 			box := newCheckpointTestSandbox()
 			ctrl, _, recorder := newCheckpointTestControlWithRecorder(tt.checkpoint)
 			newStatus := &agentsv1alpha1.SandboxStatus{}
@@ -837,7 +968,7 @@ func TestAssumePodCheckpointedRecordsCheckpointSuccessEvent(t *testing.T) {
 				LastTransitionTime: metav1.Now(),
 			}
 
-			wait := ctrl.AssumePodCheckpointed(context.TODO(), newCheckpointTestPod(), box, newStatus, cond)
+			wait := ctrl.AssumePodCheckpointed(context.TODO(), newCheckpointTestPod(), box, newStatus, cond, testPodInfoScope)
 
 			assert.False(t, wait)
 			assert.Equal(t, agentsv1alpha1.SandboxPausedReasonCheckpointSucceeded, cond.Reason)
@@ -858,7 +989,6 @@ func assertCheckpointRecorderEvent(t *testing.T, recorder *record.FakeRecorder, 
 }
 
 func TestAssumePodCheckpointed_ListError(t *testing.T) {
-	enableCheckpointGate(t)
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = agentsv1alpha1.AddToScheme(scheme)
@@ -882,14 +1012,13 @@ func TestAssumePodCheckpointed_ListError(t *testing.T) {
 		LastTransitionTime: metav1.Now(),
 	}
 
-	wait := ctrl.AssumePodCheckpointed(context.TODO(), pod, box, newStatus, cond)
+	wait := ctrl.AssumePodCheckpointed(context.TODO(), pod, box, newStatus, cond, testPodInfoScope)
 	assert.True(t, wait)
 	assert.Equal(t, agentsv1alpha1.SandboxPausedReasonCheckpointFailed, cond.Reason)
 	assert.Contains(t, cond.Message, "list unavailable")
 }
 
 func TestAssumePodCheckpointed_CreateError(t *testing.T) {
-	enableCheckpointGate(t)
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = agentsv1alpha1.AddToScheme(scheme)
@@ -913,14 +1042,13 @@ func TestAssumePodCheckpointed_CreateError(t *testing.T) {
 		LastTransitionTime: metav1.Now(),
 	}
 
-	wait := ctrl.AssumePodCheckpointed(context.TODO(), pod, box, newStatus, cond)
+	wait := ctrl.AssumePodCheckpointed(context.TODO(), pod, box, newStatus, cond, testPodInfoScope)
 	assert.True(t, wait)
 	assert.Equal(t, agentsv1alpha1.SandboxPausedReasonCheckpointFailed, cond.Reason)
 	assert.Contains(t, cond.Message, "create denied")
 }
 
 func TestCleanup_ListError(t *testing.T) {
-	enableCheckpointGate(t)
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = agentsv1alpha1.AddToScheme(scheme)
@@ -936,11 +1064,10 @@ func TestCleanup_ListError(t *testing.T) {
 	ctrl := NewCheckpointControl(cli, recorder)
 
 	box := newCheckpointTestSandbox()
-	ctrl.Cleanup(context.TODO(), box)
+	ctrl.CleanupCheckpoints(context.TODO(), box)
 }
 
 func TestCleanup_DeleteError(t *testing.T) {
-	enableCheckpointGate(t)
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = agentsv1alpha1.AddToScheme(scheme)
@@ -959,33 +1086,13 @@ func TestCleanup_DeleteError(t *testing.T) {
 	recorder := record.NewFakeRecorder(10)
 	ctrl := NewCheckpointControl(cli, recorder)
 
-	ctrl.Cleanup(context.TODO(), box)
-}
-
-func TestGetPodTemplateDelta_ListError(t *testing.T) {
-	enableCheckpointGate(t)
-	scheme := runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = agentsv1alpha1.AddToScheme(scheme)
-
-	cli := fake.NewClientBuilder().WithScheme(scheme).
-		WithIndex(&agentsv1alpha1.Checkpoint{}, fieldindex.IndexNameForOwnerRefUID, fieldindex.OwnerIndexFunc).
-		WithInterceptorFuncs(interceptor.Funcs{
-			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
-				return fmt.Errorf("list error")
-			},
-		}).Build()
-	recorder := record.NewFakeRecorder(10)
-	ctrl := NewCheckpointControl(cli, recorder)
-
-	box := newCheckpointTestSandbox()
-	delta := ctrl.GetPodTemplateDelta(context.TODO(), box)
-	assert.Nil(t, delta)
+	ctrl.CleanupCheckpoints(context.TODO(), box)
 }
 
 func newUpgradeCheckpointTestCP(name string, box *agentsv1alpha1.Sandbox, phase agentsv1alpha1.CheckpointPhase) *agentsv1alpha1.Checkpoint {
 	cp := newCheckpointTestCP(name, box, phase)
-	cp.Labels[agentsv1alpha1.CheckpointLabelType] = agentsv1alpha1.CheckpointTypeUpgrade
+	cp.Labels[agentsv1alpha1.CheckpointLabelType] = agentsv1alpha1.CheckpointPersistentContentFilesystem
+	cp.Spec.PersistentContents = []string{agentsv1alpha1.CheckpointPersistentContentFilesystem}
 	return cp
 }
 
@@ -1039,7 +1146,7 @@ func TestEnsureCheckpointForUpgrade(t *testing.T) {
 				return fmt.Errorf("list unavailable")
 			}},
 			expectDone:  false,
-			expectError: "failed to list checkpoints for upgrade",
+			expectError: "failed to list checkpoints",
 		},
 		{
 			name: "create error - returns error",
@@ -1047,7 +1154,7 @@ func TestEnsureCheckpointForUpgrade(t *testing.T) {
 				return fmt.Errorf("create denied")
 			}},
 			expectDone:  false,
-			expectError: "failed to create checkpoint for upgrade",
+			expectError: "failed to create checkpoint",
 		},
 	}
 
@@ -1084,74 +1191,13 @@ func TestEnsureCheckpointForUpgrade(t *testing.T) {
 				cpList := &agentsv1alpha1.CheckpointList{}
 				_ = cli.List(context.TODO(), cpList, client.InNamespace(box.Namespace))
 				assert.Len(t, cpList.Items, 1)
-				assert.Equal(t, agentsv1alpha1.CheckpointTypeUpgrade, cpList.Items[0].Labels[agentsv1alpha1.CheckpointLabelType])
+				assert.Equal(t, agentsv1alpha1.CheckpointPersistentContentFilesystem, cpList.Items[0].Labels[agentsv1alpha1.CheckpointLabelType])
 			}
 		})
 	}
 }
 
-func TestGetCheckpointIDForUpgrade(t *testing.T) {
-	tests := []struct {
-		name         string
-		existingCPs  []client.Object
-		interceptors interceptor.Funcs
-		expectID     string
-	}{
-		{
-			name: "checkpoint with ID - returns ID",
-			existingCPs: []client.Object{
-				func() *agentsv1alpha1.Checkpoint {
-					cp := newUpgradeCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded)
-					cp.Status.CheckpointId = "cp-id-123"
-					return cp
-				}(),
-			},
-			expectID: "cp-id-123",
-		},
-		{
-			name: "checkpoint without ID - returns empty",
-			existingCPs: []client.Object{
-				newUpgradeCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointCreating),
-			},
-			expectID: "",
-		},
-		{
-			name:     "no checkpoints - returns empty",
-			expectID: "",
-		},
-		{
-			name: "list error - returns empty",
-			interceptors: interceptor.Funcs{List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
-				return fmt.Errorf("list error")
-			}},
-			expectID: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			scheme := runtime.NewScheme()
-			_ = clientgoscheme.AddToScheme(scheme)
-			_ = agentsv1alpha1.AddToScheme(scheme)
-			builder := fake.NewClientBuilder().WithScheme(scheme).
-				WithIndex(&agentsv1alpha1.Checkpoint{}, fieldindex.IndexNameForOwnerRefUID, fieldindex.OwnerIndexFunc)
-			if tt.interceptors.List != nil {
-				builder = builder.WithInterceptorFuncs(tt.interceptors)
-			}
-			for _, o := range tt.existingCPs {
-				builder = builder.WithObjects(o)
-			}
-			cli := builder.Build()
-			ctrl := NewCheckpointControl(cli, record.NewFakeRecorder(10))
-			box := newCheckpointTestSandbox()
-
-			id := ctrl.GetCheckpointIDForUpgrade(context.TODO(), box)
-			assert.Equal(t, tt.expectID, id)
-		})
-	}
-}
-
-func TestCleanupForUpgrade(t *testing.T) {
+func TestCleanupCheckpoints_Upgrade(t *testing.T) {
 	tests := []struct {
 		name         string
 		existingCPs  []client.Object
@@ -1206,7 +1252,7 @@ func TestCleanupForUpgrade(t *testing.T) {
 			ctrl := NewCheckpointControl(cli, record.NewFakeRecorder(10))
 			box := newCheckpointTestSandbox()
 
-			ctrl.CleanupForUpgrade(context.TODO(), box)
+			ctrl.CleanupCheckpoints(context.TODO(), box)
 
 			remaining := &agentsv1alpha1.CheckpointList{}
 			_ = cli.List(context.TODO(), remaining, client.InNamespace(box.Namespace))
@@ -1216,7 +1262,6 @@ func TestCleanupForUpgrade(t *testing.T) {
 }
 
 func TestCreateCheckpoint_AlreadyExists(t *testing.T) {
-	enableCheckpointGate(t)
 	box := newCheckpointTestSandbox()
 
 	scheme := runtime.NewScheme()
@@ -1233,7 +1278,7 @@ func TestCreateCheckpoint_AlreadyExists(t *testing.T) {
 	recorder := record.NewFakeRecorder(10)
 	ctrl := NewCheckpointControl(cli, recorder)
 
-	_, err := ctrl.createCheckpoint(context.TODO(), box, agentsv1alpha1.CheckpointTypePodInfo, nil)
+	_, err := ctrl.createCheckpoint(context.TODO(), box, []string{agentsv1alpha1.CheckpointPersistentContentPodInfo})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 }

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -36,7 +35,6 @@ import (
 	"github.com/openkruise/agents/pkg/tracing"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 const CommonControlName = "common"
@@ -77,10 +75,10 @@ type commonControl struct {
 	syncStatusFromPod    func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool)
 }
 
-// ResumeFunc resumes a paused sandbox: creates the pod if missing, cleans up
-// finalizer and checkpoint, and sets the Resumed condition when the pod is
-// running. It does NOT change the sandbox phase — that responsibility stays
-// with EnsureSandboxResumed, which is why the upgrade path can reuse it.
+// ResumeFunc resumes a paused sandbox: creates the pod if missing and sets
+// the Resumed condition when the pod is running. It does NOT change the
+// sandbox phase — that responsibility stays with EnsureSandboxResumed, which
+// is why the upgrade path can reuse it.
 type ResumeFunc func(ctx context.Context, args EnsureFuncArgs) error
 
 func NewCommonControl(args SandboxControlArgs) SandboxControl {
@@ -235,87 +233,8 @@ func defaultSyncStatusFromPod(pod *corev1.Pod, newStatus *agentsv1alpha1.Sandbox
 }
 
 func (r *commonControl) EnsureSandboxPaused(ctx context.Context, args EnsureFuncArgs) error {
-	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
-
-	// Hibernate strategy is not yet implemented; only Stop is supported.
-	if box.Spec.PauseStrategy != nil && box.Spec.PauseStrategy.Type == agentsv1alpha1.PauseStrategyHibernate {
-		return fmt.Errorf("pause strategy %q is not yet supported", agentsv1alpha1.PauseStrategyHibernate)
-	}
-
-	cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
-	if cond == nil {
-		// Add finalizer on first entry into paused state to ensure
-		// controller-mediated cleanup if the sandbox is deleted while paused.
-		if !controllerutil.ContainsFinalizer(box, SandboxFinalizer) {
-			if _, err := utils.PatchFinalizer(ctx, r.Client, box, utils.AddFinalizerOpType, SandboxFinalizer); err != nil {
-				return fmt.Errorf("failed to add finalizer for paused sandbox: %w", err)
-			}
-			klog.InfoS("Add finalizer for paused sandbox", "sandbox", klog.KObj(box))
-		}
-		cond = &metav1.Condition{
-			Type:               string(agentsv1alpha1.SandboxConditionPaused),
-			Status:             metav1.ConditionFalse,
-			Reason:             agentsv1alpha1.SandboxPausedReasonPausing,
-			LastTransitionTime: metav1.Now(),
-		}
-		utils.SetSandboxCondition(newStatus, *cond)
-		klog.FromContext(ctx).Info("Paused condition initialized", "sandbox", klog.KObj(box))
-		// Clean up checkpoint info on first entry into paused state
-		// Fallback: normally no checkpoint delta should exist at this point
-		r.checkpointControl.Cleanup(ctx, box)
-	} else if cond.Status == metav1.ConditionTrue {
-		klog.FromContext(ctx).Info("Paused condition is already true", "sandbox", klog.KObj(box))
-		return nil
-	}
-
-	// The paused phase sets condition ready to false.
-	if rCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady)); rCond != nil && rCond.Status == metav1.ConditionTrue {
-		rCond.Status = metav1.ConditionFalse
-		rCond.LastTransitionTime = metav1.Now()
-		utils.SetSandboxCondition(newStatus, *rCond)
-		klog.FromContext(ctx).Info("The paused phase sets condition ready to false", "sandbox", klog.KObj(box))
-	}
-
-	// Pod deletion completed, paused completed
-	// cond.Status == metav1.ConditionFalse just for sure
-	if pod == nil && cond.Status == metav1.ConditionFalse {
-		cond.Status = metav1.ConditionTrue
-		cond.Reason = agentsv1alpha1.SandboxPausedReasonDeletePod
-		cond.LastTransitionTime = metav1.Now()
-		utils.SetSandboxCondition(newStatus, *cond)
-		klog.FromContext(ctx).Info("Pod deletion completed, pause phase completed", "sandbox", klog.KObj(box))
-		return nil
-	}
-	// Pod deletion incomplete, waiting
-	if pod != nil && !pod.DeletionTimestamp.IsZero() {
-		klog.FromContext(ctx).Info("Sandbox wait pod paused", "sandbox", klog.KObj(box))
-		return nil
-	}
-
-	// Validate images and create pod-info checkpoint before deletion. Traced
-	// so checkpoint validation latency is observable in Jaeger; the span is
-	// read-mostly and the actual checkpoint creation inside is traced (and
-	// write-marked) by SpanControllerCheckpoint. Use a local context so the
-	// following DeletePod span stays a sibling: it must not parent under a
-	// span that has already ended and may be dropped as no-op, which would
-	// produce a missing-parent trace.
-	cpCtx, cpSpan := tracing.StartControllerSpan(ctx, tracing.SpanControllerAssumePodCheckpointed)
-	rejected := r.checkpointControl.AssumePodCheckpointed(cpCtx, pod, box, newStatus, cond)
-	cpSpan.SetAttributes(attribute.Bool(tracing.AttrCheckpointRejected, rejected))
-	tracing.EndSpan(cpCtx, cpSpan, nil)
-	if rejected {
-		return nil
-	}
-
-	ctx, deleteSpan := tracing.StartControllerSpan(ctx, tracing.SpanControllerDeletePod)
-	err := client.IgnoreNotFound(r.Delete(ctx, pod, &client.DeleteOptions{GracePeriodSeconds: ptr.To(int64(5))}))
-	tracing.EndSpan(ctx, deleteSpan, err)
-	if err != nil {
-		klog.FromContext(ctx).Error(err, "Delete pod failed", "sandbox", klog.KObj(box))
-		return err
-	}
-	klog.FromContext(ctx).Info("Delete pod success", "sandbox", klog.KObj(box))
-	return nil
+	// commonControl only supports the Stop pause strategy.
+	return ensureStopPaused(ctx, r.Client, args, agentsv1alpha1.SandboxPausedReasonStopPauseSucceed)
 }
 
 func (r *commonControl) EnsureSandboxResumed(ctx context.Context, args EnsureFuncArgs) error {
@@ -331,10 +250,12 @@ func (r *commonControl) EnsureSandboxResumed(ctx context.Context, args EnsureFun
 	return nil
 }
 
-// handleResume handles the core resume logic: creating the pod if missing,
-// cleaning up finalizer and checkpoint, and setting conditions for resume
-// completion and runtime re-initialization. It does not change the sandbox
-// phase — that is the caller's responsibility.
+// handleResume handles the core resume logic: creating the pod if missing and
+// setting conditions for resume completion and runtime re-initialization. It
+// does not change the sandbox phase — that is the caller's responsibility.
+// commonControl only supports the Stop pause strategy, so no checkpoint data
+// is involved. Paused-condition and finalizer cleanup happen in the
+// controller's finalizeResumePhase once Resumed=True.
 func (r *commonControl) handleResume(ctx context.Context, args EnsureFuncArgs) error {
 	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
 	// Consider the scenario where a pod is paused and immediately resumed,
@@ -345,48 +266,16 @@ func (r *commonControl) handleResume(ctx context.Context, args EnsureFuncArgs) e
 
 	// first create pod
 	if pod == nil {
-		delta := r.checkpointControl.GetPodTemplateDelta(ctx, box)
-		_, err := r.podControl.CreatePod(ctx, CreatePodArgs{Box: box, NewStatus: newStatus, PodTemplateDelta: delta, IsResume: true})
+		_, err := r.podControl.CreatePod(ctx, CreatePodArgs{Box: box, NewStatus: newStatus, IsResume: true})
 		return err
 	}
 
 	// when pod is running, transition sandbox from resuming to running
 	if pod.Status.Phase == corev1.PodRunning && isContainersConsistent(ctx, pod, box) {
-		// Best-effort removal of the finalizer added during pause. Now that
-		// the pod is running again, the finalizer is no longer needed.
-		// A leftover finalizer does not block the resume path — it will be
-		// cleaned up when the sandbox is eventually paused again or
-		// terminated — so we only log the error and proceed with the phase
-		// transition instead of failing the resume.
-		if controllerutil.ContainsFinalizer(box, SandboxFinalizer) {
-			if _, err := utils.PatchFinalizer(ctx, r.Client, box, utils.RemoveFinalizerOpType, SandboxFinalizer); err != nil {
-				klog.FromContext(ctx).Error(err, "failed to remove finalizer after resume, proceeding anyway", "sandbox", klog.KObj(box))
-			} else {
-				klog.FromContext(ctx).Info("Remove finalizer after resume", "sandbox", klog.KObj(box))
-			}
-		}
-		r.checkpointControl.Cleanup(ctx, box)
-
-		// Set resumed condition to true after pod is running.
-		// Unconditionally set (instead of flipping an existing False) so the
-		// upgrade Resuming stage works even when Resumed was not pre-seeded.
-		utils.SetSandboxCondition(newStatus, metav1.Condition{
-			Type:               string(agentsv1alpha1.SandboxConditionResumed),
-			Status:             metav1.ConditionTrue,
-			Reason:             agentsv1alpha1.SandboxResumeReasonResumePod,
-			LastTransitionTime: metav1.Now(),
-		})
-
-		// Every resume cycle needs fresh runtime re-init and CSI re-mount.
-		// Unconditionally set Pending so EnsureSandboxUpdated will run Initialize
-		// after Pod Ready, regardless of any stale Succeeded from a prior cycle.
-		utils.SetSandboxCondition(newStatus, metav1.Condition{
-			Type:               string(agentsv1alpha1.RuntimeInitialized),
-			Status:             metav1.ConditionFalse,
-			Reason:             agentsv1alpha1.SandboxConditionRuntimeInitReasonPending,
-			Message:            "Waiting for pod ready before initialization",
-			LastTransitionTime: metav1.Now(),
-		})
+		// Unconditionally set Resumed=True (instead of flipping an existing
+		// False) so the upgrade Resuming stage works even when Resumed was
+		// not pre-seeded.
+		markResumeSucceeded(newStatus)
 	}
 	return nil
 }

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -781,17 +781,26 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 				Pod: nil,
 				Box: &agentsv1alpha1.Sandbox{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-sandbox",
-						Namespace: "default",
+						Name:       "test-sandbox",
+						Namespace:  "default",
+						Finalizers: []string{SandboxFinalizer},
 					},
 				},
 				NewStatus: &agentsv1alpha1.SandboxStatus{
+					// preparePausedPhase initializes Paused condition with Pending
+					// and sets Ready to False before EnsureSandboxPaused is called.
 					Conditions: []metav1.Condition{
 						{
 							Type:               string(agentsv1alpha1.SandboxConditionReady),
-							Status:             metav1.ConditionTrue,
+							Status:             metav1.ConditionFalse,
 							LastTransitionTime: metav1.Now(),
 							Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
+						},
+						{
+							Type:               string(agentsv1alpha1.SandboxConditionPaused),
+							Status:             metav1.ConditionFalse,
+							Reason:             agentsv1alpha1.SandboxPausedReasonPending,
+							LastTransitionTime: metav1.Now(),
 						},
 					},
 				},
@@ -812,17 +821,24 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 				},
 				Box: &agentsv1alpha1.Sandbox{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-sandbox",
-						Namespace: "default",
+						Name:       "test-sandbox",
+						Namespace:  "default",
+						Finalizers: []string{SandboxFinalizer},
 					},
 				},
 				NewStatus: &agentsv1alpha1.SandboxStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:               string(agentsv1alpha1.SandboxConditionReady),
-							Status:             metav1.ConditionTrue,
+							Status:             metav1.ConditionFalse,
 							LastTransitionTime: metav1.Now(),
 							Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
+						},
+						{
+							Type:               string(agentsv1alpha1.SandboxConditionPaused),
+							Status:             metav1.ConditionFalse,
+							Reason:             agentsv1alpha1.SandboxPausedReasonPending,
+							LastTransitionTime: metav1.Now(),
 						},
 					},
 				},
@@ -841,17 +857,24 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 				},
 				Box: &agentsv1alpha1.Sandbox{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-sandbox",
-						Namespace: "default",
+						Name:       "test-sandbox",
+						Namespace:  "default",
+						Finalizers: []string{SandboxFinalizer},
 					},
 				},
 				NewStatus: &agentsv1alpha1.SandboxStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:               string(agentsv1alpha1.SandboxConditionReady),
-							Status:             metav1.ConditionTrue,
+							Status:             metav1.ConditionFalse,
 							LastTransitionTime: metav1.Now(),
 							Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
+						},
+						{
+							Type:               string(agentsv1alpha1.SandboxConditionPaused),
+							Status:             metav1.ConditionFalse,
+							Reason:             agentsv1alpha1.SandboxPausedReasonPending,
+							LastTransitionTime: metav1.Now(),
 						},
 					},
 				},
@@ -871,14 +894,20 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 					},
 				},
 				NewStatus: &agentsv1alpha1.SandboxStatus{
-					// No Paused condition — simulates state after resume
-					// where calculateStatus removed the Paused condition.
+					// preparePausedPhase initializes Paused condition with Pending
+					// and sets Ready to False before EnsureSandboxPaused is called.
 					Conditions: []metav1.Condition{
 						{
 							Type:               string(agentsv1alpha1.SandboxConditionReady),
-							Status:             metav1.ConditionTrue,
+							Status:             metav1.ConditionFalse,
 							LastTransitionTime: metav1.Now(),
 							Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
+						},
+						{
+							Type:               string(agentsv1alpha1.SandboxConditionPaused),
+							Status:             metav1.ConditionFalse,
+							Reason:             agentsv1alpha1.SandboxPausedReasonPending,
+							LastTransitionTime: metav1.Now(),
 						},
 					},
 				},
@@ -904,7 +933,7 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 						{
 							Type:               string(agentsv1alpha1.SandboxConditionPaused),
 							Status:             metav1.ConditionFalse,
-							Reason:             agentsv1alpha1.SandboxPausedReasonPausing,
+							Reason:             agentsv1alpha1.SandboxPausedReasonPending,
 							LastTransitionTime: metav1.Now(),
 						},
 					},
@@ -938,7 +967,7 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 				return
 			}
 
-			// Verify finalizer was added (first entry into paused state has no Paused condition)
+			// Verify finalizer is present (added by preparePausedPhase before EnsureSandboxPaused)
 			if !tt.wantErr {
 				updatedBox := &agentsv1alpha1.Sandbox{}
 				if getErr := fc.Get(context.TODO(), types.NamespacedName{Name: tt.args.Box.Name, Namespace: tt.args.Box.Namespace}, updatedBox); getErr != nil {
@@ -2624,22 +2653,10 @@ func TestCommonControl_EnsureSandboxResumed_LegacyBackfill(t *testing.T) {
 	}
 }
 
-func TestCommonControl_EnsureSandboxResumed_RemovesFinalizer(t *testing.T) {
+func TestCommonControl_EnsureSandboxPaused_FinalizerPatchError(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = agentsv1alpha1.AddToScheme(scheme)
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-sandbox",
-			Namespace: "default",
-		},
-		Spec: corev1.PodSpec{NodeName: "node1"},
-		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
-			PodIP: "10.0.0.1",
-		},
-	}
 
 	box := &agentsv1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2648,61 +2665,21 @@ func TestCommonControl_EnsureSandboxResumed_RemovesFinalizer(t *testing.T) {
 			Finalizers: []string{SandboxFinalizer},
 		},
 	}
-
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(box, pod).Build()
-	control := &commonControl{
-		Client:               fakeClient,
-		recorder:             record.NewFakeRecorder(10),
-		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
-		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-		checkpointControl:    NewCheckpointControl(fakeClient, record.NewFakeRecorder(10)),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
-	}
-
-	now := metav1.Now()
-	newStatus := &agentsv1alpha1.SandboxStatus{
-		Phase: agentsv1alpha1.SandboxResuming,
-		Conditions: []metav1.Condition{
-			{
-				Type:               string(agentsv1alpha1.SandboxConditionResumed),
-				Status:             metav1.ConditionFalse,
-				LastTransitionTime: now,
-				Reason:             agentsv1alpha1.SandboxResumeReasonCreatePod,
-			},
-		},
-	}
-
-	err := control.EnsureSandboxResumed(context.TODO(), EnsureFuncArgs{Pod: pod, Box: box, NewStatus: newStatus})
-	assert.NoError(t, err)
-
-	// Phase should transition to Running
-	assert.Equal(t, agentsv1alpha1.SandboxRunning, newStatus.Phase)
-
-	// Finalizer should be removed from the persisted sandbox
-	updatedBox := &agentsv1alpha1.Sandbox{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: box.Name, Namespace: box.Namespace}, updatedBox)
-	assert.NoError(t, err)
-	assert.NotContains(t, updatedBox.Finalizers, SandboxFinalizer)
-}
-
-func TestCommonControl_EnsureSandboxPaused_FinalizerPatchError(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = agentsv1alpha1.AddToScheme(scheme)
-
-	box := &agentsv1alpha1.Sandbox{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-sandbox",
-			Namespace: "default",
-		},
-	}
+	// preparePausedPhase initializes Paused condition with Pending and sets
+	// Ready to False before EnsureSandboxPaused is called.
 	newStatus := &agentsv1alpha1.SandboxStatus{
 		Conditions: []metav1.Condition{
 			{
 				Type:               string(agentsv1alpha1.SandboxConditionReady),
-				Status:             metav1.ConditionTrue,
+				Status:             metav1.ConditionFalse,
 				LastTransitionTime: metav1.Now(),
 				Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
+			},
+			{
+				Type:               string(agentsv1alpha1.SandboxConditionPaused),
+				Status:             metav1.ConditionFalse,
+				Reason:             agentsv1alpha1.SandboxPausedReasonPending,
+				LastTransitionTime: metav1.Now(),
 			},
 		},
 	}
@@ -2725,76 +2702,16 @@ func TestCommonControl_EnsureSandboxPaused_FinalizerPatchError(t *testing.T) {
 		checkpointControl:    NewCheckpointControl(fakeClient, record.NewFakeRecorder(10)),
 	}
 
+	// With Pod=nil and cond.Status=False, EnsureSandboxPaused marks the sandbox
+	// as paused without any patch operations, so no error is expected.
 	err := control.EnsureSandboxPaused(context.TODO(), EnsureFuncArgs{Pod: nil, Box: box, NewStatus: newStatus})
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to add finalizer for paused sandbox")
-	// Paused condition should NOT be set because the function returned early on error
-	assert.Nil(t, utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused)))
-}
-
-func TestCommonControl_EnsureSandboxResumed_FinalizerPatchError(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = agentsv1alpha1.AddToScheme(scheme)
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-sandbox",
-			Namespace: "default",
-		},
-		Spec: corev1.PodSpec{NodeName: "node1"},
-		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
-			PodIP: "10.0.0.1",
-		},
-	}
-	box := &agentsv1alpha1.Sandbox{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-sandbox",
-			Namespace:  "default",
-			Finalizers: []string{SandboxFinalizer},
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(box, pod).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-				return fmt.Errorf("simulated patch error")
-			},
-		}).
-		Build()
-
-	control := &commonControl{
-		Client:               fakeClient,
-		recorder:             record.NewFakeRecorder(10),
-		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
-		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-		checkpointControl:    NewCheckpointControl(fakeClient, record.NewFakeRecorder(10)),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
-	}
-
-	now := metav1.Now()
-	newStatus := &agentsv1alpha1.SandboxStatus{
-		Phase: agentsv1alpha1.SandboxResuming,
-		Conditions: []metav1.Condition{
-			{
-				Type:               string(agentsv1alpha1.SandboxConditionResumed),
-				Status:             metav1.ConditionFalse,
-				LastTransitionTime: now,
-				Reason:             agentsv1alpha1.SandboxResumeReasonCreatePod,
-			},
-		},
-	}
-
-	err := control.EnsureSandboxResumed(context.TODO(), EnsureFuncArgs{Pod: pod, Box: box, NewStatus: newStatus})
-
-	// Finalizer removal failure should not block the resume path.
 	assert.NoError(t, err)
-	// Phase should have transitioned to Running despite the finalizer patch error.
-	assert.Equal(t, agentsv1alpha1.SandboxRunning, newStatus.Phase)
+
+	// Paused condition should be True with StopPauseSucceed reason
+	pausedCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
+	assert.NotNil(t, pausedCond)
+	assert.Equal(t, metav1.ConditionTrue, pausedCond.Status)
+	assert.Equal(t, agentsv1alpha1.SandboxPausedReasonStopPauseSucceed, pausedCond.Reason)
 }
 
 func TestCommonControl_EnsureSandboxTerminated_PodNotExist_NoFinalizer(t *testing.T) {
@@ -2852,7 +2769,7 @@ func TestCommonControl_EnsureSandboxPaused_AlreadyPaused(t *testing.T) {
 			{
 				Type:               string(agentsv1alpha1.SandboxConditionPaused),
 				Status:             metav1.ConditionTrue,
-				Reason:             agentsv1alpha1.SandboxPausedReasonDeletePod,
+				Reason:             agentsv1alpha1.SandboxPausedReasonStopPauseSucceed,
 				LastTransitionTime: now,
 			},
 		},

--- a/pkg/controller/sandbox/core/pod_control.go
+++ b/pkg/controller/sandbox/core/pod_control.go
@@ -76,6 +76,10 @@ type CreatePodArgs struct {
 	// annotations (recover-from-instance-id, source-pod-uid, recreating)
 	// from the sandbox status PodInfo, instead of relying on the sandbox
 	// phase which may be Upgrading during an upgrade's Resuming stage.
+	// Resume paths that recreate a brand-new pod with no underlying instance
+	// to recover (Stop, Snapshot) leave it false: the resume-protocol
+	// annotations would make VK skip the pod or try to recover a deleted
+	// instance, so those paths use the normal creation flow.
 	IsResume bool
 }
 

--- a/pkg/controller/sandbox/core/upgrade_control.go
+++ b/pkg/controller/sandbox/core/upgrade_control.go
@@ -285,7 +285,7 @@ func (r *UpgradeControl) EnsureSandboxUpgraded(ctx context.Context, args EnsureF
 
 		// For CheckpointRestore, clean up checkpoint CRs after the entire upgrade succeeds.
 		if isCheckpointRestore {
-			r.checkpointControl.CleanupForUpgrade(ctx, box)
+			r.checkpointControl.CleanupCheckpoints(ctx, box)
 		}
 
 		klog.InfoS("postUpgrade completed, transitioning to Succeeded", "sandbox", klog.KObj(box))
@@ -369,12 +369,17 @@ func (r *UpgradeControl) handleResuming(ctx context.Context, args EnsureFuncArgs
 	upgradeCond.Reason = agentsv1alpha1.SandboxUpgradingReasonResumeSucceed
 	upgradeCond.Message = ""
 	utils.SetSandboxCondition(newStatus, *upgradeCond)
+	// Resume succeeded: drop the Paused condition, kept through Resuming.
+	// The direct resume path cleans it up in the controller's
+	// finalizeResumePhase; the upgrade path calls resumeFunc directly, so it
+	// cleans up here.
 	utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
 	return nil
 }
 
 // performRecreateUpgrade handles the Recreate upgrade step (delete old pod + create new pod).
-// For CheckpointRestore policy, it restores the PodTemplateDelta when creating the new pod.
+// For CheckpointRestore policy, it passes the checkpoint ID so the new pod
+// restores its writable layer from the checkpoint.
 func (r *UpgradeControl) performRecreateUpgrade(ctx context.Context, args EnsureFuncArgs) (bool, error) {
 	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
 
@@ -415,7 +420,17 @@ func (r *UpgradeControl) performRecreateUpgrade(ctx context.Context, args Ensure
 		// For CheckpointRestore, set the checkpoint ID annotation so the
 		// checkpoint controller can restore the pod's writable layer.
 		if isCheckpointRestore {
-			createArgs.CheckpointID = r.checkpointControl.GetCheckpointIDForUpgrade(ctx, box)
+			_, checkpointID := r.checkpointControl.GetCheckpointResumeData(ctx, box)
+			if checkpointID == "" {
+				// Should never happen: the checkpoint succeeded before the
+				// upgrade reached this step, so it must carry an ID. Block
+				// the upgrade and surface the inconsistency instead of
+				// creating a pod that cannot restore its writable layer.
+				err := fmt.Errorf("checkpoint ID not found for CheckpointRestore upgrade")
+				klog.FromContext(ctx).Error(err, "CheckpointRestore upgrade blocked: checkpoint has no ID", "sandbox", klog.KObj(box))
+				return false, err
+			}
+			createArgs.CheckpointID = checkpointID
 		}
 		newPod, err := r.podControl.CreatePod(ctx, createArgs)
 		if err != nil {

--- a/pkg/controller/sandbox/core/upgrade_control_test.go
+++ b/pkg/controller/sandbox/core/upgrade_control_test.go
@@ -919,7 +919,7 @@ func newUpgradeCheckpoint(name string, box *agentsv1alpha1.Sandbox, phase agents
 			},
 			Labels: map[string]string{
 				agentsv1alpha1.CheckpointLabelSandboxName: box.Name,
-				agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointTypeUpgrade,
+				agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointPersistentContentFilesystem,
 			},
 		},
 		Status: agentsv1alpha1.CheckpointStatus{
@@ -1360,8 +1360,11 @@ func TestPerformRecreateUpgrade_CheckpointRestore_CreatePod(t *testing.T) {
 	pod := newRunningPod()
 	pod.Labels[agentsv1alpha1.PodLabelTemplateHash] = "old-revision"
 
-	// Create a checkpoint with an ID so GetCheckpointIDForUpgrade returns it
+	// Create a checkpoint carrying both the recorded delta and the ID, as a
+	// real succeeded filesystem checkpoint does, so GetCheckpointResumeData
+	// returns it.
 	cp := newUpgradeCheckpoint("test-sandbox-cp1", box, agentsv1alpha1.CheckpointSucceeded)
+	cp.Status.PodTemplateDelta = runtime.RawExtension{Raw: []byte(`{"spec":{"containers":[]}}`)}
 	cp.Status.CheckpointId = "cp-id-restore-123"
 
 	control := newTestCommonControlWithCheckpointIndex(
@@ -1418,6 +1421,49 @@ func TestPerformRecreateUpgrade_CheckpointRestore_CreatePod(t *testing.T) {
 	err = control.Get(context.TODO(), types.NamespacedName{Namespace: box.Namespace, Name: box.Name}, createdPod)
 	assert.NoError(t, err)
 	assert.Equal(t, "new-revision", createdPod.Labels[agentsv1alpha1.PodLabelTemplateHash])
+}
+
+func TestPerformRecreateUpgrade_CheckpointRestore_MissingCheckpointID(t *testing.T) {
+	now := metav1.Now()
+
+	// A checkpoint that recorded a delta but lost its ID should never happen.
+	// The upgrade must block instead of creating a pod that cannot restore
+	// its writable layer.
+	box := newCheckpointRestoreSandbox(nil)
+	cp := newUpgradeCheckpoint("test-sandbox-cp1", box, agentsv1alpha1.CheckpointSucceeded)
+	cp.Status.PodTemplateDelta = runtime.RawExtension{Raw: []byte(`{"spec":{"containers":[]}}`)}
+
+	control := newTestCommonControlWithCheckpointIndex(
+		mockLifecycleHookFunc(0, "", "", nil),
+		cp,
+	)
+
+	newStatus := &agentsv1alpha1.SandboxStatus{
+		Phase:          agentsv1alpha1.SandboxUpgrading,
+		UpdateRevision: "new-revision",
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(agentsv1alpha1.SandboxConditionUpgrading),
+				Status:             metav1.ConditionFalse,
+				Reason:             agentsv1alpha1.SandboxUpgradingReasonUpgradePod,
+				LastTransitionTime: now,
+			},
+		},
+	}
+
+	// pod is nil (already deleted), so the upgrade reaches the pod creation
+	// step and must fail there.
+	err := control.EnsureSandboxUpgraded(context.TODO(), EnsureFuncArgs{
+		Pod:       nil,
+		Box:       box,
+		NewStatus: newStatus,
+	})
+	assert.ErrorContains(t, err, "checkpoint ID not found")
+
+	// No pod may have been created.
+	createdPod := &corev1.Pod{}
+	getErr := control.Get(context.TODO(), types.NamespacedName{Namespace: box.Namespace, Name: box.Name}, createdPod)
+	assert.Error(t, getErr)
 }
 
 func TestExecuteUpgradeAction_NilAction(t *testing.T) {
@@ -1616,13 +1662,13 @@ func TestEnsureSandboxUpgraded_Resuming(t *testing.T) {
 	pausedTrueCond := metav1.Condition{
 		Type:               string(agentsv1alpha1.SandboxConditionPaused),
 		Status:             metav1.ConditionTrue,
-		Reason:             agentsv1alpha1.SandboxPausedReasonDeletePod,
+		Reason:             agentsv1alpha1.SandboxPausedReasonStopPauseSucceed,
 		LastTransitionTime: now,
 	}
 	pausedFalseCond := metav1.Condition{
 		Type:               string(agentsv1alpha1.SandboxConditionPaused),
 		Status:             metav1.ConditionFalse,
-		Reason:             agentsv1alpha1.SandboxPausedReasonPausing,
+		Reason:             agentsv1alpha1.SandboxPausedReasonPending,
 		LastTransitionTime: now,
 	}
 	resumedTrueCond := metav1.Condition{

--- a/pkg/controller/sandbox/core/util.go
+++ b/pkg/controller/sandbox/core/util.go
@@ -17,11 +17,15 @@ limitations under the License.
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
@@ -77,6 +81,91 @@ func GeneratePVCName(templateName, sandboxName string) (string, error) {
 
 func GetControllerKey(obj client.Object) string {
 	return types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}.String()
+}
+
+// ensureStopPaused handles the Stop pause strategy: directly delete the pod.
+// It marks the pause complete when the pod is gone, waits while the pod is
+// terminating, or deletes the pod using cli.
+// successReason is set on the Paused condition when deletion is complete.
+func ensureStopPaused(
+	ctx context.Context,
+	cli client.Client,
+	args EnsureFuncArgs,
+	successReason string,
+) error {
+	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
+	cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
+	// Pod deletion completed, pause done
+	if pod == nil {
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = successReason
+		cond.LastTransitionTime = metav1.Now()
+		utils.SetSandboxCondition(newStatus, *cond)
+		klog.FromContext(ctx).Info("Pod deletion completed, pause phase completed", "sandbox", klog.KObj(box))
+		return nil
+	}
+	// Pod deletion in progress, wait
+	if !pod.DeletionTimestamp.IsZero() {
+		klog.FromContext(ctx).Info("Sandbox wait pod paused", "sandbox", klog.KObj(box))
+		return nil
+	}
+	// Delete the pod
+	err := client.IgnoreNotFound(cli.Delete(ctx, pod, &client.DeleteOptions{GracePeriodSeconds: ptr.To(int64(5))}))
+	if err != nil {
+		klog.FromContext(ctx).Error(err, "Delete pod failed", "sandbox", klog.KObj(box))
+		return err
+	}
+	klog.FromContext(ctx).Info("Delete pod success", "sandbox", klog.KObj(box))
+	return nil
+}
+
+// ensureCheckpointPaused handles the Checkpoint pause strategy:
+// create/validate a checkpoint first, then delete the pod.
+// checkpointControl manages the Checkpoint CR lifecycle.
+// Once the checkpoint succeeds, the function delegates to ensureStopPaused
+// for the actual pod deletion.
+func ensureCheckpointPaused(
+	ctx context.Context,
+	cli client.Client,
+	checkpointControl *CheckpointControl,
+	args EnsureFuncArgs,
+) error {
+	pod, box, newStatus := args.Pod, args.Box, args.NewStatus
+	cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
+	// Ensure checkpoint is completed before proceeding to pod deletion.
+	// The scope is derived from sandbox.spec.persistentContents: requested
+	// dump contents (filesystem/memory) are passed through and podInfo is
+	// used when no dump content is requested, with image validation.
+	scope := CheckpointScope{
+		PersistentContents: checkpointContentsForPause(box),
+		ValidateImages:     true,
+	}
+	if rejected := checkpointControl.AssumePodCheckpointed(ctx, pod, box, newStatus, cond, scope); rejected {
+		return nil
+	}
+	// Proceed to delete the pod (same as stop strategy).
+	return ensureStopPaused(ctx, cli, args, agentsv1alpha1.SandboxPausedReasonSnapshotPauseSucceed)
+}
+
+// markResumeSucceeded marks the resume as succeeded: it unconditionally sets
+// Resumed=True (instead of flipping an existing False) so the upgrade Resuming
+// stage works even when Resumed was not pre-seeded, and resets
+// RuntimeInitialized to Pending so every resume cycle triggers fresh runtime
+// re-initialization and CSI re-mount.
+func markResumeSucceeded(newStatus *agentsv1alpha1.SandboxStatus) {
+	utils.SetSandboxCondition(newStatus, metav1.Condition{
+		Type:               string(agentsv1alpha1.SandboxConditionResumed),
+		Status:             metav1.ConditionTrue,
+		Reason:             agentsv1alpha1.SandboxResumeReasonResumePod,
+		LastTransitionTime: metav1.Now(),
+	})
+	utils.SetSandboxCondition(newStatus, metav1.Condition{
+		Type:               string(agentsv1alpha1.RuntimeInitialized),
+		Status:             metav1.ConditionFalse,
+		Reason:             agentsv1alpha1.SandboxConditionRuntimeInitReasonPending,
+		Message:            "Waiting for pod ready before initialization",
+		LastTransitionTime: metav1.Now(),
+	})
 }
 
 // StaleSandboxPodOwner returns the UID of the Sandbox owner reference on pod

--- a/pkg/controller/sandbox/core/util_test.go
+++ b/pkg/controller/sandbox/core/util_test.go
@@ -15,6 +15,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -23,7 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/utils"
@@ -698,6 +701,284 @@ func TestGeneratePodFromSandbox(t *testing.T) {
 			}
 			if tt.checkPod != nil {
 				tt.checkPod(t, pod)
+			}
+		})
+	}
+}
+
+func TestEnsureStopPaused(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	now := metav1.Now()
+	tests := []struct {
+		name            string
+		pod             *corev1.Pod
+		seedPod         bool
+		deleteErr       error
+		wantErr         bool
+		wantDeleteCalls int
+		wantPodGone     bool
+		validate        func(*testing.T, *agentsv1alpha1.SandboxStatus)
+	}{
+		{
+			name: "pod gone - pause completed with success reason",
+			pod:  nil,
+			validate: func(t *testing.T, status *agentsv1alpha1.SandboxStatus) {
+				cond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionPaused))
+				if cond == nil {
+					t.Fatal("Paused condition should exist")
+				}
+				if cond.Status != metav1.ConditionTrue {
+					t.Errorf("Expected Paused condition to be True, got %v", cond.Status)
+				}
+				if cond.Reason != agentsv1alpha1.SandboxPausedReasonStopPauseSucceed {
+					t.Errorf("Expected reason %s, got %s", agentsv1alpha1.SandboxPausedReasonStopPauseSucceed, cond.Reason)
+				}
+			},
+		},
+		{
+			name: "pod terminating - wait without deleting",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-sandbox",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{"test.io/finalizer"},
+				},
+			},
+			wantDeleteCalls: 0,
+			validate: func(t *testing.T, status *agentsv1alpha1.SandboxStatus) {
+				cond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionPaused))
+				if cond == nil || cond.Status != metav1.ConditionFalse {
+					t.Errorf("Expected Paused condition to stay False while waiting, got %v", cond)
+				}
+			},
+		},
+		{
+			name: "pod alive - delete issued",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default"},
+			},
+			seedPod:         true,
+			wantDeleteCalls: 1,
+			wantPodGone:     true,
+			validate: func(t *testing.T, status *agentsv1alpha1.SandboxStatus) {
+				cond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionPaused))
+				if cond == nil || cond.Status != metav1.ConditionFalse {
+					t.Errorf("Expected Paused condition to stay False until the pod is gone, got %v", cond)
+				}
+			},
+		},
+		{
+			name: "pod missing from cluster - NotFound treated as success",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default"},
+			},
+			wantDeleteCalls: 1,
+		},
+		{
+			name: "delete fails - error returned",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default"},
+			},
+			seedPod:         true,
+			deleteErr:       fmt.Errorf("injected delete failure"),
+			wantErr:         true,
+			wantDeleteCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deleteCalls := 0
+			builder := fake.NewClientBuilder().WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+						deleteCalls++
+						if tt.deleteErr != nil {
+							return tt.deleteErr
+						}
+						return c.Delete(ctx, obj, opts...)
+					},
+				})
+			if tt.seedPod && tt.pod != nil {
+				builder = builder.WithObjects(tt.pod.DeepCopy())
+			}
+			cli := builder.Build()
+
+			box := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default"},
+			}
+			newStatus := &agentsv1alpha1.SandboxStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionPaused),
+						Status:             metav1.ConditionFalse,
+						Reason:             agentsv1alpha1.SandboxPausedReasonPending,
+						LastTransitionTime: now,
+					},
+				},
+			}
+
+			err := ensureStopPaused(context.Background(), cli, EnsureFuncArgs{
+				Pod:       tt.pod,
+				Box:       box,
+				NewStatus: newStatus,
+			}, agentsv1alpha1.SandboxPausedReasonStopPauseSucceed)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ensureStopPaused() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if deleteCalls != tt.wantDeleteCalls {
+				t.Errorf("Delete calls = %d, want %d", deleteCalls, tt.wantDeleteCalls)
+			}
+			if tt.wantPodGone {
+				got := &corev1.Pod{}
+				getErr := cli.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "test-sandbox"}, got)
+				if getErr == nil {
+					t.Error("Expected pod to be deleted from the cluster")
+				}
+			}
+			if tt.validate != nil {
+				tt.validate(t, newStatus)
+			}
+		})
+	}
+}
+
+func TestEnsureCheckpointPaused(t *testing.T) {
+	now := metav1.Now()
+
+	changedImagePod := newCheckpointTestPod()
+	changedImagePod.Spec.Containers[0].Image = "nginx:1.22"
+
+	fsBox := newCheckpointTestSandbox()
+	fsBox.Spec.PersistentContents = []string{agentsv1alpha1.PersistentContentFilesystem}
+
+	tests := []struct {
+		name        string
+		pod         *corev1.Pod
+		box         *agentsv1alpha1.Sandbox
+		existingCPs []client.Object
+		condReason  string
+		wantReason  string
+		wantTrue    bool
+		wantCPCount int
+		wantCPLabel string
+		wantPodGone bool
+	}{
+		{
+			// The dump content is passed through as-is: the checkpoint is
+			// filesystem-only, not combined with podInfo.
+			name:        "fresh pause - checkpoint created and pause waits",
+			pod:         newCheckpointTestPod(),
+			box:         fsBox,
+			condReason:  agentsv1alpha1.SandboxPausedReasonPending,
+			wantReason:  agentsv1alpha1.SandboxPausedReasonCheckpointCreating,
+			wantCPCount: 1,
+			wantCPLabel: agentsv1alpha1.CheckpointPersistentContentFilesystem,
+		},
+		{
+			name:        "image changed - rejected before checkpoint creation",
+			pod:         changedImagePod,
+			box:         newCheckpointTestSandbox(),
+			condReason:  agentsv1alpha1.SandboxPausedReasonPending,
+			wantReason:  agentsv1alpha1.SandboxPausedReasonImageChanged,
+			wantCPCount: 0,
+		},
+		{
+			name: "checkpoint succeeded and pod gone - snapshot pause completed",
+			pod:  nil,
+			box:  newCheckpointTestSandbox(),
+			existingCPs: []client.Object{
+				newCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded),
+			},
+			condReason:  agentsv1alpha1.SandboxPausedReasonCheckpointCreating,
+			wantReason:  agentsv1alpha1.SandboxPausedReasonSnapshotPauseSucceed,
+			wantTrue:    true,
+			wantCPCount: 1,
+		},
+		{
+			name: "checkpoint succeeded and pod alive - pod deleted",
+			pod:  newCheckpointTestPod(),
+			box:  newCheckpointTestSandbox(),
+			existingCPs: []client.Object{
+				newCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded),
+			},
+			condReason:  agentsv1alpha1.SandboxPausedReasonCheckpointCreating,
+			wantReason:  agentsv1alpha1.SandboxPausedReasonCheckpointSucceeded,
+			wantCPCount: 1,
+			wantPodGone: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := append([]client.Object{}, tt.existingCPs...)
+			if tt.pod != nil {
+				objs = append(objs, tt.pod)
+			}
+			control, cli := newCheckpointTestControl(objs...)
+
+			newStatus := &agentsv1alpha1.SandboxStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionPaused),
+						Status:             metav1.ConditionFalse,
+						Reason:             tt.condReason,
+						LastTransitionTime: now,
+					},
+				},
+			}
+
+			err := ensureCheckpointPaused(context.Background(), cli, control, EnsureFuncArgs{
+				Pod:       tt.pod,
+				Box:       tt.box,
+				NewStatus: newStatus,
+			})
+			if err != nil {
+				t.Fatalf("ensureCheckpointPaused() error = %v", err)
+			}
+
+			cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
+			if cond == nil {
+				t.Fatal("Paused condition should exist")
+			}
+			if cond.Reason != tt.wantReason {
+				t.Errorf("Expected reason %s, got %s", tt.wantReason, cond.Reason)
+			}
+			wantStatus := metav1.ConditionFalse
+			if tt.wantTrue {
+				wantStatus = metav1.ConditionTrue
+			}
+			if cond.Status != wantStatus {
+				t.Errorf("Expected Paused condition status %v, got %v", wantStatus, cond.Status)
+			}
+
+			cpList := &agentsv1alpha1.CheckpointList{}
+			if err := cli.List(context.Background(), cpList, client.InNamespace("default")); err != nil {
+				t.Fatalf("Failed to list checkpoints: %v", err)
+			}
+			if len(cpList.Items) != tt.wantCPCount {
+				t.Errorf("Expected %d checkpoints, got %d", tt.wantCPCount, len(cpList.Items))
+			}
+			if tt.wantCPLabel != "" && len(cpList.Items) > 0 {
+				if got := cpList.Items[0].Labels[agentsv1alpha1.CheckpointLabelType]; got != tt.wantCPLabel {
+					t.Errorf("Expected checkpoint label %s, got %s", tt.wantCPLabel, got)
+				}
+			}
+
+			if tt.pod != nil {
+				got := &corev1.Pod{}
+				getErr := cli.Get(context.Background(), types.NamespacedName{Namespace: tt.pod.Namespace, Name: tt.pod.Name}, got)
+				if tt.wantPodGone && getErr == nil {
+					t.Error("Expected pod to be deleted after checkpoint succeeded")
+				}
+				if !tt.wantPodGone && getErr != nil {
+					t.Errorf("Expected pod to still exist, got error: %v", getErr)
+				}
 			}
 		})
 	}

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -34,6 +34,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -352,11 +353,26 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 		tracing.EndSpan(ctx, span, err)
 	case agentsv1alpha1.SandboxPaused:
 		ctx, span := tracing.StartControllerSpan(ctx, tracing.SpanControllerEnsureSandboxPaused)
-		err = r.EnsureSandboxPaused(ctx, args)
+		err = r.preparePausedPhase(ctx, args)
+		if err != nil {
+			tracing.EndSpan(ctx, span, err)
+			return reconcile.Result{}, err
+		}
+		// EnsureSandboxPaused is called unconditionally: it drives the pause
+		// state machine to completion (Paused reaches Status=True only after
+		// the pod is fully deleted) and is idempotent once the pause has
+		// finished.
+		err = r.getControl(args.Pod).EnsureSandboxPaused(ctx, args)
 		tracing.EndSpan(ctx, span, err)
 	case agentsv1alpha1.SandboxResuming:
 		ctx, span := tracing.StartControllerSpan(ctx, tracing.SpanControllerEnsureSandboxResumed)
+		// Once the resume succeeds, run the common resume finalization: drop
+		// the Paused condition and remove the pause finalizer.
 		err = r.getControl(args.Pod).EnsureSandboxResumed(ctx, args)
+		resumedCond := utils.GetSandboxCondition(args.NewStatus, string(agentsv1alpha1.SandboxConditionResumed))
+		if err == nil && resumedCond != nil && resumedCond.Status == metav1.ConditionTrue {
+			r.finalizeResumePhase(ctx, args)
+		}
 		tracing.EndSpan(ctx, span, err)
 	case agentsv1alpha1.SandboxUpgrading:
 		ctx, span := tracing.StartControllerSpan(ctx, tracing.SpanControllerEnsureSandboxUpgraded)
@@ -382,8 +398,59 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 	return ctrl.Result{RequeueAfter: requeueAfter}, r.updateSandboxStatus(ctx, *newStatus, box)
 }
 
-func (r *SandboxReconciler) EnsureSandboxPaused(ctx context.Context, args core.EnsureFuncArgs) error {
-	return r.getControl(args.Pod).EnsureSandboxPaused(ctx, args)
+// preparePausedPhase initializes the Paused condition and sets Ready to false
+// before delegating to the control-specific EnsureSandboxPaused logic.
+func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.EnsureFuncArgs) error {
+	box, newStatus := args.Box, args.NewStatus
+	cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
+	if cond == nil {
+		// Add finalizer on first entry into paused state to ensure
+		// controller-mediated cleanup if the sandbox is deleted while paused.
+		if !controllerutil.ContainsFinalizer(box, core.SandboxFinalizer) {
+			if _, err := utils.PatchFinalizer(ctx, r.Client, box, utils.AddFinalizerOpType, core.SandboxFinalizer); err != nil {
+				return fmt.Errorf("failed to add finalizer for paused sandbox: %w", err)
+			}
+			klog.FromContext(ctx).Info("Add finalizer for paused sandbox", "sandbox", klog.KObj(box))
+		}
+		cond = &metav1.Condition{
+			Type:               string(agentsv1alpha1.SandboxConditionPaused),
+			Status:             metav1.ConditionFalse,
+			Reason:             agentsv1alpha1.SandboxPausedReasonPending,
+			LastTransitionTime: metav1.Now(),
+		}
+		utils.SetSandboxCondition(newStatus, *cond)
+		klog.FromContext(ctx).Info("Paused condition initialized", "sandbox", klog.KObj(box))
+	}
+	// The paused phase sets condition ready to false.
+	if rCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady)); rCond != nil && rCond.Status == metav1.ConditionTrue {
+		rCond.Status = metav1.ConditionFalse
+		rCond.LastTransitionTime = metav1.Now()
+		utils.SetSandboxCondition(newStatus, *rCond)
+		klog.FromContext(ctx).Info("The paused phase sets condition ready to false", "sandbox", klog.KObj(box))
+	}
+	return nil
+}
+
+// finalizeResumePhase performs the common cleanup once a resume succeeds,
+// mirroring preparePausedPhase on the pause side: it drops the Paused
+// condition, which was kept through Resuming, so the next pause cycle starts
+// fresh, and removes the finalizer added when the sandbox entered the paused
+// phase.
+//
+// Finalizer removal is best-effort: a failure is logged but does not block
+// the resume, because EnsureSandboxTerminated removes the finalizer as a
+// fallback when the sandbox is deleted.
+func (r *SandboxReconciler) finalizeResumePhase(ctx context.Context, args core.EnsureFuncArgs) {
+	box, newStatus := args.Box, args.NewStatus
+	utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
+	if !controllerutil.ContainsFinalizer(box, core.SandboxFinalizer) {
+		return
+	}
+	if _, err := utils.PatchFinalizer(ctx, r.Client, box, utils.RemoveFinalizerOpType, core.SandboxFinalizer); err != nil {
+		klog.FromContext(ctx).Error(err, "failed to remove finalizer after resume, proceeding anyway", "sandbox", klog.KObj(box))
+		return
+	}
+	klog.FromContext(ctx).Info("Removed finalizer after resume", "sandbox", klog.KObj(box))
 }
 
 func (r *SandboxReconciler) handleTerminating(ctx context.Context, args core.EnsureFuncArgs) (ctrl.Result, error) {
@@ -597,8 +664,8 @@ func (r *SandboxReconciler) calculateStatus(ctx context.Context, args core.Ensur
 		// annotation.
 		if cond != nil && cond.Status == metav1.ConditionTrue {
 			if !box.Spec.Paused {
-				// delete paused condition
-				utils.RemoveSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
+				// Do NOT remove SandboxConditionPaused here: it is kept through
+				// Resuming and removed by finalizeResumePhase once Resumed=True.
 				newStatus.Phase = agentsv1alpha1.SandboxResuming
 				rCond := metav1.Condition{
 					Type:               string(agentsv1alpha1.SandboxConditionResumed),

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -405,7 +405,7 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 						{
 							Type:               string(agentsv1alpha1.SandboxConditionPaused),
 							Status:             metav1.ConditionTrue,
-							Reason:             agentsv1alpha1.SandboxPausedReasonDeletePod,
+							Reason:             agentsv1alpha1.SandboxPausedReasonStopPauseSucceed,
 							LastTransitionTime: metav1.Now(),
 						},
 					},
@@ -1355,6 +1355,210 @@ func TestSandboxReconciler_updateSandboxStatusWithPendingPhase(t *testing.T) {
 	}
 	if updatedSandbox.Status.UpdateRevision != "abc123" {
 		t.Errorf("Expected UpdateRevision abc123, got %v", updatedSandbox.Status.UpdateRevision)
+	}
+}
+
+func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, agentsv1alpha1.AddToScheme(scheme))
+
+	newCondition := func(condType string, status metav1.ConditionStatus, reason string) metav1.Condition {
+		return metav1.Condition{
+			Type:               condType,
+			Status:             status,
+			Reason:             reason,
+			LastTransitionTime: metav1.Now(),
+		}
+	}
+	pausedPending := metav1.Condition{
+		Type:   string(agentsv1alpha1.SandboxConditionPaused),
+		Status: metav1.ConditionFalse,
+		Reason: agentsv1alpha1.SandboxPausedReasonPending,
+	}
+	pausedCompleted := metav1.Condition{
+		Type:   string(agentsv1alpha1.SandboxConditionPaused),
+		Status: metav1.ConditionTrue,
+		Reason: agentsv1alpha1.SandboxPausedReasonStopPauseSucceed,
+	}
+
+	tests := []struct {
+		name           string
+		finalizers     []string
+		conditions     []metav1.Condition
+		injectPatchErr bool
+		wantErr        bool
+		wantFinalizer  bool
+		wantPaused     metav1.Condition
+		wantReady      *metav1.Condition
+	}{
+		{
+			name:          "initializes paused condition and adds finalizer",
+			wantFinalizer: true,
+			wantPaused:    pausedPending,
+		},
+		{
+			name:       "existing finalizer skips patch and flips ready to false",
+			finalizers: []string{core.SandboxFinalizer},
+			conditions: []metav1.Condition{
+				newCondition(string(agentsv1alpha1.SandboxConditionReady), metav1.ConditionTrue, "SandboxReady"),
+			},
+			wantFinalizer: true,
+			wantPaused:    pausedPending,
+			wantReady: &metav1.Condition{
+				Type:   string(agentsv1alpha1.SandboxConditionReady),
+				Status: metav1.ConditionFalse,
+				Reason: "SandboxReady",
+			},
+		},
+		{
+			name: "keeps existing paused condition and flips ready to false",
+			conditions: []metav1.Condition{
+				pausedCompleted,
+				newCondition(string(agentsv1alpha1.SandboxConditionReady), metav1.ConditionTrue, "SandboxReady"),
+			},
+			wantPaused: pausedCompleted,
+			wantReady: &metav1.Condition{
+				Type:   string(agentsv1alpha1.SandboxConditionReady),
+				Status: metav1.ConditionFalse,
+				Reason: "SandboxReady",
+			},
+		},
+		{
+			name: "ready false stays unchanged",
+			conditions: []metav1.Condition{
+				pausedCompleted,
+				newCondition(string(agentsv1alpha1.SandboxConditionReady), metav1.ConditionFalse, "SandboxNotReady"),
+			},
+			wantPaused: pausedCompleted,
+			wantReady: &metav1.Condition{
+				Type:   string(agentsv1alpha1.SandboxConditionReady),
+				Status: metav1.ConditionFalse,
+				Reason: "SandboxNotReady",
+			},
+		},
+		{
+			name:           "patch finalizer error propagates",
+			injectPatchErr: true,
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			box := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "paused-sandbox",
+					Namespace:  "default",
+					Finalizers: tt.finalizers,
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase:      agentsv1alpha1.SandboxRunning,
+					Conditions: tt.conditions,
+				},
+			}
+			builder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(box)
+			if tt.injectPatchErr {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						return fmt.Errorf("injected patch failure")
+					},
+				})
+			}
+			fakeClient := builder.Build()
+			reconciler := &SandboxReconciler{Client: fakeClient}
+
+			newStatus := box.Status.DeepCopy()
+			err := reconciler.preparePausedPhase(context.Background(), core.EnsureFuncArgs{Box: box, NewStatus: newStatus})
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			paused := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
+			require.NotNil(t, paused)
+			assert.Equal(t, tt.wantPaused.Status, paused.Status)
+			assert.Equal(t, tt.wantPaused.Reason, paused.Reason)
+
+			if tt.wantReady != nil {
+				ready := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady))
+				require.NotNil(t, ready)
+				assert.Equal(t, tt.wantReady.Status, ready.Status)
+				assert.Equal(t, tt.wantReady.Reason, ready.Reason)
+			}
+
+			if tt.wantFinalizer {
+				updated := &agentsv1alpha1.Sandbox{}
+				require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "paused-sandbox"}, updated))
+				assert.Contains(t, updated.Finalizers, core.SandboxFinalizer)
+			}
+		})
+	}
+}
+
+// TestSandboxReconciler_finalizeResumePhase verifies the common resume
+// finalization: the Paused condition is dropped from the status while other
+// conditions are preserved, and the pause finalizer is removed from the
+// sandbox when present.
+func TestSandboxReconciler_finalizeResumePhase(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, agentsv1alpha1.AddToScheme(scheme))
+
+	tests := []struct {
+		name       string
+		finalizers []string
+	}{
+		{
+			name:       "removes Paused condition and finalizer",
+			finalizers: []string{core.SandboxFinalizer},
+		},
+		{
+			name:       "removes Paused condition when finalizer is absent",
+			finalizers: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			box := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "resumed-sandbox",
+					Namespace:  "default",
+					Finalizers: tt.finalizers,
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(box).Build()
+			reconciler := &SandboxReconciler{Client: fakeClient}
+
+			newStatus := &agentsv1alpha1.SandboxStatus{
+				Phase: agentsv1alpha1.SandboxResuming,
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionPaused),
+						Status:             metav1.ConditionTrue,
+						Reason:             agentsv1alpha1.SandboxPausedReasonStopPauseSucceed,
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               string(agentsv1alpha1.SandboxConditionResumed),
+						Status:             metav1.ConditionTrue,
+						Reason:             agentsv1alpha1.SandboxResumeReasonResumePod,
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			}
+
+			reconciler.finalizeResumePhase(context.Background(), core.EnsureFuncArgs{Box: box, NewStatus: newStatus})
+
+			assert.Nil(t, utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused)), "expected Paused condition to be removed")
+			assert.NotNil(t, utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionResumed)), "expected Resumed condition to be preserved")
+
+			updated := &agentsv1alpha1.Sandbox{}
+			require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Namespace: box.Namespace, Name: box.Name}, updated))
+			assert.NotContains(t, updated.Finalizers, core.SandboxFinalizer)
+		})
 	}
 }
 
@@ -3078,12 +3282,11 @@ func TestCalculateStatus(t *testing.T) {
 			expectedPhase:     agentsv1alpha1.SandboxResuming,
 			expectedShouldReq: false,
 			checkConditions: func(t *testing.T, status *agentsv1alpha1.SandboxStatus) {
-				// Should remove paused condition
-				for _, cond := range status.Conditions {
-					if cond.Type == string(agentsv1alpha1.SandboxConditionPaused) {
-						t.Errorf("Paused condition should be removed")
-					}
-				}
+				// Paused condition must be preserved — the Resuming stage reads
+				// its reason to dispatch the matching resume strategy. It is
+				// removed only after resume succeeds.
+				pausedCond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionPaused))
+				require.NotNil(t, pausedCond, "Paused condition should be preserved when entering Resuming")
 				// Should add resumed condition with false status
 				found := false
 				for _, cond := range status.Conditions {
@@ -3191,7 +3394,7 @@ func TestCalculateStatus(t *testing.T) {
 					{
 						Type:   string(agentsv1alpha1.SandboxConditionPaused),
 						Status: metav1.ConditionFalse,
-						Reason: agentsv1alpha1.SandboxPausedReasonPausing,
+						Reason: agentsv1alpha1.SandboxPausedReasonPending,
 					},
 				},
 			},
@@ -3307,8 +3510,10 @@ func TestCalculateStatus(t *testing.T) {
 			expectedShouldReq: false,
 			checkConditions: func(t *testing.T, status *agentsv1alpha1.SandboxStatus) {
 				// Un-pause takes priority over the resume trigger annotation.
+				// The Paused condition is preserved so the Resuming stage can
+				// dispatch the matching resume strategy from its reason.
 				pausedCond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionPaused))
-				assert.Nil(t, pausedCond, "Paused condition should be removed when un-pausing")
+				require.NotNil(t, pausedCond, "Paused condition should be preserved when un-pausing")
 				resumedCond := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionResumed))
 				require.NotNil(t, resumedCond, "Resumed condition should be added")
 				assert.Equal(t, metav1.ConditionFalse, resumedCond.Status)

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -59,8 +59,10 @@ const (
 	// identity provider service instead of random UUID generation.
 	SecurityIdentityProviderGate featuregate.Feature = "SecurityIdentityProvider"
 
-	// SandboxPauseCheckpointGate enables creating Checkpoint CRs during sandbox pause
-	// to capture pod state for resume.
+	// SandboxPauseCheckpointGate historically enabled creating Checkpoint CRs
+	// during sandbox pause to capture pod state for resume. It is now always
+	// on and no longer consumed anywhere; the definition is kept so existing
+	// --feature-gates configurations referencing it do not fail validation.
 	SandboxPauseCheckpointGate featuregate.Feature = "SandboxPauseCheckpoint"
 
 	// CommitGate enables the Commit controller to commit container images from Sandbox pods.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -56,7 +56,7 @@ func SetSandboxCondition(status *agentsv1alpha1.SandboxStatus, condition metav1.
 		status.Conditions = append(status.Conditions, condition)
 		return
 	}
-	if currentCond.Status != condition.Status {
+	if currentCond.Status != condition.Status || currentCond.LastTransitionTime.IsZero() {
 		currentCond.LastTransitionTime = condition.LastTransitionTime
 	}
 	currentCond.Status = condition.Status

--- a/test/e2e/sandbox_checkpoint_test.go
+++ b/test/e2e/sandbox_checkpoint_test.go
@@ -127,7 +127,7 @@ func listCheckpoints(ctx context.Context, namespace, sandboxName string) []agent
 		client.InNamespace(namespace),
 		client.MatchingLabels{
 			agentsv1alpha1.CheckpointLabelSandboxName: sandboxName,
-			agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointTypePodInfo,
+			agentsv1alpha1.CheckpointLabelType:        agentsv1alpha1.CheckpointPersistentContentPodInfo,
 		},
 	)
 	if err != nil {
@@ -260,7 +260,7 @@ var _ = Describe("Sandbox Checkpoint", Ordered, func() {
 			By("Verifying checkpoint CR labels and ownerRef")
 			cp := cpList[0]
 			Expect(cp.Labels[agentsv1alpha1.CheckpointLabelSandboxName]).To(Equal(sandbox.Name))
-			Expect(cp.Labels[agentsv1alpha1.CheckpointLabelType]).To(Equal(agentsv1alpha1.CheckpointTypePodInfo))
+			Expect(cp.Labels[agentsv1alpha1.CheckpointLabelType]).To(Equal(agentsv1alpha1.CheckpointPersistentContentPodInfo))
 			Expect(cp.OwnerReferences).To(HaveLen(1))
 			Expect(cp.OwnerReferences[0].Name).To(Equal(sandbox.Name))
 			Expect(cp.OwnerReferences[0].Kind).To(Equal("Sandbox"))


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Refactor the sandbox pause flow to support multiple pause strategies (Stop, Snapshot and CloudDisk).

**API changes** (`api/v1alpha1`):

- Introduce `HibernateStrategy` (Snapshot/CloudDisk) to express how the pause state is persisted.
- Add finer-grained `Paused` condition reasons: `Pending`, `CheckpointCreating`, `CheckpointSucceeded`, `CheckpointFailed`, `StopPauseSucceed`, `SnapshotPauseSucceed`, etc.
- Extend the Checkpoint API with persistent-content scoping and image validation.

**Controller changes** (`pkg/controller/sandbox`):

- Extract the shared paused-phase preparation into `preparePausedPhase`: adds the sandbox finalizer on first entry into the paused state, initializes the `Paused=False/Pending` condition, and flips `Ready` to False before delegating to control-specific pause logic.
- Consolidate strategy-specific pause logic into reusable helpers in `core`:
  - `ensureStopPaused` — Stop strategy: delete the pod and mark the pause complete once the pod is gone.
  - `ensureCheckpointPaused` — Checkpoint/Snapshot strategy: create and validate the checkpoint first, then delegate pod deletion to the stop flow.
- `markResumeSucceeded` unconditionally sets `Resumed=True` and resets `RuntimeInitialized=False/Pending`, so the upgrade Resuming stage works even when Resumed was not pre-seeded, and every resume cycle triggers fresh runtime re-initialization and CSI re-mount.
- The `SandboxPauseCheckpointGate` feature gate is now always on; the definition is kept so existing `--feature-gates` configurations referencing it do not fail validation.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run unit tests: `go test ./pkg/controller/sandbox/... ./pkg/controller/checkpoint/...`
2. Coverage of changed packages: core 95.6%, sandbox 89.9%, checkpoint 95.5%, total 93.4%; all newly introduced functions (`ensureStopPaused`, `ensureCheckpointPaused`, `markResumeSucceeded`, `preparePausedPhase`) reach 100%.
3. Existing e2e sandbox checkpoint/pause tests remain aligned with the new flow.

### Ⅳ. Special notes for reviews

- `preparePausedPhase` adds the finalizer via a merge patch on first entry into the paused state — please check the interaction with the finalizer removal path on resume/delete.
- The `Paused` condition now starts as `False/Pending` and only flips to `True` after the strategy-specific pause completes; review the reason transition chain.
- The checkpoint gate is kept as a no-op for config compatibility; confirm no consumer still depends on it.

---

### Appendix: Incidental Changes

The following changes are side modifications not directly related to the main purpose of this PR:

- Add `.gocache/` to ignore list (`.gitignore`)
