### PR TITLE
fix: add SKI/AKI to self-signed leaf certs for Python 3.13+

### DIFF
--- a/hack/generate-certificates.sh
+++ b/hack/generate-certificates.sh
@@ -309,6 +309,8 @@ CN = ${PRIMARY_DOMAIN}
 basicConstraints = critical,CA:FALSE
 keyUsage = critical,digitalSignature,keyEncipherment
 extendedKeyUsage = serverAuth
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
 subjectAltName = @alt_names
 
 [alt_names]
@@ -358,6 +360,8 @@ emailAddress = optional
 basicConstraints = critical,CA:FALSE
 keyUsage = critical,digitalSignature,keyEncipherment
 extendedKeyUsage = serverAuth
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
 subjectAltName = @alt_names
 
 [alt_names]

--- a/hack/generate-certificates.sh
+++ b/hack/generate-certificates.sh
@@ -310,7 +310,6 @@ basicConstraints = critical,CA:FALSE
 keyUsage = critical,digitalSignature,keyEncipherment
 extendedKeyUsage = serverAuth
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer
 subjectAltName = @alt_names
 
 [alt_names]

--- a/hack/setup-local-registry.sh
+++ b/hack/setup-local-registry.sh
@@ -36,7 +36,15 @@ trap 'rm -rf "${TMPDIR}"' EXIT
 echo "==> Generating self-signed CA and server certificate..."
 
 # Generate CA key and certificate (SKI + CA basicConstraints so leaf AKI can resolve)
-cat > "${TMPDIR}/ca-ext.cnf" <<EOF
+cat > "${TMPDIR}/ca.conf" <<EOF
+[req]
+distinguished_name = dn
+x509_extensions = v3_ca
+prompt = no
+
+[dn]
+CN = e2e-registry-ca
+
 [v3_ca]
 basicConstraints = critical,CA:true
 keyUsage = critical,keyCertSign,cRLSign
@@ -46,8 +54,7 @@ EOF
 openssl genrsa -out "${TMPDIR}/ca.key" 2048 2>/dev/null
 openssl req -x509 -new -nodes -key "${TMPDIR}/ca.key" \
   -sha256 -days 365 -out "${TMPDIR}/ca.crt" \
-  -subj "/CN=e2e-registry-ca" \
-  -extfile "${TMPDIR}/ca-ext.cnf" -extensions v3_ca 2>/dev/null
+  -config "${TMPDIR}/ca.conf" 2>/dev/null
 
 # Generate server key and CSR
 openssl genrsa -out "${TMPDIR}/server.key" 2048 2>/dev/null

--- a/hack/setup-local-registry.sh
+++ b/hack/setup-local-registry.sh
@@ -35,11 +35,19 @@ trap 'rm -rf "${TMPDIR}"' EXIT
 
 echo "==> Generating self-signed CA and server certificate..."
 
-# Generate CA key and certificate
+# Generate CA key and certificate (SKI + CA basicConstraints so leaf AKI can resolve)
+cat > "${TMPDIR}/ca-ext.cnf" <<EOF
+[v3_ca]
+basicConstraints = critical,CA:true
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+EOF
+
 openssl genrsa -out "${TMPDIR}/ca.key" 2048 2>/dev/null
 openssl req -x509 -new -nodes -key "${TMPDIR}/ca.key" \
   -sha256 -days 365 -out "${TMPDIR}/ca.crt" \
-  -subj "/CN=e2e-registry-ca" 2>/dev/null
+  -subj "/CN=e2e-registry-ca" \
+  -extfile "${TMPDIR}/ca-ext.cnf" -extensions v3_ca 2>/dev/null
 
 # Generate server key and CSR
 openssl genrsa -out "${TMPDIR}/server.key" 2048 2>/dev/null
@@ -47,9 +55,14 @@ openssl req -new -key "${TMPDIR}/server.key" \
   -out "${TMPDIR}/server.csr" \
   -subj "/CN=${REGISTRY_HOST}" 2>/dev/null
 
-# Create server certificate with SAN
+# Leaf cert: SAN + server key usage + SKI/AKI for Python 3.13+ VERIFY_X509_STRICT
 cat > "${TMPDIR}/extfile.cnf" <<EOF
 [v3_req]
+basicConstraints = critical,CA:FALSE
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
 subjectAltName = DNS:${REGISTRY_HOST}
 EOF
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Python 3.13+ enables `VERIFY_X509_STRICT` in `ssl.create_default_context()`, which rejects leaf certificates that lack an Authority Key Identifier (`CERTIFICATE_VERIFY_FAILED: Missing Authority Key Identifier`).

This PR updates the local TLS cert scripts so leaf certificates explicitly include SKI/AKI:

- `hack/generate-certificates.sh`: add `subjectKeyIdentifier` to the CSR profile and `subjectKeyIdentifier` + `authorityKeyIdentifier` to the `[server]` signing extensions. Multi-domain SANs (repeated `-d`) are unchanged.
- `hack/setup-local-registry.sh`: generate a CA with SKI/`CA:true`, and sign the registry leaf with SAN + server key usage + SKI/AKI.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

```bash
# Multi-domain leaf must include AKI and both domain wildcards
bash hack/generate-certificates.sh -d a.example -d b.example -o /tmp/certs
openssl x509 -in /tmp/certs/fullchain.pem -noout -ext authorityKeyIdentifier,subjectAltName

# Python STRICT verify should succeed against the generated chain
python3 - <<'PY'
import ssl, socket, threading, http.server, time
ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
ctx.verify_mode = ssl.CERT_REQUIRED
ctx.check_hostname = True
ctx.load_verify_locations('/tmp/certs/ca-fullchain.pem')
ctx.verify_flags |= getattr(ssl, 'VERIFY_X509_STRICT', 0)
class H(http.server.BaseHTTPRequestHandler):
    def do_GET(self):
        self.send_response(200); self.end_headers(); self.wfile.write(b'ok')
    def log_message(self, *a): pass
httpd = http.server.HTTPServer(('127.0.0.1', 0), H)
sctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
sctx.load_cert_chain('/tmp/certs/fullchain.pem', '/tmp/certs/privkey.pem')
httpd.socket = sctx.wrap_socket(httpd.socket, server_side=True)
port = httpd.server_address[1]
threading.Thread(target=httpd.handle_request, daemon=True).start(); time.sleep(0.05)
with ctx.wrap_socket(socket.create_connection(('127.0.0.1', port)), server_hostname='a.example') as s:
    print('OK', s.version())
PY