### PR TITLE
fix: resolve scale up expectation race condition in SandboxSet

### DIFF
--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -380,15 +380,24 @@ func (r *Reconciler) createSandbox(ctx context.Context, sbs *agentsv1alpha1.Sand
 	}
 	sbx := NewSandboxFromSandboxSet(sbs, refTemplate)
 	sbx.Labels[agentsv1alpha1.LabelTemplateHash] = revision
+
+	// Issue 778: Generate the full name client-side so we can register the expectation before Creation.
+	// GenerateSandboxName returns a prefix ending in "-" and is max 58 characters.
+	// Appending 5 random characters keeps it within the 63-character limit.
+	sbx.Name = sbx.GenerateName + utils.RandStringN(5)
+
 	if err := ctrl.SetControllerReference(sbs, sbx, r.Scheme); err != nil {
 		return nil, err
 	}
+
+	scaleUpExpectation.ExpectScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
 	if err := r.Create(ctx, sbx); err != nil {
+		// Clean up the expectation since creation failed.
+		scaleUpExpectation.ObserveScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
 		r.Recorder.Eventf(sbs, corev1.EventTypeWarning, EventCreateSandboxFailed, "Failed to create sandbox: %s", err)
 		return nil, err
 	}
 	sandboxSetSandboxesCreatedTotal.WithLabelValues(sbs.Namespace, sbs.Name).Inc()
-	scaleUpExpectation.ExpectScale(GetControllerKey(sbs), expectations.Create, sbx.Name)
 	r.Recorder.Eventf(sbs, corev1.EventTypeNormal, EventSandboxCreated, "Sandbox %s created", klog.KObj(sbx))
 	return sbx, nil
 }

--- a/pkg/controller/sandboxset/sandboxset_controller_test.go
+++ b/pkg/controller/sandboxset/sandboxset_controller_test.go
@@ -36,7 +36,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/utils"
@@ -1371,4 +1371,52 @@ func TestReconciler_createSandbox(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconciler_createSandbox_CreateError(t *testing.T) {
+	utestutils.InitLogOutput()
+	ctx := context.Background()
+
+	sbs := &v1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sbs",
+			Namespace: "default",
+			UID:       types.UID("12345"),
+		},
+		Spec: v1alpha1.SandboxSetSpec{
+			Replicas: 1,
+			EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "img:v1"}}},
+				},
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(testScheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*v1alpha1.Sandbox); ok {
+					return fmt.Errorf("mock create error")
+				}
+				return client.Create(ctx, obj, opts...)
+			},
+		}).Build()
+
+	eventRecorder := record.NewFakeRecorder(10)
+	reconciler := &Reconciler{
+		Client:   k8sClient,
+		Scheme:   testScheme,
+		Recorder: eventRecorder,
+		Codec:    serializer.NewCodecFactory(testScheme).LegacyCodec(v1alpha1.SchemeGroupVersion),
+	}
+
+	sbx, err := reconciler.createSandbox(ctx, sbs, "rev-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mock create error")
+	assert.Nil(t, sbx)
+
+	// Ensure the failed event was emitted.
+	CheckEvent(t, eventRecorder, corev1.EventTypeWarning, EventCreateSandboxFailed)
 }


### PR DESCRIPTION

### Ⅰ. Describe what this PR does

Fixes a race condition in the `SandboxSet` controller that could cause scaling operations to stall for up to 1 minute. 

Previously, `scaleUpExpectation.ExpectScale` was called *after* `r.Create` because the controller relied on `GenerateName` and did not know the final object name until the API server responded. If the informer received the creation event before `ExpectScale` was called, the observation was ignored, leaving a dangling expectation that blocked scaling until it timed out.

This PR shifts to client-side name generation (`utils.GenerateSandboxName` + `utils.RandStringN(5)`), allowing the controller to confidently register the scale expectation before making the `Create` API call, and properly cleaning it up if the API call fails.

### Ⅱ. Does this pull request fix one issue?
fixes #778

### Ⅲ. Describe how to verify it

1. Deploy the updated `sandboxset-controller`.
2. Create a `SandboxSet` and trigger a scale-up operation with a significant replica count (e.g., 50).
3. Monitor the controller logs. You should no longer see the scaling stalled due to expectation timeouts, and sandboxes should be provisioned seamlessly.
4. Existing unit tests (`go test ./pkg/controller/sandboxset/...`) continue to pass.

### Ⅳ. Special notes for reviews

- `GenerateSandboxName` already limits the prefix to 58 characters, so appending the 5-character suffix ensures the total name is under the Kubernetes 63-character limit.

**PR Checklist:**
- [x] I have read the [CONTRIBUTING](https://github.com/openkruise/agents/blob/master/CONTRIBUTING.md) guide.
- [x] I have updated the tests to cover my changes (if applicable).
- [x] My changes follow the code style of this project.
