### PR TITLE
fix(gateway): let a route explicitly disable enable-auth

### DIFF
--- a/pkg/sandbox-gateway/filter/config.go
+++ b/pkg/sandbox-gateway/filter/config.go
@@ -141,6 +141,9 @@ type FilterConfig struct {
 	Adapter                          *adapters.E2BAdapter
 	jwtAuthManager                   JWTAuthManager
 	trafficAccessTokenHeaderExplicit bool
+	// enableAuthExplicit records that enable-auth was present in the parsed
+	// config, so Merge can tell an explicit false from an omitted field.
+	enableAuthExplicit bool
 }
 
 // NewFilterConfig creates a FilterConfig with an adapter built from the config values
@@ -163,6 +166,7 @@ func newFilterConfig(cfg *Config, jwtAuthManager JWTAuthManager) *FilterConfig {
 		Adapter:                          adapter,
 		jwtAuthManager:                   jwtAuthManager,
 		trafficAccessTokenHeaderExplicit: cfg.TrafficAccessTokenHeader != "",
+		enableAuthExplicit:               cfg.EnableAuth,
 	}
 }
 
@@ -195,6 +199,7 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 		}
 		parsed := newFilterConfig(cfg, p.jwtAuthManager)
 		parsed.trafficAccessTokenHeaderExplicit = false
+		parsed.enableAuthExplicit = false
 		return parsed, nil
 	}
 
@@ -203,6 +208,7 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 	_, jwtModeExplicit := values["enable-jwt-auth"]
 	_, tokenHeaderExplicit := values["traffic-access-token-header"]
 	_, runtimeMTLSExplicit := values["enable-runtime-mtls"]
+	_, enableAuthExplicit := values["enable-auth"]
 	if callbacks == nil && jwtModeExplicit {
 		return nil, fmt.Errorf("enable-jwt-auth is process-wide and cannot be configured per route")
 	}
@@ -232,6 +238,7 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 	}
 	parsed := newFilterConfig(cfg, p.jwtAuthManager)
 	parsed.trafficAccessTokenHeaderExplicit = tokenHeaderExplicit
+	parsed.enableAuthExplicit = enableAuthExplicit
 	return parsed, nil
 }
 
@@ -268,7 +275,7 @@ func (p *ConfigParser) Merge(parent interface{}, child interface{}) interface{} 
 	if childCfg.DefaultPort != "" {
 		merged.DefaultPort = childCfg.DefaultPort
 	}
