### PR TITLE
fix(webhook): webhook registration for sandboxtemplate

### DIFF
--- a/pkg/webhook/sandboxset/validating/sandboxset_create_update.go
+++ b/pkg/webhook/sandboxset/validating/sandboxset_create_update.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"strings"
 
-	apicorev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
@@ -124,59 +123,17 @@ func validateSandboxSetSpec(spec agentsv1alpha1.SandboxSetSpec, fldPath *field.P
 
 func validateSandboxSetPodTemplateSpec(spec agentsv1alpha1.SandboxSetSpec, fldPath *field.Path) field.ErrorList {
 	errList := field.ErrorList{}
+	template := spec.Template.DeepCopy()
 	coreTemplate := &core.PodTemplateSpec{}
 
-	if err := corev1conv.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(spec.Template.DeepCopy(), coreTemplate, nil); err != nil {
+	if len(spec.VolumeClaimTemplates) != 0 {
+		errList = append(errList, webhookutils.ValidateVolumeClaimTemplateMounts(spec.Template, spec.VolumeClaimTemplates, fldPath)...)
+		webhookutils.AppendVolumeClaimTemplateVolumes(template, spec.VolumeClaimTemplates)
+	}
+	if err := corev1conv.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(template, coreTemplate, nil); err != nil {
 		errList = append(errList, field.Invalid(fldPath.Child("template"), spec.Template, fmt.Sprintf("Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec failed: %v", err)))
 		return errList
 	}
-	if len(spec.VolumeClaimTemplates) != 0 {
-		errList = append(errList, validateVolumeClaimTemplateMounts(spec, fldPath)...)
-		for _, template := range spec.VolumeClaimTemplates {
-			coreTemplate.Spec.Volumes = append(coreTemplate.Spec.Volumes, core.Volume{
-				Name: template.Name,
-				VolumeSource: core.VolumeSource{
-					PersistentVolumeClaim: &core.PersistentVolumeClaimVolumeSource{
-						ClaimName: template.Name,
-					},
-				},
-			})
-		}
-	}
 	errList = append(errList, corevalidation.ValidatePodTemplateSpec(coreTemplate, fldPath.Child("template"), webhookutils.DefaultPodValidationOptions)...)
-	return errList
-}
-
-func validateVolumeClaimTemplateMounts(spec agentsv1alpha1.SandboxSetSpec, fldPath *field.Path) field.ErrorList {
-	errList := field.ErrorList{}
-	mountedVolumeNames := map[string]struct{}{}
-
-	recordMounts := func(containers []apicorev1.Container) {
-		for i := range containers {
-			for j := range containers[i].VolumeMounts {
-				mountedVolumeNames[containers[i].VolumeMounts[j].Name] = struct{}{}
-			}
-		}
-	}
-	recordMounts(spec.Template.Spec.InitContainers)
-	recordMounts(spec.Template.Spec.Containers)
-	for i := range spec.Template.Spec.EphemeralContainers {
-		for j := range spec.Template.Spec.EphemeralContainers[i].VolumeMounts {
-			mountedVolumeNames[spec.Template.Spec.EphemeralContainers[i].VolumeMounts[j].Name] = struct{}{}
-		}
-	}
-
-	for i, template := range spec.VolumeClaimTemplates {
-		if template.Name == "" {
-			continue
-		}
-		if _, mounted := mountedVolumeNames[template.Name]; !mounted {
-			errList = append(errList, field.Invalid(
-				fldPath.Child("volumeClaimTemplates").Index(i).Child("metadata").Child("name"),
-				template.Name,
-				"must be mounted by at least one container, init container, or ephemeral container",
-			))
-		}
-	}
 	return errList
 }

--- a/pkg/webhook/sandboxtemplate/validating/sandboxtemplate_create_update.go
+++ b/pkg/webhook/sandboxtemplate/validating/sandboxtemplate_create_update.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"strings"
 
-	apicorev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -101,58 +100,16 @@ func validateSandboxTemplateSpec(spec agentsv1alpha1.SandboxTemplateSpec, fldPat
 
 func validateSandboxPodTemplateSpec(spec agentsv1alpha1.SandboxTemplateSpec, fldPath *field.Path) field.ErrorList {
 	errList := field.ErrorList{}
+	template := spec.Template.DeepCopy()
 	coreTemplate := &core.PodTemplateSpec{}
-	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(spec.Template.DeepCopy(), coreTemplate, nil); err != nil {
+	if len(spec.VolumeClaimTemplates) != 0 {
+		errList = append(errList, webhookutils.ValidateVolumeClaimTemplateMounts(spec.Template, spec.VolumeClaimTemplates, fldPath)...)
+		webhookutils.AppendVolumeClaimTemplateVolumes(template, spec.VolumeClaimTemplates)
+	}
+	if err := corev1.Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec(template, coreTemplate, nil); err != nil {
 		errList = append(errList, field.Invalid(fldPath.Child("template"), spec.Template, fmt.Sprintf("Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec failed: %v", err)))
 		return errList
 	}
-	if len(spec.VolumeClaimTemplates) != 0 {
-		errList = append(errList, validateVolumeClaimTemplateMounts(spec, fldPath)...)
-		for _, template := range spec.VolumeClaimTemplates {
-			coreTemplate.Spec.Volumes = append(coreTemplate.Spec.Volumes, core.Volume{
-				Name: template.Name,
-				VolumeSource: core.VolumeSource{
-					PersistentVolumeClaim: &core.PersistentVolumeClaimVolumeSource{
-						ClaimName: template.Name,
-					},
-				},
-			})
-		}
-	}
 	errList = append(errList, corevalidation.ValidatePodTemplateSpec(coreTemplate, fldPath.Child("template"), webhookutils.DefaultPodValidationOptions)...)
-	return errList
-}
-
-func validateVolumeClaimTemplateMounts(spec agentsv1alpha1.SandboxTemplateSpec, fldPath *field.Path) field.ErrorList {
-	errList := field.ErrorList{}
-	mountedVolumeNames := map[string]struct{}{}
-
-	recordMounts := func(containers []apicorev1.Container) {
-		for i := range containers {
-			for j := range containers[i].VolumeMounts {
-				mountedVolumeNames[containers[i].VolumeMounts[j].Name] = struct{}{}
-			}
-		}
-	}
-	recordMounts(spec.Template.Spec.InitContainers)
-	recordMounts(spec.Template.Spec.Containers)
-	for i := range spec.Template.Spec.EphemeralContainers {
-		for j := range spec.Template.Spec.EphemeralContainers[i].VolumeMounts {
-			mountedVolumeNames[spec.Template.Spec.EphemeralContainers[i].VolumeMounts[j].Name] = struct{}{}
-		}
-	}
-
-	for i, template := range spec.VolumeClaimTemplates {
-		if template.Name == "" {
-			continue
-		}
-		if _, mounted := mountedVolumeNames[template.Name]; !mounted {
-			errList = append(errList, field.Invalid(
-				fldPath.Child("volumeClaimTemplates").Index(i).Child("metadata").Child("name"),
-				template.Name,
-				"must be mounted by at least one container, init container, or ephemeral container",
-			))
-		}
-	}
 	return errList
 }

--- a/pkg/webhook/sandboxtemplate/validating/sandboxtemplate_create_update.go
+++ b/pkg/webhook/sandboxtemplate/validating/sandboxtemplate_create_update.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"strings"
 
+	apicorev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -90,6 +91,9 @@ func validateLabelsAndAnnotations(metadata metav1.ObjectMeta, fldPath *field.Pat
 
 func validateSandboxTemplateSpec(spec agentsv1alpha1.SandboxTemplateSpec, fldPath *field.Path) field.ErrorList {
 	var errList field.ErrorList
+	if spec.Template == nil {
+		return append(errList, field.Required(fldPath.Child("template"), "template is required"))
+	}
 	errList = append(errList, validateLabelsAndAnnotations(spec.Template.ObjectMeta, fldPath.Child("template"))...)
 	errList = append(errList, validateSandboxPodTemplateSpec(spec, fldPath)...)
 	return errList
@@ -102,6 +106,53 @@ func validateSandboxPodTemplateSpec(spec agentsv1alpha1.SandboxTemplateSpec, fld
 		errList = append(errList, field.Invalid(fldPath.Child("template"), spec.Template, fmt.Sprintf("Convert_v1_PodTemplateSpec_To_core_PodTemplateSpec failed: %v", err)))
 		return errList
 	}
+	if len(spec.VolumeClaimTemplates) != 0 {
+		errList = append(errList, validateVolumeClaimTemplateMounts(spec, fldPath)...)
+		for _, template := range spec.VolumeClaimTemplates {
+			coreTemplate.Spec.Volumes = append(coreTemplate.Spec.Volumes, core.Volume{
+				Name: template.Name,
+				VolumeSource: core.VolumeSource{
+					PersistentVolumeClaim: &core.PersistentVolumeClaimVolumeSource{
+						ClaimName: template.Name,
+					},
+				},
+			})
+		}
+	}
 	errList = append(errList, corevalidation.ValidatePodTemplateSpec(coreTemplate, fldPath.Child("template"), webhookutils.DefaultPodValidationOptions)...)
+	return errList
+}
+
+func validateVolumeClaimTemplateMounts(spec agentsv1alpha1.SandboxTemplateSpec, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+	mountedVolumeNames := map[string]struct{}{}
+
+	recordMounts := func(containers []apicorev1.Container) {
+		for i := range containers {
+			for j := range containers[i].VolumeMounts {
+				mountedVolumeNames[containers[i].VolumeMounts[j].Name] = struct{}{}
+			}
+		}
+	}
+	recordMounts(spec.Template.Spec.InitContainers)
+	recordMounts(spec.Template.Spec.Containers)
+	for i := range spec.Template.Spec.EphemeralContainers {
+		for j := range spec.Template.Spec.EphemeralContainers[i].VolumeMounts {
+			mountedVolumeNames[spec.Template.Spec.EphemeralContainers[i].VolumeMounts[j].Name] = struct{}{}
+		}
+	}
+
+	for i, template := range spec.VolumeClaimTemplates {
+		if template.Name == "" {
+			continue
+		}
+		if _, mounted := mountedVolumeNames[template.Name]; !mounted {
+			errList = append(errList, field.Invalid(
+				fldPath.Child("volumeClaimTemplates").Index(i).Child("metadata").Child("name"),
+				template.Name,
+				"must be mounted by at least one container, init container, or ephemeral container",
+			))
+		}
+	}
 	return errList
 }

--- a/pkg/webhook/sandboxtemplate/validating/sandboxtemplate_create_update_test.go
+++ b/pkg/webhook/sandboxtemplate/validating/sandboxtemplate_create_update_test.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -258,94 +257,6 @@ func TestSandboxTemplateValidatingHandler_Handle(t *testing.T) {
 				g.Expect(response.Result).NotTo(gomega.BeNil())
 				g.Expect(response.Result.Message).To(gomega.ContainSubstring(tt.errorMessage))
 			}
-		})
-	}
-}
-
-func TestValidateVolumeClaimTemplateMounts(t *testing.T) {
-	tests := []struct {
-		name         string
-		spec         v1alpha1.SandboxTemplateSpec
-		expectError  bool
-		errorMessage string
-	}{
-		{
-			name: "mounted by init container",
-			spec: v1alpha1.SandboxTemplateSpec{
-				Template: &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						InitContainers: []corev1.Container{
-							{
-								Name: "init",
-								VolumeMounts: []corev1.VolumeMount{
-									{Name: "data-vol", MountPath: "/data"},
-								},
-							},
-						},
-					},
-				},
-				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
-					{ObjectMeta: metav1.ObjectMeta{Name: "data-vol"}},
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "mounted by ephemeral container",
-			spec: v1alpha1.SandboxTemplateSpec{
-				Template: &corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						EphemeralContainers: []corev1.EphemeralContainer{
-							{
-								EphemeralContainerCommon: corev1.EphemeralContainerCommon{
-									Name: "debugger",
-									VolumeMounts: []corev1.VolumeMount{
-										{Name: "data-vol", MountPath: "/data"},
-									},
-								},
-							},
-						},
-					},
-				},
-				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
-					{ObjectMeta: metav1.ObjectMeta{Name: "data-vol"}},
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "empty template name is skipped",
-			spec: v1alpha1.SandboxTemplateSpec{
-				Template: &corev1.PodTemplateSpec{},
-				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
-					{},
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "unmounted volume claim template is rejected",
-			spec: v1alpha1.SandboxTemplateSpec{
-				Template: &corev1.PodTemplateSpec{},
-				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
-					{ObjectMeta: metav1.ObjectMeta{Name: "data-vol"}},
-				},
-			},
-			expectError:  true,
-			errorMessage: "must be mounted by at least one container",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			errList := validateVolumeClaimTemplateMounts(tt.spec, field.NewPath("spec"))
-
-			if tt.expectError {
-				require.NotEmpty(t, errList)
-				require.Contains(t, errList.ToAggregate().Error(), tt.errorMessage)
-				return
-			}
-			require.Empty(t, errList)
 		})
 	}
 }

