### PR TITLE
fix(e2b): persist configured admin key and skip unreadable Secret entries

### DIFF
--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/spf13/pflag"
 	zapRaw "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -113,7 +112,7 @@ func main() {
 
 	// Register server configuration flags
 	pflag.IntVar(&port, "port", 8080, "The port the server listens on")
-	pflag.StringVar(&e2bAdminKey, "e2b-admin-key", "", "E2B admin API key (if empty, a random UUID will be generated)")
+	pflag.StringVar(&e2bAdminKey, "e2b-admin-key", "", "E2B admin API key (required when --e2b-enable-auth is true)")
 	pflag.BoolVar(&e2bEnableAuth, "e2b-enable-auth", true, "Enable E2B authentication")
 	pflag.StringVar(&domain, "e2b-domain", "",
 		"Static E2B domain. When empty, the domain is resolved per-request from "+
@@ -196,9 +195,8 @@ func main() {
 		klog.Fatalf("--peer-selector is required")
 	}
 
-	// Generate admin key if not provided
-	if e2bAdminKey == "" {
-		e2bAdminKey = uuid.NewString()
+	if e2bEnableAuth && e2bAdminKey == "" {
+		klog.Fatalf("--e2b-admin-key is required when --e2b-enable-auth is true")
 	}
 
 	// Validate positive values

--- a/pkg/servers/e2b/keys/AGENTS.md
+++ b/pkg/servers/e2b/keys/AGENTS.md
@@ -17,6 +17,7 @@ explicitly says otherwise.
   closed when safe invalidation cannot be determined.
 - Never delete the well-known admin key. Team cleanup must never remove the
   admin team.
+- The well-known admin key has no quota; do not persist one.
 - Storage backends use the API layer's canonical team identity. Team-scoped
   listing must not regress to creator-scoped behavior.
 - Invalid stored quota remains availability-compatible on authentication paths,

--- a/pkg/servers/e2b/keys/AGENTS.md
+++ b/pkg/servers/e2b/keys/AGENTS.md
@@ -16,7 +16,7 @@ explicitly says otherwise.
 - Authentication caches are populated and invalidated conservatively. Fail
   closed when safe invalidation cannot be determined.
 - Never delete the well-known admin key. Team cleanup must never remove the
-  admin team.
+  admin team. The well-known admin key belongs to the admin team.
 - The well-known admin key has no quota; do not persist one.
 - Storage backends use the API layer's canonical team identity. Team-scoped
   listing must not regress to creator-scoped behavior.

--- a/pkg/servers/e2b/keys/mysql.go
+++ b/pkg/servers/e2b/keys/mysql.go
@@ -217,6 +217,10 @@ func (k *mysqlKeyStorage) ensureAdminKey(ctx context.Context, adminTeamID uint) 
 		return nil
 	}
 
+	if adminKeyEqual(existing, key) {
+		return nil
+	}
+
 	return k.updateAdminKey(ctx, key)
 }
 

--- a/pkg/servers/e2b/keys/mysql_test.go
+++ b/pkg/servers/e2b/keys/mysql_test.go
@@ -148,7 +148,6 @@ func TestMySQL_InitBranches(t *testing.T) {
 		h := st.hashKey("admin")
 		mock.ExpectQuery("SELECT .*FROM `teams`.*").WillReturnRows(sqlmock.NewRows([]string{"id", "uid", "name"}).AddRow(1, AdminTeamUID.String(), "admin"))
 		mock.ExpectQuery("SELECT .*FROM `team_api_keys`.*").WillReturnRows(sqlmock.NewRows([]string{"id", "uid", "key_hash", "name", "team_id", "deleted_at"}).AddRow(1, AdminKeyID.String(), h, "admin", 1, nil))
-		mock.ExpectExec(updateAdminKeyRegex).WillReturnResult(sqlmock.NewResult(0, 1))
 		require.NoError(t, st.Init(context.Background()))
 	})
 
