### PR TITLE
Feature/opensandbox api adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,4 @@ REVIEW.md
 analysis/
 
 .gocache/
+ROADMAP.md

--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/openkruise/agents/pkg/servers/e2b"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/openkruise/agents/pkg/servers/opensandbox"
 	"github.com/openkruise/agents/pkg/tracing"
 	"github.com/openkruise/agents/pkg/utils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
@@ -104,6 +105,8 @@ func main() {
 	var quotaAntiDriftInterval time.Duration
 	var quotaAntiDriftGrace time.Duration
 	var runtimeClientCertSecret string
+	var enableOpenSandboxAPI bool
+	var openSandboxDefaultTemplate string
 
 	utilfeature.DefaultMutableFeatureGate.AddFlag(pflag.CommandLine)
 
@@ -155,6 +158,10 @@ func main() {
 	pflag.DurationVar(&quotaAntiDriftGrace, "quota-anti-drift-grace", consts.DefaultQuotaAntiDriftGrace, "Grace period before periodic quota anti-drift releases suspected leaked entries.")
 	pflag.StringVar(&runtimeClientCertSecret, "runtime-client-cert-secret", "",
 		"namespace/name of the Secret holding the agent-runtime client TLS bundle. Leave it empty to disable the runtime mTLS.")
+	pflag.BoolVar(&enableOpenSandboxAPI, "enable-opensandbox-api", false,
+		"Serve the OpenSandbox-compatible API alongside the E2B API on the same port. Experimental initial adapter; see pkg/servers/opensandbox/AGENTS.md.")
+	pflag.StringVar(&openSandboxDefaultTemplate, "opensandbox-default-template", "",
+		"SandboxTemplate an image-based OpenSandbox CreateSandbox request claims from before applying the requested image as an in-place update. Required when --enable-opensandbox-api is set.")
 
 	// Tracing flags (definitions shared with agent-sandbox-controller via
 	// tracing.Config.BindFlags; pulled into pflag by AddGoFlagSet below)
@@ -207,6 +214,10 @@ func main() {
 
 	if err := validateE2BTimeoutFlags(e2bMinResumeTimeout, e2bMaxTimeout); err != nil {
 		klog.Fatalf("invalid e2b timeout flags: %v", err)
+	}
+
+	if enableOpenSandboxAPI && openSandboxDefaultTemplate == "" {
+		klog.Fatalf("--opensandbox-default-template is required when --enable-opensandbox-api is set")
 	}
 	if quotaRedisOperationTimeout <= 0 {
 		klog.Fatalf("--quota-redis-operation-timeout must be greater than 0")
@@ -351,6 +362,23 @@ func main() {
 
 	if err := sandboxController.Init(); err != nil {
 		klog.Fatalf("Failed to initialize sandbox controller: %v", err)
+	}
+
+	// The OpenSandbox API is an optional second protocol adapter that
+	// coexists on the same mux/port as the E2B API above, reusing its
+	// already-built SandboxManager, cache, and API-key storage instead of
+	// standing up a second copy of any of them. See pkg/servers/opensandbox.
+	if enableOpenSandboxAPI {
+		openSandboxController := opensandbox.NewController(opensandbox.Dependencies{
+			Manager:           sandboxController.Manager(),
+			Cache:             sandboxController.Cache(),
+			Keys:              sandboxController.Keys(),
+			SystemNamespace:   sandboxController.SystemNamespace(),
+			MaxTimeoutSeconds: e2bMaxTimeout,
+			DefaultTemplate:   openSandboxDefaultTemplate,
+		})
+		openSandboxController.RegisterRoutes(sandboxController.Mux())
+		klog.InfoS("OpenSandbox API enabled", "defaultTemplate", openSandboxDefaultTemplate)
 	}
 
 	// Start HTTP Server

--- a/pkg/runtimeprovider/envd.go
+++ b/pkg/runtimeprovider/envd.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimeprovider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/utils/runtime"
+	runtimeconfig "github.com/openkruise/agents/pkg/utils/runtime/config"
+	"github.com/openkruise/agents/proto/envd/process"
+)
+
+func init() {
+	register(KindEnvd, newEnvdProvider)
+}
+
+// envdRuntime is the subset of runtime.Runtime this adapter depends on. It
+// exists so tests can substitute a fake without standing up a real envd
+// sidecar; pkg/utils/runtime.Runtime itself already satisfies it.
+type envdRuntime interface {
+	Init() runtime.InitAPI
+	Process() runtime.ProcessAPI
+	Filesystem() runtime.FilesystemAPI
+}
+
+// envdProvider adapts pkg/utils/runtime's envd client to the protocol-neutral
+// Provider interface. It performs no protocol logic of its own: every call is
+// a straight translation to/from the envd-specific request/result types.
+type envdProvider struct {
+	rt envdRuntime
+}
+
+// NewEnvdProvider wraps an already-constructed envd runtime.Runtime (bound to
+// a specific Sandbox) as a Provider. This is the constructor callers use when
+// they already build a runtime.Runtime through the existing
+// pkg/utils/runtime machinery (e.g. TLS bundle resolution during claim/clone);
+// NewProvider(KindEnvd, ...) is for the simpler case of talking to a sandbox
+// by endpoint alone.
+func NewEnvdProvider(rt runtime.Runtime) Provider {
+	return &envdProvider{rt: rt}
+}
+
+// newEnvdProvider is the Factory registered for KindEnvd. It builds a
+// runtime.Runtime bound to a minimal Sandbox shell carrying only enough
+// addressing for runtime.GetRuntimeURL to resolve: a full "scheme://host:port"
+// endpoint is stored as the runtime-URL annotation verbatim, while a bare host
+// is stored as the pod IP and combined with the well-known runtime port, same
+// as the sandbox-manager claim/clone path does for a freshly claimed pod.
+func newEnvdProvider(endpoint string, opts ...Option) (Provider, error) {
+	if endpoint == "" {
+		return nil, fmt.Errorf("runtimeprovider: envd: empty endpoint")
+	}
+	s := newSettings(opts)
+	sbx := &agentsv1alpha1.Sandbox{}
+	if strings.Contains(endpoint, "://") {
+		sbx.Annotations = map[string]string{agentsv1alpha1.AnnotationRuntimeURL: endpoint}
+	} else {
+		sbx.Status.PodInfo.PodIP = endpoint
+	}
+	rtOpts := []runtime.Option{runtime.WithRequestTimeout(s.timeout)}
+	return &envdProvider{rt: runtime.NewRuntime(sbx, rtOpts...)}, nil
+}
+
+func (p *envdProvider) Kind() Kind { return KindEnvd }
+
+func (p *envdProvider) Init(ctx context.Context, opts InitOptions) error {
+	return p.rt.Init().Init(ctx, runtimeconfig.InitRuntimeOptions{
+		EnvVars:     opts.EnvVars,
+		AccessToken: opts.AccessToken,
+		ReInit:      opts.ReInit,
+	})
+}
+
+func (p *envdProvider) Exec(ctx context.Context, opts ExecOptions) (ExecResult, error) {
+	var cwd *string
+	if opts.Cwd != "" {
+		cwd = &opts.Cwd
+	}
+	result, err := p.rt.Process().Run(ctx, runtime.RunCommandRequest{
+		ProcessConfig: &process.ProcessConfig{
+			Cmd:  opts.Cmd,
+			Args: opts.Args,
+			Envs: opts.Envs,
+			Cwd:  cwd,
+		},
+		AuthUser: opts.AuthUser,
+	})
+	if err != nil {
+		return ExecResult{}, err
+	}
+	return ExecResult{
+		Stdout:   strings.Join(result.Stdout, ""),
+		Stderr:   strings.Join(result.Stderr, ""),
+		ExitCode: result.ExitCode,
+		Exited:   result.Exited,
+	}, result.Error
+}
+
+func (p *envdProvider) WriteFile(ctx context.Context, opts WriteFileOptions) error {
+	content, err := io.ReadAll(opts.Content)
+	if err != nil {
+		return fmt.Errorf("runtimeprovider: envd: read content: %w", err)
+	}
+	_, err = p.rt.Filesystem().Write(ctx, runtime.WriteFileRequest{
+		FilePath: opts.Path,
+		Content:  content,
+		AuthUser: opts.AuthUser,
+	})
+	return err
+}
+
+// ReadFile is not exposed by the envd Filesystem service used elsewhere in
+// this repository (only Write, ListDir, and Remove are); envd instead serves
+// file content through the sandbox-gateway data plane. Returning an
+// unsupported error here is honest about that gap rather than silently
+// returning an empty file.
+func (p *envdProvider) ReadFile(_ context.Context, opts ReadFileOptions) (ReadFileResult, error) {
+	return ReadFileResult{}, fmt.Errorf("runtimeprovider: envd: ReadFile is not supported by the envd control-plane client; read %q through the sandbox-gateway data plane instead", opts.Path)
+}

--- a/pkg/runtimeprovider/envd_test.go
+++ b/pkg/runtimeprovider/envd_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimeprovider
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkruise/agents/pkg/utils/runtime"
+	runtimeconfig "github.com/openkruise/agents/pkg/utils/runtime/config"
+	"github.com/openkruise/agents/proto/envd/filesystem"
+)
+
+// fakeEnvdRuntime is a minimal envdRuntime double. A double is used here
+// (rather than a real envd sidecar) because envdProvider's job is pure
+// translation between runtimeprovider's protocol-neutral types and envd's
+// wire types; the translation is what these tests verify, not envd itself.
+type fakeEnvdRuntime struct {
+	initOpts  runtimeconfig.InitRuntimeOptions
+	initErr   error
+	runReq    runtime.RunCommandRequest
+	runResult runtime.RunCommandResult
+	runErr    error
+	writeReq  runtime.WriteFileRequest
+	writeErr  error
+}
+
+func (f *fakeEnvdRuntime) Init() runtime.InitAPI             { return fakeInitAPI{f} }
+func (f *fakeEnvdRuntime) Process() runtime.ProcessAPI       { return fakeProcessAPI{f} }
+func (f *fakeEnvdRuntime) Filesystem() runtime.FilesystemAPI { return fakeFilesystemAPI{f} }
+
+type fakeInitAPI struct{ f *fakeEnvdRuntime }
+
+func (a fakeInitAPI) Init(_ context.Context, opts runtimeconfig.InitRuntimeOptions) error {
+	a.f.initOpts = opts
+	return a.f.initErr
+}
+
+type fakeProcessAPI struct{ f *fakeEnvdRuntime }
+
+func (a fakeProcessAPI) Run(_ context.Context, req runtime.RunCommandRequest) (runtime.RunCommandResult, error) {
+	a.f.runReq = req
+	return a.f.runResult, a.f.runErr
+}
+
+func (a fakeProcessAPI) Chmod(context.Context, string, string) error {
+	return errors.New("not implemented in fake")
+}
+
+type fakeFilesystemAPI struct{ f *fakeEnvdRuntime }
+
+func (a fakeFilesystemAPI) Write(_ context.Context, req runtime.WriteFileRequest) (runtime.WriteFileResult, error) {
+	a.f.writeReq = req
+	return runtime.WriteFileResult{StatusCode: 200}, a.f.writeErr
+}
+
+func (a fakeFilesystemAPI) ListDir(context.Context, runtime.ListDirRequest) ([]*filesystem.EntryInfo, error) {
+	return nil, errors.New("not implemented in fake")
+}
+
+func (a fakeFilesystemAPI) Remove(context.Context, runtime.RemovePathRequest) error {
+	return errors.New("not implemented in fake")
+}
+
+func TestEnvdProvider_Init(t *testing.T) {
+	fake := &fakeEnvdRuntime{}
+	p := &envdProvider{rt: fake}
+
+	err := p.Init(t.Context(), InitOptions{
+		EnvVars:     map[string]string{"FOO": "bar"},
+		AccessToken: "tok",
+		ReInit:      true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "tok", fake.initOpts.AccessToken)
+	assert.Equal(t, map[string]string{"FOO": "bar"}, fake.initOpts.EnvVars)
+	assert.True(t, fake.initOpts.ReInit)
+}
+
+func TestEnvdProvider_Exec(t *testing.T) {
+	fake := &fakeEnvdRuntime{
+		runResult: runtime.RunCommandResult{
+			Stdout:   []string{"hello ", "world"},
+			Stderr:   []string{"warn"},
+			ExitCode: 0,
+			Exited:   true,
+		},
+	}
+	p := &envdProvider{rt: fake}
+
+	result, err := p.Exec(t.Context(), ExecOptions{
+		Cmd:  "echo",
+		Args: []string{"hi"},
+		Cwd:  "/work",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", result.Stdout)
+	assert.Equal(t, "warn", result.Stderr)
+	assert.True(t, result.Exited)
+	require.NotNil(t, fake.runReq.ProcessConfig.Cwd)
+	assert.Equal(t, "/work", *fake.runReq.ProcessConfig.Cwd)
+	assert.Equal(t, "echo", fake.runReq.ProcessConfig.Cmd)
+}
+
+func TestEnvdProvider_WriteFile(t *testing.T) {
+	fake := &fakeEnvdRuntime{}
+	p := &envdProvider{rt: fake}
+
+	err := p.WriteFile(t.Context(), WriteFileOptions{
+		Path:    "/tmp/a.txt",
+		Content: strings.NewReader("payload"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/a.txt", fake.writeReq.FilePath)
+	assert.Equal(t, []byte("payload"), fake.writeReq.Content)
+}
+
+// ReadFile is deliberately unsupported by the envd control-plane client (see
+// the comment on envdProvider.ReadFile); this pins that contract.
+func TestEnvdProvider_ReadFile_Unsupported(t *testing.T) {
+	p := &envdProvider{rt: &fakeEnvdRuntime{}}
+	_, err := p.ReadFile(t.Context(), ReadFileOptions{Path: "/tmp/a.txt"})
+	require.Error(t, err)
+}

--- a/pkg/runtimeprovider/execd.go
+++ b/pkg/runtimeprovider/execd.go
@@ -1,0 +1,297 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimeprovider
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func init() {
+	register(KindExecd, newExecdProvider)
+}
+
+// execd daemon endpoints, per specs/execd-api.yaml in the OpenSandbox project
+// (https://github.com/alibaba/OpenSandbox/blob/main/specs/execd-api.yaml).
+// execd listens on a fixed in-pod port (44772 by default) and authenticates
+// every call via the X-EXECD-ACCESS-TOKEN header.
+const (
+	execdDefaultPort    = "44772"
+	execdAccessTokenHdr = "X-EXECD-ACCESS-TOKEN"
+	execdCommandPath    = "/command"
+	execdUploadPath     = "/files/upload"
+	execdDownloadPath   = "/files/download"
+)
+
+// execdProvider speaks the OpenSandbox execd REST/SSE protocol directly: no
+// generated client exists for it in this repository yet, so requests are
+// built and parsed by hand the same way pkg/utils/runtime/filesystem.go talks
+// to envd's multipart /files route.
+type execdProvider struct {
+	baseURL     string
+	accessToken string
+	client      *http.Client
+	// timeout bounds a call whose context carries no deadline of its own,
+	// mirroring pkg/utils/runtime's defaultRuntimeTimeout. It is not applied
+	// via http.Client.Timeout because command execution can legitimately run
+	// long; WriteFile/ReadFile still benefit from a bound.
+	timeout time.Duration
+}
+
+func newExecdProvider(endpoint string, opts ...Option) (Provider, error) {
+	if endpoint == "" {
+		return nil, fmt.Errorf("runtimeprovider: execd: empty endpoint")
+	}
+	s := newSettings(opts)
+	base := endpoint
+	if !strings.Contains(base, "://") {
+		host := base
+		port := execdDefaultPort
+		if h, p, ok := strings.Cut(base, ":"); ok {
+			host, port = h, p
+		}
+		base = fmt.Sprintf("http://%s:%s", host, port)
+	}
+	return &execdProvider{baseURL: strings.TrimSuffix(base, "/"), client: s.httpClient, timeout: s.timeout}, nil
+}
+
+// withTimeout applies the provider's default deadline when ctx does not
+// already carry one, so a caller that forgets to bound Exec or WriteFile
+// cannot hang forever on a stuck daemon. It is not used by ReadFile: that call
+// returns its response body for the caller to stream after this function
+// returns, so imposing a deadline here would cancel a read still in progress.
+func (p *execdProvider) withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, p.timeout)
+}
+
+func (p *execdProvider) Kind() Kind { return KindExecd }
+
+// Init stores the access token used to authenticate subsequent calls. execd
+// (unlike envd) does not have a separate handshake endpoint in the lifecycle
+// spec: the token is minted by the sandbox lifecycle API at creation time and
+// simply presented on every execd call, so Init is a local, non-networked
+// assignment.
+func (p *execdProvider) Init(_ context.Context, opts InitOptions) error {
+	if opts.AccessToken == "" {
+		return fmt.Errorf("runtimeprovider: execd: access token is required")
+	}
+	p.accessToken = opts.AccessToken
+	return nil
+}
+
+// execdCommandRequest mirrors the POST /command request body in
+// specs/execd-api.yaml.
+type execdCommandRequest struct {
+	Cmd  string            `json:"cmd"`
+	Args []string          `json:"args,omitempty"`
+	Env  map[string]string `json:"env,omitempty"`
+	Cwd  string            `json:"cwd,omitempty"`
+	User string            `json:"user,omitempty"`
+}
+
+// execdEventData is the JSON payload of one Server-Sent Event frame emitted
+// by POST /command: "stdout"/"stderr" frames carry output chunks, a "status"
+// frame carries the final exit status (and marks the stream complete).
+type execdEventData struct {
+	Chunk    string `json:"chunk"`
+	ExitCode *int32 `json:"exitCode"`
+	Exited   *bool  `json:"exited"`
+}
+
+func (p *execdProvider) Exec(ctx context.Context, opts ExecOptions) (ExecResult, error) {
+	ctx, cancel := p.withTimeout(ctx)
+	defer cancel()
+	body, err := json.Marshal(execdCommandRequest{
+		Cmd:  opts.Cmd,
+		Args: opts.Args,
+		Env:  opts.Envs,
+		Cwd:  opts.Cwd,
+		User: opts.AuthUser,
+	})
+	if err != nil {
+		return ExecResult{}, fmt.Errorf("runtimeprovider: execd: marshal command: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+execdCommandPath, bytes.NewReader(body))
+	if err != nil {
+		return ExecResult{}, fmt.Errorf("runtimeprovider: execd: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set(execdAccessTokenHdr, p.accessToken)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return ExecResult{}, fmt.Errorf("runtimeprovider: execd: exec %q: %w", opts.Cmd, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return ExecResult{}, execdStatusError(resp)
+	}
+	return parseExecdCommandStream(resp.Body)
+}
+
+// parseExecdCommandStream reads the SSE-formatted /command response and
+// accumulates it into a single ExecResult. It implements just enough of SSE
+// (event:/data: lines, blank-line-terminated frames) to consume execd's
+// command stream; it is not a general-purpose SSE client.
+func parseExecdCommandStream(r io.Reader) (ExecResult, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	var result ExecResult
+	var stdout, stderr strings.Builder
+	var event, data string
+	flush := func() error {
+		if event == "" {
+			return nil
+		}
+		defer func() { event, data = "", "" }()
+		var payload execdEventData
+		if data != "" {
+			if err := json.Unmarshal([]byte(data), &payload); err != nil {
+				return fmt.Errorf("runtimeprovider: execd: decode %s event: %w", event, err)
+			}
+		}
+		switch event {
+		case "stdout":
+			stdout.WriteString(payload.Chunk)
+		case "stderr":
+			stderr.WriteString(payload.Chunk)
+		case "status":
+			if payload.ExitCode != nil {
+				result.ExitCode = *payload.ExitCode
+			}
+			if payload.Exited != nil {
+				result.Exited = *payload.Exited
+			}
+		}
+		return nil
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case line == "":
+			if err := flush(); err != nil {
+				return ExecResult{}, err
+			}
+		case strings.HasPrefix(line, "event:"):
+			event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			data = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		}
+	}
+	if err := flush(); err != nil {
+		return ExecResult{}, err
+	}
+	if err := scanner.Err(); err != nil {
+		return ExecResult{}, fmt.Errorf("runtimeprovider: execd: read command stream: %w", err)
+	}
+	result.Stdout = stdout.String()
+	result.Stderr = stderr.String()
+	return result, nil
+}
+
+func (p *execdProvider) WriteFile(ctx context.Context, opts WriteFileOptions) error {
+	ctx, cancel := p.withTimeout(ctx)
+	defer cancel()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile("file", opts.Path)
+	if err != nil {
+		return fmt.Errorf("runtimeprovider: execd: build upload form: %w", err)
+	}
+	if _, err := io.Copy(part, opts.Content); err != nil {
+		return fmt.Errorf("runtimeprovider: execd: read content: %w", err)
+	}
+	if opts.AuthUser != "" {
+		if err := writer.WriteField("user", opts.AuthUser); err != nil {
+			return fmt.Errorf("runtimeprovider: execd: write user field: %w", err)
+		}
+	}
+	if err := writer.WriteField("path", opts.Path); err != nil {
+		return fmt.Errorf("runtimeprovider: execd: write path field: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("runtimeprovider: execd: close upload form: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+execdUploadPath, &buf)
+	if err != nil {
+		return fmt.Errorf("runtimeprovider: execd: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set(execdAccessTokenHdr, p.accessToken)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("runtimeprovider: execd: upload %q: %w", opts.Path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
+		return execdStatusError(resp)
+	}
+	return nil
+}
+
+func (p *execdProvider) ReadFile(ctx context.Context, opts ReadFileOptions) (ReadFileResult, error) {
+	q := url.Values{"path": []string{opts.Path}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+execdDownloadPath+"?"+q.Encode(), nil)
+	if err != nil {
+		return ReadFileResult{}, fmt.Errorf("runtimeprovider: execd: build request: %w", err)
+	}
+	if opts.AuthUser != "" {
+		req.Header.Set("X-EXECD-USER", opts.AuthUser)
+	}
+	req.Header.Set(execdAccessTokenHdr, p.accessToken)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return ReadFileResult{}, fmt.Errorf("runtimeprovider: execd: download %q: %w", opts.Path, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		defer func() { _ = resp.Body.Close() }()
+		return ReadFileResult{}, execdStatusError(resp)
+	}
+	size := int64(-1)
+	if cl := resp.Header.Get("Content-Length"); cl != "" {
+		if n, err := strconv.ParseInt(cl, 10, 64); err == nil {
+			size = n
+		}
+	}
+	return ReadFileResult{Content: resp.Body, Size: size}, nil
+}
+
+// execdStatusError reads a bounded amount of the error body and wraps it with
+// the HTTP status so callers can tell a daemon-reported failure from a
+// transport failure.
+func execdStatusError(resp *http.Response) error {
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return fmt.Errorf("runtimeprovider: execd: unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+}

--- a/pkg/runtimeprovider/execd_test.go
+++ b/pkg/runtimeprovider/execd_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimeprovider
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestExecdProvider(t *testing.T, srv *httptest.Server) *execdProvider {
+	t.Helper()
+	p, err := newExecdProvider(strings.TrimPrefix(srv.URL, "http://"))
+	require.NoError(t, err)
+	ep := p.(*execdProvider)
+	require.NoError(t, ep.Init(t.Context(), InitOptions{AccessToken: "test-token"}))
+	return ep
+}
+
+func TestExecdProvider_Exec(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/command", r.URL.Path)
+		assert.Equal(t, "test-token", r.Header.Get(execdAccessTokenHdr))
+		var req execdCommandRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "echo", req.Cmd)
+		assert.Equal(t, []string{"hi"}, req.Args)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "event: stdout\ndata: {\"chunk\":\"hi\"}\n\n")
+		fmt.Fprint(w, "event: stderr\ndata: {\"chunk\":\"warn\"}\n\n")
+		fmt.Fprint(w, "event: status\ndata: {\"exitCode\":0,\"exited\":true}\n\n")
+	}))
+	defer srv.Close()
+
+	p := newTestExecdProvider(t, srv)
+	result, err := p.Exec(t.Context(), ExecOptions{Cmd: "echo", Args: []string{"hi"}})
+	require.NoError(t, err)
+	assert.Equal(t, "hi", result.Stdout)
+	assert.Equal(t, "warn", result.Stderr)
+	assert.True(t, result.Exited)
+	assert.Equal(t, int32(0), result.ExitCode)
+}
+
+func TestExecdProvider_Exec_NonZeroExit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "event: status\ndata: {\"exitCode\":7,\"exited\":true}\n\n")
+	}))
+	defer srv.Close()
+
+	p := newTestExecdProvider(t, srv)
+	result, err := p.Exec(t.Context(), ExecOptions{Cmd: "false"})
+	require.NoError(t, err)
+	assert.Equal(t, int32(7), result.ExitCode)
+	assert.True(t, result.Exited)
+}
+
+func TestExecdProvider_Exec_DaemonError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "boom")
+	}))
+	defer srv.Close()
+
+	p := newTestExecdProvider(t, srv)
+	_, err := p.Exec(t.Context(), ExecOptions{Cmd: "echo"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestExecdProvider_WriteFile(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/files/upload", r.URL.Path)
+		assert.Equal(t, "test-token", r.Header.Get(execdAccessTokenHdr))
+		require.NoError(t, r.ParseMultipartForm(1<<20))
+		gotPath = r.FormValue("path")
+		file, _, err := r.FormFile("file")
+		require.NoError(t, err)
+		defer func() { _ = file.Close() }()
+		gotBody, err = io.ReadAll(file)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	p := newTestExecdProvider(t, srv)
+	err := p.WriteFile(t.Context(), WriteFileOptions{
+		Path:    "/tmp/a.txt",
+		Content: strings.NewReader("payload"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/a.txt", gotPath)
+	assert.Equal(t, "payload", string(gotBody))
+}
+
+func TestExecdProvider_ReadFile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/files/download", r.URL.Path)
+		assert.Equal(t, "/tmp/a.txt", r.URL.Query().Get("path"))
+		w.Header().Set("Content-Length", "7")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer srv.Close()
+
+	p := newTestExecdProvider(t, srv)
+	result, err := p.ReadFile(t.Context(), ReadFileOptions{Path: "/tmp/a.txt"})
+	require.NoError(t, err)
+	defer func() { _ = result.Content.Close() }()
+	assert.EqualValues(t, 7, result.Size)
+	content, err := io.ReadAll(result.Content)
+	require.NoError(t, err)
+	assert.Equal(t, "payload", string(content))
+}
+
+func TestExecdProvider_ReadFile_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, "no such file")
+	}))
+	defer srv.Close()
+
+	p := newTestExecdProvider(t, srv)
+	_, err := p.ReadFile(t.Context(), ReadFileOptions{Path: "/missing"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestExecdProvider_Init_RequiresAccessToken(t *testing.T) {
+	p, err := newExecdProvider("10.0.0.5")
+	require.NoError(t, err)
+	err = p.Init(t.Context(), InitOptions{})
+	require.Error(t, err)
+}
+
+func TestNewExecdProvider_DefaultPort(t *testing.T) {
+	p, err := newExecdProvider("10.0.0.5")
+	require.NoError(t, err)
+	ep := p.(*execdProvider)
+	assert.Equal(t, "http://10.0.0.5:44772", ep.baseURL)
+}

--- a/pkg/runtimeprovider/interface.go
+++ b/pkg/runtimeprovider/interface.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package runtimeprovider defines a protocol-neutral abstraction over the
+// in-sandbox execution daemon (command execution, file I/O, and runtime
+// initialization) so that a Sandbox is not hard-wired to a single daemon
+// protocol.
+//
+// Two protocols are known today:
+//   - envd: the E2B-compatible daemon already spoken by
+//     [github.com/openkruise/agents/pkg/utils/runtime], reached over
+//     connect-RPC (proto/envd) plus a JSON /init handshake.
+//   - execd: the OpenSandbox-compatible daemon, reached over a plain JSON/SSE
+//     REST API (see specs/execd-api.yaml in the OpenSandbox project).
+//
+// A Provider is bound to one sandbox at construction time, mirroring
+// pkg/utils/runtime.Runtime. Callers select an implementation once (per
+// sandbox, at claim/clone time) via NewProvider and then depend only on this
+// package's types, never on envd- or execd-specific wire types. This keeps the
+// selection a construction-time concern rather than something every call site
+// has to branch on.
+package runtimeprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Kind identifies which concrete daemon protocol a Provider speaks.
+type Kind string
+
+const (
+	// KindEnvd selects the E2B-compatible envd daemon.
+	KindEnvd Kind = "envd"
+	// KindExecd selects the OpenSandbox-compatible execd daemon.
+	KindExecd Kind = "execd"
+)
+
+// DefaultKind is used when a sandbox does not request a runtime explicitly.
+// envd remains the default because it is the runtime every existing template
+// ships today; execd is opt-in until templates carry it.
+const DefaultKind = KindEnvd
+
+// ErrUnknownKind is returned by NewProvider when Kind names a protocol with no
+// registered factory.
+var ErrUnknownKind = errors.New("runtimeprovider: unknown runtime kind")
+
+// InitOptions carries the data the daemon needs to accept the initial
+// handshake: environment variables materialized into the sandbox process tree
+// and the access token that authenticates subsequent Exec/file calls.
+type InitOptions struct {
+	EnvVars     map[string]string
+	AccessToken string
+	// ReInit indicates a re-handshake against an already-initialized daemon
+	// (e.g. after resume). Implementations must treat "already initialized" as
+	// success rather than an error when ReInit is set.
+	ReInit bool
+}
+
+// ExecOptions describes a single command execution.
+type ExecOptions struct {
+	// Cmd is the executable to run. It is not passed through a shell, so a
+	// caller needing shell semantics (pipes, globs) must invoke a shell
+	// explicitly, e.g. Cmd: "/bin/sh", Args: []string{"-c", "..."}.
+	Cmd  string
+	Args []string
+	Envs map[string]string
+	// Cwd is the working directory for the command. Empty means the daemon's
+	// default (typically the sandbox user's home directory).
+	Cwd string
+	// AuthUser is the OS user identity the daemon should run the command as.
+	// Empty means the daemon's default user.
+	AuthUser string
+}
+
+// ExecResult is the outcome of a completed Exec call. Providers only return
+// this type after the command has exited (or the context timed out); neither
+// implementation currently exposes incremental streaming through this
+// interface, since no caller of the interface needs it yet.
+type ExecResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int32
+	// Exited is false when the command timed out or was interrupted before it
+	// reported an exit code.
+	Exited bool
+}
+
+// WriteFileOptions describes a single file write.
+type WriteFileOptions struct {
+	// Path is the absolute path inside the sandbox to write.
+	Path string
+	// Content is read fully and uploaded as the new file body, unconditionally
+	// overwriting any pre-existing file at Path.
+	Content io.Reader
+	// AuthUser is the OS user the daemon should use when writing the file.
+	AuthUser string
+}
+
+// ReadFileOptions describes a single file read.
+type ReadFileOptions struct {
+	// Path is the absolute path inside the sandbox to read.
+	Path     string
+	AuthUser string
+}
+
+// ReadFileResult carries a file's content. Callers must Close it.
+type ReadFileResult struct {
+	Content io.ReadCloser
+	// Size is the payload size in bytes when known, else -1.
+	Size int64
+}
+
+// Provider abstracts command execution, file I/O, and runtime initialization
+// against one sandbox's in-pod execution daemon, independent of which daemon
+// protocol (envd, execd, ...) actually backs it.
+type Provider interface {
+	// Kind reports which protocol this Provider speaks, e.g. for logging.
+	Kind() Kind
+	// Init performs the daemon handshake described by opts.
+	Init(ctx context.Context, opts InitOptions) error
+	// Exec runs a command to completion inside the sandbox and returns its
+	// output and exit status.
+	Exec(ctx context.Context, opts ExecOptions) (ExecResult, error)
+	// WriteFile writes a file inside the sandbox.
+	WriteFile(ctx context.Context, opts WriteFileOptions) error
+	// ReadFile reads a file from inside the sandbox.
+	ReadFile(ctx context.Context, opts ReadFileOptions) (ReadFileResult, error)
+}
+
+// Factory builds a Provider bound to the given endpoint. endpoint is the
+// scheme-less host:port (or host) at which the daemon is reachable; how it is
+// resolved (plaintext, TLS, pinned dial IP) is the caller's concern, mirroring
+// pkg/utils/runtime's transport resolution, and is passed in fully resolved.
+type Factory func(endpoint string, opts ...Option) (Provider, error)
+
+// registry maps a Kind to the Factory that builds it. Populated by the envd
+// and execd sub-files' init() functions so importing this package alone (with
+// neither daemon package) yields an empty, safely-failing registry.
+var registry = map[Kind]Factory{}
+
+// register is called from each implementation's init() function.
+func register(kind Kind, f Factory) {
+	registry[kind] = f
+}
+
+// NewProvider builds the Provider registered for kind. An empty kind selects
+// DefaultKind so per-sandbox configuration can omit the field and still get
+// envd, matching every template shipped before execd existed.
+func NewProvider(kind Kind, endpoint string, opts ...Option) (Provider, error) {
+	if kind == "" {
+		kind = DefaultKind
+	}
+	factory, ok := registry[kind]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownKind, kind)
+	}
+	return factory(endpoint, opts...)
+}

