### PR TITLE
fix(cache): index sandboxes by pool label

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -842,6 +842,24 @@ func TestCache_ListSandboxesInPool(t *testing.T) {
 			Name: "pool-sbx-1", Namespace: "default",
 			Labels: map[string]string{
 				agentsv1alpha1.LabelSandboxTemplate: "tmpl-a",
+				agentsv1alpha1.LabelSandboxPool:     "tmpl-a",
+			},
+			OwnerReferences: []metav1.OwnerReference{sbsRef},
+		},
+		Status: agentsv1alpha1.SandboxStatus{
+			Phase: agentsv1alpha1.SandboxRunning,
+			Conditions: []metav1.Condition{
+				{Type: string(agentsv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue},
+			},
+		},
+	}
+	templateRefSbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-ref-pool-sbx-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				agentsv1alpha1.LabelSandboxTemplate: "shared-template",
+				agentsv1alpha1.LabelSandboxPool:     "shared-pool",
 			},
 			OwnerReferences: []metav1.OwnerReference{sbsRef},
 		},
@@ -853,7 +871,7 @@ func TestCache_ListSandboxesInPool(t *testing.T) {
 		},
 	}
 
-	c, _, err := cachetest.NewTestCache(t, sbx)
+	c, _, err := cachetest.NewTestCache(t, sbx, templateRefSbx)
 	require.NoError(t, err)
 
 	list, err := c.ListSandboxesInPool(t.Context(), cache.ListSandboxesInPoolOptions{Pool: "tmpl-a"})
@@ -862,6 +880,15 @@ func TestCache_ListSandboxesInPool(t *testing.T) {
 	assert.Equal(t, "pool-sbx-1", list[0].Name)
 
 	list, err = c.ListSandboxesInPool(t.Context(), cache.ListSandboxesInPoolOptions{Pool: "tmpl-nonexistent"})
+	require.NoError(t, err)
+	assert.Len(t, list, 0)
+
+	list, err = c.ListSandboxesInPool(t.Context(), cache.ListSandboxesInPoolOptions{Pool: "shared-pool"})
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, "template-ref-pool-sbx-1", list[0].Name)
+
+	list, err = c.ListSandboxesInPool(t.Context(), cache.ListSandboxesInPoolOptions{Pool: "shared-template"})
 	require.NoError(t, err)
 	assert.Len(t, list, 0)
 }