@@ -172,7 +171,6 @@ func TestMySQL_InitBranches(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 		mock.ExpectQuery("SELECT .*FROM `teams`.*").WillReturnRows(sqlmock.NewRows([]string{"id", "uid", "name"}).AddRow(1, AdminTeamUID.String(), "admin"))
 		mock.ExpectQuery("SELECT .*FROM `team_api_keys`.*").WillReturnRows(sqlmock.NewRows([]string{"id", "uid", "key_hash", "name", "team_id", "deleted_at"}).AddRow(1, AdminKeyID.String(), h, "admin", 1, nil))
-		mock.ExpectExec(updateAdminKeyRegex).WillReturnResult(sqlmock.NewResult(0, 1))
 
 		require.NoError(t, st.Init(context.Background()))
 		require.Zero(t, autoMigrateCalls)
@@ -221,12 +219,21 @@ func TestMySQL_EnsureAdminTeamAndKey(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("ensure admin key existing", func(t *testing.T) {
+	t.Run("ensure admin key existing already matches", func(t *testing.T) {
 		st, mock, done := newMockStorage(t)
 		defer done()
 		h := st.hashKey("admin")
 		mock.ExpectQuery("SELECT .*FROM `team_api_keys`.*").WillReturnRows(
 			sqlmock.NewRows([]string{"id", "uid", "key_hash", "name", "team_id", "deleted_at"}).AddRow(1, AdminKeyID.String(), h, "admin", 1, nil),
+		)
+		require.NoError(t, st.ensureAdminKey(context.Background(), 1))
+	})
+
+	t.Run("ensure admin key existing stale updates", func(t *testing.T) {
+		st, mock, done := newMockStorage(t)
+		defer done()
+		mock.ExpectQuery("SELECT .*FROM `team_api_keys`.*").WillReturnRows(
+			sqlmock.NewRows([]string{"id", "uid", "key_hash", "name", "team_id", "deleted_at"}).AddRow(1, AdminKeyID.String(), "stale-hash", "admin", 1, nil),
 		)
 		mock.ExpectExec(updateAdminKeyRegex).WillReturnResult(sqlmock.NewResult(0, 1))
 		require.NoError(t, st.ensureAdminKey(context.Background(), 1))

--- a/pkg/servers/e2b/keys/secret.go
+++ b/pkg/servers/e2b/keys/secret.go
@@ -116,6 +116,11 @@ func init() {
 
 // secretKeyStorage is a simple implement for api-key storage using k8s secret as storage backend.
 // It is only for demo purpose.
+//
+// Unreadable or otherwise invalid Secret.Data entries are treated as absent.
+// Admin load, refresh, team lookup, and list paths skip them and continue; they
+// must not fail the surrounding operation. Kubernetes API errors (missing
+// Secret, conflict, patch failure) remain real failures.
 type secretKeyStorage struct {
 	Namespace string
 	AdminKey  string
@@ -156,33 +161,62 @@ func (k *secretKeyStorage) Init(ctx context.Context) error {
 	log := klog.FromContext(ctx)
 	log.Info("ensuring api-key store secret")
 
-	secret := &corev1.Secret{}
-	if err := k.APIReader.Get(ctx, client.ObjectKey{Namespace: k.Namespace, Name: KeySecretName}, secret); err != nil {
+	if err := k.ensureAdminKey(ctx); err != nil {
 		return err
 	}
 
-	// create admin key if needed. Presence is keyed by AdminKeyID because that is
-	// the Secret.Data map key used by patch/refresh; checking k.AdminKey (the raw
-	// key string) would miss an already-persisted admin entry and re-patch on every Init.
-	// all replicas does the same operation, no matter who eventually wins the race.
-	if _, ok := secret.Data[AdminKeyID.String()]; !ok {
-		adminKey := &models.CreatedTeamAPIKey{
-			CreatedAt: time.Now(),
-			ID:        AdminKeyID,
-			Key:       k.AdminKey,
-			Name:      "admin",
-			Team:      models.AdminTeam(),
-		}
-		if _, err := k.retryPatchSecretKey(ctx, k.APIReader, AdminKeyID.String(), func(*corev1.Secret) *models.CreatedTeamAPIKey {
-			return adminKey
-		}); err != nil && !apierrors.IsConflict(err) {
-			return err
-		} else if err == nil {
-			log.Info("create admin key success", "id", adminKey.ID)
-		}
-	}
-
 	return k.refresh(ctx, k.APIReader)
+}
+
+func (k *secretKeyStorage) ensureAdminKey(ctx context.Context) error {
+	log := klog.FromContext(ctx)
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &corev1.Secret{}
+		if err := k.APIReader.Get(ctx, client.ObjectKey{Namespace: k.Namespace, Name: KeySecretName}, current); err != nil {
+			return err
+		}
+		if !adminKeyStateSatisfied(current, k.AdminKey) {
+			desired := &models.CreatedTeamAPIKey{
+				CreatedAt: time.Now(),
+				ID:        AdminKeyID,
+				Key:       k.AdminKey,
+				Name:      "admin",
+				Team:      models.AdminTeam(),
+			}
+			if err := k.patchSecretKey(ctx, current, AdminKeyID.String(), desired); err != nil {
+				return err
+			}
+			log.Info("ensure admin key success", "id", desired.ID)
+		}
+		return nil
+	})
+	// Exhausted Conflict does not re-read after the last patch. Check the API
+	// server: succeed if the desired admin key is already there, otherwise fail.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	if err == nil || !apierrors.IsConflict(err) {
+		return err
+	}
+	rereadSecret := &corev1.Secret{}
+	if getErr := k.APIReader.Get(ctx, client.ObjectKey{Namespace: k.Namespace, Name: KeySecretName}, rereadSecret); getErr != nil {
+		return fmt.Errorf("ensure admin key: %w (reread after conflict: %v)", err, getErr)
+	}
+	if adminKeyStateSatisfied(rereadSecret, k.AdminKey) {
+		return nil
+	}
+	return fmt.Errorf("ensure admin key: persisted admin key does not match desired value: %w", err)
+}
+
+// adminKeyStateSatisfied reports whether Secret.Data[AdminKeyID] holds the
+// configured admin key. Missing or unreadable entries are treated as absent.
+func adminKeyStateSatisfied(secret *corev1.Secret, configuredKey string) bool {
+	raw, ok := secret.Data[AdminKeyID.String()]
+	if !ok {
+		return false
+	}
+	key, err := unmarshalStoredAPIKey(raw, false)
+	return err == nil && key.ID == AdminKeyID && key.Key == configuredKey
 }
 
 func (k *secretKeyStorage) refresh(ctx context.Context, reader client.Reader) error {
@@ -365,14 +399,17 @@ func (k *secretKeyStorage) retryPatchSecretKey(
 		patchedKey = apiKey
 		return nil
 	})
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
 	if err != nil {
 		return nil, err
 	}
 	return patchedKey, nil
 }
 
-// patchSecretKey upserts or deletes one Secret.Data entry. A nil apiKey means
-// delete the key at id; a non-nil apiKey means create or update that entry.
+// patchSecretKey upserts or deletes one Secret.Data entry.
+// A nil apiKey means delete the key at id; a non-nil apiKey means create or update it.
 func (k *secretKeyStorage) patchSecretKey(ctx context.Context, secret *corev1.Secret, id string, apiKey *models.CreatedTeamAPIKey) error {
 	base := secret.DeepCopy()
 
@@ -462,7 +499,7 @@ func (k *secretKeyStorage) CreateKey(ctx context.Context, key *models.CreatedTea
 	}
 
 	var newID, newKey uuid.UUID
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		newID = generateUUID()
 		newKey = generateUUID()
 		_, ok1 := k.LoadByID(ctx, newID.String())
@@ -549,6 +586,8 @@ func (k *secretKeyStorage) ListByOwnerTeam(_ context.Context, owner *models.Crea
 	return result, nil
 }
 
+// ListLimited returns keys whose stored quota is limited. Unreadable Secret
+// entries and invalid stored quota are omitted as absent.
 func (k *secretKeyStorage) ListLimited(ctx context.Context) ([]*models.CreatedTeamAPIKey, error) {
 	secret := &corev1.Secret{}
 	if err := k.APIReader.Get(ctx, client.ObjectKey{Namespace: k.Namespace, Name: KeySecretName}, secret); err != nil {
@@ -559,11 +598,8 @@ func (k *secretKeyStorage) ListLimited(ctx context.Context) ([]*models.CreatedTe
 	for id, raw := range secret.Data {
 		apiKey, err := unmarshalStoredAPIKey(raw, true)
 		if err != nil {
-			if errors.Is(err, quotaspec.ErrInvalidQuotaSpec) {
-				klog.FromContext(ctx).Error(err, "skip invalid api-key quota while listing limited keys", "apiKeyID", id)
-				continue
-			}
-			return nil, fmt.Errorf("decode stored api-key %q: %w", id, err)
+			klog.FromContext(ctx).Error(err, "skip unreadable api-key while listing limited keys", "apiKeyID", id)
+			continue
 		}
 		if apiKey.QuotaSpec == nil || !apiKey.QuotaSpec.IsLimited() {
 			continue

--- a/pkg/servers/e2b/keys/secret.go
+++ b/pkg/servers/e2b/keys/secret.go
@@ -193,14 +193,14 @@ func (k *secretKeyStorage) ensureAdminKey(ctx context.Context) error {
 	// Exhausted Conflict does not re-read after the last patch. Check the API
 	// server: succeed if the desired admin key is already there, otherwise fail.
 	if ctxErr := ctx.Err(); ctxErr != nil {
-		return ctxErr
+		return errors.Join(err, ctxErr)
 	}
 	if err == nil || !apierrors.IsConflict(err) {
 		return err
 	}
 	rereadSecret := &corev1.Secret{}
 	if getErr := k.APIReader.Get(ctx, client.ObjectKey{Namespace: k.Namespace, Name: KeySecretName}, rereadSecret); getErr != nil {
-		return fmt.Errorf("ensure admin key: %w (reread after conflict: %v)", err, getErr)
+		return fmt.Errorf("ensure admin key: %w", errors.Join(err, getErr))
 	}
 	if adminKeyStateSatisfied(rereadSecret, k.AdminKey) {
 		return nil
@@ -209,14 +209,19 @@ func (k *secretKeyStorage) ensureAdminKey(ctx context.Context) error {
 }
 
 // adminKeyStateSatisfied reports whether Secret.Data[AdminKeyID] holds the
-// configured admin key. Missing or unreadable entries are treated as absent.
+// configured admin key on the admin team. Missing or unreadable entries are
+// treated as absent.
 func adminKeyStateSatisfied(secret *corev1.Secret, configuredKey string) bool {
 	raw, ok := secret.Data[AdminKeyID.String()]
 	if !ok {
 		return false
 	}
 	key, err := unmarshalStoredAPIKey(raw, false)
-	return err == nil && key.ID == AdminKeyID && key.Key == configuredKey
+	return err == nil &&
+		key.ID == AdminKeyID &&
+		key.Key == configuredKey &&
+		key.Name == models.AdminTeamName &&
+		TeamForKey(key).Name == models.AdminTeamName
 }
 
 func (k *secretKeyStorage) refresh(ctx context.Context, reader client.Reader) error {
@@ -400,7 +405,7 @@ func (k *secretKeyStorage) retryPatchSecretKey(
 		return nil
 	})
 	if ctxErr := ctx.Err(); ctxErr != nil {
-		return nil, ctxErr
+		return nil, errors.Join(err, ctxErr)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/servers/e2b/keys/secret.go
+++ b/pkg/servers/e2b/keys/secret.go
@@ -193,6 +193,7 @@ func (k *secretKeyStorage) ensureAdminKey(ctx context.Context) error {
 	// Exhausted Conflict does not re-read after the last patch. Check the API
 	// server: succeed if the desired admin key is already there, otherwise fail.
 	if ctxErr := ctx.Err(); ctxErr != nil {
+		log.V(utils.DebugLogLevel).Error(ctxErr, "ensure admin key: request canceled")
 		return errors.Join(err, ctxErr)
 	}
 	if err == nil || !apierrors.IsConflict(err) {
@@ -405,6 +406,7 @@ func (k *secretKeyStorage) retryPatchSecretKey(
 		return nil
 	})
 	if ctxErr := ctx.Err(); ctxErr != nil {
+		klog.FromContext(ctx).V(utils.DebugLogLevel).Error(ctxErr, "retryPatchSecretKey: request canceled")
 		return nil, errors.Join(err, ctxErr)
 	}
 	if err != nil {

--- a/pkg/servers/e2b/keys/secret_test.go
+++ b/pkg/servers/e2b/keys/secret_test.go
@@ -292,20 +292,41 @@ func TestSecretKeyStorage_Init(t *testing.T) {
 				_, c := newSecretStorageForTest(t, map[string][]byte{
 					AdminKeyID.String(): b,
 				})
-				patchCalls := 0
 				hookClient := &patchHookClient{
 					Client: c,
 					patchHook: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
-						patchCalls++
-						return nil
+						return errors.New("unexpected patch")
 					},
 				}
 				return NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage), hookClient
+			},
+		},
+		{
+			name: "wrong team on admin key is repaired",
+			prepare: func(t *testing.T) (*secretKeyStorage, client.Client) {
+				admin := &models.CreatedTeamAPIKey{
+					ID:   AdminKeyID,
+					Key:  "admin-key",
+					Name: "not-admin",
+					Team: &models.Team{ID: uuid.New(), Name: "other-team"},
+				}
+				b, err := json.Marshal(admin)
+				require.NoError(t, err)
+				return newSecretStorageForTest(t, map[string][]byte{
+					AdminKeyID.String(): b,
+				})
 			},
 			assertion: func(t *testing.T, storage *secretKeyStorage, c client.Client) {
 				loaded, found := storage.LoadByID(context.Background(), AdminKeyID.String())
 				require.True(t, found)
 				require.Equal(t, "admin-key", loaded.Key)
+				require.Equal(t, models.AdminTeamName, loaded.Name)
+				require.Equal(t, models.AdminTeam(), loaded.Team)
+				secret := getSecretForTest(t, c)
+				var admin models.CreatedTeamAPIKey
+				require.NoError(t, json.Unmarshal(secret.Data[AdminKeyID.String()], &admin))
+				require.Equal(t, models.AdminTeamName, admin.Name)
+				require.Equal(t, models.AdminTeam(), admin.Team)
 			},
 		},
 		{
@@ -366,9 +387,16 @@ func TestSecretKeyStorage_Init(t *testing.T) {
 }
 
 func TestSecretKeyStorage_InitReturnsContextCancellation(t *testing.T) {
-	storage, _ := newSecretStorageForTest(t, map[string][]byte{})
+	_, c := newSecretStorageForTest(t, map[string][]byte{})
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
+	hookClient := &getHookClient{
+		Client: c,
+		getHook: func(ctx context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			return ctx.Err()
+		},
+	}
+	storage := NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage)
 	require.ErrorIs(t, storage.Init(ctx), context.Canceled)
 }
 
@@ -1044,6 +1072,28 @@ func TestSecretKeyStorage_RetryPatchSecretKeyErrors(t *testing.T) {
 					patchHook: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
 						cancel()
 						return apierrors.NewConflict(schema.GroupResource{Group: "", Resource: "secrets"}, KeySecretName, errors.New("conflict"))
+					},
+				}
+				storage := NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage)
+				_, err := storage.retryPatchSecretKey(ctx, hookClient, uuid.NewString(), func(*corev1.Secret) *models.CreatedTeamAPIKey {
+					return &models.CreatedTeamAPIKey{ID: uuid.New(), Key: "new"}
+				})
+				require.ErrorIs(t, err, context.Canceled)
+				require.True(t, apierrors.IsConflict(err))
+				return nil
+			},
+		},
+		{
+			name: "context cancellation after successful patch",
+			run: func(t *testing.T) error {
+				_, c := newSecretStorageForTest(t, map[string][]byte{})
+				ctx, cancel := context.WithCancel(t.Context())
+				t.Cleanup(cancel)
+				hookClient := &patchHookClient{
+					Client: c,
+					patchHook: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						cancel()
+						return nil
 					},
 				}
 				storage := NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage)

--- a/pkg/servers/e2b/keys/secret_test.go
+++ b/pkg/servers/e2b/keys/secret_test.go
@@ -243,6 +243,28 @@ func TestSecretKeyStorage_Init(t *testing.T) {
 			expectError: "not found",
 		},
 		{
+			name: "configured admin key is rotated",
+			prepare: func(t *testing.T) (*secretKeyStorage, client.Client) {
+				admin := &models.CreatedTeamAPIKey{ID: AdminKeyID, Key: "old-admin-key", Name: "admin"}
+				b, err := json.Marshal(admin)
+				require.NoError(t, err)
+				return newSecretStorageForTest(t, map[string][]byte{
+					AdminKeyID.String(): b,
+				})
+			},
+			assertion: func(t *testing.T, storage *secretKeyStorage, c client.Client) {
+				loaded, found := storage.LoadByID(context.Background(), AdminKeyID.String())
+				require.True(t, found)
+				require.Equal(t, "admin-key", loaded.Key)
+				_, foundOld := storage.LoadByKey(context.Background(), "old-admin-key")
+				assert.False(t, foundOld)
+				secret := getSecretForTest(t, c)
+				var admin models.CreatedTeamAPIKey
+				require.NoError(t, json.Unmarshal(secret.Data[AdminKeyID.String()], &admin))
+				require.Equal(t, "admin-key", admin.Key)
+			},
+		},
+		{
 			name: "admin key exists under id",
 			prepare: func(t *testing.T) (*secretKeyStorage, client.Client) {
 				admin := &models.CreatedTeamAPIKey{ID: AdminKeyID, Key: "admin-key", Name: "admin"}
@@ -259,8 +281,31 @@ func TestSecretKeyStorage_Init(t *testing.T) {
 				require.Equal(t, models.AdminTeam(), loaded.Team)
 				secret := getSecretForTest(t, c)
 				assert.Len(t, secret.Data, 1)
-				_, hasLegacy := secret.Data["admin-key"]
-				assert.False(t, hasLegacy)
+			},
+		},
+		{
+			name: "satisfied admin key does not perform patch during init",
+			prepare: func(t *testing.T) (*secretKeyStorage, client.Client) {
+				admin := &models.CreatedTeamAPIKey{ID: AdminKeyID, Key: "admin-key", Name: "admin"}
+				b, err := json.Marshal(admin)
+				require.NoError(t, err)
+				_, c := newSecretStorageForTest(t, map[string][]byte{
+					AdminKeyID.String(): b,
+				})
+				patchCalls := 0
+				hookClient := &patchHookClient{
+					Client: c,
+					patchHook: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						patchCalls++
+						return nil
+					},
+				}
+				return NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage), hookClient
+			},
+			assertion: func(t *testing.T, storage *secretKeyStorage, c client.Client) {
+				loaded, found := storage.LoadByID(context.Background(), AdminKeyID.String())
+				require.True(t, found)
+				require.Equal(t, "admin-key", loaded.Key)
 			},
 		},
 		{
@@ -278,26 +323,7 @@ func TestSecretKeyStorage_Init(t *testing.T) {
 			},
 		},
 		{
-			name: "legacy admin-key map entry gets id-keyed entry",
-			prepare: func(t *testing.T) (*secretKeyStorage, client.Client) {
-				admin := &models.CreatedTeamAPIKey{ID: AdminKeyID, Key: "admin-key", Name: "admin"}
-				b, err := json.Marshal(admin)
-				require.NoError(t, err)
-				return newSecretStorageForTest(t, map[string][]byte{
-					"admin-key": b,
-				})
-			},
-			assertion: func(t *testing.T, storage *secretKeyStorage, c client.Client) {
-				secret := getSecretForTest(t, c)
-				_, ok := secret.Data[AdminKeyID.String()]
-				assert.True(t, ok)
-				loaded, found := storage.LoadByID(context.Background(), AdminKeyID.String())
-				require.True(t, found)
-				require.Equal(t, "admin-key", loaded.Key)
-			},
-		},
-		{
-			name: "conflict while creating admin key tolerated",
+			name: "conflict while ensuring admin key returns error when persisted value differs",
 			prepare: func(t *testing.T) (*secretKeyStorage, client.Client) {
 				_, c := newSecretStorageForTest(t, map[string][]byte{})
 				hookClient := &patchHookClient{
@@ -308,6 +334,7 @@ func TestSecretKeyStorage_Init(t *testing.T) {
 				}
 				return NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage), c
 			},
+			expectError: "does not match desired value",
 		},
 		{
 			name: "non-conflict patch error returned",
@@ -336,6 +363,13 @@ func TestSecretKeyStorage_Init(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSecretKeyStorage_InitReturnsContextCancellation(t *testing.T) {
+	storage, _ := newSecretStorageForTest(t, map[string][]byte{})
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	require.ErrorIs(t, storage.Init(ctx), context.Canceled)
 }
 
 func TestSecretKeyStorage_Refresh(t *testing.T) {
@@ -849,18 +883,7 @@ func TestSecretKeyStorage_InvalidQuotaPayloadLoadsAsUnlimited(t *testing.T) {
 	}
 }
 
-func TestSecretKeyStorage_ListLimitedReturnsInvalidStoredPayload(t *testing.T) {
-	storage, _ := newSecretStorageForTest(t, map[string][]byte{
-		"broken": []byte(`{`),
-	})
-
-	limitedKeys, err := storage.ListLimited(context.Background())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "decode stored api-key")
-	require.Nil(t, limitedKeys)
-}
-
-func TestSecretKeyStorage_ListLimitedSkipsInvalidQuotaPayload(t *testing.T) {
+func TestSecretKeyStorage_ListLimitedSkipsUnreadableEntries(t *testing.T) {
 	validKeyID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
 	validPayload, err := json.Marshal(&models.CreatedTeamAPIKey{
 		ID:        validKeyID,
@@ -870,23 +893,42 @@ func TestSecretKeyStorage_ListLimitedSkipsInvalidQuotaPayload(t *testing.T) {
 		QuotaSpec: quotaSpecWithMultipleLimits(),
 	})
 	require.NoError(t, err)
-	invalidPayload := buildStoredKeyPayloadWithQuotaRaw(t, &models.CreatedTeamAPIKey{
+	invalidQuotaPayload := buildStoredKeyPayloadWithQuotaRaw(t, &models.CreatedTeamAPIKey{
 		ID:   uuid.MustParse("33333333-3333-3333-3333-333333333333"),
 		Key:  "invalid-key",
 		Name: "invalid-limited",
 		Team: &models.Team{Name: "team-a"},
 	}, `{"limits":[{"dimension":"sandbox.count","scope":"running","limit":"bad"}]}`)
 
-	storage, _ := newSecretStorageForTest(t, map[string][]byte{
-		validKeyID.String(): validPayload,
-		"invalid":           invalidPayload,
-	})
-
-	limitedKeys, err := storage.ListLimited(context.Background())
-	require.NoError(t, err)
-	require.Len(t, limitedKeys, 1)
-	assert.Equal(t, validKeyID, limitedKeys[0].ID)
-	assert.Equal(t, quotaSpecWithMultipleLimits(), limitedKeys[0].QuotaSpec)
+	tests := []struct {
+		name string
+		data map[string][]byte
+	}{
+		{
+			name: "invalid JSON",
+			data: map[string][]byte{
+				validKeyID.String(): validPayload,
+				"broken":            []byte(`{`),
+			},
+		},
+		{
+			name: "invalid quota",
+			data: map[string][]byte{
+				validKeyID.String(): validPayload,
+				"invalid":           invalidQuotaPayload,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage, _ := newSecretStorageForTest(t, tt.data)
+			limitedKeys, err := storage.ListLimited(context.Background())
+			require.NoError(t, err)
+			require.Len(t, limitedKeys, 1)
+			assert.Equal(t, validKeyID, limitedKeys[0].ID)
+			assert.Equal(t, quotaSpecWithMultipleLimits(), limitedKeys[0].QuotaSpec)
+		})
+	}
 }
 
 func TestSecretKeyStorage_LoadInvalidStoredQuotaAsUnlimited(t *testing.T) {
@@ -990,6 +1032,27 @@ func TestSecretKeyStorage_RetryPatchSecretKeyErrors(t *testing.T) {
 				return err
 			},
 			expectError: "patch failed",
+		},
+		{
+			name: "context cancellation after conflict",
+			run: func(t *testing.T) error {
+				_, c := newSecretStorageForTest(t, map[string][]byte{})
+				ctx, cancel := context.WithCancel(t.Context())
+				t.Cleanup(cancel)
+				hookClient := &patchHookClient{
+					Client: c,
+					patchHook: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						cancel()
+						return apierrors.NewConflict(schema.GroupResource{Group: "", Resource: "secrets"}, KeySecretName, errors.New("conflict"))
+					},
+				}
+				storage := NewSecretKeyStorage(hookClient, hookClient, nil, "default", "admin-key").(*secretKeyStorage)
+				_, err := storage.retryPatchSecretKey(ctx, hookClient, uuid.NewString(), func(*corev1.Secret) *models.CreatedTeamAPIKey {
+					return &models.CreatedTeamAPIKey{ID: uuid.New(), Key: "new"}
+				})
+				require.ErrorIs(t, err, context.Canceled)
+				return nil
+			},
 		},
 	}
 


### PR DESCRIPTION
## What changed

- Require `--e2b-admin-key` when `--e2b-enable-auth` is true. Empty admin keys are no longer auto-generated.
- Secret storage now reconciles the well-known admin key on Init: missing, rotated, or non-admin-team entries are rewritten to the configured key on the admin team. Unreadable `Secret.Data` entries are treated as absent on admin load, refresh, team lookup, and `ListLimited`.
- MySQL `ensureAdminKey` skips the update when the persisted row already matches.
- Conflict retries preserve both the original error and context cancellation via `errors.Join`. Exhausted Secret conflicts re-read the API server and succeed only if the desired admin key is already there.

## Why

Init previously only created the admin key when the canonical map slot was missing, so a configured rotation never overwrote a stale value. Unreadable Secret blobs also failed the whole `ListLimited` call and blocked quota anti-drift for every other key. Auto-generated admin keys made auth-enabled deployments start without an operator-known credential.

## Impact

- **Breaking:** deployments with E2B auth enabled must set `--e2b-admin-key`. In-tree `config/sandbox-manager` already does.
- Admin key rotation is config-authoritative. During a rolling update, a surviving old replica that restarts Init can write the old key back; replace all replicas before considering rotation complete.
- The well-known admin key stays on the admin team and is not given a quota.
- A corrupt Secret entry no longer fails listing limited keys; it is omitted as absent.

## Validation

```text
go test ./pkg/servers/e2b/keys/ -count=1
go vet ./pkg/servers/e2b/keys/
```