### PR TITLE
Fix invalid SandboxClaim retry loop

### DIFF
--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -155,7 +155,12 @@ func (c *commonControl) EnsureClaimClaiming(ctx context.Context, args ClaimArgs)
 	claimed, err := c.claimSandboxes(ctx, claim, sandboxSet, batchSize)
 	if err != nil {
 		if errors.Is(err, ErrInvalidClaimSpec) {
+			// Strip the generic "failed to build claim options" wrapper so users
+			// see the actual validation reason in status and events.
 			msg := err.Error()
+			if inner := errors.Unwrap(err); inner != nil {
+				msg = inner.Error()
+			}
 			log.Info("Invalid SandboxClaim spec, completing claim without retry", "err", err)
 			c.recorder.Event(claim, "Warning", "InvalidClaimSpec", msg)
 			TransitionToCompleted(args.NewStatus, "InvalidClaimSpec", msg)

--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -19,6 +19,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -61,6 +62,8 @@ type commonControl struct {
 	// plaintext (see runtime.TransportOptionsFor).
 	runtimeTLSBundle *runtimeclient.TLSBundle
 }
+
+var ErrInvalidClaimSpec = errors.New("invalid SandboxClaim spec")
 
 func NewCommonControl(c client.Client, recorder record.EventRecorder, cache cache.Provider,
 	runtimeTLSBundle *runtimeclient.TLSBundle) ClaimControl {
@@ -151,6 +154,13 @@ func (c *commonControl) EnsureClaimClaiming(ctx context.Context, args ClaimArgs)
 	// Step 8: Perform claim
 	claimed, err := c.claimSandboxes(ctx, claim, sandboxSet, batchSize)
 	if err != nil {
+		if errors.Is(err, ErrInvalidClaimSpec) {
+			msg := err.Error()
+			log.Info("Invalid SandboxClaim spec, completing claim without retry", "err", err)
+			c.recorder.Event(claim, "Warning", "InvalidClaimSpec", msg)
+			TransitionToCompleted(args.NewStatus, "InvalidClaimSpec", msg)
+			return NoRequeue(), nil
+		}
 		log.Error(err, "Claim attempts completed with errors",
 			"claimed", claimed, "attempted", batchSize)
 	}
@@ -268,10 +278,10 @@ func (c *commonControl) claimSandboxes(ctx context.Context, claim *agentsv1alpha
 // sandbox identity keys.
 func validateClaimReservedIdentityKeys(claim *agentsv1alpha1.SandboxClaim) error {
 	if _, exists := claim.Spec.Labels[agentsv1alpha1.LabelSandboxID]; exists {
-		return fmt.Errorf("label %q is reserved and cannot be set by SandboxClaim", agentsv1alpha1.LabelSandboxID)
+		return fmt.Errorf("%w: label %q is reserved and cannot be set by SandboxClaim", ErrInvalidClaimSpec, agentsv1alpha1.LabelSandboxID)
 	}
 	if _, exists := claim.Spec.Annotations[agentsv1alpha1.AnnotationSandboxID]; exists {
-		return fmt.Errorf("annotation %q is reserved and cannot be set by SandboxClaim", agentsv1alpha1.AnnotationSandboxID)
+		return fmt.Errorf("%w: annotation %q is reserved and cannot be set by SandboxClaim", ErrInvalidClaimSpec, agentsv1alpha1.AnnotationSandboxID)
 	}
 	return nil
 }

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -239,6 +239,43 @@ func TestCommonControl_EnsureClaimClaiming(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid reserved identity key - should complete without retry",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim-invalid",
+					Namespace: "default",
+					UID:       "test-uid-invalid",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "test-template",
+					Replicas:     int32Ptr(1),
+					Labels: map[string]string{
+						agentsv1alpha1.LabelSandboxID: "spoofed-id",
+					},
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-template",
+					Namespace: "default",
+				},
+			},
+			newStatus: &agentsv1alpha1.SandboxClaimStatus{
+				Phase:           agentsv1alpha1.SandboxClaimPhaseClaiming,
+				ClaimedReplicas: 0,
+			},
+			expectedStrategy: NoRequeue(),
+			expectError:      false,
+			checkStatus: func(t *testing.T, status *agentsv1alpha1.SandboxClaimStatus) {
+				assert.Equal(t, agentsv1alpha1.SandboxClaimPhaseCompleted, status.Phase)
+				assert.Contains(t, status.Message, agentsv1alpha1.LabelSandboxID)
+				condition := GetClaimCondition(status, string(agentsv1alpha1.SandboxClaimConditionCompleted))
+				require.NotNil(t, condition)
+				assert.Equal(t, "InvalidClaimSpec", condition.Reason)
+				assert.Contains(t, condition.Message, agentsv1alpha1.LabelSandboxID)
+			},
+		},
+		{
 			name: "replicas already met - should transition to completed",
 			claim: &agentsv1alpha1.SandboxClaim{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -269,10 +269,14 @@ func TestCommonControl_EnsureClaimClaiming(t *testing.T) {
 			checkStatus: func(t *testing.T, status *agentsv1alpha1.SandboxClaimStatus) {
 				assert.Equal(t, agentsv1alpha1.SandboxClaimPhaseCompleted, status.Phase)
 				assert.Contains(t, status.Message, agentsv1alpha1.LabelSandboxID)
+				// User-facing message must show the validation reason,
+				// not the internal claim-options wrapping.
+				assert.NotContains(t, status.Message, "failed to build claim options")
 				condition := GetClaimCondition(status, string(agentsv1alpha1.SandboxClaimConditionCompleted))
 				require.NotNil(t, condition)
 				assert.Equal(t, "InvalidClaimSpec", condition.Reason)
 				assert.Contains(t, condition.Message, agentsv1alpha1.LabelSandboxID)
+				assert.NotContains(t, condition.Message, "failed to build claim options")
 			},
 		},
 		{

--- a/pkg/controller/sandboxclaim/sandboxclaim_controller_test.go
+++ b/pkg/controller/sandboxclaim/sandboxclaim_controller_test.go
@@ -18,6 +18,7 @@ package sandboxclaim
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -339,6 +340,80 @@ func TestReconciler_Reconcile_Claiming(t *testing.T) {
 	}
 
 	t.Logf("Successfully claimed %d sandbox(es)", claimedCount)
+}
+
+func TestReconciler_Reconcile_InvalidReservedIdentityKeyCompletesWithoutError(t *testing.T) {
+	testutils.InitLogOutput()
+
+	claim := &agentsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "invalid-claim",
+			Namespace:  "default",
+			UID:        "invalid-uid",
+			Generation: 1,
+		},
+		Spec: agentsv1alpha1.SandboxClaimSpec{
+			TemplateName:    "test-sandboxset",
+			SkipInitRuntime: true,
+			Labels: map[string]string{
+				agentsv1alpha1.LabelSandboxID: "spoofed-id",
+			},
+		},
+	}
+	sandboxSet := &agentsv1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandboxset",
+			Namespace: "default",
+		},
+	}
+
+	cache, testClient, err := cachetest.NewTestCache(t, claim, sandboxSet)
+	if err != nil {
+		t.Fatalf("Failed to create cache: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = cache.Run(ctx)
+	}()
+	time.Sleep(200 * time.Millisecond)
+
+	fakeRecorder := record.NewFakeRecorder(100)
+	reconciler := &Reconciler{
+		Client:   testClient,
+		Scheme:   testClient.Scheme(),
+		controls: core.NewClaimControl(testClient, fakeRecorder, cache, nil),
+		recorder: fakeRecorder,
+	}
+
+	result, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if result.Requeue || result.RequeueAfter > 0 {
+		t.Fatalf("Reconcile() result = %v, want no requeue", result)
+	}
+
+	updatedClaim := &agentsv1alpha1.SandboxClaim{}
+	if err := testClient.Get(ctx, types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}, updatedClaim); err != nil {
+		t.Fatalf("Failed to get updated claim: %v", err)
+	}
+	if updatedClaim.Status.Phase != agentsv1alpha1.SandboxClaimPhaseCompleted {
+		t.Fatalf("phase = %s, want %s", updatedClaim.Status.Phase, agentsv1alpha1.SandboxClaimPhaseCompleted)
+	}
+	condition := core.GetClaimCondition(&updatedClaim.Status, string(agentsv1alpha1.SandboxClaimConditionCompleted))
+	if condition == nil {
+		t.Fatalf("Completed condition was not set")
+	}
+	if condition.Reason != "InvalidClaimSpec" {
+		t.Fatalf("condition reason = %s, want InvalidClaimSpec", condition.Reason)
+	}
+	if !strings.Contains(condition.Message, agentsv1alpha1.LabelSandboxID) {
+		t.Fatalf("condition message = %q, want reserved label key", condition.Message)
+	}
 }
 
 func TestReconciler_Reconcile_ConditionalRequeue(t *testing.T) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR stops invalid `SandboxClaim` specs from retrying indefinitely when they set reserved sandbox identity metadata.

`validateClaimReservedIdentityKeys` now wraps reserved `sandbox-id` label/annotation violations with a typed `ErrInvalidClaimSpec`. When claiming sees this non-recoverable error, the controller transitions the claim to `Completed` with reason `InvalidClaimSpec`, records a warning event, and returns without requeueing.

### Ⅱ. Does this pull request fix one issue?
NONE

### Ⅲ. Describe how to verify it

```bash
GOCACHE=/private/tmp/agents-go-build-cache go test ./pkg/controller/sandboxclaim -count=1
GOCACHE=/private/tmp/agents-go-build-cache go test ./pkg/controller/sandboxclaim/core -count=1
```

### Ⅳ. Special notes for reviews

This PR only adds the controller-side terminal handling. It intentionally does not add a `SandboxClaim` admission webhook yet, so existing invalid claims and clusters without the webhook enabled still stop retrying. Admission rejection for new invalid specs can be considered as a follow-up.
