### PR TITLE
ci: add govulncheck, zizmor and Scorecard scans; enable gosec

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,32 @@
 # Configuration options: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
+# Go module updates. Without this entry Dependabot raises no PRs for Go
+# dependencies at all, which means CVEs in go.mod are never auto-remediated
+# and govulncheck/Trivy findings have to be fixed by hand.
+- package-ecosystem: "gomod"
+  directory: "/"
+  open-pull-requests-limit: 10
+  schedule:
+    interval: "weekly"
+  groups:
+    # Keep the PR volume manageable: k8s and otel release many modules in
+    # lockstep and must be bumped together anyway.
+    k8s:
+      patterns:
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"
+    otel:
+      patterns:
+        - "go.opentelemetry.io/*"
+    golang-x:
+      patterns:
+        - "golang.org/x/*"
+  # NOTE: intentionally no `ignore:` rules here. Dependabot ignore conditions
+  # apply to security updates as well as version updates, so silencing a
+  # dependency also silences its CVE PRs. If the PR volume is too high, prefer
+  # widening the `groups` above or lowering open-pull-requests-limit.
+
 - package-ecosystem: "github-actions"
   directory: "/"
   # Allow up to 10 open pull requests for update github-actions

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,14 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-24.04
     permissions:
+      # Job-level permissions REPLACE the workflow-level `read-all`, they do not
+      # merge with it. Any scope omitted here becomes `none`, so contents and
+      # pull-requests must be listed explicitly.
+      contents: read
       security-events: write
+      # Required by golangci-lint-action's only-new-issues, which fetches the
+      # PR diff from the API.
+      pull-requests: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -64,6 +71,10 @@ jobs:
           args: --verbose
           skip-pkg-cache: true
           mod: readonly
+          # Report only issues introduced by this PR. This is what makes it safe
+          # to enable gosec without the pre-existing findings blocking every
+          # unrelated pull request.
+          only-new-issues: true
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # master
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,84 +1,86 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
   push:
-    branches: [ "master", "release-*"]
+    branches: [ "master", "release-*" ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ "master" ]
+  merge_group:
+    branches: [ "master" ]
+  schedule:
+    # Weekly full scan. Catches newly published CodeQL queries against code
+    # that has not changed, which PR-triggered runs never re-examine.
+    - cron: '27 3 * * 1'
 
+# Declare default permissions as read only.
+permissions: read-all
 
-permissions: 
-  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:
-    name: Analyze
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners
-    # Consider using larger runners for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
     permissions:
+      # required to upload results to code scanning
+      security-events: write
+      # required by github/codeql-action, see github/codeql-action#2117
       actions: read
       contents: read
-      security-events: write
 
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
-        # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
-        # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        include:
+          # Go does NOT support build-mode 'none'; it needs autobuild or manual.
+          - language: go
+            build-mode: autobuild
+          # Scans .github/workflows/*.yml and **/action.yml for CI-specific
+          # vulnerabilities: artifact/cache poisoning, script injection,
+          # untrusted checkout in privileged context, secret exposure, TOCTOU.
+          - language: actions
+            build-mode: none
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Pin the toolchain instead of relying on CodeQL's bundled Go, so that
+      # analysis uses the same version as the rest of CI.
+      - name: Setup Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version: '1.25'
+          cache: false
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # 'security-extended' = default suite + lower-precision/severity
+          # queries. It finds more, and it also reports more false positives.
+          # Copilot Autofix covers a subset of both default and
+          # security-extended, so this does not cost us Autofix coverage.
+          queries: security-extended
+          config: |
+            paths-ignore:
+              - test
+              - examples
+              - vendor
+              - third_party
 
