### PR TITLE
test(identity): verify PS256 and EdDSA tokens in oidc verifier

### DIFF
--- a/pkg/identity/oidc/verifier_test.go
+++ b/pkg/identity/oidc/verifier_test.go
@@ -285,6 +285,7 @@ func TestVerifierVerify(t *testing.T) {
 						Key: &rsaKey.PublicKey, KeyID: "ps256", Algorithm: string(jose.PS256), Use: "sig",
 					},
 					"eddsa": {
+						// ed25519.PublicKey is a slice type; go-jose expects it by value, unlike RSA/ECDSA.
 						Key: ed25519PublicKey, KeyID: "eddsa", Algorithm: string(jose.EdDSA), Use: "sig",
 					},
 					"rsa-no-alg": {

--- a/pkg/identity/oidc/verifier_test.go
+++ b/pkg/identity/oidc/verifier_test.go
@@ -39,6 +39,8 @@ func TestVerifierVerify(t *testing.T) {
 	otherRSAKey := mustRSAKey(t)
 	ecdsaKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
+	ed25519PublicKey, ed25519PrivateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
 	now := time.Now().Truncate(time.Second)
 	issuer := "https://issuer.example"
 	validClaims := tokenClaims(now, issuer)
@@ -70,6 +72,18 @@ func TestVerifierVerify(t *testing.T) {
 			name: "valid ECDSA token",
 			rawJWT: func(t *testing.T) string {
 				return signToken(t, jose.ES256, ecdsaKey, "ecdsa", validClaims)
+			},
+		},
+		{
+			name: "valid PS256 token",
+			rawJWT: func(t *testing.T) string {
+				return signToken(t, jose.PS256, rsaKey, "ps256", validClaims)
+			},
+		},
+		{
+			name: "valid EdDSA token",
+			rawJWT: func(t *testing.T) string {
+				return signToken(t, jose.EdDSA, ed25519PrivateKey, "eddsa", validClaims)
 			},
 		},
 		{
@@ -266,6 +280,12 @@ func TestVerifierVerify(t *testing.T) {
 					},
 					"ecdsa": {
 						Key: &ecdsaKey.PublicKey, KeyID: "ecdsa", Algorithm: string(jose.ES256), Use: "sig",
+					},
+					"ps256": {
+						Key: &rsaKey.PublicKey, KeyID: "ps256", Algorithm: string(jose.PS256), Use: "sig",
+					},
+					"eddsa": {
+						Key: ed25519PublicKey, KeyID: "eddsa", Algorithm: string(jose.EdDSA), Use: "sig",
 					},
 					"rsa-no-alg": {
 						Key: &rsaKey.PublicKey, KeyID: "rsa-no-alg", Use: "sig",


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The `pkg/identity/oidc` verifier supports multiple JWT signature algorithms, including `PS256` and `EdDSA`. However, the end-to-end `TestVerifierVerify` test suite did not previously include positive verification cases for these two algorithms.

This PR adds positive verification coverage for both `PS256` and `EdDSA`.

The changes:
- Add Ed25519 key generation for the EdDSA test case.
- Add a positive PS256 token verification case using the existing RSA test key.
- Add a positive EdDSA token verification case using the generated Ed25519 key.
- Register the corresponding public keys in the test verifier's mock JWK set.

The changes are limited to `pkg/identity/oidc/verifier_test.go`. No production code, dependencies, or APIs are modified.

### Ⅱ. Does this pull request fix one issue?
NONE

### Ⅲ. Describe how to verify it
The following targeted checks were run successfully:
- `go test ./pkg/identity/oidc/...`
- `go test -race ./pkg/identity/oidc/...`
- `go vet ./pkg/identity/oidc/...`
- `gofmt` check on `pkg/identity/oidc/verifier_test.go`

### Ⅳ. Special notes for reviews
This is a test-only, additive change that reuses the existing table-driven test structure, `signToken` helper, RSA fixture, and claims.

No production code, dependencies, or APIs were modified.