--- a/pkg/webhook/sandboxtemplate/validating/sandboxtemplate_create_update_test.go
+++ b/pkg/webhook/sandboxtemplate/validating/sandboxtemplate_create_update_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -109,6 +110,52 @@ func TestSandboxTemplateValidatingHandler_Handle(t *testing.T) {
 			errorMessage: "subdomain must consist of lower case alphanumeric characters, '-' or '.'",
 		},
 		{
+			name: "Valid SandboxTemplate With VolumeClaimTemplate",
+			sandboxTemplate: &v1alpha1.SandboxTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sbt",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.SandboxTemplateSpec{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							RestartPolicy:                 corev1.RestartPolicyAlways,
+							DNSPolicy:                     corev1.DNSClusterFirst,
+							TerminationGracePeriodSeconds: new(int64),
+							Containers: []corev1.Container{
+								{
+									Name:                     "test",
+									Image:                    "nginx:latest",
+									ImagePullPolicy:          corev1.PullAlways,
+									TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "data-vol",
+											MountPath: "/data",
+										},
+									},
+								},
+							},
+						},
+					},
+					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "data-vol",
+							},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									corev1.ReadWriteOnce,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectAllow: true,
+			expectError: false,
+		},
+		{
 			name: "Label with internal prefix",
 			sandboxTemplate: &v1alpha1.SandboxTemplate{
 				ObjectMeta: metav1.ObjectMeta{
@@ -152,6 +199,18 @@ func TestSandboxTemplateValidatingHandler_Handle(t *testing.T) {
 			expectAllow:  false,
 			expectError:  true,
 			errorMessage: "label cannot start with " + v1alpha1.E2BPrefix,
+		},
+		{
+			name: "Missing template",
+			sandboxTemplate: &v1alpha1.SandboxTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sbs",
+					Namespace: "default",
+				},
+			},
+			expectAllow:  false,
+			expectError:  true,
+			errorMessage: "template is required",
 		},
 	}
 