+      - name: Autobuild
+        if: matrix.build-mode == 'autobuild'
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
-    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,91 @@
+name: govulncheck
+
+# govulncheck is the only Go tool that does symbol-level reachability: it
+# reports a module CVE only when your code actually calls the vulnerable
+# function. That makes it complementary to Trivy/Dependabot (which match by
+# version) and to CodeQL (which does not look at dependency CVEs at all).
+#
+# This workflow is deliberately NON-BLOCKING. The repository currently has
+# pre-existing findings, so gating on them would red-flag every unrelated PR.
+# Findings land in the Security tab and in the job summary instead.
+
+on:
+  push:
+    branches: [ "master", "release-*" ]
+  pull_request:
+    branches: [ "master" ]
+  merge_group:
+    branches: [ "master" ]
+  schedule:
+    # New advisories are published against unchanged code, so a periodic run is
+    # the only way to notice them.
+    - cron: '41 4 * * 1'
+  workflow_dispatch: { }
+
+# Declare default permissions as read only.
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: '1.25'
+  # Bump manually; Dependabot does not track versions pinned inside run steps.
+  GOVULNCHECK_VERSION: 'v1.1.4'
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          # Avoid restoring a build cache that a release-branch push could have
+          # poisoned (zizmor: cache-poisoning).
+          cache: false
+
+      - name: Install govulncheck
+        run: go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
+
+      # -scan symbol (the default) is what gives reachability. -format sarif
+      # exits 0 even when vulnerabilities are found, which is what we want here.
+      - name: Run govulncheck (SARIF)
+        run: govulncheck -format sarif ./... > govulncheck.sarif
+
+      # Human-readable output, so contributors on fork PRs still see something
+      # even though they cannot upload to the Security tab.
+      - name: Summarize findings
+        if: always()
+        run: |
+          {
+            echo '## govulncheck'
+            echo
+            echo '```'
+            govulncheck ./... 2>&1 || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Fork PRs get a read-only GITHUB_TOKEN, so security-events: write is not
+      # available to them. Skip the upload rather than fail the job.
+      - name: Upload SARIF to code scanning
+        if: >-
+          always() &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository)
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          sarif_file: govulncheck.sarif
+          category: govulncheck

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,64 @@
+name: OpenSSF Scorecard
+
+# Scorecard grades the repository's supply-chain posture (branch protection,
+# SHA-pinned actions, dangerous workflow patterns, token permissions, signed
+# releases, CI tests, fuzzing, SAST, ...). etcd, containerd and Envoy all run
+# it; it is also what the CNCF/OpenSSF badge programs read.
+#
+# Constraints imposed by the action itself (see ossf/scorecard-action README):
+#   * only the `push` (default branch) and `schedule` triggers are supported;
+#     `pull_request` is experimental, so this is NOT a PR gate
+#   * it does not work on forks
+#   * `publish_results: true` requires `id-token: write` and forbids
+#     workflow-level write permissions, top-level `env`/`defaults`, and any
+#     step outside the action's allow-list in this job
+
+on:
+  push:
+    # Only the default branch is supported.
+    branches: [ "master" ]
+  schedule:
+    - cron: '32 6 * * 1'
+  workflow_dispatch: { }
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-24.04
+    permissions:
+      # Needed to upload the results to the code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishes results to the OpenSSF REST API so the score is publicly
+          # queryable and the README badge works. Required for the badge.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          sarif_file: results.sarif
+          category: scorecard

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,64 @@
+name: GHA security analysis
+
+# zizmor is a static analyzer for GitHub Actions workflows themselves. It
+# covers the CI-specific attack surface that no code scanner looks at:
+# script injection via template expansion, cache poisoning, credential
+# persistence, unpinned actions, impostor commits, excessive permissions.
+#
+# Kata Containers runs the same tool. This complements the CodeQL 'actions'
+# language rather than duplicating it: zizmor additionally flags
+# unpinned-uses, excessive-permissions and dangerous-triggers, and it also
+# reads dependabot.yml and action.yml.
+#
+# NOTE: this repository currently has a substantial backlog of findings
+# (mostly unpinned-uses / artipacked / cache-poisoning), so the job is
+# report-only. In SARIF mode zizmor deliberately does not use its non-zero
+# exit codes, which means this workflow always shows green; a green check
+# here does NOT mean zero findings. Read the Security tab.
+
+on:
+  push:
+    branches: [ "master", "release-*" ]
+  pull_request:
+    branches: [ "master" ]
+  merge_group:
+    branches: [ "master" ]
+  schedule:
+    - cron: '13 5 * * 1'
+  workflow_dispatch: { }
+
+# Declare default permissions as read only.
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Needed by the impostor-commit and ref-confusion audits.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          # Fork PRs cannot write security events; fall back to inline
+          # annotations for them so contributors still get feedback.
+          advanced-security: >-
+            ${{ github.event_name != 'pull_request' ||
+                github.event.pull_request.head.repo.full_name == github.repository }}
+          # 'regular' is the default persona. Switch to 'auditor' (what Kata
+          # uses) once the current backlog is cleared, or it will drown you.
+          persona: regular

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,12 +9,28 @@ linters:
     - ginkgolinter
     - goconst
     - gocyclo
