### PR TITLE
fix(e2b): harden resource ownership and key storage validation

### DIFF
--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -143,7 +143,8 @@ func main() {
 	pflag.IntVar(&memberlistBindPort, "memberlist-bind-port", 7946, "Port for memberlist gossip (default 7946)")
 	pflag.StringVar(&e2bKeyStorage, "e2b-key-storage", "secret",
 		"Storage backend for E2B API keys. Valid values: 'secret' (K8s Secret, default), 'mysql' (MySQL via GORM). "+
-			"When --e2b-key-storage=mysql and auth is enabled, set MySQL DSN via environment variable "+E2BKeyStorageDSNEnvVar)
+			"When --e2b-key-storage=mysql and auth is enabled, both the MySQL DSN (env "+E2BKeyStorageDSNEnvVar+
+			") and the HMAC key-hash pepper (env "+E2BKeyHashPepperEnvVar+") are required; secret mode does not use either.")
 	pflag.BoolVar(&e2bKeyStorageDisableAutoMigrate, "e2b-key-storage-disable-schema-auto-update", false,
 		"Disable schema auto-migration for DB-Based key storage like mysql; when enabled, schema changes are skipped but admin team/key bootstrap still runs")
 	pflag.StringVar(&quotaRedisAddr, "quota-redis-addr", "", "Redis address for sandbox-manager quota enforcement. Empty disables enforcement and fails open.")
