### PR TITLE
fix(controller): surface missing template refs

### DIFF
--- a/api/v1alpha1/sandboxset_types.go
+++ b/api/v1alpha1/sandboxset_types.go
@@ -181,8 +181,17 @@ type SandboxSetUpdateStrategy struct {
 type SandboxSetConditionType string
 
 const (
+	// SandboxSetConditionTemplateResolved tracks Sandbox template resolution.
+	SandboxSetConditionTemplateResolved SandboxSetConditionType = "TemplateResolved"
+
 	// SandboxSetConditionScalingLimited indicates whether startup blockers exhaust the scale-up budget.
 	SandboxSetConditionScalingLimited SandboxSetConditionType = "ScalingLimited"
+)
+
+const (
+	// SandboxSetConditionTemplateResolved reasons.
+	SandboxSetReasonTemplateResolved    = "TemplateResolved"
+	SandboxSetReasonTemplateResolveFail = "TemplateResolveFailed"
 )
 
 // SandboxSetStatus defines the observed state of SandboxSet.

--- a/pkg/controller/sandbox/core/pod_control.go
+++ b/pkg/controller/sandbox/core/pod_control.go
@@ -149,6 +149,15 @@ func (c *PodControl) CreatePod(ctx context.Context, args CreatePodArgs) (*corev1
 
 	pod, err := c.generatePod(ctx, PodGenerateArgs{Client: c.Client, Box: box, NewStatus: args.NewStatus, IsResume: args.IsResume, ProbeManager: c.probeManager})
 	if err != nil {
+		if args.NewStatus != nil {
+			utils.SetSandboxCondition(args.NewStatus, metav1.Condition{
+				Type:               string(agentsv1alpha1.SandboxConditionReady),
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: metav1.Now(),
+				Reason:             agentsv1alpha1.SandboxReadyReasonPodCreateFailed,
+				Message:            utils.TruncateConditionMessage(err.Error()),
+			})
+		}
 		return nil, err
 	}
 

--- a/pkg/controller/sandbox/core/pod_control_test.go
+++ b/pkg/controller/sandbox/core/pod_control_test.go
@@ -187,6 +187,49 @@ func TestCreatePod(t *testing.T) {
 	}
 }
 
+func TestCreatePod_TemplateRefResolutionFailureSetsCondition(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+	recorder := record.NewFakeRecorder(10)
+	podControl := NewPodControl(fc, recorder, GeneratePodFromSandbox)
+	newStatus := &agentsv1alpha1.SandboxStatus{}
+	box := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "broken-sandbox",
+			Namespace: "default",
+		},
+		Spec: agentsv1alpha1.SandboxSpec{
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				TemplateRef: &agentsv1alpha1.SandboxTemplateRef{Name: "missing-template"},
+			},
+		},
+	}
+
+	pod, err := podControl.CreatePod(context.TODO(), CreatePodArgs{
+		Box:       box,
+		NewStatus: newStatus,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing-template")
+	assert.Nil(t, pod)
+
+	cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady))
+	require.NotNil(t, cond, "expected Ready condition to be set")
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, agentsv1alpha1.SandboxReadyReasonPodCreateFailed, cond.Reason)
+	assert.Contains(t, cond.Message, "missing-template")
+
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("did not expect event for templateRef resolution failure: %s", event)
+	default:
+	}
+}
+
 func TestCreatePodCheckpointAnnotation(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)

--- a/pkg/controller/sandboxset/sandboxset_controller_test.go
+++ b/pkg/controller/sandboxset/sandboxset_controller_test.go
@@ -252,6 +252,49 @@ func CheckEvent(t *testing.T, eventRecorder *record.FakeRecorder, tp, evt string
 	}
 }
 
