### PR TITLE
Add SandboxUpdateOps metrics

### DIFF
--- a/pkg/controller/sandboxupdateops/metrics.go
+++ b/pkg/controller/sandboxupdateops/metrics.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandboxupdateops
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+const (
+	updateOpsReplicaTypeTotal    = "total"
+	updateOpsReplicaTypeUpdated  = "updated"
+	updateOpsReplicaTypeUpdating = "updating"
+	updateOpsReplicaTypeFailed   = "failed"
+
+	updateOpsResultCompleted  = "completed"
+	updateOpsResultFailed     = "failed"
+	updateOpsResultZeroTarget = "zero_target"
+)
+
+var (
+	sandboxUpdateOpsStatusPhase = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sandbox_updateops_status_phase",
+			Help: "The current phase of the SandboxUpdateOps (1 for active phase)",
+		},
+		[]string{"namespace", "name", "phase"},
+	)
+
+	sandboxUpdateOpsReplicas = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sandbox_updateops_replicas",
+			Help: "Current SandboxUpdateOps replica counts by type",
+		},
+		[]string{"namespace", "name", "type"},
+	)
+
+	sandboxUpdateOpsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sandbox_updateops_total",
+			Help: "Total number of SandboxUpdateOps terminal results",
+		},
+		[]string{"namespace", "result"},
+	)
+
+	allUpdateOpsPhases = []agentsv1alpha1.SandboxUpdateOpsPhase{
+		agentsv1alpha1.SandboxUpdateOpsPending,
+		agentsv1alpha1.SandboxUpdateOpsUpdating,
+		agentsv1alpha1.SandboxUpdateOpsCompleted,
+		agentsv1alpha1.SandboxUpdateOpsFailed,
+	}
+
+	observedUpdateOpsResults sync.Map
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		sandboxUpdateOpsStatusPhase,
+		sandboxUpdateOpsReplicas,
+		sandboxUpdateOpsTotal,
+	)
+}
+
+func recordSandboxUpdateOpsMetrics(ops *agentsv1alpha1.SandboxUpdateOps) {
+	recordSandboxUpdateOpsStatusMetrics(ops.Namespace, ops.Name, &ops.Status)
+	recordSandboxUpdateOpsTerminalResult(ops, &ops.Status)
+}
+
+func recordSandboxUpdateOpsStatusMetrics(namespace, name string, status *agentsv1alpha1.SandboxUpdateOpsStatus) {
+	if status.Phase != "" {
+		for _, phase := range allUpdateOpsPhases {
+			if phase != status.Phase {
+				sandboxUpdateOpsStatusPhase.DeleteLabelValues(namespace, name, string(phase))
+			}
+		}
+		sandboxUpdateOpsStatusPhase.WithLabelValues(namespace, name, string(status.Phase)).Set(1)
+	}
+
+	sandboxUpdateOpsReplicas.WithLabelValues(namespace, name, updateOpsReplicaTypeTotal).Set(float64(status.Replicas))
+	sandboxUpdateOpsReplicas.WithLabelValues(namespace, name, updateOpsReplicaTypeUpdated).Set(float64(status.UpdatedReplicas))
+	sandboxUpdateOpsReplicas.WithLabelValues(namespace, name, updateOpsReplicaTypeUpdating).Set(float64(status.UpdatingReplicas))
+	sandboxUpdateOpsReplicas.WithLabelValues(namespace, name, updateOpsReplicaTypeFailed).Set(float64(status.FailedReplicas))
+}
+
+func recordSandboxUpdateOpsTerminalResult(ops *agentsv1alpha1.SandboxUpdateOps, status *agentsv1alpha1.SandboxUpdateOpsStatus) {
+	if !isUpdateOpsTerminalPhase(status.Phase) {
+		return
+	}
+
+	key := updateOpsResultKey(ops)
+	if _, loaded := observedUpdateOpsResults.LoadOrStore(key, true); loaded {
+		return
+	}
+	sandboxUpdateOpsTotal.WithLabelValues(ops.Namespace, updateOpsResultFromStatus(status)).Inc()
+}
+
+func deleteSandboxUpdateOpsMetrics(ops *agentsv1alpha1.SandboxUpdateOps) {
+	deleteSandboxUpdateOpsGaugeMetrics(ops.Namespace, ops.Name)
+	observedUpdateOpsResults.Delete(updateOpsResultKey(ops))
+}
+
+func deleteSandboxUpdateOpsGaugeMetrics(namespace, name string) {
+	for _, phase := range allUpdateOpsPhases {
+		sandboxUpdateOpsStatusPhase.DeleteLabelValues(namespace, name, string(phase))
+	}
+	sandboxUpdateOpsReplicas.DeleteLabelValues(namespace, name, updateOpsReplicaTypeTotal)
+	sandboxUpdateOpsReplicas.DeleteLabelValues(namespace, name, updateOpsReplicaTypeUpdated)
+	sandboxUpdateOpsReplicas.DeleteLabelValues(namespace, name, updateOpsReplicaTypeUpdating)
+	sandboxUpdateOpsReplicas.DeleteLabelValues(namespace, name, updateOpsReplicaTypeFailed)
+}
+
+func isUpdateOpsTerminalPhase(phase agentsv1alpha1.SandboxUpdateOpsPhase) bool {
+	return phase == agentsv1alpha1.SandboxUpdateOpsCompleted || phase == agentsv1alpha1.SandboxUpdateOpsFailed
+}
+
+func updateOpsResultFromStatus(status *agentsv1alpha1.SandboxUpdateOpsStatus) string {
+	if status.Phase == agentsv1alpha1.SandboxUpdateOpsFailed {
+		return updateOpsResultFailed
+	}
+	if status.Replicas == 0 {
+		return updateOpsResultZeroTarget
+	}
+	return updateOpsResultCompleted
+}
+
+func updateOpsResultKey(ops *agentsv1alpha1.SandboxUpdateOps) string {
+	if ops.UID != "" {
+		return fmt.Sprintf("%s/%s/%s", ops.Namespace, ops.Name, ops.UID)
+	}
+	return types.NamespacedName{Namespace: ops.Namespace, Name: ops.Name}.String()
+}