--- a/pkg/runtimeprovider/interface_test.go
+++ b/pkg/runtimeprovider/interface_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimeprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     Kind
+		endpoint string
+		wantKind Kind
+		wantErr  error
+	}{
+		{
+			name:     "empty kind selects the default (envd)",
+			kind:     "",
+			endpoint: "10.0.0.5",
+			wantKind: KindEnvd,
+		},
+		{
+			name:     "explicit envd",
+			kind:     KindEnvd,
+			endpoint: "10.0.0.5",
+			wantKind: KindEnvd,
+		},
+		{
+			name:     "explicit execd",
+			kind:     KindExecd,
+			endpoint: "10.0.0.5:44772",
+			wantKind: KindExecd,
+		},
+		{
+			name:     "unknown kind is rejected",
+			kind:     Kind("bogus"),
+			endpoint: "10.0.0.5",
+			wantErr:  ErrUnknownKind,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewProvider(tt.kind, tt.endpoint)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantKind, p.Kind())
+		})
+	}
+}

--- a/pkg/runtimeprovider/options.go
+++ b/pkg/runtimeprovider/options.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimeprovider
+
+import (
+	"net/http"
+	"time"
+)
+
+// settings collects the values every Option mutates. It is unexported: both
+// implementations read it through their own constructors so a caller of
+// NewProvider never has to know which fields a given Kind actually consumes.
+type settings struct {
+	httpClient *http.Client
+	timeout    time.Duration
+}
+
+func newSettings(opts []Option) settings {
+	s := settings{timeout: defaultTimeout}
+	for _, opt := range opts {
+		opt(&s)
+	}
+	if s.httpClient == nil {
+		s.httpClient = &http.Client{}
+	}
+	return s
+}
+
+// defaultTimeout bounds a single Exec/WriteFile/ReadFile/Init call when the
+// caller does not override it via WithTimeout. Command execution can
+// legitimately run long, so this is intentionally generous; a caller running
+// short-lived commands should pass a context deadline instead of relying on
+// this floor.
+const defaultTimeout = 60 * time.Second
+
+// Option customizes a Provider built by NewProvider.
+type Option func(*settings)
+
+// WithHTTPClient overrides the transport used to reach the daemon. Useful for
+// injecting a TLS-configured client (e.g. runtime mTLS) or a test double.
+func WithHTTPClient(c *http.Client) Option {
+	return func(s *settings) {
+		if c != nil {
+			s.httpClient = c
+		}
+	}
+}
+
+// WithTimeout bounds every call made by the Provider when the caller's
+// context carries no earlier deadline. Values <= 0 are ignored.
+func WithTimeout(d time.Duration) Option {
+	return func(s *settings) {
+		if d > 0 {
+			s.timeout = d
+		}
+	}
+}

