### PR TITLE
fix(controller): skip SandboxSet reconcile when deleting

### DIFF
--- a/pkg/controller/sandboxset/AGENTS.md
+++ b/pkg/controller/sandboxset/AGENTS.md
@@ -6,9 +6,6 @@ This package maintains the pool of unclaimed Sandboxes for each `SandboxSet`.
 
 - Scale and rolling-update logic operates only on unclaimed pool members.
   Claimed Sandboxes must not be deleted or replaced by this controller.
-- Skip Reconcile when the SandboxSet has a non-empty deletion timestamp.
-  Owner-ref GC owns dependents; do not scale, update, or rewrite status
-  while the object is terminating.
 - Keep create and delete expectations around cache-delayed writes. Do not
   start conflicting scale or update work while expectations are unsatisfied.
 - Preserve availability budgets across scaling and rolling updates, and keep

--- a/pkg/controller/sandboxset/AGENTS.md
+++ b/pkg/controller/sandboxset/AGENTS.md
@@ -6,6 +6,9 @@ This package maintains the pool of unclaimed Sandboxes for each `SandboxSet`.
 
 - Scale and rolling-update logic operates only on unclaimed pool members.
   Claimed Sandboxes must not be deleted or replaced by this controller.
+- Skip Reconcile when the SandboxSet has a non-empty deletion timestamp.
+  Owner-ref GC owns dependents; do not scale, update, or rewrite status
+  while the object is terminating.
 - Keep create and delete expectations around cache-delayed writes. Do not
   start conflicting scale or update work while expectations are unsatisfied.
 - Preserve availability budgets across scaling and rolling updates, and keep

--- a/pkg/controller/sandboxset/sandboxset_controller.go
+++ b/pkg/controller/sandboxset/sandboxset_controller.go
@@ -115,6 +115,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
+	// Owner-ref GC handles dependents; do not scale, update, or rewrite status
+	// while the SandboxSet is terminating.
+	if !sbs.DeletionTimestamp.IsZero() {
+		log.Info("sandboxset is deleting, skip reconcile")
+		return ctrl.Result{}, nil
+	}
+
 	recordSandboxSetMetrics(sbs)
 
 	// Preparation

--- a/pkg/controller/sandboxset/sandboxset_controller_test.go
+++ b/pkg/controller/sandboxset/sandboxset_controller_test.go
@@ -329,6 +329,42 @@ func TestReconcile_DeleteDead(t *testing.T) {
 	}
 }
 
+func TestReconcile_SkipWhenDeleting(t *testing.T) {
+	utestutils.InitLogOutput()
+	ctx := context.Background()
+	k8sClient := NewClient()
+
+	sbs := getSandboxSet(2)
+	sbs.Finalizers = []string{"kruise.test/finalizer"}
+	assert.NoError(t, k8sClient.Create(ctx, sbs))
+	assert.NoError(t, k8sClient.Delete(ctx, sbs))
+
+	got := &v1alpha1.SandboxSet{}
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(sbs), got))
+	require.NotNil(t, got.DeletionTimestamp)
+
+	eventRecorder := record.NewFakeRecorder(10)
+	reconciler := &Reconciler{
+		Client:   k8sClient,
+		Scheme:   testScheme,
+		Recorder: eventRecorder,
+		Codec:    serializer.NewCodecFactory(testScheme).LegacyCodec(v1alpha1.SchemeGroupVersion),
+	}
+
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(sbs)})
+	assert.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	var sandboxList v1alpha1.SandboxList
+	assert.NoError(t, k8sClient.List(ctx, &sandboxList))
+	assert.Empty(t, sandboxList.Items)
+
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(sbs), got))
+	assert.Empty(t, got.Status.UpdateRevision)
+	assert.Zero(t, got.Status.Replicas)
+	CheckAllEvents(t, eventRecorder, nil)
+}
+
 func TestReconcile_BasicScale(t *testing.T) {
 	utestutils.InitLogOutput()
 	checkFunc := func(totCnt, newCnt int) func(t *testing.T, client client.Client, sbs *v1alpha1.SandboxSet) {
@@ -860,7 +896,7 @@ func TestCompareScaleDownPriority(t *testing.T) {
 		}
 		return &v1alpha1.Sandbox{
 			Status: v1alpha1.SandboxStatus{
-				Phase:        phase,
+				Phase:         phase,
 				RecycledCount: recycledCount,
 				Conditions: []metav1.Condition{
 					{Type: string(v1alpha1.SandboxConditionReady), Status: readyStatus},


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Skip `SandboxSet` Reconcile when the object already has a non-empty deletion timestamp.

Previously, a terminating SandboxSet still ran scale, rolling update, template revision, and status updates. That can create new pool members while owner-ref GC is collecting dependents. After this change, Reconcile returns immediately in that case and leaves cleanup to Kubernetes GC.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

```bash
go test -count=1 -run TestReconcile_SkipWhenDeleting ./pkg/controller/sandboxset/