+func TestReconcile_MissingTemplateRefSetsCondition(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := NewClient()
+	eventRecorder := record.NewFakeRecorder(10)
+	reconciler := &Reconciler{
+		Client:   k8sClient,
+		Scheme:   testScheme,
+		Recorder: eventRecorder,
+		Codec:    serializer.NewCodecFactory(testScheme).LegacyCodec(v1alpha1.SchemeGroupVersion),
+	}
+	sbs := getSandboxSet(1)
+	sbs.Name = "broken-pool"
+	const expectedGeneration int64 = 1
+	sbs.Generation = expectedGeneration
+	sbs.Spec.EmbeddedSandboxTemplate = v1alpha1.EmbeddedSandboxTemplate{
+		TemplateRef: &v1alpha1.SandboxTemplateRef{Name: "missing-template"},
+	}
+	require.NoError(t, k8sClient.Create(ctx, sbs))
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: sbs.Namespace,
+		Name:      sbs.Name,
+	}})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing-template")
+
+	var updated v1alpha1.SandboxSet
+	require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(sbs), &updated))
+	assert.Equal(t, expectedGeneration, updated.Status.ObservedGeneration)
+	cond := utils.GetCondition(updated.Status.Conditions, string(v1alpha1.SandboxSetConditionTemplateResolved))
+	require.NotNil(t, cond, "expected TemplateResolved condition to be set")
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, v1alpha1.SandboxSetReasonTemplateResolveFail, cond.Reason)
+	assert.Contains(t, cond.Message, "missing-template")
+
+	select {
+	case event := <-eventRecorder.Events:
+		t.Fatalf("did not expect event for templateRef resolution failure: %s", event)
+	default:
+	}
+}
+
 func TestReconcile_DeleteDead(t *testing.T) {
 	utestutils.InitLogOutput()
 	checkFunc := func(expectNonDeletedCnt int) func(t *testing.T, client client.Client, sbs *v1alpha1.SandboxSet) {

--- a/pkg/controller/sandboxset/utils.go
+++ b/pkg/controller/sandboxset/utils.go
@@ -18,6 +18,7 @@ package sandboxset
 
 import (
 	"context"
+	"errors"
 	"maps"
 	"strings"
 	"time"
@@ -59,13 +60,31 @@ type initStatusResult struct {
 
 func (r *Reconciler) initNewStatus(ctx context.Context, ss *agentsv1alpha1.SandboxSet) (*initStatusResult, error) {
 	newStatus := ss.Status.DeepCopy()
+	// Record the generation even when template resolution fails.
+	newStatus.ObservedGeneration = ss.Generation
 	hash, name, err := r.ensureTemplateRevision(ctx, ss)
 	if err != nil {
+		utils.SetCondition(&newStatus.Conditions, metav1.Condition{
+			Type:               string(agentsv1alpha1.SandboxSetConditionTemplateResolved),
+			Status:             metav1.ConditionFalse,
+			LastTransitionTime: metav1.Now(),
+			Reason:             agentsv1alpha1.SandboxSetReasonTemplateResolveFail,
+			Message:            utils.TruncateConditionMessage(err.Error()),
+		})
+		if updateErr := r.updateSandboxSetStatus(ctx, *newStatus, ss); updateErr != nil {
+			return nil, errors.Join(err, updateErr)
+		}
 		return nil, err
 	}
 	newStatus.UpdateRevision = hash
-	newStatus.ObservedGeneration = ss.Generation
 	newStatus.CurrentRevision = name
+	utils.SetCondition(&newStatus.Conditions, metav1.Condition{
+		Type:               string(agentsv1alpha1.SandboxSetConditionTemplateResolved),
+		Status:             metav1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Reason:             agentsv1alpha1.SandboxSetReasonTemplateResolved,
+		Message:            "Sandbox template resolved",
+	})
 
 	// Compute legacy hash for backward compatibility with sandboxes created
 	// before the hash algorithm was changed. Errors are non-fatal: if legacy
@@ -138,10 +157,6 @@ func NewSandboxFromSandboxSet(sbs *agentsv1alpha1.SandboxSet, refTemplate *agent
 	// source pod template before reading labels/annotations so subsequent
 	// mutations (clearAndInitInnerKeys, internal label writes) never leak
 	// back into the SandboxSet spec or the cached SandboxTemplate.
-	// The metadata maps are cloned (not shared) so that the internal labels
-	// written below land only on the Sandbox metadata: if they shared the Pod
-	// template's maps, they would be persisted into spec.template and thus
-	// propagated onto every Pod created from it.
 	if sbs.Spec.Template != nil {
 		template = sbs.Spec.Template.DeepCopy()
 		inheritedLabels = maps.Clone(template.Labels)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -47,12 +47,16 @@ func TruncateConditionMessage(msg string) string {
 }
 
 func SetSandboxCondition(status *agentsv1alpha1.SandboxStatus, condition metav1.Condition) {
-	currentCond := GetSandboxCondition(status, condition.Type)
+	SetCondition(&status.Conditions, condition)
+}
+
+func SetCondition(conditions *[]metav1.Condition, condition metav1.Condition) {
+	currentCond := GetCondition(*conditions, condition.Type)
 	if currentCond != nil && currentCond.Status == condition.Status && currentCond.Reason == condition.Reason &&
 		currentCond.Message == condition.Message {
 		return
 	} else if currentCond == nil {
-		status.Conditions = append(status.Conditions, condition)
+		*conditions = append(*conditions, condition)
 		return
 	}
 	if currentCond.Status != condition.Status || currentCond.LastTransitionTime.IsZero() {
@@ -64,8 +68,12 @@ func SetSandboxCondition(status *agentsv1alpha1.SandboxStatus, condition metav1.
 }
 
 func GetSandboxCondition(status *agentsv1alpha1.SandboxStatus, condType string) *metav1.Condition {
-	for i := range status.Conditions {
-		c := &status.Conditions[i]
+	return GetCondition(status.Conditions, condType)
+}
+
+func GetCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conditions {
+		c := &conditions[i]
 		if c.Type == condType {
 			return c
 		}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -150,6 +150,36 @@ func TestSetSandboxCondition(t *testing.T) {
 	}
 }
 
+func TestSetCondition(t *testing.T) {
+	transitionTime := metav1.Now()
+	conditions := []metav1.Condition{
+		{
+			Type:               "Ready",
+			Status:             metav1.ConditionFalse,
+			LastTransitionTime: transitionTime,
+			Reason:             "OldReason",
+			Message:            "old message",
+		},
+	}
+
+	SetCondition(&conditions, metav1.Condition{
+		Type:               "Ready",
+		Status:             metav1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Reason:             "NewReason",
+		Message:            "new message",
+	})
+
+	cond := GetCondition(conditions, "Ready")
+	if cond == nil {
+		t.Fatal("expected condition")
+	}
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Equal(t, "NewReason", cond.Reason)
+	assert.Equal(t, "new message", cond.Message)
+	assert.NotEqual(t, transitionTime, cond.LastTransitionTime)
+}
+
 func TestTruncateConditionMessage(t *testing.T) {
 	// Ensure default MaxConditionMessageLen is 1024 (no env override in this test).
 	if MaxConditionMessageLen != 1024 {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Surface missing SandboxTemplate references to users instead of leaving the CR status without the root cause.

- Set `TemplateResolved=False` when SandboxSet `templateRef` resolution fails during status initialization.
- Set Sandbox `Ready=False` when Pod generation fails before Pod creation, including missing `templateRef`.
- Add regression tests for visible condition feedback on missing template references.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

NONE

### Ⅲ. Describe how to verify it

- `GOCACHE=/private/tmp/agents-go-build-cache go test ./pkg/controller/sandbox/core -count=1`
- `GOCACHE=/private/tmp/agents-go-build-cache go test ./pkg/controller/sandboxset -count=1`
- `GOCACHE=/private/tmp/agents-go-build-cache go test ./pkg/controller/sandbox/... -count=1`

### Ⅳ. Special notes for reviews

The local git transport to GitHub was unavailable in this environment, so the branch commit was created on the fork through GitHub API with the same file changes and Signed-off-by trailer.