--- a/pkg/sandbox-manager/infra/interface.go
+++ b/pkg/sandbox-manager/infra/interface.go
@@ -311,6 +311,12 @@ type Sandbox interface {
 	SetTimeout(opts timeout.Options)
 	SaveTimeoutWithPolicy(ctx context.Context, opts SaveTimeoutOptions, policy timeout.UpdatePolicy) (TimeoutUpdateResult, error)
 	GetTimeout() timeout.Options
+	// PatchAnnotations applies a partial, persisted update to the sandbox's
+	// annotations: a non-nil value sets or overwrites the key, a nil value
+	// deletes it, and keys absent from patch are left untouched (JSON Merge
+	// Patch / RFC 7396 semantics). Retries on update conflict like
+	// SaveTimeoutWithPolicy.
+	PatchAnnotations(ctx context.Context, patch map[string]*string) error
 	GetClaimTime() (time.Time, error)
 	Kill(ctx context.Context) error                                                                     // Delete the Sandbox resource
 	TriggerRecycle(ctx context.Context) error                                                           // Trigger sandbox recycle flow instead of deletion

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox.go
@@ -386,6 +386,30 @@ func (s *Sandbox) GetTimeout() timeout.Options {
 	return timeout.GetTimeoutFromSandbox(s.Sandbox)
 }
 
+// PatchAnnotations implements infra.Sandbox.PatchAnnotations: a nil value in
+// patch deletes the key, a non-nil value sets it, and retryUpdate's
+// read-modify-write-with-conflict-retry loop keeps this safe against
+// concurrent writers, the same way SaveTimeoutWithPolicy is.
+func (s *Sandbox) PatchAnnotations(ctx context.Context, patch map[string]*string) error {
+	if len(patch) == 0 {
+		return nil
+	}
+	_, err := s.retryUpdate(ctx, func(sbx *agentsv1alpha1.Sandbox) (bool, error) {
+		if sbx.Annotations == nil {
+			sbx.Annotations = map[string]string{}
+		}
+		for key, value := range patch {
+			if value == nil {
+				delete(sbx.Annotations, key)
+			} else {
+				sbx.Annotations[key] = *value
+			}
+		}
+		return true, nil
+	})
+	return err
+}
+
 func (s *Sandbox) GetResource() infra.SandboxResource {
 	if s.Spec.Template == nil {
 		return infra.SandboxResource{}

--- a/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/sandbox_test.go
@@ -200,6 +200,77 @@ func TestSandbox_SaveTimeoutWithPolicy(t *testing.T) {
 	}
 }
 
+func TestSandbox_PatchAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing map[string]string
+		patch    map[string]*string
+		expect   map[string]string
+	}{
+		{
+			name:     "sets a new key",
+			existing: map[string]string{"a": "1"},
+			patch:    map[string]*string{"b": ptr.To("2")},
+			expect:   map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			name:     "overwrites an existing key",
+			existing: map[string]string{"a": "1"},
+			patch:    map[string]*string{"a": ptr.To("2")},
+			expect:   map[string]string{"a": "2"},
+		},
+		{
+			name:     "a nil value deletes the key",
+			existing: map[string]string{"a": "1", "b": "2"},
+			patch:    map[string]*string{"a": nil},
+			expect:   map[string]string{"b": "2"},
+		},
+		{
+			name:     "set and delete in the same patch",
+			existing: map[string]string{"a": "1"},
+			patch:    map[string]*string{"a": nil, "c": ptr.To("3")},
+			expect:   map[string]string{"c": "3"},
+		},
+		{
+			name:     "an empty patch is a no-op",
+			existing: map[string]string{"a": "1"},
+			patch:    map[string]*string{},
+			expect:   map[string]string{"a": "1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			infraInstance, fc := NewTestInfra(t)
+
+			sbx := createTestSandboxWithDefaults("test-sandbox-patch-annotations", "default")
+			sbx.Annotations = tt.existing
+			CreateSandboxWithStatus(t, fc, sbx)
+
+			var sandbox infra.Sandbox
+			require.Eventually(t, func() bool {
+				var err error
+				sandbox, err = infraInstance.GetSandbox(t.Context(), infra.GetSandboxOptions{
+					SandboxID: sandboxid.Resolve(sbx),
+					Namespace: sbx.Namespace,
+				})
+				return err == nil
+			}, time.Second, 10*time.Millisecond)
+
+			require.NoError(t, sandbox.PatchAnnotations(t.Context(), tt.patch))
+
+			for k, v := range tt.expect {
+				assert.Equal(t, v, sandbox.GetAnnotations()[k])
+			}
+			assert.Len(t, sandbox.GetAnnotations(), len(tt.expect))
+
+			var updated v1alpha1.Sandbox
+			require.NoError(t, fc.Get(t.Context(), types.NamespacedName{Namespace: sbx.Namespace, Name: sbx.Name}, &updated))
+			assert.Equal(t, tt.expect, updated.Annotations)
+		})
+	}
+}
+
 const testRetentionAnnotation = "example.openkruise.io/retention"
 
 func TestSandbox_SaveTimeoutWithPolicyExtraAnnotations(t *testing.T) {

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -207,6 +207,41 @@ func (sc *Controller) Run() (context.Context, error) {
 	return ctx, nil
 }
 
+// Mux returns the HTTP request multiplexer this Controller registers its
+// routes on. It is exported so a second protocol adapter that must coexist in
+// the same process (e.g. pkg/servers/opensandbox) can register its own routes
+// on the same mux/port after Init, instead of duplicating the server and its
+// orchestration wiring.
+func (sc *Controller) Mux() *http.ServeMux {
+	return sc.mux
+}
+
+// Manager returns the sandbox-manager instance this Controller built during
+// Init. Exported for the same coexistence reason as Mux: a second protocol
+// adapter reuses this Manager rather than building its own.
+func (sc *Controller) Manager() *sandboxmanager.SandboxManager {
+	return sc.manager
+}
+
+// Cache returns the shared cache.Provider this Controller built during Init.
+func (sc *Controller) Cache() cache.Provider {
+	return sc.cache
+}
+
+// Keys returns the E2B API key storage, or nil when E2B authentication is
+// disabled. A second protocol adapter that wants to reuse the same
+// team/API-key identity system (rather than inventing its own) depends on
+// this accessor instead of a separate key store.
+func (sc *Controller) Keys() keys.KeyStorage {
+	return sc.keys
+}
+
+// SystemNamespace returns the namespace sandbox-manager itself runs in, the
+// same fallback namespace E2B handlers use for admin-team requests.
+func (sc *Controller) SystemNamespace() string {
+	return sc.mgrOpts.SystemNamespace
+}
+
 func (sc *Controller) shutdown(ctx context.Context, cancel context.CancelFunc) {
 	log := klog.FromContext(ctx)
 	log.Info("Shutting down server...")

--- a/pkg/servers/opensandbox/AGENTS.md
+++ b/pkg/servers/opensandbox/AGENTS.md
@@ -1,0 +1,36 @@
+# OpenSandbox API
+
+This directory implements the OpenSandbox-compatible API layer, coexisting in
+the same process as the E2B API (`pkg/servers/e2b`) and reusing the same
+Manager-layer orchestration (`pkg/sandbox-manager`) and identity/quota system
+(`pkg/servers/e2b/keys`) rather than duplicating them. It owns OpenSandbox
+protocol behavior only; business rules stay in Manager per the root
+`AGENTS.md` layering rules.
+
+## Protocol Contract
+
+- Before changing endpoints, status codes, request/response fields, or
+  validation, check the upstream OpenSandbox lifecycle spec:
+  https://github.com/alibaba/OpenSandbox/blob/main/specs/sandbox-lifecycle.yml
+  (and `diagnostic-api.yml` / `execd-api.yaml` for diagnostics and execd).
+- `opensandbox.io/`-prefixed metadata keys are reserved and must be rejected
+  on create and on metadata patch, mirroring the E2B API's
+  `BlackListPrefix` guard for the same underlying annotation/label store.
+- POST /v1/sandboxes/{id}/pause and /resume return 202 Accepted per the spec's
+  async contract. This adapter's current backend operations
+  (`SandboxManager.PauseSandbox` / `ResumeSandbox`) are synchronous, so the
+  202 is returned only after the state change has already completed; a
+  polling client sees the sandbox already in its terminal state on the very
+  next GET. True asynchronous pause/resume (returning 202 before completion)
+  is tracked as follow-up work, not implemented here.
+
+## Known Gaps (tracked, not silently swept under the rug)
+
+- Error responses reuse `web.ApiError` (`{code:<http status>, message}`)
+  rather than the spec's `{code:<string>, message}` machine-readable
+  envelope. Byte-for-byte error-shape parity is lower priority than endpoint
+  and state-machine coverage for this initial slice.
+- Snapshot creation from `image`+`snapshotId` restore-on-create and
+  Kubernetes-CRD-native concepts without a spec equivalent (e.g. per-sandbox
+  runtime provider selection, in-place image update) are recorded in
+  `docs/proposals/` rather than expanded here.

--- a/pkg/servers/opensandbox/AGENTS.md
+++ b/pkg/servers/opensandbox/AGENTS.md
@@ -26,10 +26,17 @@ protocol behavior only; business rules stay in Manager per the root
 
 ## Known Gaps (tracked, not silently swept under the rug)
 
-- Error responses reuse `web.ApiError` (`{code:<http status>, message}`)
-  rather than the spec's `{code:<string>, message}` machine-readable
-  envelope. Byte-for-byte error-shape parity is lower priority than endpoint
-  and state-machine coverage for this initial slice.
+- Error response bodies follow the spec's `{code:<string>, message}`
+  envelope (`errors.go`'s `apiError`/`apiErrorf` set `web.ApiError.SpecCode`,
+  an opt-in field added to the shared framework that leaves E2B's
+  `{code:<http status>, headers, message, request_id}` shape byte-identical
+  when unset). The `X-Request-ID` response *header* the spec's error
+  responses also carry is not set on this adapter's error responses today —
+  `pkg/servers/web`'s `RegisterRoute` only sets that header on 2xx bodies by
+  design (see `TestRequestIDHandling` in `pkg/servers/web/framework_test.go`);
+  fixing that would be a broader framework change than this initial
+  error-envelope pass, and callers can still read the request ID from
+  `X-Request-ID` on 2xx polling calls or from server logs.
 - Snapshot creation from `image`+`snapshotId` restore-on-create and
   Kubernetes-CRD-native concepts without a spec equivalent (e.g. per-sandbox
   runtime provider selection, in-place image update) are recorded in

--- a/pkg/servers/opensandbox/CLAUDE.md
+++ b/pkg/servers/opensandbox/CLAUDE.md
@@ -1,0 +1,1 @@
+@./AGENTS.md

--- a/pkg/servers/opensandbox/auth.go
+++ b/pkg/servers/opensandbox/auth.go
@@ -18,7 +18,6 @@ package opensandbox
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"k8s.io/klog/v2"
@@ -54,7 +53,7 @@ func (sc *Controller) CheckAPIKey(ctx context.Context, r *http.Request) (context
 		loaded, ok := sc.keys.LoadByKey(ctx, rawAPIKey)
 		if !ok {
 			log.Info("failed to load key by API key")
-			return ctx, &web.ApiError{Code: http.StatusUnauthorized, Message: "Invalid API Key"}
+			return ctx, apiError(http.StatusUnauthorized, "Invalid API Key")
 		}
 		user = loaded
 	}
@@ -62,16 +61,10 @@ func (sc *Controller) CheckAPIKey(ctx context.Context, r *http.Request) (context
 	if sandboxID := r.PathValue("sandboxId"); sandboxID != "" {
 		owner, ok := sc.manager.GetOwnerOfSandbox(sandboxID)
 		if !ok {
-			return ctx, &web.ApiError{
-				Code:    http.StatusNotFound,
-				Message: fmt.Sprintf("sandbox not found: %s", sandboxID),
-			}
+			return ctx, apiErrorf(http.StatusNotFound, "sandbox not found: %s", sandboxID)
 		}
 		if owner != anonymousUser.ID.String() && owner != user.ID.String() {
-			return ctx, &web.ApiError{
-				Code:    http.StatusForbidden,
-				Message: fmt.Sprintf("the caller is not the owner of sandbox: %s", sandboxID),
-			}
+			return ctx, apiErrorf(http.StatusForbidden, "the caller is not the owner of sandbox: %s", sandboxID)
 		}
 	}
 

--- a/pkg/servers/opensandbox/auth.go
+++ b/pkg/servers/opensandbox/auth.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opensandbox
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"k8s.io/klog/v2"
+
+	"github.com/openkruise/agents/pkg/servers/e2b/keys"
+	e2bmodels "github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/openkruise/agents/pkg/servers/opensandbox/models"
+	"github.com/openkruise/agents/pkg/servers/web"
+)
+
+type userContextKey struct{}
+
+// anonymousUser is used only when sc.keys is nil (OpenSandbox authentication
+// disabled), mirroring e2b.AnonymousUser: it carries the admin identity so
+// every caller can reach any namespace.
+var anonymousUser = &e2bmodels.CreatedTeamAPIKey{
+	ID:   keys.AdminKeyID,
+	Name: "auth-disabled",
+	Team: e2bmodels.AdminTeam(),
+}
+
+// CheckAPIKey authenticates the caller against the same team/API-key store
+// the E2B API uses (see Dependencies.Keys), so a key minted through the E2B
+// API-key endpoints also authenticates OpenSandbox requests and vice versa.
+func (sc *Controller) CheckAPIKey(ctx context.Context, r *http.Request) (context.Context, *web.ApiError) {
+	log := klog.FromContext(ctx).WithValues("middleware", "CheckAPIKey")
+	apiKey := r.Header.Get(models.HeaderAPIKey)
+	var user *e2bmodels.CreatedTeamAPIKey
+	if sc.keys == nil {
+		user = anonymousUser
+	} else {
+		rawAPIKey := keys.ToStoredRawAPIKey(apiKey)
+		loaded, ok := sc.keys.LoadByKey(ctx, rawAPIKey)
+		if !ok {
+			log.Info("failed to load key by API key")
+			return ctx, &web.ApiError{Code: http.StatusUnauthorized, Message: "Invalid API Key"}
+		}
+		user = loaded
+	}
+
+	if sandboxID := r.PathValue("sandboxId"); sandboxID != "" {
+		owner, ok := sc.manager.GetOwnerOfSandbox(sandboxID)
+		if !ok {
+			return ctx, &web.ApiError{
+				Code:    http.StatusNotFound,
+				Message: fmt.Sprintf("sandbox not found: %s", sandboxID),
+			}
+		}
+		if owner != anonymousUser.ID.String() && owner != user.ID.String() {
+			return ctx, &web.ApiError{
+				Code:    http.StatusForbidden,
+				Message: fmt.Sprintf("the caller is not the owner of sandbox: %s", sandboxID),
+			}
+		}
+	}
+
+	ctx = klog.NewContext(ctx, klog.FromContext(ctx).WithValues("user", user.Name))
+	ctx = context.WithValue(ctx, userContextKey{}, user)
+	return ctx, nil
+}
+
+func userFromContext(ctx context.Context) *e2bmodels.CreatedTeamAPIKey {
+	user, _ := ctx.Value(userContextKey{}).(*e2bmodels.CreatedTeamAPIKey)
+	return user
+}
+
+// namespaceOfUser mirrors e2b.Controller.getNamespaceOfUser: the admin team
+// operates cluster-scoped (empty namespace, i.e. no namespace filter), every
+// other team is namespaced by its team name.
+func (sc *Controller) namespaceOfUser(user *e2bmodels.CreatedTeamAPIKey) string {
+	team := keys.TeamForKey(user)
+	if team.Name == e2bmodels.AdminTeamName {
+		return ""
+	}
+	return team.Name
+}

--- a/pkg/servers/opensandbox/core.go
+++ b/pkg/servers/opensandbox/core.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package opensandbox implements an OpenSandbox-compatible REST API layer
+// that coexists in the same process as the E2B API (pkg/servers/e2b) and
+// reuses its Manager-layer orchestration and team/API-key identity system
+// instead of duplicating them, following the adapter pattern established by
+// pkg/servers/e2b.
+package opensandbox
+
+import (
+	"net/http"
+
+	"github.com/openkruise/agents/pkg/cache"
+	sandboxmanager "github.com/openkruise/agents/pkg/sandbox-manager"
+	"github.com/openkruise/agents/pkg/servers/e2b/keys"
+)
+
+// Dependencies wires an already-initialized E2B Controller's orchestration
+// into a new OpenSandbox Controller, so the two protocol adapters share one
+// SandboxManager, one cache, and one API-key/team identity system rather than
+// each building their own.
+type Dependencies struct {
+	// Manager is the shared sandbox-manager. Required.
+	Manager *sandboxmanager.SandboxManager
+	// Cache is the shared Kubernetes cache/client. Required.
+	Cache cache.Provider
+	// Keys is the shared E2B API-key storage. Nil disables OpenSandbox
+	// authentication, mirroring E2B's --e2b-enable-auth=false behavior: every
+	// caller is treated as the anonymous admin identity.
+	Keys keys.KeyStorage
+	// SystemNamespace is the namespace admin-identity requests fall back to,
+	// same as E2B's --system-namespace.
+	SystemNamespace string
+	// MaxTimeoutSeconds bounds CreateSandboxRequest.Timeout. Zero disables the
+	// ceiling (only the spec's 60s floor applies).
+	MaxTimeoutSeconds int
+	// DefaultTemplate is the SandboxTemplate an image-based CreateSandboxRequest
+	// claims from before applying the requested image as an in-place update
+	// (see sandbox.go's CreateSandbox). OpenSandbox's create contract has no
+	// template/pool concept of its own — a caller supplies only a container
+	// image — so this backend needs one pre-provisioned template to claim a
+	// pod shape (resources, service account, volumes, ...) from. Required for
+	// image-based creation to work; snapshot-restore creation does not need it.
+	DefaultTemplate string
+}
+
+// Controller handles OpenSandbox-compatible sandbox-related operations. It
+// holds no orchestration state of its own: every operation delegates to the
+// shared Manager from Dependencies.
+type Controller struct {
+	manager           *sandboxmanager.SandboxManager
+	cache             cache.Provider
+	keys              keys.KeyStorage
+	systemNamespace   string
+	maxTimeoutSeconds int
+	defaultTemplate   string
+
+	mux *http.ServeMux
+}
+
+// NewController builds a Controller from deps but does not register routes;
+// call RegisterRoutes with the mux to serve on (typically the same mux the
+// E2B Controller already listens on, via its Mux() accessor).
+func NewController(deps Dependencies) *Controller {
+	return &Controller{
+		manager:           deps.Manager,
+		cache:             deps.Cache,
+		keys:              deps.Keys,
+		systemNamespace:   deps.SystemNamespace,
+		maxTimeoutSeconds: deps.MaxTimeoutSeconds,
+		defaultTemplate:   deps.DefaultTemplate,
+	}
+}
+
+// RegisterRoutes registers every OpenSandbox route on mux. Safe to call with
+// a mux that already serves other routes (e.g. the E2B API's), since every
+// path is under the /v1 prefix reserved for this adapter.
+func (sc *Controller) RegisterRoutes(mux *http.ServeMux) {
+	sc.mux = mux
+	sc.registerRoutes()
+}

--- a/pkg/servers/opensandbox/core_test.go
+++ b/pkg/servers/opensandbox/core_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opensandbox
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/cache/cachetest"
+	"github.com/openkruise/agents/pkg/proxy"
+	sandboxmanager "github.com/openkruise/agents/pkg/sandbox-manager"
+	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
+)
+
+const (
+	testNamespace       = "sandbox-system"
+	testDefaultTemplate = "opensandbox-default"
+)
+
+// Setup builds a Controller wired to a real SandboxManager backed by a fake
+// Kubernetes client (pkg/cache/cachetest), the same fake-client test
+// infrastructure pkg/servers/e2b's own test suite uses for its Infra layer.
+// Authentication is left disabled (Keys: nil), matching how E2B's
+// --e2b-enable-auth=false path resolves every caller to the built-in admin
+// identity, since these tests exercise orchestration and protocol behavior,
+// not the (already separately tested) API-key store.
+func Setup(t *testing.T) (*Controller, ctrlclient.Client) {
+	t.Helper()
+	opts := config.InitOptions(config.SandboxManagerOptions{
+		SystemNamespace:    testNamespace,
+		MaxClaimWorkers:    10,
+		MemberlistBindPort: config.DefaultMemberlistBindPort,
+	})
+	cache, fc, err := cachetest.NewTestCache(t)
+	require.NoError(t, err)
+
+	proxyServer := proxy.NewServer(opts)
+	infraInstance := sandboxcr.NewInfraBuilder(opts).
+		WithCache(cache).
+		WithAPIReader(fc).
+		WithRouteReader(proxyServer).
+		Build()
+	require.NoError(t, infraInstance.Run(t.Context()))
+
+	manager, err := sandboxmanager.NewSandboxManagerBuilder(opts).
+		WithCustomInfra(func() (infra.Builder, error) {
+			return sandboxcr.NewInfraBuilder(opts).
+				WithCache(cache).
+				WithAPIReader(fc).
+				WithRouteReader(proxyServer), nil
+		}).
+		Build()
+	require.NoError(t, err)
+	require.NoError(t, manager.InitQuota(t.Context(), config.QuotaOptions{}, nil))
+
+	controller := NewController(Dependencies{
+		Manager:         manager,
+		Cache:           cache,
+		SystemNamespace: testNamespace,
+		DefaultTemplate: testDefaultTemplate,
+	})
+	controller.RegisterRoutes(http.NewServeMux())
+	return controller, fc
+}
+
+// createDefaultTemplateFixture provisions the zero-replica SandboxSet that
+// image-based CreateSandbox claims from, using a directly embedded pod
+// template (rather than a SandboxTemplate + TemplateRef indirection) so a
+// claim-on-no-stock materializes Spec.Template directly onto the new
+// Sandbox — the same construction pkg/servers/e2b's own exercised claim-pool
+// test fixture (CreateSandboxPool in core_test.go) uses.
+func createDefaultTemplateFixture(t *testing.T, fc ctrlclient.Client, namespace string) {
+	t.Helper()
+	sbs := &agentsv1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testDefaultTemplate,
+			Namespace: namespace,
+			UID:       types.UID(uuid.NewString()),
+		},
+		Spec: agentsv1alpha1.SandboxSetSpec{
+			Replicas: 0,
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "main",
+							Image: "placeholder:base",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, fc.Create(t.Context(), sbs))
+}
+
+// simulateInstantReadySandbox overrides sandboxcr.DefaultCreateSandbox for the
+// duration of the calling test so a claimed-on-no-stock Sandbox reaches
+// Running/Ready synchronously, standing in for the agent-sandbox-controller
+// reconcile loop that would normally drive that transition against a real
+// kubelet. This is the same substitution pkg/servers/e2b's create tests use,
+// since these unit tests run against a fake client with no controller
+// actually watching Sandbox objects.
+func simulateInstantReadySandbox(t *testing.T) {
+	t.Helper()
+	orig := sandboxcr.DefaultCreateSandbox
+	sandboxcr.DefaultCreateSandbox = func(ctx context.Context, sbx *agentsv1alpha1.Sandbox, c ctrlclient.Client) (*agentsv1alpha1.Sandbox, error) {
+		// The fake client does not auto-assign a UID the way a real API
+		// server does, but sandboxroute.RouteFromSandbox requires one; set it
+		// explicitly before creation, the same as every pre-populated pooled
+		// Sandbox fixture in pkg/servers/e2b's test suite does.
+		if sbx.UID == "" {
+			sbx.UID = types.UID(uuid.NewString())
+		}
+		created, err := orig(ctx, sbx, c)
+		if err != nil {
+			return nil, err
+		}
+		created.Status = agentsv1alpha1.SandboxStatus{
+			Phase:              agentsv1alpha1.SandboxRunning,
+			ObservedGeneration: created.Generation,
+			Conditions: []metav1.Condition{{
+				Type:   string(agentsv1alpha1.SandboxConditionReady),
+				Status: metav1.ConditionTrue,
+				Reason: agentsv1alpha1.SandboxReadyReasonPodReady,
+			}},
+			PodInfo: agentsv1alpha1.PodInfo{PodIP: "10.0.0.5"},
+		}
+		if err := c.Status().Update(ctx, created); err != nil {
+			return nil, err
+		}
+		return created, nil
+	}
+	t.Cleanup(func() { sandboxcr.DefaultCreateSandbox = orig })
+}
+
+func doRequest(t *testing.T, mux *http.ServeMux, method, path string, header http.Header, body []byte) *http.Response {
+	t.Helper()
+	var reader io.Reader = http.NoBody
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, reader)
+	for k, values := range header {
+		for _, v := range values {
+			req.Header.Add(k, v)
+		}
+	}
+	mux.ServeHTTP(rec, req)
+	return rec.Result()
+}

