### PR TITLE
fix(gateway): refresh the OIDC verifier so provider key rotation is picked up

### DIFF
--- a/pkg/sandbox-gateway/jwtauth/manager.go
+++ b/pkg/sandbox-gateway/jwtauth/manager.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package jwtauth manages process-wide initialization of the gateway JWT verifier.
+// Package jwtauth manages process-wide initialization and refresh of the
+// gateway JWT verifier.
 package jwtauth
 
 import (
@@ -35,6 +36,11 @@ import (
 const (
 	defaultInitialBackoff = time.Second
 	defaultMaxBackoff     = 30 * time.Second
+	// defaultRefreshInterval is how often a published verifier is rebuilt from
+	// the identity provider. A verifier holds an immutable JWKS snapshot, so
+	// without periodic refresh every token signed with a rotated key is
+	// rejected as an unknown kid until the process restarts.
+	defaultRefreshInterval = 10 * time.Minute
 )
 
 var (
@@ -68,13 +74,15 @@ type verifierHolder struct {
 	verifier oidc.Verifier
 }
 
-// Manager coordinates one-time, process-level OIDC verifier initialization.
+// Manager coordinates process-level OIDC verifier initialization and keeps the
+// published verifier refreshed so that provider key rotation is picked up.
 type Manager struct {
-	optionsSource  OptionsSource
-	loader         VerifierLoader
-	initialBackoff time.Duration
-	maxBackoff     time.Duration
-	wake           chan struct{}
+	optionsSource   OptionsSource
+	loader          VerifierLoader
+	initialBackoff  time.Duration
+	maxBackoff      time.Duration
+	refreshInterval time.Duration
+	wake            chan struct{}
 
 	state    atomic.Uint32
 	verifier atomic.Pointer[verifierHolder]
@@ -97,11 +105,23 @@ func NewManager() *Manager {
 	)
 }
 
-// NewManagerWithDependencies creates a manager with injectable dependencies.
+// NewManagerWithDependencies creates a manager with injectable dependencies and
+// the default verifier refresh interval.
 func NewManagerWithDependencies(
 	optionsSource OptionsSource,
 	loader VerifierLoader,
 	initialBackoff, maxBackoff time.Duration,
+) *Manager {
+	return newManager(optionsSource, loader, initialBackoff, maxBackoff, defaultRefreshInterval)
+}
+
+// newManager additionally takes the refresh interval so tests can exercise the
+// refresh loop without waiting for the production interval. A non-positive
+// interval disables refresh and keeps the first published verifier forever.
+func newManager(
+	optionsSource OptionsSource,
+	loader VerifierLoader,
+	initialBackoff, maxBackoff, refreshInterval time.Duration,
 ) *Manager {
 	if initialBackoff < 0 {
 		initialBackoff = 0
@@ -114,11 +134,12 @@ func NewManagerWithDependencies(
 	}
 
 	m := &Manager{
-		optionsSource:  optionsSource,
-		loader:         loader,
-		initialBackoff: initialBackoff,
-		maxBackoff:     maxBackoff,
-		wake:           make(chan struct{}, 1),
+		optionsSource:   optionsSource,
+		loader:          loader,
+		initialBackoff:  initialBackoff,
+		maxBackoff:      maxBackoff,
+		refreshInterval: refreshInterval,
+		wake:            make(chan struct{}, 1),
 	}
 	m.state.Store(uint32(AwaitingConfig))
 	return m
@@ -189,7 +210,8 @@ func (m *Manager) SetReader(reader client.Reader) error {
 	return nil
 }
 
-// Start waits for configuration and a reader, then retries verifier construction.
+// Start waits for configuration and a reader, retries verifier construction,
+// then keeps the published verifier refreshed until the context is canceled.
 func (m *Manager) Start(ctx context.Context) error {
 	m.mu.Lock()
 	if m.started {
@@ -235,41 +257,98 @@ func (m *Manager) loadUntilReady(ctx context.Context, reader client.Reader, opti
 		if ctx.Err() != nil {
 			return nil
 		}
-		if m.loader == nil {
-			m.recordFailure(ctx, errors.New("verifier loader is nil"))
-		} else {
-			verifier, err := m.loader(ctx, reader, options)
-			if err == nil && !isNilVerifier(verifier) {
-				m.verifier.Store(&verifierHolder{verifier: verifier})
-				m.mu.Lock()
-				m.lastFailure = nil
-				m.state.Store(uint32(Ready))
-				m.mu.Unlock()
-				<-ctx.Done()
-				return nil
-			}
-			if err == nil {
-				err = errors.New("verifier loader returned a nil verifier")
-			}
-			m.recordFailure(ctx, err)
+		verifier, err := m.load(ctx, reader, options)
+		if err == nil {
+			m.publish(verifier)
+			return m.refreshUntilDone(ctx, reader, options)
 		}
+		m.recordFailure(ctx, err, "failed to initialize traffic access token JWT verifier")
 
-		timer := time.NewTimer(backoff)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
+		if !m.sleep(ctx, backoff) {
 			return nil
-		case <-timer.C:
 		}
 		backoff = nextBackoff(backoff, m.maxBackoff)
 	}
 }
 
-func (m *Manager) recordFailure(ctx context.Context, err error) {
+// refreshUntilDone rebuilds the verifier every refresh interval so that a
+// rotated provider signing key is picked up without restarting the process.
+// A failed refresh keeps the last published verifier in place and is retried
+// with backoff, because stale keys still verify unrotated tokens.
+func (m *Manager) refreshUntilDone(ctx context.Context, reader client.Reader, options oidc.Options) error {
+	if m.refreshInterval <= 0 {
+		<-ctx.Done()
+		return nil
+	}
+
+	backoff := m.initialBackoff
+	wait := m.refreshInterval
+	for {
+		if !m.sleep(ctx, wait) {
+			return nil
+		}
+
+		verifier, err := m.load(ctx, reader, options)
+		if err != nil {
+			m.recordFailure(ctx, err, "failed to refresh traffic access token JWT verifier, keeping the current one")
+			// Retry sooner than the refresh interval while the provider is
+			// unavailable, but never spin when no backoff is configured.
+			wait = backoff
+			if wait <= 0 {
+				wait = m.refreshInterval
+			}
+			backoff = nextBackoff(backoff, m.maxBackoff)
+			continue
+		}
+
+		m.publish(verifier)
+		backoff = m.initialBackoff
+		wait = m.refreshInterval
+	}
+}
+
+// load builds a verifier and normalizes a nil verifier into an error.
+func (m *Manager) load(ctx context.Context, reader client.Reader, options oidc.Options) (oidc.Verifier, error) {
+	if m.loader == nil {
+		return nil, errors.New("verifier loader is nil")
+	}
+	verifier, err := m.loader(ctx, reader, options)
+	if err != nil {
+		return nil, err
+	}
+	if isNilVerifier(verifier) {
+		return nil, errors.New("verifier loader returned a nil verifier")
+	}
+	return verifier, nil
+}
+
+// publish installs the verifier for readers and marks the manager ready.
+func (m *Manager) publish(verifier oidc.Verifier) {
+	m.verifier.Store(&verifierHolder{verifier: verifier})
+	m.mu.Lock()
+	m.lastFailure = nil
+	m.state.Store(uint32(Ready))
+	m.mu.Unlock()
+}
+
+// sleep waits for the duration and reports whether it elapsed rather than the
+// context being canceled.
+func (m *Manager) sleep(ctx context.Context, duration time.Duration) bool {
+	timer := time.NewTimer(duration)
+	select {
+	case <-ctx.Done():
+		timer.Stop()
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func (m *Manager) recordFailure(ctx context.Context, err error, message string) {
 	m.mu.Lock()
 	m.lastFailure = err
 	m.mu.Unlock()
-	log.FromContext(ctx).Error(err, "failed to initialize traffic access token JWT verifier")
+	log.FromContext(ctx).Error(err, message)
 }
 
 func nextBackoff(current, maximum time.Duration) time.Duration {

--- a/pkg/sandbox-gateway/jwtauth/manager_test.go
+++ b/pkg/sandbox-gateway/jwtauth/manager_test.go
@@ -522,7 +522,87 @@ func TestManagerRetryAndPublication(t *testing.T) {
 			expectCalls := int32(len(tt.failedResults) + 1)
 			assert.Equal(t, expectCalls, calls.Load())
 			time.Sleep(20 * time.Millisecond)
-			assert.Equal(t, expectCalls, calls.Load(), "loader must not refresh after readiness")
+			assert.Equal(t, expectCalls, calls.Load(), "loader must not refresh before the refresh interval elapses")
+			stopManager(t, cancel, done)
+		})
+	}
+}
+
+func TestManagerRefresh(t *testing.T) {
+	rotated := &fakeVerifier{name: "rotated"}
+	tests := []struct {
+		name            string
+		refreshInterval time.Duration
+		refreshResult   func() (oidc.Verifier, error)
+		expectRefresh   bool
+		expectCurrent   func(initial oidc.Verifier) oidc.Verifier
+	}{
+		{
+			name:            "rotated keys are published without a restart",
+			refreshInterval: time.Millisecond,
+			refreshResult:   func() (oidc.Verifier, error) { return rotated, nil },
+			expectRefresh:   true,
+			expectCurrent:   func(oidc.Verifier) oidc.Verifier { return rotated },
+		},
+		{
+			name:            "failed refresh keeps the last published verifier",
+			refreshInterval: time.Millisecond,
+			refreshResult:   func() (oidc.Verifier, error) { return nil, errors.New("JWKS unavailable") },
+			expectRefresh:   true,
+			expectCurrent:   func(initial oidc.Verifier) oidc.Verifier { return initial },
+		},
+		{
+			name:            "nil verifier from refresh keeps the last published verifier",
+			refreshInterval: time.Millisecond,
+			refreshResult:   func() (oidc.Verifier, error) { return nil, nil },
+			expectRefresh:   true,
+			expectCurrent:   func(initial oidc.Verifier) oidc.Verifier { return initial },
+		},
+		{
+			name:            "non-positive interval disables refresh",
+			refreshInterval: 0,
+			refreshResult:   func() (oidc.Verifier, error) { return rotated, nil },
+			expectRefresh:   false,
+			expectCurrent:   func(initial oidc.Verifier) oidc.Verifier { return initial },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initial := &fakeVerifier{name: "initial"}
+			var calls atomic.Int32
+			manager := newManager(func() (oidc.Options, error) {
+				return testOptions("refresh"), nil
+			}, func(context.Context, client.Reader, oidc.Options) (oidc.Verifier, error) {
+				if calls.Add(1) == 1 {
+					return initial, nil
+				}
+				return tt.refreshResult()
+			}, time.Millisecond, time.Millisecond, tt.refreshInterval)
+			require.NoError(t, manager.Configure(true))
+			require.NoError(t, manager.SetReader(&fakeReader{name: "refresh"}))
+			cancel, done := startManager(t, manager)
+
+			waitForState(t, manager, Ready)
+			assert.NotNil(t, manager.Current())
+
+			if tt.expectRefresh {
+				// Wait for several refresh attempts so the failure cases below
+				// assert that repeated failures never drop the good verifier.
+				require.Eventually(t, func() bool {
+					return calls.Load() > 2
+				}, testTimeout, time.Millisecond, "verifier was never refreshed")
+			} else {
+				time.Sleep(20 * time.Millisecond)
+				assert.Equal(t, int32(1), calls.Load(), "refresh must stay disabled")
+			}
+
+			require.Eventually(t, func() bool {
+				return manager.Current() == tt.expectCurrent(initial)
+			}, testTimeout, time.Millisecond, "unexpected published verifier")
+			// A refresh must never revoke authentication that already works.
+			assert.NoError(t, manager.Ready())
+			assert.Equal(t, Ready, manager.State())
 			stopManager(t, cancel, done)
 		})
 	}

--- a/pkg/sandbox-gateway/jwtauth/rotation_test.go
+++ b/pkg/sandbox-gateway/jwtauth/rotation_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jwtauth
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openkruise/agents/pkg/identity/oidc"
+)
+
+const (
+	rotationIssuer      = "https://issuer.example"
+	rotationCANamespace = "identity-system"
+	rotationCAName      = "oidc-ca"
+)
+
+// TestManagerKeyRotation exercises the real OIDC loader against a JWKS endpoint
+// that rotates its signing key, which is the outage the refresh loop prevents:
+// without refresh, every token signed with the rotated key stays rejected as an
+// unknown kid until the process restarts.
+func TestManagerKeyRotation(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "rotated signing key is accepted without a restart"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldKey, oldJWK := rotationKey(t, "key-old")
+			newKey, newJWK := rotationKey(t, "key-new")
+
+			var mu sync.Mutex
+			published := []jose.JSONWebKey{oldJWK}
+			server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				switch request.URL.Path {
+				case "/discovery":
+					_, _ = fmt.Fprintf(response, `{"issuer":%q,"jwks_uri":%q}`,
+						rotationIssuer, "https://"+request.Host+"/jwks")
+				case "/jwks":
+					mu.Lock()
+					keys := published
+					mu.Unlock()
+					_ = json.NewEncoder(response).Encode(jose.JSONWebKeySet{Keys: keys})
+				default:
+					response.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			options := oidc.Options{
+				DiscoveryURL:         server.URL + "/discovery",
+				CAConfigMapNamespace: rotationCANamespace,
+				CAConfigMapName:      rotationCAName,
+			}
+			manager := newManager(func() (oidc.Options, error) {
+				return options, nil
+			}, oidc.NewVerifier, time.Millisecond, 5*time.Millisecond, 10*time.Millisecond)
+			require.NoError(t, manager.Configure(true))
+			require.NoError(t, manager.SetReader(rotationReader(t, server)))
+			cancel, done := startManager(t, manager)
+
+			waitForState(t, manager, Ready)
+			oldToken := rotationToken(t, oldKey, "key-old")
+			newToken := rotationToken(t, newKey, "key-new")
+
+			// Before rotation the provider's current key verifies and the
+			// not-yet-published key is rejected as an unknown kid.
+			_, err := manager.Current().Verify(oldToken)
+			require.NoError(t, err)
+			_, err = manager.Current().Verify(newToken)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unknown kid")
+
+			mu.Lock()
+			published = []jose.JSONWebKey{newJWK}
+			mu.Unlock()
+
+			require.Eventually(t, func() bool {
+				_, err := manager.Current().Verify(newToken)
+				return err == nil
+			}, testTimeout, time.Millisecond, "verifier never picked up the rotated signing key")
+			stopManager(t, cancel, done)
+		})
+	}
+}
+
+func rotationKey(t *testing.T, keyID string) (*ecdsa.PrivateKey, jose.JSONWebKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	return key, jose.JSONWebKey{
+		Key:       &key.PublicKey,
+		KeyID:     keyID,
+		Use:       "sig",
+		Algorithm: string(jose.ES256),
+	}
+}
+
+func rotationToken(t *testing.T, key *ecdsa.PrivateKey, keyID string) string {
+	t.Helper()
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: key},
+		(&jose.SignerOptions{}).WithHeader("kid", keyID),
+	)
+	require.NoError(t, err)
+	now := time.Now()
+	rawJWT, err := jwt.Signed(signer).Claims(map[string]interface{}{
+		"iss": rotationIssuer,
+		"sub": "sandbox-1",
+		"iat": now.Add(-time.Minute).Unix(),
+		"nbf": now.Add(-time.Minute).Unix(),
+		"exp": now.Add(time.Hour).Unix(),
+	}).Serialize()
+	require.NoError(t, err)
+	return rawJWT
+}
+
+func rotationReader(t *testing.T, server *httptest.Server) client.Reader {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: rotationCANamespace, Name: rotationCAName},
+		Data:       map[string]string{oidc.DefaultCAConfigMapKey: string(caPEM)},
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+}

--- a/pkg/sandbox-manager/infra/sandboxcr/network_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/network_test.go
@@ -380,7 +380,7 @@ func TestUpdateSelectNetworkPolicy_RoundTrip(t *testing.T) {
 	assert.Nil(t, result.DenyOut)
 
 	// Simulate a legacy policy so the update verifies priority migration too.
-	sandboxID := utils.GetSandboxID(sbx)
+	sandboxID := sandboxid.Resolve(sbx)
 	tpList := &agentsv1alpha1.TrafficPolicyList{}
 	require.NoError(t, fc.List(t.Context(), tpList,
 		ctrlclient.InNamespace(sbx.Namespace),


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

`oidc.NewVerifier` builds an **immutable** JWKS snapshot, and `jwtauth.Manager.loadUntilReady` published that snapshot exactly once and then blocked on `<-ctx.Done()` for the rest of the process lifetime:

```go
verifier, err := m.loader(ctx, reader, options)
if err == nil && !isNilVerifier(verifier) {
    m.verifier.Store(&verifierHolder{verifier: verifier})
    ...
    <-ctx.Done()   // never reloaded
    return nil
}
```

The verifier is registered as a long-lived `manager.Runnable` in the sandbox-gateway process (`cmd/sandbox-gateway/main.go` → `controller.StartManager` → `addJWTAuthManager`), so the key set it loaded at startup was the only key set it would ever use.

Once the identity provider rotates its signing key, every newly-issued traffic access token references a `kid` that is not in the startup snapshot and is rejected by `verifier.Verify` with `token references unknown kid`. Recovery requires restarting every gateway pod — routine, expected key rotation turns into an authentication outage.

This PR keeps rebuilding the verifier on a refresh interval (default 10m) after the first successful load and hot-swaps it through the `atomic.Pointer` that `Current()` already reads lock-free, so the request path is unaffected.

Behaviour on a failed refresh is deliberate: the last published verifier **stays in place**, the manager **stays `Ready`**, and the refresh is retried with the existing backoff. Stale keys still verify unrotated tokens, so a provider blip must never revoke authentication that currently works.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

```bash
go test ./pkg/sandbox-gateway/jwtauth/... -race -count=1
```

Two layers of tests were added, and **both were confirmed to fail against the pre-fix code** (by restoring the old publish-once-then-block behaviour) and pass with the fix:

1. `TestManagerKeyRotation` — end-to-end against a real `httptest` TLS JWKS endpoint using the production `oidc.NewVerifier` loader. It asserts the actual outage: a token signed with the not-yet-published key is first rejected with `unknown kid`, then the server rotates its key set, and the manager's verifier must accept the rotated token without a restart. Pre-fix result:

   ```
   --- FAIL: TestManagerKeyRotation/rotated_signing_key_is_accepted_without_a_restart
       Messages: verifier never picked up the rotated signing key
   ```

2. `TestManagerRefresh` — table-driven coverage of the manager's refresh contract: rotated keys are published; a failing refresh and a nil-verifier refresh both keep the last good verifier and keep the manager `Ready`; a non-positive interval disables refresh.

Also run: `go build ./...`, `go vet ./pkg/sandbox-gateway/... ./pkg/identity/...`, and the full `pkg/sandbox-gateway/...` + `pkg/identity/...` suites with `-race`. The timing-sensitive package was rerun with `-count=15 -race` to check for flakiness.

### Ⅳ. Special notes for reviews

- **No behaviour change on the request path.** Publication still goes through the existing `atomic.Pointer`; `Current()` is untouched.
- The refresh interval is a package constant (`defaultRefreshInterval = 10 * time.Minute`) rather than new configuration, to keep this a focused bug fix. `NewManagerWithDependencies` keeps its existing signature and delegates to an unexported `newManager` that takes the interval, which is the seam the tests use. Happy to promote it to an `OIDC_*` env var if reviewers prefer it configurable.
- `loadUntilReady` was factored into `load`/`publish`/`sleep` helpers so the initial-load and refresh loops share one code path; the nil-loader and nil-verifier errors reported through `Ready()` are unchanged.
- One existing assertion message in `TestManagerRetryAndPublication` was reworded (`loader must not refresh after readiness` → `...before the refresh interval elapses`). The assertion itself is unchanged and still passes, since the production interval is far longer than that test's window.
