### PR TITLE
E2B inline security rules / network L7 rules support

### DIFF
--- a/api/v1alpha1/annotations.go
+++ b/api/v1alpha1/annotations.go
@@ -59,6 +59,12 @@ const (
 	// deletion.
 	AnnotationCleanupCandidate = InternalPrefix + "cleanup-candidate"
 
+	// AnnotationSecurityRules carries the normalized inline egress security
+	// rules (a JSON array of SecurityRule) for one Sandbox. Only the Sandbox
+	// Manager writes it; the Egress Policy Enforcer evaluates the rules under
+	// the calling workload's verified identity.
+	AnnotationSecurityRules = InternalPrefix + "security-rules"
+
 	// SandboxAnnotationPriority is the annotation key for sandbox priority.
 	// If not set, the default value is 0.
 	// Larger values indicate higher priority.
@@ -84,6 +90,11 @@ const (
 	AnnotationEnvdURL         = E2BPrefix + "envd-url"
 	// AnnotationCSIVolumeConfig is the annotation key for CSI mount configuration.
 	AnnotationCSIVolumeConfig = E2BPrefix + "csi-volume-config"
+	// MetadataKeySecurityRules is the reserved E2B metadata key whose value is
+	// a JSON array of inline security rules. It is consumed by the Sandbox
+	// Manager and normalized into AnnotationSecurityRules; tenants can never
+	// write AnnotationSecurityRules directly.
+	MetadataKeySecurityRules = E2BPrefix + "security-rules"
 )
 
 // AnnotationUpgradeResumeTrigger is set by SandboxUpdateOps on a paused sandbox

--- a/api/v1alpha1/sandboxset_types.go
+++ b/api/v1alpha1/sandboxset_types.go
@@ -43,6 +43,10 @@ var AnnotationsClearedOnRecycle = []string{
 	AnnotationEnvdAccessToken,
 	AnnotationEnvdURL,
 	AnnotationRuntimeURL,
+	// AnnotationSecurityRules carries the previous tenant's L7 egress rules
+	// (header injections, blocks); leaking it across a claim would apply one
+	// tenant's rules — potentially carrying credentials — to another.
+	AnnotationSecurityRules,
 }
 
 // InternalKeysPreservedOnCreation lists internal keys (with the InternalPrefix)

--- a/pkg/controller/sandbox/core/recycle_test.go
+++ b/pkg/controller/sandbox/core/recycle_test.go
@@ -1181,6 +1181,7 @@ func TestResetForPool(t *testing.T) {
 						agentsv1alpha1.AnnotationEnvdAccessToken:        "legacy-envd-token",
 						agentsv1alpha1.AnnotationEnvdURL:                "http://legacy-envd.example.com",
 						agentsv1alpha1.AnnotationRuntimeURL:             "http://runtime.example.com",
+						agentsv1alpha1.AnnotationSecurityRules:          `[{"name":"leaked","match":[{"domains":["api.example.com"]}],"actions":{"block":{"statusCode":403}}}]`,
 						"user-anno":                                     "user-value",
 						agentsv1alpha1.AnnotationUpdatedMetadataInClaim: mustMarshal(agentsv1alpha1.UpdatedMetadataInClaim{
 							Labels:      []string{"user-label"},
@@ -1303,6 +1304,10 @@ func TestResetForPool(t *testing.T) {
 			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationEnvdAccessToken])
 			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationEnvdURL])
 			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationRuntimeURL])
+			// The previous tenant's L7 rule chain must never survive into the
+			// pool: a leaked chain would apply that tenant's rules (and any
+			// injected credentials) to the next claimant.
+			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationSecurityRules])
 			assert.Empty(t, updated.Annotations[agentsv1alpha1.AnnotationUpdatedMetadataInClaim])
 			if tt.expectLabels != nil {
 				assert.Equal(t, tt.expectLabels, updated.Labels)

--- a/pkg/sandbox-manager/infra/interface.go
+++ b/pkg/sandbox-manager/infra/interface.go
@@ -323,6 +323,10 @@ type Sandbox interface {
 	CreateNetworkPolicy(ctx context.Context, network SandboxNetworkConfig) error // Create TrafficPolicy CR for the sandbox
 	UpdateNetworkPolicy(ctx context.Context, network SandboxNetworkConfig) error // Update (replace) existing TrafficPolicy CR with new config
 	SelectNetworkPolicy(ctx context.Context) (*SandboxNetworkConfig, error)      // Query current TrafficPolicy CR and return the effective config
+	// UpdateSecurityRules replaces the sandbox's normalized inline
+	// security-rules annotation with rulesJSON; an empty value removes the
+	// annotation. The write is conflict-retried.
+	UpdateSecurityRules(ctx context.Context, rulesJSON string) error
 }
 
 // MergePodLabels merges the given labels into the sandbox's pod template labels.

--- a/pkg/sandbox-manager/infra/sandboxcr/network.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/network.go
@@ -208,6 +208,34 @@ func (s *Sandbox) UpdateNetworkPolicy(ctx context.Context, netConfig infra.Sandb
 	return nil
 }
 
+// UpdateSecurityRules replaces the sandbox's normalized inline security-rules
+// annotation. An empty value removes the annotation. The write goes through
+// retryUpdate so a concurrent controller write cannot drop it.
+func (s *Sandbox) UpdateSecurityRules(ctx context.Context, rulesJSON string) error {
+	_, err := s.retryUpdate(ctx, func(sbx *agentsv1alpha1.Sandbox) (bool, error) {
+		current, exists := sbx.Annotations[agentsv1alpha1.AnnotationSecurityRules]
+		if rulesJSON == "" {
+			if !exists {
+				return false, nil
+			}
+			delete(sbx.Annotations, agentsv1alpha1.AnnotationSecurityRules)
+			return true, nil
+		}
+		if current == rulesJSON {
+			return false, nil
+		}
+		if sbx.Annotations == nil {
+			sbx.Annotations = map[string]string{}
+		}
+		sbx.Annotations[agentsv1alpha1.AnnotationSecurityRules] = rulesJSON
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update security-rules annotation: %w", err)
+	}
+	return nil
+}
+
 // SelectNetworkPolicy queries the existing TrafficPolicy CR and returns the
 // all network configuration. Both CIDR and FQDN entries are read back
 // from the single TrafficPolicy CR.

--- a/pkg/sandbox-manager/infra/sandboxcr/network_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/network_test.go
@@ -443,6 +443,54 @@ func TestUpdateSelectNetworkPolicy_RoundTrip(t *testing.T) {
 	assert.Nil(t, result, "after clearing all rules, SelectNetworkPolicy should return nil")
 }
 
+// TestUpdateSecurityRules verifies the annotation replacement contract: a
+// non-empty value is written, the same value is a no-op, and an empty value
+// removes the annotation.
+func TestUpdateSecurityRules(t *testing.T) {
+	infraInstance, fc := NewTestInfra(t)
+
+	sbx := createTestSandbox("security-rules-sandbox", "test-user", agentsv1alpha1.SandboxRunning, true)
+	CreateSandboxWithStatus(t, fc, sbx)
+
+	var sandbox infra.Sandbox
+	require.Eventually(t, func() bool {
+		var err error
+		sandbox, err = infraInstance.GetSandbox(t.Context(), infra.GetSandboxOptions{
+			SandboxID: sandboxid.Resolve(sbx),
+			Namespace: sbx.Namespace,
+		})
+		return err == nil
+	}, time.Second, 10*time.Millisecond)
+
+	readAnnotation := func() (string, bool) {
+		latest := &agentsv1alpha1.Sandbox{}
+		require.NoError(t, fc.Get(t.Context(), ctrlclient.ObjectKeyFromObject(sbx), latest))
+		v, ok := latest.Annotations[agentsv1alpha1.AnnotationSecurityRules]
+		return v, ok
+	}
+
+	const rulesA = `[{"name":"a"}]`
+	const rulesB = `[{"name":"b"}]`
+
+	require.NoError(t, sandbox.UpdateSecurityRules(t.Context(), rulesA))
+	v, ok := readAnnotation()
+	require.True(t, ok)
+	assert.Equal(t, rulesA, v)
+
+	// Replacement overwrites.
+	require.NoError(t, sandbox.UpdateSecurityRules(t.Context(), rulesB))
+	v, _ = readAnnotation()
+	assert.Equal(t, rulesB, v)
+
+	// Empty value removes the annotation.
+	require.NoError(t, sandbox.UpdateSecurityRules(t.Context(), ""))
+	_, ok = readAnnotation()
+	assert.False(t, ok, "empty value must remove the annotation")
+
+	// Removing again is a no-op, not an error.
+	require.NoError(t, sandbox.UpdateSecurityRules(t.Context(), ""))
+}
+
 // TestUpdateNetworkPolicy_CreateWhenNoExisting verifies that UpdateNetworkPolicy
 // creates a new TrafficPolicy when none exists for the sandbox (the "create"
 // branch), as opposed to the "update existing" and "delete" branches already

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -396,6 +396,18 @@ func (sc *Controller) parseCreateSandboxRequest(r *http.Request) (models.NewSand
 	}
 	request.Network = networkConfig
 
+	// Resolve security rules from either the native network.rules input or the
+	// e2b.agents.kruise.io/security-rules metadata JSON. The two inputs are
+	// mutually exclusive and normalize to one annotation value.
+	securityRulesJSON, err := resolveSecurityRules(&request)
+	if err != nil {
+		return request, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: err.Error(),
+		}
+	}
+	request.SecurityRulesJSON = securityRulesJSON
+
 	return request, nil
 }
 