--- a/pkg/servers/opensandbox/diagnostics.go
+++ b/pkg/servers/opensandbox/diagnostics.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opensandbox
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/openkruise/agents/pkg/servers/opensandbox/models"
+	"github.com/openkruise/agents/pkg/servers/web"
+)
+
+// diagnosticScope resolves the required "scope" query parameter, defaulting
+// to "all" when absent (the spec requires the parameter but every scope value
+// maps to the same content in this initial adapter, see below).
+func diagnosticScope(r *http.Request) string {
+	if scope := r.URL.Query().Get("scope"); scope != "" {
+		return scope
+	}
+	return models.DiagnosticScopeAll
+}
+
+// diagnosticSummary builds the one piece of diagnostic content this initial
+// adapter can honestly produce from the infra.Sandbox interface today: its
+// current lifecycle state, reason, and pod IP. It does not differentiate by
+// scope (container/lifecycle/runtime/network/process) and does not include
+// actual container log lines, since neither is exposed by infra.Sandbox yet
+// (streaming pod logs would need a new Infra capability — see the package
+// AGENTS.md "Known Gaps" and the design proposal's Non-Goals section).
+func (sc *Controller) diagnosticSummary(sandboxID string, sbx interface {
+	GetState() (string, string)
+	GetIP() string
+	Phase() string
+}) string {
+	state, reason := sbx.GetState()
+	return fmt.Sprintf("sandboxId=%s state=%s reason=%s phase=%s podIP=%s",
+		sandboxID, state, reason, sbx.Phase(), sbx.GetIP())
+}
+
+// GetDiagnosticLogs implements GET /v1/sandboxes/{sandboxId}/diagnostics/logs.
+func (sc *Controller) GetDiagnosticLogs(r *http.Request) (web.ApiResponse[*models.DiagnosticContentResponse], *web.ApiError) {
+	sandboxID := r.PathValue("sandboxId")
+	sbx, apiErr := sc.getSandboxOfUser(r.Context(), sandboxID)
+	if apiErr != nil {
+		return web.ApiResponse[*models.DiagnosticContentResponse]{}, apiErr
+	}
+	content := sc.diagnosticSummary(sandboxID, sbx)
+	return web.ApiResponse[*models.DiagnosticContentResponse]{
+		Body: &models.DiagnosticContentResponse{
+			SandboxID:     sandboxID,
+			Kind:          models.DiagnosticKindLogs,
+			Scope:         diagnosticScope(r),
+			Delivery:      models.DiagnosticDeliveryInline,
+			ContentType:   "text/plain; charset=utf-8",
+			Content:       content,
+			ContentLength: int64(len(content)),
+			Truncated:     false,
+			Warnings:      []string{"this initial adapter reports lifecycle state, not container log lines; see AGENTS.md Known Gaps"},
+		},
+	}, nil
+}
+
+// GetDiagnosticEvents implements GET /v1/sandboxes/{sandboxId}/diagnostics/events.
+func (sc *Controller) GetDiagnosticEvents(r *http.Request) (web.ApiResponse[*models.DiagnosticContentResponse], *web.ApiError) {
+	sandboxID := r.PathValue("sandboxId")
+	sbx, apiErr := sc.getSandboxOfUser(r.Context(), sandboxID)
+	if apiErr != nil {
+		return web.ApiResponse[*models.DiagnosticContentResponse]{}, apiErr
+	}
+	content := sc.diagnosticSummary(sandboxID, sbx)
+	return web.ApiResponse[*models.DiagnosticContentResponse]{
+		Body: &models.DiagnosticContentResponse{
+			SandboxID:     sandboxID,
+			Kind:          models.DiagnosticKindEvents,
+			Scope:         diagnosticScope(r),
+			Delivery:      models.DiagnosticDeliveryInline,
+			ContentType:   "text/plain; charset=utf-8",
+			Content:       content,
+			ContentLength: int64(len(content)),
+			Truncated:     false,
+			Warnings:      []string{"this initial adapter reports lifecycle state, not Kubernetes Events; see AGENTS.md Known Gaps"},
+		},
+	}, nil
+}

--- a/pkg/servers/opensandbox/errors.go
+++ b/pkg/servers/opensandbox/errors.go
@@ -18,6 +18,7 @@ package opensandbox
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/openkruise/agents/pkg/servers/web"
@@ -35,7 +36,47 @@ func decodeJSONBody(r *http.Request, v any) *web.ApiError {
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(v); err != nil {
-		return &web.ApiError{Code: http.StatusBadRequest, Message: err.Error()}
+		return apiError(http.StatusBadRequest, err.Error())
 	}
 	return nil
+}
+
+// specErrorCode maps an HTTP status this adapter returns to the OpenSandbox
+// lifecycle spec's ErrorResponse.code values. The spec documents code as a
+// free-form machine-readable string with examples (INVALID_REQUEST,
+// NOT_FOUND, INTERNAL_ERROR) rather than a fixed enum; these five statuses
+// are exactly the ones the spec gives named response components for
+// (BadRequest, Unauthorized, Forbidden, NotFound, Conflict,
+// InternalServerError), so status <-> code is a stable 1:1 mapping here.
+func specErrorCode(status int) string {
+	switch status {
+	case http.StatusBadRequest:
+		return "INVALID_REQUEST"
+	case http.StatusUnauthorized:
+		return "UNAUTHORIZED"
+	case http.StatusForbidden:
+		return "FORBIDDEN"
+	case http.StatusNotFound:
+		return "NOT_FOUND"
+	case http.StatusConflict:
+		return "CONFLICT"
+	default:
+		return "INTERNAL_ERROR"
+	}
+}
+
+// apiError builds a web.ApiError whose JSON body follows the OpenSandbox
+// spec's ErrorResponse shape ({code:<string>, message}) instead of E2B's
+// ({code:<http status>, headers, message, request_id}) — see
+// web.ApiError.SpecCode. message is used verbatim, never as a format string,
+// so caller-controlled or Kubernetes-error text can never be misread as
+// format verbs.
+func apiError(status int, message string) *web.ApiError {
+	return &web.ApiError{Code: status, SpecCode: specErrorCode(status), Message: message}
+}
+
+// apiErrorf is apiError with fmt.Sprintf formatting for call sites that
+// build the message from multiple parts.
+func apiErrorf(status int, format string, args ...any) *web.ApiError {
+	return apiError(status, fmt.Sprintf(format, args...))
 }

--- a/pkg/servers/opensandbox/errors.go
+++ b/pkg/servers/opensandbox/errors.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opensandbox
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/openkruise/agents/pkg/servers/web"
+)
+
+// decodeJSONBody decodes r's JSON body into v, translating a decode failure
+// into the spec's 400 Bad Request. A missing body decodes to v's zero value
+// rather than erroring, since several OpenSandbox endpoints (pause, resume)
+// accept an empty body and a couple of others (renew-expiration) are decoded
+// through this same helper for consistency.
+func decodeJSONBody(r *http.Request, v any) *web.ApiError {
+	if r.Body == nil || r.ContentLength == 0 {
+		return nil
+	}
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(v); err != nil {
+		return &web.ApiError{Code: http.StatusBadRequest, Message: err.Error()}
+	}
+	return nil
+}

--- a/pkg/servers/opensandbox/errors_test.go
+++ b/pkg/servers/opensandbox/errors_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opensandbox
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApiError verifies apiError/apiErrorf produce the OpenSandbox lifecycle
+// spec's ErrorResponse envelope ({code:<string>, message:<string>}) on the
+// wire, for every HTTP status this adapter actually returns as an error —
+// see the spec's named error response components (BadRequest, Unauthorized,
+// Forbidden, NotFound, Conflict, InternalServerError).
+func TestApiError(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		wantCode   string
+		wantStatus int
+	}{
+		{name: "bad request", status: http.StatusBadRequest, wantCode: "INVALID_REQUEST"},
+		{name: "unauthorized", status: http.StatusUnauthorized, wantCode: "UNAUTHORIZED"},
+		{name: "forbidden", status: http.StatusForbidden, wantCode: "FORBIDDEN"},
+		{name: "not found", status: http.StatusNotFound, wantCode: "NOT_FOUND"},
+		{name: "conflict", status: http.StatusConflict, wantCode: "CONFLICT"},
+		{name: "internal server error", status: http.StatusInternalServerError, wantCode: "INTERNAL_ERROR"},
+		{name: "unmapped status falls back to INTERNAL_ERROR", status: http.StatusTeapot, wantCode: "INTERNAL_ERROR"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := apiError(tt.status, "boom")
+			assert.Equal(t, tt.status, err.Code, "HTTP status must be preserved for RegisterRoute's w.WriteHeader")
+			assert.Equal(t, tt.wantCode, err.SpecCode)
+			assert.Equal(t, "boom", err.Message)
+
+			body, marshalErr := json.Marshal(err)
+			require.NoError(t, marshalErr)
+			assert.JSONEq(t, `{"code":"`+tt.wantCode+`","message":"boom"}`, string(body))
+		})
+	}
+}
+
+// TestApiErrorf_NeverInterpretsMessageAsFormatString guards the reason
+// apiError takes message as a plain string rather than doing the
+// fmt.Sprintf(err.Error()) callers used to write directly: an upstream error
+// string containing a literal "%" (e.g. from a Kubernetes quantity parse
+// error) must never be misread as a format verb.
+func TestApiErrorf_NeverInterpretsMessageAsFormatString(t *testing.T) {
+	err := apiError(http.StatusBadRequest, "invalid quantity: 100%!s(MISSING)")
+	assert.Equal(t, "invalid quantity: 100%!s(MISSING)", err.Message)
+
+	formatted := apiErrorf(http.StatusBadRequest, "sandbox %s not found", "abc-100%")
+	assert.Equal(t, "sandbox abc-100% not found", formatted.Message)
+}

--- a/pkg/servers/opensandbox/metadata.go
+++ b/pkg/servers/opensandbox/metadata.go
@@ -17,7 +17,6 @@ limitations under the License.
 package opensandbox
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/openkruise/agents/pkg/servers/opensandbox/models"
@@ -36,10 +35,7 @@ func (sc *Controller) PatchSandboxMetadata(r *http.Request) (web.ApiResponse[*mo
 		return web.ApiResponse[*models.Sandbox]{}, apiErr
 	}
 	if key, found := patch.HasReservedKey(); found {
-		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
-			Code:    http.StatusBadRequest,
-			Message: fmt.Sprintf("metadata key %q uses the reserved prefix %q", key, models.ReservedMetadataPrefix),
-		}
+		return web.ApiResponse[*models.Sandbox]{}, apiErrorf(http.StatusBadRequest, "metadata key %q uses the reserved prefix %q", key, models.ReservedMetadataPrefix)
 	}
 
 	sbx, apiErr := sc.getSandboxOfUser(ctx, sandboxID)
@@ -50,7 +46,7 @@ func (sc *Controller) PatchSandboxMetadata(r *http.Request) (web.ApiResponse[*mo
 	// delete on nil) and updates sbx in place on success, so no separate
 	// refresh is needed before converting the response.
 	if err := sbx.PatchAnnotations(ctx, patch); err != nil {
-		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{Code: http.StatusInternalServerError, Message: fmt.Sprintf("failed to persist metadata: %v", err)}
+		return web.ApiResponse[*models.Sandbox]{}, apiErrorf(http.StatusInternalServerError, "failed to persist metadata: %v", err)
 	}
 	return web.ApiResponse[*models.Sandbox]{Body: sc.convertToOpenSandbox(sbx)}, nil
 }

--- a/pkg/servers/opensandbox/metadata.go
+++ b/pkg/servers/opensandbox/metadata.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opensandbox
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/openkruise/agents/pkg/servers/opensandbox/models"
+	"github.com/openkruise/agents/pkg/servers/web"
+)
+
+// PatchSandboxMetadata implements PATCH /v1/sandboxes/{sandboxId}/metadata:
+// a JSON Merge Patch (RFC 7396) over the sandbox's metadata, stored as
+// annotations on the underlying Sandbox CR.
+func (sc *Controller) PatchSandboxMetadata(r *http.Request) (web.ApiResponse[*models.Sandbox], *web.ApiError) {
+	ctx := r.Context()
+	sandboxID := r.PathValue("sandboxId")
+
+	var patch models.PatchMetadataRequest
+	if apiErr := decodeJSONBody(r, &patch); apiErr != nil {
+		return web.ApiResponse[*models.Sandbox]{}, apiErr
+	}
+	if key, found := patch.HasReservedKey(); found {
+		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: fmt.Sprintf("metadata key %q uses the reserved prefix %q", key, models.ReservedMetadataPrefix),
+		}
+	}
+
+	sbx, apiErr := sc.getSandboxOfUser(ctx, sandboxID)
+	if apiErr != nil {
+		return web.ApiResponse[*models.Sandbox]{}, apiErr
+	}
+	// PatchAnnotations persists the merge patch directly (set on non-nil,
+	// delete on nil) and updates sbx in place on success, so no separate
+	// refresh is needed before converting the response.
+	if err := sbx.PatchAnnotations(ctx, patch); err != nil {
+		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{Code: http.StatusInternalServerError, Message: fmt.Sprintf("failed to persist metadata: %v", err)}
+	}
+	return web.ApiResponse[*models.Sandbox]{Body: sc.convertToOpenSandbox(sbx)}, nil
+}

