### PR TITLE
fix(controller): ops template patch sanitization and checkpoint resume selection

### DIFF
--- a/pkg/controller/sandbox/core/checkpoint.go
+++ b/pkg/controller/sandbox/core/checkpoint.go
@@ -213,12 +213,14 @@ func (c *CheckpointControl) ensureCheckpointCR(ctx context.Context, box *agentsv
 
 // GetCheckpointResumeData retrieves the pod template delta and the checkpoint
 // ID from the sandbox's checkpoints in a single list operation. Both fields
-// come from the same checkpoint: the first one that recorded a non-empty pod
-// template delta. The delta rebuilds the pod on resume or a CheckpointRestore
-// upgrade, and the checkpoint ID restores the pod's writable layer. A sandbox
-// holds at most one active checkpoint at a time (created by the pause or the
-// upgrade flow and cleaned up afterwards), so both fields always belong to a
-// single checkpoint.
+// come from the same checkpoint: the first one that recorded resume data, a
+// non-empty pod template delta or a checkpoint ID. The delta may legitimately
+// be empty when the pod carries no resource drift and no injected containers,
+// so the checkpoint ID alone still qualifies the checkpoint. The delta rebuilds
+// the pod on resume or a CheckpointRestore upgrade, and the checkpoint ID
+// restores the pod's writable layer. A sandbox holds at most one active
+// checkpoint at a time (created by the pause or the upgrade flow and cleaned
+// up afterwards), so both fields always belong to a single checkpoint.
 //
 // Unlike the checkpoint creation path, reading here needs no feature gate
 // check: a checkpoint only exists if the creation path created it in the
@@ -230,8 +232,14 @@ func (c *CheckpointControl) GetCheckpointResumeData(ctx context.Context, box *ag
 		return nil, ""
 	}
 	for i := range cpList {
-		if len(cpList[i].Status.PodTemplateDelta.Raw) > 0 {
-			return &cpList[i].Status.PodTemplateDelta, cpList[i].Status.CheckpointId
+		hasDelta := len(cpList[i].Status.PodTemplateDelta.Raw) > 0
+		hasID := cpList[i].Status.CheckpointId != ""
+		if hasDelta || hasID {
+			var delta *runtime.RawExtension
+			if hasDelta {
+				delta = &cpList[i].Status.PodTemplateDelta
+			}
+			return delta, cpList[i].Status.CheckpointId
 		}
 	}
 	return nil, ""

--- a/pkg/controller/sandbox/core/checkpoint_test.go
+++ b/pkg/controller/sandbox/core/checkpoint_test.go
@@ -801,12 +801,14 @@ func TestGetCheckpointResumeData(t *testing.T) {
 			expectID:  "",
 		},
 		{
-			// Without a recorded delta the checkpoint is not selected, even
-			// when it carries an ID.
-			name:        "upgrade checkpoint with ID only - not selected",
+			// The delta is legitimately empty when the pod carries no resource
+			// drift and no injected containers, so a checkpoint recording only
+			// its ID must still be selected; otherwise a CheckpointRestore
+			// upgrade cannot find the checkpoint to restore from.
+			name:        "upgrade checkpoint with ID only - selected",
 			existingCPs: []client.Object{upgradeCPWithID()},
 			expectNil:   true,
-			expectID:    "",
+			expectID:    "cp-id-123",
 		},
 		{
 			name: "single checkpoint with both delta and ID",
@@ -823,7 +825,7 @@ func TestGetCheckpointResumeData(t *testing.T) {
 		},
 		{
 			// The delta and the ID always come from the same checkpoint: the
-			// first one with a non-empty delta wins, and the ID of a later
+			// first one with resume data wins, and the ID of a later
 			// checkpoint is not picked up.
 			name: "multiple checkpoints - delta and ID from the same checkpoint",
 			existingCPs: []client.Object{
@@ -839,6 +841,8 @@ func TestGetCheckpointResumeData(t *testing.T) {
 			expectID:  "cp-id-first",
 		},
 		{
+			// A checkpoint without delta and without ID carries no resume data
+			// (e.g. still in progress), so nothing is returned.
 			name:        "checkpoint with empty delta - returns nil",
 			existingCPs: []client.Object{newCheckpointTestCP("test-sandbox-cp1", newCheckpointTestSandbox(), agentsv1alpha1.CheckpointSucceeded)},
 			expectNil:   true,

--- a/pkg/controller/sandboxupdateops/patch.go
+++ b/pkg/controller/sandboxupdateops/patch.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sandboxupdateops
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -38,9 +39,13 @@ import (
 // containers of the sandbox template. The raw bytes are returned unchanged
 // when the patch does not carry such nulls or cannot be parsed (parse errors
 // are left to the strategic merge patch call, which reports them).
+// Numbers are decoded with UseNumber so the round trip keeps int64 values
+// (e.g. activeDeadlineSeconds, runAsUser) beyond float64 precision intact.
 func sanitizeTemplatePatch(raw []byte) []byte {
 	var obj map[string]interface{}
-	if err := json.Unmarshal(raw, &obj); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	if err := dec.Decode(&obj); err != nil {
 		return raw
 	}
 	spec, ok := obj["spec"].(map[string]interface{})

--- a/pkg/controller/sandboxupdateops/patch.go
+++ b/pkg/controller/sandboxupdateops/patch.go
@@ -30,6 +30,41 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 )
 
+// sanitizeTemplatePatch strips explicit nulls for fields a pod template can
+// never drop, so they cannot act as strategic-merge-patch delete directives.
+// Marshaling a PodTemplateSpec whose PodSpec is empty emits
+// "spec":{"containers":null} because PodSpec.Containers has no omitempty tag;
+// without this cleanup an annotation-only patch would delete the required
+// containers of the sandbox template. The raw bytes are returned unchanged
+// when the patch does not carry such nulls or cannot be parsed (parse errors
+// are left to the strategic merge patch call, which reports them).
+func sanitizeTemplatePatch(raw []byte) []byte {
+	var obj map[string]interface{}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return raw
+	}
+	spec, ok := obj["spec"].(map[string]interface{})
+	if !ok {
+		return raw
+	}
+	// containers is required in a pod spec, so a null value can never be a
+	// legitimate delete request; it only appears when an empty PodSpec is
+	// marshaled into the patch.
+	containers, exists := spec["containers"]
+	if !exists || containers != nil {
+		return raw
+	}
+	delete(spec, "containers")
+	if len(spec) == 0 {
+		delete(obj, "spec")
+	}
+	sanitized, err := json.Marshal(obj)
+	if err != nil {
+		return raw
+	}
+	return sanitized
+}
+
 // isSandboxTemplateMatchPatch checks whether the sandbox template already matches
 // the patch target. If applying the SMP produces no change, the sandbox is already
 // up-to-date and should be skipped entirely (no patch, no counting).
@@ -41,7 +76,7 @@ func isSandboxTemplateMatchPatch(sbx *agentsv1alpha1.Sandbox, ops *agentsv1alpha
 	if err != nil {
 		return false
 	}
-	mergedBytes, err := strategicpatch.StrategicMergePatch(originalBytes, ops.Spec.Patch.Raw, &v1.PodTemplateSpec{})
+	mergedBytes, err := strategicpatch.StrategicMergePatch(originalBytes, sanitizeTemplatePatch(ops.Spec.Patch.Raw), &v1.PodTemplateSpec{})
 	if err != nil {
 		klog.ErrorS(err, "Failed to apply strategic merge patch for match check", "sandbox", klog.KObj(sbx))
 		return false
@@ -65,7 +100,7 @@ func mergeTemplate(modified *agentsv1alpha1.Sandbox, ops *agentsv1alpha1.Sandbox
 	if err != nil {
 		return fmt.Errorf("failed to marshal original template: %w", err)
 	}
-	mergedBytes, err := strategicpatch.StrategicMergePatch(originalBytes, ops.Spec.Patch.Raw, &v1.PodTemplateSpec{})
+	mergedBytes, err := strategicpatch.StrategicMergePatch(originalBytes, sanitizeTemplatePatch(ops.Spec.Patch.Raw), &v1.PodTemplateSpec{})
 	if err != nil {
 		return fmt.Errorf("failed to apply strategic merge patch: %w", err)
 	}

--- a/pkg/controller/sandboxupdateops/patch_test.go
+++ b/pkg/controller/sandboxupdateops/patch_test.go
@@ -484,6 +484,50 @@ func TestSanitizeTemplatePatch(t *testing.T) {
 			raw:  `{"metadata":{"labels":{"app":"test"}}}`,
 			want: `{"metadata":{"labels":{"app":"test"}}}`,
 		},
+		{
+			// The sanitize round trip must not corrupt int64 fields beyond
+			// float64 precision (2^53), e.g. activeDeadlineSeconds or runAsUser.
+			name: "large integers survive the round trip",
+			raw:  `{"spec":{"containers":null,"activeDeadlineSeconds":9007199254740993,"securityContext":{"runAsUser":1000000000000000001}}}`,
+			want: `{"spec":{"activeDeadlineSeconds":9007199254740993,"securityContext":{"runAsUser":1000000000000000001}}}`,
+		},
+		{
+			name: "typical patch with ordinary numbers is unchanged",
+			raw:  `{"spec":{"containers":[{"name":"main","image":"nginx:2.0"}],"terminationGracePeriodSeconds":30}}`,
+			want: `{"spec":{"containers":[{"name":"main","image":"nginx:2.0"}],"terminationGracePeriodSeconds":30}}`,
+		},
+		{
+			name: "empty object is unchanged",
+			raw:  `{}`,
+			want: `{}`,
+		},
+		{
+			name: "explicit null spec is unchanged",
+			raw:  `{"metadata":{"labels":{"app":"test"}},"spec":null}`,
+			want: `{"metadata":{"labels":{"app":"test"}},"spec":null}`,
+		},
+		{
+			name: "spec not an object is unchanged",
+			raw:  `{"spec":"invalid"}`,
+			want: `{"spec":"invalid"}`,
+		},
+		{
+			name: "non-object json root is unchanged",
+			raw:  `["not","an","object"]`,
+			want: `["not","an","object"]`,
+		},
+		{
+			// An explicit empty list is a user-authored delete-all directive
+			// and must not be confused with the marshaling null artifact.
+			name: "empty containers list is kept as delete-all directive",
+			raw:  `{"spec":{"containers":[]}}`,
+			want: `{"spec":{"containers":[]}}`,
+		},
+		{
+			name: "null containers dropped while other spec fields are kept",
+			raw:  `{"spec":{"containers":null,"nodeSelector":{"zone":"a"}}}`,
+			want: `{"spec":{"nodeSelector":{"zone":"a"}}}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/sandboxupdateops/patch_test.go
+++ b/pkg/controller/sandboxupdateops/patch_test.go
@@ -452,3 +452,123 @@ func TestApplyTemplatePatch_PatchError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "simulated patch error")
 }
+
+func TestSanitizeTemplatePatch(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "annotation-only patch drops null containers",
+			raw:  `{"metadata":{"annotations":{"agents.kruise.io/upgrade-marker":"v2"}},"spec":{"containers":null}}`,
+			want: `{"metadata":{"annotations":{"agents.kruise.io/upgrade-marker":"v2"}}}`,
+		},
+		{
+			name: "patch with real containers is unchanged",
+			raw:  `{"spec":{"containers":[{"name":"main","image":"nginx:2.0"}]}}`,
+			want: `{"spec":{"containers":[{"name":"main","image":"nginx:2.0"}]}}`,
+		},
+		{
+			name: "null optional lists are kept as delete directives",
+			raw:  `{"spec":{"containers":[{"name":"main"}],"initContainers":null,"volumes":null}}`,
+			want: `{"spec":{"containers":[{"name":"main"}],"initContainers":null,"volumes":null}}`,
+		},
+		{
+			name: "invalid json is returned unchanged",
+			raw:  `{invalid json}`,
+			want: `{invalid json}`,
+		},
+		{
+			name: "patch without spec is unchanged",
+			raw:  `{"metadata":{"labels":{"app":"test"}}}`,
+			want: `{"metadata":{"labels":{"app":"test"}}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, string(sanitizeTemplatePatch([]byte(tt.raw))))
+		})
+	}
+}
+
+// TestApplySandboxPatch_AnnotationOnlyPatchKeepsContainers guards against the
+// regression where marshaling a PodTemplateSpec that only sets ObjectMeta
+// emits "spec":{"containers":null} (PodSpec.Containers has no omitempty) and
+// the strategic merge patch treated it as a delete directive, wiping the
+// required containers of the sandbox template.
+func TestApplySandboxPatch_AnnotationOnlyPatchKeepsContainers(t *testing.T) {
+	ops := &agentsv1alpha1.SandboxUpdateOps{
+		ObjectMeta: metav1.ObjectMeta{Name: "ops-1", Namespace: "default"},
+		Spec: agentsv1alpha1.SandboxUpdateOpsSpec{
+			Patch: mustMarshalPatch(corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"agents.kruise.io/upgrade-marker": "v2"},
+				},
+			}),
+		},
+	}
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sbx-1",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test"},
+		},
+		Spec: agentsv1alpha1.SandboxSpec{
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "main", Image: "nginx:1.0"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	r := newTestReconciler(sbx)
+	err := r.applySandboxPatch(context.Background(), sbx, ops)
+	assert.NoError(t, err)
+
+	updated := &agentsv1alpha1.Sandbox{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "sbx-1", Namespace: "default"}, updated)
+	assert.NoError(t, err)
+	assert.Equal(t, "v2", updated.Spec.Template.Annotations["agents.kruise.io/upgrade-marker"])
+	assert.Len(t, updated.Spec.Template.Spec.Containers, 1)
+	assert.Equal(t, "nginx:1.0", updated.Spec.Template.Spec.Containers[0].Image)
+}
+
+func TestIsSandboxTemplateMatchPatch_AnnotationOnlyPatch(t *testing.T) {
+	newSandbox := func(annotations map[string]string) *agentsv1alpha1.Sandbox {
+		return &agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{Name: "sbx-1", Namespace: "default"},
+			Spec: agentsv1alpha1.SandboxSpec{
+				EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+					Template: &corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Annotations: annotations},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "main", Image: "nginx:1.0"},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	ops := &agentsv1alpha1.SandboxUpdateOps{
+		Spec: agentsv1alpha1.SandboxUpdateOpsSpec{
+			Patch: mustMarshalPatch(corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"agents.kruise.io/upgrade-marker": "v2"},
+				},
+			}),
+		},
+	}
+
+	assert.False(t, isSandboxTemplateMatchPatch(newSandbox(nil), ops),
+		"sandbox without the annotation needs an upgrade")
+	assert.True(t, isSandboxTemplateMatchPatch(newSandbox(map[string]string{"agents.kruise.io/upgrade-marker": "v2"}), ops),
+		"sandbox already carrying the annotation must be skipped")
+}