@@ -236,21 +237,6 @@ func main() {
 	e2bKeyStoragePepper := strings.TrimSpace(os.Getenv(E2BKeyHashPepperEnvVar))
 	quotaRedisUsername := strings.TrimSpace(os.Getenv(QuotaRedisUsernameEnvVar))
 	quotaRedisPassword := strings.TrimSpace(os.Getenv(QuotaRedisPasswordEnvVar))
-	if e2bEnableAuth {
-		// Validate key storage args
-		switch e2bKeyStorage {
-		case "secret": // No validation needed
-		case "mysql":
-			if e2bKeyStorageDSN == "" {
-				klog.Fatalf("env %s is required when --e2b-key-storage=mysql", E2BKeyStorageDSNEnvVar)
-			}
-			if e2bKeyStoragePepper == "" {
-				klog.Fatalf("env %s is required when --e2b-key-storage=mysql", E2BKeyHashPepperEnvVar)
-			}
-		default:
-			klog.Fatalf("--e2b-key-storage must be 'secret' or 'mysql'")
-		}
-	}
 
 	quotaOpts := config.QuotaOptions{
 		RedisAddr:         quotaRedisAddr,

--- a/pkg/servers/e2b/keys/factory.go
+++ b/pkg/servers/e2b/keys/factory.go
@@ -45,25 +45,46 @@ type Config struct {
 	Cache              ctrlcache.Cache // required for secret mode; ignored for mysql mode
 }
 
-// NewKeyStorage returns a KeyStorage implementation for the given config.
-func NewKeyStorage(cfg Config) (KeyStorage, error) {
+// validate reports whether the operator-supplied fields are usable. The controller-runtime
+// dependencies are injected only once the shared cache exists, so NewKeyStorage checks
+// those separately.
+func (cfg Config) validate() error {
 	switch cfg.Mode {
 	case "", StorageModeSecret:
-		if cfg.Client == nil || cfg.APIReader == nil || cfg.Cache == nil {
-			return nil, errors.New("secret key storage requires controller-runtime client, api-reader, and cache")
-		}
-		return NewSecretKeyStorage(cfg.Client, cfg.APIReader, cfg.Cache, cfg.Namespace, cfg.AdminKey), nil
 	case StorageModeMySQL:
 		if cfg.DSN == "" {
-			return nil, errors.New("mysql key storage requires a DSN")
+			return errors.New("mysql key storage requires a DSN")
 		}
+		// The pepper is the only secret component of the stored HMAC key hashes.
+		if cfg.Pepper == "" {
+			return errors.New("mysql key storage requires a non-empty pepper")
+		}
+	default:
+		return fmt.Errorf("unknown key storage mode: %q, must be %q or %q", cfg.Mode, StorageModeSecret, StorageModeMySQL)
+	}
+	// An empty admin key would let an empty API-key header authenticate as admin.
+	if cfg.AdminKey == "" {
+		return errors.New("key storage requires a non-empty admin key")
+	}
+	return nil
+}
+
+// NewKeyStorage returns a KeyStorage implementation for the given config.
+func NewKeyStorage(cfg Config) (KeyStorage, error) {
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	if cfg.Mode == StorageModeMySQL {
 		return newMySQLKeyStorage(mysqlConfig{
 			DSN:                cfg.DSN,
 			AdminKey:           cfg.AdminKey,
 			Pepper:             cfg.Pepper,
 			DisableAutoMigrate: cfg.DisableAutoMigrate,
 		}), nil
-	default:
-		return nil, fmt.Errorf("unknown key storage mode: %q", cfg.Mode)
 	}
+	// validate accepted the mode, so only secret mode remains.
+	if cfg.Client == nil || cfg.APIReader == nil || cfg.Cache == nil {
+		return nil, errors.New("secret key storage requires controller-runtime client, api-reader, and cache")
+	}
+	return NewSecretKeyStorage(cfg.Client, cfg.APIReader, cfg.Cache, cfg.Namespace, cfg.AdminKey), nil
 }

--- a/pkg/servers/e2b/keys/factory_test.go
+++ b/pkg/servers/e2b/keys/factory_test.go
@@ -35,7 +35,7 @@ func TestNewKeyStorage(t *testing.T) {
 	}{
 		{
 			name:        "default secret mode requires client",
-			config:      Config{},
+			config:      Config{AdminKey: "admin"},
 			wantErr:     true,
 			errContains: "secret key storage requires",
 		},
@@ -66,10 +66,42 @@ func TestNewKeyStorage(t *testing.T) {
 			errContains: "cache",
 		},
 		{
+			name: "secret mode requires admin key",
+			config: Config{
+				Mode:      StorageModeSecret,
+				Namespace: "default",
+				Client:    fc,
+				APIReader: fc,
+				Cache:     newStubCache(),
+			},
+			wantErr:     true,
+			errContains: "non-empty admin key",
+		},
+		{
 			name:        "mysql mode requires dsn",
 			config:      Config{Mode: StorageModeMySQL},
 			wantErr:     true,
 			errContains: "requires a DSN",
+		},
+		{
+			name: "mysql mode requires admin key",
+			config: Config{
+				Mode:   StorageModeMySQL,
+				DSN:    "user:pass@tcp(localhost:3306)/db",
+				Pepper: "pepper",
+			},
+			wantErr:     true,
+			errContains: "non-empty admin key",
+		},
+		{
+			name: "mysql mode requires pepper",
+			config: Config{
+				Mode:     StorageModeMySQL,
+				DSN:      "user:pass@tcp(localhost:3306)/db",
+				AdminKey: "admin",
+			},
+			wantErr:     true,
+			errContains: "non-empty pepper",
 		},
 		{
 			name: "mysql mode success",

--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -103,7 +103,7 @@ var AnonymousUser = &models.CreatedTeamAPIKey{
 // CheckApiKey implements common ApiKey validation
 func (sc *Controller) CheckApiKey(ctx context.Context, r *http.Request) (context.Context, *web.ApiError) {
 	logger := klog.FromContext(ctx)
-	middleWareLog := logger.WithValues("middleware", "CheckApiKey").V(utils.DebugLogLevel)
+	middleWareLog := logger.WithValues("middleware", "CheckApiKey")
 	apiKey := r.Header.Get(models.HeaderApiKey)
 	var user *models.CreatedTeamAPIKey
 	var ok bool
@@ -115,7 +115,7 @@ func (sc *Controller) CheckApiKey(ctx context.Context, r *http.Request) (context
 		rawAPIKey := keys.ToStoredRawAPIKey(apiKey)
 		user, ok = sc.keys.LoadByKey(ctx, rawAPIKey)
 		if !ok {
-			middleWareLog.Info("failed to load key by API-KEY")
+			middleWareLog.V(utils.DebugLogLevel).Info("failed to load key by API-KEY")
 			return ctx, &web.ApiError{
 				Code:    http.StatusUnauthorized,
 				Message: "Invalid API Key",
@@ -126,7 +126,7 @@ func (sc *Controller) CheckApiKey(ctx context.Context, r *http.Request) (context
 		middleWareLog = middleWareLog.WithValues("sandboxID", sandboxID)
 		owner, ok := sc.manager.GetOwnerOfSandbox(sandboxID)
 		if !ok {
-			middleWareLog.Info("failed to get owner of sandbox")
+			middleWareLog.V(utils.DebugLogLevel).Info("failed to get owner of sandbox")
 			return ctx, &web.ApiError{
 				Code:    http.StatusNotFound,
 				Message: fmt.Sprintf("Sandbox route not found, maybe it is crashed or killed: %s", sandboxID),
@@ -134,10 +134,9 @@ func (sc *Controller) CheckApiKey(ctx context.Context, r *http.Request) (context
 		}
 		// An ownership mismatch returns the same not-found response as a missing route so
 		// authenticated callers cannot probe which sandbox IDs exist. That makes this log
-		// the only signal separating a denial from a genuine miss, so it carries the ID
-		// itself rather than relying on the logger's accumulated values.
+		// the only signal separating a denial from a genuine miss.
 		if owner != user.ID.String() {
-			middleWareLog.Info("sandbox owner mismatch", "sandboxID", sandboxID, "owner", owner, "user", user.ID.String())
+			middleWareLog.Info("sandbox owner mismatch", "owner", owner, "user", user.ID.String())
 			return ctx, &web.ApiError{
 				Code:    http.StatusNotFound,
 				Message: fmt.Sprintf("Sandbox route not found, maybe it is crashed or killed: %s", sandboxID),
@@ -152,7 +151,7 @@ func (sc *Controller) CheckApiKey(ctx context.Context, r *http.Request) (context
 		}
 		owner, ok := sc.manager.GetOwnerOfVolume(ctx, namespace, volumeID)
 		if !ok {
-			middleWareLog.Info("failed to get owner of volume")
+			middleWareLog.V(utils.DebugLogLevel).Info("failed to get owner of volume")
 			return ctx, &web.ApiError{
 				Code:    http.StatusNotFound,
 				Message: fmt.Sprintf("Volume not found: %s", volumeID),
@@ -161,7 +160,7 @@ func (sc *Controller) CheckApiKey(ctx context.Context, r *http.Request) (context
 		// Same anti-enumeration rule as the sandbox check above: ownership mismatch is
 		// indistinguishable from a missing volume.
 		if owner != user.ID.String() {
-			middleWareLog.Info("volume owner mismatch", "volumeID", volumeID, "owner", owner, "user", user.ID.String())
+			middleWareLog.Info("volume owner mismatch", "owner", owner, "user", user.ID.String())
 			return ctx, &web.ApiError{
 				Code:    http.StatusNotFound,
 				Message: fmt.Sprintf("Volume not found: %s", volumeID),

--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -92,8 +92,8 @@ func RegisterE2BRoute[T any](mux *http.ServeMux, method, path string, handler we
 	web.RegisterRoute(mux, method, adapters.CustomPrefix+"/api"+path, handler, middlewares...)
 }
 
-// AnonymousUser is used only when authentication is disabled. It has the same Key as Admin,
-// allowing for subsequent restrictions on Admin user request interfaces.
+// AnonymousUser owns resources created while authentication is disabled. Reusing AdminKeyID
+// lets the canonical admin key access those resources after authentication is enabled.
 var AnonymousUser = &models.CreatedTeamAPIKey{
 	ID:   keys.AdminKeyID,
 	Name: "auth-disabled",
@@ -132,10 +132,15 @@ func (sc *Controller) CheckApiKey(ctx context.Context, r *http.Request) (context
 				Message: fmt.Sprintf("Sandbox route not found, maybe it is crashed or killed: %s", sandboxID),
 			}
 		}
-		if owner != AnonymousUser.ID.String() && owner != user.ID.String() {
+		// An ownership mismatch returns the same not-found response as a missing route so
+		// authenticated callers cannot probe which sandbox IDs exist. That makes this log
+		// the only signal separating a denial from a genuine miss, so it carries the ID
+		// itself rather than relying on the logger's accumulated values.
+		if owner != user.ID.String() {
+			middleWareLog.Info("sandbox owner mismatch", "sandboxID", sandboxID, "owner", owner, "user", user.ID.String())
 			return ctx, &web.ApiError{
-				Code:    http.StatusUnauthorized,
-				Message: fmt.Sprintf("The user of API key is not the owner of sandbox: %s", sandboxID),
+				Code:    http.StatusNotFound,
+				Message: fmt.Sprintf("Sandbox route not found, maybe it is crashed or killed: %s", sandboxID),
 			}
 		}
 	}
@@ -153,10 +158,13 @@ func (sc *Controller) CheckApiKey(ctx context.Context, r *http.Request) (context
 				Message: fmt.Sprintf("Volume not found: %s", volumeID),
 			}
 		}
-		if owner != AnonymousUser.ID.String() && owner != user.ID.String() {
+		// Same anti-enumeration rule as the sandbox check above: ownership mismatch is
+		// indistinguishable from a missing volume.
+		if owner != user.ID.String() {
+			middleWareLog.Info("volume owner mismatch", "volumeID", volumeID, "owner", owner, "user", user.ID.String())
 			return ctx, &web.ApiError{
-				Code:    http.StatusUnauthorized,
-				Message: fmt.Sprintf("The user of API key is not the owner of volume: %s", volumeID),
+				Code:    http.StatusNotFound,
+				Message: fmt.Sprintf("Volume not found: %s", volumeID),
 			}
 		}
 	}

--- a/pkg/servers/e2b/routes_test.go
+++ b/pkg/servers/e2b/routes_test.go
@@ -89,11 +89,6 @@ func (s *lookupKeyStorage) FindTeamByName(context.Context, string) (*models.Team
 	return nil, false, nil
 }
 
-// TestCheckApiKey_BasicTests tests basic CheckApiKey middleware functionality
-// Note: The "keys nil (auth disabled)" scenario is tested separately
-// to avoid peer initialization timeout issues. See TestCheckApiKey_AnonymousUserWithAdminKeyID
-// for AnonymousUser validation.
-
 // TestCheckApiKey_WithRealSetup tests CheckApiKey with full Setup
 func TestCheckApiKey_WithRealSetup(t *testing.T) {
 	controller, _, teardown := Setup(t)
@@ -346,20 +341,28 @@ func TestCheckApiKey_SandboxOwnership(t *testing.T) {
 			expectError:  false,
 		},
 		{
+			name:         "regular user cannot access admin-owned sandbox",
+			apiKeyHeader: regularUser.Key,
+			sandboxID:    adminSandboxID,
+			expectError:  true,
+			expectedCode: http.StatusNotFound,
+			expectedMsg:  "Sandbox route not found, maybe it is crashed or killed: " + adminSandboxID,
+		},
+		{
 			name:         "non-owner cannot access sandbox",
 			apiKeyHeader: anotherUser.Key,
 			sandboxID:    sandboxID,
 			expectError:  true,
-			expectedCode: http.StatusUnauthorized,
-			expectedMsg:  "The user of API key is not the owner of sandbox: " + sandboxID,
+			expectedCode: http.StatusNotFound,
+			expectedMsg:  "Sandbox route not found, maybe it is crashed or killed: " + sandboxID,
 		},
 		{
 			name:         "admin cannot access other user's sandbox",
 			apiKeyHeader: InitKey,
 			sandboxID:    sandboxID,
 			expectError:  true,
-			expectedCode: http.StatusUnauthorized,
-			expectedMsg:  "The user of API key is not the owner of sandbox: " + sandboxID,
+			expectedCode: http.StatusNotFound,
+			expectedMsg:  "Sandbox route not found, maybe it is crashed or killed: " + sandboxID,
 		},
 		{
 			name:         "sandbox not found",
@@ -404,12 +407,28 @@ func TestCheckApiKey_SandboxOwnership(t *testing.T) {
 			}
 		})
 	}
+
+	// Authentication disabled resolves the caller to AnonymousUser, whose ID is AdminKeyID,
+	// so an AdminKeyID-owned sandbox passes on the plain owner comparison alone. This is why
+	// dropping the former AnonymousUser.ID exemption cannot regress the auth-disabled path.
+	// A dedicated Controller with keys=nil isolates this from the running server Setup started,
+	// so the assertion neither races on nor mutates shared state.
+	t.Run("auth disabled caller can access AdminKeyID-owned sandbox", func(t *testing.T) {
+		anonController := &Controller{manager: controller.manager, mgrOpts: controller.mgrOpts}
+
+		req, err := http.NewRequest(http.MethodGet, "http://localhost/test", nil)
+		require.NoError(t, err)
+		req.SetPathValue("sandboxID", adminSandboxID)
+
+		_, apiErr := anonController.CheckApiKey(logs.NewContext(), req)
+		assert.Nil(t, apiErr)
+	})
 }
 
-// TestCheckApiKey_AnonymousUserWithAdminKeyID tests that AnonymousUser has AdminKeyID
-func TestCheckApiKey_AnonymousUserWithAdminKeyID(t *testing.T) {
-	// Verify AnonymousUser has AdminKeyID - this allows admin to access any sandbox
-	assert.Equal(t, keys.AdminKeyID, AnonymousUser.ID, "AnonymousUser should have AdminKeyID")
+// TestCheckApiKey_AnonymousUserAdminKeyCompatibility protects the one-way transition from
+// authentication disabled to enabled: the canonical admin key adopts anonymously owned resources.
+func TestCheckApiKey_AnonymousUserAdminKeyCompatibility(t *testing.T) {
+	assert.Equal(t, keys.AdminKeyID, AnonymousUser.ID, "AnonymousUser resources should remain accessible to the canonical admin key")
 	assert.Equal(t, "auth-disabled", AnonymousUser.Name, "AnonymousUser should have auth-disabled name")
 	assert.Equal(t, models.AdminTeam(), AnonymousUser.Team, "AnonymousUser should carry canonical admin team")
 }
@@ -565,6 +584,12 @@ func TestCheckApiKey_VolumeOwnership(t *testing.T) {
 	anotherUser, err := controller.keys.CreateKey(ctx, adminUser, keys.CreateKeyOptions{Name: "another-user", TeamName: "another-team"})
 	require.NoError(t, err)
 	require.NotNil(t, anotherUser)
+
+	// Create another key in the admin namespace to exercise the owner check instead of
+	// returning NotFound during namespace-scoped volume lookup.
+	otherAdminKey, err := controller.keys.CreateKey(ctx, adminUser, keys.CreateKeyOptions{Name: "other-admin-key"})
+	require.NoError(t, err)
+	require.NotNil(t, otherAdminKey)
 	refreshKeyStorageForTest(t, controller)
 
 	// Create namespaces for regular teams (admin uses sandbox-system as fallback)
@@ -637,6 +662,14 @@ func TestCheckApiKey_VolumeOwnership(t *testing.T) {
 			expectError:  false,
 		},
 		{
+			name:         "non-owner admin-team key cannot access admin-owned volume",
+			apiKeyHeader: otherAdminKey.Key,
+			volumeID:     "pv-admin-vol",
+			expectError:  true,
+			expectedCode: http.StatusNotFound,
+			expectedMsg:  "Volume not found: pv-admin-vol",
+		},
+		{
 			name:         "non-owner cannot access volume in same namespace",
 			apiKeyHeader: anotherUser.Key,
 			volumeID:     "pv-regular-vol",
@@ -695,4 +728,20 @@ func TestCheckApiKey_VolumeOwnership(t *testing.T) {
 			}
 		})
 	}
+
+	// Mirror of the sandbox-side auth-disabled case: AnonymousUser is AdminKeyID and admin
+	// resolves to the empty namespace, so getNamespaceOfUser falls back to SystemNamespace
+	// (sandbox-system), where the AdminKeyID-owned volume lives. Dropping the former
+	// AnonymousUser.ID exemption therefore cannot regress the auth-disabled volume path.
+	// A dedicated Controller with keys=nil isolates this from the running server.
+	t.Run("auth disabled caller can access AdminKeyID-owned volume", func(t *testing.T) {
+		anonController := &Controller{manager: controller.manager, mgrOpts: controller.mgrOpts}
+
+		req, err := http.NewRequest(http.MethodGet, "http://localhost/test", nil)
+		require.NoError(t, err)
+		req.SetPathValue("volumeID", "pv-admin-vol")
+
+		_, apiErr := anonController.CheckApiKey(logs.NewContext(), req)
+		assert.Nil(t, apiErr)
+	})
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Hardens E2B API key authorization and key-storage configuration validation:

- Require an exact caller/owner match for Sandbox and Volume access. Ownership mismatches now return the same HTTP 404 response as missing resources, preventing authenticated callers from enumerating existing IDs.
- Preserve the authentication-disabled compatibility path: resources created without authentication remain owned by `AdminKeyID`, and the canonical admin key can still access them after authentication is enabled.
- Validate key-storage configuration in `NewKeyStorage`: both backends require a non-empty admin key, while MySQL also requires a DSN and a non-empty hash pepper. This protects direct factory callers and removes duplicate validation from `main`.
- Keep the existing Secret backend dependency checks and update the CLI help to document the MySQL pepper requirement.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how to verify it

```bash
GOFLAGS=-mod=readonly go test ./pkg/servers/e2b ./pkg/servers/e2b/keys \
  -run 'TestCheckApiKey_(SandboxOwnership|VolumeOwnership|AnonymousUserAdminKeyCompatibility)$|TestNewKeyStorage$' \
  -count=1
```

### Ⅳ. Special notes for reviews

- The canonical admin key is not a general ownership bypass; admin and regular keys must both match the persisted owner.
- Ownership mismatches are intentionally indistinguishable from missing resources. Structured logs retain the owner and caller UUIDs for diagnostics without exposing them to the client.
- Authentication-disabled mode remains unchanged: it does not construct key storage, and `AnonymousUser.ID` remains `AdminKeyID` for one-way compatibility.
- This PR does not change `/debug`, `/metrics`, list endpoints, resource creation, or Volume route availability.