--- a/pkg/controller/sandboxupdateops/metrics_test.go
+++ b/pkg/controller/sandboxupdateops/metrics_test.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sandboxupdateops
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+func TestRecordSandboxUpdateOpsStatusMetrics(t *testing.T) {
+	ns, name := "metrics-status", "update-a"
+	deleteSandboxUpdateOpsMetrics(&agentsv1alpha1.SandboxUpdateOps{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+	})
+
+	recordSandboxUpdateOpsStatusMetrics(ns, name, &agentsv1alpha1.SandboxUpdateOpsStatus{
+		Phase:            agentsv1alpha1.SandboxUpdateOpsPending,
+		Replicas:         3,
+		UpdatedReplicas:  1,
+		UpdatingReplicas: 2,
+		FailedReplicas:   0,
+	})
+	recordSandboxUpdateOpsStatusMetrics(ns, name, &agentsv1alpha1.SandboxUpdateOpsStatus{
+		Phase:            agentsv1alpha1.SandboxUpdateOpsUpdating,
+		Replicas:         4,
+		UpdatedReplicas:  2,
+		UpdatingReplicas: 1,
+		FailedReplicas:   1,
+	})
+
+	assert.Equal(t, float64(0), testutil.ToFloat64(sandboxUpdateOpsStatusPhase.WithLabelValues(ns, name, string(agentsv1alpha1.SandboxUpdateOpsPending))))
+	assert.Equal(t, float64(1), testutil.ToFloat64(sandboxUpdateOpsStatusPhase.WithLabelValues(ns, name, string(agentsv1alpha1.SandboxUpdateOpsUpdating))))
+	assert.Equal(t, float64(4), testutil.ToFloat64(sandboxUpdateOpsReplicas.WithLabelValues(ns, name, updateOpsReplicaTypeTotal)))
+	assert.Equal(t, float64(2), testutil.ToFloat64(sandboxUpdateOpsReplicas.WithLabelValues(ns, name, updateOpsReplicaTypeUpdated)))
+	assert.Equal(t, float64(1), testutil.ToFloat64(sandboxUpdateOpsReplicas.WithLabelValues(ns, name, updateOpsReplicaTypeUpdating)))
+	assert.Equal(t, float64(1), testutil.ToFloat64(sandboxUpdateOpsReplicas.WithLabelValues(ns, name, updateOpsReplicaTypeFailed)))
+
+	deleteSandboxUpdateOpsMetrics(&agentsv1alpha1.SandboxUpdateOps{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+	})
+}
+
+func TestDeleteSandboxUpdateOpsMetrics(t *testing.T) {
+	ns, name := "metrics-delete", "update-a"
+	recordSandboxUpdateOpsStatusMetrics(ns, name, &agentsv1alpha1.SandboxUpdateOpsStatus{
+		Phase:            agentsv1alpha1.SandboxUpdateOpsUpdating,
+		Replicas:         5,
+		UpdatedReplicas:  3,
+		UpdatingReplicas: 1,
+		FailedReplicas:   1,
+	})
+
+	deleteSandboxUpdateOpsMetrics(&agentsv1alpha1.SandboxUpdateOps{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+	})
+
+	assert.Equal(t, float64(0), testutil.ToFloat64(sandboxUpdateOpsStatusPhase.WithLabelValues(ns, name, string(agentsv1alpha1.SandboxUpdateOpsUpdating))))
+	assert.Equal(t, float64(0), testutil.ToFloat64(sandboxUpdateOpsReplicas.WithLabelValues(ns, name, updateOpsReplicaTypeTotal)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(sandboxUpdateOpsReplicas.WithLabelValues(ns, name, updateOpsReplicaTypeUpdated)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(sandboxUpdateOpsReplicas.WithLabelValues(ns, name, updateOpsReplicaTypeUpdating)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(sandboxUpdateOpsReplicas.WithLabelValues(ns, name, updateOpsReplicaTypeFailed)))
+}
+
+func TestUpdateStatusRecordsTerminalResultOnce(t *testing.T) {
+	tests := []struct {
+		name      string
+		newStatus agentsv1alpha1.SandboxUpdateOpsStatus
+		result    string
+	}{
+		{
+			name: "completed",
+			newStatus: agentsv1alpha1.SandboxUpdateOpsStatus{
+				Phase:           agentsv1alpha1.SandboxUpdateOpsCompleted,
+				Replicas:        2,
+				UpdatedReplicas: 2,
+			},
+			result: updateOpsResultCompleted,
+		},
+		{
+			name: "zero target",
+			newStatus: agentsv1alpha1.SandboxUpdateOpsStatus{
+				Phase: agentsv1alpha1.SandboxUpdateOpsCompleted,
+			},
+			result: updateOpsResultZeroTarget,
+		},
+		{
+			name: "failed",
+			newStatus: agentsv1alpha1.SandboxUpdateOpsStatus{
+				Phase:          agentsv1alpha1.SandboxUpdateOpsFailed,
+				Replicas:       1,
+				FailedReplicas: 1,
+			},
+			result: updateOpsResultFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := "metrics-terminal-" + tt.result
+			name := "update-a"
+			ops := newSandboxUpdateOps(name, ns, agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil)
+			ops.UID = types.UID("uid-" + tt.result)
+			observedUpdateOpsResults.Delete(updateOpsResultKey(ops))
+			deleteSandboxUpdateOpsMetrics(ops)
+			before := testutil.ToFloat64(sandboxUpdateOpsTotal.WithLabelValues(ns, tt.result))
+
+			r := newTestReconciler(ops)
+			newStatus := tt.newStatus.DeepCopy()
+			err := r.updateStatus(context.Background(), ops, newStatus)
+			assert.NoError(t, err)
+			err = r.updateStatus(context.Background(), ops, newStatus)
+			assert.NoError(t, err)
+
+			assert.Equal(t, before+1, testutil.ToFloat64(sandboxUpdateOpsTotal.WithLabelValues(ns, tt.result)))
+			assert.Equal(t, float64(1), testutil.ToFloat64(sandboxUpdateOpsStatusPhase.WithLabelValues(ns, name, string(tt.newStatus.Phase))))
+			assert.Equal(t, float64(tt.newStatus.Replicas), testutil.ToFloat64(sandboxUpdateOpsReplicas.WithLabelValues(ns, name, updateOpsReplicaTypeTotal)))
+			observedUpdateOpsResults.Delete(updateOpsResultKey(ops))
+			deleteSandboxUpdateOpsMetrics(ops)
+		})
+	}
+}
+
+func TestUpdateStatusRecordsObservedTerminalResultOnce(t *testing.T) {
+	ns, name := "metrics-terminal-old", "update-a"
+	ops := newSandboxUpdateOps(name, ns, agentsv1alpha1.SandboxUpdateOpsCompleted, false, nil)
+	ops.UID = types.UID("uid-terminal-old")
+	ops.Status.Replicas = 1
+	ops.Status.UpdatedReplicas = 1
+	observedUpdateOpsResults.Delete(updateOpsResultKey(ops))
+	before := testutil.ToFloat64(sandboxUpdateOpsTotal.WithLabelValues(ns, updateOpsResultCompleted))
+
+	r := newTestReconciler(ops)
+	newStatus := ops.Status.DeepCopy()
+	newStatus.ObservedGeneration = 2
+	err := r.updateStatus(context.Background(), ops, newStatus)
+	assert.NoError(t, err)
+	err = r.updateStatus(context.Background(), ops, newStatus)
+
+	assert.NoError(t, err)
+	assert.Equal(t, before+1, testutil.ToFloat64(sandboxUpdateOpsTotal.WithLabelValues(ns, updateOpsResultCompleted)))
+	observedUpdateOpsResults.Delete(updateOpsResultKey(ops))
+	deleteSandboxUpdateOpsMetrics(ops)
+}
+
+func TestReconcileRecordsObservedTerminalResult(t *testing.T) {
+	ns, name := "metrics-observed-terminal", "update-a"
+	ops := newSandboxUpdateOps(name, ns, agentsv1alpha1.SandboxUpdateOpsCompleted, false, nil)
+	ops.UID = types.UID("uid-observed-terminal")
+	ops.Status.Replicas = 1
+	ops.Status.UpdatedReplicas = 1
+	observedUpdateOpsResults.Delete(updateOpsResultKey(ops))
+	deleteSandboxUpdateOpsMetrics(ops)
+	before := testutil.ToFloat64(sandboxUpdateOpsTotal.WithLabelValues(ns, updateOpsResultCompleted))
+
+	r := newTestReconciler(ops)
+	result, err := r.Reconcile(context.Background(), ctrlRequest(ns, name))
+	assert.NoError(t, err)
+	assert.Equal(t, ctrlResultZero(), result)
+	result, err = r.Reconcile(context.Background(), ctrlRequest(ns, name))
+	assert.NoError(t, err)
+	assert.Equal(t, ctrlResultZero(), result)
+
+	assert.Equal(t, before+1, testutil.ToFloat64(sandboxUpdateOpsTotal.WithLabelValues(ns, updateOpsResultCompleted)))
+	assert.Equal(t, float64(1), testutil.ToFloat64(sandboxUpdateOpsStatusPhase.WithLabelValues(ns, name, string(agentsv1alpha1.SandboxUpdateOpsCompleted))))
+	observedUpdateOpsResults.Delete(updateOpsResultKey(ops))
+	deleteSandboxUpdateOpsMetrics(ops)
+}
+
+func TestHandleDeletionDeletesSandboxUpdateOpsGaugeMetrics(t *testing.T) {
+	ns, name := "metrics-handle-delete", "update-a"
+	ops := newSandboxUpdateOps(name, ns, agentsv1alpha1.SandboxUpdateOpsUpdating, false, nil)
+	ops.UID = types.UID("uid-handle-delete")
+	ops.Finalizers = []string{finalizerName}
+	observedUpdateOpsResults.Store(updateOpsResultKey(ops), true)
+	recordSandboxUpdateOpsStatusMetrics(ns, name, &agentsv1alpha1.SandboxUpdateOpsStatus{
+		Phase:            agentsv1alpha1.SandboxUpdateOpsUpdating,
+		Replicas:         1,
+		UpdatingReplicas: 1,
+	})
+
+	r := newTestReconciler(ops)
+	err := r.Delete(context.Background(), ops)
+	assert.NoError(t, err)
+
+	result, err := r.Reconcile(context.Background(), ctrlRequest(ns, name))
+
+	assert.NoError(t, err)
+	assert.Equal(t, ctrlResultZero(), result)
+	assert.Equal(t, float64(0), testutil.ToFloat64(sandboxUpdateOpsStatusPhase.WithLabelValues(ns, name, string(agentsv1alpha1.SandboxUpdateOpsUpdating))))
+	assert.Equal(t, float64(0), testutil.ToFloat64(sandboxUpdateOpsReplicas.WithLabelValues(ns, name, updateOpsReplicaTypeTotal)))
+	_, ok := observedUpdateOpsResults.Load(updateOpsResultKey(ops))
+	assert.False(t, ok)
+}
+
+func TestReconcileDeletesSandboxUpdateOpsGaugeMetricsOnNotFound(t *testing.T) {
+	ns, name := "metrics-not-found", "update-a"
+	ops := newSandboxUpdateOps(name, ns, agentsv1alpha1.SandboxUpdateOpsCompleted, false, nil)
+	ops.UID = types.UID("uid-not-found")
+	observedUpdateOpsResults.Store(updateOpsResultKey(ops), true)
+	recordSandboxUpdateOpsStatusMetrics(ns, name, &agentsv1alpha1.SandboxUpdateOpsStatus{
+		Phase:           agentsv1alpha1.SandboxUpdateOpsCompleted,
+		Replicas:        2,
+		UpdatedReplicas: 2,
+	})
+
+	r := newTestReconciler()
+	result, err := r.Reconcile(context.Background(), ctrlRequest(ns, name))
+
+	assert.NoError(t, err)
+	assert.Equal(t, ctrlResultZero(), result)
+	assert.Equal(t, float64(0), testutil.ToFloat64(sandboxUpdateOpsStatusPhase.WithLabelValues(ns, name, string(agentsv1alpha1.SandboxUpdateOpsCompleted))))
+	assert.Equal(t, float64(0), testutil.ToFloat64(sandboxUpdateOpsReplicas.WithLabelValues(ns, name, updateOpsReplicaTypeTotal)))
+	_, ok := observedUpdateOpsResults.Load(updateOpsResultKey(ops))
+	assert.True(t, ok)
+	observedUpdateOpsResults.Delete(updateOpsResultKey(ops))
+}
+
+func ctrlRequest(namespace, name string) ctrl.Request {
+	return ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}}
+}
+
+func ctrlResultZero() ctrl.Result {
+	return ctrl.Result{}
+}

