### PR TITLE
fix(proxy): ignore reserved keys in the untrusted header modifier

### DIFF
--- a/pkg/proxy/ext_proc.go
+++ b/pkg/proxy/ext_proc.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -93,6 +94,14 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 }
 
 var OrigDstHeader = "x-envoy-original-dst-host"
+
+const (
+	// requestHeaderModifier is the request header carrying extra header mutations
+	// as a JSON object. Its content is downstream input and never authoritative.
+	requestHeaderModifier = "request-header-modifier"
+	// envoyHeaderPrefix is the header namespace Envoy reserves for itself.
+	envoyHeaderPrefix = "x-envoy-"
+)
 
 func (s *Server) handleRequestHeaders(requestHeaders *extProcPb.ProcessingRequest_RequestHeaders, log logr.Logger) *extProcPb.ProcessingResponse {
 	// Step 1: Convert ext_proc headers to flat map[string]string
@@ -167,7 +176,7 @@ func (s *Server) logAndCreateDstResponse(requestHeaders *extProcPb.HttpHeaders,
 	}
 	resp.Response.(*extProcPb.ProcessingResponse_RequestHeaders).RequestHeaders.Response.HeaderMutation.SetHeaders = append(
 		resp.Response.(*extProcPb.ProcessingResponse_RequestHeaders).RequestHeaders.Response.HeaderMutation.SetHeaders,
-		headerModifiers("request-header-modifier", requestHeaders, log)...)
+		headerModifiers(requestHeaderModifier, requestHeaders, extraHeaders, log)...)
 	return resp
 }
 
@@ -196,7 +205,14 @@ func extProcHeadersToMap(httpHeaders *extProcPb.HttpHeaders) map[string]string {
 	return headers
 }
 
-func headerModifiers(key string, in *extProcPb.HttpHeaders, log logr.Logger) []*configPb.HeaderValueOption {
+// headerModifiers builds the header mutations requested through the modifier
+// header carried by the request. That header comes from the downstream client,
+// so the mutations it asks for are untrusted: reservedHeaderModifierKey drops
+// every key that would let a client redirect its own request or forge a header
+// Envoy considers trusted. reserved holds the headers this filter derived from
+// the route, which always win over a client request.
+func headerModifiers(key string, in *extProcPb.HttpHeaders, reserved map[string]string,
+	log logr.Logger) []*configPb.HeaderValueOption {
 	var modifiers []*configPb.HeaderValueOption
 	value := ""
 	for _, header := range in.Headers.Headers {
@@ -211,7 +227,12 @@ func headerModifiers(key string, in *extProcPb.HttpHeaders, log logr.Logger) []*
 			log.Error(err, "failed to unmarshall header-modifier", "value", value)
 			return modifiers
 		}
+		var rejected []string
 		for k, v := range unmarshalled {
+			if reservedHeaderModifierKey(k, reserved) {
+				rejected = append(rejected, k)
+				continue
+			}
 			modifiers = append(modifiers, &configPb.HeaderValueOption{
 				Header: &configPb.HeaderValue{
 					Key:      k,
@@ -219,6 +240,26 @@ func headerModifiers(key string, in *extProcPb.HttpHeaders, log logr.Logger) []*
 				},
 			})
 		}
+		if len(rejected) > 0 {
+			log.Info("rejected reserved keys in header-modifier", "keys", rejected)
+		}
 	}
 	return modifiers
+}
+
+// reservedHeaderModifierKey reports whether key must not be settable through the
+// modifier header: the routing and other headers this filter derives itself,
+// HTTP/2 pseudo-headers, Host, and the x-envoy- namespace that Envoy strips
+// from untrusted downstream requests but honors from this filter.
+func reservedHeaderModifierKey(key string, reserved map[string]string) bool {
+	if _, ok := reserved[key]; ok {
+		return true
+	}
+	lower := strings.ToLower(key)
+	if _, ok := reserved[lower]; ok {
+		return true
+	}
+	return strings.HasPrefix(lower, ":") ||
+		strings.HasPrefix(lower, envoyHeaderPrefix) ||
+		lower == "host"
 }

--- a/pkg/proxy/ext_proc_test.go
+++ b/pkg/proxy/ext_proc_test.go
@@ -26,6 +26,7 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	types "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -617,6 +618,117 @@ func TestServer_Process(t *testing.T) {
 						}
 					}
 				}
