### PR TITLE
fix(e2b): correct query parsing for ListSandboxes filters

### DIFF
--- a/pkg/servers/e2b/list.go
+++ b/pkg/servers/e2b/list.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -112,16 +111,20 @@ func parseListSandboxesRequest(r *http.Request) (ListSandboxesRequest, *web.ApiE
 		}
 		switch key {
 		case "state":
-			for _, state := range strings.Split(values[0], ",") {
-				innerState := convertE2bStateToInnerState(state)
-				if innerState != agentsv1alpha1.SandboxStateRunning && innerState != agentsv1alpha1.SandboxStatePaused {
-					return request, &web.ApiError{
-						Code: http.StatusBadRequest,
-						Message: fmt.Sprintf("Only '%s' and '%s' state are supported, not: '%s'",
-							models.SandboxStateRunning, models.SandboxStatePaused, values[0]),
+			// A client may repeat the parameter or comma-separate it, so read
+			// every value rather than only the first.
+			for _, value := range values {
+				for _, state := range strings.Split(value, ",") {
+					innerState := convertE2bStateToInnerState(state)
+					if innerState != agentsv1alpha1.SandboxStateRunning && innerState != agentsv1alpha1.SandboxStatePaused {
+						return request, &web.ApiError{
+							Code: http.StatusBadRequest,
+							Message: fmt.Sprintf("Only '%s' and '%s' state are supported, not: '%s'",
+								models.SandboxStateRunning, models.SandboxStatePaused, state),
+						}
 					}
+					request.States = append(request.States, innerState)
 				}
-				request.States = append(request.States, innerState)
 			}
 		case "nextToken":
 			request.NextToken = values[0]
@@ -135,34 +138,32 @@ func parseListSandboxesRequest(r *http.Request) (ListSandboxesRequest, *web.ApiE
 			}
 			request.Limit = limit
 		case "metadata":
-			if len(values) > 0 && values[0] != "" {
-				decodedStr, err := url.QueryUnescape(values[0])
-				if err != nil {
-					return request, &web.ApiError{
-						Code:    http.StatusBadRequest,
-						Message: fmt.Sprintf("Invalid metadata format: %v", err),
-					}
+			// r.URL.Query() has already unescaped these, so they are used as-is.
+			// Unescaping a second time corrupts any value that legitimately
+			// contains a percent sign: "%25" arrives here decoded to "%", which
+			// is then read as the start of a new escape sequence.
+			for _, value := range values {
+				if value == "" {
+					continue
 				}
-
-				metadataPairs := strings.Split(decodedStr, "&")
-				for _, pair := range metadataPairs {
+				for _, pair := range strings.Split(value, "&") {
 					if pair == "" {
 						continue
 					}
 					kv := strings.SplitN(pair, "=", 2)
-					if len(kv) == 2 {
-						key := kv[0]
-						value := kv[1]
-						for _, prefix := range BlackListPrefix {
-							if strings.HasPrefix(key, prefix) {
-								return request, &web.ApiError{
-									Code:    http.StatusBadRequest,
-									Message: fmt.Sprintf("Forbidden metadata key: %v", key),
-								}
+					if len(kv) != 2 {
+						continue
+					}
+					key, metaValue := kv[0], kv[1]
+					for _, prefix := range BlackListPrefix {
+						if strings.HasPrefix(key, prefix) {
+							return request, &web.ApiError{
+								Code:    http.StatusBadRequest,
+								Message: fmt.Sprintf("Forbidden metadata key: %v", key),
 							}
 						}
-						request.Metadata[key] = value
 					}
+					request.Metadata[key] = metaValue
 				}
 			}
 

--- a/pkg/servers/e2b/list_test.go
+++ b/pkg/servers/e2b/list_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"sort"
 	"testing"
 	"time"
@@ -1142,6 +1143,74 @@ func TestListSnapshots(t *testing.T) {
 			// For multipage tests, verify total count
 			if tt.expectedTotal > 0 {
 				assert.Len(t, allSnapshotIDs, tt.expectedTotal, "total snapshots across all pages should be %d", tt.expectedTotal)
+			}
+		})
+	}
+}
+
+func TestParseListSandboxesRequest(t *testing.T) {
+	tests := []struct {
+		name         string
+		query        string
+		expectStates []string
+		expectMeta   map[string]string
+		expectError  string
+	}{
+		{
+			name:       "percent sign in a metadata value survives",
+			query:      "metadata=note=50%25off",
+			expectMeta: map[string]string{"note": "50%off"},
+		},
+		{
+			name:       "encoded separators still split into pairs",
+			query:      "metadata=k1%3Dv1%26k2%3Dv2",
+			expectMeta: map[string]string{"k1": "v1", "k2": "v2"},
+		},
+		{
+			name:       "repeated metadata parameters are all kept",
+			query:      "metadata=a=1&metadata=b=2",
+			expectMeta: map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			name:         "repeated state parameters are all kept",
+			query:        "state=running&state=paused",
+			expectStates: []string{agentsv1alpha1.SandboxStateRunning, agentsv1alpha1.SandboxStatePaused},
+		},
+		{
+			name:         "comma separated states still work",
+			query:        "state=running,paused",
+			expectStates: []string{agentsv1alpha1.SandboxStateRunning, agentsv1alpha1.SandboxStatePaused},
+		},
+		{
+			name:        "an invalid state names the offending token",
+			query:       "state=running,foo",
+			expectError: "not: 'foo'",
+		},
+		{
+			name:        "a forbidden metadata key is still rejected",
+			query:       "metadata=" + BlackListPrefix[0] + "x=1",
+			expectError: "Forbidden metadata key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/v2/sandboxes?"+tt.query, nil)
+			request, apiErr := parseListSandboxesRequest(r)
+
+			if tt.expectError != "" {
+				require.NotNil(t, apiErr)
+				assert.Equal(t, http.StatusBadRequest, apiErr.Code)
+				assert.Contains(t, apiErr.Message, tt.expectError)
+				return
+			}
+
+			require.Nil(t, apiErr)
+			if tt.expectMeta != nil {
+				assert.Equal(t, tt.expectMeta, request.Metadata)
+			}
+			if tt.expectStates != nil {
+				assert.ElementsMatch(t, tt.expectStates, request.States)
 			}
 		})
 	}


### PR DESCRIPTION
### I. Describe what this PR does

Three fixes in `parseListSandboxesRequest`, all from #804.

`r.URL.Query()` has already unescaped the query, so the extra `url.QueryUnescape` on metadata decoded it a second time. Dropped.

The loop read only `values[0]`, so a repeated parameter lost everything after the first. `state` and `metadata` now read every value. `state` still accepts the comma separated form as well.

An invalid state reported the whole parameter instead of the token that failed, so `state=running,foo` said `not: 'running,foo'`. It now names `foo`.

The `default` branch is left alone. It maps an unknown parameter to a single metadata key, and a map holds one value per key either way, so picking `values[0]` over the last one is arbitrary rather than wrong.

### II. Does this pull request fix one issue?

fixes #804

### III. Describe how to verify it

`go test ./pkg/servers/e2b/ -run TestParseListSandboxesRequest -count=1`

Four of the seven cases fail on master and pass here. The other three cover behaviour that should not change: the comma separated state form, encoded separators still splitting into pairs, and forbidden metadata keys still being rejected.

### IV. Special notes for reviews

One correction to the issue. It gives `?metadata=progress=100%` as the repro for the 400, but a bare `%` never reaches this function: `url.ParseQuery` fails on the invalid escape and `r.URL.Query()` drops the parameter, so metadata is silently empty and no error is returned.

The 400 comes from the opposite case, a correctly encoded value. `?metadata=note=50%25off` arrives here already decoded to `note=50%off`, and the second unescape then reads `%of` as an escape sequence and fails. So the bug is real but it hits clients that encode properly rather than clients that do not, which seemed worth getting right in the test. That case is `percent sign in a metadata value survives`.

`TestParseCreateSandboxRequest`, `TestCreateSandbox` and `TestCloneSandbox` fail for me on a clean master too, so they look unrelated to this.