--- a/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
+++ b/pkg/controller/sandboxupdateops/sandboxupdateops_controller.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -104,8 +105,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// 1. Get SandboxUpdateOps
 	ops := &agentsv1alpha1.SandboxUpdateOps{}
 	if err := r.Get(ctx, req.NamespacedName, ops); err != nil {
+		if apierrors.IsNotFound(err) {
+			deleteSandboxUpdateOpsGaugeMetrics(req.Namespace, req.Name)
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	recordSandboxUpdateOpsMetrics(ops)
 
 	// 2. Check if another SandboxUpdateOps in the same namespace is already Updating
 	// TODO: This is a short-term solution to prevent concurrent ops in the same namespace.
@@ -606,6 +611,7 @@ func (r *Reconciler) handleDeletion(ctx context.Context, ops *agentsv1alpha1.San
 	if err := r.Update(ctx, ops); err != nil {
 		return ctrl.Result{}, err
 	}
+	deleteSandboxUpdateOpsMetrics(ops)
 	klog.InfoS("Finalizer removed, SandboxUpdateOps can be deleted",
 		"ops", klog.KObj(ops))
 	return ctrl.Result{}, nil
@@ -628,6 +634,8 @@ func (r *Reconciler) updateStatus(ctx context.Context, ops *agentsv1alpha1.Sandb
 		klog.ErrorS(err, "Failed to update SandboxUpdateOps status", "ops", klog.KObj(ops), "patch", patchStatus)
 	} else {
 		klog.InfoS("Successfully updated SandboxUpdateOps status", "ops", klog.KObj(ops), "patch", patchStatus)
+		recordSandboxUpdateOpsStatusMetrics(ops.Namespace, ops.Name, newStatus)
+		recordSandboxUpdateOpsTerminalResult(ops, newStatus)
 		r.recordPhaseEvent(ops, oldPhase, newStatus)
 	}
 	return err


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Add Prometheus metrics for SandboxUpdateOps reconciliation:

- `sandbox_updateops_status_phase{namespace,name,phase}` reports the active phase as `1`.
- `sandbox_updateops_replicas{namespace,name,type}` reports total, updated, updating, and failed replica counts from status.
- `sandbox_updateops_total{namespace,result}` counts terminal results by namespace with `completed`, `failed`, and `zero_target`.

The terminal result counter is recorded from observed terminal status with a per-UID in-process guard, so it can still count objects first seen after restart or leader handoff.

### Ⅱ. Does this pull request fix one issue?
NONE

### Ⅲ. Describe how to verify it

```bash
go test ./pkg/controller/sandboxupdateops -count=1
git diff --check
```

### Ⅳ. Special notes for reviews

Gauge series are cleaned up when the SandboxUpdateOps finalizer cleanup completes. The historical terminal-result counter is intentionally retained.
