### PR TITLE
test(storage): add AgenticBucket/BucketSpace tests 

### DIFF
--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -2938,6 +2938,107 @@ func TestBuildClaimOptions_CSIMount_Test(t *testing.T) {
 			},
 		},
 		{
+			name: "CSI mount with bucketSpacePrefix and region injects storage-auth annotation with agentic bucket attributes",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim-csi-agentic-bucket",
+					Namespace: "default",
+					UID:       "test-uid-agentic-bucket",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "test-template",
+					DynamicVolumesMount: []agentsv1alpha1.CSIMountConfig{
+						{
+							PvName:    "test-pv-nas",
+							MountPath: "/data",
+							SubPath:   "user-data",
+							Attributes: map[string]string{
+								"credentialProviderName": "oss-bs-rw",
+								"bucketSpacePrefix":      "sandbox-a",
+								"region":                 "cn-hangzhou",
+							},
+						},
+					},
+				},
+			},
+			setup: func(t *testing.T) {
+				origHook := csiutils.BuildStorageAuthAnnotation
+				t.Cleanup(func() { csiutils.BuildStorageAuthAnnotation = origHook })
+				csiutils.BuildStorageAuthAnnotation = func(_ context.Context, _ client.Client, mounts []agentsv1alpha1.CSIMountConfig) (string, string, error) {
+					type storageAuthItem struct {
+						CredentialProviderName string            `json:"credentialProviderName"`
+						Attributes             map[string]string `json:"attributes,omitempty"`
+					}
+					var items []storageAuthItem
+					for _, m := range mounts {
+						if cpName, ok := m.Attributes["credentialProviderName"]; ok {
+							attrs := map[string]string{}
+							if m.SubPath != "" {
+								attrs["sub-path"] = m.SubPath
+							}
+							if bs := m.Attributes["bucketSpace"]; bs != "" {
+								attrs["bucket-space-name"] = bs
+							} else if bsp := m.Attributes["bucketSpacePrefix"]; bsp != "" {
+								attrs["bucket-space-prefix"] = bsp
+								if r := m.Attributes["region"]; r != "" {
+									attrs["region"] = r
+								}
+							}
+							items = append(items, storageAuthItem{
+								CredentialProviderName: cpName,
+								Attributes:             attrs,
+							})
+						}
+					}
+					if len(items) == 0 {
+						return "", "", nil
+					}
+					data, err := json.Marshal(items)
+					if err != nil {
+						return "", "", err
+					}
+					return "security.agents.kruise.io/storage-auth", string(data), nil
+				}
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-template",
+					Namespace: "default",
+				},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Runtimes: []agentsv1alpha1.RuntimeConfig{
+						{Name: agentsv1alpha1.RuntimeConfigForInjectAgentRuntime},
+					},
+				},
+			},
+			expectError:        false,
+			expectedMountCount: 1,
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				require.NotNil(t, opts.CSIMount, "CSIMount should not be nil")
+				mockSandbox := &sandboxcr.Sandbox{
+					Sandbox: &agentsv1alpha1.Sandbox{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-sandbox",
+							Namespace: "default",
+						},
+					},
+				}
+				opts.Modifier(mockSandbox)
+				storageAuthVal := mockSandbox.GetAnnotations()["security.agents.kruise.io/storage-auth"]
+				assert.NotEmpty(t, storageAuthVal, "storage-auth annotation should be injected")
+				var items []map[string]interface{}
+				err := json.Unmarshal([]byte(storageAuthVal), &items)
+				require.NoError(t, err, "storage-auth should be valid JSON")
+				assert.Len(t, items, 1, "Expected 1 storage auth item")
+				assert.Equal(t, "oss-bs-rw", items[0]["credentialProviderName"], "credentialProviderName mismatch")
+				attrs, ok := items[0]["attributes"].(map[string]interface{})
+				require.True(t, ok, "attributes should be a map")
+				assert.Equal(t, "sandbox-a", attrs["bucket-space-prefix"], "bucket-space-prefix attribute mismatch")
+				assert.Equal(t, "cn-hangzhou", attrs["region"], "region attribute mismatch")
+				assert.Equal(t, "user-data", attrs["sub-path"], "sub-path attribute mismatch")
+			},
+		},
+		{
 			name: "CSI mount without credentialProviderName attribute does NOT inject storage-auth annotation",
 			claim: &agentsv1alpha1.SandboxClaim{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -395,6 +395,52 @@ func TestCreateSandboxWithClaim_CSIMount(t *testing.T) {
 			expectCSIMount:     true,
 			expectedMountCount: 1,
 		},
+		{
+			name: "csi mount with bucketSpace attribute for AgenticBucket",
+			request: models.NewSandboxRequest{
+				TemplateID: "test-template",
+				Extensions: models.NewSandboxRequestExtension{
+					CSIMount: models.CSIMountExtension{
+						MountConfigs: []v1alpha1.CSIMountConfig{
+							{
+								PvName:    "pv-oss-agentic",
+								MountPath: "/data",
+								Attributes: map[string]string{
+									"credentialProviderName": "oss-bs-rw",
+									"bucketSpace":            "my-space-xxx-bs-apsr",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectCSIMount:     true,
+			expectedMountCount: 1,
+		},
+		{
+			name: "csi mount with bucketSpacePrefix and region for AgenticBucket",
+			request: models.NewSandboxRequest{
+				TemplateID: "test-template",
+				Extensions: models.NewSandboxRequestExtension{
+					CSIMount: models.CSIMountExtension{
+						MountConfigs: []v1alpha1.CSIMountConfig{
+							{
+								PvName:    "pv-oss-agentic",
+								MountPath: "/data",
+								SubPath:   "user-data",
+								Attributes: map[string]string{
+									"credentialProviderName": "oss-bs-rw",
+									"bucketSpacePrefix":      "sandbox-a",
+									"region":                 "cn-hangzhou",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectCSIMount:     true,
+			expectedMountCount: 1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/utils/csiutils/storages_provider_test.go
+++ b/pkg/utils/csiutils/storages_provider_test.go
@@ -1156,6 +1156,64 @@ func TestGenerateNodePublishVolumeRequest_NodePublishVolumeEnricher_KmsKeyId(t *
 	assert.Equal(t, "agent-identity", capturedAttrs["authType"])
 }
 
+func TestGenerateNodePublishVolumeRequest_NodePublishVolumeEnricher_AgenticBucket(t *testing.T) {
+	ctx := context.Background()
+	initObjs := []client.Object{
+		&corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: "pv-enricher-agentic-test"},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					CSI: &corev1.CSIPersistentVolumeSource{
+						Driver: "nas-driver",
+						VolumeAttributes: map[string]string{
+							"authType":      "agent-identity",
+							"agenticBucket": "my-agentic-xxx-ab-apsr",
+						},
+					},
+				},
+			},
+		},
+	}
+	c, _, err := cachetest.NewTestCache(t, initObjs...)
+	require.NoError(t, err)
+
+	registry := &mockStorageProviderRegistry{
+		supportedDrivers: map[string]bool{"nas-driver": true},
+		providers:        map[string]storages.VolumeMountProvider{"nas-driver": &mockVolumeMountProvider{}},
+	}
+	handler := NewCSIMountHandler(c.GetClient(), c.GetAPIReader(), registry, utils.DefaultSandboxDeployNamespace)
+
+	saved := NodePublishVolumeEnricher
+	var capturedAttrs map[string]string
+	NodePublishVolumeEnricher = func(_ context.Context, req v1alpha1.CSIMountConfig, volumeAttributes map[string]string) {
+		if bucketSpace := req.Attributes["bucketSpace"]; bucketSpace != "" {
+			volumeAttributes["bucketSpace"] = bucketSpace
+		} else if bucketSpacePrefix := req.Attributes["bucketSpacePrefix"]; bucketSpacePrefix != "" {
+			volumeAttributes["bucketSpacePrefix"] = bucketSpacePrefix
+		}
+		if region := req.Attributes["region"]; region != "" {
+			volumeAttributes["region"] = region
+		}
+		capturedAttrs = volumeAttributes
+	}
+	t.Cleanup(func() { NodePublishVolumeEnricher = saved })
+
+	_, csiReq, err := handler.GenerateNodePublishVolumeRequest(ctx, v1alpha1.CSIMountConfig{
+		PvName:    "pv-enricher-agentic-test",
+		MountPath: "/mnt/data",
+		Attributes: map[string]string{
+			"bucketSpacePrefix": "sandbox-a",
+			"region":            "cn-hangzhou",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, csiReq)
+	assert.Equal(t, "sandbox-a", capturedAttrs["bucketSpacePrefix"])
+	assert.Equal(t, "cn-hangzhou", capturedAttrs["region"])
+	assert.Equal(t, "agent-identity", capturedAttrs["authType"])
+	assert.Equal(t, "my-agentic-xxx-ab-apsr", capturedAttrs["agenticBucket"])
+}
+
 func TestMergeAndValidatePaths(t *testing.T) {
 	tests := []struct {
 		name                   string


### PR DESCRIPTION

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
Add test coverage for AgenticBucket/BucketSpace support:

- storages_provider_test: NodePublishVolumeEnricher with agenticBucket attributes
- common_control_test: CSI mount with bucketSpacePrefix and region storage-auth
- create_test: E2B create with bucketSpace/bucketSpacePrefix attributes

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

