### PR TITLE
feat: improve CSI mount error observability in SandboxClaim

### DIFF
--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -159,6 +159,9 @@ func (c *commonControl) EnsureClaimClaiming(ctx context.Context, args ClaimArgs)
 	finalCount := currentCount + int32(claimed) // #nosec G115 -- K8s object count
 	args.NewStatus.ClaimedReplicas = finalCount
 	args.NewStatus.Message = fmt.Sprintf("Claiming sandboxes: %d/%d claimed", finalCount, desiredReplicas)
+	if err != nil {
+		args.NewStatus.Message = fmt.Sprintf("%s, last error: %s", args.NewStatus.Message, utils.TruncateConditionMessage(err.Error()))
+	}
 
 	// Step 10: Record results and determine requeue strategy
 	if claimed > 0 {
@@ -176,8 +179,11 @@ func (c *commonControl) EnsureClaimClaiming(ctx context.Context, args ClaimArgs)
 	// No progress - no available sandboxes
 	log.Info("No available sandboxes, will retry",
 		"retryInterval", ClaimRetryInterval)
-	c.recorder.Event(claim, "Warning", "NoAvailableSandboxes",
-		fmt.Sprintf("No available sandboxes in pool %s", sandboxSet.Name))
+	eventMsg := fmt.Sprintf("No available sandboxes in pool %s", sandboxSet.Name)
+	if err != nil {
+		eventMsg = fmt.Sprintf("%s, last error: %s", eventMsg, utils.TruncateConditionMessage(err.Error()))
+	}
+	c.recorder.Event(claim, "Warning", "NoAvailableSandboxes", eventMsg)
 	sandboxSetClaimsTotal.WithLabelValues(claim.Namespace, "failed").Inc()
 	// Retry after interval to avoid busy loop
 	return RequeueAfter(ClaimRetryInterval), nil

--- a/pkg/sandbox-manager/infra/sandboxcr/infra.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra.go
@@ -211,8 +211,13 @@ func buildClaimError(err error, lastError error, failures []infra.PickSandboxFai
 	if errors.As(err, &mErr) {
 		return mErr
 	}
-	// Retry exhausted or interrupted: wrap as Internal
-	base := fmt.Sprintf("%v, last error: %v", err, lastError)
+	// Retry exhausted or interrupted: wrap as Internal. On retry exhaustion the
+	// caller already promoted lastError into err, so appending it again would
+	// duplicate the whole message (stderr included).
+	base := fmt.Sprintf("%v", err)
+	if lastError != nil && lastError.Error() != err.Error() {
+		base = fmt.Sprintf("%s, last error: %v", base, lastError)
+	}
 	if len(failures) > 0 {
 		raw, marshalErr := json.Marshal(failures)
 		if marshalErr == nil {

--- a/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/infra_test.go
@@ -1469,6 +1469,7 @@ func TestBuildClaimError_PreservesTerminalError(t *testing.T) {
 		failures        []infra.PickSandboxFailure
 		expectErrorCode managererrors.ErrorCode
 		expectCause     bool
+		expectError     string
 	}{
 		{
 			name:            "nil error returns nil",
@@ -1495,6 +1496,23 @@ func TestBuildClaimError_PreservesTerminalError(t *testing.T) {
 			lastError:       fmt.Errorf("last attempt failed"),
 			expectErrorCode: managererrors.ErrorInternal,
 			expectCause:     true,
+			expectError:     "retry exhausted, last error: last attempt failed",
+		},
+		{
+			name:            "last error identical to err is not duplicated",
+			err:             fmt.Errorf("failed to perform csi mount: stderr: ossfs failed"),
+			lastError:       fmt.Errorf("failed to perform csi mount: stderr: ossfs failed"),
+			expectErrorCode: managererrors.ErrorInternal,
+			expectCause:     true,
+			expectError:     "failed to perform csi mount: stderr: ossfs failed",
+		},
+		{
+			name:            "claim timeout keeps the distinct last error",
+			err:             context.DeadlineExceeded,
+			lastError:       fmt.Errorf("failed to perform csi mount: stderr: ossfs failed"),
+			expectErrorCode: managererrors.ErrorInternal,
+			expectCause:     true,
+			expectError:     "context deadline exceeded, last error: failed to perform csi mount: stderr: ossfs failed",
 		},
 	}
 	for _, tt := range tests {
@@ -1507,6 +1525,9 @@ func TestBuildClaimError_PreservesTerminalError(t *testing.T) {
 			code := managererrors.GetErrCode(result)
 			assert.Equal(t, tt.expectErrorCode, code)
 			assert.Equal(t, tt.expectCause, errors.Is(result, tt.err))
+			if tt.expectError != "" {
+				assert.Equal(t, tt.expectError, result.(*managererrors.Error).Message)
+			}
 		})
 	}
 }

--- a/pkg/utils/runtime/csi.go
+++ b/pkg/utils/runtime/csi.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -74,10 +75,10 @@ func CSIMount(ctx context.Context, sbx *agentsv1alpha1.Sandbox, driver string, r
 	})
 	if err != nil {
 		log.Error(err, "failed to run command", "stdout", result.Stdout, "stderr", result.Stderr)
-		return err
+		return fmt.Errorf("%w%s", err, stderrSuffix(result.Stderr))
 	}
 	if result.ExitCode != 0 {
-		err = fmt.Errorf("command failed: [%d] %s", result.ExitCode, result.Stderr)
+		err = fmt.Errorf("command failed: [%d]%s", result.ExitCode, stderrSuffix(result.Stderr))
 		log.Error(err, "command failed", "exitCode", result.ExitCode)
 		return err
 	}
@@ -232,4 +233,15 @@ func ResolveCSIMountFromAnnotation(ctx context.Context, obj metav1.Object, clien
 		mountOptionList = append(mountOptionList, config.MountConfig{Driver: driverName, PublishRequest: publishRequest})
 	}
 	return &config.CSIMountOptions{MountOptionList: mountOptionList}, nil
+}
+
+// stderrSuffix appends captured stderr only when there is some, so the
+// transport-error path - where the command never ran and produced none - does
+// not end the message with a dangling label.
+func stderrSuffix(stderr []string) string {
+	joined := strings.Join(stderr, "")
+	if joined == "" {
+		return ""
+	}
+	return ", stderr: " + joined
 }

--- a/pkg/utils/runtime/csi_test.go
+++ b/pkg/utils/runtime/csi_test.go
@@ -810,3 +810,31 @@ func TestDoCSIMount_TransportDispatch(t *testing.T) {
 		})
 	}
 }
