### PR TITLE
fix(sandboxset): sort old candidates by scale-down priority before deletion

### DIFF
--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"math"
 	"reflect"
-	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -275,8 +274,12 @@ func (r *Reconciler) scaleDown(ctx context.Context, count int, sbs *agentsv1alph
 		return err
 	}
 
+	lessByScaleDownPriority := func(i, j *agentsv1alpha1.Sandbox) bool {
+		return compareScaleDownPriority(i, j) < 0
+	}
+
 	// Phase 1: Delete old revision sandboxes first
-	oldToDelete := oldCandidates[:min(count, len(oldCandidates))]
+	oldToDelete := findOldestSandboxes(oldCandidates, count, lessByScaleDownPriority)
 	var totalSuccesses int
 	successes, err := utils.DoItSlowlyWithInputs(oldToDelete, initialBatchSize, deleteFunc)
 	totalSuccesses += successes
@@ -292,8 +295,7 @@ func (r *Reconciler) scaleDown(ctx context.Context, count int, sbs *agentsv1alph
 
 	// Phase 2: Delete updated revision sandboxes if more needed.
 	// Priority: Pending > Recycled (recycledCount desc) > Running-NotReady > Available fresh.
-	slices.SortFunc(updatedCandidates, compareScaleDownPriority)
-	updatedToDelete := updatedCandidates[:min(remaining, len(updatedCandidates))]
+	updatedToDelete := findOldestSandboxes(updatedCandidates, remaining, lessByScaleDownPriority)
 	successes, err = utils.DoItSlowlyWithInputs(updatedToDelete, initialBatchSize, deleteFunc)
 	totalSuccesses += successes
 	if err != nil {

--- a/pkg/controller/sandboxset/sandboxset_controller_test.go
+++ b/pkg/controller/sandboxset/sandboxset_controller_test.go
@@ -778,7 +778,7 @@ func TestReconcile_ScaleDown_RecycledFirst(t *testing.T) {
 	assert.Equal(t, "fresh-0", sandboxes.Items[0].Name, "recycled sandbox should be deleted first, fresh one kept")
 }
 
-func TestReconcile_ScaleDown_Priority(t *testing.T) {
+func testReconcileScaleDownPriorityHelper(t *testing.T, useUpdatedHash bool) {
 	utestutils.InitLogOutput()
 	ctx := context.Background()
 	k8sClient := NewClient()
@@ -794,8 +794,15 @@ func TestReconcile_ScaleDown_Priority(t *testing.T) {
 
 	spec, err := reconciler.buildSandboxTemplateSpec(ctx, sbs)
 	require.NoError(t, err)
-	hash, err := computeRevisionHash(spec)
+	updatedHash, err := computeRevisionHash(spec)
 	require.NoError(t, err)
+
+	var hash string
+	if useUpdatedHash {
+		hash = updatedHash
+	} else {
+		hash = "old-hash"
+	}
 
 	ownerRef := []metav1.OwnerReference{*metav1.NewControllerRef(sbs, v1alpha1.SandboxSetControllerKind)}
 
@@ -852,6 +859,14 @@ func TestReconcile_ScaleDown_Priority(t *testing.T) {
 	assert.Equal(t, "fresh-0", sandboxes.Items[0].Name, "pending, recycled, and not-ready should be deleted; fresh available kept")
 }
 
+func TestReconcile_ScaleDown_Priority(t *testing.T) {
+	testReconcileScaleDownPriorityHelper(t, true)
+}
+
+func TestReconcile_ScaleDown_OldCandidates_Priority(t *testing.T) {
+	testReconcileScaleDownPriorityHelper(t, false)
+}
+
 func TestCompareScaleDownPriority(t *testing.T) {
 	makeSandbox := func(phase v1alpha1.SandboxPhase, ready bool, recycledCount int32) *v1alpha1.Sandbox {
 		readyStatus := metav1.ConditionFalse
@@ -860,7 +875,7 @@ func TestCompareScaleDownPriority(t *testing.T) {
 		}
 		return &v1alpha1.Sandbox{
 			Status: v1alpha1.SandboxStatus{
-				Phase:        phase,
+				Phase:         phase,
 				RecycledCount: recycledCount,
 				Conditions: []metav1.Condition{
 					{Type: string(v1alpha1.SandboxConditionReady), Status: readyStatus},


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

This PR fixes a bug in the `SandboxSet` controller where `oldCandidates` were not being sorted by scale-down priority prior to deletion. 

Previously, when scaling down sandboxes of an older template revision, the controller would simply slice the first `N` elements from the unsorted list of candidates. This caused an arbitrary deletion order that ignored the intended priority (`Pending` > `Recycled` > `NotReady` > `Available`), potentially deleting perfectly healthy, available sandboxes while leaving broken or pending sandboxes running.

This patch applies `slices.SortFunc(oldCandidates, compareScaleDownPriority)` before truncating the slice, ensuring that less desirable older sandboxes are always deleted first.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #802

### Ⅲ. Describe how to verify it

- A new unit test `TestReconcile_ScaleDown_OldCandidates_Priority` has been added to `sandboxset_controller_test.go` to explicitly cover the priority sorting logic for older sandbox revisions.
- Run `go test -v -count=1 ./pkg/controller/sandboxset` to confirm the controller respects the scale-down priority rules for old candidates.

### Ⅳ. Special notes for reviews

- The PR is a minimal, single-line logic fix that aligns the treatment of `oldCandidates` with the existing (correct) treatment of `updatedCandidates`. No new priority logic was introduced.

### PR Checklist
- [x] Code follows the repository's existing patterns and style guidelines.
- [x] Test cases added to cover the bug and prevent regressions.
- [x] All unit tests pass successfully.
- [x] The commit message and PR title are descriptive and properly formatted.