@@ -877,9 +904,12 @@ func TestCache_ListSandboxesInPoolWithOptions_NamespaceScoped(t *testing.T) {
 	sandboxes := []ctrlclient.Object{
 		&agentsv1alpha1.Sandbox{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            "pool-a",
-				Namespace:       "team-a",
-				Labels:          map[string]string{agentsv1alpha1.LabelSandboxTemplate: "shared-template"},
+				Name:      "pool-a",
+				Namespace: "team-a",
+				Labels: map[string]string{
+					agentsv1alpha1.LabelSandboxTemplate: "shared-template",
+					agentsv1alpha1.LabelSandboxPool:     "shared-template",
+				},
 				OwnerReferences: []metav1.OwnerReference{sbsRef},
 			},
 			Status: agentsv1alpha1.SandboxStatus{
@@ -889,9 +919,12 @@ func TestCache_ListSandboxesInPoolWithOptions_NamespaceScoped(t *testing.T) {
 		},
 		&agentsv1alpha1.Sandbox{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            "pool-b",
-				Namespace:       "team-b",
-				Labels:          map[string]string{agentsv1alpha1.LabelSandboxTemplate: "shared-template"},
+				Name:      "pool-b",
+				Namespace: "team-b",
+				Labels: map[string]string{
+					agentsv1alpha1.LabelSandboxTemplate: "shared-template",
+					agentsv1alpha1.LabelSandboxPool:     "shared-template",
+				},
 				OwnerReferences: []metav1.OwnerReference{sbsRef},
 			},
 			Status: agentsv1alpha1.SandboxStatus{

--- a/pkg/cache/index.go
+++ b/pkg/cache/index.go
@@ -76,9 +76,9 @@ func GetIndexFuncs() []IndexFunc {
 				state, _ := utils.GetSandboxState(sbx)
 				if state == agentsv1alpha1.SandboxStateAvailable ||
 					(state == agentsv1alpha1.SandboxStateCreating && utils.IsControlledBySandboxSet(sbx)) {
-					tmpl := utils.GetTemplateFromSandbox(sbx)
-					if tmpl != "" {
-						return []string{tmpl}
+					pool := sbx.GetLabels()[agentsv1alpha1.LabelSandboxPool]
+					if pool != "" {
+						return []string{pool}
 					}
 				}
 				return nil

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -569,7 +569,7 @@ func TestCommonControl_EnsureClaimClaiming_ClaimedGreaterThanZero(t *testing.T) 
 	// Create an available sandbox in the pool:
 	// - owned by SandboxSet (OwnerReference)
 	// - Phase=Running, Ready=True, PodIP set
-	// - has template label
+	// - has template and pool labels
 	availableSandbox := &agentsv1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "available-sbx-1",
@@ -586,6 +586,7 @@ func TestCommonControl_EnsureClaimClaiming_ClaimedGreaterThanZero(t *testing.T) 
 			},
 			Labels: map[string]string{
 				agentsv1alpha1.LabelSandboxTemplate: sbsName,
+				agentsv1alpha1.LabelSandboxPool:     sbsName,
 			},
 		},
 		Status: agentsv1alpha1.SandboxStatus{
@@ -765,9 +766,12 @@ func TestCommonControl_EnsureClaimClaiming_ResizeIncompatibleSandboxRetries(t *t
 	// candidate is incompatible and the claim must keep retrying.
 	warm := &agentsv1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              "warm-sbx",
-			Namespace:         "default",
-			Labels:            map[string]string{agentsv1alpha1.LabelSandboxTemplate: "test-template"},
+			Name:      "warm-sbx",
+			Namespace: "default",
+			Labels: map[string]string{
+				agentsv1alpha1.LabelSandboxTemplate: "test-template",
+				agentsv1alpha1.LabelSandboxPool:     "test-template",
+			},
 			Annotations:       map[string]string{},
 			CreationTimestamp: metav1.Now(),
 			OwnerReferences:   []metav1.OwnerReference{*metav1.NewControllerRef(sandboxSet, agentsv1alpha1.SandboxSetControllerKind)},

--- a/pkg/controller/sandboxclaim/sandboxclaim_controller_test.go
+++ b/pkg/controller/sandboxclaim/sandboxclaim_controller_test.go
@@ -181,6 +181,7 @@ func TestReconciler_Reconcile_Claiming(t *testing.T) {
 			Namespace: "default",
 			Labels: map[string]string{
 				agentsv1alpha1.LabelSandboxTemplate:  "test-sandboxset",
+				agentsv1alpha1.LabelSandboxPool:      "test-sandboxset",
 				agentsv1alpha1.LabelSandboxIsClaimed: "false",
 			},
 			CreationTimestamp: now,
@@ -215,6 +216,7 @@ func TestReconciler_Reconcile_Claiming(t *testing.T) {
 			CreationTimestamp: now,
 			Labels: map[string]string{
 				agentsv1alpha1.LabelSandboxTemplate:  "test-sandboxset",
+				agentsv1alpha1.LabelSandboxPool:      "test-sandboxset",
 				agentsv1alpha1.LabelSandboxIsClaimed: "false",
 			},
 			Annotations: map[string]string{}, // Initialize annotations map

--- a/pkg/sandbox-manager/api_test.go
+++ b/pkg/sandbox-manager/api_test.go
@@ -441,6 +441,7 @@ func TestSandboxManager_ClaimSandbox(t *testing.T) {
 							Namespace: "default",
 							Labels: map[string]string{
 								agentsv1alpha1.LabelSandboxTemplate: template,
+								agentsv1alpha1.LabelSandboxPool:     template,
 							},
 							CreationTimestamp: createAt,
 							Annotations:       map[string]string{},

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -678,6 +678,7 @@ func TestInfra_ClaimSandbox(t *testing.T) {
 						Namespace: "default",
 						Labels: map[string]string{
 							v1alpha1.LabelSandboxTemplate:        existTemplate,
+							v1alpha1.LabelSandboxPool:            existTemplate,
 							agentsv1alpha1.LabelSandboxIsClaimed: "false",
 						},
 						CreationTimestamp: now,
@@ -966,6 +967,7 @@ func TestClaimSandboxFailed(t *testing.T) {
 					Namespace: "default",
 					Labels: map[string]string{
 						v1alpha1.LabelSandboxTemplate: existTemplate,
+						v1alpha1.LabelSandboxPool:     existTemplate,
 					},
 					Annotations:       map[string]string{},
 					OwnerReferences:   GetSbsOwnerReference(),
@@ -2822,6 +2824,7 @@ func TestTryClaimSandbox_LockConflict(t *testing.T) {
 					UID:       types.UID(uuid.NewString()),
 					Labels: map[string]string{
 						v1alpha1.LabelSandboxTemplate:  existTemplate,
+						v1alpha1.LabelSandboxPool:      existTemplate,
 						v1alpha1.LabelSandboxIsClaimed: "false",
 					},
 					CreationTimestamp: metav1.Now(),
@@ -3847,6 +3850,7 @@ func createAvailableSandboxForFailureRecord(t *testing.T, fc client.Client, temp
 			Namespace: "default",
 			Labels: map[string]string{
 				v1alpha1.LabelSandboxTemplate:        template,
+				v1alpha1.LabelSandboxPool:            template,
 				agentsv1alpha1.LabelSandboxIsClaimed: "false",
 			},
 			Annotations:       map[string]string{},
@@ -3971,6 +3975,7 @@ func TestInfra_ClaimSandboxWithNamespace(t *testing.T) {
 							CreationTimestamp: now,
 							Labels: map[string]string{
 								v1alpha1.LabelSandboxTemplate:        "shared-template",
+								v1alpha1.LabelSandboxPool:            "shared-template",
 								agentsv1alpha1.LabelSandboxIsClaimed: "false",
 							},
 							Annotations:     map[string]string{},
@@ -4165,6 +4170,7 @@ func TestPickAnAvailableSandbox_PrefersMatchingRevision(t *testing.T) {
 						Name: fmt.Sprintf("match-%d", i), Namespace: "default",
 						Labels: map[string]string{
 							v1alpha1.LabelSandboxTemplate:  template,
+							v1alpha1.LabelSandboxPool:      template,
 							v1alpha1.LabelSandboxIsClaimed: "false",
 							v1alpha1.LabelTemplateHash:     updateRevision,
 						},
@@ -4186,6 +4192,7 @@ func TestPickAnAvailableSandbox_PrefersMatchingRevision(t *testing.T) {
 						Name: fmt.Sprintf("old-%d", i), Namespace: "default",
 						Labels: map[string]string{
 							v1alpha1.LabelSandboxTemplate:  template,
+							v1alpha1.LabelSandboxPool:      template,
 							v1alpha1.LabelSandboxIsClaimed: "false",
 							v1alpha1.LabelTemplateHash:     oldRevision,
 						},
@@ -4396,6 +4403,7 @@ func TestPickAnAvailableSandbox_ResizeCompatibilityUsesCandidateResources(t *tes
 				Namespace: "default",
 				Labels: map[string]string{
 					v1alpha1.LabelSandboxTemplate:  template,
+					v1alpha1.LabelSandboxPool:      template,
 					v1alpha1.LabelSandboxIsClaimed: "false",
 					v1alpha1.LabelTemplateHash:     templateHash,
 				},
@@ -4967,6 +4975,7 @@ func TestTryClaimSandbox_SecurityToken(t *testing.T) {
 					Namespace: "default",
 					Labels: map[string]string{
 						v1alpha1.LabelSandboxTemplate:        existTemplate,
+						v1alpha1.LabelSandboxPool:            existTemplate,
 						agentsv1alpha1.LabelSandboxIsClaimed: "false",
 					},
 					CreationTimestamp: metav1.Now(),

--- a/pkg/servers/e2b/core_test.go
+++ b/pkg/servers/e2b/core_test.go
@@ -463,11 +463,12 @@ func GetSbsOwnerReference(sbs *agentsv1alpha1.SandboxSet) []metav1.OwnerReferenc
 }
 
 type CreateSandboxPoolOptions struct {
-	Namespace   string
-	RuntimeURL  string
-	AccessToken string
-	CPURequest  string
-	Memory      string
+	Namespace     string
+	TemplateLabel string
+	RuntimeURL    string
+	AccessToken   string
+	CPURequest    string
+	Memory        string
 }
 
 func CreateSandboxPool(t *testing.T, controller *Controller, name string, available int, opts ...CreateSandboxPoolOptions) func() {
@@ -478,6 +479,10 @@ func CreateSandboxPool(t *testing.T, controller *Controller, name string, availa
 	ns := Namespace
 	if options.Namespace != "" {
 		ns = options.Namespace
+	}
+	templateLabel := name
+	if options.TemplateLabel != "" {
+		templateLabel = options.TemplateLabel
 	}
 	container := corev1.Container{Name: "main", Image: "old-image"}
 	if options.CPURequest != "" || options.Memory != "" {
@@ -519,7 +524,8 @@ func CreateSandboxPool(t *testing.T, controller *Controller, name string, availa
 			ObjectMeta: metav1.ObjectMeta{
 				Name: fmt.Sprintf("%s-%d", name, i), Namespace: ns,
 				Labels: map[string]string{
-					agentsv1alpha1.LabelSandboxTemplate:  name,
+					agentsv1alpha1.LabelSandboxTemplate:  templateLabel,
+					agentsv1alpha1.LabelSandboxPool:      name,
 					agentsv1alpha1.LabelSandboxIsClaimed: "false",
 				},
 				Annotations: annotations, OwnerReferences: GetSbsOwnerReference(sbs),

--- a/pkg/servers/e2b/create_test.go
+++ b/pkg/servers/e2b/create_test.go
@@ -1255,6 +1255,35 @@ func TestCreateSandbox_TopLevelMissingTemplateOrCheckpointReturns400(t *testing.
 	assert.Equal(t, int64(0), fakeQuota.acquireCalls.Load())
 }
 
+func TestCreateSandbox_ClaimsTemplateRefPoolBySandboxSetName(t *testing.T) {
+	fakeQuota := &fakeQuotaManager{}
+	controller, _, teardown := SetupWithQuota(t, fakeQuota)
+	defer teardown()
+	cleanup := CreateSandboxPool(t, controller, "shared-pool", 1, CreateSandboxPoolOptions{
+		TemplateLabel: "shared-template",
+	})
+	defer cleanup()
+
+	user := quotaLimitedUser([]quotaspec.QuotaLimit{{
+		Dimension: quotaspec.DimLimitsCPU,
+		Scope:     quotaspec.ScopeRunning,
+		Limit:     4000,
+	}})
+
+	resp, apiErr := controller.CreateSandbox(NewRequest(t, nil, models.NewSandboxRequest{
+		TemplateID: "shared-pool",
+		Metadata: map[string]string{
+			models.ExtensionKeySkipInitRuntime: v1alpha1.True,
+		},
+	}, nil, user))
+
+	require.Nil(t, apiErr)
+	require.NotNil(t, resp.Body)
+	assert.Equal(t, http.StatusCreated, resp.Code)
+	assert.Equal(t, "admin--shared-pool-0", resp.Body.SandboxID)
+	assert.Equal(t, int64(1), fakeQuota.acquireCalls.Load())
+}
+
 func TestCreateSandbox_MemoryOverridePropagatedToClaimedSandbox(t *testing.T) {
 	fakeQuota := &fakeQuotaManager{}
 	controller, client, teardown := SetupWithQuota(t, fakeQuota)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

This PR fixes pooled Sandbox lookup for SandboxSet templateRef mode.

Previously, the cache field index named `IndexSandboxPool` indexed available Sandbox objects by `utils.GetTemplateFromSandbox()`. That helper prefers `agents.kruise.io/sandbox-template` over `agents.kruise.io/sandbox-pool`. In templateRef mode, SandboxSet-created Sandbox objects have:

- `agents.kruise.io/sandbox-template=shared-template`
- `agents.kruise.io/sandbox-pool=shared-pool`

SandboxClaim requests inventory by pool name through `ListSandboxesInPool(Pool: "shared-pool")`, so those Sandbox objects were indexed under `shared-template` and were not discoverable by the claim path.

This PR changes the `IndexSandboxPool` extractor to index by `LabelSandboxPool` directly. `LabelSandboxTemplate` continues to represent which template produced the Sandbox and remains available through existing template helpers.

It also updates test fixtures that manually create available pooled Sandboxes so they include the pool label produced by the SandboxSet controller.

For the E2B API, `templateID` is treated as the SandboxSet/pool ID. The `/templates` API is backed by SandboxSets, `CreateSandbox` first resolves `request.TemplateID` through `HasTemplate(Name: request.TemplateID)`, and the claim path passes that same value to `ClaimSandboxOptions.Template`. A referenced SandboxTemplate name is not an E2B template ID unless there is also a SandboxSet with that name. This PR adds an E2B regression test where `sandbox-template=shared-template` diverges from `sandbox-pool=shared-pool` and `templateID=shared-pool` claims the pooled Sandbox.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

Unit/regression tests:

```bash
env GOCACHE=/private/tmp/codex-go-build-cache go test ./pkg/cache -run TestCache_ListSandboxesInPool -count=1
env GOCACHE=/private/tmp/codex-go-build-cache go test ./pkg/cache ./pkg/sandbox-manager/infra/sandboxcr -count=1
env GOCACHE=/private/tmp/codex-go-build-cache go test -race ./pkg/servers/e2b -run TestCreateSandbox_ClaimsTemplateRefPoolBySandboxSetName -count=1
env GOCACHE=/private/tmp/codex-go-build-cache go test -race ./pkg/cache ./pkg/sandbox-manager ./pkg/sandbox-manager/infra/sandboxcr ./pkg/controller/sandboxclaim ./pkg/controller/sandboxclaim/core ./pkg/servers/e2b -count=1
env GOCACHE=/private/tmp/codex-go-build-cache go test -race ./pkg/...
```

Minimal minikube reproduction YAML:

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: sandbox-pool-index-repro
---
apiVersion: agents.kruise.io/v1alpha1
kind: SandboxTemplate
metadata:
  name: shared-template
  namespace: sandbox-pool-index-repro
spec:
  template:
    metadata:
      labels:
        app: sandbox-pool-index-repro
    spec:
      containers:
        - name: pause
          image: registry.k8s.io/pause:3.9
          imagePullPolicy: IfNotPresent
      terminationGracePeriodSeconds: 1
---
apiVersion: agents.kruise.io/v1alpha1
kind: SandboxSet
metadata:
  name: shared-pool
  namespace: sandbox-pool-index-repro
spec:
  replicas: 1
  templateRef:
    name: shared-template
---
apiVersion: agents.kruise.io/v1alpha1
kind: SandboxClaim
metadata:
  name: claim-shared-pool
  namespace: sandbox-pool-index-repro
spec:
  templateName: shared-pool
  replicas: 1
  claimTimeout: 30s
  ttlAfterCompleted: "-1s"
  createOnNoStock: false
  skipInitRuntime: true
```

Minikube reproduction commands:

```bash
kubectl apply -f repro-template-ref-pool-claim.yaml
kubectl -n sandbox-pool-index-repro wait --for=condition=Ready sandbox --all --timeout=120s
kubectl -n sandbox-pool-index-repro get sandboxsets,sandboxes,sandboxclaims,pods -o wide --show-labels
```

Reproduction case:

1. Create a `SandboxTemplate` named `shared-template`.
2. Create a `SandboxSet` named `shared-pool` with `spec.templateRef.name=shared-template`.
3. Wait until the pool has one available Sandbox.
4. Create a `SandboxClaim` with `spec.templateName=shared-pool`, `createOnNoStock=false`, and `skipInitRuntime=true`.
5. The claim should acquire the available Sandbox from `shared-pool`.

Observed before this fix on minikube:

```text
Sandbox labels:
agents.kruise.io/sandbox-claimed=false
agents.kruise.io/sandbox-pool=shared-pool
agents.kruise.io/sandbox-template=shared-template

SandboxSet status:
availableReplicas: 1
selector: agents.kruise.io/sandbox-claimed=false,agents.kruise.io/sandbox-pool=shared-pool

SandboxClaim status:
phase: Completed
claimedReplicas: 0
message: Timeout reached after 30.492137334s, claimed 0/1 sandboxes
```

That shows the inventory Sandbox exists in the requested pool, but the claim path cannot find it because the cache index uses the template label instead of the pool label.

### Ⅳ. Special notes for reviews

The production change is intentionally limited to the cache index extractor. It does not change `utils.GetTemplateFromSandbox`, because that helper still preserves the existing "template source" semantics needed outside pool lookup.