+    # gosec covers the security rules that CodeQL's Go queries do not: file and
+    # directory permissions (G301-G307), integer overflow conversions (G115),
+    # weak TLS/crypto config (G402-G404), subprocess handling (G204). For a
+    # sandbox/container codebase these matter more than the injection queries,
+    # because CodeQL's Go threat model only treats *remote* input as tainted.
+    - gosec
     - govet
     - ineffassign
     - misspell
     - unconvert
     - unused
   settings:
+    gosec:
+      # Report everything. The current volume is 3 findings repo-wide, so there
+      # is no need to filter by severity/confidence yet. Existing findings do
+      # not block PRs because the CI job runs with only-new-issues: true.
+      excludes:
+        # G104 (unhandled errors) overlaps with errcheck and is very noisy.
+        - G104
+      # Caveat worth knowing: a `#nosec` comment does NOT take effect when the
+      # flagged call sits in an `if err := f(); err != nil` init statement.
+      # Hoist the call to its own line for the suppression to apply.
     revive:
       rules:
         - name: comment-spacings


### PR DESCRIPTION
Rounds out the security tooling to match what mature Go projects in the CNCF ecosystem run (etcd, containerd, Envoy, Kata Containers).

New jobs:
- govulncheck: the only Go tool that does symbol-level reachability, so a module CVE is reported only when the vulnerable function is actually called. Complements Trivy/Dependabot (version matching) and CodeQL (which does not look at dependency CVEs at all).
- zizmor: static analysis of the workflows themselves - script injection via template expansion, cache poisoning, credential persistence, unpinned actions. Same tool Kata Containers uses.
- OpenSSF Scorecard: supply-chain posture grading. Only runs on the default branch and on a schedule, as the action does not support PR triggers.

Changes to existing config:
- codeql: add the `actions` language, which scans .github/workflows for CI-specific vulnerabilities (artifact/cache poisoning, script injection, untrusted checkout in privileged contexts). Also switch to security-extended, add merge_group and a weekly schedule, and exclude test/examples/vendor from analysis.
- dependabot: add the `gomod` ecosystem. Without it no PRs were ever raised for Go dependencies, so CVEs in go.mod had to be fixed by hand.
- golangci: enable gosec. It covers what CodeQL's Go queries do not - file and directory permissions, integer overflow conversions, weak TLS config - which matter more here because CodeQL's Go threat model only treats remote input as tainted, while a sandbox runtime is mostly fed local input.
- ci: set only-new-issues so the pre-existing gosec findings do not block unrelated PRs, and list contents/pull-requests in the job permissions block, which previously reduced them to `none` by omission.

All new scans are report-only and publish SARIF to the Security tab rather than gating merges, because the repository has a backlog of findings.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

