### PR TITLE
fix(discovery): stop retrying a kind discovery reported absent

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -17,6 +17,7 @@ limitations under the License.
 package discovery
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	clientdiscovery "k8s.io/client-go/discovery"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
@@ -52,10 +54,16 @@ func DiscoverGVK(gvk schema.GroupVersionKind) bool {
 	if genericClient == nil {
 		return false
 	}
-	discoveryClient := genericClient.DiscoveryClient
+	return discoverGVKWithClient(genericClient.DiscoveryClient, gvk)
+}
 
+func discoverGVKWithClient(discoveryClient clientdiscovery.DiscoveryInterface, gvk schema.GroupVersionKind) bool {
 	startTime := time.Now()
-	err := retry.OnError(backOff, func(err error) bool { return true }, func() error {
+	// errKindNotFound means discovery answered and the kind is absent, which no
+	// amount of retrying can change. Retry only the errors that reaching the API
+	// server can still resolve, so an uninstalled optional CRD is reported at
+	// once instead of after the whole backoff.
+	err := retry.OnError(backOff, func(err error) bool { return !errors.Is(err, errKindNotFound) }, func() error {
 		resourceList, err := discoveryClient.ServerResourcesForGroupVersion(gvk.GroupVersion().String())
 		if err != nil {
 			return err
@@ -69,7 +77,7 @@ func DiscoverGVK(gvk schema.GroupVersionKind) bool {
 	})
 
 	if err != nil {
-		if err == errKindNotFound {
+		if errors.Is(err, errKindNotFound) {
 			klog.InfoS("Not found kind in group version", "kind", gvk.Kind, "groupVersion", gvk.GroupVersion().String(), "cost", time.Since(startTime))
 			return false
 		}

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/openkruise/agents/api/v1alpha1"
+)
+
+func TestDiscoverGVKRetriesOnlyRecoverableErrors(t *testing.T) {
+	gvk := v1alpha1.GroupVersion.WithKind("TrafficPolicy")
+	groupVersion := gvk.GroupVersion().String()
+
+	tests := []struct {
+		name string
+		// resources is what the API server reports for the group version. Omitting
+		// the group version makes the fake return an error, standing in for a
+		// discovery failure the caller may still recover from.
+		resources []*metav1.APIResourceList
+		want      bool
+		wantCalls int
+	}{
+		{
+			name: "kind present is discovered in one call",
+			resources: []*metav1.APIResourceList{{
+				GroupVersion: groupVersion,
+				APIResources: []metav1.APIResource{{Kind: gvk.Kind}},
+			}},
+			want:      true,
+			wantCalls: 1,
+		},
+		{
+			// Discovery answered and the kind is absent, so the answer cannot
+			// change; retrying would only delay an uninstalled optional CRD.
+			name: "absent kind is reported without retrying",
+			resources: []*metav1.APIResourceList{{
+				GroupVersion: groupVersion,
+				APIResources: []metav1.APIResource{{Kind: "SomeOtherKind"}},
+			}},
+			want:      false,
+			wantCalls: 1,
+		},
+		{
+			// Discovery failure keeps its existing retry-then-fail-open
+			// behavior: this fix narrows only the absent-kind case.
+			name:      "failed discovery is retried",
+			resources: nil,
+			want:      true,
+			wantCalls: backOff.Steps,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Keep the retried case from sleeping out the production backoff.
+			restore := backOff
+			backOff = wait.Backoff{Steps: restore.Steps, Duration: time.Millisecond}
+			defer func() { backOff = restore }()
+
+			calls := 0
+			client := &fakediscovery.FakeDiscovery{Fake: &k8stesting.Fake{Resources: tt.resources}}
+			client.PrependReactor("*", "*", func(k8stesting.Action) (bool, runtime.Object, error) {
+				calls++
+				return false, nil, nil
+			})
+
+			if got := discoverGVKWithClient(client, gvk); got != tt.want {
+				t.Errorf("discoverGVKWithClient() = %v, want %v", got, tt.want)
+			}
+			if calls != tt.wantCalls {
+				t.Errorf("discovery calls = %d, want %d", calls, tt.wantCalls)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

**Reported problem** — *DiscoverGVK retries unconditionally, including non-transient errors* (`pkg/discovery/discovery.go:58`):

> `retry.OnError`'s retry predicate always returns true, so errors that can never succeed still consume the full retry budget with backoff, wasting time on calls that cannot possibly succeed.

**What happens today**

The clearest case is the package's own `errKindNotFound` sentinel. `DiscoverGVK` returns it from inside the retried closure when the API server answered successfully and the requested kind was simply not in the returned resource list.

- Expected: a definitive "kind is absent" answer returns immediately.
- Actual: the sentinel is handed back to the always-true predicate and retried. With `Steps: 4, Duration: 500ms, Factor: 5.0` that is four discovery calls and about 16s of backoff before the lookup reports the kind absent.

This is a real cost rather than a theoretical one, because an absent kind is a supported configuration. `BuildCacheConfig` treats `TrafficPolicy` as optional and skips its informer when the CRD is not discovered, and controller `Add` functions skip registration when their own kind is absent. Both run during startup, so the delay lands on the startup path.

**Root cause**

The retried closure signals two different outcomes through the same error return: a genuine discovery failure, and `errKindNotFound`, which is a successful discovery result meaning "the kind is not served". The predicate `func(err error) bool { return true }` cannot tell them apart, so it retries a definitive answer that no further call can change.

**Fix**

Exclude the sentinel from the retry predicate:

```go
retry.OnError(backOff, func(err error) bool { return !errors.Is(err, errKindNotFound) }, ...)
```

`errKindNotFound` now ends the retry loop on the first attempt, which is what makes the absent-kind lookup return immediately. Every other discovery error keeps its existing retry-then-fail-open behavior. `errors.Is` is used so a wrapped sentinel is still classified correctly.

### Ⅱ. Does this pull request fix one issue?

No GitHub issue tracks this. The problem was identified in a code audit of the control plane as:

**DiscoverGVK retries unconditionally, including non-transient errors** — `retry.OnError`'s retry predicate always returns true, so errors that can never succeed still consume the full retry budget with backoff.

The audit suggested two changes: return immediately for non-retryable errors, and retry only transient/network errors. This PR implements the first for `errKindNotFound`, which is unambiguously non-retryable and measurably costly on the startup path. It deliberately does not implement transient-error classification for API server errors such as permission failures, since deciding which of those are permanently non-retryable is a behavior change better made with maintainer input. Those errors are unaffected by this PR and still consume the full budget.

### Ⅲ. Describe how to verify it

```
go test ./pkg/discovery/ -race
```

A table-driven test injects a discovery client and asserts the call count for each outcome:

| Case | Expected calls | Expected result |
|---|---|---|
| Kind present | 1 | `true` |
| Kind absent | 1 | `false` |
| Discovery failure | `backOff.Steps` | `true` |

The absent-kind row is what proves the reported problem is gone: it asserts a single discovery call, and against the previous predicate it fails with `discovery calls = 4, want 1`. The other two rows pass both before and after, showing the change is confined to the absent-kind path.

Run on this branch, all passing: `make test` (full `pkg/...` suite with `-race`, 90 packages), `go build ./...`, `go vet ./...`, `gofmt -l pkg/discovery/`, and `golangci-lint run pkg/discovery/...` (0 issues).

### Ⅳ. Special notes for reviews

Behavior change: previously an absent kind was retried through the configured backoff, so if the CRD appeared during that window a later attempt could discover it. Now the result is returned as soon as discovery reports the kind absent.

`DiscoverGVK` is called during startup rather than as an ongoing watch, and `BuildCacheConfig` documents the absent-CRD case as expected rather than exceptional, so returning the answer immediately fits how the lookup is used.