@@ -199,6 +258,94 @@ func TestSandboxTemplateValidatingHandler_Handle(t *testing.T) {
 				g.Expect(response.Result).NotTo(gomega.BeNil())
 				g.Expect(response.Result.Message).To(gomega.ContainSubstring(tt.errorMessage))
 			}
+		})
+	}
+}
+
+func TestValidateVolumeClaimTemplateMounts(t *testing.T) {
+	tests := []struct {
+		name         string
+		spec         v1alpha1.SandboxTemplateSpec
+		expectError  bool
+		errorMessage string
+	}{
+		{
+			name: "mounted by init container",
+			spec: v1alpha1.SandboxTemplateSpec{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						InitContainers: []corev1.Container{
+							{
+								Name: "init",
+								VolumeMounts: []corev1.VolumeMount{
+									{Name: "data-vol", MountPath: "/data"},
+								},
+							},
+						},
+					},
+				},
+				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+					{ObjectMeta: metav1.ObjectMeta{Name: "data-vol"}},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "mounted by ephemeral container",
+			spec: v1alpha1.SandboxTemplateSpec{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						EphemeralContainers: []corev1.EphemeralContainer{
+							{
+								EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+									Name: "debugger",
+									VolumeMounts: []corev1.VolumeMount{
+										{Name: "data-vol", MountPath: "/data"},
+									},
+								},
+							},
+						},
+					},
+				},
+				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+					{ObjectMeta: metav1.ObjectMeta{Name: "data-vol"}},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "empty template name is skipped",
+			spec: v1alpha1.SandboxTemplateSpec{
+				Template: &corev1.PodTemplateSpec{},
+				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+					{},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "unmounted volume claim template is rejected",
+			spec: v1alpha1.SandboxTemplateSpec{
+				Template: &corev1.PodTemplateSpec{},
+				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+					{ObjectMeta: metav1.ObjectMeta{Name: "data-vol"}},
+				},
+			},
+			expectError:  true,
+			errorMessage: "must be mounted by at least one container",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errList := validateVolumeClaimTemplateMounts(tt.spec, field.NewPath("spec"))
+
+			if tt.expectError {
+				require.NotEmpty(t, errList)
+				require.Contains(t, errList.ToAggregate().Error(), tt.errorMessage)
+				return
+			}
+			require.Empty(t, errList)
 		})
 	}
 }

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/openkruise/agents/pkg/webhook/pod"
 	"github.com/openkruise/agents/pkg/webhook/sandboxset"