+			}
+		})
+	}
+}
+
+// TestHandleRequestHeaders_RequestHeaderModifier verifies that the
+// request-header-modifier header, which is supplied by the untrusted downstream
+// client, cannot override the routing decision made by the proxy and cannot
+// inject headers Envoy treats as trusted.
+func TestHandleRequestHeaders_RequestHeaderModifier(t *testing.T) {
+	const routeDst = "192.168.1.10:8080"
+
+	tests := []struct {
+		name           string
+		modifier       string
+		adapterHeaders map[string]string
+		expectHeaders  map[string]string
+	}{
+		{
+			name:          "routing header cannot be overridden",
+			modifier:      `{"x-envoy-original-dst-host":"10.0.0.9:9999"}`,
+			expectHeaders: map[string]string{OrigDstHeader: routeDst},
+		},
+		{
+			name:          "other envoy headers are dropped",
+			modifier:      `{"x-envoy-internal":"true","x-envoy-upstream-rq-timeout-ms":"1"}`,
+			expectHeaders: map[string]string{OrigDstHeader: routeDst},
+		},
+		{
+			name:          "pseudo headers are dropped",
+			modifier:      `{":path":"/admin",":authority":"internal.svc"}`,
+			expectHeaders: map[string]string{OrigDstHeader: routeDst},
+		},
+		{
+			name:          "host is dropped",
+			modifier:      `{"Host":"internal.svc"}`,
+			expectHeaders: map[string]string{OrigDstHeader: routeDst},
+		},
+		{
+			name:           "adapter headers cannot be overridden",
+			modifier:       `{"x-sandbox-port":"22"}`,
+			adapterHeaders: map[string]string{"x-sandbox-port": "8080"},
+			expectHeaders:  map[string]string{OrigDstHeader: routeDst, "x-sandbox-port": "8080"},
+		},
+		{
+			name:          "benign headers are preserved",
+			modifier:      `{"x-trace-id":"abc"}`,
+			expectHeaders: map[string]string{OrigDstHeader: routeDst, "x-trace-id": "abc"},
+		},
+		{
+			name:          "malformed payload is ignored",
+			modifier:      `not-json`,
+			expectHeaders: map[string]string{OrigDstHeader: routeDst},
+		},
+		{
+			name:          "absent header keeps routing intact",
+			expectHeaders: map[string]string{OrigDstHeader: routeDst},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := NewServer(config.SandboxManagerOptions{ExtProcMaxConcurrency: 1000})
+			server.SetRequestAdapter(&testRequestAdapter{
+				isSandboxRequest: true,
+				entry:            "127.0.0.1:8080",
+				mapResult: mapResult{
+					sandboxID:    "sandbox1",
+					sandboxPort:  8080,
+					extraHeaders: tt.adapterHeaders,
+				},
+			})
+			server.SetRoute(sandboxroute.Route{
+				ID:              "sandbox1",
+				IP:              "192.168.1.10",
+				Namespace:       "ns",
+				Name:            "sandbox1",
+				UID:             k8stypes.UID("uid-sandbox1"),
+				ResourceVersion: "1",
+				State:           agentsv1alpha1.SandboxStateRunning,
+			})
+
+			headers := []*corev3.HeaderValue{
+				{Key: ":scheme", RawValue: []byte("http")},
+				{Key: ":authority", RawValue: []byte("localhost:9002")},
+				{Key: ":path", RawValue: []byte("/sandbox")},
+			}
+			if tt.modifier != "" {
+				headers = append(headers, &corev3.HeaderValue{
+					Key:      "request-header-modifier",
+					RawValue: []byte(tt.modifier),
+				})
+			}
+
+			resp := server.handleRequestHeaders(&extProcPb.ProcessingRequest_RequestHeaders{
+				RequestHeaders: &extProcPb.HttpHeaders{Headers: &corev3.HeaderMap{Headers: headers}},
+			}, logr.Discard())
+
+			headersResp, ok := resp.Response.(*extProcPb.ProcessingResponse_RequestHeaders)
+			if !ok {
+				t.Fatalf("expect a RequestHeaders response, got %T", resp.Response)
+			}
+			got := map[string][]string{}
+			for _, h := range headersResp.RequestHeaders.Response.HeaderMutation.SetHeaders {
+				got[h.Header.Key] = append(got[h.Header.Key], string(h.Header.RawValue))
+			}
+			assert.Len(t, got, len(tt.expectHeaders))
+			for key, want := range tt.expectHeaders {
+				// A duplicated key leaves the effective value up to Envoy, so a
+				// single mutation per key is part of the contract.
+				assert.Equal(t, []string{want}, got[key], "header %s", key)
 			}
 		})
 	}


### PR DESCRIPTION
## What

`headerModifiers` in the ext-proc data plane reads the `request-header-modifier`
request header, unmarshals it as a JSON object, and emits every key/value as an
ext-proc `SetHeaders` mutation. That header arrives on the downstream request, so
its content is client input, but the mutations built from it were unrestricted.

Two things make those mutations privileged in the shipped configuration
(`config/sandbox-manager/envoy-config.yaml`):

- `mutation_rules: allow_envoy: true`, so this filter may set `x-envoy-*` headers
  that Envoy strips from untrusted downstream requests
- `sbx_original_dst_cluster` is `ORIGINAL_DST` with `use_http_header: true`, so
  the upstream is resolved from `x-envoy-original-dst-host` — the same header
  `handleRequestHeaders` sets from the resolved route

So a client could ask for the routing header itself and reach an address the
proxy never selected, bypassing the sandbox-ID-to-IP mapping and the
`State != Running` check; forge other `x-envoy-*` headers; or replace headers the
adapter derived, such as a rewritten `:path`. The modifier mutations were also
appended after the route-derived ones, leaving the effective value up to Envoy's
set-header semantics.

Nothing in the repository sets `request-header-modifier`, and it had no test
coverage, so the only source reaching this code is the client request.

The standalone gateway data plane (`pkg/sandbox-gateway/filter`) has no
equivalent path and is unaffected.

## How

`headerModifiers` now rejects reserved keys while building the mutations:

- headers this filter already derived from the route or the adapter
- HTTP/2 pseudo-headers (`:path`, `:authority`, ...)
- `Host`
- the `x-envoy-` namespace

Any other key keeps working exactly as before. Rejected keys are logged.

## Testing

`TestHandleRequestHeaders_RequestHeaderModifier` covers routing-header override,
other `x-envoy-*` keys, pseudo-headers, `Host`, adapter-derived headers, a benign
key, malformed JSON, and the absent header. Five of its cases fail on the current
code and pass with this change.

```
go test ./pkg/proxy/... -count=1 -race     # ok
go test ./pkg/sandbox-gateway/... ./pkg/sandboxroute/... -count=1   # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