@@ -421,6 +433,9 @@ func (sc *Controller) basicSandboxCreateModifier(ctx context.Context, sbx infra.
 	annotations[agentsv1alpha1.AnnotationReservePausedSandboxDuration] = request.Extensions.ReservePausedSandboxDuration
 	for k, v := range request.Metadata {
 		annotations[k] = v
+	}
+	if request.SecurityRulesJSON != "" {
+		annotations[agentsv1alpha1.AnnotationSecurityRules] = request.SecurityRulesJSON
 	}
 	if request.Extensions.ReturnPodIP {
 		annotations[models.ExtensionKeyReturnPodIP] = agentsv1alpha1.True

--- a/pkg/servers/e2b/create.go
+++ b/pkg/servers/e2b/create.go
@@ -436,6 +436,11 @@ func (sc *Controller) basicSandboxCreateModifier(ctx context.Context, sbx infra.
 	}
 	if request.SecurityRulesJSON != "" {
 		annotations[agentsv1alpha1.AnnotationSecurityRules] = request.SecurityRulesJSON
+	} else {
+		// The claimed CR may come from the pool with a previous tenant's
+		// rules; recycle clears the key (AnnotationsClearedOnRecycle), and
+		// this delete keeps a missed recycle from inheriting them.
+		delete(annotations, agentsv1alpha1.AnnotationSecurityRules)
 	}
 	if request.Extensions.ReturnPodIP {
 		annotations[models.ExtensionKeyReturnPodIP] = agentsv1alpha1.True

--- a/pkg/servers/e2b/models/extensions.go
+++ b/pkg/servers/e2b/models/extensions.go
@@ -68,6 +68,9 @@ const (
 	MetadataKeySandboxResource                = v1alpha1.E2BPrefix + "sandbox-resource"
 	ExtensionKeySandboxName                   = v1alpha1.E2BPrefix + "sandbox-name"
 	ExtensionKeySandboxGenerateName           = v1alpha1.E2BPrefix + "sandbox-generate-name"
+	// ExtensionKeySecurityRules is the reserved metadata key carrying inline
+	// egress security rules as a JSON array of SecurityRule.
+	ExtensionKeySecurityRules = v1alpha1.MetadataKeySecurityRules
 )
 
 const (
@@ -102,6 +105,14 @@ func (r *NewSandboxRequest) ParseExtensions() error {
 	// parse csi mount config
 	if err := r.parseExtensionCSIMount(); err != nil {
 		return err
+	}
+	// Capture the reserved inline security-rules key. The raw value is only
+	// moved into Extensions; validation and normalization happen in the e2b
+	// server layer before the sandbox is created.
+	if raw, ok := r.Metadata[ExtensionKeySecurityRules]; ok {
+		r.Extensions.SecurityRulesRaw = raw
+		r.Extensions.SecurityRulesPresent = true
+		delete(r.Metadata, ExtensionKeySecurityRules)
 	}
 	return nil
 }

--- a/pkg/servers/e2b/models/extensions.go
+++ b/pkg/servers/e2b/models/extensions.go
@@ -19,6 +19,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -106,15 +107,40 @@ func (r *NewSandboxRequest) ParseExtensions() error {
 	if err := r.parseExtensionCSIMount(); err != nil {
 		return err
 	}
-	// Capture the reserved inline security-rules key. The raw value is only
-	// moved into Extensions; validation and normalization happen in the e2b
-	// server layer before the sandbox is created.
+	// Parse the reserved inline security-rules key into structured rules.
+	// Validation and normalization happen in the e2b server layer before
+	// the sandbox is created.
 	if raw, ok := r.Metadata[ExtensionKeySecurityRules]; ok {
-		r.Extensions.SecurityRulesRaw = raw
-		r.Extensions.SecurityRulesPresent = true
+		rules, err := parseInlineSecurityRules(raw)
+		if err != nil {
+			return err
+		}
+		r.Extensions.SecurityRules = rules
 		delete(r.Metadata, ExtensionKeySecurityRules)
 	}
 	return nil
+}
+
+// parseInlineSecurityRules decodes the reserved metadata value strictly:
+// unknown fields fail the request instead of being silently dropped, and the
+// value must be exactly one JSON array with nothing but whitespace after it.
+func parseInlineSecurityRules(raw string) ([]v1alpha1.SecurityRule, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, fmt.Errorf("metadata key %q must not be empty: provide a security-rules JSON array or omit the key", ExtensionKeySecurityRules)
+	}
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var rules []v1alpha1.SecurityRule
+	if err := dec.Decode(&rules); err != nil {
+		return nil, fmt.Errorf("metadata %q is not a valid security-rules JSON array: %v", ExtensionKeySecurityRules, err)
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		return nil, fmt.Errorf("metadata %q must contain exactly one security-rules JSON array value", ExtensionKeySecurityRules)
+	}
+	if len(rules) == 0 {
+		return nil, fmt.Errorf("metadata %q must contain at least one security rule", ExtensionKeySecurityRules)
+	}
+	return rules, nil
 }
 
 func (r *NewSandboxRequest) parseCommonExtensions() error {

--- a/pkg/servers/e2b/models/extensions_test.go
+++ b/pkg/servers/e2b/models/extensions_test.go
@@ -447,16 +447,55 @@ func TestParseExtensions(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "security rules raw value captured and consumed",
+			name: "security rules parsed and consumed",
 			metadata: map[string]string{
 				ExtensionKeySecurityRules: `[{"name":"r1"}]`,
 			},
 			expectExtension: NewSandboxRequestExtension{
 				CreateOnNoStock:              true,
 				ReservePausedSandboxDuration: timeout.ReservePausedSandboxDurationForeverValue,
-				SecurityRulesRaw:             `[{"name":"r1"}]`,
-				SecurityRulesPresent:         true,
+				SecurityRules:                []v1alpha1.SecurityRule{{Name: "r1"}},
 			},
+		},
+		{
+			name: "security rules empty value rejected",
+			metadata: map[string]string{
+				ExtensionKeySecurityRules: "",
+			},
+			wantErr:     true,
+			errContains: "must not be empty",
+		},
+		{
+			name: "security rules invalid JSON rejected",
+			metadata: map[string]string{
+				ExtensionKeySecurityRules: `{"name":"r1"}`,
+			},
+			wantErr:     true,
+			errContains: "not a valid security-rules JSON array",
+		},
+		{
+			name: "security rules unknown field rejected",
+			metadata: map[string]string{
+				ExtensionKeySecurityRules: `[{"name":"r1","nope":true}]`,
+			},
+			wantErr:     true,
+			errContains: "not a valid security-rules JSON array",
+		},
+		{
+			name: "security rules trailing content rejected",
+			metadata: map[string]string{
+				ExtensionKeySecurityRules: `[{"name":"r1"}][]`,
+			},
+			wantErr:     true,
+			errContains: "exactly one security-rules JSON array value",
+		},
+		{
+			name: "security rules empty array rejected",
+			metadata: map[string]string{
+				ExtensionKeySecurityRules: `[]`,
+			},
+			wantErr:     true,
+			errContains: "at least one security rule",
 		},
 	}
 

--- a/pkg/servers/e2b/models/extensions_test.go
+++ b/pkg/servers/e2b/models/extensions_test.go
@@ -446,6 +446,18 @@ func TestParseExtensions(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "security rules raw value captured and consumed",
+			metadata: map[string]string{
+				ExtensionKeySecurityRules: `[{"name":"r1"}]`,
+			},
+			expectExtension: NewSandboxRequestExtension{
+				CreateOnNoStock:              true,
+				ReservePausedSandboxDuration: timeout.ReservePausedSandboxDurationForeverValue,
+				SecurityRulesRaw:             `[{"name":"r1"}]`,
+				SecurityRulesPresent:         true,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -117,8 +117,7 @@ type SandboxNetworkUpdateConfig struct {
 	// Rules carries full-replacement L7 security rules: a nil map (field
 	// absent) keeps the existing rule chain, an explicit empty object clears
 	// it, and a non-empty map replaces it after the same validation as
-	// creation, including the whitelist-mode allowOut contract against this
-	// update's own allowOut list.
+	// creation.
 	Rules map[string][]SandboxNetworkRule `json:"rules,omitempty"`
 }
 

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -63,17 +63,56 @@ type NewSandboxRequest struct {
 	Network             *SandboxNetworkConfig `json:"network,omitempty"`
 
 	Extensions NewSandboxRequestExtension `json:"-"`
+
+	// SecurityRulesJSON is the normalized agents.kruise.io/security-rules
+	// annotation value produced by the server from either input entry. It is
+	// never decoded from the request body.
+	SecurityRulesJSON string `json:"-"`
 }
 
 type SandboxNetworkConfig struct {
 	AllowOut []string `json:"allowOut,omitempty"`
 	DenyOut  []string `json:"denyOut,omitempty"`
+	// Rules maps a target domain to its egress rules. It is the native E2B
+	// network.rules field; header transforms are normalized into the
+	// agents.kruise.io/security-rules annotation. L4 allowOut/denyOut keep
+	// their existing TrafficPolicy behavior.
+	Rules map[string][]SandboxNetworkRule `json:"rules,omitempty"`
+}
+
+// SandboxNetworkRule is one per-domain entry of the E2B network.rules field.
+// Only transform.headers is expressible today; the remaining fields are
+// parsed solely so unsupported shapes can be rejected explicitly.
+type SandboxNetworkRule struct {
+	// Transform describes request transformations applied on egress.
+	// +optional
+	Transform *SandboxNetworkTransform `json:"transform,omitempty"`
+	// EgressProxy is not supported and must be absent.
+	// +optional
+	EgressProxy *string `json:"egressProxy,omitempty"`
+	// MaskRequestHost is not supported and must be absent.
+	// +optional
+	MaskRequestHost *string `json:"maskRequestHost,omitempty"`
+}
+
+// SandboxNetworkTransform is the E2B transform block. Headers are injected
+// or overridden; an existing header with the same name is replaced.
+type SandboxNetworkTransform struct {
+	// Headers maps header names to plaintext values.
+	// +optional
+	Headers map[string]string `json:"headers,omitempty"`
 }
 
 type SandboxNetworkUpdateConfig struct {
 	AllowInternetAccess *bool    `json:"allow_internet_access,omitempty"`
 	AllowOut            []string `json:"allowOut,omitempty"`
 	DenyOut             []string `json:"denyOut,omitempty"`
+	// Rules carries full-replacement L7 security rules: a nil map (field
+	// absent) keeps the existing rule chain, an explicit empty object clears
+	// it, and a non-empty map replaces it after the same validation as
+	// creation, including the whitelist-mode allowOut contract against this
+	// update's own allowOut list.
+	Rules map[string][]SandboxNetworkRule `json:"rules,omitempty"`
 }
 
 // VolumeMount represents a volume mount configuration for the sandbox
@@ -96,6 +135,13 @@ type NewSandboxRequestExtension struct {
 	Labels                       map[string]string
 	Name                         string
 	GenerateName                 string
+	// SecurityRulesRaw holds the captured value of the reserved
+	// e2b.agents.kruise.io/security-rules metadata key before validation.
+	SecurityRulesRaw string
+	// SecurityRulesPresent records that the reserved metadata key was sent,
+	// even with an empty value, so validation can reject an explicit empty
+	// entry instead of treating it as absent.
+	SecurityRulesPresent bool
 }
 
 type InplaceUpdateExtension struct {

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -18,6 +18,7 @@ limitations under the License.
 package models
 
 import (
+	"encoding/json"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -73,6 +74,14 @@ type NewSandboxRequest struct {
 type SandboxNetworkConfig struct {
 	AllowOut []string `json:"allowOut,omitempty"`
 	DenyOut  []string `json:"denyOut,omitempty"`
+	// EgressProxy mirrors the upstream E2B top-level field. It is not
+	// supported by the L7 egress policy engine and must be absent. It is
+	// modeled as an opaque value so any shape is rejected explicitly instead
+	// of being silently dropped by the decoder.
+	EgressProxy json.RawMessage `json:"egressProxy,omitempty"`
+	// MaskRequestHost mirrors the upstream E2B top-level field. It is not
+	// supported and must be absent.
+	MaskRequestHost *string `json:"maskRequestHost,omitempty"`
 	// Rules maps a target domain to its egress rules. It is the native E2B
 	// network.rules field; header transforms are normalized into the
 	// agents.kruise.io/security-rules annotation. L4 allowOut/denyOut keep
@@ -81,18 +90,11 @@ type SandboxNetworkConfig struct {
 }
 
 // SandboxNetworkRule is one per-domain entry of the E2B network.rules field.
-// Only transform.headers is expressible today; the remaining fields are
-// parsed solely so unsupported shapes can be rejected explicitly.
+// Per the upstream spec its only property is transform.
 type SandboxNetworkRule struct {
 	// Transform describes request transformations applied on egress.
 	// +optional
 	Transform *SandboxNetworkTransform `json:"transform,omitempty"`
-	// EgressProxy is not supported and must be absent.
-	// +optional
-	EgressProxy *string `json:"egressProxy,omitempty"`
-	// MaskRequestHost is not supported and must be absent.
-	// +optional
-	MaskRequestHost *string `json:"maskRequestHost,omitempty"`
 }
 
 // SandboxNetworkTransform is the E2B transform block. Headers are injected
@@ -107,6 +109,11 @@ type SandboxNetworkUpdateConfig struct {
 	AllowInternetAccess *bool    `json:"allow_internet_access,omitempty"`
 	AllowOut            []string `json:"allowOut,omitempty"`
 	DenyOut             []string `json:"denyOut,omitempty"`
+	// EgressProxy / MaskRequestHost mirror the upstream E2B top-level
+	// fields; both are unsupported and must be absent (see
+	// SandboxNetworkConfig).
+	EgressProxy     json.RawMessage `json:"egressProxy,omitempty"`
+	MaskRequestHost *string         `json:"maskRequestHost,omitempty"`
 	// Rules carries full-replacement L7 security rules: a nil map (field
 	// absent) keeps the existing rule chain, an explicit empty object clears
 	// it, and a non-empty map replaces it after the same validation as

--- a/pkg/servers/e2b/models/sandbox.go
+++ b/pkg/servers/e2b/models/sandbox.go
@@ -142,13 +142,12 @@ type NewSandboxRequestExtension struct {
 	Labels                       map[string]string
 	Name                         string
 	GenerateName                 string
-	// SecurityRulesRaw holds the captured value of the reserved
-	// e2b.agents.kruise.io/security-rules metadata key before validation.
-	SecurityRulesRaw string
-	// SecurityRulesPresent records that the reserved metadata key was sent,
-	// even with an empty value, so validation can reject an explicit empty
-	// entry instead of treating it as absent.
-	SecurityRulesPresent bool
+	// SecurityRules holds the parsed value of the reserved
+	// e2b.agents.kruise.io/security-rules metadata key. Parsing happens at
+	// extension-parse time; validation and normalization happen in the e2b
+	// server layer before the sandbox is created. A successful parse yields
+	// at least one rule, so a non-empty slice means the key was sent.
+	SecurityRules []v1alpha1.SecurityRule
 }
 
 type InplaceUpdateExtension struct {

--- a/pkg/servers/e2b/network.go
+++ b/pkg/servers/e2b/network.go
@@ -24,7 +24,6 @@ import (
 
 	"k8s.io/klog/v2"
 
-	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
@@ -112,18 +111,8 @@ func (sc *Controller) UpdateSandboxNetwork(r *http.Request) (web.ApiResponse[str
 		}
 	}
 
-	// Resolve the L7 rule replacement before touching any resource so a
-	// validation failure returns 400 with nothing written. Nil rules keep
-	// the existing chain; an explicit empty object clears it.
-	rulesJSON, rulesPresent, err := resolveSecurityRulesUpdate(&req)
-	if err != nil {
-		return web.ApiResponse[struct{}]{}, &web.ApiError{
-			Code:    http.StatusBadRequest,
-			Message: err.Error(),
-		}
-	}
-
-	// Validate and build the network config in one step.
+	// Validate and build the network config in one step, before resolving
+	// the L7 replacement, so the L4 lists are checked first.
 	netConfig, err := validateAndBuildNetworkConfig(&models.SandboxNetworkConfig{
 		AllowOut: req.AllowOut,
 		DenyOut:  req.DenyOut,
@@ -135,22 +124,20 @@ func (sc *Controller) UpdateSandboxNetwork(r *http.Request) (web.ApiResponse[str
 		}
 	}
 
+	// Resolve the L7 rule replacement before touching any resource so a
+	// validation failure returns 400 with nothing written. Nil rules keep
+	// the existing chain; an explicit empty object clears it.
+	rulesJSON, rulesPresent, err := resolveSecurityRulesUpdate(&req)
+	if err != nil {
+		return web.ApiResponse[struct{}]{}, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: err.Error(),
+		}
+	}
+
 	sbx, apiErr := sc.getSandboxOfUser(ctx, sandboxID, liveSandboxStates)
 	if apiErr != nil {
 		return web.ApiResponse[struct{}]{}, apiErr
-	}
-
-	// When the rules field is absent the existing chain is kept; narrowing
-	// allowOut must not silently strand kept transform rules on domains the
-	// L4 whitelist no longer lets out.
-	if !rulesPresent {
-		if err := validateKeptRulesAgainstAllowOut(
-			sbx.GetAnnotations()[agentsv1alpha1.AnnotationSecurityRules], req.AllowOut); err != nil {
-			return web.ApiResponse[struct{}]{}, &web.ApiError{
-				Code:    http.StatusBadRequest,
-				Message: err.Error(),
-			}
-		}
 	}
 
 	// Replace the rule chain before widening L4: a sandbox must never reach

--- a/pkg/servers/e2b/network.go
+++ b/pkg/servers/e2b/network.go
@@ -67,8 +67,9 @@ func validateDenyOut(denyOut []string) error {
 // validateAndBuildNetworkConfig is the single entry point for validating raw
 // network parameters and producing a normalized SandboxNetworkConfig ready for CR creation.
 func validateAndBuildNetworkConfig(netConfig *models.SandboxNetworkConfig) (*models.SandboxNetworkConfig, error) {
-	// Step 1: Return nil if no network rules are needed
-	if netConfig == nil || (len(netConfig.AllowOut) == 0 && len(netConfig.DenyOut) == 0) {
+	// Step 1: Return nil if no network rules are needed. Rules carries L7
+	// security rules and is handled separately, so its presence keeps the config.
+	if netConfig == nil || (len(netConfig.AllowOut) == 0 && len(netConfig.DenyOut) == 0 && len(netConfig.Rules) == 0) {
 		return nil, nil
 	}
 
@@ -99,6 +100,17 @@ func (sc *Controller) UpdateSandboxNetwork(r *http.Request) (web.ApiResponse[str
 		}
 	}
 
+	// Resolve the L7 rule replacement before touching any resource so a
+	// validation failure returns 400 with nothing written. Nil rules keep
+	// the existing chain; an explicit empty object clears it.
+	rulesJSON, rulesPresent, err := resolveSecurityRulesUpdate(&req)
+	if err != nil {
+		return web.ApiResponse[struct{}]{}, &web.ApiError{
+			Code:    http.StatusBadRequest,
+			Message: err.Error(),
+		}
+	}
+
 	// Validate and build the network config in one step.
 	netConfig, err := validateAndBuildNetworkConfig(&models.SandboxNetworkConfig{
 		AllowOut: req.AllowOut,
@@ -114,6 +126,20 @@ func (sc *Controller) UpdateSandboxNetwork(r *http.Request) (web.ApiResponse[str
 	sbx, apiErr := sc.getSandboxOfUser(ctx, sandboxID, liveSandboxStates)
 	if apiErr != nil {
 		return web.ApiResponse[struct{}]{}, apiErr
+	}
+
+	// Replace the rule chain before widening L4: a sandbox must never reach
+	// a newly allowed target without its new rules already persisted. The
+	// data plane converges on both writes independently, exactly as at
+	// creation.
+	if rulesPresent {
+		if err := sbx.UpdateSecurityRules(ctx, rulesJSON); err != nil {
+			log.Error(err, "failed to update security rules")
+			return web.ApiResponse[struct{}]{}, withSandboxResourceContext(&web.ApiError{
+				Code:    http.StatusInternalServerError,
+				Message: fmt.Sprintf("Failed to update security rules: %v", err),
+			}, sbx)
+		}
 	}
 
 	var cfg infra.SandboxNetworkConfig

--- a/pkg/servers/e2b/network.go
+++ b/pkg/servers/e2b/network.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
@@ -67,9 +68,20 @@ func validateDenyOut(denyOut []string) error {
 // validateAndBuildNetworkConfig is the single entry point for validating raw
 // network parameters and producing a normalized SandboxNetworkConfig ready for CR creation.
 func validateAndBuildNetworkConfig(netConfig *models.SandboxNetworkConfig) (*models.SandboxNetworkConfig, error) {
+	if netConfig == nil {
+		return nil, nil
+	}
+
+	// Reject unsupported upstream top-level fields before the empty-config
+	// early return: an egressProxy-only request must 400, not silently
+	// become "no network config".
+	if err := rejectUnsupportedNetworkFeatures(netConfig.EgressProxy, netConfig.MaskRequestHost); err != nil {
+		return nil, err
+	}
+
 	// Step 1: Return nil if no network rules are needed. Rules carries L7
 	// security rules and is handled separately, so its presence keeps the config.
-	if netConfig == nil || (len(netConfig.AllowOut) == 0 && len(netConfig.DenyOut) == 0 && len(netConfig.Rules) == 0) {
+	if len(netConfig.AllowOut) == 0 && len(netConfig.DenyOut) == 0 && len(netConfig.Rules) == 0 {
 		return nil, nil
 	}
 
@@ -126,6 +138,19 @@ func (sc *Controller) UpdateSandboxNetwork(r *http.Request) (web.ApiResponse[str
 	sbx, apiErr := sc.getSandboxOfUser(ctx, sandboxID, liveSandboxStates)
 	if apiErr != nil {
 		return web.ApiResponse[struct{}]{}, apiErr
+	}
+
+	// When the rules field is absent the existing chain is kept; narrowing
+	// allowOut must not silently strand kept transform rules on domains the
+	// L4 whitelist no longer lets out.
+	if !rulesPresent {
+		if err := validateKeptRulesAgainstAllowOut(
+			sbx.GetAnnotations()[agentsv1alpha1.AnnotationSecurityRules], req.AllowOut); err != nil {
+			return web.ApiResponse[struct{}]{}, &web.ApiError{
+				Code:    http.StatusBadRequest,
+				Message: err.Error(),
+			}
+		}
 	}
 
 	// Replace the rule chain before widening L4: a sandbox must never reach

--- a/pkg/servers/e2b/network_test.go
+++ b/pkg/servers/e2b/network_test.go
@@ -380,6 +380,18 @@ func TestValidateAndBuildNetworkConfig(t *testing.T) {
 			wantNil:     true,
 			expectError: "denyOut list exceeds maximum",
 		},
+		{
+			name: "rules-only network config is kept, not nilled",
+			network: &models.SandboxNetworkConfig{
+				Rules: map[string][]models.SandboxNetworkRule{
+					"api.example.com": {{Transform: &models.SandboxNetworkTransform{
+						Headers: map[string]string{"X-A": "1"},
+					}}},
+				},
+			},
+			wantNil:     false,
+			expectError: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/servers/e2b/securityrules.go
+++ b/pkg/servers/e2b/securityrules.go
@@ -1,0 +1,422 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2b
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+)
+
+// Inline security-rules limits. They bound the agents.kruise.io/security-rules
+// annotation so neither the Sandbox object nor the data-plane compilation can
+// be exhausted by a single create request.
+const (
+	maxSecurityRules            = 64
+	maxSecurityRuleDomains      = 64
+	maxHeaderManipulationSet    = 16
+	maxHeaderManipulationRemove = 16
+	maxSecurityRulesBytes       = 32 * 1024
+	maxHeaderValueLength        = 2048
+)
+
+// headerNamePattern mirrors the CRD tchar subset used by AuditHeader.Name and
+// HeaderValue.Name so inline rules can never persist a name the data plane
+// would reject.
+var headerNamePattern = regexp.MustCompile(`^[A-Za-z0-9!#$%&'*+\-.^_|~]+$`)
+
+// resolveSecurityRules produces the normalized agents.kruise.io/security-rules
+// annotation value from the two exclusive input entries: the reserved
+// e2b.agents.kruise.io/security-rules metadata key and the native E2B
+// network.rules field. It returns "" when neither entry is used, which keeps
+// requests without egress rules byte-identical to today's behavior.
+func resolveSecurityRules(request *models.NewSandboxRequest) (string, error) {
+	inlineRaw := request.Extensions.SecurityRulesRaw
+	hasInline := request.Extensions.SecurityRulesPresent
+	hasNetworkRules := request.Network != nil && len(request.Network.Rules) > 0
+	if hasInline && hasNetworkRules {
+		return "", fmt.Errorf("metadata key %q and network.rules are mutually exclusive: use exactly one entry for inline security rules",
+			models.ExtensionKeySecurityRules)
+	}
+	if hasInline && inlineRaw == "" {
+		return "", fmt.Errorf("metadata key %q must not be empty: provide a security-rules JSON array or omit the key",
+			models.ExtensionKeySecurityRules)
+	}
+
+	var rules []agentsv1alpha1.SecurityRule
+	switch {
+	case hasInline:
+		parsed, err := parseInlineSecurityRules(inlineRaw)
+		if err != nil {
+			return "", err
+		}
+		rules = parsed
+	case hasNetworkRules:
+		translated, err := translateNetworkRules(request.Network)
+		if err != nil {
+			return "", err
+		}
+		if len(translated) == 0 {
+			return "", nil
+		}
+		rules = translated
+	default:
+		return "", nil
+	}
+
+	if err := validateInlineSecurityRules(rules); err != nil {
+		return "", err
+	}
+	return marshalSecurityRules(rules)
+}
+
+// resolveSecurityRulesUpdate produces the replacement annotation value for a
+// runtime network update. A nil rules map (field absent) keeps the existing
+// chain and returns present=false; an explicit empty object, or rules with no
+// effective transform, clears the chain; a non-empty map is translated and
+// validated exactly like the creation path, including the whitelist-mode
+// allowOut contract against the update's own allowOut list.
+func resolveSecurityRulesUpdate(req *models.SandboxNetworkUpdateConfig) (rulesJSON string, present bool, err error) {
+	if req.Rules == nil {
+		return "", false, nil
+	}
+	if len(req.Rules) == 0 {
+		return "", true, nil
+	}
+	translated, err := translateNetworkRules(&models.SandboxNetworkConfig{
+		AllowOut: req.AllowOut,
+		Rules:    req.Rules,
+	})
+	if err != nil {
+		return "", false, err
+	}
+	if len(translated) == 0 {
+		return "", true, nil
+	}
+	if err := validateInlineSecurityRules(translated); err != nil {
+		return "", false, err
+	}
+	out, err := marshalSecurityRules(translated)
+	if err != nil {
+		return "", false, err
+	}
+	return out, true, nil
+}
+
+// parseInlineSecurityRules decodes the reserved metadata value strictly:
+// unknown fields fail the request instead of being silently dropped, and the
+// value must be exactly one JSON array with nothing but whitespace after it.
+func parseInlineSecurityRules(raw string) ([]agentsv1alpha1.SecurityRule, error) {
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	var rules []agentsv1alpha1.SecurityRule
+	if err := dec.Decode(&rules); err != nil {
+		return nil, fmt.Errorf("metadata %q is not a valid security-rules JSON array: %v", models.ExtensionKeySecurityRules, err)
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		return nil, fmt.Errorf("metadata %q must contain exactly one security-rules JSON array value", models.ExtensionKeySecurityRules)
+	}
+	if len(rules) == 0 {
+		return nil, fmt.Errorf("metadata %q must contain at least one security rule", models.ExtensionKeySecurityRules)
+	}
+	return rules, nil
+}
+
+// translateNetworkRules converts the native E2B network.rules field into
+// inline security rules. Each domain with at least one header transform
+// becomes one headerManipulation rule; E2B set/replace semantics map to
+// headerManipulation.set. Domains are emitted in sorted order and headers are
+// sorted by name so the persisted annotation is deterministic.
+//
+// In whitelist mode (a non-empty allowOut) a domain with an effective
+// transform must also be listed in allowOut: the L7 rule only fires on
+// traffic the L4 whitelist lets out, so a transform on an unreachable domain
+// is a contract error the caller must see, not a rule that silently never
+// runs. In open-egress mode (no allowOut) every domain is reachable and the
+// check does not apply.
+func translateNetworkRules(net *models.SandboxNetworkConfig) ([]agentsv1alpha1.SecurityRule, error) {
+	domains := make([]string, 0, len(net.Rules))
+	for domain := range net.Rules {
+		domains = append(domains, domain)
+	}
+	sort.Strings(domains)
+
+	whitelistMode := len(net.AllowOut) > 0
+	allowed := make(map[string]struct{}, len(net.AllowOut))
+	for _, entry := range net.AllowOut {
+		allowed[strings.ToLower(entry)] = struct{}{}
+	}
+
+	rules := make([]agentsv1alpha1.SecurityRule, 0, len(domains))
+	for _, domain := range domains {
+		if domain == "" {
+			return nil, fmt.Errorf("network.rules: empty domain key is not allowed")
+		}
+		if len(domain) > 253 {
+			return nil, fmt.Errorf("network.rules[%q]: domain exceeds 253 characters", domain)
+		}
+		set, err := translateDomainTransforms(domain, net.Rules[domain])
+		if err != nil {
+			return nil, err
+		}
+		if len(set) == 0 {
+			// A domain whose rules carry no effective transform needs no L7
+			// rule; L4 allowOut/denyOut keep governing it.
+			continue
+		}
+		if whitelistMode {
+			if _, ok := allowed[strings.ToLower(domain)]; !ok {
+				return nil, fmt.Errorf("network.rules[%q]: a domain with transform.headers must also be listed in network.allowOut", domain)
+			}
+		}
+		rules = append(rules, agentsv1alpha1.SecurityRule{
+			Name: securityRuleNameForDomain(domain),
+			Match: []agentsv1alpha1.RuleMatch{{
+				Domains: []string{domain},
+			}},
+			Actions: agentsv1alpha1.SecurityRuleActions{
+				HeaderManipulation: &agentsv1alpha1.HeaderManipulationAction{Set: set},
+			},
+		})
+	}
+	return rules, nil
+}
+
+// translateDomainTransforms merges every transform.headers map of one domain
+// into a single headerManipulation.set list. Later rules replace earlier
+// values for the same header, matching E2B set/replace semantics.
+func translateDomainTransforms(domain string, domainRules []models.SandboxNetworkRule) ([]agentsv1alpha1.HeaderValue, error) {
+	merged := map[string]agentsv1alpha1.HeaderValue{}
+	for i, rule := range domainRules {
+		if rule.EgressProxy != nil {
+			return nil, fmt.Errorf("network.rules[%q][%d].egressProxy is not supported by the L7 egress policy engine", domain, i)
+		}
+		if rule.MaskRequestHost != nil {
+			return nil, fmt.Errorf("network.rules[%q][%d].maskRequestHost is not supported by the L7 egress policy engine", domain, i)
+		}
+		if rule.Transform == nil {
+			continue
+		}
+		for name, value := range rule.Transform.Headers {
+			if err := validateHeaderAssignment(name, value); err != nil {
+				return nil, fmt.Errorf("network.rules[%q][%d].transform.headers: %v", domain, i, err)
+			}
+			merged[strings.ToLower(name)] = agentsv1alpha1.HeaderValue{Name: name, Value: value}
+		}
+	}
+
+	set := make([]agentsv1alpha1.HeaderValue, 0, len(merged))
+	for _, hv := range merged {
+		set = append(set, hv)
+	}
+	sort.Slice(set, func(i, j int) bool { return strings.ToLower(set[i].Name) < strings.ToLower(set[j].Name) })
+	return set, nil
+}
+
+// securityRuleNameForDomain derives a deterministic rule name from a domain.
+// Characters outside the CRD name alphabet are folded to '-' so wildcard and
+// dotted domains always yield a valid name.
+func securityRuleNameForDomain(domain string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(domain) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	name := "e2b-rules-" + strings.Trim(b.String(), "-")
+	if len(name) > 253 {
+		name = name[:253]
+	}
+	return name
+}
+
+// validateInlineSecurityRules enforces the inline action-set restrictions and
+// size limits that apply to both input entries. Errors name the rule index so
+// the HTTP response points at the offending entry.
+func validateInlineSecurityRules(rules []agentsv1alpha1.SecurityRule) error {
+	if len(rules) > maxSecurityRules {
+		return fmt.Errorf("security-rules: %d rules exceed the maximum of %d", len(rules), maxSecurityRules)
+	}
+	for i := range rules {
+		rule := &rules[i]
+		if rule.Name == "" {
+			return fmt.Errorf("security-rules[%d].name is required", i)
+		}
+		if len(rule.Name) > 253 {
+			return fmt.Errorf("security-rules[%d].name exceeds 253 characters", i)
+		}
+		if len(rule.Match) == 0 {
+			return fmt.Errorf("security-rules[%d].match must contain at least one entry", i)
+		}
+		for j := range rule.Match {
+			if err := validateRuleMatch(i, j, &rule.Match[j]); err != nil {
+				return err
+			}
+		}
+		if err := validateRuleActions(i, &rule.Actions); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRuleMatch(ruleIdx, matchIdx int, match *agentsv1alpha1.RuleMatch) error {
+	path := fmt.Sprintf("security-rules[%d].match[%d]", ruleIdx, matchIdx)
+	if len(match.Domains) == 0 {
+		return fmt.Errorf("%s.domains is required", path)
+	}
+	if len(match.Domains) > maxSecurityRuleDomains {
+		return fmt.Errorf("%s: %d domains exceed the maximum of %d", path, len(match.Domains), maxSecurityRuleDomains)
+	}
+	for _, domain := range match.Domains {
+		if domain == "" {
+			return fmt.Errorf("%s.domains contains an empty domain", path)
+		}
+	}
+	for k := range match.Paths {
+		p := &match.Paths[k]
+		if p.Type == agentsv1alpha1.PathMatchTypeRegex {
+			if _, err := regexp.Compile(p.Value); err != nil {
+				return fmt.Errorf("%s.paths[%d] regex %q does not compile: %v", path, k, p.Value, err)
+			}
+		}
+	}
+	for k := range match.Headers {
+		h := &match.Headers[k]
+		if h.Type == agentsv1alpha1.StringMatchTypeRegex {
+			if _, err := regexp.Compile(h.Value); err != nil {
+				return fmt.Errorf("%s.headers[%d] regex %q does not compile: %v", path, k, h.Value, err)
+			}
+		}
+	}
+	for k := range match.QueryParams {
+		q := &match.QueryParams[k]
+		if q.Type == agentsv1alpha1.StringMatchTypeRegex {
+			if _, err := regexp.Compile(q.Value); err != nil {
+				return fmt.Errorf("%s.queryParams[%d] regex %q does not compile: %v", path, k, q.Value, err)
+			}
+		}
+	}
+	return nil
+}
+
+// validateRuleActions enforces the inline action set: only block and
+// headerManipulation are accepted. bypass would short-circuit administrator
+// baselines, and credential-backed or body-dependent actions need server-side
+// materialization that the inline entry does not provide.
+func validateRuleActions(ruleIdx int, actions *agentsv1alpha1.SecurityRuleActions) error {
+	path := fmt.Sprintf("security-rules[%d].actions", ruleIdx)
+	if actions.Bypass {
+		return fmt.Errorf("%s.bypass: bypass is not allowed in inline rules", path)
+	}
+	if actions.TokenTransformation != nil {
+		return fmt.Errorf("%s.tokenTransformation is not supported in inline rules", path)
+	}
+	if actions.MCPToolPolicy != nil {
+		return fmt.Errorf("%s.mcpToolPolicy is not supported in inline rules", path)
+	}
+	if len(actions.Audit) > 0 {
+		return fmt.Errorf("%s.audit is not supported in inline rules", path)
+	}
+	if actions.Block == nil && actions.HeaderManipulation == nil {
+		return fmt.Errorf("%s: at least one of block or headerManipulation is required", path)
+	}
+	if actions.HeaderManipulation != nil {
+		if err := validateHeaderManipulation(path+".headerManipulation", actions.HeaderManipulation); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateHeaderManipulation(path string, hm *agentsv1alpha1.HeaderManipulationAction) error {
+	if len(hm.Set) == 0 && len(hm.Remove) == 0 {
+		return fmt.Errorf("%s: at least one of set or remove must be specified", path)
+	}
+	if len(hm.Set) > maxHeaderManipulationSet {
+		return fmt.Errorf("%s: %d set entries exceed the maximum of %d", path, len(hm.Set), maxHeaderManipulationSet)
+	}
+	if len(hm.Remove) > maxHeaderManipulationRemove {
+		return fmt.Errorf("%s: %d remove entries exceed the maximum of %d", path, len(hm.Remove), maxHeaderManipulationRemove)
+	}
+
+	seen := make(map[string]string, len(hm.Set)+len(hm.Remove))
+	for k := range hm.Set {
+		hv := &hm.Set[k]
+		if err := validateHeaderAssignment(hv.Name, hv.Value); err != nil {
+			return fmt.Errorf("%s.set[%d]: %v", path, k, err)
+		}
+		lower := strings.ToLower(hv.Name)
+		if prev, exists := seen[lower]; exists {
+			if prev == "set" {
+				return fmt.Errorf("%s: header %q appears more than once in set (names are case-insensitive)", path, hv.Name)
+			}
+			return fmt.Errorf("%s: header %q appears in both %s and set", path, hv.Name, prev)
+		}
+		seen[lower] = "set"
+	}
+	for k, name := range hm.Remove {
+		if !headerNamePattern.MatchString(name) {
+			return fmt.Errorf("%s.remove[%d]: header name %q is invalid", path, k, name)
+		}
+		if strings.EqualFold(name, "host") {
+			return fmt.Errorf("%s.remove[%d]: Host cannot be modified", path, k)
+		}
+		lower := strings.ToLower(name)
+		if prev, exists := seen[lower]; exists {
+			return fmt.Errorf("%s: header %q appears in both %s and remove", path, name, prev)
+		}
+		seen[lower] = "remove"
+	}
+	return nil
+}
+
+func validateHeaderAssignment(name, value string) error {
+	if !headerNamePattern.MatchString(name) {
+		return fmt.Errorf("header name %q is invalid", name)
+	}
+	if strings.EqualFold(name, "host") {
+		return fmt.Errorf("Host cannot be modified")
+	}
+	if len(value) > maxHeaderValueLength {
+		return fmt.Errorf("header %q value exceeds %d characters", name, maxHeaderValueLength)
+	}
+	return nil
+}
+
+// marshalSecurityRules serializes the normalized rule chain. The annotation
+// stores the server artifact, never the user's raw text.
+func marshalSecurityRules(rules []agentsv1alpha1.SecurityRule) (string, error) {
+	raw, err := json.Marshal(rules)
+	if err != nil {
+		return "", fmt.Errorf("marshal normalized security rules: %v", err)
+	}
+	if len(raw) > maxSecurityRulesBytes {
+		return "", fmt.Errorf("security-rules: serialized rules exceed the maximum of %d bytes", maxSecurityRulesBytes)
+	}
+	return string(raw), nil
+}

--- a/pkg/servers/e2b/securityrules.go
+++ b/pkg/servers/e2b/securityrules.go
@@ -17,10 +17,8 @@ limitations under the License.
 package e2b
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"reflect"
 	"regexp"
 	"sort"
@@ -28,7 +26,6 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
-	"github.com/openkruise/agents/pkg/utils/network"
 )
 
 // Inline security-rules limits. They bound the agents.kruise.io/security-rules
@@ -42,6 +39,10 @@ const (
 	maxSecurityRulesBytes       = 32 * 1024
 	maxHeaderValueLength        = 2048
 )
+
+// securityRuleNamePrefix marks server-generated rules translated from the
+// native network.rules field, distinguishing them from metadata-authored ones.
+const securityRuleNamePrefix = "e2b-rules-"
 
 // headerNameSyntaxPattern is the RFC 7230 tchar subset accepted as header
 // name syntax on both input surfaces. Persisted names are additionally
@@ -84,26 +85,18 @@ func resolveSecurityRules(request *models.NewSandboxRequest) (string, error) {
 			return "", err
 		}
 	}
-	inlineRaw := request.Extensions.SecurityRulesRaw
-	hasInline := request.Extensions.SecurityRulesPresent
+	inline := request.Extensions.SecurityRules
+	hasInline := len(inline) > 0
 	hasNetworkRules := request.Network != nil && len(request.Network.Rules) > 0
 	if hasInline && hasNetworkRules {
 		return "", fmt.Errorf("metadata key %q and network.rules are mutually exclusive: use exactly one entry for inline security rules",
-			models.ExtensionKeySecurityRules)
-	}
-	if hasInline && inlineRaw == "" {
-		return "", fmt.Errorf("metadata key %q must not be empty: provide a security-rules JSON array or omit the key",
 			models.ExtensionKeySecurityRules)
 	}
 
 	var rules []agentsv1alpha1.SecurityRule
 	switch {
 	case hasInline:
-		parsed, err := parseInlineSecurityRules(inlineRaw)
-		if err != nil {
-			return "", err
-		}
-		rules = parsed
+		rules = inline
 	case hasNetworkRules:
 		translated, err := translateNetworkRules(request.Network)
 		if err != nil {
@@ -127,8 +120,7 @@ func resolveSecurityRules(request *models.NewSandboxRequest) (string, error) {
 // runtime network update. A nil rules map (field absent) keeps the existing
 // chain and returns present=false; an explicit empty object, or rules with no
 // effective transform, clears the chain; a non-empty map is translated and
-// validated exactly like the creation path, including the whitelist-mode
-// allowOut contract against the update's own allowOut list.
+// validated exactly like the creation path.
 func resolveSecurityRulesUpdate(req *models.SandboxNetworkUpdateConfig) (rulesJSON string, present bool, err error) {
 	if err := rejectUnsupportedNetworkFeatures(req.EgressProxy, req.MaskRequestHost); err != nil {
 		return "", false, err
@@ -140,8 +132,7 @@ func resolveSecurityRulesUpdate(req *models.SandboxNetworkUpdateConfig) (rulesJS
 		return "", true, nil
 	}
 	translated, err := translateNetworkRules(&models.SandboxNetworkConfig{
-		AllowOut: req.AllowOut,
-		Rules:    req.Rules,
+		Rules: req.Rules,
 	})
 	if err != nil {
 		return "", false, err
@@ -159,69 +150,22 @@ func resolveSecurityRulesUpdate(req *models.SandboxNetworkUpdateConfig) (rulesJS
 	return out, true, nil
 }
 
-// parseInlineSecurityRules decodes the reserved metadata value strictly:
-// unknown fields fail the request instead of being silently dropped, and the
-// value must be exactly one JSON array with nothing but whitespace after it.
-func parseInlineSecurityRules(raw string) ([]agentsv1alpha1.SecurityRule, error) {
-	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
-	dec.DisallowUnknownFields()
-	var rules []agentsv1alpha1.SecurityRule
-	if err := dec.Decode(&rules); err != nil {
-		return nil, fmt.Errorf("metadata %q is not a valid security-rules JSON array: %v", models.ExtensionKeySecurityRules, err)
-	}
-	if _, err := dec.Token(); err != io.EOF {
-		return nil, fmt.Errorf("metadata %q must contain exactly one security-rules JSON array value", models.ExtensionKeySecurityRules)
-	}
-	if len(rules) == 0 {
-		return nil, fmt.Errorf("metadata %q must contain at least one security rule", models.ExtensionKeySecurityRules)
-	}
-	return rules, nil
-}
-
-// allowOutContract is the whitelist-mode transform-domain contract: a domain
-// with an effective transform must also be listed in allowOut, because the L7
-// rule only fires on traffic the L4 whitelist lets out. The literal check is
-// enforced only when every allowOut entry is an FQDN — CIDR and IP entries
-// admit traffic by resolved address, which a static check cannot correlate
-// with a domain, so their presence disables the contract instead of
-// producing false 400s.
-type allowOutContract struct {
-	enforce bool
-	allowed map[string]struct{}
-}
-
-func newAllowOutContract(allowOut []string) allowOutContract {
-	c := allowOutContract{enforce: len(allowOut) > 0, allowed: make(map[string]struct{}, len(allowOut))}
-	for _, entry := range allowOut {
-		if network.IsCIDROrIP(entry) {
-			c.enforce = false
-		}
-		c.allowed[strings.ToLower(entry)] = struct{}{}
-	}
-	return c
-}
-
-func (c allowOutContract) permits(domain string) bool {
-	if !c.enforce {
-		return true
-	}
-	_, ok := c.allowed[strings.ToLower(domain)]
-	return ok
-}
-
 // translateNetworkRules converts the native E2B network.rules field into
 // inline security rules. Each domain with at least one header transform
 // becomes one headerManipulation rule; E2B set/replace semantics map to
 // headerManipulation.set. Domains are emitted in sorted order and headers are
 // sorted by name so the persisted annotation is deterministic.
+//
+// Matching the upstream E2B contract, a rules domain does not grant egress
+// and is not required to appear in allowOut: reachability may come from the
+// request's own allowOut or from administrator-level traffic policy, and the
+// L7 rule simply never fires on traffic the L4 layer does not let out.
 func translateNetworkRules(net *models.SandboxNetworkConfig) ([]agentsv1alpha1.SecurityRule, error) {
 	domains := make([]string, 0, len(net.Rules))
 	for domain := range net.Rules {
 		domains = append(domains, domain)
 	}
 	sort.Strings(domains)
-
-	contract := newAllowOutContract(net.AllowOut)
 
 	rules := make([]agentsv1alpha1.SecurityRule, 0, len(domains))
 	for _, domain := range domains {
@@ -239,9 +183,6 @@ func translateNetworkRules(net *models.SandboxNetworkConfig) ([]agentsv1alpha1.S
 			// A domain whose rules carry no effective transform needs no L7
 			// rule; L4 allowOut/denyOut keep governing it.
 			continue
-		}
-		if !contract.permits(domain) {
-			return nil, fmt.Errorf("network.rules[%q]: a domain with transform.headers must also be listed in network.allowOut", domain)
 		}
 		rules = append(rules, agentsv1alpha1.SecurityRule{
 			Name: securityRuleNameForDomain(domain),
@@ -304,7 +245,7 @@ func securityRuleNameForDomain(domain string) string {
 			b.WriteRune('-')
 		}
 	}
-	name := "e2b-rules-" + strings.Trim(b.String(), "-")
+	name := securityRuleNamePrefix + strings.Trim(b.String(), "-")
 	if len(name) > 253 {
 		name = name[:253]
 	}
@@ -320,6 +261,7 @@ func validateInlineSecurityRules(rules []agentsv1alpha1.SecurityRule) error {
 	if len(rules) > maxSecurityRules {
 		return fmt.Errorf("security-rules: %d rules exceed the maximum of %d", len(rules), maxSecurityRules)
 	}
+	seenNames := make(map[string]int, len(rules))
 	for i := range rules {
 		rule := &rules[i]
 		if rule.Name == "" {
@@ -328,6 +270,10 @@ func validateInlineSecurityRules(rules []agentsv1alpha1.SecurityRule) error {
 		if len(rule.Name) > 253 {
 			return fmt.Errorf("security-rules[%d].name exceeds 253 characters", i)
 		}
+		if prev, dup := seenNames[rule.Name]; dup {
+			return fmt.Errorf("security-rules[%d].name %q duplicates security-rules[%d].name", i, rule.Name, prev)
+		}
+		seenNames[rule.Name] = i
 		if len(rule.Match) == 0 {
 			return fmt.Errorf("security-rules[%d].match must contain at least one entry", i)
 		}
@@ -380,6 +326,13 @@ func validateRuleMatch(ruleIdx, matchIdx int, match *agentsv1alpha1.RuleMatch) e
 	}
 	for k := range match.Paths {
 		p := &match.Paths[k]
+		switch p.Type {
+		// An empty type is valid: EPE applies the CRD default (Prefix) at
+		// match time, mirroring what apiserver defaulting would have done.
+		case "", agentsv1alpha1.PathMatchTypePrefix, agentsv1alpha1.PathMatchTypeExact, agentsv1alpha1.PathMatchTypeRegex:
+		default:
+			return fmt.Errorf("%s.paths[%d].type: %q is not one of Prefix, Exact, Regex", path, k, p.Type)
+		}
 		if p.Type == agentsv1alpha1.PathMatchTypeRegex {
 			if _, err := regexp.Compile(p.Value); err != nil {
 				return fmt.Errorf("%s.paths[%d] regex %q does not compile: %v", path, k, p.Value, err)
@@ -394,6 +347,9 @@ func validateRuleMatch(ruleIdx, matchIdx int, match *agentsv1alpha1.RuleMatch) e
 		if h.Value == "" {
 			return fmt.Errorf("%s.headers[%d]: value is required", path, k)
 		}
+		if err := validateStringMatchType(h.Type); err != nil {
+			return fmt.Errorf("%s.headers[%d].type: %v", path, k, err)
+		}
 		if h.Type == agentsv1alpha1.StringMatchTypeRegex {
 			if _, err := regexp.Compile(h.Value); err != nil {
 				return fmt.Errorf("%s.headers[%d] regex %q does not compile: %v", path, k, h.Value, err)
@@ -402,6 +358,9 @@ func validateRuleMatch(ruleIdx, matchIdx int, match *agentsv1alpha1.RuleMatch) e
 	}
 	for k := range match.QueryParams {
 		q := &match.QueryParams[k]
+		if err := validateStringMatchType(q.Type); err != nil {
+			return fmt.Errorf("%s.queryParams[%d].type: %v", path, k, err)
+		}
 		if q.Type == agentsv1alpha1.StringMatchTypeRegex {
 			if _, err := regexp.Compile(q.Value); err != nil {
 				return fmt.Errorf("%s.queryParams[%d] regex %q does not compile: %v", path, k, q.Value, err)
@@ -409,6 +368,18 @@ func validateRuleMatch(ruleIdx, matchIdx int, match *agentsv1alpha1.RuleMatch) e
 		}
 	}
 	return nil
+}
+
+// validateStringMatchType re-applies the CRD StringMatchType enum. An empty
+// type is valid: EPE applies the CRD default (Exact) at match time, mirroring
+// what apiserver defaulting would have done.
+func validateStringMatchType(t agentsv1alpha1.StringMatchType) error {
+	switch t {
+	case "", agentsv1alpha1.StringMatchTypeExact, agentsv1alpha1.StringMatchTypePrefix, agentsv1alpha1.StringMatchTypeRegex:
+		return nil
+	default:
+		return fmt.Errorf("%q is not one of Exact, Prefix, Regex", t)
+	}
 }
 
 // validateRuleActions enforces the inline action allowlist: only block and
@@ -528,38 +499,6 @@ func validateHeaderAssignment(name, value string) error {
 	for i := 0; i < len(value); i++ {
 		if value[i] < 0x20 || value[i] == 0x7f {
 			return fmt.Errorf("header %q value contains a control character at position %d", name, i)
-		}
-	}
-	return nil
-}
-
-// validateKeptRulesAgainstAllowOut re-checks the whitelist-mode transform
-// contract when an update keeps the existing rule chain (rules field absent)
-// while replacing allowOut: narrowing the L4 whitelist must not silently
-// strand transform rules on domains that are no longer reachable. Only
-// server-generated native-path rules (the e2b-rules- prefix) are checked —
-// metadata-authored chains were never subject to the contract at creation,
-// and update must not be stricter than create. An unreadable annotation is
-// ignored: it is a server artifact this handler did not write.
-func validateKeptRulesAgainstAllowOut(rulesJSON string, allowOut []string) error {
-	if rulesJSON == "" || len(allowOut) == 0 {
-		return nil
-	}
-	var rules []agentsv1alpha1.SecurityRule
-	if err := json.Unmarshal([]byte(rulesJSON), &rules); err != nil {
-		return nil
-	}
-	contract := newAllowOutContract(allowOut)
-	for i := range rules {
-		if !strings.HasPrefix(rules[i].Name, "e2b-rules-") || rules[i].Actions.HeaderManipulation == nil {
-			continue
-		}
-		for _, match := range rules[i].Match {
-			for _, domain := range match.Domains {
-				if !contract.permits(domain) {
-					return fmt.Errorf("allowOut no longer lists %q, but the kept network.rules chain still transforms it; update rules in the same request (send the new chain, or {} to clear it)", domain)
-				}
-			}
 		}
 	}
 	return nil

--- a/pkg/servers/e2b/securityrules.go
+++ b/pkg/servers/e2b/securityrules.go
@@ -21,12 +21,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/openkruise/agents/pkg/utils/network"
 )
 
 // Inline security-rules limits. They bound the agents.kruise.io/security-rules
@@ -41,10 +43,35 @@ const (
 	maxHeaderValueLength        = 2048
 )
 
-// headerNamePattern mirrors the CRD tchar subset used by AuditHeader.Name and
-// HeaderValue.Name so inline rules can never persist a name the data plane
-// would reject.
-var headerNamePattern = regexp.MustCompile(`^[A-Za-z0-9!#$%&'*+\-.^_|~]+$`)
+// headerNameSyntaxPattern is the RFC 7230 tchar subset accepted as header
+// name syntax on both input surfaces. Persisted names are additionally
+// lowercase-only: HeaderValue.Name and HeaderManipulationAction.Remove
+// require lowercase in the CRD schema, so the native path normalizes with
+// strings.ToLower and the metadata path rejects uppercase explicitly.
+var headerNameSyntaxPattern = regexp.MustCompile(`^[A-Za-z0-9!#$%&'*+\-.^_|~]+$`)
+
+// httpMethods is the CRD RuleMatch.Methods enum.
+var httpMethods = map[string]struct{}{
+	"GET": {}, "HEAD": {}, "POST": {}, "PUT": {}, "PATCH": {},
+	"DELETE": {}, "OPTIONS": {}, "CONNECT": {}, "TRACE": {},
+}
+
+// schemePattern is the CRD RuleMatch.Schemes item pattern.
+var schemePattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+\-.]*$`)
+
+// rejectUnsupportedNetworkFeatures fails requests that carry the upstream
+// top-level egressProxy / maskRequestHost fields. Neither is supported by
+// the L7 egress policy engine, and dropping them silently would let callers
+// believe proxying or host masking is in effect.
+func rejectUnsupportedNetworkFeatures(egressProxy json.RawMessage, maskRequestHost *string) error {
+	if len(egressProxy) > 0 && string(egressProxy) != "null" {
+		return fmt.Errorf("network.egressProxy is not supported by the L7 egress policy engine")
+	}
+	if maskRequestHost != nil {
+		return fmt.Errorf("network.maskRequestHost is not supported by the L7 egress policy engine")
+	}
+	return nil
+}
 
 // resolveSecurityRules produces the normalized agents.kruise.io/security-rules
 // annotation value from the two exclusive input entries: the reserved
@@ -52,6 +79,11 @@ var headerNamePattern = regexp.MustCompile(`^[A-Za-z0-9!#$%&'*+\-.^_|~]+$`)
 // network.rules field. It returns "" when neither entry is used, which keeps
 // requests without egress rules byte-identical to today's behavior.
 func resolveSecurityRules(request *models.NewSandboxRequest) (string, error) {
+	if request.Network != nil {
+		if err := rejectUnsupportedNetworkFeatures(request.Network.EgressProxy, request.Network.MaskRequestHost); err != nil {
+			return "", err
+		}
+	}
 	inlineRaw := request.Extensions.SecurityRulesRaw
 	hasInline := request.Extensions.SecurityRulesPresent
 	hasNetworkRules := request.Network != nil && len(request.Network.Rules) > 0
@@ -98,6 +130,9 @@ func resolveSecurityRules(request *models.NewSandboxRequest) (string, error) {
 // validated exactly like the creation path, including the whitelist-mode
 // allowOut contract against the update's own allowOut list.
 func resolveSecurityRulesUpdate(req *models.SandboxNetworkUpdateConfig) (rulesJSON string, present bool, err error) {
+	if err := rejectUnsupportedNetworkFeatures(req.EgressProxy, req.MaskRequestHost); err != nil {
+		return "", false, err
+	}
 	if req.Rules == nil {
 		return "", false, nil
 	}
@@ -143,18 +178,42 @@ func parseInlineSecurityRules(raw string) ([]agentsv1alpha1.SecurityRule, error)
 	return rules, nil
 }
 
+// allowOutContract is the whitelist-mode transform-domain contract: a domain
+// with an effective transform must also be listed in allowOut, because the L7
+// rule only fires on traffic the L4 whitelist lets out. The literal check is
+// enforced only when every allowOut entry is an FQDN — CIDR and IP entries
+// admit traffic by resolved address, which a static check cannot correlate
+// with a domain, so their presence disables the contract instead of
+// producing false 400s.
+type allowOutContract struct {
+	enforce bool
+	allowed map[string]struct{}
+}
+
+func newAllowOutContract(allowOut []string) allowOutContract {
+	c := allowOutContract{enforce: len(allowOut) > 0, allowed: make(map[string]struct{}, len(allowOut))}
+	for _, entry := range allowOut {
+		if network.IsCIDROrIP(entry) {
+			c.enforce = false
+		}
+		c.allowed[strings.ToLower(entry)] = struct{}{}
+	}
+	return c
+}
+
+func (c allowOutContract) permits(domain string) bool {
+	if !c.enforce {
+		return true
+	}
+	_, ok := c.allowed[strings.ToLower(domain)]
+	return ok
+}
+
 // translateNetworkRules converts the native E2B network.rules field into
 // inline security rules. Each domain with at least one header transform
 // becomes one headerManipulation rule; E2B set/replace semantics map to
 // headerManipulation.set. Domains are emitted in sorted order and headers are
 // sorted by name so the persisted annotation is deterministic.
-//
-// In whitelist mode (a non-empty allowOut) a domain with an effective
-// transform must also be listed in allowOut: the L7 rule only fires on
-// traffic the L4 whitelist lets out, so a transform on an unreachable domain
-// is a contract error the caller must see, not a rule that silently never
-// runs. In open-egress mode (no allowOut) every domain is reachable and the
-// check does not apply.
 func translateNetworkRules(net *models.SandboxNetworkConfig) ([]agentsv1alpha1.SecurityRule, error) {
 	domains := make([]string, 0, len(net.Rules))
 	for domain := range net.Rules {
@@ -162,11 +221,7 @@ func translateNetworkRules(net *models.SandboxNetworkConfig) ([]agentsv1alpha1.S
 	}
 	sort.Strings(domains)
 
-	whitelistMode := len(net.AllowOut) > 0
-	allowed := make(map[string]struct{}, len(net.AllowOut))
-	for _, entry := range net.AllowOut {
-		allowed[strings.ToLower(entry)] = struct{}{}
-	}
+	contract := newAllowOutContract(net.AllowOut)
 
 	rules := make([]agentsv1alpha1.SecurityRule, 0, len(domains))
 	for _, domain := range domains {
@@ -185,10 +240,8 @@ func translateNetworkRules(net *models.SandboxNetworkConfig) ([]agentsv1alpha1.S
 			// rule; L4 allowOut/denyOut keep governing it.
 			continue
 		}
-		if whitelistMode {
-			if _, ok := allowed[strings.ToLower(domain)]; !ok {
-				return nil, fmt.Errorf("network.rules[%q]: a domain with transform.headers must also be listed in network.allowOut", domain)
-			}
+		if !contract.permits(domain) {
+			return nil, fmt.Errorf("network.rules[%q]: a domain with transform.headers must also be listed in network.allowOut", domain)
 		}
 		rules = append(rules, agentsv1alpha1.SecurityRule{
 			Name: securityRuleNameForDomain(domain),
@@ -205,24 +258,28 @@ func translateNetworkRules(net *models.SandboxNetworkConfig) ([]agentsv1alpha1.S
 
 // translateDomainTransforms merges every transform.headers map of one domain
 // into a single headerManipulation.set list. Later rules replace earlier
-// values for the same header, matching E2B set/replace semantics.
+// values for the same header, matching E2B set/replace semantics. Names are
+// normalized to lowercase — HeaderValue.Name is lowercase-only in the CRD
+// schema — and two case-variant keys inside one map are rejected because Go
+// map iteration order would otherwise make the winner nondeterministic.
 func translateDomainTransforms(domain string, domainRules []models.SandboxNetworkRule) ([]agentsv1alpha1.HeaderValue, error) {
 	merged := map[string]agentsv1alpha1.HeaderValue{}
 	for i, rule := range domainRules {
-		if rule.EgressProxy != nil {
-			return nil, fmt.Errorf("network.rules[%q][%d].egressProxy is not supported by the L7 egress policy engine", domain, i)
-		}
-		if rule.MaskRequestHost != nil {
-			return nil, fmt.Errorf("network.rules[%q][%d].maskRequestHost is not supported by the L7 egress policy engine", domain, i)
-		}
 		if rule.Transform == nil {
 			continue
 		}
+		inThisMap := make(map[string]string, len(rule.Transform.Headers))
 		for name, value := range rule.Transform.Headers {
 			if err := validateHeaderAssignment(name, value); err != nil {
 				return nil, fmt.Errorf("network.rules[%q][%d].transform.headers: %v", domain, i, err)
 			}
-			merged[strings.ToLower(name)] = agentsv1alpha1.HeaderValue{Name: name, Value: value}
+			lower := strings.ToLower(name)
+			if prev, dup := inThisMap[lower]; dup {
+				return nil, fmt.Errorf("network.rules[%q][%d].transform.headers: %q and %q are the same header (names are case-insensitive)",
+					domain, i, prev, name)
+			}
+			inThisMap[lower] = name
+			merged[lower] = agentsv1alpha1.HeaderValue{Name: lower, Value: value}
 		}
 	}
 
@@ -230,7 +287,7 @@ func translateDomainTransforms(domain string, domainRules []models.SandboxNetwor
 	for _, hv := range merged {
 		set = append(set, hv)
 	}
-	sort.Slice(set, func(i, j int) bool { return strings.ToLower(set[i].Name) < strings.ToLower(set[j].Name) })
+	sort.Slice(set, func(i, j int) bool { return set[i].Name < set[j].Name })
 	return set, nil
 }
 
@@ -255,8 +312,10 @@ func securityRuleNameForDomain(domain string) string {
 }
 
 // validateInlineSecurityRules enforces the inline action-set restrictions and
-// size limits that apply to both input entries. Errors name the rule index so
-// the HTTP response points at the offending entry.
+// size limits that apply to both input entries, and fills the block
+// statusCode default — the annotation bypasses the apiserver, so kubebuilder
+// defaults never run for it. Errors name the rule index so the HTTP response
+// points at the offending entry.
 func validateInlineSecurityRules(rules []agentsv1alpha1.SecurityRule) error {
 	if len(rules) > maxSecurityRules {
 		return fmt.Errorf("security-rules: %d rules exceed the maximum of %d", len(rules), maxSecurityRules)
@@ -284,6 +343,10 @@ func validateInlineSecurityRules(rules []agentsv1alpha1.SecurityRule) error {
 	return nil
 }
 
+// validateRuleMatch re-applies the CRD RuleMatch schema constraints that the
+// annotation path skips (kubebuilder markers only run in the apiserver): a
+// value the CRD would reject must not reach the data-plane compiler through
+// the annotation either.
 func validateRuleMatch(ruleIdx, matchIdx int, match *agentsv1alpha1.RuleMatch) error {
 	path := fmt.Sprintf("security-rules[%d].match[%d]", ruleIdx, matchIdx)
 	if len(match.Domains) == 0 {
@@ -296,6 +359,24 @@ func validateRuleMatch(ruleIdx, matchIdx int, match *agentsv1alpha1.RuleMatch) e
 		if domain == "" {
 			return fmt.Errorf("%s.domains contains an empty domain", path)
 		}
+		if len(domain) > 253 {
+			return fmt.Errorf("%s.domains: %q exceeds 253 characters", path, domain)
+		}
+	}
+	for k, method := range match.Methods {
+		if _, ok := httpMethods[method]; !ok {
+			return fmt.Errorf("%s.methods[%d]: %q is not a valid HTTP method", path, k, method)
+		}
+	}
+	for k, port := range match.Ports {
+		if port < 1 || port > 65535 {
+			return fmt.Errorf("%s.ports[%d]: %d is outside 1-65535", path, k, port)
+		}
+	}
+	for k, scheme := range match.Schemes {
+		if len(scheme) > 32 || !schemePattern.MatchString(scheme) {
+			return fmt.Errorf("%s.schemes[%d]: %q is not a valid scheme", path, k, scheme)
+		}
 	}
 	for k := range match.Paths {
 		p := &match.Paths[k]
@@ -307,6 +388,12 @@ func validateRuleMatch(ruleIdx, matchIdx int, match *agentsv1alpha1.RuleMatch) e
 	}
 	for k := range match.Headers {
 		h := &match.Headers[k]
+		if len(h.Name) > 256 || !headerNameSyntaxPattern.MatchString(h.Name) {
+			return fmt.Errorf("%s.headers[%d]: header name %q is invalid", path, k, h.Name)
+		}
+		if h.Value == "" {
+			return fmt.Errorf("%s.headers[%d]: value is required", path, k)
+		}
 		if h.Type == agentsv1alpha1.StringMatchTypeRegex {
 			if _, err := regexp.Compile(h.Value); err != nil {
 				return fmt.Errorf("%s.headers[%d] regex %q does not compile: %v", path, k, h.Value, err)
@@ -324,10 +411,13 @@ func validateRuleMatch(ruleIdx, matchIdx int, match *agentsv1alpha1.RuleMatch) e
 	return nil
 }
 
-// validateRuleActions enforces the inline action set: only block and
+// validateRuleActions enforces the inline action allowlist: only block and
 // headerManipulation are accepted. bypass would short-circuit administrator
 // baselines, and credential-backed or body-dependent actions need server-side
-// materialization that the inline entry does not provide.
+// materialization that the inline entry does not provide. The final
+// zero-value check rejects any action field this function does not know
+// about, so a new SecurityRuleActions field is denied to tenants by default
+// instead of leaking through an outdated blocklist.
 func validateRuleActions(ruleIdx int, actions *agentsv1alpha1.SecurityRuleActions) error {
 	path := fmt.Sprintf("security-rules[%d].actions", ruleIdx)
 	if actions.Bypass {
@@ -342,8 +432,28 @@ func validateRuleActions(ruleIdx int, actions *agentsv1alpha1.SecurityRuleAction
 	if len(actions.Audit) > 0 {
 		return fmt.Errorf("%s.audit is not supported in inline rules", path)
 	}
+	rest := *actions
+	rest.Bypass = false
+	rest.TokenTransformation = nil
+	rest.MCPToolPolicy = nil
+	rest.Audit = nil
+	rest.Block = nil
+	rest.HeaderManipulation = nil
+	if !reflect.DeepEqual(rest, agentsv1alpha1.SecurityRuleActions{}) {
+		return fmt.Errorf("%s: only block and headerManipulation are allowed in inline rules", path)
+	}
 	if actions.Block == nil && actions.HeaderManipulation == nil {
 		return fmt.Errorf("%s: at least one of block or headerManipulation is required", path)
+	}
+	if actions.Block != nil {
+		if actions.Block.StatusCode == 0 {
+			// The CRD default (+kubebuilder:default:=403) only runs in the
+			// apiserver; the annotation must carry the resolved value.
+			actions.Block.StatusCode = 403
+		}
+		if actions.Block.StatusCode < 100 || actions.Block.StatusCode > 599 {
+			return fmt.Errorf("%s.block.statusCode: %d is outside 100-599", path, actions.Block.StatusCode)
+		}
 	}
 	if actions.HeaderManipulation != nil {
 		if err := validateHeaderManipulation(path+".headerManipulation", actions.HeaderManipulation); err != nil {
@@ -370,33 +480,40 @@ func validateHeaderManipulation(path string, hm *agentsv1alpha1.HeaderManipulati
 		if err := validateHeaderAssignment(hv.Name, hv.Value); err != nil {
 			return fmt.Errorf("%s.set[%d]: %v", path, k, err)
 		}
-		lower := strings.ToLower(hv.Name)
-		if prev, exists := seen[lower]; exists {
+		// HeaderValue.Name is lowercase-only in the CRD schema; the user
+		// authored this value directly, so an explicit error is more honest
+		// than silent normalization.
+		if hv.Name != strings.ToLower(hv.Name) {
+			return fmt.Errorf("%s.set[%d]: header name %q must be lowercase", path, k, hv.Name)
+		}
+		if prev, exists := seen[hv.Name]; exists {
 			if prev == "set" {
 				return fmt.Errorf("%s: header %q appears more than once in set (names are case-insensitive)", path, hv.Name)
 			}
 			return fmt.Errorf("%s: header %q appears in both %s and set", path, hv.Name, prev)
 		}
-		seen[lower] = "set"
+		seen[hv.Name] = "set"
 	}
 	for k, name := range hm.Remove {
-		if !headerNamePattern.MatchString(name) {
+		if !headerNameSyntaxPattern.MatchString(name) {
 			return fmt.Errorf("%s.remove[%d]: header name %q is invalid", path, k, name)
 		}
-		if strings.EqualFold(name, "host") {
+		if name != strings.ToLower(name) {
+			return fmt.Errorf("%s.remove[%d]: header name %q must be lowercase", path, k, name)
+		}
+		if name == "host" {
 			return fmt.Errorf("%s.remove[%d]: Host cannot be modified", path, k)
 		}
-		lower := strings.ToLower(name)
-		if prev, exists := seen[lower]; exists {
+		if prev, exists := seen[name]; exists {
 			return fmt.Errorf("%s: header %q appears in both %s and remove", path, name, prev)
 		}
-		seen[lower] = "remove"
+		seen[name] = "remove"
 	}
 	return nil
 }
 
 func validateHeaderAssignment(name, value string) error {
-	if !headerNamePattern.MatchString(name) {
+	if !headerNameSyntaxPattern.MatchString(name) {
 		return fmt.Errorf("header name %q is invalid", name)
 	}
 	if strings.EqualFold(name, "host") {
@@ -404,6 +521,46 @@ func validateHeaderAssignment(name, value string) error {
 	}
 	if len(value) > maxHeaderValueLength {
 		return fmt.Errorf("header %q value exceeds %d characters", name, maxHeaderValueLength)
+	}
+	// The value is stored and injected verbatim; a control character (most
+	// importantly CR/LF) would let a tenant smuggle additional headers into
+	// the mutated request.
+	for i := 0; i < len(value); i++ {
+		if value[i] < 0x20 || value[i] == 0x7f {
+			return fmt.Errorf("header %q value contains a control character at position %d", name, i)
+		}
+	}
+	return nil
+}
+
+// validateKeptRulesAgainstAllowOut re-checks the whitelist-mode transform
+// contract when an update keeps the existing rule chain (rules field absent)
+// while replacing allowOut: narrowing the L4 whitelist must not silently
+// strand transform rules on domains that are no longer reachable. Only
+// server-generated native-path rules (the e2b-rules- prefix) are checked —
+// metadata-authored chains were never subject to the contract at creation,
+// and update must not be stricter than create. An unreadable annotation is
+// ignored: it is a server artifact this handler did not write.
+func validateKeptRulesAgainstAllowOut(rulesJSON string, allowOut []string) error {
+	if rulesJSON == "" || len(allowOut) == 0 {
+		return nil
+	}
+	var rules []agentsv1alpha1.SecurityRule
+	if err := json.Unmarshal([]byte(rulesJSON), &rules); err != nil {
+		return nil
+	}
+	contract := newAllowOutContract(allowOut)
+	for i := range rules {
+		if !strings.HasPrefix(rules[i].Name, "e2b-rules-") || rules[i].Actions.HeaderManipulation == nil {
+			continue
+		}
+		for _, match := range rules[i].Match {
+			for _, domain := range match.Domains {
+				if !contract.permits(domain) {
+					return fmt.Errorf("allowOut no longer lists %q, but the kept network.rules chain still transforms it; update rules in the same request (send the new chain, or {} to clear it)", domain)
+				}
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/servers/e2b/securityrules.go
+++ b/pkg/servers/e2b/securityrules.go
@@ -17,6 +17,8 @@ limitations under the License.
 package e2b
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -234,10 +236,13 @@ func translateDomainTransforms(domain string, domainRules []models.SandboxNetwor
 
 // securityRuleNameForDomain derives a deterministic rule name from a domain.
 // Characters outside the CRD name alphabet are folded to '-' so wildcard and
-// dotted domains always yield a valid name.
+// dotted domains always yield a valid name. Folding and truncation are lossy,
+// so a short hash of the original (lowercased) domain is appended to keep
+// names collision-free across distinct domains such as a_b.com and a-b.com.
 func securityRuleNameForDomain(domain string) string {
+	lower := strings.ToLower(domain)
 	var b strings.Builder
-	for _, r := range strings.ToLower(domain) {
+	for _, r := range lower {
 		switch {
 		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.', r == '-':
 			b.WriteRune(r)
@@ -245,11 +250,13 @@ func securityRuleNameForDomain(domain string) string {
 			b.WriteRune('-')
 		}
 	}
+	sum := sha256.Sum256([]byte(lower))
+	suffix := "-" + hex.EncodeToString(sum[:4])
 	name := securityRuleNamePrefix + strings.Trim(b.String(), "-")
-	if len(name) > 253 {
-		name = name[:253]
+	if len(name)+len(suffix) > 253 {
+		name = name[:253-len(suffix)]
 	}
-	return name
+	return name + suffix
 }
 
 // validateInlineSecurityRules enforces the inline action-set restrictions and

--- a/pkg/servers/e2b/securityrules.go
+++ b/pkg/servers/e2b/securityrules.go
@@ -170,6 +170,10 @@ func translateNetworkRules(net *models.SandboxNetworkConfig) ([]agentsv1alpha1.S
 	sort.Strings(domains)
 
 	rules := make([]agentsv1alpha1.SecurityRule, 0, len(domains))
+	// DNS names are case-insensitive, so case-variant keys are the same domain;
+	// rejecting them here surfaces the input problem instead of a downstream
+	// generated-name collision.
+	seenDomains := make(map[string]string, len(domains))
 	for _, domain := range domains {
 		if domain == "" {
 			return nil, fmt.Errorf("network.rules: empty domain key is not allowed")
@@ -177,6 +181,12 @@ func translateNetworkRules(net *models.SandboxNetworkConfig) ([]agentsv1alpha1.S
 		if len(domain) > 253 {
 			return nil, fmt.Errorf("network.rules[%q]: domain exceeds 253 characters", domain)
 		}
+		lower := strings.ToLower(domain)
+		if prev, dup := seenDomains[lower]; dup {
+			return nil, fmt.Errorf("network.rules: %q and %q are the same domain (domains are case-insensitive)",
+				prev, domain)
+		}
+		seenDomains[lower] = domain
 		set, err := translateDomainTransforms(domain, net.Rules[domain])
 		if err != nil {
 			return nil, err

--- a/pkg/servers/e2b/securityrules_test.go
+++ b/pkg/servers/e2b/securityrules_test.go
@@ -378,6 +378,14 @@ func TestResolveSecurityRules_NetworkRules(t *testing.T) {
 			expectError: "same header",
 		},
 		{
+			name: "case-variant domain keys rejected with domain-level error",
+			rules: map[string][]models.SandboxNetworkRule{
+				"Example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"x-one": "1"}}}},
+				"example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"x-two": "2"}}}},
+			},
+			expectError: "same domain",
+		},
+		{
 			name: "Host header in transform rejected",
 			rules: map[string][]models.SandboxNetworkRule{
 				"api.example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"Host": "evil.com"}}}},

--- a/pkg/servers/e2b/securityrules_test.go
+++ b/pkg/servers/e2b/securityrules_test.go
@@ -65,19 +65,10 @@ func TestResolveSecurityRules_InlineJSON(t *testing.T) {
 				`"actions":{"headerManipulation":{"set":[{"name":"x-a","value":"1"}],"remove":["x-b"]}}}]`,
 		},
 		{
-			name:        "invalid JSON",
-			raw:         `{not json`,
-			expectError: "not a valid security-rules JSON array",
-		},
-		{
-			name:        "empty array",
-			raw:         `[]`,
-			expectError: "must contain at least one security rule",
-		},
-		{
-			name:        "unknown field rejected",
-			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"headerManipulation":{"set":[{"name":"X-A","value":"1"}]}},"priority":10}]`,
-			expectError: "not a valid security-rules JSON array",
+			name: "duplicate rule names rejected",
+			raw: `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"block":{}}},` +
+				`{"name":"r1","match":[{"domains":["b.example.com"]}],"actions":{"block":{}}}]`,
+			expectError: "duplicates",
 		},
 		{
 			name:        "bypass rejected",
@@ -217,13 +208,55 @@ func TestResolveSecurityRules_InlineJSON(t *testing.T) {
 			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"],"paths":[{"type":"Regex","value":"["}]}],"actions":{"headerManipulation":{"set":[{"name":"X-A","value":"1"}]}}}]`,
 			expectError: "does not compile",
 		},
+		{
+			name:        "invalid path match type rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"],"paths":[{"type":"Suffix","value":"/x"}]}],"actions":{"block":{}}}]`,
+			expectError: "not one of Prefix, Exact, Regex",
+		},
+		{
+			name: "empty path match type accepted as CRD default",
+			raw:  `[{"name":"r1","match":[{"domains":["a.example.com"],"paths":[{"value":"/x"}]}],"actions":{"block":{}}}]`,
+		},
+		{
+			name:        "invalid header match name rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"],"headers":[{"name":"x a","value":"1"}]}],"actions":{"block":{}}}]`,
+			expectError: "header name",
+		},
+		{
+			name:        "empty header match value rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"],"headers":[{"name":"x-a"}]}],"actions":{"block":{}}}]`,
+			expectError: "value is required",
+		},
+		{
+			name:        "invalid header match type rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"],"headers":[{"name":"x-a","value":"1","type":"Contains"}]}],"actions":{"block":{}}}]`,
+			expectError: "not one of Exact, Prefix, Regex",
+		},
+		{
+			name:        "invalid regex in header match rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"],"headers":[{"name":"x-a","value":"[","type":"Regex"}]}],"actions":{"block":{}}}]`,
+			expectError: "does not compile",
+		},
+		{
+			name: "empty header match type accepted as CRD default",
+			raw:  `[{"name":"r1","match":[{"domains":["a.example.com"],"headers":[{"name":"x-a","value":"1"}]}],"actions":{"block":{}}}]`,
+		},
+		{
+			name:        "invalid queryParam match type rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"],"queryParams":[{"name":"q","value":"1","type":"Contains"}]}],"actions":{"block":{}}}]`,
+			expectError: "not one of Exact, Prefix, Regex",
+		},
+		{
+			name:        "invalid regex in queryParam match rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"],"queryParams":[{"name":"q","value":"[","type":"Regex"}]}],"actions":{"block":{}}}]`,
+			expectError: "does not compile",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			request := &models.NewSandboxRequest{}
-			request.Extensions.SecurityRulesRaw = tt.raw
-			request.Extensions.SecurityRulesPresent = true
+			request.Extensions.SecurityRules = parseResolvedRules(t, tt.raw)
 			got, err := resolveSecurityRules(request)
 			if tt.expectError == "" {
 				require.NoError(t, err)
@@ -243,8 +276,7 @@ func TestResolveSecurityRules_InlineJSON(t *testing.T) {
 // stable server artifact.
 func TestResolveSecurityRules_InlineNormalizedShape(t *testing.T) {
 	request := &models.NewSandboxRequest{}
-	request.Extensions.SecurityRulesRaw = validInlineRulesJSON
-	request.Extensions.SecurityRulesPresent = true
+	request.Extensions.SecurityRules = parseResolvedRules(t, validInlineRulesJSON)
 
 	got, err := resolveSecurityRules(request)
 	require.NoError(t, err)
@@ -301,14 +333,6 @@ func TestResolveSecurityRules_NetworkRules(t *testing.T) {
 			wantRules: 0,
 		},
 		{
-			name:     "allowOut match is case-insensitive",
-			allowOut: []string{"API.Example.COM"},
-			rules: map[string][]models.SandboxNetworkRule{
-				"api.example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "1"}}}},
-			},
-			wantRules: 1,
-		},
-		{
 			name: "open-egress mode accepts transforms without allowOut",
 			rules: map[string][]models.SandboxNetworkRule{
 				"api.example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "1"}}}},
@@ -316,12 +340,20 @@ func TestResolveSecurityRules_NetworkRules(t *testing.T) {
 			wantRules: 1,
 		},
 		{
-			name:     "transform domain missing from a non-empty allowOut rejected",
+			name:     "transform domain absent from allowOut accepted",
 			allowOut: []string{"api.other.com"},
 			rules: map[string][]models.SandboxNetworkRule{
 				"api.example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "1"}}}},
 			},
-			expectError: "must also be listed in network.allowOut",
+			wantRules: 1,
+		},
+		{
+			name:     "wildcard rule domain accepted alongside concrete allowOut",
+			allowOut: []string{"api.example.com"},
+			rules: map[string][]models.SandboxNetworkRule{
+				"*.example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "1"}}}},
+			},
+			wantRules: 1,
 		},
 		{
 			name: "empty domain key rejected",
@@ -329,14 +361,6 @@ func TestResolveSecurityRules_NetworkRules(t *testing.T) {
 				"": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "1"}}}},
 			},
 			expectError: "empty domain key",
-		},
-		{
-			name:     "CIDR entries in allowOut disable the literal contract",
-			allowOut: []string{"93.184.216.0/24"},
-			rules: map[string][]models.SandboxNetworkRule{
-				"api.example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "1"}}}},
-			},
-			wantRules: 1,
 		},
 		{
 			name: "case-variant duplicate keys in one map rejected",
@@ -435,76 +459,11 @@ func TestResolveSecurityRules_MutualExclusion(t *testing.T) {
 			},
 		},
 	}
-	request.Extensions.SecurityRulesRaw = validInlineRulesJSON
-	request.Extensions.SecurityRulesPresent = true
+	request.Extensions.SecurityRules = parseResolvedRules(t, validInlineRulesJSON)
 
 	_, err := resolveSecurityRules(request)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mutually exclusive")
-}
-
-// TestResolveSecurityRules_EmptyMetadataValueRejected locks the boundary where
-// the reserved key is sent with an empty value: presence alone must fail the
-// request instead of being treated as "no inline rules".
-func TestResolveSecurityRules_EmptyMetadataValueRejected(t *testing.T) {
-	request := &models.NewSandboxRequest{}
-	request.Extensions.SecurityRulesPresent = true
-
-	_, err := resolveSecurityRules(request)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must not be empty")
-}
-
-// TestResolveSecurityRules_EmptyMetadataValueWithNetworkRules locks that an
-// explicit empty metadata entry combined with network.rules still hits the
-// mutual-exclusion 400 instead of silently using network.rules alone.
-func TestResolveSecurityRules_EmptyMetadataValueWithNetworkRules(t *testing.T) {
-	request := &models.NewSandboxRequest{
-		Network: &models.SandboxNetworkConfig{
-			Rules: map[string][]models.SandboxNetworkRule{
-				"api.example.com": {{Transform: &models.SandboxNetworkTransform{
-					Headers: map[string]string{"X-A": "1"},
-				}}},
-			},
-		},
-	}
-	request.Extensions.SecurityRulesPresent = true
-
-	_, err := resolveSecurityRules(request)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "mutually exclusive")
-}
-
-// TestResolveSecurityRules_TrailingJSONValueRejected locks that the metadata
-// value must contain exactly one JSON array value.
-func TestResolveSecurityRules_TrailingJSONValueRejected(t *testing.T) {
-	tests := []struct {
-		name string
-		raw  string
-	}{
-		{name: "second array appended", raw: validInlineRulesJSON + validInlineRulesJSON},
-		{name: "trailing object", raw: validInlineRulesJSON + `{"name":"extra"}`},
-		{name: "trailing garbage", raw: validInlineRulesJSON + " x"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			request := &models.NewSandboxRequest{}
-			request.Extensions.SecurityRulesRaw = tt.raw
-			request.Extensions.SecurityRulesPresent = true
-
-			_, err := resolveSecurityRules(request)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "exactly one security-rules JSON array value")
-		})
-	}
-
-	// trailing whitespace only is still accepted
-	request := &models.NewSandboxRequest{}
-	request.Extensions.SecurityRulesRaw = validInlineRulesJSON + "\n  \t"
-	request.Extensions.SecurityRulesPresent = true
-	got, err := resolveSecurityRules(request)
-	require.NoError(t, err)
-	assert.NotEmpty(t, got)
 }
 
 // TestResolveSecurityRules_NoInput verifies requests without either entry keep
@@ -613,7 +572,7 @@ func TestParseCreateSandboxRequest_SecurityRules(t *testing.T) {
 		assert.Contains(t, apiErr.Message, "must not be empty")
 	})
 
-	t.Run("empty metadata value plus network rules rejected with mutual-exclusion 400", func(t *testing.T) {
+	t.Run("empty metadata value plus network rules fails at parse with 400", func(t *testing.T) {
 		req := NewRequest(t, nil, models.NewSandboxRequest{
 			TemplateID: "t",
 			Metadata: map[string]string{
@@ -630,7 +589,7 @@ func TestParseCreateSandboxRequest_SecurityRules(t *testing.T) {
 		_, apiErr := controller.parseCreateSandboxRequest(req)
 		require.NotNil(t, apiErr)
 		assert.Equal(t, 400, apiErr.Code)
-		assert.Contains(t, apiErr.Message, "mutually exclusive")
+		assert.Contains(t, apiErr.Message, "must not be empty")
 	})
 
 	t.Run("trailing second JSON value rejected with 400", func(t *testing.T) {
@@ -664,7 +623,7 @@ func TestParseCreateSandboxRequest_SecurityRules(t *testing.T) {
 		assert.Equal(t, []string{"api.example.com"}, rules[0].Match[0].Domains)
 	})
 
-	t.Run("whitelist-mode transform missing from allowOut rejected with 400", func(t *testing.T) {
+	t.Run("transform domain absent from allowOut accepted", func(t *testing.T) {
 		req := NewRequest(t, nil, models.NewSandboxRequest{
 			TemplateID: "t",
 			Network: &models.SandboxNetworkConfig{
@@ -676,10 +635,11 @@ func TestParseCreateSandboxRequest_SecurityRules(t *testing.T) {
 				},
 			},
 		}, nil, user)
-		_, apiErr := controller.parseCreateSandboxRequest(req)
-		require.NotNil(t, apiErr)
-		assert.Equal(t, 400, apiErr.Code)
-		assert.Contains(t, apiErr.Message, "must also be listed in network.allowOut")
+		parsed, apiErr := controller.parseCreateSandboxRequest(req)
+		require.Nil(t, apiErr)
+		rules := parseResolvedRules(t, parsed.SecurityRulesJSON)
+		require.Len(t, rules, 1)
+		assert.Equal(t, []string{"api.example.com"}, rules[0].Match[0].Domains)
 	})
 
 	t.Run("case-insensitive duplicate set names rejected with 400", func(t *testing.T) {
@@ -699,7 +659,7 @@ func TestParseCreateSandboxRequest_SecurityRules(t *testing.T) {
 
 // TestResolveSecurityRulesUpdate pins the PUT replacement semantics: absent
 // keeps, explicit empty clears, and a non-empty map is validated like the
-// creation path including the allowOut contract.
+// creation path.
 func TestResolveSecurityRulesUpdate(t *testing.T) {
 	t.Run("absent rules keep the existing chain", func(t *testing.T) {
 		_, present, err := resolveSecurityRulesUpdate(&models.SandboxNetworkUpdateConfig{
@@ -756,8 +716,8 @@ func TestResolveSecurityRulesUpdate(t *testing.T) {
 		assert.NotEmpty(t, got)
 	})
 
-	t.Run("replacement is validated against the update's own allowOut", func(t *testing.T) {
-		_, _, err := resolveSecurityRulesUpdate(&models.SandboxNetworkUpdateConfig{
+	t.Run("replacement domain absent from the update's allowOut accepted", func(t *testing.T) {
+		got, present, err := resolveSecurityRulesUpdate(&models.SandboxNetworkUpdateConfig{
 			AllowOut: []string{"api.other.com"},
 			Rules: map[string][]models.SandboxNetworkRule{
 				"api.example.com": {{Transform: &models.SandboxNetworkTransform{
@@ -765,8 +725,9 @@ func TestResolveSecurityRulesUpdate(t *testing.T) {
 				}}},
 			},
 		})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "must also be listed in network.allowOut")
+		require.NoError(t, err)
+		assert.True(t, present)
+		assert.NotEmpty(t, got)
 	})
 
 	t.Run("valid replacement produces the normalized chain", func(t *testing.T) {
@@ -833,16 +794,16 @@ func TestUpdateSandboxNetwork_RulesReplaced(t *testing.T) {
 
 	t.Run("invalid replacement returns 400 and keeps the chain", func(t *testing.T) {
 		_, apiErr := controller.UpdateSandboxNetwork(NewRequest(t, nil, models.SandboxNetworkUpdateConfig{
-			AllowOut: []string{"api.other.com"},
+			AllowOut: []string{"api.example.com"},
 			Rules: map[string][]models.SandboxNetworkRule{
 				"api.example.com": {{Transform: &models.SandboxNetworkTransform{
-					Headers: map[string]string{"X-A": "1"},
+					Headers: map[string]string{"Host": "evil.com"},
 				}}},
 			},
 		}, map[string]string{"sandboxID": sandboxID}, user))
 		require.NotNil(t, apiErr)
 		assert.Equal(t, 400, apiErr.Code)
-		assert.Contains(t, apiErr.Message, "must also be listed in network.allowOut")
+		assert.Contains(t, apiErr.Message, "Host cannot be modified")
 		v, _ := readAnnotation()
 		assert.Contains(t, v, "created", "failed update must not change the chain")
 	})
@@ -864,16 +825,15 @@ func TestUpdateSandboxNetwork_RulesReplaced(t *testing.T) {
 		assert.NotContains(t, v, "created")
 	})
 
-	t.Run("narrowing allowOut with kept transform rules returns 400", func(t *testing.T) {
-		_, apiErr := controller.UpdateSandboxNetwork(NewRequest(t, nil, models.SandboxNetworkUpdateConfig{
+	t.Run("narrowing allowOut with kept transform rules is accepted", func(t *testing.T) {
+		resp, apiErr := controller.UpdateSandboxNetwork(NewRequest(t, nil, models.SandboxNetworkUpdateConfig{
 			AllowOut: []string{"api.other.com"},
 		}, map[string]string{"sandboxID": sandboxID}, user))
-		require.NotNil(t, apiErr)
-		assert.Equal(t, 400, apiErr.Code)
-		assert.Contains(t, apiErr.Message, "no longer lists")
+		require.Nil(t, apiErr)
+		assert.Equal(t, http.StatusNoContent, resp.Code)
 		v, ok := readAnnotation()
 		require.True(t, ok)
-		assert.Contains(t, v, "updated", "failed update must not change the chain")
+		assert.Contains(t, v, "updated", "absent rules must keep the chain")
 	})
 
 	t.Run("absent rules keep the chain", func(t *testing.T) {
@@ -902,8 +862,8 @@ func TestUpdateSandboxNetwork_RulesReplaced(t *testing.T) {
 // must persist statusCode 403 instead of 0.
 func TestResolveSecurityRules_BlockStatusCodeDefaulted(t *testing.T) {
 	request := &models.NewSandboxRequest{}
-	request.Extensions.SecurityRulesRaw = `[{"name":"b","match":[{"domains":["a.example.com"]}],"actions":{"block":{}}}]`
-	request.Extensions.SecurityRulesPresent = true
+	request.Extensions.SecurityRules = parseResolvedRules(t,
+		`[{"name":"b","match":[{"domains":["a.example.com"]}],"actions":{"block":{}}}]`)
 
 	got, err := resolveSecurityRules(request)
 	require.NoError(t, err)

--- a/pkg/servers/e2b/securityrules_test.go
+++ b/pkg/servers/e2b/securityrules_test.go
@@ -34,7 +34,7 @@ import (
 
 // validInlineRulesJSON is the minimal accepted inline security-rules payload.
 const validInlineRulesJSON = `[{"name":"trace-header","match":[{"domains":["api.example.com"]}],` +
-	`"actions":{"headerManipulation":{"set":[{"name":"X-E2E-Trace","value":"abc123"}]}}}]`
+	`"actions":{"headerManipulation":{"set":[{"name":"x-e2e-trace","value":"abc123"}]}}}]`
 
 // parseResolvedRules decodes the annotation value back into the API types so
 // tests can pin the normalized structure, not the raw byte layout.
@@ -62,7 +62,7 @@ func TestResolveSecurityRules_InlineJSON(t *testing.T) {
 		{
 			name: "valid set and remove on distinct headers",
 			raw: `[{"name":"r1","match":[{"domains":["api.example.com"]}],` +
-				`"actions":{"headerManipulation":{"set":[{"name":"X-A","value":"1"}],"remove":["X-B"]}}}]`,
+				`"actions":{"headerManipulation":{"set":[{"name":"x-a","value":"1"}],"remove":["x-b"]}}}]`,
 		},
 		{
 			name:        "invalid JSON",
@@ -106,8 +106,43 @@ func TestResolveSecurityRules_InlineJSON(t *testing.T) {
 		},
 		{
 			name:        "same header in set and remove rejected case-insensitively",
-			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"headerManipulation":{"set":[{"name":"X-A","value":"1"}],"remove":["x-a"]}}}]`,
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"headerManipulation":{"set":[{"name":"x-a","value":"1"}],"remove":["x-a"]}}}]`,
 			expectError: "appears in both",
+		},
+		{
+			name:        "uppercase set name rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"headerManipulation":{"set":[{"name":"X-A","value":"1"}]}}}]`,
+			expectError: "must be lowercase",
+		},
+		{
+			name:        "uppercase remove name rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"headerManipulation":{"remove":["X-B"]}}}]`,
+			expectError: "must be lowercase",
+		},
+		{
+			name:        "control character in value rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"headerManipulation":{"set":[{"name":"x-a","value":"v\r\nx-evil: 1"}]}}}]`,
+			expectError: "control character",
+		},
+		{
+			name:        "block statusCode out of range rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"block":{"statusCode":99}}}]`,
+			expectError: "outside 100-599",
+		},
+		{
+			name:        "invalid method rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"],"methods":["FETCH"]}],"actions":{"block":{}}}]`,
+			expectError: "not a valid HTTP method",
+		},
+		{
+			name:        "port out of range rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"],"ports":[70000]}],"actions":{"block":{}}}]`,
+			expectError: "outside 1-65535",
+		},
+		{
+			name:        "invalid scheme rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"],"schemes":["9bad"]}],"actions":{"block":{}}}]`,
+			expectError: "not a valid scheme",
 		},
 		{
 			name:        "Host in set rejected",
@@ -115,8 +150,8 @@ func TestResolveSecurityRules_InlineJSON(t *testing.T) {
 			expectError: "Host cannot be modified",
 		},
 		{
-			name:        "Host in remove rejected case-insensitively",
-			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"headerManipulation":{"remove":["HOST"]}}}]`,
+			name:        "Host in remove rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"headerManipulation":{"remove":["host"]}}}]`,
 			expectError: "Host cannot be modified",
 		},
 		{
@@ -222,7 +257,7 @@ func TestResolveSecurityRules_InlineNormalizedShape(t *testing.T) {
 	require.NotNil(t, rules[0].Actions.HeaderManipulation)
 	assert.Nil(t, rules[0].Actions.Block)
 	require.Len(t, rules[0].Actions.HeaderManipulation.Set, 1)
-	assert.Equal(t, agentsv1alpha1.HeaderValue{Name: "X-E2E-Trace", Value: "abc123"},
+	assert.Equal(t, agentsv1alpha1.HeaderValue{Name: "x-e2e-trace", Value: "abc123"},
 		rules[0].Actions.HeaderManipulation.Set[0])
 }
 
@@ -296,18 +331,19 @@ func TestResolveSecurityRules_NetworkRules(t *testing.T) {
 			expectError: "empty domain key",
 		},
 		{
-			name: "egressProxy rejected",
+			name:     "CIDR entries in allowOut disable the literal contract",
+			allowOut: []string{"93.184.216.0/24"},
 			rules: map[string][]models.SandboxNetworkRule{
-				"api.example.com": {{EgressProxy: ptrString("http://proxy:8080")}},
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "1"}}}},
 			},
-			expectError: "egressProxy is not supported",
+			wantRules: 1,
 		},
 		{
-			name: "maskRequestHost rejected",
+			name: "case-variant duplicate keys in one map rejected",
 			rules: map[string][]models.SandboxNetworkRule{
-				"api.example.com": {{MaskRequestHost: ptrString("masked.example.com")}},
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "one", "x-a": "two"}}}},
 			},
-			expectError: "maskRequestHost is not supported",
+			expectError: "same header",
 		},
 		{
 			name: "Host header in transform rejected",
@@ -378,11 +414,12 @@ func TestResolveSecurityRules_NetworkNormalizedShape(t *testing.T) {
 	assert.Equal(t, "e2b-rules-a.example.com", rules[0].Name)
 	assert.Equal(t, []string{"a.example.com"}, rules[0].Match[0].Domains)
 	assert.Equal(t, "e2b-rules-b.example.com", rules[1].Name)
-	// Headers within one rule are sorted by name.
+	// Headers within one rule are sorted by name and normalized to lowercase
+	// (HeaderValue.Name is lowercase-only in the CRD schema).
 	require.Len(t, rules[1].Actions.HeaderManipulation.Set, 2)
-	assert.Equal(t, "X-A", rules[1].Actions.HeaderManipulation.Set[0].Name)
+	assert.Equal(t, "x-a", rules[1].Actions.HeaderManipulation.Set[0].Name)
 	assert.Equal(t, "1", rules[1].Actions.HeaderManipulation.Set[0].Value)
-	assert.Equal(t, "X-B", rules[1].Actions.HeaderManipulation.Set[1].Name)
+	assert.Equal(t, "x-b", rules[1].Actions.HeaderManipulation.Set[1].Name)
 	assert.Equal(t, "2", rules[1].Actions.HeaderManipulation.Set[1].Value)
 }
 
@@ -554,9 +591,7 @@ func TestParseCreateSandboxRequest_SecurityRules(t *testing.T) {
 		req := NewRequest(t, nil, models.NewSandboxRequest{
 			TemplateID: "t",
 			Network: &models.SandboxNetworkConfig{
-				Rules: map[string][]models.SandboxNetworkRule{
-					"api.example.com": {{EgressProxy: ptrString("http://proxy:8080")}},
-				},
+				EgressProxy: json.RawMessage(`{"address":"http://proxy:8080"}`),
 			},
 		}, nil, user)
 		_, apiErr := controller.parseCreateSandboxRequest(req)
@@ -652,7 +687,7 @@ func TestParseCreateSandboxRequest_SecurityRules(t *testing.T) {
 			TemplateID: "t",
 			Metadata: map[string]string{
 				models.ExtensionKeySecurityRules: `[{"name":"r1","match":[{"domains":["api.example.com"]}],` +
-					`"actions":{"headerManipulation":{"set":[{"name":"X-Dup","value":"a"},{"name":"x-dup","value":"b"}]}}}]`,
+					`"actions":{"headerManipulation":{"set":[{"name":"x-dup","value":"a"},{"name":"x-dup","value":"b"}]}}}]`,
 			},
 		}, nil, user)
 		_, apiErr := controller.parseCreateSandboxRequest(req)
@@ -672,6 +707,22 @@ func TestResolveSecurityRulesUpdate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.False(t, present)
+	})
+
+	t.Run("top-level maskRequestHost rejected", func(t *testing.T) {
+		_, _, err := resolveSecurityRulesUpdate(&models.SandboxNetworkUpdateConfig{
+			MaskRequestHost: ptrString("masked.example.com"),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "maskRequestHost is not supported")
+	})
+
+	t.Run("top-level egressProxy rejected", func(t *testing.T) {
+		_, _, err := resolveSecurityRulesUpdate(&models.SandboxNetworkUpdateConfig{
+			EgressProxy: json.RawMessage(`{"address":"http://proxy:8080"}`),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "egressProxy is not supported")
 	})
 
 	t.Run("explicit empty object clears the chain", func(t *testing.T) {
@@ -813,6 +864,18 @@ func TestUpdateSandboxNetwork_RulesReplaced(t *testing.T) {
 		assert.NotContains(t, v, "created")
 	})
 
+	t.Run("narrowing allowOut with kept transform rules returns 400", func(t *testing.T) {
+		_, apiErr := controller.UpdateSandboxNetwork(NewRequest(t, nil, models.SandboxNetworkUpdateConfig{
+			AllowOut: []string{"api.other.com"},
+		}, map[string]string{"sandboxID": sandboxID}, user))
+		require.NotNil(t, apiErr)
+		assert.Equal(t, 400, apiErr.Code)
+		assert.Contains(t, apiErr.Message, "no longer lists")
+		v, ok := readAnnotation()
+		require.True(t, ok)
+		assert.Contains(t, v, "updated", "failed update must not change the chain")
+	})
+
 	t.Run("absent rules keep the chain", func(t *testing.T) {
 		_, apiErr := controller.UpdateSandboxNetwork(NewRequest(t, nil, models.SandboxNetworkUpdateConfig{
 			AllowOut: []string{"1.2.3.4"},
@@ -832,6 +895,22 @@ func TestUpdateSandboxNetwork_RulesReplaced(t *testing.T) {
 		_, ok := readAnnotation()
 		assert.False(t, ok, "explicit empty rules must remove the annotation")
 	})
+}
+
+// TestResolveSecurityRules_BlockStatusCodeDefaulted pins the server-side
+// default: the annotation bypasses apiserver defaulting, so `{"block":{}}`
+// must persist statusCode 403 instead of 0.
+func TestResolveSecurityRules_BlockStatusCodeDefaulted(t *testing.T) {
+	request := &models.NewSandboxRequest{}
+	request.Extensions.SecurityRulesRaw = `[{"name":"b","match":[{"domains":["a.example.com"]}],"actions":{"block":{}}}]`
+	request.Extensions.SecurityRulesPresent = true
+
+	got, err := resolveSecurityRules(request)
+	require.NoError(t, err)
+	rules := parseResolvedRules(t, got)
+	require.Len(t, rules, 1)
+	require.NotNil(t, rules[0].Actions.Block)
+	assert.Equal(t, int32(403), rules[0].Actions.Block.StatusCode)
 }
 
 func ptrString(s string) *string { return &s }

--- a/pkg/servers/e2b/securityrules_test.go
+++ b/pkg/servers/e2b/securityrules_test.go
@@ -333,6 +333,14 @@ func TestResolveSecurityRules_NetworkRules(t *testing.T) {
 			wantRules: 0,
 		},
 		{
+			name: "domains folding to the same sanitized name both accepted",
+			rules: map[string][]models.SandboxNetworkRule{
+				"a_b.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "1"}}}},
+				"a-b.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-B": "2"}}}},
+			},
+			wantRules: 2,
+		},
+		{
 			name: "open-egress mode accepts transforms without allowOut",
 			rules: map[string][]models.SandboxNetworkRule{
 				"api.example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "1"}}}},
@@ -434,10 +442,11 @@ func TestResolveSecurityRules_NetworkNormalizedShape(t *testing.T) {
 
 	rules := parseResolvedRules(t, got)
 	require.Len(t, rules, 2)
-	// Domains are emitted in sorted order.
-	assert.Equal(t, "e2b-rules-a.example.com", rules[0].Name)
+	// Domains are emitted in sorted order; names carry a short hash of the
+	// original domain so lossy sanitization cannot collide.
+	assert.Equal(t, "e2b-rules-a.example.com-7653e495", rules[0].Name)
 	assert.Equal(t, []string{"a.example.com"}, rules[0].Match[0].Domains)
-	assert.Equal(t, "e2b-rules-b.example.com", rules[1].Name)
+	assert.Equal(t, "e2b-rules-b.example.com-cd59d56f", rules[1].Name)
 	// Headers within one rule are sorted by name and normalized to lowercase
 	// (HeaderValue.Name is lowercase-only in the CRD schema).
 	require.Len(t, rules[1].Actions.HeaderManipulation.Set, 2)
@@ -743,7 +752,7 @@ func TestResolveSecurityRulesUpdate(t *testing.T) {
 		assert.True(t, present)
 		rules := parseResolvedRules(t, got)
 		require.Len(t, rules, 1)
-		assert.Equal(t, "e2b-rules-api.example.com", rules[0].Name)
+		assert.Equal(t, "e2b-rules-api.example.com-d0c43d38", rules[0].Name)
 	})
 }
 

--- a/pkg/servers/e2b/securityrules_test.go
+++ b/pkg/servers/e2b/securityrules_test.go
@@ -1,0 +1,837 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2b
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/sandboxid"
+	"github.com/openkruise/agents/pkg/servers/e2b/models"
+)
+
+// validInlineRulesJSON is the minimal accepted inline security-rules payload.
+const validInlineRulesJSON = `[{"name":"trace-header","match":[{"domains":["api.example.com"]}],` +
+	`"actions":{"headerManipulation":{"set":[{"name":"X-E2E-Trace","value":"abc123"}]}}}]`
+
+// parseResolvedRules decodes the annotation value back into the API types so
+// tests can pin the normalized structure, not the raw byte layout.
+func parseResolvedRules(t *testing.T, raw string) []agentsv1alpha1.SecurityRule {
+	t.Helper()
+	var rules []agentsv1alpha1.SecurityRule
+	require.NoError(t, json.Unmarshal([]byte(raw), &rules))
+	return rules
+}
+
+func TestResolveSecurityRules_InlineJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         string
+		expectError string
+	}{
+		{
+			name: "valid headerManipulation rule",
+			raw:  validInlineRulesJSON,
+		},
+		{
+			name: "valid block rule",
+			raw:  `[{"name":"block-evil","match":[{"domains":["evil.com"]}],"actions":{"block":{"statusCode":403}}}]`,
+		},
+		{
+			name: "valid set and remove on distinct headers",
+			raw: `[{"name":"r1","match":[{"domains":["api.example.com"]}],` +
+				`"actions":{"headerManipulation":{"set":[{"name":"X-A","value":"1"}],"remove":["X-B"]}}}]`,
+		},
+		{
+			name:        "invalid JSON",
+			raw:         `{not json`,
+			expectError: "not a valid security-rules JSON array",
+		},
+		{
+			name:        "empty array",
+			raw:         `[]`,
+			expectError: "must contain at least one security rule",
+		},
+		{
+			name:        "unknown field rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"headerManipulation":{"set":[{"name":"X-A","value":"1"}]}},"priority":10}]`,
+			expectError: "not a valid security-rules JSON array",
+		},
+		{
+			name:        "bypass rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"bypass":true,"headerManipulation":{"set":[{"name":"X-A","value":"1"}]}}}]`,
+			expectError: "bypass is not allowed",
+		},
+		{
+			name:        "tokenTransformation rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"tokenTransformation":{}}}]`,
+			expectError: "tokenTransformation is not supported",
+		},
+		{
+			name:        "mcpToolPolicy rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"mcpToolPolicy":{"defaultAction":"deny"}}}]`,
+			expectError: "mcpToolPolicy is not supported",
+		},
+		{
+			name:        "audit rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"headerManipulation":{"set":[{"name":"X-A","value":"1"}]},"audit":[{"name":"log"}]}}]`,
+			expectError: "audit is not supported",
+		},
+		{
+			name:        "empty actions rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{}}]`,
+			expectError: "at least one of block or headerManipulation is required",
+		},
+		{
+			name:        "same header in set and remove rejected case-insensitively",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"headerManipulation":{"set":[{"name":"X-A","value":"1"}],"remove":["x-a"]}}}]`,
+			expectError: "appears in both",
+		},
+		{
+			name:        "Host in set rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"headerManipulation":{"set":[{"name":"Host","value":"evil.com"}]}}}]`,
+			expectError: "Host cannot be modified",
+		},
+		{
+			name:        "Host in remove rejected case-insensitively",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"headerManipulation":{"remove":["HOST"]}}}]`,
+			expectError: "Host cannot be modified",
+		},
+		{
+			name:        "invalid header name rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"]}],"actions":{"headerManipulation":{"set":[{"name":"X A","value":"1"}]}}}]`,
+			expectError: "header name",
+		},
+		{
+			name: "set over limit rejected",
+			raw: `[{"name":"r1","match":[{"domains":["a.example.com"]}],` +
+				`"actions":{"headerManipulation":{"set":[` +
+				strings.Join(func() []string {
+					s := make([]string, maxHeaderManipulationSet+1)
+					for i := range s {
+						s[i] = fmt.Sprintf(`{"name":"X-H%d","value":"v"}`, i)
+					}
+					return s
+				}(), ",") + `]}}}]`,
+			expectError: "exceed the maximum",
+		},
+		{
+			name: "remove over limit rejected",
+			raw: `[{"name":"r1","match":[{"domains":["a.example.com"]}],` +
+				`"actions":{"headerManipulation":{"remove":[` +
+				strings.Join(func() []string {
+					s := make([]string, maxHeaderManipulationRemove+1)
+					for i := range s {
+						s[i] = fmt.Sprintf(`"X-H%d"`, i)
+					}
+					return s
+				}(), ",") + `]}}}]`,
+			expectError: "exceed the maximum",
+		},
+		{
+			name: "header value over limit rejected",
+			raw: `[{"name":"r1","match":[{"domains":["a.example.com"]}],` +
+				`"actions":{"headerManipulation":{"set":[{"name":"X-A","value":"` + strings.Repeat("v", maxHeaderValueLength+1) + `"}]}}}]`,
+			expectError: "exceeds",
+		},
+		{
+			name:        "missing match domains rejected",
+			raw:         `[{"name":"r1","match":[{"domains":[]}],"actions":{"headerManipulation":{"set":[{"name":"X-A","value":"1"}]}}}]`,
+			expectError: "domains is required",
+		},
+		{
+			name:        "missing match rejected",
+			raw:         `[{"name":"r1","match":[],"actions":{"headerManipulation":{"set":[{"name":"X-A","value":"1"}]}}}]`,
+			expectError: "match must contain at least one entry",
+		},
+		{
+			name: "rules over limit rejected",
+			raw: "[" + strings.Join(func() []string {
+				s := make([]string, maxSecurityRules+1)
+				for i := range s {
+					s[i] = fmt.Sprintf(`{"name":"r%d","match":[{"domains":["a.example.com"]}],"actions":{"headerManipulation":{"set":[{"name":"X-A","value":"1"}]}}}`, i)
+				}
+				return s
+			}(), ",") + "]",
+			expectError: "exceed the maximum",
+		},
+		{
+			name:        "invalid regex in path match rejected",
+			raw:         `[{"name":"r1","match":[{"domains":["a.example.com"],"paths":[{"type":"Regex","value":"["}]}],"actions":{"headerManipulation":{"set":[{"name":"X-A","value":"1"}]}}}]`,
+			expectError: "does not compile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := &models.NewSandboxRequest{}
+			request.Extensions.SecurityRulesRaw = tt.raw
+			request.Extensions.SecurityRulesPresent = true
+			got, err := resolveSecurityRules(request)
+			if tt.expectError == "" {
+				require.NoError(t, err)
+				assert.NotEmpty(t, got)
+				rules := parseResolvedRules(t, got)
+				assert.NotEmpty(t, rules)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+}
+
+// TestResolveSecurityRules_InlineNormalizedShape pins the exact annotation
+// structure produced from the metadata entry so the data plane can rely on a
+// stable server artifact.
+func TestResolveSecurityRules_InlineNormalizedShape(t *testing.T) {
+	request := &models.NewSandboxRequest{}
+	request.Extensions.SecurityRulesRaw = validInlineRulesJSON
+	request.Extensions.SecurityRulesPresent = true
+
+	got, err := resolveSecurityRules(request)
+	require.NoError(t, err)
+
+	rules := parseResolvedRules(t, got)
+	require.Len(t, rules, 1)
+	assert.Equal(t, "trace-header", rules[0].Name)
+	require.Len(t, rules[0].Match, 1)
+	assert.Equal(t, []string{"api.example.com"}, rules[0].Match[0].Domains)
+	require.NotNil(t, rules[0].Actions.HeaderManipulation)
+	assert.Nil(t, rules[0].Actions.Block)
+	require.Len(t, rules[0].Actions.HeaderManipulation.Set, 1)
+	assert.Equal(t, agentsv1alpha1.HeaderValue{Name: "X-E2E-Trace", Value: "abc123"},
+		rules[0].Actions.HeaderManipulation.Set[0])
+}
+
+func TestResolveSecurityRules_NetworkRules(t *testing.T) {
+	tests := []struct {
+		name        string
+		allowOut    []string
+		rules       map[string][]models.SandboxNetworkRule
+		wantRules   int
+		expectError string
+	}{
+		{
+			name:     "transform headers become one rule per domain",
+			allowOut: []string{"api.example.com", "api.other.com"},
+			rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{
+					Headers: map[string]string{"X-E2E-Trace": "abc"},
+				}}},
+				"api.other.com": {{Transform: &models.SandboxNetworkTransform{
+					Headers: map[string]string{"Authorization": "Bearer t"},
+				}}},
+			},
+			wantRules: 2,
+		},
+		{
+			name:     "same domain rules merge with later value replacing",
+			allowOut: []string{"api.example.com"},
+			rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {
+					{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "first", "X-B": "keep"}}},
+					{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "second"}}},
+				},
+			},
+			wantRules: 1,
+		},
+		{
+			name: "rule without transform produces no security rule",
+			rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{}},
+			},
+			wantRules: 0,
+		},
+		{
+			name:     "allowOut match is case-insensitive",
+			allowOut: []string{"API.Example.COM"},
+			rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "1"}}}},
+			},
+			wantRules: 1,
+		},
+		{
+			name: "open-egress mode accepts transforms without allowOut",
+			rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "1"}}}},
+			},
+			wantRules: 1,
+		},
+		{
+			name:     "transform domain missing from a non-empty allowOut rejected",
+			allowOut: []string{"api.other.com"},
+			rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "1"}}}},
+			},
+			expectError: "must also be listed in network.allowOut",
+		},
+		{
+			name: "empty domain key rejected",
+			rules: map[string][]models.SandboxNetworkRule{
+				"": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X-A": "1"}}}},
+			},
+			expectError: "empty domain key",
+		},
+		{
+			name: "egressProxy rejected",
+			rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{EgressProxy: ptrString("http://proxy:8080")}},
+			},
+			expectError: "egressProxy is not supported",
+		},
+		{
+			name: "maskRequestHost rejected",
+			rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{MaskRequestHost: ptrString("masked.example.com")}},
+			},
+			expectError: "maskRequestHost is not supported",
+		},
+		{
+			name: "Host header in transform rejected",
+			rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"Host": "evil.com"}}}},
+			},
+			expectError: "Host cannot be modified",
+		},
+		{
+			name: "invalid header name rejected",
+			rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{Headers: map[string]string{"X A": "1"}}}},
+			},
+			expectError: "header name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := &models.NewSandboxRequest{
+				Network: &models.SandboxNetworkConfig{AllowOut: tt.allowOut, Rules: tt.rules},
+			}
+			got, err := resolveSecurityRules(request)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantRules == 0 {
+				assert.Empty(t, got)
+				return
+			}
+			assert.Equal(t, tt.wantRules, len(parseResolvedRules(t, got)))
+		})
+	}
+}
+
+// TestResolveSecurityRules_NetworkNormalizedShape pins the translation of the
+// native E2B network.rules entry: one headerManipulation rule per domain with
+// deterministic sorted output.
+func TestResolveSecurityRules_NetworkNormalizedShape(t *testing.T) {
+	request := &models.NewSandboxRequest{
+		Network: &models.SandboxNetworkConfig{
+			AllowOut: []string{"a.example.com", "b.example.com"},
+			Rules: map[string][]models.SandboxNetworkRule{
+				"b.example.com": {{Transform: &models.SandboxNetworkTransform{
+					Headers: map[string]string{"X-B": "2", "X-A": "1"},
+				}}},
+				"a.example.com": {{Transform: &models.SandboxNetworkTransform{
+					Headers: map[string]string{"X-E2E-Trace": "abc"},
+				}}},
+			},
+		},
+	}
+
+	got, err := resolveSecurityRules(request)
+	require.NoError(t, err)
+
+	// Determinism: identical input always yields an identical annotation.
+	got2, err := resolveSecurityRules(request)
+	require.NoError(t, err)
+	assert.Equal(t, got, got2)
+
+	rules := parseResolvedRules(t, got)
+	require.Len(t, rules, 2)
+	// Domains are emitted in sorted order.
+	assert.Equal(t, "e2b-rules-a.example.com", rules[0].Name)
+	assert.Equal(t, []string{"a.example.com"}, rules[0].Match[0].Domains)
+	assert.Equal(t, "e2b-rules-b.example.com", rules[1].Name)
+	// Headers within one rule are sorted by name.
+	require.Len(t, rules[1].Actions.HeaderManipulation.Set, 2)
+	assert.Equal(t, "X-A", rules[1].Actions.HeaderManipulation.Set[0].Name)
+	assert.Equal(t, "1", rules[1].Actions.HeaderManipulation.Set[0].Value)
+	assert.Equal(t, "X-B", rules[1].Actions.HeaderManipulation.Set[1].Name)
+	assert.Equal(t, "2", rules[1].Actions.HeaderManipulation.Set[1].Value)
+}
+
+// TestResolveSecurityRules_MutualExclusion locks the 400 boundary when both
+// input entries are used together.
+func TestResolveSecurityRules_MutualExclusion(t *testing.T) {
+	request := &models.NewSandboxRequest{
+		Network: &models.SandboxNetworkConfig{
+			Rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{
+					Headers: map[string]string{"X-A": "1"},
+				}}},
+			},
+		},
+	}
+	request.Extensions.SecurityRulesRaw = validInlineRulesJSON
+	request.Extensions.SecurityRulesPresent = true
+
+	_, err := resolveSecurityRules(request)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// TestResolveSecurityRules_EmptyMetadataValueRejected locks the boundary where
+// the reserved key is sent with an empty value: presence alone must fail the
+// request instead of being treated as "no inline rules".
+func TestResolveSecurityRules_EmptyMetadataValueRejected(t *testing.T) {
+	request := &models.NewSandboxRequest{}
+	request.Extensions.SecurityRulesPresent = true
+
+	_, err := resolveSecurityRules(request)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be empty")
+}
+
+// TestResolveSecurityRules_EmptyMetadataValueWithNetworkRules locks that an
+// explicit empty metadata entry combined with network.rules still hits the
+// mutual-exclusion 400 instead of silently using network.rules alone.
+func TestResolveSecurityRules_EmptyMetadataValueWithNetworkRules(t *testing.T) {
+	request := &models.NewSandboxRequest{
+		Network: &models.SandboxNetworkConfig{
+			Rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{
+					Headers: map[string]string{"X-A": "1"},
+				}}},
+			},
+		},
+	}
+	request.Extensions.SecurityRulesPresent = true
+
+	_, err := resolveSecurityRules(request)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// TestResolveSecurityRules_TrailingJSONValueRejected locks that the metadata
+// value must contain exactly one JSON array value.
+func TestResolveSecurityRules_TrailingJSONValueRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "second array appended", raw: validInlineRulesJSON + validInlineRulesJSON},
+		{name: "trailing object", raw: validInlineRulesJSON + `{"name":"extra"}`},
+		{name: "trailing garbage", raw: validInlineRulesJSON + " x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := &models.NewSandboxRequest{}
+			request.Extensions.SecurityRulesRaw = tt.raw
+			request.Extensions.SecurityRulesPresent = true
+
+			_, err := resolveSecurityRules(request)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "exactly one security-rules JSON array value")
+		})
+	}
+
+	// trailing whitespace only is still accepted
+	request := &models.NewSandboxRequest{}
+	request.Extensions.SecurityRulesRaw = validInlineRulesJSON + "\n  \t"
+	request.Extensions.SecurityRulesPresent = true
+	got, err := resolveSecurityRules(request)
+	require.NoError(t, err)
+	assert.NotEmpty(t, got)
+}
+
+// TestResolveSecurityRules_NoInput verifies requests without either entry keep
+// today's behavior: no annotation value is produced.
+func TestResolveSecurityRules_NoInput(t *testing.T) {
+	got, err := resolveSecurityRules(&models.NewSandboxRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	// network present but without rules is still no input
+	request := &models.NewSandboxRequest{
+		Network: &models.SandboxNetworkConfig{AllowOut: []string{"api.example.com"}},
+	}
+	got, err = resolveSecurityRules(request)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestParseCreateSandboxRequest_SecurityRules covers the create API boundary:
+// the reserved metadata key is consumed (so the blacklist check passes), the
+// normalized value lands on the request, and both entries together yield 400.
+func TestParseCreateSandboxRequest_SecurityRules(t *testing.T) {
+	controller, _, teardown := Setup(t)
+	defer teardown()
+	user := adminTestUser()
+
+	t.Run("metadata entry produces normalized value", func(t *testing.T) {
+		req := NewRequest(t, nil, models.NewSandboxRequest{
+			TemplateID: "t",
+			Metadata: map[string]string{
+				models.ExtensionKeySecurityRules: validInlineRulesJSON,
+			},
+		}, nil, user)
+		parsed, apiErr := controller.parseCreateSandboxRequest(req)
+		require.Nil(t, apiErr)
+		assert.NotEmpty(t, parsed.SecurityRulesJSON)
+		_, stillPresent := parsed.Metadata[models.ExtensionKeySecurityRules]
+		assert.False(t, stillPresent, "reserved metadata key must be consumed before the blacklist check")
+		rules := parseResolvedRules(t, parsed.SecurityRulesJSON)
+		require.Len(t, rules, 1)
+		assert.Equal(t, "trace-header", rules[0].Name)
+	})
+
+	t.Run("network entry produces normalized value", func(t *testing.T) {
+		req := NewRequest(t, nil, models.NewSandboxRequest{
+			TemplateID: "t",
+			Network: &models.SandboxNetworkConfig{
+				AllowOut: []string{"api.example.com"},
+				Rules: map[string][]models.SandboxNetworkRule{
+					"api.example.com": {{Transform: &models.SandboxNetworkTransform{
+						Headers: map[string]string{"X-E2E-Trace": "abc"},
+					}}},
+				},
+			},
+		}, nil, user)
+		parsed, apiErr := controller.parseCreateSandboxRequest(req)
+		require.Nil(t, apiErr)
+		rules := parseResolvedRules(t, parsed.SecurityRulesJSON)
+		require.Len(t, rules, 1)
+		assert.Equal(t, []string{"api.example.com"}, rules[0].Match[0].Domains)
+	})
+
+	t.Run("both entries rejected with 400", func(t *testing.T) {
+		req := NewRequest(t, nil, models.NewSandboxRequest{
+			TemplateID: "t",
+			Metadata: map[string]string{
+				models.ExtensionKeySecurityRules: validInlineRulesJSON,
+			},
+			Network: &models.SandboxNetworkConfig{
+				Rules: map[string][]models.SandboxNetworkRule{
+					"api.example.com": {{Transform: &models.SandboxNetworkTransform{
+						Headers: map[string]string{"X-A": "1"},
+					}}},
+				},
+			},
+		}, nil, user)
+		_, apiErr := controller.parseCreateSandboxRequest(req)
+		require.NotNil(t, apiErr)
+		assert.Equal(t, 400, apiErr.Code)
+		assert.Contains(t, apiErr.Message, "mutually exclusive")
+	})
+
+	t.Run("unsupported egressProxy shape rejected with 400", func(t *testing.T) {
+		req := NewRequest(t, nil, models.NewSandboxRequest{
+			TemplateID: "t",
+			Network: &models.SandboxNetworkConfig{
+				Rules: map[string][]models.SandboxNetworkRule{
+					"api.example.com": {{EgressProxy: ptrString("http://proxy:8080")}},
+				},
+			},
+		}, nil, user)
+		_, apiErr := controller.parseCreateSandboxRequest(req)
+		require.NotNil(t, apiErr)
+		assert.Equal(t, 400, apiErr.Code)
+		assert.Contains(t, apiErr.Message, "egressProxy is not supported")
+	})
+
+	t.Run("empty metadata value rejected with 400", func(t *testing.T) {
+		req := NewRequest(t, nil, models.NewSandboxRequest{
+			TemplateID: "t",
+			Metadata: map[string]string{
+				models.ExtensionKeySecurityRules: "",
+			},
+		}, nil, user)
+		_, apiErr := controller.parseCreateSandboxRequest(req)
+		require.NotNil(t, apiErr)
+		assert.Equal(t, 400, apiErr.Code)
+		assert.Contains(t, apiErr.Message, "must not be empty")
+	})
+
+	t.Run("empty metadata value plus network rules rejected with mutual-exclusion 400", func(t *testing.T) {
+		req := NewRequest(t, nil, models.NewSandboxRequest{
+			TemplateID: "t",
+			Metadata: map[string]string{
+				models.ExtensionKeySecurityRules: "",
+			},
+			Network: &models.SandboxNetworkConfig{
+				Rules: map[string][]models.SandboxNetworkRule{
+					"api.example.com": {{Transform: &models.SandboxNetworkTransform{
+						Headers: map[string]string{"X-A": "1"},
+					}}},
+				},
+			},
+		}, nil, user)
+		_, apiErr := controller.parseCreateSandboxRequest(req)
+		require.NotNil(t, apiErr)
+		assert.Equal(t, 400, apiErr.Code)
+		assert.Contains(t, apiErr.Message, "mutually exclusive")
+	})
+
+	t.Run("trailing second JSON value rejected with 400", func(t *testing.T) {
+		req := NewRequest(t, nil, models.NewSandboxRequest{
+			TemplateID: "t",
+			Metadata: map[string]string{
+				models.ExtensionKeySecurityRules: validInlineRulesJSON + validInlineRulesJSON,
+			},
+		}, nil, user)
+		_, apiErr := controller.parseCreateSandboxRequest(req)
+		require.NotNil(t, apiErr)
+		assert.Equal(t, 400, apiErr.Code)
+		assert.Contains(t, apiErr.Message, "exactly one security-rules JSON array value")
+	})
+
+	t.Run("open-egress transform without allowOut accepted", func(t *testing.T) {
+		req := NewRequest(t, nil, models.NewSandboxRequest{
+			TemplateID: "t",
+			Network: &models.SandboxNetworkConfig{
+				Rules: map[string][]models.SandboxNetworkRule{
+					"api.example.com": {{Transform: &models.SandboxNetworkTransform{
+						Headers: map[string]string{"X-E2E-Trace": "abc"},
+					}}},
+				},
+			},
+		}, nil, user)
+		parsed, apiErr := controller.parseCreateSandboxRequest(req)
+		require.Nil(t, apiErr)
+		rules := parseResolvedRules(t, parsed.SecurityRulesJSON)
+		require.Len(t, rules, 1)
+		assert.Equal(t, []string{"api.example.com"}, rules[0].Match[0].Domains)
+	})
+
+	t.Run("whitelist-mode transform missing from allowOut rejected with 400", func(t *testing.T) {
+		req := NewRequest(t, nil, models.NewSandboxRequest{
+			TemplateID: "t",
+			Network: &models.SandboxNetworkConfig{
+				AllowOut: []string{"api.other.com"},
+				Rules: map[string][]models.SandboxNetworkRule{
+					"api.example.com": {{Transform: &models.SandboxNetworkTransform{
+						Headers: map[string]string{"X-E2E-Trace": "abc"},
+					}}},
+				},
+			},
+		}, nil, user)
+		_, apiErr := controller.parseCreateSandboxRequest(req)
+		require.NotNil(t, apiErr)
+		assert.Equal(t, 400, apiErr.Code)
+		assert.Contains(t, apiErr.Message, "must also be listed in network.allowOut")
+	})
+
+	t.Run("case-insensitive duplicate set names rejected with 400", func(t *testing.T) {
+		req := NewRequest(t, nil, models.NewSandboxRequest{
+			TemplateID: "t",
+			Metadata: map[string]string{
+				models.ExtensionKeySecurityRules: `[{"name":"r1","match":[{"domains":["api.example.com"]}],` +
+					`"actions":{"headerManipulation":{"set":[{"name":"X-Dup","value":"a"},{"name":"x-dup","value":"b"}]}}}]`,
+			},
+		}, nil, user)
+		_, apiErr := controller.parseCreateSandboxRequest(req)
+		require.NotNil(t, apiErr)
+		assert.Equal(t, 400, apiErr.Code)
+		assert.Contains(t, apiErr.Message, "appears more than once in set")
+	})
+}
+
+// TestResolveSecurityRulesUpdate pins the PUT replacement semantics: absent
+// keeps, explicit empty clears, and a non-empty map is validated like the
+// creation path including the allowOut contract.
+func TestResolveSecurityRulesUpdate(t *testing.T) {
+	t.Run("absent rules keep the existing chain", func(t *testing.T) {
+		_, present, err := resolveSecurityRulesUpdate(&models.SandboxNetworkUpdateConfig{
+			AllowOut: []string{"1.2.3.4"},
+		})
+		require.NoError(t, err)
+		assert.False(t, present)
+	})
+
+	t.Run("explicit empty object clears the chain", func(t *testing.T) {
+		got, present, err := resolveSecurityRulesUpdate(&models.SandboxNetworkUpdateConfig{
+			Rules: map[string][]models.SandboxNetworkRule{},
+		})
+		require.NoError(t, err)
+		assert.True(t, present)
+		assert.Empty(t, got)
+	})
+
+	t.Run("rules without effective transform clear the chain", func(t *testing.T) {
+		got, present, err := resolveSecurityRulesUpdate(&models.SandboxNetworkUpdateConfig{
+			Rules: map[string][]models.SandboxNetworkRule{"api.example.com": {{}}},
+		})
+		require.NoError(t, err)
+		assert.True(t, present)
+		assert.Empty(t, got)
+	})
+
+	t.Run("open-egress replacement without allowOut accepted", func(t *testing.T) {
+		got, present, err := resolveSecurityRulesUpdate(&models.SandboxNetworkUpdateConfig{
+			Rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{
+					Headers: map[string]string{"X-A": "1"},
+				}}},
+			},
+		})
+		require.NoError(t, err)
+		assert.True(t, present)
+		assert.NotEmpty(t, got)
+	})
+
+	t.Run("replacement is validated against the update's own allowOut", func(t *testing.T) {
+		_, _, err := resolveSecurityRulesUpdate(&models.SandboxNetworkUpdateConfig{
+			AllowOut: []string{"api.other.com"},
+			Rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{
+					Headers: map[string]string{"X-A": "1"},
+				}}},
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must also be listed in network.allowOut")
+	})
+
+	t.Run("valid replacement produces the normalized chain", func(t *testing.T) {
+		got, present, err := resolveSecurityRulesUpdate(&models.SandboxNetworkUpdateConfig{
+			AllowOut: []string{"api.example.com"},
+			Rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{
+					Headers: map[string]string{"X-E2E-Trace": "updated"},
+				}}},
+			},
+		})
+		require.NoError(t, err)
+		assert.True(t, present)
+		rules := parseResolvedRules(t, got)
+		require.Len(t, rules, 1)
+		assert.Equal(t, "e2b-rules-api.example.com", rules[0].Name)
+	})
+}
+
+// TestUpdateSandboxNetwork_RulesReplaced covers the PUT boundary end to end:
+// replace writes the annotation, explicit empty clears it, absent keeps it,
+// and an invalid replacement returns 400 without touching the sandbox.
+func TestUpdateSandboxNetwork_RulesReplaced(t *testing.T) {
+	controller, _, teardown := Setup(t)
+	defer teardown()
+	templateName := "test-rules-update-template"
+	cleanup := CreateSandboxPool(t, controller, templateName, 10)
+	defer cleanup()
+	user := adminTestUser()
+
+	createResp, createErr := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+		TemplateID: templateName,
+		Metadata: map[string]string{
+			models.ExtensionKeySkipInitRuntime: agentsv1alpha1.True,
+		},
+		Network: &models.SandboxNetworkConfig{
+			AllowOut: []string{"api.example.com"},
+			Rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{
+					Headers: map[string]string{"X-E2E-Trace": "created"},
+				}}},
+			},
+		},
+	}, nil, user))
+	require.Nil(t, createErr)
+	sandboxID := createResp.Body.SandboxID
+
+	readAnnotation := func() (string, bool) {
+		sbxList := &agentsv1alpha1.SandboxList{}
+		require.NoError(t, getTestCRClient(controller).List(t.Context(), sbxList, ctrlclient.InNamespace(Namespace)))
+		for i := range sbxList.Items {
+			if sandboxid.Resolve(&sbxList.Items[i]) == sandboxID {
+				v, ok := sbxList.Items[i].Annotations[agentsv1alpha1.AnnotationSecurityRules]
+				return v, ok
+			}
+		}
+		t.Fatalf("sandbox %s not found", sandboxID)
+		return "", false
+	}
+
+	v, ok := readAnnotation()
+	require.True(t, ok)
+	assert.Contains(t, v, "created")
+
+	t.Run("invalid replacement returns 400 and keeps the chain", func(t *testing.T) {
+		_, apiErr := controller.UpdateSandboxNetwork(NewRequest(t, nil, models.SandboxNetworkUpdateConfig{
+			AllowOut: []string{"api.other.com"},
+			Rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{
+					Headers: map[string]string{"X-A": "1"},
+				}}},
+			},
+		}, map[string]string{"sandboxID": sandboxID}, user))
+		require.NotNil(t, apiErr)
+		assert.Equal(t, 400, apiErr.Code)
+		assert.Contains(t, apiErr.Message, "must also be listed in network.allowOut")
+		v, _ := readAnnotation()
+		assert.Contains(t, v, "created", "failed update must not change the chain")
+	})
+
+	t.Run("replacement rewrites the annotation", func(t *testing.T) {
+		resp, apiErr := controller.UpdateSandboxNetwork(NewRequest(t, nil, models.SandboxNetworkUpdateConfig{
+			AllowOut: []string{"api.example.com"},
+			Rules: map[string][]models.SandboxNetworkRule{
+				"api.example.com": {{Transform: &models.SandboxNetworkTransform{
+					Headers: map[string]string{"X-E2E-Trace": "updated"},
+				}}},
+			},
+		}, map[string]string{"sandboxID": sandboxID}, user))
+		require.Nil(t, apiErr)
+		assert.Equal(t, http.StatusNoContent, resp.Code)
+		v, ok := readAnnotation()
+		require.True(t, ok)
+		assert.Contains(t, v, "updated")
+		assert.NotContains(t, v, "created")
+	})
+
+	t.Run("absent rules keep the chain", func(t *testing.T) {
+		_, apiErr := controller.UpdateSandboxNetwork(NewRequest(t, nil, models.SandboxNetworkUpdateConfig{
+			AllowOut: []string{"1.2.3.4"},
+		}, map[string]string{"sandboxID": sandboxID}, user))
+		require.Nil(t, apiErr)
+		v, ok := readAnnotation()
+		require.True(t, ok)
+		assert.Contains(t, v, "updated")
+	})
+
+	t.Run("explicit empty object clears the chain", func(t *testing.T) {
+		// omitempty drops an empty map from struct marshalling, so send the
+		// raw body to exercise the explicit `"rules": {}` wire shape.
+		_, apiErr := controller.UpdateSandboxNetwork(NewRequest(t, nil, json.RawMessage(`{"rules":{}}`),
+			map[string]string{"sandboxID": sandboxID}, user))
+		require.Nil(t, apiErr)
+		_, ok := readAnnotation()
+		assert.False(t, ok, "explicit empty rules must remove the annotation")
+	})
+}
+
+func ptrString(s string) *string { return &s }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Builds the Sandbox-Manager half of the per-sandbox inline L7 egress rules loop (data-plane half: openkruise/agentio#18, merged, on top of the API from #829). Tenants author egress header rules through two mutually exclusive E2B inputs, which the server validates, normalizes, and persists as the `agents.kruise.io/security-rules` Sandbox annotation for the data plane to enforce under verified workload identity:

1. **Native `network.rules[domain].transform.headers`** — translated into one `headerManipulation` rule per domain (sorted domains, lowercase sorted header names, deterministic output).
2. **Reserved metadata key `e2b.agents.kruise.io/security-rules`** — a strict JSON array of `SecurityRule` (unknown fields rejected, exactly one JSON value), admitting only `block` and `headerManipulation` actions.

`PUT /sandboxes/{id}/network` replaces the rule chain with full-replacement semantics: an absent `rules` field keeps the existing chain, an explicit `{}` clears it, and a non-empty map replaces it after the same validation as creation. The annotation write (conflict-retried, no-op when unchanged) lands before the L4 TrafficPolicy widens.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

Unit tests:

```bash
go test ./pkg/servers/e2b/... ./api/... ./pkg/sandbox-manager/... ./pkg/controller/sandbox/...
```

Table-driven coverage includes both input paths, PUT semantics, every rejection above, the recycle wipe (`TestResetForPool`), and annotation write/no-op/delete round trips (`TestUpdateSecurityRules`).

End to end (verified on a real cluster against the merged agentio EPE):

1. Create a sandbox with `network.rules` header transforms → the annotation carries the normalized chain; egress requests to the matched domain arrive with the header injected, and a client-supplied header of the same name is replaced.
2. Create a sandbox with the metadata key carrying `set` + `remove` → injected and stripped respectively; `block: {}` returns HTTP 403 via the defaulted statusCode.
3. `PUT /sandboxes/{id}/network`: replace → new value takes effect; absent `rules` → chain kept; `"rules": {}` → annotation removed and mutation stops; narrowing `allowOut` while keeping the chain → 400.
4. Negative requests (dual input, top-level `egressProxy`/`maskRequestHost`, whitelist violation, `Host`, uppercase names, control characters, `bypass`, out-of-range values) → all 400 with nothing written.
5. Pre-annotate a pooled Sandbox CR with a stale rule chain, then claim it without rules → the annotation is removed at claim and traffic is unaffected.

### Ⅳ. Special notes for reviews

- Both data planes (annotation → EPE, TrafficPolicy → xDS) converge eventually and independently, matching the existing L4 behavior; the write ordering (rules before allowOut widening) bounds the exposure on updates, but neither path today offers a convergence signal to the caller. We need to open a follow-up issue to track convergence/observability improvements for both the L4 TrafficPolicy and the L7 rule chain together (e.g. a readiness signal or status condition), rather than solving it piecemeal in this PR.
- The whitelist-contract relaxation for CIDR/IP `allowOut` entries is a deliberate deviation from a strict literal check: a static check cannot correlate an address-based entry with a domain, so its presence disables the contract rather than producing false 400s.