+	"github.com/openkruise/agents/pkg/webhook/sandboxtemplate"
 	"github.com/openkruise/agents/pkg/webhook/sandboxupdateops"
 	"github.com/openkruise/agents/pkg/webhook/types"
 )
@@ -46,6 +47,7 @@ var (
 func init() {
 	HandlerGetters = append(HandlerGetters, sandboxset.GetHandlerGetters()...)
 	HandlerGetters = append(HandlerGetters, sandboxupdateops.GetHandlerGetters()...)
+	HandlerGetters = append(HandlerGetters, sandboxtemplate.GetHandlerGetters()...)
 	HandlerGetters = append(HandlerGetters, pod.GetHandlerGetters()...)
 }
 

--- a/pkg/webhook/utils/volume_claim_template.go
+++ b/pkg/webhook/utils/volume_claim_template.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func ValidateVolumeClaimTemplateMounts(template *corev1.PodTemplateSpec, claims []corev1.PersistentVolumeClaim, fldPath *field.Path) field.ErrorList {
+	errList := field.ErrorList{}
+	mountedVolumeNames := map[string]struct{}{}
+
+	if template != nil {
+		recordMounts := func(containers []corev1.Container) {
+			for i := range containers {
+				for j := range containers[i].VolumeMounts {
+					mountedVolumeNames[containers[i].VolumeMounts[j].Name] = struct{}{}
+				}
+			}
+		}
+		recordMounts(template.Spec.InitContainers)
+		recordMounts(template.Spec.Containers)
+		for i := range template.Spec.EphemeralContainers {
+			for j := range template.Spec.EphemeralContainers[i].VolumeMounts {
+				mountedVolumeNames[template.Spec.EphemeralContainers[i].VolumeMounts[j].Name] = struct{}{}
+			}
+		}
+	}
+
+	for i, claim := range claims {
+		if claim.Name == "" {
+			continue
+		}
+		if _, mounted := mountedVolumeNames[claim.Name]; !mounted {
+			errList = append(errList, field.Invalid(
+				fldPath.Child("volumeClaimTemplates").Index(i).Child("metadata").Child("name"),
+				claim.Name,
+				"must be mounted by at least one container, init container, or ephemeral container",
+			))
+		}
+	}
+	return errList
+}
+
+func AppendVolumeClaimTemplateVolumes(template *corev1.PodTemplateSpec, claims []corev1.PersistentVolumeClaim) {
+	if template == nil {
+		return
+	}
+	for _, claim := range claims {
+		template.Spec.Volumes = append(template.Spec.Volumes, corev1.Volume{
+			Name: claim.Name,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: claim.Name,
+				},
+			},
+		})
+	}
+}