--- a/pkg/servers/opensandbox/metadata_test.go
+++ b/pkg/servers/opensandbox/metadata_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opensandbox
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkruise/agents/pkg/servers/opensandbox/models"
+)
+
+func TestPatchSandboxMetadata(t *testing.T) {
+	controller, fc := Setup(t)
+	createDefaultTemplateFixture(t, fc, testNamespace)
+	simulateInstantReadySandbox(t)
+
+	body, err := json.Marshal(models.CreateSandboxRequest{
+		Image:      &models.ImageSpec{URI: "python:3.11"},
+		Metadata:   map[string]string{"a": "1", "b": "2"},
+		Extensions: map[string]string{"skipInitRuntime": "true"},
+	})
+	require.NoError(t, err)
+	createResp := doRequest(t, controller.mux, http.MethodPost, "/v1/sandboxes", nil, body)
+	var created models.Sandbox
+	require.NoError(t, json.NewDecoder(createResp.Body).Decode(&created))
+	_ = createResp.Body.Close()
+
+	// JSON Merge Patch: overwrite "a", delete "b" (null), leave others untouched.
+	patchBody := []byte(`{"a":"one","b":null,"c":"three"}`)
+	patchResp := doRequest(t, controller.mux, http.MethodPatch, "/v1/sandboxes/"+created.ID+"/metadata", nil, patchBody)
+	defer func() { _ = patchResp.Body.Close() }()
+	require.Equal(t, http.StatusOK, patchResp.StatusCode)
+
+	var patched models.Sandbox
+	require.NoError(t, json.NewDecoder(patchResp.Body).Decode(&patched))
+	assert.Equal(t, "one", patched.Metadata["a"])
+	assert.Equal(t, "three", patched.Metadata["c"])
+	_, hasB := patched.Metadata["b"]
+	assert.False(t, hasB)
+
+	// The patch must be persisted, not just reflected in the response.
+	getResp := doRequest(t, controller.mux, http.MethodGet, "/v1/sandboxes/"+created.ID, nil, nil)
+	defer func() { _ = getResp.Body.Close() }()
+	var fetched models.Sandbox
+	require.NoError(t, json.NewDecoder(getResp.Body).Decode(&fetched))
+	assert.Equal(t, "one", fetched.Metadata["a"])
+	assert.Equal(t, "three", fetched.Metadata["c"])
+}
+
+func TestPatchSandboxMetadata_ReservedPrefixRejected(t *testing.T) {
+	controller, fc := Setup(t)
+	createDefaultTemplateFixture(t, fc, testNamespace)
+	simulateInstantReadySandbox(t)
+	sandboxID := createTestSandbox(t, controller)
+
+	patchBody := []byte(`{"opensandbox.io/x":"y"}`)
+	resp := doRequest(t, controller.mux, http.MethodPatch, "/v1/sandboxes/"+sandboxID+"/metadata", nil, patchBody)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/pkg/servers/opensandbox/models/diagnostics.go
+++ b/pkg/servers/opensandbox/models/diagnostics.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+// DiagnosticKind distinguishes the two diagnostics endpoints.
+type DiagnosticKind string
+
+const (
+	DiagnosticKindLogs   DiagnosticKind = "logs"
+	DiagnosticKindEvents DiagnosticKind = "events"
+)
+
+// DiagnosticDelivery reports how DiagnosticContentResponse carries its
+// payload. This initial adapter only ever produces "inline"; "url" is
+// reserved for a future large-payload path (e.g. presigned log storage).
+type DiagnosticDelivery string
+
+const (
+	DiagnosticDeliveryInline DiagnosticDelivery = "inline"
+	DiagnosticDeliveryURL    DiagnosticDelivery = "url"
+)
+
+// DiagnosticContentResponse is the response body for both
+// GET /v1/sandboxes/{sandboxId}/diagnostics/logs and .../diagnostics/events.
+type DiagnosticContentResponse struct {
+	SandboxID     string             `json:"sandboxId"`
+	Kind          DiagnosticKind     `json:"kind"`
+	Scope         string             `json:"scope"`
+	Delivery      DiagnosticDelivery `json:"delivery"`
+	ContentType   string             `json:"contentType"`
+	Content       string             `json:"content,omitempty"`
+	ContentURL    string             `json:"contentUrl,omitempty"`
+	ContentLength int64              `json:"contentLength,omitempty"`
+	ExpiresAt     string             `json:"expiresAt,omitempty"`
+	Truncated     bool               `json:"truncated"`
+	Warnings      []string           `json:"warnings,omitempty"`
+}
+
+// DiagnosticScopeAll is the "all" scope selector; the other spec values
+// (container, lifecycle, runtime, network, process) are accepted but not yet
+// differentiated by this initial adapter (see the opensandbox package's
+// AGENTS.md for the tracked follow-up).
+const DiagnosticScopeAll = "all"

--- a/pkg/servers/opensandbox/models/metadata.go
+++ b/pkg/servers/opensandbox/models/metadata.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import "strings"
+
+// PatchMetadataRequest is a JSON Merge Patch (RFC 7396) body: present keys
+// with a string value are set, present keys mapped to JSON null are deleted,
+// and absent keys are left untouched. A nil *string marshals to JSON null.
+type PatchMetadataRequest map[string]*string
+
+// HasReservedKey reports whether the patch touches a key under
+// ReservedMetadataPrefix, which the spec requires the server to reject.
+func (p PatchMetadataRequest) HasReservedKey() (key string, found bool) {
+	for k := range p {
+		if strings.HasPrefix(k, ReservedMetadataPrefix) {
+			return k, true
+		}
+	}
+	return "", false
+}

--- a/pkg/servers/opensandbox/models/sandbox.go
+++ b/pkg/servers/opensandbox/models/sandbox.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package models defines the OpenSandbox-compatible wire types, mirroring
+// pkg/servers/e2b/models for the OpenSandbox protocol. Field names and shapes
+// follow the OpenSandbox sandbox-lifecycle OpenAPI spec:
+// https://github.com/alibaba/OpenSandbox/blob/main/specs/sandbox-lifecycle.yml
+package models
+
+import "time"
+
+// SandboxState is the OpenSandbox lifecycle state, distinct from (and richer
+// than) the E2B API's running/paused states and from the internal Sandbox CRD
+// state machine. See state.go for the conversion.
+type SandboxState string
+
+const (
+	SandboxStatePending    SandboxState = "Pending"
+	SandboxStateRunning    SandboxState = "Running"
+	SandboxStatePausing    SandboxState = "Pausing"
+	SandboxStatePaused     SandboxState = "Paused"
+	SandboxStateResuming   SandboxState = "Resuming"
+	SandboxStateStopping   SandboxState = "Stopping"
+	SandboxStateTerminated SandboxState = "Terminated"
+	SandboxStateFailed     SandboxState = "Failed"
+)
+
+// HeaderAPIKey is the OpenSandbox API key header, per the lifecycle spec's
+// security scheme. OPEN_SANDBOX_API_KEY (the env-var form) is a client-side
+// convention and has no server-side header equivalent.
+const HeaderAPIKey = "OPEN-SANDBOX-API-KEY" // #nosec G101 -- header name, not a credential
+
+const (
+	MinListLimit = 1
+	MaxListLimit = 100
+
+	// ReservedMetadataPrefix keys are rejected on create and on metadata patch,
+	// mirroring the spec's "opensandbox.io/ prefix is reserved" constraint.
+	ReservedMetadataPrefix = "opensandbox.io/"
+
+	// MinTimeoutSeconds is the spec's documented floor ("min 60"). A nil
+	// Timeout (field omitted, or explicit JSON null) means "never expire", per
+	// the spec's description of the null value.
+	MinTimeoutSeconds = 60
+)
+
+// ImageSpec identifies the container image a sandbox is created from.
+type ImageSpec struct {
+	URI  string     `json:"uri"`
+	Auth *ImageAuth `json:"auth,omitempty"`
+}
+
+type ImageAuth struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+// PlatformSpec constrains scheduling. Only linux/amd64 and linux/arm64 are
+// meaningful against this Kubernetes-backed implementation; windows sandboxes
+// are rejected at create time (see validate.go).
+type PlatformSpec struct {
+	OS   string `json:"os"`
+	Arch string `json:"arch"`
+}
+
+// ResourceLimits is a free-form quantity map (e.g. {"cpu":"500m","memory":"512Mi"}),
+// per the spec's ResourceLimits schema.
+type ResourceLimits map[string]string
+
+// NetworkPolicy is the sandbox's egress policy.
+type NetworkPolicy struct {
+	DefaultAction string          `json:"defaultAction,omitempty"`
+	Egress        []NetworkEgress `json:"egress,omitempty"`
+}
+
+type NetworkEgress struct {
+	Action string `json:"action"`
+	Target string `json:"target"`
+}
+
+// CreateSandboxRequest is the POST /v1/sandboxes request body.
+type CreateSandboxRequest struct {
+	Image            *ImageSpec        `json:"image,omitempty"`
+	SnapshotID       string            `json:"snapshotId,omitempty"`
+	Platform         *PlatformSpec     `json:"platform,omitempty"`
+	Timeout          *int              `json:"timeout,omitempty"`
+	ResourceLimits   ResourceLimits    `json:"resourceLimits,omitempty"`
+	ResourceRequests ResourceLimits    `json:"resourceRequests,omitempty"`
+	Env              map[string]string `json:"env,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+	Entrypoint       []string          `json:"entrypoint,omitempty"`
+	NetworkPolicy    *NetworkPolicy    `json:"networkPolicy,omitempty"`
+	SecureAccess     bool              `json:"secureAccess,omitempty"`
+	Extensions       map[string]string `json:"extensions,omitempty"`
+}
+
+// SandboxStatus is the nested status object on Sandbox.
+type SandboxStatus struct {
+	State            SandboxState `json:"state"`
+	Reason           string       `json:"reason,omitempty"`
+	Message          string       `json:"message,omitempty"`
+	LastTransitionAt string       `json:"lastTransitionAt,omitempty"`
+}
+
+// Sandbox is the OpenSandbox lifecycle API's sandbox representation, returned
+// by create/get/list/patch.
+type Sandbox struct {
+	ID         string            `json:"id"`
+	Image      *ImageSpec        `json:"image,omitempty"`
+	SnapshotID string            `json:"snapshotId,omitempty"`
+	Platform   *PlatformSpec     `json:"platform,omitempty"`
+	Status     SandboxStatus     `json:"status"`
+	Metadata   map[string]string `json:"metadata,omitempty"`
+	Entrypoint []string          `json:"entrypoint"`
+	ExpiresAt  string            `json:"expiresAt,omitempty"`
+	CreatedAt  string            `json:"createdAt"`
+}
+
+// PaginationInfo mirrors the spec's shared pagination envelope.
+type PaginationInfo struct {
+	Page        int  `json:"page"`
+	PageSize    int  `json:"pageSize"`
+	TotalItems  int  `json:"totalItems"`
+	TotalPages  int  `json:"totalPages"`
+	HasNextPage bool `json:"hasNextPage"`
+}
+
+// ListSandboxesResponse is the GET /v1/sandboxes response body.
+type ListSandboxesResponse struct {
+	Items      []*Sandbox     `json:"items"`
+	Pagination PaginationInfo `json:"pagination"`
+}
+
+// RenewSandboxExpirationRequest is the POST .../renew-expiration request body.
+type RenewSandboxExpirationRequest struct {
+	ExpiresAt time.Time `json:"expiresAt"`
+}
+
+// RenewSandboxExpirationResponse is the POST .../renew-expiration response body.
+type RenewSandboxExpirationResponse struct {
+	ExpiresAt time.Time `json:"expiresAt"`
+}

--- a/pkg/servers/opensandbox/models/snapshot.go
+++ b/pkg/servers/opensandbox/models/snapshot.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+// SnapshotState is the OpenSandbox snapshot lifecycle state.
+type SnapshotState string
+
+const (
+	SnapshotStateCreating SnapshotState = "Creating"
+	SnapshotStateDeleting SnapshotState = "Deleting"
+	SnapshotStateReady    SnapshotState = "Ready"
+	SnapshotStateFailed   SnapshotState = "Failed"
+)
+
+// CreateSnapshotRequest is the POST /v1/sandboxes/{sandboxId}/snapshots request body.
+type CreateSnapshotRequest struct {
+	Name string `json:"name,omitempty"`
+}
+
+// SnapshotStatus is the nested status object on Snapshot.
+type SnapshotStatus struct {
+	State            SnapshotState `json:"state"`
+	Reason           string        `json:"reason,omitempty"`
+	Message          string        `json:"message,omitempty"`
+	LastTransitionAt string        `json:"lastTransitionAt,omitempty"`
+}
+
+// Snapshot is the OpenSandbox snapshot representation.
+type Snapshot struct {
+	ID        string         `json:"id"`
+	SandboxID string         `json:"sandboxId"`
+	Name      string         `json:"name,omitempty"`
+	Status    SnapshotStatus `json:"status"`
+	CreatedAt string         `json:"createdAt"`
+}
+
+// ListSnapshotsResponse is the GET /v1/snapshots response body.
+type ListSnapshotsResponse struct {
+	Items      []*Snapshot    `json:"items"`
+	Pagination PaginationInfo `json:"pagination"`
+}

--- a/pkg/servers/opensandbox/pause_resume.go
+++ b/pkg/servers/opensandbox/pause_resume.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opensandbox
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	cacheutils "github.com/openkruise/agents/pkg/cache/utils"
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/servers/opensandbox/models"
+	"github.com/openkruise/agents/pkg/servers/web"
+	"github.com/openkruise/agents/pkg/utils/timeout"
+)
+
+func pauseResumeErrorCode(err error) int {
+	if apierrors.IsNotFound(err) {
+		return http.StatusNotFound
+	}
+	if managererrors.GetErrCode(err) == managererrors.ErrorConflict || errors.Is(err, cacheutils.ErrWaitTaskConflict) {
+		return http.StatusConflict
+	}
+	return http.StatusInternalServerError
+}
+
+// PauseSandbox implements POST /v1/sandboxes/{sandboxId}/pause. Per the
+// package AGENTS.md, SandboxManager.PauseSandbox is synchronous on this
+// backend, so the 202 below is returned only once the sandbox has actually
+// finished pausing rather than while a Pausing transition is still in flight.
+func (sc *Controller) PauseSandbox(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
+	ctx := r.Context()
+	sandboxID := r.PathValue("sandboxId")
+	sbx, apiErr := sc.getSandboxOfUser(ctx, sandboxID)
+	if apiErr != nil {
+		return web.ApiResponse[struct{}]{}, apiErr
+	}
+	if err := sc.manager.PauseSandbox(ctx, sbx, infra.PauseOptions{}); err != nil {
+		return web.ApiResponse[struct{}]{}, &web.ApiError{
+			Code:    pauseResumeErrorCode(err),
+			Message: fmt.Sprintf("failed to pause sandbox %s: %v", sandboxID, err),
+		}
+	}
+	return web.ApiResponse[struct{}]{Code: http.StatusAccepted}, nil
+}
+
+// ResumeSandbox implements POST /v1/sandboxes/{sandboxId}/resume.
+func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
+	ctx := r.Context()
+	sandboxID := r.PathValue("sandboxId")
+	sbx, apiErr := sc.getSandboxOfUser(ctx, sandboxID)
+	if apiErr != nil {
+		return web.ApiResponse[struct{}]{}, apiErr
+	}
+	if err := sc.manager.ResumeSandbox(ctx, sbx, infra.ResumeOptions{}); err != nil {
+		return web.ApiResponse[struct{}]{}, &web.ApiError{
+			Code:    pauseResumeErrorCode(err),
+			Message: fmt.Sprintf("failed to resume sandbox %s: %v", sandboxID, err),
+		}
+	}
+	return web.ApiResponse[struct{}]{Code: http.StatusAccepted}, nil
+}
+
+// RenewSandboxExpiration implements POST /v1/sandboxes/{sandboxId}/renew-expiration.
+func (sc *Controller) RenewSandboxExpiration(r *http.Request) (web.ApiResponse[*models.RenewSandboxExpirationResponse], *web.ApiError) {
+	ctx := r.Context()
+	sandboxID := r.PathValue("sandboxId")
+	var request models.RenewSandboxExpirationRequest
+	if apiErr := decodeJSONBody(r, &request); apiErr != nil {
+		return web.ApiResponse[*models.RenewSandboxExpirationResponse]{}, apiErr
+	}
+	sbx, apiErr := sc.getSandboxOfUser(ctx, sandboxID)
+	if apiErr != nil {
+		return web.ApiResponse[*models.RenewSandboxExpirationResponse]{}, apiErr
+	}
+	current := sbx.GetTimeout().ShutdownTime
+	if !current.IsZero() && !request.ExpiresAt.After(current) {
+		return web.ApiResponse[*models.RenewSandboxExpirationResponse]{}, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: fmt.Sprintf("expiresAt must be after the current expiration %s", current.Format(time.RFC3339)),
+		}
+	}
+	newTimeout := sbx.GetTimeout()
+	newTimeout.ShutdownTime = request.ExpiresAt
+	result, err := sbx.SaveTimeoutWithPolicy(ctx, infra.SaveTimeoutOptions{
+		Timeout: newTimeout,
+	}, timeout.UpdatePolicyExtendOnly)
+	if err != nil {
+		return web.ApiResponse[*models.RenewSandboxExpirationResponse]{}, &web.ApiError{Code: http.StatusInternalServerError, Message: err.Error()}
+	}
+	if !result.Updated {
+		return web.ApiResponse[*models.RenewSandboxExpirationResponse]{}, &web.ApiError{
+			Code:    http.StatusConflict,
+			Message: "expiration was not extended (a concurrent update already set a later deadline)",
+		}
+	}
+	return web.ApiResponse[*models.RenewSandboxExpirationResponse]{
+		Body: &models.RenewSandboxExpirationResponse{ExpiresAt: request.ExpiresAt},
+	}, nil
+}

--- a/pkg/servers/opensandbox/pause_resume.go
+++ b/pkg/servers/opensandbox/pause_resume.go
@@ -18,7 +18,6 @@ package opensandbox
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -54,10 +53,7 @@ func (sc *Controller) PauseSandbox(r *http.Request) (web.ApiResponse[struct{}], 
 		return web.ApiResponse[struct{}]{}, apiErr
 	}
 	if err := sc.manager.PauseSandbox(ctx, sbx, infra.PauseOptions{}); err != nil {
-		return web.ApiResponse[struct{}]{}, &web.ApiError{
-			Code:    pauseResumeErrorCode(err),
-			Message: fmt.Sprintf("failed to pause sandbox %s: %v", sandboxID, err),
-		}
+		return web.ApiResponse[struct{}]{}, apiErrorf(pauseResumeErrorCode(err), "failed to pause sandbox %s: %v", sandboxID, err)
 	}
 	return web.ApiResponse[struct{}]{Code: http.StatusAccepted}, nil
 }
@@ -71,10 +67,7 @@ func (sc *Controller) ResumeSandbox(r *http.Request) (web.ApiResponse[struct{}],
 		return web.ApiResponse[struct{}]{}, apiErr
 	}
 	if err := sc.manager.ResumeSandbox(ctx, sbx, infra.ResumeOptions{}); err != nil {
-		return web.ApiResponse[struct{}]{}, &web.ApiError{
-			Code:    pauseResumeErrorCode(err),
-			Message: fmt.Sprintf("failed to resume sandbox %s: %v", sandboxID, err),
-		}
+		return web.ApiResponse[struct{}]{}, apiErrorf(pauseResumeErrorCode(err), "failed to resume sandbox %s: %v", sandboxID, err)
 	}
 	return web.ApiResponse[struct{}]{Code: http.StatusAccepted}, nil
 }
@@ -93,10 +86,7 @@ func (sc *Controller) RenewSandboxExpiration(r *http.Request) (web.ApiResponse[*
 	}
 	current := sbx.GetTimeout().ShutdownTime
 	if !current.IsZero() && !request.ExpiresAt.After(current) {
-		return web.ApiResponse[*models.RenewSandboxExpirationResponse]{}, &web.ApiError{
-			Code:    http.StatusBadRequest,
-			Message: fmt.Sprintf("expiresAt must be after the current expiration %s", current.Format(time.RFC3339)),
-		}
+		return web.ApiResponse[*models.RenewSandboxExpirationResponse]{}, apiErrorf(http.StatusBadRequest, "expiresAt must be after the current expiration %s", current.Format(time.RFC3339))
 	}
 	newTimeout := sbx.GetTimeout()
 	newTimeout.ShutdownTime = request.ExpiresAt
@@ -104,13 +94,10 @@ func (sc *Controller) RenewSandboxExpiration(r *http.Request) (web.ApiResponse[*
 		Timeout: newTimeout,
 	}, timeout.UpdatePolicyExtendOnly)
 	if err != nil {
-		return web.ApiResponse[*models.RenewSandboxExpirationResponse]{}, &web.ApiError{Code: http.StatusInternalServerError, Message: err.Error()}
+		return web.ApiResponse[*models.RenewSandboxExpirationResponse]{}, apiError(http.StatusInternalServerError, err.Error())
 	}
 	if !result.Updated {
-		return web.ApiResponse[*models.RenewSandboxExpirationResponse]{}, &web.ApiError{
-			Code:    http.StatusConflict,
-			Message: "expiration was not extended (a concurrent update already set a later deadline)",
-		}
+		return web.ApiResponse[*models.RenewSandboxExpirationResponse]{}, apiError(http.StatusConflict, "expiration was not extended (a concurrent update already set a later deadline)")
 	}
 	return web.ApiResponse[*models.RenewSandboxExpirationResponse]{
 		Body: &models.RenewSandboxExpirationResponse{ExpiresAt: request.ExpiresAt},

--- a/pkg/servers/opensandbox/pause_resume_test.go
+++ b/pkg/servers/opensandbox/pause_resume_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opensandbox
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	infracache "github.com/openkruise/agents/pkg/cache"
+	"github.com/openkruise/agents/pkg/servers/opensandbox/models"
+)
+
+// createTestSandbox creates one image-based sandbox through the HTTP API and
+// returns its ID, reused by every pause/resume/metadata test below.
+func createTestSandbox(t *testing.T, controller *Controller) string {
+	t.Helper()
+	body, err := json.Marshal(models.CreateSandboxRequest{
+		Image:      &models.ImageSpec{URI: "python:3.11"},
+		Extensions: map[string]string{"skipInitRuntime": "true"},
+	})
+	require.NoError(t, err)
+	resp := doRequest(t, controller.mux, http.MethodPost, "/v1/sandboxes", nil, body)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+	var created models.Sandbox
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&created))
+	require.NotEmpty(t, created.ID)
+	return created.ID
+}
+
+// enableWaitSim and updateSandboxWhen stand in for the agent-sandbox-controller,
+// which normally drives a Sandbox's Paused/Ready conditions in response to
+// Spec.Paused. Pause/Resume block on the cache's wait-reconcile mechanism for
+// that confirmation, so a fake-client-only test must simulate it — the same
+// pattern pkg/servers/e2b's own pause/resume tests use (EnableWaitSim /
+// UpdateSandboxWhen / DoSetSandboxStatus in its core_test.go), reimplemented
+// here because those are test-only helpers unexported from another package.
+func enableWaitSim(t *testing.T, controller *Controller, sandboxID string) {
+	t.Helper()
+	mockMgr := controller.cache.(*infracache.Cache).GetMockManager()
+	namespace, name, ok := strings.Cut(sandboxID, "--")
+	require.True(t, ok, "expected legacy namespace--name sandboxID, got %q", sandboxID)
+	sbx := &agentsv1alpha1.Sandbox{}
+	require.NoError(t, mockMgr.GetClient().Get(t.Context(), ctrlclient.ObjectKey{Namespace: namespace, Name: name}, sbx))
+	mockMgr.AddWaitReconcileKey(sbx)
+}
+
+// simulateControllerPauseOrResume watches for spec.Paused to reach want, then
+// writes the status a real sandbox controller would after actuating it.
+func simulateControllerPauseOrResume(t *testing.T, fc ctrlclient.Client, sandboxID string, want bool) {
+	t.Helper()
+	namespace, name, ok := strings.Cut(sandboxID, "--")
+	require.True(t, ok, "expected legacy namespace--name sandboxID, got %q", sandboxID)
+	require.Eventually(t, func() bool {
+		sbx := &agentsv1alpha1.Sandbox{}
+		if err := fc.Get(t.Context(), ctrlclient.ObjectKey{Namespace: namespace, Name: name}, sbx); err != nil {
+			return false
+		}
+		return sbx.Spec.Paused == want
+	}, 5*time.Second, 10*time.Millisecond)
+
+	sbx := &agentsv1alpha1.Sandbox{}
+	require.NoError(t, fc.Get(t.Context(), ctrlclient.ObjectKey{Namespace: namespace, Name: name}, sbx))
+	pausedStatus, readyStatus := metav1.ConditionFalse, metav1.ConditionTrue
+	phase := agentsv1alpha1.SandboxRunning
+	if want {
+		pausedStatus, readyStatus = metav1.ConditionTrue, metav1.ConditionFalse
+		phase = agentsv1alpha1.SandboxPaused
+	}
+	sbx.Status.Phase = phase
+	sbx.Status.Conditions = []metav1.Condition{
+		{Type: string(agentsv1alpha1.SandboxConditionPaused), Status: pausedStatus},
+		{Type: string(agentsv1alpha1.SandboxConditionReady), Status: readyStatus},
+	}
+	require.NoError(t, fc.Status().Update(t.Context(), sbx))
+}
+
+func TestPauseAndResumeSandbox(t *testing.T) {
+	controller, fc := Setup(t)
+	createDefaultTemplateFixture(t, fc, testNamespace)
+	simulateInstantReadySandbox(t)
+	sandboxID := createTestSandbox(t, controller)
+	enableWaitSim(t, controller, sandboxID)
+
+	go simulateControllerPauseOrResume(t, fc, sandboxID, true)
+	pauseResp := doRequest(t, controller.mux, http.MethodPost, "/v1/sandboxes/"+sandboxID+"/pause", nil, nil)
+	defer func() { _ = pauseResp.Body.Close() }()
+	require.Equal(t, http.StatusAccepted, pauseResp.StatusCode)
+
+	getResp := doRequest(t, controller.mux, http.MethodGet, "/v1/sandboxes/"+sandboxID, nil, nil)
+	var afterPause models.Sandbox
+	require.NoError(t, json.NewDecoder(getResp.Body).Decode(&afterPause))
+	_ = getResp.Body.Close()
+	assert.Equal(t, models.SandboxStatePaused, afterPause.Status.State)
+
+	go simulateControllerPauseOrResume(t, fc, sandboxID, false)
+	resumeResp := doRequest(t, controller.mux, http.MethodPost, "/v1/sandboxes/"+sandboxID+"/resume", nil, nil)
+	defer func() { _ = resumeResp.Body.Close() }()
+	require.Equal(t, http.StatusAccepted, resumeResp.StatusCode)
+
+	getResp2 := doRequest(t, controller.mux, http.MethodGet, "/v1/sandboxes/"+sandboxID, nil, nil)
+	defer func() { _ = getResp2.Body.Close() }()
+	var afterResume models.Sandbox
+	require.NoError(t, json.NewDecoder(getResp2.Body).Decode(&afterResume))
+	assert.Equal(t, models.SandboxStateRunning, afterResume.Status.State)
+}
+
+func TestPauseSandbox_NotFound(t *testing.T) {
+	controller, _ := Setup(t)
+	resp := doRequest(t, controller.mux, http.MethodPost, "/v1/sandboxes/does-not-exist/pause", nil, nil)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}

--- a/pkg/servers/opensandbox/routes.go
+++ b/pkg/servers/opensandbox/routes.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opensandbox
+
+import (
+	"net/http"
+
+	"github.com/openkruise/agents/pkg/servers/web"
+)
+
+// pathPrefix namespaces every OpenSandbox route under /v1, per the lifecycle
+// spec's basePath, so it can never collide with the E2B API's paths when both
+// are registered on the same mux.
+const pathPrefix = "/v1"
+
+func (sc *Controller) registerRoutes() {
+	registerRoute(sc.mux, http.MethodPost, "/sandboxes", sc.CreateSandbox, sc.CheckAPIKey)
+	registerRoute(sc.mux, http.MethodGet, "/sandboxes", sc.ListSandboxes, sc.CheckAPIKey)
+	registerRoute(sc.mux, http.MethodGet, "/sandboxes/{sandboxId}", sc.GetSandbox, sc.CheckAPIKey)
+	registerRoute(sc.mux, http.MethodDelete, "/sandboxes/{sandboxId}", sc.DeleteSandbox, sc.CheckAPIKey)
+	registerRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxId}/pause", sc.PauseSandbox, sc.CheckAPIKey)
+	registerRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxId}/resume", sc.ResumeSandbox, sc.CheckAPIKey)
+	registerRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxId}/renew-expiration", sc.RenewSandboxExpiration, sc.CheckAPIKey)
+	registerRoute(sc.mux, http.MethodPatch, "/sandboxes/{sandboxId}/metadata", sc.PatchSandboxMetadata, sc.CheckAPIKey)
+
+	registerRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxId}/snapshots", sc.CreateSnapshot, sc.CheckAPIKey)
+	registerRoute(sc.mux, http.MethodGet, "/snapshots", sc.ListSnapshots, sc.CheckAPIKey)
+
+	registerRoute(sc.mux, http.MethodGet, "/sandboxes/{sandboxId}/diagnostics/logs", sc.GetDiagnosticLogs, sc.CheckAPIKey)
+	registerRoute(sc.mux, http.MethodGet, "/sandboxes/{sandboxId}/diagnostics/events", sc.GetDiagnosticEvents, sc.CheckAPIKey)
+}
+
+func registerRoute[T any](mux *http.ServeMux, method, path string, handler web.Handler[T], middlewares ...web.MiddleWare) {
+	web.RegisterRoute(mux, method, pathPrefix+path, handler, middlewares...)
+}

--- a/pkg/servers/opensandbox/sandbox.go
+++ b/pkg/servers/opensandbox/sandbox.go
@@ -1,0 +1,458 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opensandbox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog/v2"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	sandboxmanager "github.com/openkruise/agents/pkg/sandbox-manager"
+	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/servers/opensandbox/models"
+	"github.com/openkruise/agents/pkg/servers/web"
+	annotationutils "github.com/openkruise/agents/pkg/utils/annotations"
+	"github.com/openkruise/agents/pkg/utils/pagination"
+	"github.com/openkruise/agents/pkg/utils/timeout"
+)
+
+// claimSandboxTimeout and waitReadyTimeout bound the (synchronous, on our
+// backend) claim/clone that backs the spec's async POST /sandboxes; see the
+// package AGENTS.md "Protocol Contract" note on why this adapter still
+// returns 202 only after the operation has actually completed.
+const (
+	claimSandboxTimeout = 60 * time.Second
+	waitReadyTimeout    = 60 * time.Second
+)
+
+func mapManagerErrorToAPIError(err error) *web.ApiError {
+	switch managererrors.GetErrCode(err) {
+	case managererrors.ErrorBadRequest, managererrors.ErrorNotFound:
+		return &web.ApiError{Code: http.StatusBadRequest, Message: err.Error()}
+	case managererrors.ErrorConflict:
+		return &web.ApiError{Code: http.StatusConflict, Message: err.Error()}
+	case managererrors.ErrorQuotaExceeded:
+		return &web.ApiError{Code: http.StatusForbidden, Message: err.Error()}
+	case managererrors.ErrorNotAllowed:
+		return &web.ApiError{Code: http.StatusForbidden, Message: err.Error()}
+	default:
+		return &web.ApiError{Code: http.StatusInternalServerError, Message: err.Error()}
+	}
+}
+
+func parseCreateSandboxRequest(r *http.Request) (models.CreateSandboxRequest, *web.ApiError) {
+	var request models.CreateSandboxRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		return request, &web.ApiError{Code: http.StatusBadRequest, Message: err.Error()}
+	}
+	hasImage := request.Image != nil && request.Image.URI != ""
+	hasSnapshot := request.SnapshotID != ""
+	if hasImage == hasSnapshot {
+		return request, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: "exactly one of image.uri or snapshotId is required",
+		}
+	}
+	if request.Platform != nil && request.Platform.OS != "" && request.Platform.OS != "linux" {
+		return request, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: fmt.Sprintf("unsupported platform.os %q: only linux sandboxes are supported by this backend", request.Platform.OS),
+		}
+	}
+	if request.Timeout != nil && *request.Timeout < models.MinTimeoutSeconds {
+		return request, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: fmt.Sprintf("timeout must be at least %d seconds", models.MinTimeoutSeconds),
+		}
+	}
+	for k := range request.Metadata {
+		if strings.HasPrefix(k, models.ReservedMetadataPrefix) {
+			return request, &web.ApiError{
+				Code:    http.StatusBadRequest,
+				Message: fmt.Sprintf("metadata key %q uses the reserved prefix %q", k, models.ReservedMetadataPrefix),
+			}
+		}
+	}
+	return request, nil
+}
+
+// resolveTimeoutOptions converts the spec's Timeout (nil == never expire,
+// seconds otherwise) into the same timeout.Options every other API surface of
+// this backend persists on the Sandbox. OpenSandbox has no auto-pause concept
+// distinct from expiration, so PauseTime is always left zero: a timed-out
+// OpenSandbox sandbox is deleted, not paused.
+func resolveTimeoutOptions(now time.Time, seconds *int) timeout.Options {
+	if seconds == nil {
+		return timeout.Options{}
+	}
+	return timeout.Options{ShutdownTime: now.Add(time.Duration(*seconds) * time.Second)}
+}
+
+func resourceListFrom(limits models.ResourceLimits) (corev1.ResourceList, error) {
+	if len(limits) == 0 {
+		return nil, nil
+	}
+	out := make(corev1.ResourceList, len(limits))
+	for k, v := range limits {
+		q, err := resource.ParseQuantity(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid resource quantity %q=%q: %w", k, v, err)
+		}
+		out[corev1.ResourceName(k)] = q
+	}
+	return out, nil
+}
+
+// CreateSandbox implements POST /v1/sandboxes. Exactly one of image or
+// snapshotId selects the creation path:
+//   - image claims a sandbox from DefaultTemplate (see Dependencies) and then
+//     applies an in-place image update, reusing the same
+//     SandboxManager.ClaimSandbox + InplaceUpdate capability the E2B API's
+//     create-with-InplaceUpdate.Image extension already uses.
+//   - snapshotId clones a sandbox from the named checkpoint, reusing
+//     SandboxManager.CloneSandbox exactly as the E2B API's snapshot-restore
+//     path does.
+func (sc *Controller) CreateSandbox(r *http.Request) (web.ApiResponse[*models.Sandbox], *web.ApiError) {
+	ctx := r.Context()
+	log := klog.FromContext(ctx)
+	user := userFromContext(ctx)
+	if user == nil {
+		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{Code: http.StatusUnauthorized, Message: "caller not authenticated"}
+	}
+	request, apiErr := parseCreateSandboxRequest(r)
+	if apiErr != nil {
+		return web.ApiResponse[*models.Sandbox]{}, apiErr
+	}
+
+	requestLimits, err := resourceListFrom(request.ResourceLimits)
+	if err != nil {
+		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{Code: http.StatusBadRequest, Message: err.Error()}
+	}
+	requestRequests, err := resourceListFrom(request.ResourceRequests)
+	if err != nil {
+		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{Code: http.StatusBadRequest, Message: err.Error()}
+	}
+
+	namespace := sc.namespaceOfUser(user)
+	now := time.Now()
+	modifier := func(sbx infra.Sandbox) error {
+		sc.applyCreateMetadata(sbx, request, now)
+		return nil
+	}
+
+	if request.SnapshotID != "" {
+		log.Info("create sandbox from snapshot", "snapshotId", request.SnapshotID)
+		if !sc.manager.GetInfra().HasCheckpoint(ctx, infra.HasCheckpointOptions{Namespace: namespace, CheckpointID: request.SnapshotID}) {
+			return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{Code: http.StatusBadRequest, Message: fmt.Sprintf("snapshot %s not found", request.SnapshotID)}
+		}
+		sbx, err := sc.manager.CloneSandbox(ctx, sandboxmanager.CloneSandboxOptions{
+			Infra: infra.CloneSandboxOptions{
+				Namespace:        namespace,
+				User:             user.ID.String(),
+				CheckPointID:     request.SnapshotID,
+				CloneTimeout:     claimSandboxTimeout,
+				WaitReadyTimeout: waitReadyTimeout,
+				Modifier:         modifier,
+			},
+			Quota: user.QuotaSpec.DeepCopy(),
+		})
+		if err != nil {
+			log.Error(err, "failed to clone sandbox from snapshot")
+			return web.ApiResponse[*models.Sandbox]{}, mapManagerErrorToAPIError(err)
+		}
+		return web.ApiResponse[*models.Sandbox]{Code: http.StatusAccepted, Body: sc.convertToOpenSandbox(sbx)}, nil
+	}
+
+	if sc.defaultTemplate == "" {
+		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
+			Code:    http.StatusInternalServerError,
+			Message: "server misconfiguration: no default sandbox template configured for image-based creation",
+		}
+	}
+	if !sc.manager.GetInfra().HasTemplate(ctx, infra.HasTemplateOptions{Namespace: namespace, Name: sc.defaultTemplate}) {
+		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
+			Code:    http.StatusInternalServerError,
+			Message: fmt.Sprintf("default sandbox template %q not found", sc.defaultTemplate),
+		}
+	}
+
+	log.Info("create sandbox from image", "image", request.Image.URI, "template", sc.defaultTemplate)
+	infraOpts := infra.ClaimSandboxOptions{
+		Namespace:        namespace,
+		Template:         sc.defaultTemplate,
+		User:             user.ID.String(),
+		ClaimTimeout:     claimSandboxTimeout,
+		WaitReadyTimeout: waitReadyTimeout,
+		CreateOnNoStock:  true,
+		Modifier:         modifier,
+		InplaceUpdate: &config.InplaceUpdateOptions{
+			Image: request.Image.URI,
+		},
+	}
+	if len(requestRequests) > 0 || len(requestLimits) > 0 {
+		infraOpts.InplaceUpdate.Resources = &config.InplaceUpdateResourcesOptions{
+			Requests: requestRequests,
+			Limits:   requestLimits,
+		}
+	}
+	// extensionSkipInitRuntime is this adapter's own vendor extension (the
+	// spec explicitly reserves "extensions" for provider-specific
+	// parameters): it skips the agent-runtime /init handshake, for callers
+	// that only need the Kubernetes-level sandbox and drive execution through
+	// their own channel.
+	if request.Extensions["skipInitRuntime"] != "true" {
+		infraOpts.InitRuntime = &config.InitRuntimeOptions{
+			EnvVars:     request.Env,
+			AccessToken: config.NewDefaultAccessToken(),
+		}
+	}
+	sbx, err := sc.manager.ClaimSandbox(ctx, sandboxmanager.ClaimSandboxOptions{
+		Infra: infraOpts,
+		Quota: user.QuotaSpec.DeepCopy(),
+	})
+	if err != nil {
+		log.Error(err, "failed to claim sandbox for image-based create")
+		return web.ApiResponse[*models.Sandbox]{}, mapManagerErrorToAPIError(err)
+	}
+	body := sc.convertToOpenSandbox(sbx)
+	body.Image = request.Image
+	body.Entrypoint = request.Entrypoint
+	return web.ApiResponse[*models.Sandbox]{Code: http.StatusAccepted, Body: body}, nil
+}
+
+// applyCreateMetadata writes the request's timeout and user metadata onto sbx
+// before it is persisted, mirroring e2b.Controller.basicSandboxCreateModifier
+// for the fields OpenSandbox actually has.
+func (sc *Controller) applyCreateMetadata(sbx infra.Sandbox, request models.CreateSandboxRequest, now time.Time) {
+	sbx.SetTimeout(resolveTimeoutOptions(now, request.Timeout))
+	annotations := sbx.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string, len(request.Metadata))
+	}
+	maps.Copy(annotations, request.Metadata)
+	sbx.SetAnnotations(annotations)
+}
+
+func (sc *Controller) getSandboxOfUser(ctx context.Context, sandboxID string) (infra.Sandbox, *web.ApiError) {
+	user := userFromContext(ctx)
+	if user == nil {
+		return nil, &web.ApiError{Code: http.StatusUnauthorized, Message: "caller not authenticated"}
+	}
+	getCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	sbx, err := sc.manager.GetSandbox(getCtx, user.ID.String(), nil, infra.GetSandboxOptions{
+		Namespace: sc.namespaceOfUser(user),
+		SandboxID: sandboxID,
+	})
+	if err != nil {
+		return nil, &web.ApiError{
+			Code:    getSandboxErrorCode(err),
+			Message: fmt.Sprintf("sandbox %s not found: %v", sandboxID, err),
+		}
+	}
+	return sbx, nil
+}
+
+func getSandboxErrorCode(err error) int {
+	if managererrors.GetErrCode(err) == managererrors.ErrorInternal {
+		return http.StatusInternalServerError
+	}
+	return http.StatusNotFound
+}
+
+// GetSandbox implements GET /v1/sandboxes/{sandboxId}.
+func (sc *Controller) GetSandbox(r *http.Request) (web.ApiResponse[*models.Sandbox], *web.ApiError) {
+	sandboxID := r.PathValue("sandboxId")
+	sbx, apiErr := sc.getSandboxOfUser(r.Context(), sandboxID)
+	if apiErr != nil {
+		return web.ApiResponse[*models.Sandbox]{}, apiErr
+	}
+	return web.ApiResponse[*models.Sandbox]{Body: sc.convertToOpenSandbox(sbx)}, nil
+}
+
+// DeleteSandbox implements DELETE /v1/sandboxes/{sandboxId}.
+func (sc *Controller) DeleteSandbox(r *http.Request) (web.ApiResponse[struct{}], *web.ApiError) {
+	ctx := r.Context()
+	sandboxID := r.PathValue("sandboxId")
+	user := userFromContext(ctx)
+	if user == nil {
+		return web.ApiResponse[struct{}]{}, &web.ApiError{Code: http.StatusUnauthorized, Message: "caller not authenticated"}
+	}
+	sbx, apiErr := sc.getSandboxOfUser(ctx, sandboxID)
+	if apiErr != nil {
+		return web.ApiResponse[struct{}]{}, apiErr
+	}
+	if err := sc.manager.DeleteSandbox(ctx, sandboxmanager.DeleteSandboxOptions{
+		Sandbox: sbx,
+		User:    user.ID.String(),
+		Quota:   user.QuotaSpec.DeepCopy(),
+	}); err != nil {
+		return web.ApiResponse[struct{}]{}, mapManagerErrorToAPIError(err)
+	}
+	return web.ApiResponse[struct{}]{Code: http.StatusNoContent}, nil
+}
+
+// ListSandboxes implements GET /v1/sandboxes.
+func (sc *Controller) ListSandboxes(r *http.Request) (web.ApiResponse[*models.ListSandboxesResponse], *web.ApiError) {
+	ctx := r.Context()
+	user := userFromContext(ctx)
+	if user == nil {
+		return web.ApiResponse[*models.ListSandboxesResponse]{}, &web.ApiError{Code: http.StatusUnauthorized, Message: "caller not authenticated"}
+	}
+
+	page, pageSize, apiErr := parsePagination(r)
+	if apiErr != nil {
+		return web.ApiResponse[*models.ListSandboxesResponse]{}, apiErr
+	}
+	states, metadataFilter := parseListFilters(r)
+
+	sandboxes, _, err := sc.manager.ListSandboxes(ctx, infra.SelectSandboxesOptions{
+		Namespace: sc.namespaceOfUser(user),
+		User:      user.ID.String(),
+	}, &pagination.Paginator[infra.Sandbox]{
+		// Limit 0 returns every match; this handler applies the spec's
+		// page/pageSize windowing itself below rather than the paginator's
+		// cursor-token scheme, since OpenSandbox's list contract is
+		// page-number based with a totalItems/totalPages count.
+		Limit: 0,
+		Filter: func(sbx infra.Sandbox) bool {
+			if len(states) > 0 && !states[string(convertPhaseToOpenSandboxState(sbx.Phase()))] {
+				return false
+			}
+			for k, v := range metadataFilter {
+				if sbx.GetAnnotations()[k] != v {
+					return false
+				}
+			}
+			return true
+		},
+		GetKey:       func(sbx infra.Sandbox) string { return sbx.GetAnnotations()[agentsv1alpha1.AnnotationClaimTime] },
+		GetUniqueKey: func(sbx infra.Sandbox) string { return sbx.GetSandboxID() },
+	})
+	if err != nil {
+		return web.ApiResponse[*models.ListSandboxesResponse]{}, &web.ApiError{Code: http.StatusInternalServerError, Message: fmt.Sprintf("failed to list sandboxes: %v", err)}
+	}
+
+	totalItems := len(sandboxes)
+	start := min((page-1)*pageSize, totalItems)
+	end := min(start+pageSize, totalItems)
+	items := make([]*models.Sandbox, 0, end-start)
+	for _, sbx := range sandboxes[start:end] {
+		items = append(items, sc.convertToOpenSandbox(sbx))
+	}
+	totalPages := (totalItems + pageSize - 1) / pageSize
+
+	return web.ApiResponse[*models.ListSandboxesResponse]{
+		Body: &models.ListSandboxesResponse{
+			Items: items,
+			Pagination: models.PaginationInfo{
+				Page:        page,
+				PageSize:    pageSize,
+				TotalItems:  totalItems,
+				TotalPages:  totalPages,
+				HasNextPage: end < totalItems,
+			},
+		},
+	}, nil
+}
+
+func parsePagination(r *http.Request) (page, pageSize int, apiErr *web.ApiError) {
+	page, pageSize = 1, 20
+	if v := r.URL.Query().Get("page"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			return 0, 0, &web.ApiError{Code: http.StatusBadRequest, Message: "page must be a positive integer"}
+		}
+		page = n
+	}
+	if v := r.URL.Query().Get("pageSize"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < models.MinListLimit || n > models.MaxListLimit {
+			return 0, 0, &web.ApiError{Code: http.StatusBadRequest, Message: fmt.Sprintf("pageSize must be between %d and %d", models.MinListLimit, models.MaxListLimit)}
+		}
+		pageSize = n
+	}
+	return page, pageSize, nil
+}
+
+func parseListFilters(r *http.Request) (states map[string]bool, metadata map[string]string) {
+	if values := r.URL.Query()["state"]; len(values) > 0 {
+		states = make(map[string]bool, len(values))
+		for _, v := range values {
+			states[v] = true
+		}
+	}
+	if raw := r.URL.Query().Get("metadata"); raw != "" {
+		metadata = make(map[string]string)
+		for pair := range strings.SplitSeq(raw, "&") {
+			if k, v, ok := strings.Cut(pair, "="); ok {
+				metadata[k] = v
+			}
+		}
+	}
+	return states, metadata
+}
+
+// convertToOpenSandbox projects an infra.Sandbox onto the OpenSandbox wire
+// representation. Only user-supplied (non-reserved-prefix) annotations are
+// surfaced as metadata, mirroring the E2B adapter's ValidateMetadataKey guard
+// so internal bookkeeping annotations never leak to callers.
+func (sc *Controller) convertToOpenSandbox(sbx infra.Sandbox) *models.Sandbox {
+	annotations := sbx.GetAnnotations()
+	metadata := make(map[string]string, len(annotations))
+	for k, v := range annotations {
+		if annotationutils.IsBlackListed(k) || strings.HasPrefix(k, models.ReservedMetadataPrefix) {
+			continue
+		}
+		metadata[k] = v
+	}
+
+	status := models.SandboxStatus{State: convertPhaseToOpenSandboxState(sbx.Phase())}
+	if _, reason := sbx.GetState(); reason != "" {
+		status.Reason = reason
+	}
+
+	result := &models.Sandbox{
+		ID:       sbx.GetSandboxID(),
+		Status:   status,
+		Metadata: metadata,
+	}
+	if claimTime, err := sbx.GetClaimTime(); err == nil {
+		result.CreatedAt = claimTime.Format(time.RFC3339)
+	}
+	if shutdown := sbx.GetTimeout().ShutdownTime; !shutdown.IsZero() {
+		result.ExpiresAt = shutdown.Format(time.RFC3339)
+	}
+	if image := sbx.GetImage(); image != "" {
+		result.Image = &models.ImageSpec{URI: image}
+	}
+	return result
+}

--- a/pkg/servers/opensandbox/sandbox.go
+++ b/pkg/servers/opensandbox/sandbox.go
@@ -54,15 +54,15 @@ const (
 func mapManagerErrorToAPIError(err error) *web.ApiError {
 	switch managererrors.GetErrCode(err) {
 	case managererrors.ErrorBadRequest, managererrors.ErrorNotFound:
-		return &web.ApiError{Code: http.StatusBadRequest, Message: err.Error()}
+		return apiError(http.StatusBadRequest, err.Error())
 	case managererrors.ErrorConflict:
-		return &web.ApiError{Code: http.StatusConflict, Message: err.Error()}
+		return apiError(http.StatusConflict, err.Error())
 	case managererrors.ErrorQuotaExceeded:
-		return &web.ApiError{Code: http.StatusForbidden, Message: err.Error()}
+		return apiError(http.StatusForbidden, err.Error())
 	case managererrors.ErrorNotAllowed:
-		return &web.ApiError{Code: http.StatusForbidden, Message: err.Error()}
+		return apiError(http.StatusForbidden, err.Error())
 	default:
-		return &web.ApiError{Code: http.StatusInternalServerError, Message: err.Error()}
+		return apiError(http.StatusInternalServerError, err.Error())
 	}
 }
 
@@ -71,34 +71,22 @@ func parseCreateSandboxRequest(r *http.Request) (models.CreateSandboxRequest, *w
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&request); err != nil {
-		return request, &web.ApiError{Code: http.StatusBadRequest, Message: err.Error()}
+		return request, apiError(http.StatusBadRequest, err.Error())
 	}
 	hasImage := request.Image != nil && request.Image.URI != ""
 	hasSnapshot := request.SnapshotID != ""
 	if hasImage == hasSnapshot {
-		return request, &web.ApiError{
-			Code:    http.StatusBadRequest,
-			Message: "exactly one of image.uri or snapshotId is required",
-		}
+		return request, apiError(http.StatusBadRequest, "exactly one of image.uri or snapshotId is required")
 	}
 	if request.Platform != nil && request.Platform.OS != "" && request.Platform.OS != "linux" {
-		return request, &web.ApiError{
-			Code:    http.StatusBadRequest,
-			Message: fmt.Sprintf("unsupported platform.os %q: only linux sandboxes are supported by this backend", request.Platform.OS),
-		}
+		return request, apiErrorf(http.StatusBadRequest, "unsupported platform.os %q: only linux sandboxes are supported by this backend", request.Platform.OS)
 	}
 	if request.Timeout != nil && *request.Timeout < models.MinTimeoutSeconds {
-		return request, &web.ApiError{
-			Code:    http.StatusBadRequest,
-			Message: fmt.Sprintf("timeout must be at least %d seconds", models.MinTimeoutSeconds),
-		}
+		return request, apiErrorf(http.StatusBadRequest, "timeout must be at least %d seconds", models.MinTimeoutSeconds)
 	}
 	for k := range request.Metadata {
 		if strings.HasPrefix(k, models.ReservedMetadataPrefix) {
-			return request, &web.ApiError{
-				Code:    http.StatusBadRequest,
-				Message: fmt.Sprintf("metadata key %q uses the reserved prefix %q", k, models.ReservedMetadataPrefix),
-			}
+			return request, apiErrorf(http.StatusBadRequest, "metadata key %q uses the reserved prefix %q", k, models.ReservedMetadataPrefix)
 		}
 	}
 	return request, nil
@@ -145,7 +133,7 @@ func (sc *Controller) CreateSandbox(r *http.Request) (web.ApiResponse[*models.Sa
 	log := klog.FromContext(ctx)
 	user := userFromContext(ctx)
 	if user == nil {
-		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{Code: http.StatusUnauthorized, Message: "caller not authenticated"}
+		return web.ApiResponse[*models.Sandbox]{}, apiError(http.StatusUnauthorized, "caller not authenticated")
 	}
 	request, apiErr := parseCreateSandboxRequest(r)
 	if apiErr != nil {
@@ -154,11 +142,11 @@ func (sc *Controller) CreateSandbox(r *http.Request) (web.ApiResponse[*models.Sa
 
 	requestLimits, err := resourceListFrom(request.ResourceLimits)
 	if err != nil {
-		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{Code: http.StatusBadRequest, Message: err.Error()}
+		return web.ApiResponse[*models.Sandbox]{}, apiError(http.StatusBadRequest, err.Error())
 	}
 	requestRequests, err := resourceListFrom(request.ResourceRequests)
 	if err != nil {
-		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{Code: http.StatusBadRequest, Message: err.Error()}
+		return web.ApiResponse[*models.Sandbox]{}, apiError(http.StatusBadRequest, err.Error())
 	}
 
 	namespace := sc.namespaceOfUser(user)
@@ -171,7 +159,7 @@ func (sc *Controller) CreateSandbox(r *http.Request) (web.ApiResponse[*models.Sa
 	if request.SnapshotID != "" {
 		log.Info("create sandbox from snapshot", "snapshotId", request.SnapshotID)
 		if !sc.manager.GetInfra().HasCheckpoint(ctx, infra.HasCheckpointOptions{Namespace: namespace, CheckpointID: request.SnapshotID}) {
-			return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{Code: http.StatusBadRequest, Message: fmt.Sprintf("snapshot %s not found", request.SnapshotID)}
+			return web.ApiResponse[*models.Sandbox]{}, apiErrorf(http.StatusBadRequest, "snapshot %s not found", request.SnapshotID)
 		}
 		sbx, err := sc.manager.CloneSandbox(ctx, sandboxmanager.CloneSandboxOptions{
 			Infra: infra.CloneSandboxOptions{
@@ -192,16 +180,10 @@ func (sc *Controller) CreateSandbox(r *http.Request) (web.ApiResponse[*models.Sa
 	}
 
 	if sc.defaultTemplate == "" {
-		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
-			Code:    http.StatusInternalServerError,
-			Message: "server misconfiguration: no default sandbox template configured for image-based creation",
-		}
+		return web.ApiResponse[*models.Sandbox]{}, apiError(http.StatusInternalServerError, "server misconfiguration: no default sandbox template configured for image-based creation")
 	}
 	if !sc.manager.GetInfra().HasTemplate(ctx, infra.HasTemplateOptions{Namespace: namespace, Name: sc.defaultTemplate}) {
-		return web.ApiResponse[*models.Sandbox]{}, &web.ApiError{
-			Code:    http.StatusInternalServerError,
-			Message: fmt.Sprintf("default sandbox template %q not found", sc.defaultTemplate),
-		}
+		return web.ApiResponse[*models.Sandbox]{}, apiErrorf(http.StatusInternalServerError, "default sandbox template %q not found", sc.defaultTemplate)
 	}
 
 	log.Info("create sandbox from image", "image", request.Image.URI, "template", sc.defaultTemplate)
@@ -264,7 +246,7 @@ func (sc *Controller) applyCreateMetadata(sbx infra.Sandbox, request models.Crea
 func (sc *Controller) getSandboxOfUser(ctx context.Context, sandboxID string) (infra.Sandbox, *web.ApiError) {
 	user := userFromContext(ctx)
 	if user == nil {
-		return nil, &web.ApiError{Code: http.StatusUnauthorized, Message: "caller not authenticated"}
+		return nil, apiError(http.StatusUnauthorized, "caller not authenticated")
 	}
 	getCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
@@ -273,10 +255,7 @@ func (sc *Controller) getSandboxOfUser(ctx context.Context, sandboxID string) (i
 		SandboxID: sandboxID,
 	})
 	if err != nil {
-		return nil, &web.ApiError{
-			Code:    getSandboxErrorCode(err),
-			Message: fmt.Sprintf("sandbox %s not found: %v", sandboxID, err),
-		}
+		return nil, apiErrorf(getSandboxErrorCode(err), "sandbox %s not found: %v", sandboxID, err)
 	}
 	return sbx, nil
 }
@@ -304,7 +283,7 @@ func (sc *Controller) DeleteSandbox(r *http.Request) (web.ApiResponse[struct{}],
 	sandboxID := r.PathValue("sandboxId")
 	user := userFromContext(ctx)
 	if user == nil {
-		return web.ApiResponse[struct{}]{}, &web.ApiError{Code: http.StatusUnauthorized, Message: "caller not authenticated"}
+		return web.ApiResponse[struct{}]{}, apiError(http.StatusUnauthorized, "caller not authenticated")
 	}
 	sbx, apiErr := sc.getSandboxOfUser(ctx, sandboxID)
 	if apiErr != nil {
@@ -325,7 +304,7 @@ func (sc *Controller) ListSandboxes(r *http.Request) (web.ApiResponse[*models.Li
 	ctx := r.Context()
 	user := userFromContext(ctx)
 	if user == nil {
-		return web.ApiResponse[*models.ListSandboxesResponse]{}, &web.ApiError{Code: http.StatusUnauthorized, Message: "caller not authenticated"}
+		return web.ApiResponse[*models.ListSandboxesResponse]{}, apiError(http.StatusUnauthorized, "caller not authenticated")
 	}
 
 	page, pageSize, apiErr := parsePagination(r)
@@ -358,7 +337,7 @@ func (sc *Controller) ListSandboxes(r *http.Request) (web.ApiResponse[*models.Li
 		GetUniqueKey: func(sbx infra.Sandbox) string { return sbx.GetSandboxID() },
 	})
 	if err != nil {
-		return web.ApiResponse[*models.ListSandboxesResponse]{}, &web.ApiError{Code: http.StatusInternalServerError, Message: fmt.Sprintf("failed to list sandboxes: %v", err)}
+		return web.ApiResponse[*models.ListSandboxesResponse]{}, apiErrorf(http.StatusInternalServerError, "failed to list sandboxes: %v", err)
 	}
 
 	totalItems := len(sandboxes)
@@ -389,14 +368,14 @@ func parsePagination(r *http.Request) (page, pageSize int, apiErr *web.ApiError)
 	if v := r.URL.Query().Get("page"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n < 1 {
-			return 0, 0, &web.ApiError{Code: http.StatusBadRequest, Message: "page must be a positive integer"}
+			return 0, 0, apiError(http.StatusBadRequest, "page must be a positive integer")
 		}
 		page = n
 	}
 	if v := r.URL.Query().Get("pageSize"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n < models.MinListLimit || n > models.MaxListLimit {
-			return 0, 0, &web.ApiError{Code: http.StatusBadRequest, Message: fmt.Sprintf("pageSize must be between %d and %d", models.MinListLimit, models.MaxListLimit)}
+			return 0, 0, apiErrorf(http.StatusBadRequest, "pageSize must be between %d and %d", models.MinListLimit, models.MaxListLimit)
 		}
 		pageSize = n
 	}

--- a/pkg/servers/opensandbox/sandbox_test.go
+++ b/pkg/servers/opensandbox/sandbox_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opensandbox
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/servers/opensandbox/models"
+)
+
+// TestCreateSandbox_Image is the "demonstrate the work on pod/containers"
+// test: it drives a real POST /v1/sandboxes request through the full stack
+// (opensandbox handler -> SandboxManager.ClaimSandbox -> Infra -> a real
+// Sandbox custom resource carrying a Kubernetes PodTemplateSpec), then reads
+// back the persisted object directly through the fake API server to prove the
+// caller's image actually landed in the pod's container spec — not just in
+// the HTTP response.
+func TestCreateSandbox_Image(t *testing.T) {
+	controller, fc := Setup(t)
+	createDefaultTemplateFixture(t, fc, testNamespace)
+	simulateInstantReadySandbox(t)
+
+	body, err := json.Marshal(models.CreateSandboxRequest{
+		Image: &models.ImageSpec{URI: "python:3.11"},
+		ResourceLimits: models.ResourceLimits{
+			"cpu":    "250m",
+			"memory": "256Mi",
+		},
+		Metadata: map[string]string{"team": "agents"},
+		// This unit test runs against a fake Kubernetes client with no real
+		// agent-runtime to answer the /init handshake, so it opts out via this
+		// adapter's skipInitRuntime vendor extension (see sandbox.go).
+		Extensions: map[string]string{"skipInitRuntime": "true"},
+	})
+	require.NoError(t, err)
+
+	resp := doRequest(t, controller.mux, http.MethodPost, "/v1/sandboxes", nil, body)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+
+	var created models.Sandbox
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&created))
+	assert.Equal(t, models.SandboxStateRunning, created.Status.State)
+	assert.Equal(t, "python:3.11", created.Image.URI)
+	assert.Equal(t, "agents", created.Metadata["team"])
+	require.NotEmpty(t, created.ID)
+
+	// Read the underlying Sandbox CR directly to prove the image requested
+	// through the OpenSandbox API actually landed on the pod template the
+	// sandbox controller would schedule as a real Pod — the concrete
+	// "demonstrated on a pod" artifact for this adapter.
+	var sandboxList agentsv1alpha1.SandboxList
+	require.NoError(t, fc.List(t.Context(), &sandboxList, client.InNamespace(testNamespace)))
+	require.Len(t, sandboxList.Items, 1)
+	pod := sandboxList.Items[0].Spec.Template
+	require.NotNil(t, pod)
+	require.Len(t, pod.Spec.Containers, 1)
+	assert.Equal(t, "python:3.11", pod.Spec.Containers[0].Image)
+}
+
+func TestCreateSandbox_Validation(t *testing.T) {
+	controller, _ := Setup(t)
+
+	tests := []struct {
+		name string
+		body models.CreateSandboxRequest
+	}{
+		{
+			name: "neither image nor snapshotId",
+			body: models.CreateSandboxRequest{},
+		},
+		{
+			name: "both image and snapshotId",
+			body: models.CreateSandboxRequest{
+				Image:      &models.ImageSpec{URI: "python:3.11"},
+				SnapshotID: "snap-1",
+			},
+		},
+		{
+			name: "windows platform is rejected",
+			body: models.CreateSandboxRequest{
+				Image:    &models.ImageSpec{URI: "python:3.11"},
+				Platform: &models.PlatformSpec{OS: "windows", Arch: "amd64"},
+			},
+		},
+		{
+			name: "timeout below the spec floor is rejected",
+			body: models.CreateSandboxRequest{
+				Image:   &models.ImageSpec{URI: "python:3.11"},
+				Timeout: intPtr(10),
+			},
+		},
+		{
+			name: "reserved metadata prefix is rejected",
+			body: models.CreateSandboxRequest{
+				Image:    &models.ImageSpec{URI: "python:3.11"},
+				Metadata: map[string]string{"opensandbox.io/x": "y"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+			resp := doRequest(t, controller.mux, http.MethodPost, "/v1/sandboxes", nil, body)
+			defer func() { _ = resp.Body.Close() }()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+	}
+}
+
+func TestGetAndDeleteSandbox(t *testing.T) {
+	controller, fc := Setup(t)
+	createDefaultTemplateFixture(t, fc, testNamespace)
+	simulateInstantReadySandbox(t)
+
+	body, err := json.Marshal(models.CreateSandboxRequest{Image: &models.ImageSpec{URI: "python:3.11"}, Extensions: map[string]string{"skipInitRuntime": "true"}})
+	require.NoError(t, err)
+	createResp := doRequest(t, controller.mux, http.MethodPost, "/v1/sandboxes", nil, body)
+	var created models.Sandbox
+	require.NoError(t, json.NewDecoder(createResp.Body).Decode(&created))
+	_ = createResp.Body.Close()
+
+	getResp := doRequest(t, controller.mux, http.MethodGet, "/v1/sandboxes/"+created.ID, nil, nil)
+	defer func() { _ = getResp.Body.Close() }()
+	require.Equal(t, http.StatusOK, getResp.StatusCode)
+	var fetched models.Sandbox
+	require.NoError(t, json.NewDecoder(getResp.Body).Decode(&fetched))
+	assert.Equal(t, created.ID, fetched.ID)
+
+	delResp := doRequest(t, controller.mux, http.MethodDelete, "/v1/sandboxes/"+created.ID, nil, nil)
+	defer func() { _ = delResp.Body.Close() }()
+	assert.Equal(t, http.StatusNoContent, delResp.StatusCode)
+
+	notFoundResp := doRequest(t, controller.mux, http.MethodGet, "/v1/sandboxes/"+created.ID, nil, nil)
+	defer func() { _ = notFoundResp.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, notFoundResp.StatusCode)
+}
+
+func TestListSandboxes_Pagination(t *testing.T) {
+	controller, fc := Setup(t)
+	createDefaultTemplateFixture(t, fc, testNamespace)
+	simulateInstantReadySandbox(t)
+
+	for range 3 {
+		body, err := json.Marshal(models.CreateSandboxRequest{Image: &models.ImageSpec{URI: "python:3.11"}, Extensions: map[string]string{"skipInitRuntime": "true"}})
+		require.NoError(t, err)
+		resp := doRequest(t, controller.mux, http.MethodPost, "/v1/sandboxes", nil, body)
+		require.Equal(t, http.StatusAccepted, resp.StatusCode)
+		_ = resp.Body.Close()
+	}
+
+	resp := doRequest(t, controller.mux, http.MethodGet, "/v1/sandboxes?pageSize=2&page=1", nil, nil)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var page1 models.ListSandboxesResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&page1))
+	assert.Len(t, page1.Items, 2)
+	assert.Equal(t, 3, page1.Pagination.TotalItems)
+	assert.True(t, page1.Pagination.HasNextPage)
+
+	resp2 := doRequest(t, controller.mux, http.MethodGet, "/v1/sandboxes?pageSize=2&page=2", nil, nil)
+	defer func() { _ = resp2.Body.Close() }()
+	var page2 models.ListSandboxesResponse
+	require.NoError(t, json.NewDecoder(resp2.Body).Decode(&page2))
+	assert.Len(t, page2.Items, 1)
+	assert.False(t, page2.Pagination.HasNextPage)
+}
+
+func intPtr(v int) *int { return &v }

--- a/pkg/servers/opensandbox/snapshot.go
+++ b/pkg/servers/opensandbox/snapshot.go
@@ -50,15 +50,12 @@ func (sc *Controller) CreateSnapshot(r *http.Request) (web.ApiResponse[*models.S
 		return web.ApiResponse[*models.Snapshot]{}, apiErr
 	}
 	if state, reason := sbx.GetState(); state != agentsv1alpha1.SandboxStateRunning {
-		return web.ApiResponse[*models.Snapshot]{}, &web.ApiError{
-			Code:    http.StatusConflict,
-			Message: fmt.Sprintf("sandbox %s is not running (state=%s reason=%s)", sandboxID, state, reason),
-		}
+		return web.ApiResponse[*models.Snapshot]{}, apiErrorf(http.StatusConflict, "sandbox %s is not running (state=%s reason=%s)", sandboxID, state, reason)
 	}
 
 	checkpointID, err := sbx.CreateCheckpoint(ctx, infra.CreateCheckpointOptions{})
 	if err != nil {
-		return web.ApiResponse[*models.Snapshot]{}, &web.ApiError{Code: http.StatusInternalServerError, Message: err.Error()}
+		return web.ApiResponse[*models.Snapshot]{}, apiError(http.StatusInternalServerError, err.Error())
 	}
 	return web.ApiResponse[*models.Snapshot]{
 		Code: http.StatusAccepted,
@@ -78,7 +75,7 @@ func (sc *Controller) ListSnapshots(r *http.Request) (web.ApiResponse[*models.Li
 	ctx := r.Context()
 	user := userFromContext(ctx)
 	if user == nil {
-		return web.ApiResponse[*models.ListSnapshotsResponse]{}, &web.ApiError{Code: http.StatusUnauthorized, Message: "caller not authenticated"}
+		return web.ApiResponse[*models.ListSnapshotsResponse]{}, apiError(http.StatusUnauthorized, "caller not authenticated")
 	}
 	page, pageSize, apiErr := parsePagination(r)
 	if apiErr != nil {
@@ -98,7 +95,7 @@ func (sc *Controller) ListSnapshots(r *http.Request) (web.ApiResponse[*models.Li
 		GetUniqueKey: func(cp infra.CheckpointInfo) string { return fmt.Sprintf("%s/%s", cp.Namespace, cp.Name) },
 	})
 	if err != nil {
-		return web.ApiResponse[*models.ListSnapshotsResponse]{}, &web.ApiError{Code: http.StatusInternalServerError, Message: fmt.Sprintf("failed to list snapshots: %v", err)}
+		return web.ApiResponse[*models.ListSnapshotsResponse]{}, apiErrorf(http.StatusInternalServerError, "failed to list snapshots: %v", err)
 	}
 
 	totalItems := len(checkpoints)

--- a/pkg/servers/opensandbox/snapshot.go
+++ b/pkg/servers/opensandbox/snapshot.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opensandbox
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/servers/opensandbox/models"
+	"github.com/openkruise/agents/pkg/servers/web"
+	"github.com/openkruise/agents/pkg/utils/pagination"
+)
+
+// CreateSnapshot implements POST /v1/sandboxes/{sandboxId}/snapshots,
+// reusing the same Sandbox.CreateCheckpoint capability the E2B API's
+// CreateSnapshot handler uses. The spec's response carries the snapshot in
+// its "Creating" state; this backend's CreateCheckpoint call is synchronous,
+// so — like pause/resume — the 202 here is returned only once creation has
+// already reached a terminal outcome. A checkpoint ID is only known on
+// success, so a Ready state is reported directly rather than a Creating
+// placeholder that would immediately be stale.
+func (sc *Controller) CreateSnapshot(r *http.Request) (web.ApiResponse[*models.Snapshot], *web.ApiError) {
+	ctx := r.Context()
+	sandboxID := r.PathValue("sandboxId")
+
+	var request models.CreateSnapshotRequest
+	if apiErr := decodeJSONBody(r, &request); apiErr != nil {
+		return web.ApiResponse[*models.Snapshot]{}, apiErr
+	}
+
+	sbx, apiErr := sc.getSandboxOfUser(ctx, sandboxID)
+	if apiErr != nil {
+		return web.ApiResponse[*models.Snapshot]{}, apiErr
+	}
+	if state, reason := sbx.GetState(); state != agentsv1alpha1.SandboxStateRunning {
+		return web.ApiResponse[*models.Snapshot]{}, &web.ApiError{
+			Code:    http.StatusConflict,
+			Message: fmt.Sprintf("sandbox %s is not running (state=%s reason=%s)", sandboxID, state, reason),
+		}
+	}
+
+	checkpointID, err := sbx.CreateCheckpoint(ctx, infra.CreateCheckpointOptions{})
+	if err != nil {
+		return web.ApiResponse[*models.Snapshot]{}, &web.ApiError{Code: http.StatusInternalServerError, Message: err.Error()}
+	}
+	return web.ApiResponse[*models.Snapshot]{
+		Code: http.StatusAccepted,
+		Body: &models.Snapshot{
+			ID:        checkpointID,
+			SandboxID: sandboxID,
+			Name:      request.Name,
+			Status:    models.SnapshotStatus{State: models.SnapshotStateReady},
+			CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		},
+	}, nil
+}
+
+// ListSnapshots implements GET /v1/snapshots, reusing SandboxManager's
+// checkpoint listing exactly as the E2B API's ListSnapshots does.
+func (sc *Controller) ListSnapshots(r *http.Request) (web.ApiResponse[*models.ListSnapshotsResponse], *web.ApiError) {
+	ctx := r.Context()
+	user := userFromContext(ctx)
+	if user == nil {
+		return web.ApiResponse[*models.ListSnapshotsResponse]{}, &web.ApiError{Code: http.StatusUnauthorized, Message: "caller not authenticated"}
+	}
+	page, pageSize, apiErr := parsePagination(r)
+	if apiErr != nil {
+		return web.ApiResponse[*models.ListSnapshotsResponse]{}, apiErr
+	}
+	sandboxIDFilter := r.URL.Query().Get("sandboxId")
+
+	checkpoints, _, err := sc.manager.ListCheckpoints(ctx, infra.SelectSucceededCheckpointsOptions{
+		Namespace: sc.namespaceOfUser(user),
+		User:      user.ID.String(),
+	}, &pagination.Paginator[infra.CheckpointInfo]{
+		Limit: 0,
+		Filter: func(cp infra.CheckpointInfo) bool {
+			return sandboxIDFilter == "" || cp.SandboxID == sandboxIDFilter
+		},
+		GetKey:       func(cp infra.CheckpointInfo) string { return cp.CreationTimestamp },
+		GetUniqueKey: func(cp infra.CheckpointInfo) string { return fmt.Sprintf("%s/%s", cp.Namespace, cp.Name) },
+	})
+	if err != nil {
+		return web.ApiResponse[*models.ListSnapshotsResponse]{}, &web.ApiError{Code: http.StatusInternalServerError, Message: fmt.Sprintf("failed to list snapshots: %v", err)}
+	}
+
+	totalItems := len(checkpoints)
+	start := min((page-1)*pageSize, totalItems)
+	end := min(start+pageSize, totalItems)
+	items := make([]*models.Snapshot, 0, end-start)
+	for _, cp := range checkpoints[start:end] {
+		items = append(items, &models.Snapshot{
+			ID:        cp.CheckpointID,
+			SandboxID: cp.SandboxID,
+			Status:    models.SnapshotStatus{State: models.SnapshotStateReady},
+			CreatedAt: cp.CreationTimestamp,
+		})
+	}
+	totalPages := (totalItems + pageSize - 1) / pageSize
+
+	return web.ApiResponse[*models.ListSnapshotsResponse]{
+		Body: &models.ListSnapshotsResponse{
+			Items: items,
+			Pagination: models.PaginationInfo{
+				Page:        page,
+				PageSize:    pageSize,
+				TotalItems:  totalItems,
+				TotalPages:  totalPages,
+				HasNextPage: end < totalItems,
+			},
+		},
+	}, nil
+}

--- a/pkg/servers/opensandbox/state.go
+++ b/pkg/servers/opensandbox/state.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opensandbox
+
+import (
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/servers/opensandbox/models"
+)
+
+// convertPhaseToOpenSandboxState maps the Sandbox CRD's finer-grained
+// SandboxPhase to the OpenSandbox lifecycle spec's SandboxState
+// (Pending/Running/Pausing/Paused/Resuming/Stopping/Terminated/Failed).
+//
+// Two mappings are heuristic rather than exact, and are called out here so a
+// reviewer can judge them rather than discover them by surprise:
+//   - SandboxUpgrading (an in-place image/resource update, a KruiseAgents
+//     concept with no OpenSandbox equivalent) maps to Running because the
+//     sandbox keeps serving traffic during the update.
+//   - "Pausing" (the async in-flight moment between a pause request and the
+//     sandbox actually reaching Paused) is not currently observable through
+//     the infra.Sandbox interface, and in practice is rarely observed here:
+//     SandboxManager.PauseSandbox is synchronous, so by the time this
+//     adapter's 202 response is written the phase has usually already
+//     reached Paused. See the package AGENTS.md "Known Gaps" for the
+//     asynchronous-pause follow-up.
+func convertPhaseToOpenSandboxState(phase string) models.SandboxState {
+	switch agentsv1alpha1.SandboxPhase(phase) {
+	case agentsv1alpha1.SandboxPending:
+		return models.SandboxStatePending
+	case agentsv1alpha1.SandboxRunning, agentsv1alpha1.SandboxUpgrading:
+		return models.SandboxStateRunning
+	case agentsv1alpha1.SandboxPaused:
+		return models.SandboxStatePaused
+	case agentsv1alpha1.SandboxResuming:
+		return models.SandboxStateResuming
+	case agentsv1alpha1.SandboxRecycling, agentsv1alpha1.SandboxTerminating:
+		return models.SandboxStateStopping
+	case agentsv1alpha1.SandboxSucceeded:
+		return models.SandboxStateTerminated
+	case agentsv1alpha1.SandboxFailed:
+		return models.SandboxStateFailed
+	default:
+		// An unrecognized phase is surfaced as Failed rather than silently
+		// defaulting to a healthy-looking state, since a caller polling for
+		// completion must never mistake "unknown" for "fine".
+		return models.SandboxStateFailed
+	}
+}

--- a/pkg/servers/opensandbox/state_test.go
+++ b/pkg/servers/opensandbox/state_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opensandbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/servers/opensandbox/models"
+)
+
+func TestConvertPhaseToOpenSandboxState(t *testing.T) {
+	tests := []struct {
+		phase agentsv1alpha1.SandboxPhase
+		want  models.SandboxState
+	}{
+		{agentsv1alpha1.SandboxPending, models.SandboxStatePending},
+		{agentsv1alpha1.SandboxRunning, models.SandboxStateRunning},
+		{agentsv1alpha1.SandboxUpgrading, models.SandboxStateRunning},
+		{agentsv1alpha1.SandboxPaused, models.SandboxStatePaused},
+		{agentsv1alpha1.SandboxResuming, models.SandboxStateResuming},
+		{agentsv1alpha1.SandboxRecycling, models.SandboxStateStopping},
+		{agentsv1alpha1.SandboxTerminating, models.SandboxStateStopping},
+		{agentsv1alpha1.SandboxSucceeded, models.SandboxStateTerminated},
+		{agentsv1alpha1.SandboxFailed, models.SandboxStateFailed},
+		{agentsv1alpha1.SandboxPhase("SomeUnknownPhase"), models.SandboxStateFailed},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.phase), func(t *testing.T) {
+			assert.Equal(t, tt.want, convertPhaseToOpenSandboxState(string(tt.phase)))
+		})
+	}
+}

--- a/pkg/servers/web/framework.go
+++ b/pkg/servers/web/framework.go
@@ -46,6 +46,28 @@ type ApiError struct {
 	Headers   map[string]string `json:"headers"`
 	Message   string            `json:"message"`
 	RequestID string            `json:"request_id"`
+	// SpecCode, when non-empty, is a machine-readable error code string used
+	// in place of Code for protocols (e.g. OpenSandbox) whose error envelope
+	// is {code:<string>, message:<string>} rather than E2B's
+	// {code:<http status>, headers, message, request_id}. Code still drives
+	// the actual HTTP status written by RegisterRoute; SpecCode only changes
+	// what MarshalJSON puts in the response body.
+	SpecCode string `json:"-"`
+}
+
+// MarshalJSON serializes the E2B-shaped envelope (Code/Headers/Message/
+// RequestID, unchanged from before SpecCode existed) unless SpecCode is set,
+// in which case it serializes the spec-shaped {code, message} envelope
+// instead.
+func (r *ApiError) MarshalJSON() ([]byte, error) {
+	if r.SpecCode != "" {
+		return json.Marshal(struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		}{Code: r.SpecCode, Message: r.Message})
+	}
+	type apiErrorAlias ApiError
+	return json.Marshal((*apiErrorAlias)(r))
 }
 
 func (r *ApiError) Error() string {

--- a/pkg/servers/web/framework_test.go
+++ b/pkg/servers/web/framework_test.go
@@ -233,6 +233,52 @@ func TestRegisterRoute(t *testing.T) {
 	}
 }
 
+// TestApiError_MarshalJSON verifies ApiError serializes the original
+// E2B-shaped envelope when SpecCode is unset (byte-identical to before
+// SpecCode existed), and the OpenSandbox-shaped {code, message} envelope
+// when a caller (e.g. pkg/servers/opensandbox) opts in via SpecCode.
+func TestApiError_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		err  ApiError
+		want string
+	}{
+		{
+			name: "no SpecCode marshals the full E2B envelope",
+			err: ApiError{
+				Code:      http.StatusBadRequest,
+				Headers:   map[string]string{"X-Foo": "bar"},
+				Message:   "bad request",
+				RequestID: "req-1",
+			},
+			want: `{"code":400,"headers":{"X-Foo":"bar"},"message":"bad request","request_id":"req-1"}`,
+		},
+		{
+			name: "no SpecCode with zero-value fields",
+			err:  ApiError{Code: http.StatusInternalServerError, Message: "boom"},
+			want: `{"code":500,"headers":null,"message":"boom","request_id":""}`,
+		},
+		{
+			name: "SpecCode set marshals only code and message",
+			err: ApiError{
+				Code:      http.StatusBadRequest,
+				SpecCode:  "INVALID_REQUEST",
+				Headers:   map[string]string{"X-Foo": "bar"},
+				Message:   "exactly one of image.uri or snapshotId is required",
+				RequestID: "req-2",
+			},
+			want: `{"code":"INVALID_REQUEST","message":"exactly one of image.uri or snapshotId is required"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(&tt.err)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.want, string(got))
+		})
+	}
+}
+
 // requestIDPattern matches the representation required by the tracing scheme:
 // 32 lowercase hex characters, directly usable as an OTel TraceID.
 var requestIDPattern = regexp.MustCompile(`^[0-9a-f]{32}$`)


