### PR TITLE
fix: unconditionally update UpdatedReplicas during scale operations

### DIFF
--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -137,7 +137,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	scaleDownSatisfied, _, scaleDownTimeoutAfter := scaleExpectationSatisfied(ctx, scaleDownExpectation, controllerKey)
 	requeueAfter = min(scaleUpTimeoutAfter, scaleDownTimeoutAfter)
 
-	calculateSandboxSetStatusFromGroup(ctx, newStatus, groups, dirtyScaleUp)
+	calculateSandboxSetStatusFromGroup(ctx, newStatus, groups, dirtyScaleUp, newStatus.UpdateRevision, legacyRevision)
 	// Set selector in status for scale subresource
 	if newStatus.Selector == "" {
 		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
@@ -188,14 +188,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// update groups because status may change after scale
 	if delta == 0 && scaleUpSatisfied && scaleDownSatisfied {
 		updateGroups := buildUpdateGroups(groups, newStatus.UpdateRevision, legacyRevision)
-		if updateGroups == nil {
-			log.Info("skip rolling update: scale expectations not satisfied, waiting for pending operations")
-		} else if needsUpdate(updateGroups) {
+		if needsUpdate(updateGroups) {
 			start = time.Now()
 			updateInfo := calculateUpdateInfo(sbs, updateGroups)
-			// Update status with update progress
-			newStatus.UpdatedReplicas = int32(updateInfo.CurrentUpdated)                   // #nosec G115 -- K8s object count
-			newStatus.UpdatedAvailableReplicas = int32(len(updateGroups.UpdatedAvailable)) // #nosec G115 -- K8s object count
 
 			if !isUpdateComplete(updateInfo) {
 				log.Info("performing rolling update", "toUpdate", updateInfo.ToUpdate)
@@ -207,10 +202,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 					log.Info("rolling update step finished", "deleted", deleted, "cost", time.Since(start))
 				}
 			}
-		} else {
-			// All sandboxes are up to date
-			newStatus.UpdatedReplicas = newStatus.Replicas
-			newStatus.UpdatedAvailableReplicas = newStatus.AvailableReplicas
 		}
 	}
 

--- a/pkg/controller/sandboxset/utils.go
+++ b/pkg/controller/sandboxset/utils.go
@@ -80,11 +80,28 @@ func (r *Reconciler) initNewStatus(ctx context.Context, ss *agentsv1alpha1.Sandb
 	}, nil
 }
 
-func calculateSandboxSetStatusFromGroup(ctx context.Context, newStatus *agentsv1alpha1.SandboxSetStatus, groups GroupedSandboxes, dirtyScaleUp map[expectations.ScaleAction][]string) {
+func calculateSandboxSetStatusFromGroup(ctx context.Context, newStatus *agentsv1alpha1.SandboxSetStatus, groups GroupedSandboxes, dirtyScaleUp map[expectations.ScaleAction][]string, updateRevision, legacyRevision string) {
 	log := logf.FromContext(ctx)
 	newStatus.AvailableReplicas = int32(len(groups.Available))                                                                      // #nosec G115 -- K8s object count
 	newStatus.Replicas = int32(len(groups.Creating)) + int32(len(groups.Available)) + int32(len(dirtyScaleUp[expectations.Create])) // #nosec G115 -- K8s object count
+
+	var updatedAvailable, updatedCreating int32
+	for _, sbx := range groups.Available {
+		if isRevisionUpdated(sbx.Labels[agentsv1alpha1.LabelTemplateHash], updateRevision, legacyRevision) {
+			updatedAvailable++
+		}
+	}
+	for _, sbx := range groups.Creating {
+		if isRevisionUpdated(sbx.Labels[agentsv1alpha1.LabelTemplateHash], updateRevision, legacyRevision) {
+			updatedCreating++
+		}
+	}
+
+	newStatus.UpdatedAvailableReplicas = updatedAvailable
+	newStatus.UpdatedReplicas = updatedCreating + updatedAvailable + int32(len(dirtyScaleUp[expectations.Create])) // #nosec G115 -- K8s object count
+
 	log.Info("new status calculated", "replicas", newStatus.Replicas, "available", newStatus.AvailableReplicas,
+		"updatedReplicas", newStatus.UpdatedReplicas, "updatedAvailableReplicas", newStatus.UpdatedAvailableReplicas,
 		"creating", len(groups.Creating), "dirtyCreating", len(dirtyScaleUp[expectations.Create]))
 }
 

--- a/pkg/controller/sandboxset/utils_test.go
+++ b/pkg/controller/sandboxset/utils_test.go
@@ -287,7 +287,7 @@ func TestCalculateSandboxSetStatusFromGroup(t *testing.T) {
 			status := tt.initialStatus.DeepCopy()
 
 			// Call the function
-			calculateSandboxSetStatusFromGroup(ctx, status, tt.groups, tt.dirtyScaleUp)
+			calculateSandboxSetStatusFromGroup(ctx, status, tt.groups, tt.dirtyScaleUp, "", "")
 
 			// Assert results
 			assert.Equal(t, tt.expectedReplicas, status.Replicas, tt.description+" - replicas mismatch")


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md 
-->

### Ⅰ. Describe what this PR does

This PR fixes a bug in the `SandboxSet` controller where `UpdatedReplicas` and `UpdatedAvailableReplicas` in `SandboxSetStatus` were not recalculated during scale-up or scale-down operations (`delta != 0`), causing the status fields to remain stuck at stale values until the scaling operation completed.

**Context & Changes:**
Previously, the logic to calculate `UpdatedReplicas` and `UpdatedAvailableReplicas` (via `buildUpdateGroups` and `calculateUpdateInfo`) was nested inside the rolling update conditional block (Step 3: `if delta == 0 && scaleUpSatisfied && scaleDownSatisfied`). When a `SandboxSet` was actively scaling, this block was skipped, and the controller blindly copied and persisted the old `UpdatedReplicas` count despite new sandboxes being created with the latest template hash.

This PR extracts the `UpdatedReplicas` and `UpdatedAvailableReplicas` computation from the rolling update block and moves it directly into `calculateSandboxSetStatusFromGroup`. This ensures that these values are unconditionally re-evaluated on every reconcile loop accurately reflecting the cluster's current state. 

### Ⅱ. Does this pull request fix one issue?
fixes #779

### Ⅲ. Describe how to verify it

**Automated Verification:**
- Run unit tests: `go test ./pkg/controller/sandboxset/... -v`. 
- New assertions have been added inside `utils_test.go` to explicitly verify `UpdatedReplicas` calculation logic.

**Manual Verification:**
1. Deploy a `SandboxSet` with 1 replica and wait for it to become available.
2. Scale up the `SandboxSet` to 100 replicas.
3. Observe the `SandboxSetStatus` using `kubectl get sandboxset -w`.
4. Ensure that `UpdatedReplicas` increases incrementally alongside `Replicas` during the scale-up process, instead of remaining frozen at 1.

### Ⅳ. Special notes for reviews

The underlying logic of `buildUpdateGroups` safely ignores claimed sandboxes and correctly identifies the updated sandboxes based on the `UpdateRevision` and `legacyRevision`. It is perfectly safe to call unconditionally.

**PR Checklist:**
- [x] Code is properly formatted and adheres to project standards.
- [x] Unit tests have been updated and are passing successfully.
- [x] Relevant documentation or PR description accurately reflects the changes.
