### PR TITLE
fix(sandboxclaim): scope claims to namespace

### DIFF
--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -291,8 +291,9 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 	var storageAuthKey, storageAuthValue string
 
 	opts := infra.ClaimSandboxOptions{
-		User:     string(claim.UID), // Use UID to ensure uniqueness across claim recreations
-		Template: sandboxSet.Name,
+		Namespace: claim.Namespace,
+		User:      string(claim.UID), // Use UID to ensure uniqueness across claim recreations
+		Template:  sandboxSet.Name,
 		Modifier: func(sbx infra.Sandbox) error {
 			// propagate annotations to sandbox
 			if len(claim.Spec.Annotations) > 0 {

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -159,6 +159,38 @@ func TestNewClaimControl_ForwardsRuntimeTLSBundle(t *testing.T) {
 	assert.Same(t, bundle, cc.runtimeTLSBundle, "runtime TLS bundle must be forwarded to commonControl")
 }
 
+func TestCommonControl_BuildClaimOptionsScopesToClaimNamespace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+	control := NewCommonControl(fakeClient, record.NewFakeRecorder(10), nil, nil).(*commonControl)
+
+	claim := &agentsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim",
+			Namespace: "team-a",
+			UID:       "test-uid",
+		},
+		Spec: agentsv1alpha1.SandboxClaimSpec{
+			TemplateName:    "shared-pool",
+			SkipInitRuntime: true,
+		},
+	}
+	sandboxSet := &agentsv1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-pool",
+			Namespace: "team-a",
+		},
+	}
+
+	opts, err := control.buildClaimOptions(context.Background(), claim, sandboxSet)
+	require.NoError(t, err)
+	assert.Equal(t, claim.Namespace, opts.Namespace)
+}
+
 func TestCommonControl_EnsureClaimClaiming(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = agentsv1alpha1.AddToScheme(scheme)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Fixes SandboxClaim CRD claiming so the controller passes the claim namespace into the underlying ClaimSandboxOptions.

Without this namespace, ListSandboxesInPool and PickSandboxSet may search across namespaces for same-name SandboxSet pools, allowing a SandboxClaim in one namespace to claim Sandbox inventory from another namespace.

This PR also adds a regression test covering the namespace propagation.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how to verify it

go test ./pkg/controller/sandboxclaim/core -run TestCommonControl_BuildClaimOptionsScopesToClaimNamespace -count=1

go test ./pkg/controller/sandboxclaim/core -count=1

### Ⅳ. Special notes for reviews

The change is intentionally scoped to the CRD SandboxClaim path. The underlying cache and sandboxcr claim helpers already accept namespace-scoped options.