### PR DESCRIPTION
**Do not merge.** This is a working demo of progress against #690, opened for review/discussion as part of an LFX Mentorship Term 3 application. It is an initial slice, not a finished feature; see "Known gaps" below.

Closes/relates to #690 (does not close it, substantial work remains).

## What this demonstrates

Following the existing `API → Manager → Infra` layering (E2B adapter as blueprint), this adds an OpenSandbox-compatible REST API layer that coexists with the E2B API in the same `sandbox-manager` process, plus a protocol-neutral runtime-provider abstraction (envd + execd) for in-sandbox execution.

- `pkg/servers/opensandbox/` — controller, routes, auth, handlers, models for `/v1/sandboxes`, `/v1/snapshots`, `/v1/sandboxes/{id}/{pause,resume,renew-expiration,metadata}`, `/v1/sandboxes/{id}/diagnostics/{logs,events}`
- `pkg/runtimeprovider/` — `Provider` interface + `EnvdRuntimeProvider` (wraps the existing `pkg/utils/runtime.Runtime`, no reimplementation) + `ExecdRuntimeProvider` (new HTTP/SSE client against execd's spec)
- Shared identity: OpenSandbox requests authenticate through the same `keys.KeyStorage` E2B already uses (`OPEN-SANDBOX-API-KEY` header)
- Error responses now match the spec's `{code:<string>, message}` envelope (E2B's own error shape is untouched, verified byte-identical when the new opt-in field is unset)
- Full unit test suite, including a real fake-client-backed Kubernetes object model test (`TestCreateSandbox_Image`) exercising handler → `SandboxManager` → `infra.Sandbox` → an actual `Sandbox` CR

