### PR TITLE
Fix SandboxUpdateOps skipping bug by adding requeue

### DIFF
--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,7 +121,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if other.Name != ops.Name && other.Status.Phase == agentsv1alpha1.SandboxUpdateOpsUpdating {
 			klog.InfoS("Another SandboxUpdateOps is already updating, skipping this one",
 				"current", klog.KObj(ops), "active", klog.KObj(other))
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 	}
 

--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
@@ -1334,7 +1334,7 @@ func TestReconcile_ConcurrentOpsInNamespace(t *testing.T) {
 		NamespacedName: types.NamespacedName{Name: "ops-pending", Namespace: "default"},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, ctrl.Result{}, result)
+	assert.Equal(t, ctrl.Result{RequeueAfter: 5 * time.Second}, result)
 
 	// Verify ops-pending was NOT transitioned (still Pending, no status update)
 	updatedOps := &agentsv1alpha1.SandboxUpdateOps{}


### PR DESCRIPTION

### Ⅰ. Describe what this PR does
This PR resolves an issue in the `SandboxUpdateOps` controller where operations were silently dropped from the reconcile queue if another operation in the same namespace was already in the `Updating` phase. 

By adding a `RequeueAfter: 5 * time.Second` to the return result when skipping, the controller will automatically requeue the skipped operation, allowing it to resume processing once the active one finishes. The test expectations have also been updated to assert the proper requeue behavior.

### Ⅱ. Does this pull request fix one issue?
fixes #776

### Ⅲ. Describe how to verify it
1. Deploy the controller with this patch.
2. Rapidly create two `SandboxUpdateOps` objects in the same namespace.
3. Observe the logs: the second one should log "Another SandboxUpdateOps is already updating, skipping this one".
4. Wait for the first operation to reach `Completed` or `Failed`.
5. Observe that the second operation automatically transitions to `Updating` and completes its workflow instead of hanging indefinitely.
6. Run the unit tests locally (`go test ./pkg/controller/sandboxupdateops/...`) to ensure they pass successfully.

### Ⅳ. Special notes for reviews
None.

---

### PR Checklist
- [x] Read the contributing guidelines
- [x] Followed repository-wide patterns and best practices
- [x] Tested changes locally with `make test`
- [x] Verified fix on the targeted issue