+
+// The transport-error path reports a command that never ran, so there is no
+// stderr to show and the message must not end on an empty label.
+func TestStderrSuffix(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr []string
+		expect string
+	}{
+		{name: "nothing captured yields nothing"},
+		{name: "empty strings count as nothing", stderr: []string{"", ""}},
+		{
+			name:   "captured output is labelled",
+			stderr: []string{"ossfs: mount failed\n"},
+			expect: ", stderr: ossfs: mount failed\n",
+		},
+		{
+			name:   "several lines are joined as captured",
+			stderr: []string{"first\n", "second\n"},
+			expect: ", stderr: first\nsecond\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, stderrSuffix(tt.stderr))
+		})
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net"
 	"time"
+	"unicode/utf8"
 
 	"github.com/golang/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
@@ -43,7 +44,14 @@ func TruncateConditionMessage(msg string) string {
 	if len(msg) <= MaxConditionMessageLen {
 		return msg
 	}
-	return msg[:MaxConditionMessageLen] + "..."
+	// Back off to a rune boundary. The limit counts bytes, and these messages
+	// carry paths and mount helper output, so a cut landing mid-character would
+	// put a replacement character in the very field this exists to make readable.
+	cut := MaxConditionMessageLen
+	for cut > 0 && !utf8.RuneStart(msg[cut]) {
+		cut--
+	}
+	return msg[:cut] + "..."
 }
 
 func SetSandboxCondition(status *agentsv1alpha1.SandboxStatus, condition metav1.Condition) {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -183,6 +184,32 @@ func TestTruncateConditionMessage(t *testing.T) {
 			got := TruncateConditionMessage(tt.msg)
 			if got != tt.expected {
 				t.Fatalf("TruncateConditionMessage() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+// A message carries paths and mount helper output, so the byte limit can land
+// inside a multi-byte character. Shifting the character across the cut covers
+// every way it can straddle it.
+func TestTruncateConditionMessageNeverSplitsARune(t *testing.T) {
+	const wide = "世"
+	for shift := 0; shift < len(wide)+1; shift++ {
+		t.Run(fmt.Sprintf("character starts %d bytes before the limit", len(wide)-shift), func(t *testing.T) {
+			msg := strings.Repeat("a", MaxConditionMessageLen-len(wide)+shift) + wide + strings.Repeat("b", 16)
+			got := TruncateConditionMessage(msg)
+
+			if !utf8.ValidString(got) {
+				t.Fatalf("TruncateConditionMessage() produced invalid UTF-8: %q", got[len(got)-8:])
+			}
+			if strings.ContainsRune(got, utf8.RuneError) {
+				t.Fatalf("TruncateConditionMessage() emitted a replacement character: %q", got[len(got)-8:])
+			}
+			if !strings.HasSuffix(got, "...") {
+				t.Fatalf("TruncateConditionMessage() dropped the ellipsis: %q", got)
+			}
+			if len(got) > MaxConditionMessageLen+len("...") {
+				t.Fatalf("TruncateConditionMessage() len = %d, must not exceed the limit", len(got))
 			}
 		})
 	}


### PR DESCRIPTION


<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
- Include stderr content in CSIMount error messages
- Add last error to SandboxClaim status.Message and Warning events
- Add truncateError helper for event message length limits
- Keep the last error on the clone path so a CloneTimeout no longer discards the CSI mount cause, mirroring the claim path
- Stop duplicating the whole message on both paths when the retry loop already promoted the last error into the returned error

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it


### Ⅳ. Special notes for reviews