-	if childCfg.EnableAuth {
+	if childCfg.enableAuthExplicit {
 		merged.EnableAuth = childCfg.EnableAuth
 	}
 	if childCfg.EnableJWTAuth {

--- a/pkg/sandbox-gateway/filter/config_test.go
+++ b/pkg/sandbox-gateway/filter/config_test.go
@@ -668,6 +668,55 @@ func TestConfigParserMerge(t *testing.T) {
 	}
 }
 
+func TestConfigParserMergeRouteEnableAuth(t *testing.T) {
+	tests := []struct {
+		name           string
+		parentValues   map[string]any
+		routeValues    map[string]any
+		wantEnableAuth bool
+	}{
+		{
+			name:           "route omitting the field inherits the enabled listener",
+			parentValues:   map[string]any{"enable-auth": true},
+			routeValues:    map[string]any{},
+			wantEnableAuth: true,
+		},
+		{
+			name:           "route explicitly enabling auth keeps it enabled",
+			parentValues:   map[string]any{"enable-auth": true},
+			routeValues:    map[string]any{"enable-auth": true},
+			wantEnableAuth: true,
+		},
+		{
+			name:           "route explicitly disables auth enabled by the listener",
+			parentValues:   map[string]any{"enable-auth": true},
+			routeValues:    map[string]any{"enable-auth": false},
+			wantEnableAuth: false,
+		},
+		{
+			name:           "route explicitly disabling auth is a no-op when already disabled",
+			parentValues:   map[string]any{"enable-auth": false},
+			routeValues:    map[string]any{"enable-auth": false},
+			wantEnableAuth: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := NewConfigParser(&fakeJWTAuthManager{})
+
+			parent, err := parser.Parse(typedFilterConfig(t, tt.parentValues), &fakeConfigCallbackHandler{})
+			require.NoError(t, err)
+			// A route-level config is parsed with nil callbacks.
+			route, err := parser.Parse(typedFilterConfig(t, tt.routeValues), nil)
+			require.NoError(t, err)
+
+			merged := parser.Merge(parent, route).(*FilterConfig)
+			assert.Equal(t, tt.wantEnableAuth, merged.EnableAuth)
+		})
+	}
+}
+
 func TestConfigParserMergeJWT(t *testing.T) {
 	manager := &fakeJWTAuthManager{}
 	parser := NewConfigParser(manager)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Fixes code-audit finding `#09` — "Per-route auth flags can't be explicitly disabled by a child route" (Gateway layer), in `pkg/sandbox-gateway/filter/config.go`.

**The bug**

A route-level `enable-auth: false` is silently ignored. A child route can turn access-token auth **ON**, but can never turn it back **OFF** once the listener has enabled it. There is no error and no log line — the configuration says one thing and the data plane does another.

`ConfigParser` is registered with Envoy in `cmd/sandbox-gateway/main.go`, so `Parse`/`Merge` are the real data-plane path: Envoy calls `Parse` once for the listener-level `plugin_config` (with callbacks) and once per route-level config (with `callbacks == nil`), then calls `Merge(parent, child)`. Driving that path with listener `{"enable-auth": true}` and route `{"enable-auth": false}` shows the route override being dropped — merged `EnableAuth` stays `true`.

This is a reachable, supported configuration surface: `Parse` explicitly *rejects* `enable-jwt-auth` and `enable-runtime-mtls` per route, but deliberately permits `enable-auth`, and the `Merge` branch exists precisely so a route can override it. It simply only ever worked in one direction.

**Root cause**

`Config.EnableAuth` is a plain `bool` with `json:"enable-auth,omitempty"`, so after `json.Unmarshal` an explicit `enable-auth: false` and an omitted `enable-auth` are both the zero value. `Merge` used the *value* as a stand-in for *presence*:

```go
if childCfg.EnableAuth {
    merged.EnableAuth = childCfg.EnableAuth
}
```

That guard never fires for an explicit `false`, so the parent's `true` always survives.

`Parse` already had the information needed to tell the two apart: it reads the raw `values` map and records explicit presence for `enable-jwt-auth`, `enable-runtime-mtls` and `traffic-access-token-header`. `enable-auth` was simply not tracked alongside them.

**The exact fix**

Reuse the existing explicit-presence pattern (`trafficAccessTokenHeaderExplicit`) rather than introducing a new mechanism:

- record `_, enableAuthExplicit := values["enable-auth"]` in `Parse`, and carry it on `FilterConfig` as `enableAuthExplicit`, set on **both** `Parse` return paths;
- in `Merge`, key the override off that presence flag instead of off the value:

```go
if childCfg.enableAuthExplicit {
    merged.EnableAuth = childCfg.EnableAuth
}
```

`EnableJWTAuth` is deliberately left untouched: `Parse` already rejects it per route (`"enable-jwt-auth is process-wide and cannot be configured per route"`), so a route-level child can never carry it and there is no explicit-`false` ambiguity to fix. No other `Merge` flag is changed.

Scope is two files, +57/−1:

```
pkg/sandbox-gateway/filter/config.go      |  9 +++++-
pkg/sandbox-gateway/filter/config_test.go | 49 +++++++++++++++++++++++++++++++
```

**Regression test**

`TestConfigParserMergeRouteEnableAuth` in `pkg/sandbox-gateway/filter/config_test.go` — table-driven, covering the four parent/route combinations through the real `Parse` → `Merge` path. It reuses the existing test helpers in that file; no new stubs, fakes or mocks were introduced.

### Ⅱ. Does this pull request fix one issue?

NONE

No GitHub issue is filed for this. It fixes code-audit finding `#09`, "Per-route auth flags can't be explicitly disabled by a child route": a route-level `enable-auth: false` was indistinguishable from an omitted field during merge, so a child route could enable access-token auth but never disable it once a parent had enabled it. This PR makes that explicit `false` take effect.

### Ⅲ. Describe how to verify it

`TestConfigParserMergeRouteEnableAuth` drives the real `Parse` → `Merge` path with route configs parsed at `callbacks == nil`. A new test was needed because the pre-existing `TestConfigParserMerge` table builds configs via `NewFilterConfig` and so structurally cannot express "explicit `false`" versus "omitted".

| listener | route | expected merged `EnableAuth` |
| --- | --- | --- |
| `true` | omitted | `true` |
| `true` | `true` | `true` |
| `true` | `false` | `false` |
| `false` | `false` | `false` |

```bash
go test ./pkg/sandbox-gateway/filter/ -run TestConfigParserMergeRouteEnableAuth -count=1
```

**Before/after proof that the test actually catches the bug**

Restoring the previous `config.go` while keeping the new test reproduces the defect, and exactly one subtest fails:

```
--- FAIL: TestConfigParserMergeRouteEnableAuth
    --- PASS: route_omitting_the_field_inherits_the_enabled_listener
    --- PASS: route_explicitly_enabling_auth_keeps_it_enabled
    --- FAIL: route_explicitly_disables_auth_enabled_by_the_listener
                Error: Not equal:   expected: false   actual: true
    --- PASS: route_explicitly_disabling_auth_is_a_no-op_when_already_disabled
FAIL
```

With the fix applied:

```
--- PASS: TestConfigParserMergeRouteEnableAuth (0.00s)
    --- PASS: route_omitting_the_field_inherits_the_enabled_listener
    --- PASS: route_explicitly_enabling_auth_keeps_it_enabled
    --- PASS: route_explicitly_disables_auth_enabled_by_the_listener
    --- PASS: route_explicitly_disabling_auth_is_a_no-op_when_already_disabled
ok      github.com/openkruise/agents/pkg/sandbox-gateway/filter  0.674s
```

Only the defect case flips; the other three pass in both states, confirming the test is specific to this bug rather than trivially failing.

**Validation results**

| Check | Result |
| --- | --- |
| `gofmt -l` on both changed files | clean |
| `go build ./...` | pass |
| `go vet ./pkg/sandbox-gateway/... ./cmd/sandbox-gateway/...` | pass |
| `golangci-lint run ./pkg/sandbox-gateway/filter/...` | 0 issues |
| `go test ./pkg/sandbox-gateway/... -count=1` | 6/6 packages ok |
| `go test ./pkg/sandbox-gateway/filter/ -count=3 -race` | clean |
| `go test ./pkg/... -count=1` | zero failures |
| Merge into current `master` | clean, no conflicts |

No API types changed, so `make generate manifests` does not apply.

### Ⅳ. Special notes for reviews

**The one failing E2E check is an unrelated Redis flake, not a regression from this change.**

`sandbox (with sandbox-gateway)` in *E2E for E2B SDK - latest (MySQL Key Storage)* fails on `test/e2b/test_api_key_quota.py::test_count_all_limit_blocks_then_delete_releases` with `403 QuotaExceeded` (`1 failed, 12 passed`). The sandbox-manager log shows the actual cause — the delete path could not release quota because Redis timed out:

```
quota release backend failed ... "quota backend unavailable: release quota in redis: context deadline exceeded"
failed to release quota after accepted sandbox delete ... context deadline exceeded
→ subsequent create: 403 QuotaExceeded: api-key quota exceeded
```

Evidence that it is unrelated:

1. The identically-named `sandbox (with sandbox-gateway)` job **passed** in the sibling *E2E for E2B SDK - latest* workflow on this same commit — the gateway code path is identical there; only the key-storage backend differs.
2. All three *E2E for sandbox-gateway security* jobs (UUID auth, JWT auth, Runtime mTLS) passed.
3. The failing test exercises sandbox-manager quota/Redis through the E2B API and never reaches `ConfigParser.Merge`.
4. Redis quota E2E flakiness is a known issue already being worked on — see #816, "test(e2b): dump Redis/CR state on quota rebuild E2E failure".

A re-run of that single job should clear it.

**Why existing deployments are unaffected**

`Merge` runs only when a route-level config exists, and there is no `typed_per_filter_config` anywhere in the repo. The `enable-auth: false` at `config/sandbox-gateway/configmap.yaml` (and the runtime-mTLS patch at `configmap-patch.yaml`) is the *listener-level* `plugin_config`, i.e. the merge parent. `e2e-sandbox-gateway-security.yaml` flips those same listener-level values via `jq` substitution to build its UUID-auth and JWT-auth profiles, so it never exercises a route child either. Only the previously-broken route-override path changes behavior.

Behavior is also unchanged for configs built through the exported `NewFilterConfig` helper: `enableAuthExplicit` is derived there as `cfg.EnableAuth`, which reproduces the old semantics exactly (`true` overrides, `false` inherits). `Parse` then overwrites it with true raw-map presence.

Other flags in `Merge` (`SandboxHeaderName`, `HostHeaderName`, `DefaultPort`, …) are strings whose empty value is a genuine "unset" sentinel, so they do not share this ambiguity and are left untouched.