--- a/pkg/webhook/utils/volume_claim_template_test.go
+++ b/pkg/webhook/utils/volume_claim_template_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateVolumeClaimTemplateMounts(t *testing.T) {
+	tests := []struct {
+		name         string
+		template     *corev1.PodTemplateSpec
+		claims       []corev1.PersistentVolumeClaim
+		expectError  bool
+		errorMessage string
+	}{
+		{
+			name: "mounted by init container",
+			template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "init",
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "data-vol", MountPath: "/data"},
+							},
+						},
+					},
+				},
+			},
+			claims: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: metav1.ObjectMeta{Name: "data-vol"}},
+			},
+			expectError: false,
+		},
+		{
+			name: "mounted by ephemeral container",
+			template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					EphemeralContainers: []corev1.EphemeralContainer{
+						{
+							EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+								Name: "debugger",
+								VolumeMounts: []corev1.VolumeMount{
+									{Name: "data-vol", MountPath: "/data"},
+								},
+							},
+						},
+					},
+				},
+			},
+			claims: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: metav1.ObjectMeta{Name: "data-vol"}},
+			},
+			expectError: false,
+		},
+		{
+			name:     "empty template name is skipped",
+			template: &corev1.PodTemplateSpec{},
+			claims: []corev1.PersistentVolumeClaim{
+				{},
+			},
+			expectError: false,
+		},
+		{
+			name:     "unmounted volume claim template is rejected",
+			template: &corev1.PodTemplateSpec{},
+			claims: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: metav1.ObjectMeta{Name: "data-vol"}},
+			},
+			expectError:  true,
+			errorMessage: "must be mounted by at least one container",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errList := ValidateVolumeClaimTemplateMounts(tt.template, tt.claims, field.NewPath("spec"))
+
+			if tt.expectError {
+				require.NotEmpty(t, errList)
+				require.Contains(t, errList.ToAggregate().Error(), tt.errorMessage)
+				return
+			}
+			require.Empty(t, errList)
+		})
+	}
+}
+
+func TestAppendVolumeClaimTemplateVolumes(t *testing.T) {
+	template := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{Name: "existing"},
+			},
+		},
+	}
+	claims := []corev1.PersistentVolumeClaim{
+		{ObjectMeta: metav1.ObjectMeta{Name: "data-vol"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "cache-vol"}},
+	}
+
+	AppendVolumeClaimTemplateVolumes(template, claims)
+
+	require.Equal(t, []corev1.Volume{
+		{Name: "existing"},
+		{
+			Name: "data-vol",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "data-vol",
+				},
+			},
+		},
+		{
+			Name: "cache-vol",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "cache-vol",
+				},
+			},
+		},
+	}, template.Spec.Volumes)
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR fixes SandboxTemplate admission webhook registration and validation:

- register SandboxTemplate mutating and validating webhook handlers at runtime
- return a validation error when `spec.template` is missing instead of panicking
- allow SandboxTemplate `volumeClaimTemplates` to satisfy pod volume mounts during validation
- add regression tests for missing `spec.template` and mounted volume claim templates

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

```shell
go test ./pkg/webhook/...
```

### Ⅳ. Special notes for reviews

N/A
