### PR TITLE
fix(sandboxupdateops): clear sandbox upgrade policy once upgrade succ…

### DIFF
--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
@@ -326,13 +326,13 @@ func (r *Reconciler) classifySandboxes(ctx context.Context, sandboxList *agentsv
 
 		switch category {
 		case sandboxUpdated:
-			r.syncUpgradeFailedLabel(ctx, sbx, ops, false)
+			r.syncSandboxUpgradeState(ctx, sbx, ops, sandboxUpdated)
 			updated++
 		case sandboxFailed:
-			r.syncUpgradeFailedLabel(ctx, sbx, ops, true)
+			r.syncSandboxUpgradeState(ctx, sbx, ops, sandboxFailed)
 			failed++
 		case sandboxUpdating:
-			r.syncUpgradeFailedLabel(ctx, sbx, ops, false)
+			r.syncSandboxUpgradeState(ctx, sbx, ops, sandboxUpdating)
 			updating++
 		case sandboxNoNeedUpdate:
 			continue
@@ -340,7 +340,7 @@ func (r *Reconciler) classifySandboxes(ctx context.Context, sandboxList *agentsv
 			// upgrade-failed label is cleared during applySandboxPatch
 			candidates = append(candidates, sbx)
 		case sandboxResumeSucceed:
-			r.syncUpgradeFailedLabel(ctx, sbx, ops, false)
+			r.syncSandboxUpgradeState(ctx, sbx, ops, sandboxResumeSucceed)
 			updating++
 			resumeSucceedCandidates = append(resumeSucceedCandidates, sbx)
 		}
@@ -425,12 +425,13 @@ func (r *Reconciler) classifySandbox(ctx context.Context, sbx *agentsv1alpha1.Sa
 		return sandboxUpdating
 	}
 
+	// Terminal: upgrade completed.
+	if isUpgradeSucceeded(sbx) {
+		return sandboxUpdated
+	}
+
 	cond := findCondition(sbx.Status.Conditions, string(agentsv1alpha1.SandboxConditionUpgrading))
 	if cond != nil {
-		// Terminal: upgrade completed
-		if cond.Reason == agentsv1alpha1.SandboxUpgradingReasonSucceeded && cond.Status == metav1.ConditionTrue {
-			return sandboxUpdated
-		}
 		// Terminal: upgrade failed
 		if cond.Status == metav1.ConditionFalse &&
 			(cond.Reason == agentsv1alpha1.SandboxUpgradingReasonPreUpgradeFailed ||
@@ -481,35 +482,63 @@ func findCondition(conditions []metav1.Condition, condType string) *metav1.Condi
 	return nil
 }
 
-// syncUpgradeFailedLabel adds the upgrade-failed label when add is true and
-// removes it when add is false. It is best-effort: patch errors are logged but
-// never block reconciliation.
-func (r *Reconciler) syncUpgradeFailedLabel(ctx context.Context, sbx *agentsv1alpha1.Sandbox, ops *agentsv1alpha1.SandboxUpdateOps, add bool) {
-	hasLabel := sbx.Labels[agentsv1alpha1.LabelSandboxUpgradeFailed] == agentsv1alpha1.True
+// isUpgradeSucceeded reports whether the sandbox's Upgrading condition is in
+// the terminal-success state (Reason=Succeeded, Status=True).
+func isUpgradeSucceeded(sbx *agentsv1alpha1.Sandbox) bool {
+	cond := findCondition(sbx.Status.Conditions, string(agentsv1alpha1.SandboxConditionUpgrading))
+	return cond != nil &&
+		cond.Reason == agentsv1alpha1.SandboxUpgradingReasonSucceeded &&
+		cond.Status == metav1.ConditionTrue
+}
 
-	var patchJSON string
-	if add && !hasLabel {
-		// Add upgrade-failed label
-		patchJSON = fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`,
-			agentsv1alpha1.LabelSandboxUpgradeFailed, agentsv1alpha1.True)
-	} else if !add && hasLabel {
-		// Remove upgrade-failed label
-		patchJSON = fmt.Sprintf(`{"metadata":{"labels":{"%s":null}}}`,
-			agentsv1alpha1.LabelSandboxUpgradeFailed)
-	} else {
+// syncSandboxUpgradeState aligns the sandbox's upgrade-failed label and
+// spec.upgradePolicy with its classification in a single merge patch:
+//   - sandboxFailed adds the upgrade-failed label;
+//   - sandboxUpdated removes the label and clears spec.upgradePolicy, so
+//     later template changes fall back to the default behavior instead of
+//     silently re-entering the pod-replacement upgrade lifecycle;
+//   - any other state only removes a stale upgrade-failed label, keeping
+//     the policy so the sandbox controller can finish the upgrade.
+//
+// It is best-effort: patch errors are logged but never block reconciliation;
+// handleDeletion provides a second cleanup chance when the ops is deleted.
+func (r *Reconciler) syncSandboxUpgradeState(ctx context.Context, sbx *agentsv1alpha1.Sandbox, ops *agentsv1alpha1.SandboxUpdateOps, state sandboxUpdateState) {
+	hasFailedLabel := sbx.Labels[agentsv1alpha1.LabelSandboxUpgradeFailed] == agentsv1alpha1.True
+	wantFailedLabel := state == sandboxFailed
+	clearPolicy := state == sandboxUpdated && sbx.Spec.UpgradePolicy != nil
+
+	var labelPatch string
+	if wantFailedLabel && !hasFailedLabel {
+		labelPatch = fmt.Sprintf(`"%s":"%s"`, agentsv1alpha1.LabelSandboxUpgradeFailed, agentsv1alpha1.True)
+	} else if !wantFailedLabel && hasFailedLabel {
+		labelPatch = fmt.Sprintf(`"%s":null`, agentsv1alpha1.LabelSandboxUpgradeFailed)
+	}
+	if labelPatch == "" && !clearPolicy {
 		return // already in desired state
 	}
+
+	patchJSON := "{"
+	if labelPatch != "" {
+		patchJSON += fmt.Sprintf(`"metadata":{"labels":{%s}}`, labelPatch)
+		if clearPolicy {
+			patchJSON += ","
+		}
+	}
+	if clearPolicy {
+		patchJSON += `"spec":{"upgradePolicy":null}`
+	}
+	patchJSON += "}"
 
 	rcvObject := &agentsv1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{Namespace: sbx.Namespace, Name: sbx.Name},
 	}
 	if err := r.Patch(ctx, rcvObject, client.RawPatch(types.MergePatchType, []byte(patchJSON))); err != nil {
-		klog.ErrorS(err, "Failed to sync upgrade-failed label",
-			"sandbox", klog.KObj(sbx), "ops", klog.KObj(ops), "add", add)
+		klog.ErrorS(err, "Failed to sync sandbox upgrade state",
+			"sandbox", klog.KObj(sbx), "ops", klog.KObj(ops), "state", state)
 		return
 	}
-	klog.InfoS("Synced upgrade-failed label",
-		"sandbox", klog.KObj(sbx), "ops", klog.KObj(ops), "add", add)
+	klog.InfoS("Synced sandbox upgrade state",
+		"sandbox", klog.KObj(sbx), "ops", klog.KObj(ops), "state", state)
 	ResourceVersionExpectations.Expect(rcvObject)
 }
 
@@ -549,8 +578,17 @@ func (r *Reconciler) handleDeletion(ctx context.Context, ops *agentsv1alpha1.San
 		if sbx.Labels[agentsv1alpha1.LabelSandboxUpdateOps] != ops.Name {
 			continue
 		}
-		patchJSON := fmt.Sprintf(`{"metadata":{"labels":{"%s":null},"annotations":{"%s":null}}}`,
-			agentsv1alpha1.LabelSandboxUpdateOps, agentsv1alpha1.AnnotationUpgradeResumeTrigger)
+		specPatch := ""
+		// Fallback cleanup: also clear the upgrade policy of sandboxes whose
+		// upgrade already succeeded, in case the per-sandbox cleanup in the
+		// normal reconcile path was missed. Sandboxes still upgrading keep
+		// their policy — the sandbox controller still reads it to drive the
+		// upgrade state machine.
+		if isUpgradeSucceeded(sbx) && sbx.Spec.UpgradePolicy != nil {
+			specPatch = `,"spec":{"upgradePolicy":null}`
+		}
+		patchJSON := fmt.Sprintf(`{"metadata":{"labels":{"%s":null},"annotations":{"%s":null}}%s}`,
+			agentsv1alpha1.LabelSandboxUpdateOps, agentsv1alpha1.AnnotationUpgradeResumeTrigger, specPatch)
 		rcvObject := &agentsv1alpha1.Sandbox{
 			ObjectMeta: metav1.ObjectMeta{Namespace: sbx.Namespace, Name: sbx.Name},
 		}

--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller_test.go
@@ -225,6 +225,9 @@ func TestReconcile_AllCompletedToCompleted(t *testing.T) {
 	sbx := newSandbox("sbx-1", "default", "test-ops", agentsv1alpha1.SandboxRunning, []metav1.Condition{
 		{Type: string(agentsv1alpha1.SandboxConditionUpgrading), Reason: agentsv1alpha1.SandboxUpgradingReasonSucceeded, Status: metav1.ConditionTrue},
 	})
+	// The upgrade policy was written by the ops and must be cleared once the
+	// upgrade succeeds.
+	sbx.Spec.UpgradePolicy = &agentsv1alpha1.SandboxUpgradePolicy{Type: agentsv1alpha1.SandboxUpgradePolicyRecreate}
 	r := newTestReconciler(ops, sbx)
 
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
@@ -236,6 +239,12 @@ func TestReconcile_AllCompletedToCompleted(t *testing.T) {
 	err = r.Get(context.Background(), types.NamespacedName{Name: "test-ops", Namespace: "default"}, updatedOps)
 	assert.NoError(t, err)
 	assert.Equal(t, agentsv1alpha1.SandboxUpdateOpsCompleted, updatedOps.Status.Phase)
+
+	// The sandbox upgrade policy must be cleared on the success path.
+	updatedSbx := &agentsv1alpha1.Sandbox{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "sbx-1", Namespace: "default"}, updatedSbx)
+	assert.NoError(t, err)
+	assert.Nil(t, updatedSbx.Spec.UpgradePolicy)
 }
 
 func TestReconcile_SkipsSandboxWhoseTemplateAlreadyMatchesPatch(t *testing.T) {
@@ -1621,6 +1630,204 @@ func TestHandleDeletion_RemoveLabelFromMultipleSandboxes(t *testing.T) {
 	assert.True(t, errors.IsNotFound(err), "ops should be fully deleted after finalizer removal")
 }
 
+func TestHandleDeletion_ClearsUpgradePolicyOnlyForUpdatedSandboxes(t *testing.T) {
+	// Create ops with finalizer
+	ops := newSandboxUpdateOps("test-ops", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil)
+	ops.Finalizers = []string{finalizerName}
+
+	policy := &agentsv1alpha1.SandboxUpgradePolicy{Type: agentsv1alpha1.SandboxUpgradePolicyCheckpointRestore}
+	// Upgrade already succeeded: the fallback cleanup must clear its policy.
+	sbxUpdated := newSandbox("sbx-updated", "default", "test-ops", agentsv1alpha1.SandboxRunning, []metav1.Condition{
+		{Type: string(agentsv1alpha1.SandboxConditionUpgrading), Reason: agentsv1alpha1.SandboxUpgradingReasonSucceeded, Status: metav1.ConditionTrue},
+	})
+	sbxUpdated.Spec.UpgradePolicy = policy.DeepCopy()
+	// Upgrade still in progress: the sandbox controller still reads the policy
+	// to drive the upgrade state machine, so it must be kept.
+	sbxUpgrading := newSandbox("sbx-upgrading", "default", "test-ops", agentsv1alpha1.SandboxUpgrading, []metav1.Condition{
+		{Type: string(agentsv1alpha1.SandboxConditionUpgrading), Reason: agentsv1alpha1.SandboxUpgradingReasonUpgradePod, Status: metav1.ConditionFalse},
+	})
+	sbxUpgrading.Spec.UpgradePolicy = policy.DeepCopy()
+
+	r := newTestReconciler(ops, sbxUpdated, sbxUpgrading)
+
+	// Delete the ops to set DeletionTimestamp
+	err := r.Delete(context.Background(), ops)
+	assert.NoError(t, err)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-ops", Namespace: "default"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// Updated sandbox: label removed and upgrade policy cleared.
+	gotUpdated := &agentsv1alpha1.Sandbox{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "sbx-updated", Namespace: "default"}, gotUpdated)
+	assert.NoError(t, err)
+	assert.Empty(t, gotUpdated.Labels[agentsv1alpha1.LabelSandboxUpdateOps])
+	assert.Nil(t, gotUpdated.Spec.UpgradePolicy)
+
+	// Upgrading sandbox: label removed but upgrade policy preserved.
+	gotUpgrading := &agentsv1alpha1.Sandbox{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "sbx-upgrading", Namespace: "default"}, gotUpgrading)
+	assert.NoError(t, err)
+	assert.Empty(t, gotUpgrading.Labels[agentsv1alpha1.LabelSandboxUpdateOps])
+	assert.NotNil(t, gotUpgrading.Spec.UpgradePolicy)
+	assert.Equal(t, agentsv1alpha1.SandboxUpgradePolicyCheckpointRestore, gotUpgrading.Spec.UpgradePolicy.Type)
+}
+
+func TestIsUpgradeSucceeded(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		want       bool
+	}{
+		{name: "no conditions", conditions: nil, want: false},
+		{
+			name: "upgrade succeeded",
+			conditions: []metav1.Condition{
+				{Type: string(agentsv1alpha1.SandboxConditionUpgrading), Reason: agentsv1alpha1.SandboxUpgradingReasonSucceeded, Status: metav1.ConditionTrue},
+			},
+			want: true,
+		},
+		{
+			name: "succeeded reason but status false",
+			conditions: []metav1.Condition{
+				{Type: string(agentsv1alpha1.SandboxConditionUpgrading), Reason: agentsv1alpha1.SandboxUpgradingReasonSucceeded, Status: metav1.ConditionFalse},
+			},
+			want: false,
+		},
+		{
+			name: "upgrade in progress",
+			conditions: []metav1.Condition{
+				{Type: string(agentsv1alpha1.SandboxConditionUpgrading), Reason: agentsv1alpha1.SandboxUpgradingReasonUpgradePod, Status: metav1.ConditionFalse},
+			},
+			want: false,
+		},
+		{
+			name: "upgrade failed",
+			conditions: []metav1.Condition{
+				{Type: string(agentsv1alpha1.SandboxConditionUpgrading), Reason: agentsv1alpha1.SandboxUpgradingReasonPreUpgradeFailed, Status: metav1.ConditionFalse},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbx := newSandbox("sbx-1", "default", "test-ops", agentsv1alpha1.SandboxRunning, tt.conditions)
+			assert.Equal(t, tt.want, isUpgradeSucceeded(sbx))
+		})
+	}
+}
+
+func TestReconcile_CleanupUpdatedSandbox(t *testing.T) {
+	policy := &agentsv1alpha1.SandboxUpgradePolicy{Type: agentsv1alpha1.SandboxUpgradePolicyRecreate}
+	tests := []struct {
+		name           string
+		policy         *agentsv1alpha1.SandboxUpgradePolicy
+		hasFailedLabel bool
+		injectPatchErr bool
+		wantPatches    int
+		wantPolicyNil  bool
+		wantLabelGone  bool
+	}{
+		{
+			name:          "clears policy after upgrade succeeds",
+			policy:        policy.DeepCopy(),
+			wantPatches:   1,
+			wantPolicyNil: true,
+		},
+		{
+			name:           "clears failed label and policy in a single patch",
+			policy:         policy.DeepCopy(),
+			hasFailedLabel: true,
+			wantPatches:    1,
+			wantPolicyNil:  true,
+			wantLabelGone:  true,
+		},
+		{
+			name:           "removes stale failed label when policy already absent",
+			policy:         nil,
+			hasFailedLabel: true,
+			wantPatches:    1,
+			wantPolicyNil:  true,
+			wantLabelGone:  true,
+		},
+		{
+			name:          "no patch issued when nothing needs cleanup",
+			policy:        nil,
+			wantPatches:   0,
+			wantPolicyNil: true,
+		},
+		{
+			name:           "patch error is best-effort and does not block reconciliation",
+			policy:         policy.DeepCopy(),
+			hasFailedLabel: true,
+			injectPatchErr: true,
+			wantPatches:    1,
+			wantPolicyNil:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := newSandboxUpdateOps("test-ops", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil)
+			ops.Finalizers = []string{finalizerName}
+			sbx := newSandbox("sbx-1", "default", "test-ops", agentsv1alpha1.SandboxRunning, []metav1.Condition{
+				{Type: string(agentsv1alpha1.SandboxConditionUpgrading), Reason: agentsv1alpha1.SandboxUpgradingReasonSucceeded, Status: metav1.ConditionTrue},
+			})
+			sbx.Spec.UpgradePolicy = tt.policy
+			if tt.hasFailedLabel {
+				sbx.Labels[agentsv1alpha1.LabelSandboxUpgradeFailed] = agentsv1alpha1.True
+			}
+
+			sandboxPatches := 0
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithStatusSubresource(&agentsv1alpha1.SandboxUpdateOps{}, &agentsv1alpha1.Sandbox{}).
+				WithRuntimeObjects(ops, sbx).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if _, ok := obj.(*agentsv1alpha1.Sandbox); ok {
+							sandboxPatches++
+							if tt.injectPatchErr {
+								return fmt.Errorf("simulated cleanup patch error")
+							}
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			r := &Reconciler{Client: fakeClient, Scheme: testScheme, Recorder: record.NewFakeRecorder(10)}
+			_, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: "test-ops", Namespace: "default"},
+			})
+			assert.NoError(t, err)
+
+			// The ops still reaches Completed even when the cleanup patch fails.
+			updatedOps := &agentsv1alpha1.SandboxUpdateOps{}
+			err = r.Get(context.Background(), types.NamespacedName{Name: "test-ops", Namespace: "default"}, updatedOps)
+			assert.NoError(t, err)
+			assert.Equal(t, agentsv1alpha1.SandboxUpdateOpsCompleted, updatedOps.Status.Phase)
+			assert.Equal(t, tt.wantPatches, sandboxPatches)
+
+			updatedSbx := &agentsv1alpha1.Sandbox{}
+			err = r.Get(context.Background(), types.NamespacedName{Name: "sbx-1", Namespace: "default"}, updatedSbx)
+			assert.NoError(t, err)
+			if tt.wantPolicyNil {
+				assert.Nil(t, updatedSbx.Spec.UpgradePolicy)
+			} else {
+				assert.NotNil(t, updatedSbx.Spec.UpgradePolicy)
+			}
+			if tt.wantLabelGone {
+				assert.NotEqual(t, agentsv1alpha1.True, updatedSbx.Labels[agentsv1alpha1.LabelSandboxUpgradeFailed])
+			} else if tt.hasFailedLabel {
+				assert.Equal(t, agentsv1alpha1.True, updatedSbx.Labels[agentsv1alpha1.LabelSandboxUpgradeFailed])
+			}
+		})
+	}
+}
+
 func TestReconcile_DeletionTimestamp_CallsHandleDeletion(t *testing.T) {
 	// Create ops with finalizer and a sandbox with ops label
 	ops := newSandboxUpdateOps("test-ops", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil)
@@ -2081,82 +2288,145 @@ func assertNoUpdateOpsRecorderEvent(t *testing.T, recorder *record.FakeRecorder)
 	}
 }
 
-func TestSyncUpgradeFailedLabel(t *testing.T) {
+func TestSyncSandboxUpgradeState(t *testing.T) {
 	ops := newSandboxUpdateOps("test-ops", "default", agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil)
+	policy := &agentsv1alpha1.SandboxUpgradePolicy{Type: agentsv1alpha1.SandboxUpgradePolicyRecreate}
+
+	opsLabels := map[string]string{agentsv1alpha1.LabelSandboxUpdateOps: "test-ops"}
+	failedLabels := map[string]string{
+		agentsv1alpha1.LabelSandboxUpdateOps:     "test-ops",
+		agentsv1alpha1.LabelSandboxUpgradeFailed: agentsv1alpha1.True,
+	}
+	newStateSandbox := func(name string, labels map[string]string, withPolicy bool) *agentsv1alpha1.Sandbox {
+		sbx := &agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", Labels: labels},
+		}
+		if withPolicy {
+			sbx.Spec.UpgradePolicy = policy.DeepCopy()
+		}
+		return sbx
+	}
 
 	tests := []struct {
-		name      string
-		sandbox   *agentsv1alpha1.Sandbox
-		failed    bool
-		wantLabel bool
+		name           string
+		sandbox        *agentsv1alpha1.Sandbox
+		state          sandboxUpdateState
+		injectPatchErr bool
+		wantPatches    int
+		wantLabel      bool
+		wantLabelGone  bool
+		wantPolicyNil  bool
+		wantPolicyKept bool
 	}{
 		{
-			name: "failed and no label -> add label",
-			sandbox: &agentsv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "sbx-1",
-					Namespace: "default",
-					Labels:    map[string]string{agentsv1alpha1.LabelSandboxUpdateOps: "test-ops"},
-				},
-			},
-			failed:    true,
-			wantLabel: true,
+			name:        "failed and no label -> add label",
+			sandbox:     newStateSandbox("sbx-1", opsLabels, false),
+			state:       sandboxFailed,
+			wantPatches: 1,
+			wantLabel:   true,
 		},
 		{
-			name: "failed and already has label -> no change",
-			sandbox: &agentsv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "sbx-2",
-					Namespace: "default",
-					Labels: map[string]string{
-						agentsv1alpha1.LabelSandboxUpdateOps:     "test-ops",
-						agentsv1alpha1.LabelSandboxUpgradeFailed: agentsv1alpha1.True,
-					},
-				},
-			},
-			failed:    true,
-			wantLabel: true,
+			name:        "failed and already has label -> no patch",
+			sandbox:     newStateSandbox("sbx-2", failedLabels, false),
+			state:       sandboxFailed,
+			wantPatches: 0,
+			wantLabel:   true,
 		},
 		{
-			name: "not failed and has label -> remove label",
-			sandbox: &agentsv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "sbx-3",
-					Namespace: "default",
-					Labels: map[string]string{
-						agentsv1alpha1.LabelSandboxUpdateOps:     "test-ops",
-						agentsv1alpha1.LabelSandboxUpgradeFailed: agentsv1alpha1.True,
-					},
-				},
-			},
-			failed:    false,
-			wantLabel: false,
+			name:          "updating and has label -> remove label",
+			sandbox:       newStateSandbox("sbx-3", failedLabels, false),
+			state:         sandboxUpdating,
+			wantPatches:   1,
+			wantLabelGone: true,
 		},
 		{
-			name: "not failed and no label -> no change",
-			sandbox: &agentsv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "sbx-4",
-					Namespace: "default",
-					Labels:    map[string]string{agentsv1alpha1.LabelSandboxUpdateOps: "test-ops"},
-				},
-			},
-			failed:    false,
-			wantLabel: false,
+			name:        "updating and no label -> no patch",
+			sandbox:     newStateSandbox("sbx-4", opsLabels, false),
+			state:       sandboxUpdating,
+			wantPatches: 0,
+		},
+		{
+			name:          "updated removes stale label and clears policy in a single patch",
+			sandbox:       newStateSandbox("sbx-5", failedLabels, true),
+			state:         sandboxUpdated,
+			wantPatches:   1,
+			wantLabelGone: true,
+			wantPolicyNil: true,
+		},
+		{
+			name:          "updated clears policy only",
+			sandbox:       newStateSandbox("sbx-6", opsLabels, true),
+			state:         sandboxUpdated,
+			wantPatches:   1,
+			wantPolicyNil: true,
+		},
+		{
+			name:          "updated removes stale label when policy already absent",
+			sandbox:       newStateSandbox("sbx-7", failedLabels, false),
+			state:         sandboxUpdated,
+			wantPatches:   1,
+			wantLabelGone: true,
+		},
+		{
+			name:        "updated and nothing to clean -> no patch",
+			sandbox:     newStateSandbox("sbx-8", opsLabels, false),
+			state:       sandboxUpdated,
+			wantPatches: 0,
+		},
+		{
+			name:           "resumeSucceed removes stale label and keeps policy",
+			sandbox:        newStateSandbox("sbx-9", failedLabels, true),
+			state:          sandboxResumeSucceed,
+			wantPatches:    1,
+			wantLabelGone:  true,
+			wantPolicyKept: true,
+		},
+		{
+			name:           "patch error is best-effort",
+			sandbox:        newStateSandbox("sbx-10", failedLabels, true),
+			state:          sandboxUpdated,
+			injectPatchErr: true,
+			wantPatches:    1,
+			wantPolicyKept: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := newTestReconciler(tt.sandbox)
-			r.syncUpgradeFailedLabel(context.Background(), tt.sandbox, ops, tt.failed)
+			sandboxPatches := 0
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithRuntimeObjects(tt.sandbox).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if _, ok := obj.(*agentsv1alpha1.Sandbox); ok {
+							sandboxPatches++
+							if tt.injectPatchErr {
+								return fmt.Errorf("simulated sync patch error")
+							}
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+			r := &Reconciler{Client: fakeClient, Scheme: testScheme, Recorder: record.NewFakeRecorder(10)}
+
+			r.syncSandboxUpgradeState(context.Background(), tt.sandbox, ops, tt.state)
+			assert.Equal(t, tt.wantPatches, sandboxPatches)
 
 			updated := &agentsv1alpha1.Sandbox{}
 			err := r.Get(context.Background(), types.NamespacedName{Name: tt.sandbox.Name, Namespace: tt.sandbox.Namespace}, updated)
 			assert.NoError(t, err)
 			if tt.wantLabel {
 				assert.Equal(t, agentsv1alpha1.True, updated.Labels[agentsv1alpha1.LabelSandboxUpgradeFailed])
-			} else {
+			}
+			if tt.wantLabelGone {
 				assert.NotEqual(t, agentsv1alpha1.True, updated.Labels[agentsv1alpha1.LabelSandboxUpgradeFailed])
+			}
+			if tt.wantPolicyNil {
+				assert.Nil(t, updated.Spec.UpgradePolicy)
+			}
+			if tt.wantPolicyKept {
+				assert.NotNil(t, updated.Spec.UpgradePolicy)
 			}
 		})
 	}

--- a/test/e2e/sandboxupdateops_test.go
+++ b/test/e2e/sandboxupdateops_test.go
@@ -351,6 +351,16 @@ var _ = Describe("SandboxUpdateOps E2E", func() {
 			Expect(ops.Status.UpdatedReplicas).To(Equal(int32(2)))
 			klog.InfoS("Ops status verified", "replicas", ops.Status.Replicas, "updated", ops.Status.UpdatedReplicas)
 
+			By("Verifying each Sandbox's UpgradePolicy is cleared after the upgrade succeeds")
+			for _, sbx := range sandboxes {
+				Eventually(func(g Gomega) {
+					updated := &agentsv1alpha1.Sandbox{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), updated)).To(Succeed())
+					g.Expect(updated.Spec.UpgradePolicy).To(BeNil(),
+						"sandbox %s should have its upgrade policy cleared after upgrade succeeds", sbx.Name)
+				}, 30*time.Second, time.Second).Should(Succeed())
+			}
+
 			By("Verifying each Sandbox's Pod has new image, volume1, volume3, and no volume2")
 			for _, sbx := range sandboxes {
 				pod := &corev1.Pod{}
@@ -507,6 +517,14 @@ var _ = Describe("SandboxUpdateOps E2E", func() {
 			}
 			klog.InfoS("Sandbox ops labels verified clean after failed ops deletion")
 
+			By("Verifying sandboxes keep their UpgradePolicy since no upgrade has succeeded")
+			for _, sbx := range sandboxes {
+				updated := &agentsv1alpha1.Sandbox{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), updated)).To(Succeed())
+				Expect(updated.Spec.UpgradePolicy).NotTo(BeNil(),
+					"sandbox %s should keep its upgrade policy before any upgrade succeeds", sbx.Name)
+			}
+
 			By("Creating new SandboxUpdateOps with fixed preUpgrade=exit 0")
 			ops2 := &agentsv1alpha1.SandboxUpdateOps{
 				ObjectMeta: metav1.ObjectMeta{
@@ -548,6 +566,16 @@ var _ = Describe("SandboxUpdateOps E2E", func() {
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: sbx.Name, Namespace: sbx.Namespace}, pod)).To(Succeed())
 				Expect(pod.Spec.Containers[0].Image).To(Equal(updateImage),
 					"sandbox %s should have updated image after recovery", sbx.Name)
+			}
+
+			By("Verifying each Sandbox's UpgradePolicy is cleared after the recovery upgrade succeeds")
+			for _, sbx := range sandboxes {
+				Eventually(func(g Gomega) {
+					updated := &agentsv1alpha1.Sandbox{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), updated)).To(Succeed())
+					g.Expect(updated.Spec.UpgradePolicy).To(BeNil(),
+						"sandbox %s should have its upgrade policy cleared after recovery succeeds", sbx.Name)
+				}, 30*time.Second, time.Second).Should(Succeed())
 			}
 		})
 
@@ -817,6 +845,16 @@ var _ = Describe("SandboxUpdateOps E2E", func() {
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: sbx.Name, Namespace: sbx.Namespace}, pod)).To(Succeed())
 				Expect(pod.Spec.Containers[0].Image).To(Equal(updateImage),
 					"sandbox %s should have updated image after recovery", sbx.Name)
+			}
+
+			By("Verifying each Sandbox's UpgradePolicy is cleared after the recovery upgrade succeeds")
+			for _, sbx := range sandboxes {
+				Eventually(func(g Gomega) {
+					updated := &agentsv1alpha1.Sandbox{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), updated)).To(Succeed())
+					g.Expect(updated.Spec.UpgradePolicy).To(BeNil(),
+						"sandbox %s should have its upgrade policy cleared after recovery succeeds", sbx.Name)
+				}, 30*time.Second, time.Second).Should(Succeed())
 			}
 		})
 
@@ -1317,6 +1355,14 @@ var _ = Describe("SandboxUpdateOps E2E", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: sbx.Name, Namespace: sbx.Namespace}, pod)).To(Succeed())
 			Expect(pod.Spec.Containers[0].Image).To(Equal(updateImage),
 				"paused sandbox should have updated image after upgrade with StateFilter=[Running,Paused]")
+
+			By("Verifying the sandbox's UpgradePolicy is cleared after the upgrade succeeds")
+			Eventually(func(g Gomega) {
+				updated := &agentsv1alpha1.Sandbox{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), updated)).To(Succeed())
+				g.Expect(updated.Spec.UpgradePolicy).To(BeNil(),
+					"paused sandbox should have its upgrade policy cleared after upgrade succeeds")
+			}, 30*time.Second, time.Second).Should(Succeed())
 
 			By("Verifying the sandbox re-paused after upgrade")
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sbx), sbx)).To(Succeed())


### PR DESCRIPTION
…eeds

The ops writes spec.upgradePolicy to each sandbox to drive one upgrade round. Leaving it set after success makes later template changes silently re-enter the pod-replacement upgrade lifecycle and blocks the inplace update path. Clear the policy when the sandbox Upgrading condition reaches Succeeded, and also clear it as a fallback in handleDeletion for sandboxes whose upgrade already succeeded; sandboxes still upgrading keep their policy so the sandbox controller can finish the upgrade state machine.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