## Known gaps (intentionally not hidden)

Audited against the issue's "Rough Work Items" table and the design concerns raised in the issue comments:

- **`GET`/`DELETE /v1/snapshots/{id}`**: not implemented (only list + create). No new Infra capability needed, just unregistered.
- **Image→SandboxSet mapping**: simplified to one pre-configured default template + in-place image update, not the issue's proposed per-image auto-create/reuse pool. Resource overrides are a no-op when that pool is empty. @chacha923's comment on the issue (idempotent config-fingerprint pool identity) is closer to the right design than what's here.
- **Diagnostics**: returns lifecycle state as text, not real pod logs / Kubernetes Events.
- **Runtime-provider selection**: the interface and both implementations exist, but nothing wires per-sandbox selection into claim/clone yet. `RuntimeConfig.Name` is already taken by sidecar-injection markers (csi/agent-runtime/traffic-proxy), so this needs a new field, gated on finishing the design proposal first.
- **Streaming**: `Provider.Exec` returns fully-buffered stdout/stderr (matches the issue's own proposed signature, but @Aryanbhargava18's comment on the issue correctly flags this as an OOM risk for long-running/streaming workloads, not addressed here).
- **True async pause/resume**: returns 202 only after the operation has already completed (backend is synchronous today).
- **`GET /v1/sandboxes/{id}/endpoints/{port}`** and execd's code-interpreter/bash-session/directory/metrics endpoints: not implemented.
- **OSEP proposal in `docs/proposals/`**: not yet written; the issue asks for one to accompany the implementation.

## Test plan

- [x] `go test ./pkg/servers/opensandbox/... -race -count=1`
- [x] `go test ./pkg/servers/web/... -race -count=1`
- [x] `go test ./pkg/servers/e2b/... -count=1` (regression check, E2B behavior unchanged)
- [x] `gofmt -l`, `go build ./...`, `go vet ./...` all clean