### PR TITLE
fix(proxy): answer each ext_proc phase with its matching response

### DIFF
--- a/pkg/proxy/ext_proc.go
+++ b/pkg/proxy/ext_proc.go
@@ -65,22 +65,55 @@ func (s *Server) Process(srv extProcPb.ExternalProcessor_ProcessServer) error {
 			return status.Errorf(codes.Unknown, "cannot receive stream request: %v", err)
 		}
 
-		// build response based on request type
-		resp := &extProcPb.ProcessingResponse{
-			Response: &extProcPb.ProcessingResponse_RequestHeaders{
-				RequestHeaders: &extProcPb.HeadersResponse{
-					Response: &extProcPb.CommonResponse{},
-				},
-			},
-		}
+		// Build the response for the phase envoy is in. ext_proc requires the
+		// response variant to match the request variant: envoy up to 1.34 ignores
+		// a mismatch, but from 1.35 it fails the stream closed and returns 500.
+		// Phases we do not act on are answered with an empty continue response.
+		var resp *extProcPb.ProcessingResponse
 		switch v := req.Request.(type) {
 		case *extProcPb.ProcessingRequest_RequestHeaders:
-			h := req.Request.(*extProcPb.ProcessingRequest_RequestHeaders)
-			resp = s.handleRequestHeaders(h, log)
-
+			resp = s.handleRequestHeaders(v, log)
+		case *extProcPb.ProcessingRequest_ResponseHeaders:
+			resp = &extProcPb.ProcessingResponse{
+				Response: &extProcPb.ProcessingResponse_ResponseHeaders{
+					ResponseHeaders: &extProcPb.HeadersResponse{
+						Response: &extProcPb.CommonResponse{},
+					},
+				},
+			}
+		case *extProcPb.ProcessingRequest_RequestBody:
+			resp = &extProcPb.ProcessingResponse{
+				Response: &extProcPb.ProcessingResponse_RequestBody{
+					RequestBody: &extProcPb.BodyResponse{
+						Response: &extProcPb.CommonResponse{},
+					},
+				},
+			}
+		case *extProcPb.ProcessingRequest_ResponseBody:
+			resp = &extProcPb.ProcessingResponse{
+				Response: &extProcPb.ProcessingResponse_ResponseBody{
+					ResponseBody: &extProcPb.BodyResponse{
+						Response: &extProcPb.CommonResponse{},
+					},
+				},
+			}
+		case *extProcPb.ProcessingRequest_RequestTrailers:
+			resp = &extProcPb.ProcessingResponse{
+				Response: &extProcPb.ProcessingResponse_RequestTrailers{
+					RequestTrailers: &extProcPb.TrailersResponse{},
+				},
+			}
+		case *extProcPb.ProcessingRequest_ResponseTrailers:
+			resp = &extProcPb.ProcessingResponse{
+				Response: &extProcPb.ProcessingResponse_ResponseTrailers{
+					ResponseTrailers: &extProcPb.TrailersResponse{},
+				},
+			}
 		default:
+			// Answering an unrecognized phase with a guessed variant is what envoy
+			// rejects, so skip the turn instead of sending a mismatched response.
 			log.Info("Unknown Request type", "type", v)
-
+			continue
 		}
 
 		if err = srv.Send(resp); err != nil {

--- a/pkg/proxy/ext_proc_test.go
+++ b/pkg/proxy/ext_proc_test.go
@@ -421,28 +421,18 @@ func TestServer_Process(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:        "unknown request type",
+			// A phase the server does not recognize is skipped rather than
+			// answered with a guessed response variant.
+			name:        "unset request type",
 			setupRoutes: []sandboxroute.Route{},
 			adapter: &testRequestAdapter{
 				entry: "127.0.0.1:8080",
 			},
 			requests: []*extProcPb.ProcessingRequest{
-				{
-					Request: &extProcPb.ProcessingRequest_ResponseHeaders{
-						ResponseHeaders: &extProcPb.HttpHeaders{},
-					},
-				},
+				{Request: nil},
 			},
 			expectError: false,
-			expectResp: []*extProcPb.ProcessingResponse{
-				{
-					Response: &extProcPb.ProcessingResponse_RequestHeaders{
-						RequestHeaders: &extProcPb.HeadersResponse{
-							Response: &extProcPb.CommonResponse{},
-						},
-					},
-				},
-			},
+			expectResp:  []*extProcPb.ProcessingResponse{},
 		},
 		{
 			name: "extra headers",
@@ -500,6 +490,75 @@ func TestServer_Process(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+			},
+		},
+		{
+			// envoy is configured with response_header_mode: SEND, so it always
+			// reaches this phase and expects a matching ResponseHeaders reply.
+			name:    "response headers phase",
+			adapter: &testRequestAdapter{},
+			requests: []*extProcPb.ProcessingRequest{
+				{
+					Request: &extProcPb.ProcessingRequest_ResponseHeaders{
+						ResponseHeaders: &extProcPb.HttpHeaders{
+							Headers: &corev3.HeaderMap{
+								Headers: []*corev3.HeaderValue{
+									{Key: ":status", RawValue: []byte("200")},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+			expectResp: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_ResponseHeaders{
+						ResponseHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "request body phase",
+			adapter: &testRequestAdapter{},
+			requests: []*extProcPb.ProcessingRequest{
+				{
+					Request: &extProcPb.ProcessingRequest_RequestBody{
+						RequestBody: &extProcPb.HttpBody{EndOfStream: true},
+					},
+				},
+			},
+			expectError: false,
+			expectResp: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_RequestBody{
+						RequestBody: &extProcPb.BodyResponse{
+							Response: &extProcPb.CommonResponse{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "response trailers phase",
+			adapter: &testRequestAdapter{},
+			requests: []*extProcPb.ProcessingRequest{
+				{
+					Request: &extProcPb.ProcessingRequest_ResponseTrailers{
+						ResponseTrailers: &extProcPb.HttpTrailers{},
+					},
+				},
+			},
+			expectError: false,
+			expectResp: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_ResponseTrailers{
+						ResponseTrailers: &extProcPb.TrailersResponse{},
 					},
 				},
 			},
@@ -562,6 +621,10 @@ func TestServer_Process(t *testing.T) {
 					}
 
 					actual := mockServer.resp[i]
+
+					// The ext_proc contract requires the response variant to match
+					// the request phase; envoy >= 1.35 fails the stream otherwise.
+					assert.IsType(t, expected.Response, actual.Response)
 
 					// Check response type
 					switch expected.Response.(type) {

--- a/pkg/proxy/ext_proc_test.go
+++ b/pkg/proxy/ext_proc_test.go
@@ -563,6 +563,46 @@ func TestServer_Process(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "response body phase",
+			adapter: &testRequestAdapter{},
+			requests: []*extProcPb.ProcessingRequest{
+				{
+					Request: &extProcPb.ProcessingRequest_ResponseBody{
+						ResponseBody: &extProcPb.HttpBody{EndOfStream: true},
+					},
+				},
+			},
+			expectError: false,
+			expectResp: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_ResponseBody{
+						ResponseBody: &extProcPb.BodyResponse{
+							Response: &extProcPb.CommonResponse{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "request trailers phase",
+			adapter: &testRequestAdapter{},
+			requests: []*extProcPb.ProcessingRequest{
+				{
+					Request: &extProcPb.ProcessingRequest_RequestTrailers{
+						RequestTrailers: &extProcPb.HttpTrailers{},
+					},
+				},
+			},
+			expectError: false,
+			expectResp: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_RequestTrailers{
+						RequestTrailers: &extProcPb.TrailersResponse{},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Fixes #834.

**Problem**

`Server.Process` (`pkg/proxy/ext_proc.go`) pre-built a single `RequestHeaders` response and sent it for every `ProcessingRequest`, whatever phase envoy was in. The `default` branch logged the unhandled type and then sent that same `RequestHeaders` response anyway:

```go
resp := &extProcPb.ProcessingResponse{
    Response: &extProcPb.ProcessingResponse_RequestHeaders{...},
}
switch v := req.Request.(type) {
case *extProcPb.ProcessingRequest_RequestHeaders:
    resp = s.handleRequestHeaders(...)
default:
    log.Info("Unknown Request type", "type", v)
}
srv.Send(resp)
```

ext_proc requires the response variant to match the request variant. The mismatched phase is reached in the shipped configuration — `config/sandbox-manager/envoy-config.yaml` sets `response_header_mode: SEND`, so envoy always reaches the response-header phase and receives a `RequestHeaders` reply for it.

**Impact**

envoy up to 1.34 unconditionally ignores an out-of-order message and resumes the paused stream, so the request still succeeds and the only symptom is one warning per request:

```
[warning][ext_proc] Spurious response message 1 received on gRPC stream
```

From envoy 1.35 that branch is gated by `envoy.reloadable_features.ext_proc_fail_close_spurious_resp`, declared `RUNTIME_GUARD` and therefore on by default, and the stream instead fails closed. Every request through the sidecar then returns a locally generated 500 with an empty body, which surfaces in the E2B SDK as `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`.

Scoping this honestly: **this is latent, not a live outage.** `config/sandbox-manager/deployment.yaml` pins the sidecar to `envoyproxy/envoy:v1.33-latest`, where the mismatch is tolerated. The value of the fix is that the handler stops depending on that pin — the sandbox-gateway image already moved to envoy 1.37.3 in #509, so a sidecar bump is a realistic change that would otherwise take the data path down.

**Root cause**

The phase was never used to select the response variant. A single `RequestHeaders` response was built up front and only overwritten for the `RequestHeaders` case, so every other phase — including the one the shipped config enables — received a variant that does not correspond to the request.

**Fix**

Select the response variant from the phase, covering all six processing phases. Phases the proxy does not act on are answered with an empty continue response (`CommonResponse` defaults to `CONTINUE`), which leaves existing behavior for the request-header phase untouched.

A phase the server does not recognize is now skipped instead of being answered with a guessed variant, since sending the wrong variant is precisely what envoy rejects.

The change is confined to the phase dispatch in `Process`; `handleRequestHeaders` and the routing logic are unchanged.

### Ⅱ. Does this pull request fix one issue?

fixes #834

### Ⅲ. Describe how to verify it

The regression coverage extends the existing `TestServer_Process` table in `pkg/proxy/ext_proc_test.go`, which drives the real `Process` loop over a mock `ExternalProcessor_ProcessServer` — the same entry point envoy talks to.

Two parts:

1. A response-variant assertion in the verification loop, so a phase/response mismatch fails the test instead of being ignored:

   ```go
   assert.IsType(t, expected.Response, actual.Response)
   ```

2. New cases for the `response headers`, `request body` and `response trailers` phases, each expecting its matching response variant.

One pre-existing case needed correcting rather than extending. The case named `unknown request type` sent a **`ResponseHeaders`** request and asserted a **`RequestHeaders`** reply — it had codified the mismatch, and treated a phase the shipped config explicitly enables as "unknown". It now exercises the `default` branch honestly with an unset request type and expects no response to be sent.

```bash
go test ./pkg/proxy/ -run 'TestServer_Process$' -count=1
```

**Before the fix** (final test file, previous `ext_proc.go`):

```
--- FAIL: TestServer_Process
    --- FAIL: TestServer_Process/unset_request_type
        ext_proc_test.go:615: expect 0 responses, got 1
    --- FAIL: TestServer_Process/response_headers_phase
        Error: Object expected to be of type *ext_procv3.ProcessingResponse_ResponseHeaders,
               but was *ext_procv3.ProcessingResponse_RequestHeaders
    --- FAIL: TestServer_Process/request_body_phase
        Error: Object expected to be of type *ext_procv3.ProcessingResponse_RequestBody,
               but was *ext_procv3.ProcessingResponse_RequestHeaders
    --- FAIL: TestServer_Process/response_trailers_phase
        Error: Object expected to be of type *ext_procv3.ProcessingResponse_ResponseTrailers,
               but was *ext_procv3.ProcessingResponse_RequestHeaders
FAIL
```

**After the fix** — all 13 subtests pass, including the 8 pre-existing ones that are unaffected by the change:

```
--- PASS: TestServer_Process
ok      github.com/openkruise/agents/pkg/proxy  0.406s
```

Validation performed:

| Check | Result |
| --- | --- |
| `gofmt -l` on both changed files | clean |
| `go build ./...` | pass |
| `go vet ./pkg/proxy/...` | pass |
| `golangci-lint run ./pkg/proxy/...` | 0 issues |
| `go test ./pkg/proxy/... -count=1` | pass |
| `go test ./pkg/proxy/... -count=3 -race` | clean |
| `go test ./pkg/... -count=1` | zero failures |

No API types changed, so `make generate manifests` does not apply.

### Ⅳ. Special notes for reviews

The empty responses are deliberate: `CommonResponse.Status` defaults to `CONTINUE`, and `TrailersResponse` carries only an optional header mutation, so an empty value for each is the "continue, change nothing" answer for that phase. The proxy's behavior on the request-header phase — the only phase it acts on — is byte-for-byte unchanged.

`processing_mode` in the shipped config currently enables only `request_header_mode: SEND` and `response_header_mode: SEND`, so the body and trailer cases are not reachable with today's ConfigMap. They are handled anyway so that widening `processing_mode` later does not reintroduce the same class of failure.

The `default` branch now skips the turn instead of sending a response. All six phases are enumerated in the ext_proc proto, so this is reachable only for an unset or newly added request variant; for those, sending nothing is strictly safer than sending a variant envoy will reject.

This touches `pkg/proxy/ext_proc.go`, which #704 and #818 also modify. There is no functional overlap — #704 adds nil guards to the header helpers and #818 filters reserved keys in the header modifier, while this PR only changes how the phase selects the response variant. Whichever merges first, the others should rebase cleanly or need only a trivial resolution in `Process`.
