### PR TITLE
fix(sandbox-manager): repair sandboxcr test build broken on master

### DIFF
--- a/pkg/sandbox-manager/infra/sandboxcr/network_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/network_test.go
@@ -380,7 +380,7 @@ func TestUpdateSelectNetworkPolicy_RoundTrip(t *testing.T) {
 	assert.Nil(t, result.DenyOut)
 
 	// Simulate a legacy policy so the update verifies priority migration too.
-	sandboxID := utils.GetSandboxID(sbx)
+	sandboxID := sandboxid.Resolve(sbx)
 	tpList := &agentsv1alpha1.TrafficPolicyList{}
 	require.NoError(t, fc.List(t.Context(), tpList,
 		ctrlclient.InNamespace(sbx.Namespace),


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

`master` currently does not compile, so `golangci-lint` and `unit-tests` fail on **every** pull request:

```
pkg/sandbox-manager/infra/sandboxcr/network_test.go:383:15: undefined: utils (typecheck)
```

`network_test.go` still calls `utils.GetSandboxID(sbx)`, but that helper no longer exists: #686 (`feat: short and stable sandbox IDs`) replaced it with the `pkg/sandboxid` package, and #740 (`fix(sandbox-manager): correct E2B traffic policy precedence`) landed a call site that was written before that rename. Neither PR conflicted textually, so the break only appeared once both were on `master`.

This replaces the stale call with `sandboxid.Resolve`, which is what the rest of the package already uses (`network.go` uses `s.GetSandboxID()`, backed by the same resolver). The `pkg/sandboxid` import is already present in the file, so this is a one-line change with no import churn.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

On `master` (9f59342), the package fails to build:

```bash
go vet ./pkg/sandbox-manager/infra/sandboxcr/
# vet: pkg/sandbox-manager/infra/sandboxcr/network_test.go:383:15: undefined: utils
```

With this change:

```bash
go vet ./pkg/sandbox-manager/infra/sandboxcr/          # clean
go test ./pkg/sandbox-manager/infra/sandboxcr/ -count=1 # ok, 22.9s
```

The test that owns the affected line, `TestUpdateNetworkPolicy` priority migration, passes — `sandboxid.Resolve(sbx)` returns the same ID the traffic-policy index is populated with, so the `MatchingFields` lookup still finds exactly one policy.

### Ⅳ. Special notes for reviews

- Test-only, one line, no production code touched.
- Worth merging ahead of other open PRs, since it unblocks CI repository-wide.