--- a/pkg/sandbox-manager/infra/sandboxcr/network_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/network_test.go
@@ -380,7 +380,7 @@ func TestUpdateSelectNetworkPolicy_RoundTrip(t *testing.T) {
 	assert.Nil(t, result.DenyOut)
 
 	// Simulate a legacy policy so the update verifies priority migration too.
-	sandboxID := utils.GetSandboxID(sbx)
+	sandboxID := sandboxid.Resolve(sbx)
 	tpList := &agentsv1alpha1.TrafficPolicyList{}
 	require.NoError(t, fc.List(t.Context(), tpList,
 		ctrlclient.InNamespace(sbx.Namespace),


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Two fixes for sandbox upgrades:

1. **Keep required containers from being deleted by ops template patch** (`pkg/controller/sandboxupdateops/patch.go`)
   An annotation-only `SandboxUpdateOps` patch was serialized with an empty containers slice, producing `"spec":{"containers":null}` in the strategic merge patch. The delete semantics of that field removed all existing containers from the sandbox pod template and blocked the upgrade. A new `sanitizeTemplatePatch` helper drops explicit nulls for fields a pod template can never drop before patching.

2. **Select checkpoint by ID when pod template delta is empty** (`pkg/controller/sandbox/core/checkpoint.go`)
   `GetCheckpointResumeData` only selected a checkpoint with a non-empty `PodTemplateDelta`, so checkpoints carrying a valid `checkpointId` but an empty delta were skipped and CheckpointRestore upgrades always failed with "checkpoint ID not found". A checkpoint is now selected when it carries either a delta or a checkpoint ID.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run unit tests: `go test ./pkg/controller/sandboxupdateops/... ./pkg/controller/sandbox/core/...`
2. Verification scenario 1: create a `SandboxUpdateOps` with an annotation-only template patch; verify the upgrade proceeds and existing containers are preserved.
3. Verification scenario 2: upgrade a paused sandbox via CheckpointRestore whose checkpoint has an empty `PodTemplateDelta` but a valid `checkpointId`; verify the upgrade no longer fails with "checkpoint ID not found".

### Ⅳ. Special notes for reviews

- `sanitizeTemplatePatch` returns the raw bytes unchanged when the patch carries no such nulls or cannot be parsed; parse errors are left to the strategic merge patch call which reports them.
- `containers` is required in a pod spec, so a null value can never be a legitimate delete request — it only appears when an empty PodSpec is marshaled into the patch.
- A sandbox holds at most one active checkpoint at a time, so selecting by "delta or ID" still resolves to a single checkpoint.
