### PR TITLE
feat(customfuse): add control-plane CustomFuseMountProvider

### DIFF
--- a/pkg/agent-runtime/customfusevalidate/validate.go
+++ b/pkg/agent-runtime/customfusevalidate/validate.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package customfusevalidate holds the security checks shared between the
+// control-plane CustomFuseMountProvider and the sandbox-side CSI node server.
+// Both ends must reject the same inputs because mount-proxy exports every
+// Secret entry and mount flag as an environment variable of the same name
+// into the entrypoint shell: the provider validates the PV+Secret path, and
+// the node server repeats the checks for requests that reach it directly
+// over the per-driver unix socket without passing through the provider.
+package customfusevalidate
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// secretKeyPattern matches Secret keys that can be exported as environment
+// variables. The customfuse contract maps every Secret key to an env var of
+// the same name consumed by the entrypoint, and bash cannot reference names
+// with dashes ($access-key expands as $access plus the literal "-key").
+var secretKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// blockedMountOptionKeys are mount options that would become environment
+// variables with code-execution or command-redirection side effects once
+// mount-proxy exports them to the entrypoint shell: bash sources BASH_ENV at
+// startup, glibc loads LD_PRELOAD, PATH redirects command lookup, and
+// IFS/PS4/SHELLOPTS alter shell behavior. These keys are rejected outright.
+// The match is exact: bash and glibc read only the canonical uppercase names,
+// so lowercase variants are harmless and stay allowed.
+var blockedMountOptionKeys = map[string]bool{
+	"BASH_ENV": true, "ENV": true, "BASHOPTS": true, "SHELLOPTS": true,
+	"PROMPT_COMMAND": true, "PS4": true, "IFS": true, "BASH_XTRACEFD": true,
+	"LD_PRELOAD": true, "LD_LIBRARY_PATH": true, "LD_AUDIT": true,
+	"LD_BIND_NOW": true, "LD_DEBUG": true, "GLIBC_TUNABLES": true,
+	"PATH": true, "CDPATH": true, "HISTFILE": true,
+}
+
+// reservedSecretKeys are Secret keys that would overwrite the environment
+// variables the provider itself injects for the entrypoint: mount-proxy
+// exports every Secret entry verbatim and in a duplicate-key env the last
+// occurrence wins, so a Secret key like "source" would replace the validated
+// mount source, "readOnly" would weaken the read-only semantics derived from
+// the CSI request, and "mountpoint" would redirect the mount target.
+// Credentials never legitimately share names with these reserved keys.
+var reservedSecretKeys = map[string]bool{
+	"source": true, "readOnly": true, "mountpoint": true,
+	"bucket": true, "url": true, "path": true, "otherOpts": true,
+	"capacity": true, "fuseType": true, "authType": true,
+	"storageType": true,
+}
+
+// optionValuePattern matches key=value pairs in option strings (e.g.
+// "cache-size=1024") so that error messages can mask the value part, which
+// may carry credential material. The key is any run of non-separator
+// characters, possibly empty so a malformed "=secret" input is masked
+// too: a narrow key charset would leave "x.y=Secret" unmasked and leak
+// the value into error logs. Values are masked up to the next separator:
+// a value containing a comma is an invalid mount option (comma is the
+// option separator), and masking past the comma would swallow the
+// following option from the error message entirely.
+var optionValuePattern = regexp.MustCompile(`([^=,;\s]*)=([^,;\s]*)`)
+
+// HasShellMetachar returns true when s contains characters that could be
+// interpreted by a shell: ; | & ` $ ( ) \r \n \x00 and the escape
+// character \ which can change how a later character is parsed.
+func HasShellMetachar(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		switch c {
+		case ';', '|', '&', '`', '$', '(', ')', '\\', '\r', '\n', '\x00':
+			return true
+		}
+	}
+	return false
+}
+
+// SafeForwardPattern matches values made only of characters that are safe
+// to forward to the sidecar entrypoint: metadata URLs (redis://host:6379/0,
+// s3://bucket, redis://[::1]:6379/0) and plain identifiers. It is shared by
+// the control-plane provider and the sandbox-side node server so both ends
+// reject the same inputs; the allowlist approach (rather than a denylist)
+// keeps every future entrypoint safe even when it forgets to quote.
+var SafeForwardPattern = regexp.MustCompile(`^[A-Za-z0-9_\-:/@.%\[\]]+$`)
+
+// AllowedFuseTypes is the allowlist of FUSE client identifiers shared by
+// the control-plane provider and the sandbox-side node server. Only clients
+// with a shipped entrypoint belong here; "customfuse" is the default
+// sentinel for "no client specified" (injected by the provider when neither
+// fuseType nor CSI fsType is set), not a client type.
+var AllowedFuseTypes = map[string]bool{
+	"juicefs":    true,
+	"s3fs":       true,
+	"customfuse": true,
+}
+
+// CapacityPattern mirrors the JuiceFS entrypoint's accepted capacity forms:
+// a plain integer or an integer with Ti/TiB, Gi/GiB, Mi/MiB, Ki/KiB units.
+// It is shared by the control-plane provider and the sandbox-side node
+// server so a value accepted at the control plane never fails later in the
+// entrypoint. Both branches carry the 15-digit bound: unit-bearing values
+// are multiplied in bash arithmetic, which must stay inside 64-bit range,
+// and absurdly large plain integers are rejected early instead of failing
+// quota set at mount time with only a warning.
+var CapacityPattern = regexp.MustCompile(`^([0-9]{1,15}(TiB|Ti|GiB|Gi|MiB|Mi|KiB|Ki)|[0-9]{1,15})$`)
+
+// MaskOptionValues masks the value of every key=value pair in an option
+// string so error messages never echo potential credential material.
+func MaskOptionValues(s string) string {
+	return optionValuePattern.ReplaceAllString(s, "${1}=***")
+}
+
+// ValidateSecretData validates every entry of a Secret's Data map: the key
+// must be a valid environment variable name, must not be a dangerous
+// environment key, must not be a reserved provider key, and the value must
+// be single-line. A value containing a newline would inject extra lines into
+// the s3fs credential file.
+func ValidateSecretData(data map[string][]byte) error {
+	for key, value := range data {
+		if err := validateSecretEntry(key, string(value)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateSecrets validates every entry of a CSI request's Secrets map, which
+// is how the sandbox-side node server receives Secret material.
+func ValidateSecrets(secrets map[string]string) error {
+	for key, value := range secrets {
+		if err := validateSecretEntry(key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSecretEntry(key, value string) error {
+	if err := ValidateEnvKeyName(key); err != nil {
+		return fmt.Errorf("secret key %v", err)
+	}
+	if reservedSecretKeys[key] {
+		return fmt.Errorf("secret key %q is reserved for provider-injected environment variables and must not be overridden", key)
+	}
+	// NUL is rejected along with newlines: environment values are C
+	// strings, so an embedded NUL would truncate the variable at execve
+	// time or make the exec fail outright. A tab is rejected too: the
+	// s3fs credential file is parsed as access_key:secret_key pairs and
+	// an embedded tab would corrupt that parsing.
+	if strings.ContainsAny(value, "\n\r\x00\t") {
+		return fmt.Errorf("secret %q must not contain a newline, tab or NUL byte", key)
+	}
+	return nil
+}
+
+// ValidateEnvKeyName checks a single key that may be exported as an
+// environment variable to the entrypoint: it must be a valid variable name
+// of a sane length and must not be one of the dangerous keys bash or glibc
+// would act on.
+func ValidateEnvKeyName(key string) error {
+	if !secretKeyPattern.MatchString(key) {
+		return fmt.Errorf("%q is not a valid environment variable name", key)
+	}
+	if len(key) > 256 {
+		return fmt.Errorf("environment variable name is too long (%d bytes)", len(key))
+	}
+	if blockedMountOptionKeys[key] {
+		return fmt.Errorf("%q is not allowed: it would be exported as a dangerous environment variable to the entrypoint", key)
+	}
+	return nil
+}
+
+// IsBlockedEnvKey reports whether key is one of the dangerous environment
+// variables bash or glibc would act on. Used for VolumeContext keys on the
+// control plane, where an invalid variable name is harmless (bash cannot
+// reference it) but a dangerous exact-name key would take effect if
+// mount-proxy ever starts exporting VolumeContext keys as environment
+// variables — defense in depth.
+func IsBlockedEnvKey(key string) bool {
+	return blockedMountOptionKeys[key]
+}
+
+// IsReservedKey reports whether key is a provider-injected environment name
+// that callers must not override through mount options or Secret keys.
+func IsReservedKey(key string) bool {
+	return reservedSecretKeys[key]
+}
+
+// credentialKeys lists key names that denote credential material and must
+// not appear in volumeAttributes or in mount-option sub-keys. Credentials
+// belong in a Kubernetes Secret referenced by the PV's
+// NodePublishSecretRef, never in plain-text PV fields or option lists.
+// The list is a best-effort guard against common mistakes; the security
+// boundary is the Secret mechanism itself.
+var credentialKeys = []string{
+	"token", "accessKeyId", "accessKeySecret", "passphrase", "password", "passwd",
+	"access-key", "secret-key", "access_key", "secret_key", "ak", "sk", "secret",
+	"securityToken", "sessionToken", "authToken",
+}
+
+// IsCredentialKey reports whether key names a credential, matched
+// case-insensitively. Mount-option sub-keys that look like credentials
+// (e.g. "token=xxx" inside otherOpts) must be rejected rather than let
+// the value travel into mount options and logs.
+func IsCredentialKey(key string) bool {
+	for _, credKey := range credentialKeys {
+		if strings.EqualFold(key, credKey) {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateMountOptions checks every mount option entry (pv.Spec.MountOptions
+// on the control plane, VolumeCapability.MountFlags on the node server). Each
+// entry becomes one environment variable in the entrypoint, so shell
+// metacharacters are rejected and entries whose keys are dangerous
+// environment variables or provider-reserved keys are denied outright.
+func ValidateMountOptions(opts []string) error {
+	for _, opt := range opts {
+		if HasShellMetachar(opt) {
+			return fmt.Errorf("mount option %q contains invalid shell characters", MaskOptionValues(opt))
+		}
+		// Entries are split on space, tab and comma, mirroring the
+		// entrypoint's option-list parsing: a comma-only split would let
+		// "cache-size=1024 BASH_ENV=x" hide a dangerous key inside one
+		// token. FieldsFunc also drops empty fields, so a whitespace
+		// padded key (" BASH_ENV=x") cannot dodge the exact match either.
+		for _, entry := range strings.FieldsFunc(opt, func(r rune) bool { return r == ',' || r == ' ' || r == '\t' }) {
+			key, _, _ := strings.Cut(entry, "=")
+			// A keyless "=value" entry is malformed and would dodge the
+			// key-based checks below ("" is neither blocked nor reserved).
+			if key == "" {
+				return fmt.Errorf("mount option %q is not allowed: empty option key", MaskOptionValues(opt))
+			}
+			// subdir= follows the official JuiceFS CSI mountOptions
+			// convention, but this driver mounts sub-directories via the
+			// path volumeAttribute; a subdir option would reach the
+			// client's -o string and be rejected or silently ignored.
+			// Exact match only, consistent with the case-sensitive option
+			// checks: the client treats option keys case-sensitively.
+			if key == "subdir" {
+				return fmt.Errorf("mount option %q is not supported: use the path volumeAttribute to mount a sub-directory", MaskOptionValues(opt))
+			}
+			if blockedMountOptionKeys[key] {
+				return fmt.Errorf("mount option %q is not allowed: it would be exported as a dangerous environment variable to the entrypoint", MaskOptionValues(opt))
+			}
+			if reservedSecretKeys[key] {
+				return fmt.Errorf("mount option %q is reserved for provider-injected mount semantics and must not be overridden", MaskOptionValues(opt))
+			}
+			if IsCredentialKey(key) {
+				return fmt.Errorf("mount option %q must not carry credential material, put it in Secret instead", MaskOptionValues(opt))
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/agent-runtime/customfusevalidate/validate_test.go
+++ b/pkg/agent-runtime/customfusevalidate/validate_test.go
@@ -1,0 +1,267 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customfusevalidate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateSecrets(t *testing.T) {
+	tests := []struct {
+		name        string
+		secrets     map[string]string
+		expectError string
+	}{
+		{name: "nil secrets pass", secrets: nil, expectError: ""},
+		{name: "empty secrets pass", secrets: map[string]string{}, expectError: ""},
+		{
+			name:        "credential keys pass",
+			secrets:     map[string]string{"access_key": "AKID", "secret_key": "SK", "token": "tok"},
+			expectError: "",
+		},
+		{
+			name:        "key with dash rejected",
+			secrets:     map[string]string{"access-key": "AKID"},
+			expectError: "not a valid environment variable name",
+		},
+		{
+			name:        "key with leading digit rejected",
+			secrets:     map[string]string{"1secret": "v"},
+			expectError: "not a valid environment variable name",
+		},
+		{
+			name:        "BASH_ENV rejected",
+			secrets:     map[string]string{"BASH_ENV": "/tmp/x.sh"},
+			expectError: "not allowed",
+		},
+		{
+			name:        "LD_PRELOAD rejected",
+			secrets:     map[string]string{"LD_PRELOAD": "/tmp/x.so"},
+			expectError: "not allowed",
+		},
+		{
+			name:        "IFS rejected",
+			secrets:     map[string]string{"IFS": ":"},
+			expectError: "not allowed",
+		},
+		{
+			name:        "reserved source key rejected",
+			secrets:     map[string]string{"source": "redis://evil:6379/0"},
+			expectError: "reserved",
+		},
+		{
+			name:        "reserved readOnly key rejected",
+			secrets:     map[string]string{"readOnly": "false"},
+			expectError: "reserved",
+		},
+		{
+			name:        "reserved url key rejected",
+			secrets:     map[string]string{"url": "http://attacker:9000"},
+			expectError: "reserved",
+		},
+		{
+			name:        "reserved storageType key rejected",
+			secrets:     map[string]string{"storageType": "oss"},
+			expectError: "reserved",
+		},
+		{
+			name:        "newline value rejected",
+			secrets:     map[string]string{"access_key": "AK\nID"},
+			expectError: "must not contain a newline",
+		},
+		{
+			name:        "carriage return value rejected",
+			secrets:     map[string]string{"access_key": "AK\rID"},
+			expectError: "must not contain a newline",
+		},
+		{
+			name:        "NUL byte value rejected",
+			secrets:     map[string]string{"access_key": "AK\x00ID"},
+			expectError: "must not contain a newline, tab or NUL byte",
+		},
+		{
+			name:        "tab value rejected",
+			secrets:     map[string]string{"access_key": "AK\tID"},
+			expectError: "must not contain a newline, tab or NUL byte",
+		},
+		{
+			name:        "lowercase dangerous key stays allowed",
+			secrets:     map[string]string{"bash_env": "/tmp/x.sh"},
+			expectError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSecrets(tt.secrets)
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			}
+		})
+	}
+}
+
+func TestValidateSecretData(t *testing.T) {
+	err := ValidateSecretData(map[string][]byte{
+		"access_key": []byte("AKID"),
+		"secret_key": []byte("SK\nline2"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must not contain a newline")
+
+	assert.NoError(t, ValidateSecretData(nil))
+}
+
+func TestValidateEnvKeyName(t *testing.T) {
+	tests := []struct {
+		name        string
+		key         string
+		expectError string
+	}{
+		{name: "plain name passes", key: "access_key", expectError: ""},
+		{name: "name with dash rejected", key: "access-key", expectError: "not a valid environment variable name"},
+		{name: "name with leading digit rejected", key: "1key", expectError: "not a valid environment variable name"},
+		{name: "BASH_ENV rejected", key: "BASH_ENV", expectError: "not allowed"},
+		{name: "LD_PRELOAD rejected", key: "LD_PRELOAD", expectError: "not allowed"},
+		{name: "lowercase dangerous key passes", key: "bash_env", expectError: ""},
+		{name: "overlong key rejected", key: strings.Repeat("a", 300), expectError: "too long"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateEnvKeyName(tt.key)
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			}
+		})
+	}
+}
+
+func TestIsBlockedEnvKey(t *testing.T) {
+	for _, key := range []string{"BASH_ENV", "LD_PRELOAD", "IFS", "PATH"} {
+		assert.True(t, IsBlockedEnvKey(key), "expected %q to be blocked", key)
+	}
+	for _, key := range []string{"bash_env", "access_key", "custom-key", ""} {
+		assert.False(t, IsBlockedEnvKey(key), "expected %q not to be blocked", key)
+	}
+}
+
+func TestValidateMountOptions(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        []string
+		expectError string
+	}{
+		{name: "nil options pass", opts: nil, expectError: ""},
+		{name: "safe options pass", opts: []string{"cache-size=1024", "no-update"}, expectError: ""},
+		{name: "shell metachar rejected", opts: []string{"opt; rm -rf /"}, expectError: "invalid shell characters"},
+		{name: "BASH_ENV rejected", opts: []string{"BASH_ENV=/tmp/x.sh"}, expectError: "not allowed"},
+		{name: "LD_PRELOAD rejected", opts: []string{"LD_PRELOAD=/tmp/x.so"}, expectError: "not allowed"},
+		{name: "PATH rejected", opts: []string{"PATH=/tmp"}, expectError: "not allowed"},
+		{name: "space-padded dangerous key rejected", opts: []string{"  BASH_ENV=/tmp/x.sh"}, expectError: "not allowed"},
+		{name: "tab-padded reserved key rejected", opts: []string{"\tsource=redis://evil:6379/0"}, expectError: "reserved"},
+		{name: "bare dangerous key rejected", opts: []string{"IFS"}, expectError: "not allowed"},
+		{name: "reserved url rejected", opts: []string{"url=http://attacker:9000"}, expectError: "reserved"},
+		{name: "reserved source rejected", opts: []string{"source=redis://evil:6379/0"}, expectError: "reserved"},
+		{name: "reserved readOnly rejected", opts: []string{"readOnly=false"}, expectError: "reserved"},
+		{name: "subdir option rejected with path hint", opts: []string{"subdir=/my/sub/dir"}, expectError: "use the path volumeAttribute"},
+		{name: "case variant of subdir stays allowed", opts: []string{"Subdir=/my/sub/dir"}, expectError: ""},
+		{name: "space-separated entry hiding reserved key rejected", opts: []string{"cache-size=1024 source=evil"}, expectError: "reserved"},
+		{name: "space-separated entry hiding dangerous key rejected", opts: []string{"cache-size=1024 BASH_ENV=/tmp/x.sh"}, expectError: "not allowed"},
+		{name: "keyless entry rejected", opts: []string{"=value"}, expectError: "empty option key"},
+		{name: "bare flag without equals stays allowed", opts: []string{"allow_other"}, expectError: ""},
+		{name: "credential-like sub-key rejected", opts: []string{"cache-size=1024,token=xxx"}, expectError: "must not carry credential material"},
+		{name: "password sub-key rejected", opts: []string{"password=secret"}, expectError: "must not carry credential material"},
+		{
+			name:        "blocked option error masks value",
+			opts:        []string{"BASH_ENV=/tmp/x.sh"},
+			expectError: "not allowed",
+		},
+		{
+			name:        "lowercase dangerous key stays allowed",
+			opts:        []string{"bash_env=/tmp/x.sh"},
+			expectError: "",
+		},
+		{
+			name:        "case variant of reserved key stays allowed",
+			opts:        []string{"Url=http://attacker:9000"},
+			expectError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMountOptions(tt.opts)
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			}
+		})
+	}
+}
+
+func TestBlockedOptionErrorMasksValue(t *testing.T) {
+	err := ValidateMountOptions([]string{"BASH_ENV=/tmp/x.sh"})
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "/tmp/x.sh")
+}
+
+func TestIsReservedKey(t *testing.T) {
+	for _, key := range []string{"source", "readOnly", "mountpoint", "bucket", "url", "path", "otherOpts", "capacity", "fuseType", "authType", "storageType"} {
+		assert.True(t, IsReservedKey(key), "expected %q to be reserved", key)
+	}
+	for _, key := range []string{"Url", "URL", "SOURCE", "access_key", "token", "cache-size", "no-update", ""} {
+		assert.False(t, IsReservedKey(key), "expected %q not to be reserved", key)
+	}
+}
+
+func TestHasShellMetachar(t *testing.T) {
+	for _, c := range []string{";", "|", "&", "`", "$", "(", ")", "\\", "\r", "\n", "\x00"} {
+		assert.True(t, HasShellMetachar("a"+c+"b"), "expected metachar %q", c)
+	}
+	for _, s := range []string{"", "cache-size=1024", "http://host:9000", "a b", "a<b>c", "a'b\"c"} {
+		assert.False(t, HasShellMetachar(s), "expected no metachar in %q", s)
+	}
+}
+
+func TestMaskOptionValues(t *testing.T) {
+	assert.Equal(t, "passwd_file=***,allow_other", MaskOptionValues("passwd_file=/tmp/x,allow_other"))
+	assert.Equal(t, "opt1; x", MaskOptionValues("opt1; x"))
+	// Keys containing characters outside [A-Za-z0-9_-] must be masked too,
+	// or their values would leak into error messages.
+	assert.Equal(t, "x.y=***,allow_other", MaskOptionValues("x.y=Secret,allow_other"))
+	assert.Equal(t, "x.y=*** BASH_ENV=***", MaskOptionValues("x.y=Secret BASH_ENV=/evil"))
+	// Values are masked up to the next separator. A value containing a
+	// comma is an invalid mount option; masking past the comma would
+	// swallow the following option from the error message, so the mask
+	// stops at the boundary.
+	assert.Equal(t, "cache-size=***,no-update", MaskOptionValues("cache-size=1024,no-update"))
+	assert.Equal(t, "cache-dir=***,b", MaskOptionValues("cache-dir=/path/a,b"))
+	// Malformed keyless input ("=secret") is masked as well.
+	assert.Equal(t, "=***", MaskOptionValues("=secret"))
+}

--- a/pkg/agent-runtime/storages/config.go
+++ b/pkg/agent-runtime/storages/config.go
@@ -27,15 +27,49 @@ type initProviderFunc func(*StorageProvider)
 
 var (
 	initializeProviderFuncs = []initProviderFunc{}
-	driversConfig           = map[string]string{}
+	// driversConfig feeds PublishContext in the generated
+	// NodePublishVolumeRequest (see volume_mount_provider.go); providers
+	// may populate it as a hook for downstream pipeline enrichment. It is
+	// written only during initialization and read-only afterwards.
+	driversConfig = map[string]string{}
 )
 
-func init() {
-	dynamicDriverList := strings.Split(os.Getenv(common.ENV_DYNAMIC_STORAGE_DRIVER_LIST), ",")
-	for _, driverName := range dynamicDriverList {
-		initializeProviderFuncs = append(initializeProviderFuncs,
-			func(sp *StorageProvider) {
-				sp.RegisterProvider(driverName, &MountProvider{})
-			})
+// buildProviderFuncs turns the DYNAMIC_STORAGE_DRIVER_LIST env value into
+// provider registration functions. Names are trimmed, duplicates are
+// dropped, and the customfuse driver is matched by its canonical name
+// case-insensitively — a substring match would misclassify unrelated
+// drivers whose names merely contain "customfuse", while a case-sensitive
+// match would let a casing typo in the environment silently downgrade the
+// customfuse driver to the unvalidated generic MountProvider.
+//
+// A missing or empty env value produces no registration functions, which
+// leaves dynamic volume mounting unavailable: deployments must set the
+// env explicitly (the sandbox-controller Deployment sets it).
+func buildProviderFuncs(driverList string) []initProviderFunc {
+	funcs := []initProviderFunc{}
+	seen := map[string]bool{}
+	for _, driverName := range strings.Split(driverList, ",") {
+		drv := strings.TrimSpace(driverName)
+		if drv == "" || seen[strings.ToLower(drv)] {
+			continue
+		}
+		seen[strings.ToLower(drv)] = true
+		provider := VolumeMountProvider(&MountProvider{})
+		if strings.EqualFold(drv, "customfuseplugin.csi.openkruise.io") {
+			// Register under the canonical lowercase name: PVs look the
+			// driver up by Spec.CSI.Driver, and a registration key that
+			// kept the user's casing would register successfully but
+			// never be found.
+			drv = "customfuseplugin.csi.openkruise.io"
+			provider = &CustomFuseMountProvider{}
+		}
+		funcs = append(funcs, func(sp *StorageProvider) {
+			sp.RegisterProvider(drv, provider)
+		})
 	}
+	return funcs
+}
+
+func init() {
+	initializeProviderFuncs = buildProviderFuncs(os.Getenv(common.ENV_DYNAMIC_STORAGE_DRIVER_LIST))
 }

--- a/pkg/agent-runtime/storages/config_test.go
+++ b/pkg/agent-runtime/storages/config_test.go
@@ -17,80 +17,117 @@ limitations under the License.
 package storages
 
 import (
-	"os"
-	"strings"
 	"testing"
-
-	"github.com/openkruise/agents/pkg/agent-runtime/common"
 )
 
-// TestInitFunction tests the package initialization logic with environment variable
-func TestInitFunction(t *testing.T) {
-	// Save original environment variable value
-	originalEnvValue := os.Getenv(common.ENV_DYNAMIC_STORAGE_DRIVER_LIST)
-	defer func() {
-		// Restore original environment variable after test
-		if originalEnvValue == "" {
-			os.Unsetenv(common.ENV_DYNAMIC_STORAGE_DRIVER_LIST)
-		} else {
-			os.Setenv(common.ENV_DYNAMIC_STORAGE_DRIVER_LIST, originalEnvValue)
-		}
-	}()
-
-	// Reset global state before test
-	resetInitializeProviderFuncs()
-
-	// Set up test environment variable
-	testDriverList := "driver1,driver2,driver3"
-	os.Setenv(common.ENV_DYNAMIC_STORAGE_DRIVER_LIST, testDriverList)
-
-	// Manually execute initialization logic to simulate init function behavior
-	// Note: We can't directly test init() as it runs only once during package loading
-	// So we manually implement the same logic with closure fix
-	dynamicDriverList := strings.Split(testDriverList, ",")
-	var tempInitializeProviderFuncs []initProviderFunc
-
-	for _, driverName := range dynamicDriverList {
-		driverName := driverName                 // Capture loop variable to avoid closure trap
-		if strings.TrimSpace(driverName) != "" { // Skip empty entries
-			tempInitializeProviderFuncs = append(tempInitializeProviderFuncs,
-				func(sp *StorageProvider) {
-					sp.RegisterProvider(driverName, &MountProvider{})
-				})
-		}
+// applyFuncs registers every provider function against a fresh registry and
+// returns it, so tests can assert on the final registration state.
+func applyFuncs(t *testing.T, funcs []initProviderFunc) *StorageProvider {
+	t.Helper()
+	sp := NewStorageProvider()
+	registry := sp.(*StorageProvider)
+	for _, fn := range funcs {
+		fn(registry)
 	}
-
-	// Verify that initialization logic would create correct number of provider functions
-	expectedCount := 3 // Number of non-empty drivers in our test case
-	actualCount := len(tempInitializeProviderFuncs)
-
-	if actualCount != expectedCount {
-		t.Errorf("Expected %d provider functions, got %d", expectedCount, actualCount)
-	}
-
-	// Test with empty environment variable
-	resetInitializeProviderFuncs()
-	os.Setenv(common.ENV_DYNAMIC_STORAGE_DRIVER_LIST, "")
-
-	emptyDriverList := strings.Split("", ",")
-	var emptyTempFuncs []initProviderFunc
-	for _, driverName := range emptyDriverList {
-		driverName := driverName
-		if strings.TrimSpace(driverName) != "" {
-			emptyTempFuncs = append(emptyTempFuncs,
-				func(sp *StorageProvider) {
-					sp.RegisterProvider(driverName, &MountProvider{})
-				})
-		}
-	}
-
-	// Should have 1 element because Split("") returns [""]
-	if len(emptyTempFuncs) != 0 { // After trimming empty string
-		t.Errorf("Expected 0 provider functions for empty env var, got %d", len(emptyTempFuncs))
-	}
+	return registry
 }
 
-// resetInitializeProviderFuncs resets the global initializeProviderFuncs slice for testing
-func resetInitializeProviderFuncs() {
-	initializeProviderFuncs = []initProviderFunc{}
+func TestBuildProviderFuncs(t *testing.T) {
+	tests := []struct {
+		name         string
+		driverList   string
+		wantCount    int
+		wantCustom   string
+		wantMounted  []string
+		absentDriver string
+	}{
+		{
+			name:       "empty list produces no providers",
+			driverList: "",
+			wantCount:  0,
+		},
+		{
+			name:        "plain drivers map to MountProvider",
+			driverList:  "driver1,driver2,driver3",
+			wantCount:   3,
+			wantMounted: []string{"driver1", "driver2", "driver3"},
+		},
+		{
+			name:        "canonical customfuse driver maps to CustomFuseMountProvider",
+			driverList:  "nasplugin.csi.alibabacloud.com,customfuseplugin.csi.openkruise.io,ossplugin.csi.alibabacloud.com",
+			wantCount:   3,
+			wantCustom:  "customfuseplugin.csi.openkruise.io",
+			wantMounted: []string{"nasplugin.csi.alibabacloud.com", "ossplugin.csi.alibabacloud.com"},
+		},
+		{
+			name:         "substring containing customfuse is not the customfuse driver",
+			driverList:   "my-customfuse-driver",
+			wantCount:    1,
+			wantMounted:  []string{"my-customfuse-driver"},
+			absentDriver: "customfuseplugin.csi.openkruise.io",
+		},
+		{
+			name:        "surrounding whitespace is trimmed",
+			driverList:  " nasplugin.csi.alibabacloud.com , customfuseplugin.csi.openkruise.io ",
+			wantCount:   2,
+			wantCustom:  "customfuseplugin.csi.openkruise.io",
+			wantMounted: []string{"nasplugin.csi.alibabacloud.com"},
+		},
+		{
+			name:        "duplicate drivers are deduplicated",
+			driverList:  "driver1,driver1,driver2",
+			wantCount:   2,
+			wantMounted: []string{"driver1", "driver2"},
+		},
+		{
+			// A casing typo in the environment must not silently downgrade
+			// the customfuse driver to the unvalidated generic provider,
+			// and the registration key must be the canonical lowercase
+			// name so PV lookups by Spec.CSI.Driver still find it.
+			name:         "casing variant of canonical customfuse driver registers under canonical name",
+			driverList:   "CUSTOMFUSEPLUGIN.CSI.OPENKRUISE.IO",
+			wantCount:    1,
+			wantCustom:   "customfuseplugin.csi.openkruise.io",
+			absentDriver: "CUSTOMFUSEPLUGIN.CSI.OPENKRUISE.IO",
+		},
+		{
+			name:       "casing duplicate of customfuse driver is deduplicated",
+			driverList: "customfuseplugin.csi.openkruise.io,CUSTOMFUSEPLUGIN.CSI.OPENKRUISE.IO",
+			wantCount:  1,
+			wantCustom: "customfuseplugin.csi.openkruise.io",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			funcs := buildProviderFuncs(tt.driverList)
+			if len(funcs) != tt.wantCount {
+				t.Fatalf("expected %d provider funcs, got %d", tt.wantCount, len(funcs))
+			}
+			registry := applyFuncs(t, funcs)
+			for _, drv := range tt.wantMounted {
+				provider, exists := registry.GetProvider(drv)
+				if !exists {
+					t.Fatalf("driver %q not registered", drv)
+				}
+				if _, ok := provider.(*MountProvider); !ok {
+					t.Errorf("driver %q expected *MountProvider, got %T", drv, provider)
+				}
+			}
+			if tt.wantCustom != "" {
+				provider, exists := registry.GetProvider(tt.wantCustom)
+				if !exists {
+					t.Fatalf("customfuse driver %q not registered", tt.wantCustom)
+				}
+				if _, ok := provider.(*CustomFuseMountProvider); !ok {
+					t.Errorf("driver %q expected *CustomFuseMountProvider, got %T", tt.wantCustom, provider)
+				}
+			}
+			if tt.absentDriver != "" {
+				if _, exists := registry.GetProvider(tt.absentDriver); exists {
+					t.Errorf("driver %q must not be registered", tt.absentDriver)
+				}
+			}
+		})
+	}
 }

--- a/pkg/agent-runtime/storages/customfuse_provider.go
+++ b/pkg/agent-runtime/storages/customfuse_provider.go
@@ -1,0 +1,535 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storages
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openkruise/agents/pkg/agent-runtime/customfusevalidate"
+)
+
+// allowedFuseTypes and safeForwardPattern live in customfusevalidate so
+// the provider and the sandbox-side node server share one allowlist and
+// one charset; see customfusevalidate.AllowedFuseTypes and
+// customfusevalidate.SafeForwardPattern.
+
+// credentialKeys lives in customfusevalidate so the provider and the
+// mount-option validation share one list; see
+// customfusevalidate.IsCredentialKey.
+
+// mountPathPattern matches absolute, shell-safe container mount targets.
+var mountPathPattern = regexp.MustCompile(`^/[A-Za-z0-9_\-./]+$`)
+
+// credInURLPattern matches userinfo (user:pass) embedded in a URL. It masks
+// up to the last '@' before the path or whitespace so that URLs containing
+// multiple '@' segments never leak credentials into error messages.
+var credInURLPattern = regexp.MustCompile(`://[^/\s]*@`)
+
+// credUserInfoPattern matches userinfo without a scheme (user:pass@host),
+// which safeForwardPattern allows through but a scheme-bearing pattern would
+// miss in error output: the value is rejected by the charset check only when
+// it also carries an invalid character, and the error message must not echo
+// the credential part.
+var credUserInfoPattern = regexp.MustCompile(`([^/\s:@]+:)[^/@\s]*@`)
+
+// queryValuePattern matches name=value pairs in URL query strings and
+// fragments (e.g. ?token=xxx or ?X-Amz-Signature=yyy) so their values can be
+// masked in error messages. Query URLs never pass the source allowlist, but
+// they must not leak credentials into logs when rejected. A URL-encoded
+// equals sign (%3D) counts as the separator too.
+var queryValuePattern = regexp.MustCompile(`([?&#][^=&\s]*(?:=|%3[Dd]))[^&\s#]*`)
+
+// CustomFuseMountProvider generates CSI NodePublishVolume requests for the
+// generic FUSE driver (customfuseplugin.csi.openkruise.io). It validates
+// inputs for shell safety and credential hygiene, then forwards the PV's
+// volume attributes and the referenced Secret verbatim to the FUSE
+// entrypoint inside the sandbox csi-sidecar container.
+type CustomFuseMountProvider struct{}
+
+// GenerateCSINodePublishVolumeRequest validates the PV, Secret and mount
+// target, then builds a NodePublishVolumeRequest whose VolumeContext and
+// Secrets pass through unchanged to the FUSE entrypoint. The returned
+// request is never partially built alongside an error: callers can rely on
+// (nil, err) when validation fails.
+func (p *CustomFuseMountProvider) GenerateCSINodePublishVolumeRequest(
+	ctx context.Context,
+	containerMountTarget string,
+	pv *corev1.PersistentVolume,
+	readOnly bool,
+	secret *corev1.Secret,
+) (*csi.NodePublishVolumeRequest, error) {
+	if err := p.validate(containerMountTarget, pv, secret); err != nil {
+		return nil, err
+	}
+
+	// VolumeContext: copy all VolumeAttributes as-is
+	// validate() guarantees VolumeAttributes is non-nil (source is required),
+	// so the fuseType default below cannot assign to a nil map. The explicit
+	// nil check keeps that guarantee from becoming a panic if the validate
+	// call order ever changes.
+	volCtx := maps.Clone(pv.Spec.CSI.VolumeAttributes)
+	if volCtx == nil {
+		return nil, fmt.Errorf("volumeAttributes must not be nil")
+	}
+	// Whitespace-only values count as unset everywhere; drop their keys
+	// so the VolumeContext carries only meaningful entries. mount-proxy's
+	// parseOptions extracts known fields only, so stray empty keys are
+	// inert today — dropping them guards against a future revision that
+	// exports every VolumeContext key as an environment variable.
+	for k, v := range volCtx {
+		if strings.TrimSpace(v) == "" {
+			delete(volCtx, k)
+		}
+	}
+
+	// Set fuseType default after copy so the original is not modified.
+	// validate() accepts case-insensitive input; normalize to lowercase here
+	// so the entrypoint always receives the canonical identifier. All case
+	// variants of the key are collapsed into the canonical lowercase key so
+	// parseOptions, which extracts keys case-insensitively, sees exactly one
+	// value and the FsType/VolumeContext cross-check can never fire on
+	// provider-generated requests. validateFuseType rejected conflicting
+	// variants and mismatching CSI fsType, so the first non-empty value
+	// below is unambiguous.
+	fuseType := "customfuse"
+	if fst := strings.ToLower(strings.TrimSpace(pv.Spec.CSI.FSType)); fst != "" {
+		fuseType = fst
+	}
+	for k, v := range volCtx {
+		if strings.EqualFold(k, "fuseType") {
+			if strings.TrimSpace(v) != "" {
+				fuseType = strings.ToLower(strings.TrimSpace(v))
+			}
+			delete(volCtx, k)
+		}
+	}
+	volCtx["fuseType"] = fuseType
+
+	// Secrets: copy all Secret entries as-is
+	// Each key becomes an environment variable of the same name in the
+	// entrypoint, so the entrypoint author controls the env-var schema by
+	// naming the Secret keys accordingly.
+	secrets := make(map[string]string)
+	if secret != nil {
+		for k, v := range secret.Data {
+			secrets[k] = string(v)
+		}
+	}
+
+	// Read-only must be derived from both the requested mount and the PV
+	// access modes; do not weaken either source.
+	isReadOnly := IsPureReadOnly(pv.Spec.AccessModes) || readOnly
+
+	// The access mode follows the PV's access modes: the On-Demand Volume
+	// Mounting doc shares one PV across sandboxes, so a ReadWriteMany
+	// volume must advertise MULTI_NODE_MULTI_WRITER instead of a
+	// single-node default. A read-only mount is advertised as READER_ONLY
+	// so the CSI plugin and the entrypoint can rely on the AccessMode
+	// semantics.
+	accessMode := csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
+	if isReadOnly {
+		accessMode = csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY
+		if hasAccessMode(pv, corev1.ReadOnlyMany) || hasAccessMode(pv, corev1.ReadWriteMany) {
+			accessMode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
+		}
+	} else if hasAccessMode(pv, corev1.ReadWriteMany) {
+		accessMode = csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER
+	}
+
+	// VolumeId must be stable per volume because the CSI node plugin keys
+	// mount state by it. Prefer the storage-system handle and fall back to
+	// the PV name for statically provisioned volumes.
+	volumeID := pv.Name
+	if pv.Spec.CSI.VolumeHandle != "" {
+		volumeID = pv.Spec.CSI.VolumeHandle
+	}
+
+	// Build the CSI request
+	return &csi.NodePublishVolumeRequest{
+		VolumeId:   volumeID,
+		TargetPath: containerMountTarget,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{
+					FsType:     volCtx["fuseType"],
+					MountFlags: pv.Spec.MountOptions,
+				},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: accessMode,
+			},
+		},
+		VolumeContext: volCtx,
+		Secrets:       secrets,
+		Readonly:      isReadOnly,
+	}, nil
+}
+
+// validate performs structural, security, and field-level checks on the
+// provider inputs. It returns nil when the input is safe and complete enough
+// to construct a CSI request.
+func (p *CustomFuseMountProvider) validate(containerMountTarget string, pv *corev1.PersistentVolume, secret *corev1.Secret) error {
+	if err := validateVolume(containerMountTarget, pv); err != nil {
+		return err
+	}
+	volCtx := pv.Spec.CSI.VolumeAttributes
+	if err := validateVolumeAttributeKeys(volCtx); err != nil {
+		return err
+	}
+	if err := validateUnambiguousAttrs(volCtx); err != nil {
+		return err
+	}
+	if err := validateForwardedFields(volCtx); err != nil {
+		return err
+	}
+	if err := validateMountTarget(containerMountTarget); err != nil {
+		return err
+	}
+	if err := validateFuseType(volCtx, pv.Spec.CSI.FSType); err != nil {
+		return err
+	}
+	if err := validateShellSafeFields(volCtx, pv.Spec.MountOptions); err != nil {
+		return err
+	}
+	if err := validateCredentialSeparation(volCtx); err != nil {
+		return err
+	}
+	return validateSecret(secret)
+}
+
+// validateVolume checks the structural preconditions: a non-nil PV with a
+// CSI spec and a non-empty mount target.
+func validateVolume(containerMountTarget string, pv *corev1.PersistentVolume) error {
+	if pv == nil {
+		return fmt.Errorf("persistent volume object is nil")
+	}
+	if strings.TrimSpace(containerMountTarget) == "" {
+		return fmt.Errorf("containerMountTarget is empty")
+	}
+	if pv.Spec.CSI == nil {
+		return fmt.Errorf("no CSI spec in persistent volume")
+	}
+	return nil
+}
+
+// forEachAttr applies fn to the value of every volCtx key whose
+// case-insensitive form matches attr. parseOptions extracts keys from the
+// VolumeContext case-insensitively, so a key like "CAPACITY" would otherwise
+// bypass every check here; every variant must be validated and any invalid
+// value rejects the request.
+func forEachAttr(volCtx map[string]string, attr string, fn func(value string) error) error {
+	for k, v := range volCtx {
+		if strings.EqualFold(k, attr) {
+			if err := fn(v); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// validateVolumeAttributeKeys rejects volumeAttributes keys that are
+// dangerous environment variable names. mount-proxy does not export
+// VolumeContext keys as environment variables today (parseOptions extracts
+// only known fields), but a future revision might — this is defense in
+// depth. Invalid variable names stay allowed: bash cannot reference them,
+// so they are inert rather than dangerous, and rejecting them would break
+// the passthrough of arbitrary provider-specific keys.
+func validateVolumeAttributeKeys(volCtx map[string]string) error {
+	for key := range volCtx {
+		if customfusevalidate.IsBlockedEnvKey(key) {
+			return fmt.Errorf("volumeAttributes key %q is not allowed: it would be exported as a dangerous environment variable to the entrypoint", key)
+		}
+	}
+	return nil
+}
+
+// validateUnambiguousAttrs rejects volumeAttributes where multiple case
+// variants of the same known field carry different non-empty values.
+// parseOptions extracts keys case-insensitively by iterating the map, so
+// duplicate variants would make the effective value depend on map iteration
+// order. fuseType is handled in validateFuseType.
+func validateUnambiguousAttrs(volCtx map[string]string) error {
+	for _, attr := range []string{"source", "bucket", "url", "path", "otherOpts", "mountOptions", "capacity", "storageType", "authType"} {
+		first := ""
+		if err := forEachAttr(volCtx, attr, func(value string) error {
+			// Compare trimmed values so whitespace-only differences are
+			// reported by the character-set check below (the more
+			// accurate error) rather than as a spurious conflict.
+			value = strings.TrimSpace(value)
+			if value == "" {
+				return nil
+			}
+			if first == "" {
+				first = value
+				return nil
+			}
+			if value != first {
+				return fmt.Errorf("conflicting %s values %q and %q", attr, maskURLCreds(first), maskURLCreds(value))
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateForwardedFields checks every volumeAttributes field that is
+// forwarded to the sidecar entrypoint as an environment variable.
+//
+// source is required and shell-safe: it may be interpolated into a mount
+// command, so it must match a strict character set rather than a denylist.
+// The charset check runs on the raw value because the raw value is what gets
+// forwarded; the error message masks credentials embedded in the URL so they
+// never reach logs.
+//
+// url, bucket, path and storageType are optional and must match the same
+// safe character set. Whitespace-only values count as unset. url may embed
+// credentials (http://user:pass@host), so its error output is masked.
+func validateForwardedFields(volCtx map[string]string) error {
+	// Every case variant of source is checked because parseOptions extracts
+	// keys case-insensitively; whitespace-only variants count as unset and
+	// an all-unset source set is missing.
+	sourceSet := false
+	if err := forEachAttr(volCtx, "source", func(value string) error {
+		if strings.TrimSpace(value) == "" {
+			return nil
+		}
+		sourceSet = true
+		if !customfusevalidate.SafeForwardPattern.MatchString(value) {
+			return fmt.Errorf("source %q contains invalid characters", maskURLCreds(value))
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	if !sourceSet {
+		return fmt.Errorf("source is required for customfuse driver (e.g. JuiceFS META-URL like redis://host:6379/0)")
+	}
+
+	// url, bucket, path and storageType are optional: whitespace-only values
+	// count as unset. When present they must match the same safe character set
+	// as source; url may embed credentials (http://user:pass@host), so its
+	// error output is masked.
+	for _, field := range []string{"url", "bucket", "path", "storageType"} {
+		if err := forEachAttr(volCtx, field, func(value string) error {
+			if strings.TrimSpace(value) == "" {
+				return nil
+			}
+			if !customfusevalidate.SafeForwardPattern.MatchString(value) {
+				return fmt.Errorf("%s %q contains invalid characters", field, maskURLCreds(value))
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateMountTarget checks that the container mount target is an absolute
+// path made only of safe characters, and that it does not traverse to the
+// parent directory. Traversal would let a malicious volume escape the
+// mount-root subtree and shadow host paths.
+func validateMountTarget(containerMountTarget string) error {
+	if !strings.HasPrefix(containerMountTarget, "/") {
+		return fmt.Errorf("containerMountTarget %q must be absolute", containerMountTarget)
+	}
+	if !mountPathPattern.MatchString(containerMountTarget) {
+		return fmt.Errorf("containerMountTarget %q must contain only safe characters", containerMountTarget)
+	}
+	if strings.Contains(containerMountTarget, "//") {
+		return fmt.Errorf("containerMountTarget %q must not contain empty path segments", containerMountTarget)
+	}
+	for _, seg := range strings.Split(containerMountTarget, "/") {
+		if seg == ".." {
+			return fmt.Errorf("containerMountTarget %q must not traverse to the parent directory", containerMountTarget)
+		}
+	}
+	return nil
+}
+
+// validateFuseType restricts volumeAttributes.fuseType to the allowlist and
+// checks it against the PV's CSI fsType. Empty means "customfuse" (the
+// provider default), set by the caller after validation. The match is
+// case-insensitive; the canonical lowercase value is what reaches the
+// entrypoint. Conflicting case variants of fuseType are rejected: the
+// effective value would otherwise depend on map iteration order.
+func validateFuseType(volCtx map[string]string, fsType string) error {
+	// fsType is trimmed for the same reason as the volumeAttributes
+	// variants: trailing whitespace in YAML is invisible and must not
+	// turn a valid value into an unknown one.
+	fsType = strings.TrimSpace(fsType)
+	if fsType != "" && !customfusevalidate.AllowedFuseTypes[strings.ToLower(fsType)] {
+		return fmt.Errorf("unknown CSI fsType %q (allowed: %v)", customfusevalidate.MaskOptionValues(fsType), mapKeys(customfusevalidate.AllowedFuseTypes))
+	}
+	var explicit string
+	// Case variants of the key are checked because parseOptions extracts
+	// keys case-insensitively.
+	if err := forEachAttr(volCtx, "fuseType", func(value string) error {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return nil
+		}
+		low := strings.ToLower(value)
+		if !customfusevalidate.AllowedFuseTypes[low] {
+			return fmt.Errorf("unknown fuseType %q (allowed: %v)", customfusevalidate.MaskOptionValues(value), mapKeys(customfusevalidate.AllowedFuseTypes))
+		}
+		if explicit != "" && explicit != low {
+			return fmt.Errorf("conflicting fuseType values %q and %q", customfusevalidate.MaskOptionValues(explicit), customfusevalidate.MaskOptionValues(low))
+		}
+		explicit = low
+		return nil
+	}); err != nil {
+		return err
+	}
+	if explicit != "" && fsType != "" && !strings.EqualFold(explicit, fsType) {
+		return fmt.Errorf("fuseType %q conflicts with CSI fsType %q", customfusevalidate.MaskOptionValues(explicit), customfusevalidate.MaskOptionValues(fsType))
+	}
+	return nil
+}
+
+// validateShellSafeFields checks every option string that mount-proxy will
+// export as an environment variable and that the entrypoint may interpolate
+// into a mount command: the otherOpts/mountOptions/capacity volumeAttributes
+// fields, and pv.Spec.MountOptions (each entry becomes one env var). Shell
+// metacharacters are rejected, and mountOptions entries whose keys are
+// environment variables with code-execution or command-redirection side
+// effects are denied outright.
+func validateShellSafeFields(volCtx map[string]string, mountOptions []string) error {
+	// Case variants of the keys are checked because parseOptions extracts
+	// keys case-insensitively.
+	for _, field := range []string{"otherOpts", "mountOptions", "capacity"} {
+		if err := forEachAttr(volCtx, field, func(value string) error {
+			if customfusevalidate.HasShellMetachar(value) {
+				return fmt.Errorf("%s contains invalid shell characters: %q", field, customfusevalidate.MaskOptionValues(value))
+			}
+			// Same format the node server and the JuiceFS entrypoint
+			// accept, so a value passing the control plane never fails
+			// later in the chain. Trimmed like every other field:
+			// whitespace-only counts as unset.
+			if field == "capacity" {
+				trimmed := strings.TrimSpace(value)
+				if trimmed != "" && !customfusevalidate.CapacityPattern.MatchString(trimmed) {
+					return fmt.Errorf("invalid capacity %q: must be a plain integer or one of Ti/TiB, Gi/GiB, Mi/MiB, Ki/KiB units (e.g. 100, 100Gi)", customfusevalidate.MaskOptionValues(trimmed))
+				}
+			}
+			// otherOpts/mountOptions are option lists ("key=value,...") that
+			// the entrypoint appends to the -o string after the
+			// provider-composed options, so a reserved key inside them would
+			// override provider-injected mount semantics just like a
+			// pv.Spec.MountOptions entry. capacity is a plain value and has no
+			// option list. Options are split on both space and comma because
+			// the entrypoint accepts either separator; splitting on comma
+			// alone would let a space-separated entry ("cache-size=1024
+			// source=evil") hide a reserved key inside one token.
+			if field != "capacity" {
+				for _, opt := range strings.FieldsFunc(value, func(r rune) bool { return r == ',' || r == ' ' || r == '\t' }) {
+					key, _, _ := strings.Cut(opt, "=")
+					// Same rejection as ValidateMountOptions: a keyless
+					// "=value" entry is malformed and would dodge the
+					// key-based check below ("" is not reserved).
+					if key == "" {
+						return fmt.Errorf("%s option %q is not allowed: empty option key", field, customfusevalidate.MaskOptionValues(opt))
+					}
+					// Same rejection as ValidateMountOptions: subdir= follows
+					// the official JuiceFS CSI mountOptions convention but is
+					// not supported here (use the path volumeAttribute).
+					// Exact match only, consistent with the case-sensitive
+					// option checks: the client treats option keys
+					// case-sensitively.
+					if key == "subdir" {
+						return fmt.Errorf("%s option %q is not supported: use the path volumeAttribute to mount a sub-directory", field, customfusevalidate.MaskOptionValues(opt))
+					}
+					if customfusevalidate.IsReservedKey(key) {
+						return fmt.Errorf("%s option %q is reserved for provider-injected mount semantics and must not be overridden", field, customfusevalidate.MaskOptionValues(opt))
+					}
+					// Credential-like sub-keys inside option lists would
+					// carry their values into mount options and logs.
+					if customfusevalidate.IsCredentialKey(key) {
+						return fmt.Errorf("%s option %q must not carry credential material, put it in Secret instead", field, customfusevalidate.MaskOptionValues(opt))
+					}
+				}
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return customfusevalidate.ValidateMountOptions(mountOptions)
+}
+
+// validateCredentialSeparation forces token, access keys, and passphrases to
+// live in a Kubernetes Secret (PV.Spec.CSI.NodePublishSecretRef) instead of
+// plain-text VolumeAttributes.
+func validateCredentialSeparation(volCtx map[string]string) error {
+	// Keys are matched case-insensitively against the shared credential
+	// list (customfusevalidate.IsCredentialKey), mirroring parseOptions.
+	for key := range volCtx {
+		if customfusevalidate.IsCredentialKey(key) {
+			return fmt.Errorf("credential %q must not be in volumeAttributes, put it in Secret instead", key)
+		}
+	}
+	return nil
+}
+
+// validateSecret checks that every Secret key is a valid environment variable
+// name, is not a dangerous environment key, is not a reserved provider key,
+// and that every value is single-line. The customfuse contract maps each
+// Secret key to an environment variable of the same name in the entrypoint:
+// bash cannot reference names with dashes or leading digits, a key like
+// BASH_ENV would be sourced by the entrypoint shell at startup (arbitrary
+// code execution), a reserved key would override provider-injected mount
+// semantics, and a value containing a newline would inject extra lines into
+// the s3fs credential file.
+func validateSecret(secret *corev1.Secret) error {
+	if secret == nil {
+		return nil
+	}
+	return customfusevalidate.ValidateSecretData(secret.Data)
+}
+
+// maskURLCreds replaces credentials embedded in URLs with *** so that error
+// messages never leak them into logs. It masks userinfo and query/fragment
+// values, where credentials canonically live. URL path segments are not
+// masked: paths can legitimately carry bucket/object keys and masking them
+// would corrupt the diagnostic value of the error message.
+func maskURLCreds(s string) string {
+	s = credInURLPattern.ReplaceAllString(s, "://***@")
+	s = credUserInfoPattern.ReplaceAllString(s, "${1}***@")
+	return queryValuePattern.ReplaceAllString(s, "${1}***")
+}
+
+// mapKeys returns the sorted keys of m. It is used only for error messages;
+// sorting keeps the allowed list stable across calls and test runs.
+func mapKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/agent-runtime/storages/customfuse_provider_test.go
+++ b/pkg/agent-runtime/storages/customfuse_provider_test.go
@@ -1,0 +1,1610 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storages
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	csiapi "github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/golang/protobuf/proto" // required: the csi spec dependency is generated with the legacy protobuf API
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCustomFuseMountProvider_GenerateCSINodePublishVolumeRequest(t *testing.T) {
+	tests := []struct {
+		name                  string
+		containerMountTarget  string
+		volumeAttributes      map[string]string
+		csiFSType             string
+		accessModes           []corev1.PersistentVolumeAccessMode
+		pvMountOptions        []string
+		secretData            map[string][]byte
+		readOnly              bool
+		expectError           string
+		expectErrorNotContain []string
+		nilPV                 bool
+		nilCSI                bool
+		validateResult        func(*testing.T, *csiapi.NodePublishVolumeRequest)
+	}{
+		// Happy path
+		{
+			name:                 "valid JuiceFS mount with source and fuseType",
+			containerMountTarget: "/workspace/data",
+			volumeAttributes: map[string]string{
+				"source":   "redis://redis-cluster:6379/0",
+				"fuseType": "juicefs",
+			},
+			secretData: map[string][]byte{
+				"token": []byte("test-token"),
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "/workspace/data", req.TargetPath)
+				assert.Equal(t, "juicefs", req.VolumeContext["fuseType"])
+				assert.Equal(t, "redis://redis-cluster:6379/0", req.VolumeContext["source"])
+				assert.Equal(t, "test-token", req.Secrets["token"])
+				assert.Equal(t, "pv-test-handle", req.VolumeId)
+				assert.NotNil(t, req.VolumeCapability)
+			},
+		},
+		{
+			name:                 "default fuseType when not set",
+			containerMountTarget: "/mnt/data",
+			volumeAttributes: map[string]string{
+				"source": "redis://localhost:6379/1",
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "customfuse", req.VolumeContext["fuseType"])
+			},
+		},
+		{
+			name:                 "fuseType from VolumeCapability.FsType",
+			containerMountTarget: "/mnt/data",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0",
+				// fuseType not set in volumeAttributes, but FsType in the PV CSI spec
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				// fuseType is set in the Provider from VolumeAttributes, not FsType
+				// verify defaults are applied correctly
+				assert.NotEmpty(t, req.VolumeContext["fuseType"])
+			},
+		},
+		{
+			name:                 "includes bucket, url, path, and capacity",
+			containerMountTarget: "/mnt/data",
+			volumeAttributes: map[string]string{
+				"source":   "redis://redis:6379/0",
+				"fuseType": "juicefs",
+				"bucket":   "ml-datasets",
+				"url":      "https://s3.amazonaws.com",
+				"path":     "/user-123",
+				"capacity": "100Gi",
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "ml-datasets", req.VolumeContext["bucket"])
+				assert.Equal(t, "https://s3.amazonaws.com", req.VolumeContext["url"])
+				assert.Equal(t, "/user-123", req.VolumeContext["path"])
+				assert.Equal(t, "100Gi", req.VolumeContext["capacity"])
+			},
+		},
+		{
+			name:                 "all volumeAttributes passed through unchanged",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":       "redis://redis:6379/0",
+				"fuseType":     "juicefs",
+				"bucket":       "my-bucket",
+				"url":          "https://oss.example.com",
+				"path":         "/sub/path",
+				"capacity":     "50Gi",
+				"otherOpts":    "cache-size=1024",
+				"otheropts":    "cache-size=1024",
+				"extra-custom": "custom-value",
+			},
+			secretData: map[string][]byte{
+				"access_key":    []byte("AKID123"),
+				"secret_key":    []byte("SECRET456"),
+				"custom_config": []byte("config-value"),
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				// All volumeAttributes are preserved
+				assert.Equal(t, "my-bucket", req.VolumeContext["bucket"])
+				assert.Equal(t, "custom-value", req.VolumeContext["extra-custom"])
+				// All secrets are passed through
+				assert.Equal(t, "AKID123", req.Secrets["access_key"])
+				assert.Equal(t, "config-value", req.Secrets["custom_config"])
+			},
+		},
+
+		// ReadOnly
+		{
+			name:                 "readOnly=true is set on request",
+			containerMountTarget: "/mnt/data",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			readOnly:             true,
+			expectError:          "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.True(t, req.Readonly)
+				assert.Equal(t, csiapi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY,
+					req.VolumeCapability.GetAccessMode().GetMode())
+			},
+		},
+		{
+			name:                 "readOnly=false by default",
+			containerMountTarget: "/mnt/data",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			readOnly:             false,
+			expectError:          "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.False(t, req.Readonly)
+				assert.Equal(t, csiapi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					req.VolumeCapability.GetAccessMode().GetMode())
+			},
+		},
+		{
+			name:                 "ReadOnlyMany PV implies read-only even when readOnly=false",
+			containerMountTarget: "/mnt/data",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			accessModes:          []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany},
+			expectError:          "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.True(t, req.Readonly)
+				assert.Equal(t, csiapi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+					req.VolumeCapability.GetAccessMode().GetMode())
+			},
+		},
+		{
+			name:                 "ReadWriteMany PV advertises multi-node writer",
+			containerMountTarget: "/mnt/data",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			accessModes:          []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+			expectError:          "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.False(t, req.Readonly)
+				assert.Equal(t, csiapi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+					req.VolumeCapability.GetAccessMode().GetMode())
+			},
+		},
+		{
+			name:                 "ReadWriteMany PV with readOnly=true becomes multi-node reader",
+			containerMountTarget: "/mnt/data",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			accessModes:          []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+			readOnly:             true,
+			expectError:          "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.True(t, req.Readonly)
+				assert.Equal(t, csiapi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+					req.VolumeCapability.GetAccessMode().GetMode())
+			},
+		},
+		{
+			name:                 "ReadWriteOnce PV stays writable when readOnly=false",
+			containerMountTarget: "/mnt/data",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			accessModes:          []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			expectError:          "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.False(t, req.Readonly)
+				assert.Equal(t, csiapi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					req.VolumeCapability.GetAccessMode().GetMode())
+			},
+		},
+		{
+			name:                 "mixed access modes weaken read-only to writable",
+			containerMountTarget: "/mnt/data",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			accessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadOnlyMany, corev1.ReadWriteOnce,
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.False(t, req.Readonly)
+				assert.Equal(t, csiapi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					req.VolumeCapability.GetAccessMode().GetMode())
+			},
+		},
+
+		// Error: structural checks
+		{
+			name:                 "nil persistent volume",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			expectError:          "persistent volume object is nil",
+			nilPV:                true,
+		},
+		{
+			name:                 "nil CSI spec",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			expectError:          "no CSI spec",
+			nilCSI:               true,
+		},
+		{
+			name:                 "empty mount path",
+			containerMountTarget: "",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			expectError:          "containerMountTarget is empty",
+		},
+
+		// Error: source required / shell-safe
+		{
+			name:                 "empty source",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{},
+			expectError:          "source is required",
+		},
+		{
+			name:                 "whitespace-only source",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "   "},
+			expectError:          "source is required",
+		},
+		{
+			name:                 "source with semicolon injection",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0; rm -rf /",
+			},
+			expectError: "contains invalid characters",
+		},
+		{
+			name:                 "source with command substitution",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0$(whoami)",
+			},
+			expectError: "contains invalid characters",
+		},
+		{
+			name:                 "source with embedded space",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0 extra",
+			},
+			expectError: "contains invalid characters",
+		},
+		{
+			name:                 "source with trailing whitespace is rejected on the raw value",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0 ",
+			},
+			expectError: "contains invalid characters",
+		},
+		{
+			name:                 "source error message masks embedded credentials",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://user:pass@host:6379/0?secret=xyz",
+			},
+			expectError:           "contains invalid characters",
+			expectErrorNotContain: []string{"user:pass", "xyz"},
+		},
+		{
+			name:                 "source error message masks query-string signature",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc123&X-Amz-Credential=AKID",
+			},
+			expectError:           "contains invalid characters",
+			expectErrorNotContain: []string{"abc123", "AKID"},
+		},
+		{
+			name:                  "source error message masks bare userinfo without scheme",
+			containerMountTarget:  "/mnt",
+			volumeAttributes:      map[string]string{"source": "user:pass@host;evil"},
+			expectError:           "invalid characters",
+			expectErrorNotContain: []string{"pass"},
+		},
+		{
+			name:                 "url error message masks multiple bare userinfo segments",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0",
+				"url":    "user:pass@host;evil",
+			},
+			expectError:           "invalid characters",
+			expectErrorNotContain: []string{"pass"},
+		},
+		{
+			name:                 "source error message masks multiple credential segments",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://user:pass@sub@host:6379/0;touch /tmp/x",
+			},
+			expectError:           "contains invalid characters",
+			expectErrorNotContain: []string{"user:pass@sub", "pass@sub"},
+		},
+		{
+			name:                 "source with embedded credentials is allowed and passes through",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://user:pass@host:6379/0",
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "redis://user:pass@host:6379/0", req.VolumeContext["source"])
+			},
+		},
+		{
+			name:                 "url-encoded equals in query is masked",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0?token%3Dsecret;touch /tmp/x",
+			},
+			expectError:           "contains invalid characters",
+			expectErrorNotContain: []string{"secret"},
+		},
+
+		// Error: url/bucket/path character checks
+		{
+			name:                 "url with whitespace rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "s3://ml-datasets",
+				"url":    "http://host:9000 path",
+			},
+			expectError: "contains invalid characters",
+		},
+		{
+			name:                 "url with shell metachar rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "s3://ml-datasets",
+				"url":    "http://host:9000;rm -rf /",
+			},
+			expectError: "contains invalid characters",
+		},
+		{
+			name:                 "url error masks embedded credentials",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "s3://ml-datasets",
+				"url":    "http://user:pass@host:9000 path",
+			},
+			expectError:           "contains invalid characters",
+			expectErrorNotContain: []string{"user:pass"},
+		},
+		{
+			name:                 "valid url passes",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "s3://ml-datasets",
+				"url":    "http://minio.sandbox-system:9000",
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "http://minio.sandbox-system:9000", req.VolumeContext["url"])
+			},
+		},
+		{
+			name:                 "bucket with shell metachar rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "s3://ml-datasets",
+				"bucket": "b;rm -rf /",
+			},
+			expectError: "contains invalid characters",
+		},
+		{
+			name:                 "path with shell metachar rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0",
+				"path":   "/sub;rm -rf /",
+			},
+			expectError: "contains invalid characters",
+		},
+		{
+			name:                 "storageType with shell metachar rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":      "redis://host:6379/0",
+				"storageType": "oss;rm -rf /",
+			},
+			expectError: "contains invalid characters",
+		},
+		{
+			name:                 "valid storageType passes through",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":      "redis://host:6379/0",
+				"storageType": "oss",
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "oss", req.VolumeContext["storageType"])
+			},
+		},
+
+		// Error: mountPath shell-safety
+		{
+			name:                 "relative mount path",
+			containerMountTarget: "workspace/data",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			expectError:          "must be absolute",
+		},
+		{
+			name:                 "mount path with semicolon injection",
+			containerMountTarget: "/mnt;rm -rf /",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			expectError:          "safe characters",
+		},
+		{
+			name:                 "mount path with embedded space",
+			containerMountTarget: "/mnt/data dir",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			expectError:          "safe characters",
+		},
+		{
+			name:                 "mount path traverses to parent",
+			containerMountTarget: "/mnt/../etc",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			expectError:          "must not traverse",
+		},
+		{
+			name:                 "mount path with trailing parent segment",
+			containerMountTarget: "/mnt/..",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			expectError:          "must not traverse",
+		},
+		{
+			name:                 "mount path with double dots inside a segment is allowed",
+			containerMountTarget: "/mnt/data..2026",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			expectError:          "",
+		},
+
+		// Error: fuseType allowlist
+		{
+			name:                 "unknown fuseType",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"fuseType": "unknown-fuse-client",
+			},
+			expectError: "unknown fuseType",
+		},
+		{
+			name:                 "uppercase fuseType normalized to lowercase",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"fuseType": "JuiceFS",
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "juicefs", req.VolumeContext["fuseType"])
+				assert.Equal(t, "juicefs", req.VolumeCapability.GetMount().FsType)
+			},
+		},
+		{
+			name:                 "conflicting case variants of fuseType rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"fuseType": "juicefs",
+				"FUSETYPE": "s3fs",
+			},
+			expectError: "conflicting fuseType values",
+		},
+		{
+			name:                 "identical case variants of fuseType accepted",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"fuseType": "JuiceFS",
+				"FUSETYPE": "juicefs",
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "juicefs", req.VolumeContext["fuseType"])
+			},
+		},
+		{
+			// Trailing whitespace in YAML is invisible; it must not turn a
+			// valid value into an unknown one or leak into the request.
+			name:                 "fuseType with trailing whitespace normalized",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"fuseType": "juicefs ",
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "juicefs", req.VolumeContext["fuseType"])
+				assert.Equal(t, "juicefs", req.VolumeCapability.GetMount().FsType)
+			},
+		},
+		{
+			name:                 "IPv6 source accepted",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://[::1]:6379/0",
+			},
+			expectError: "",
+		},
+		{
+			name:                 "mount target with empty segment rejected",
+			containerMountTarget: "/a//b",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			expectError:          "must not contain empty path segments",
+		},
+		{
+			name:                 "CSI fsType used as default when fuseType unset",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0",
+			},
+			csiFSType:   "s3fs",
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "s3fs", req.VolumeContext["fuseType"])
+				assert.Equal(t, "s3fs", req.VolumeCapability.GetMount().FsType)
+			},
+		},
+		{
+			name:                 "fuseType conflicting with CSI fsType rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"fuseType": "juicefs",
+			},
+			csiFSType:   "s3fs",
+			expectError: "conflicts with CSI fsType",
+		},
+		{
+			name:                 "unknown CSI fsType rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0",
+			},
+			csiFSType:   "unknown-fs",
+			expectError: "unknown CSI fsType",
+		},
+		{
+			name:                 "BASH_ENV volumeAttributes key rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"BASH_ENV": "/tmp/evil.sh",
+			},
+			expectError: "not allowed",
+		},
+		{
+			name:                 "conflicting case variants of source rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0",
+				"Source": "redis://host:6379/1",
+			},
+			expectError: "conflicting source values",
+		},
+		{
+			name:                 "identical case variants of source accepted",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0",
+				"Source": "redis://host:6379/0",
+			},
+			expectError: "",
+		},
+		{
+			// Whitespace-only differences are not a conflict: the
+			// character-set check reports the padded value instead.
+			name:                 "whitespace-padded variant rejected by charset check",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0",
+				"Source": " redis://host:6379/0",
+			},
+			expectError: "invalid characters",
+		},
+		{
+			name:                 "empty value variant dropped from VolumeContext",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "",
+				"Source": "redis://host:6379/0",
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "redis://host:6379/0", req.VolumeContext["Source"])
+				assert.NotContains(t, req.VolumeContext, "source")
+			},
+		},
+
+		// Error: shell injection prevention
+		{
+			name:                 "otherOpts contains semicolon",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"otherOpts": "cache-dir=/tmp; rm -rf /",
+			},
+			expectError: "invalid shell characters",
+		},
+		{
+			name:                 "otherOpts contains pipe",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"otherOpts": "opt1 | cat /etc/passwd",
+			},
+			expectError: "invalid shell characters",
+		},
+		{
+			name:                 "otherOpts contains backtick",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"otherOpts": "opt=`id`",
+			},
+			expectError: "invalid shell characters",
+		},
+		{
+			name:                 "otherOpts contains dollar",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"otherOpts": "opt=$(whoami)",
+			},
+			expectError: "invalid shell characters",
+		},
+		{
+			name:                 "otherOpts contains null byte",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"otherOpts": "safe\x00injection",
+			},
+			expectError: "invalid shell characters",
+		},
+		{
+			name:                 "mountOptions contains semicolon",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":       "redis://host:6379/0",
+				"mountOptions": "opt1; rm /tmp",
+			},
+			expectError: "invalid shell characters",
+		},
+		{
+			name:                 "capacity contains command substitution",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"capacity": "100Gi$(whoami)",
+			},
+			expectError: "invalid shell characters",
+		},
+		{
+			name:                 "otherOpts contains carriage return",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"otherOpts": "safe\rvalue",
+			},
+			expectError: "invalid shell characters",
+		},
+		{
+			name:                 "otherOpts error masks key=value credential material",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"otherOpts": "token=xyz123; rm -rf /",
+			},
+			expectError:           "invalid shell characters",
+			expectErrorNotContain: []string{"xyz123"},
+		},
+
+		// Error: credential separation
+		{
+			name:                 "token in volumeAttributes should fail",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0",
+				"token":  "secret-token-in-wrong-place",
+			},
+			expectError: "must not be in volumeAttributes",
+		},
+		{
+			name:                 "accessKeyId in volumeAttributes should fail",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":      "redis://host:6379/0",
+				"accessKeyId": "AKID123",
+			},
+			expectError: "must not be in volumeAttributes",
+		},
+		{
+			name:                 "access-key in volumeAttributes should fail",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":     "redis://host:6379/0",
+				"access-key": "AKID123",
+			},
+			expectError: "must not be in volumeAttributes",
+		},
+		{
+			name:                 "passphrase in volumeAttributes should fail",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":     "redis://host:6379/0",
+				"passphrase": "my-passphrase",
+			},
+			expectError: "must not be in volumeAttributes",
+		},
+		{
+			name:                 "secret-key in volumeAttributes should fail",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":     "redis://host:6379/0",
+				"secret-key": "SECRET456",
+			},
+			expectError: "must not be in volumeAttributes",
+		},
+		{
+			name:                 "access_key in volumeAttributes should fail",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":     "redis://host:6379/0",
+				"access_key": "AKID123",
+			},
+			expectError: "must not be in volumeAttributes",
+		},
+		{
+			name:                 "password in volumeAttributes should fail",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"password": "p@ssw0rd",
+			},
+			expectError: "must not be in volumeAttributes",
+		},
+		{
+			name:                 "ak in volumeAttributes should fail",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0",
+				"ak":     "AKID123",
+			},
+			expectError: "must not be in volumeAttributes",
+		},
+		{
+			name:                 "sk in volumeAttributes should fail",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0",
+				"sk":     "SECRET456",
+			},
+			expectError: "must not be in volumeAttributes",
+		},
+
+		// Error: case-variant keys must not bypass validation. parseOptions
+		// extracts keys from the VolumeContext case-insensitively, so the
+		// provider must validate every case variant of the keys it forwards.
+		{
+			name:                 "uppercase CAPACITY with command substitution rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"CAPACITY": "100Gi$(whoami)",
+			},
+			expectError: "invalid shell characters",
+		},
+		{
+			name:                 "uppercase OTHEROPTS with semicolon rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"OTHEROPTS": "opt1; rm -rf /",
+			},
+			expectError: "invalid shell characters",
+		},
+		{
+			name:                 "uppercase MOUNTOPTIONS with backtick rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":       "redis://host:6379/0",
+				"MOUNTOPTIONS": "opt=`id`",
+			},
+			expectError: "invalid shell characters",
+		},
+		{
+			name:                 "uppercase SOURCE with invalid characters rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"SOURCE": "redis://host:6379/0; rm -rf /",
+			},
+			expectError: "contains invalid characters",
+		},
+		{
+			name:                 "uppercase URL with whitespace rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "s3://ml-datasets",
+				"URL":    "http://host:9000 path",
+			},
+			expectError: "contains invalid characters",
+		},
+		{
+			name:                 "uppercase BUCKET with shell metachar rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "s3://ml-datasets",
+				"BUCKET": "b;rm -rf /",
+			},
+			expectError: "contains invalid characters",
+		},
+		{
+			// PATH is a dangerous environment key: rejected by the key
+			// check before the value is even inspected.
+			name:                 "uppercase PATH key rejected as dangerous env key",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0",
+				"PATH":   "/sub;rm -rf /",
+			},
+			expectError: "not allowed",
+		},
+		{
+			name:                 "uppercase FUSETYPE unknown value rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"FUSETYPE": "unknown-fuse-client",
+			},
+			expectError: "unknown fuseType",
+		},
+		{
+			name:                 "uppercase TOKEN in volumeAttributes rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0",
+				"TOKEN":  "secret-token-in-wrong-place",
+			},
+			expectError: "must not be in volumeAttributes",
+		},
+		{
+			name:                 "mixed-case ACCESSKEYID in volumeAttributes rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":      "redis://host:6379/0",
+				"accessKeyId": "AKID123",
+			},
+			expectError: "must not be in volumeAttributes",
+		},
+		{
+			name:                 "uppercase SOURCE variant alone is a valid source",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"SOURCE": "redis://host:6379/0",
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				// Keys pass through unchanged; parseOptions extracts them
+				// case-insensitively downstream.
+				assert.Equal(t, "redis://host:6379/0", req.VolumeContext["SOURCE"])
+			},
+		},
+		{
+			name:                 "whitespace-only uppercase SOURCE counts as missing",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"SOURCE": "   ",
+			},
+			expectError: "source is required",
+		},
+		{
+			name:                 "empty SOURCE variant next to valid source is ignored",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source": "redis://host:6379/0",
+				"SOURCE": "",
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "redis://host:6379/0", req.VolumeContext["source"])
+			},
+		},
+		{
+			name:                 "uppercase FuseType normalized to canonical lowercase key",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"FuseType": "JuiceFS",
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "juicefs", req.VolumeContext["fuseType"])
+				assert.Equal(t, "juicefs", req.VolumeCapability.GetMount().FsType)
+				assert.NotContains(t, req.VolumeContext, "FuseType")
+				assert.Len(t, req.VolumeContext, 2)
+			},
+		},
+		{
+			name:                 "duplicate fuseType case variants collapsed to one canonical key",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"fuseType": "juicefs",
+				"FuseType": "JUICEfs",
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "juicefs", req.VolumeContext["fuseType"])
+				assert.Equal(t, "juicefs", req.VolumeCapability.GetMount().FsType)
+				assert.NotContains(t, req.VolumeContext, "FuseType")
+				assert.Len(t, req.VolumeContext, 2)
+			},
+		},
+
+		// Error: secret key env-identifier validation
+		{
+			name:                 "secret key with dash rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			secretData: map[string][]byte{
+				"access-key": []byte("AKID123"),
+			},
+			expectError: "not a valid environment variable name",
+		},
+		{
+			name:                 "secret key starting with digit rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			secretData: map[string][]byte{
+				"1token": []byte("value"),
+			},
+			expectError: "not a valid environment variable name",
+		},
+		{
+			name:                 "secret key with underscore is valid",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			secretData: map[string][]byte{
+				"access_key": []byte("AKID123"),
+			},
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "AKID123", req.Secrets["access_key"])
+			},
+		},
+		{
+			name:                 "secret value with newline rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			secretData: map[string][]byte{
+				"access_key": []byte("line1\nline2"),
+			},
+			expectError: "must not contain a newline",
+		},
+		{
+			name:                 "secret value with carriage return rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			secretData: map[string][]byte{
+				"access_key": []byte("line1\rline2"),
+			},
+			expectError: "must not contain a newline",
+		},
+
+		// Error: dangerous environment keys in Secret (exported as env vars
+		// by mount-proxy; bash would source BASH_ENV at startup)
+		{
+			name:                 "secret key BASH_ENV rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			secretData: map[string][]byte{
+				"BASH_ENV": []byte("/run/csi/mount-root/evil.sh"),
+			},
+			expectError: "not allowed",
+		},
+		{
+			name:                 "secret key LD_PRELOAD rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			secretData: map[string][]byte{
+				"LD_PRELOAD": []byte("/tmp/x.so"),
+			},
+			expectError: "not allowed",
+		},
+		{
+			name:                 "secret key IFS rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			secretData: map[string][]byte{
+				"IFS": []byte("x"),
+			},
+			expectError: "not allowed",
+		},
+
+		// Error: reserved provider-injected keys in Secret (mount-proxy exports
+		// Secret entries verbatim and the last duplicate env wins, so these
+		// would override the validated mount source / read-only / target)
+		{
+			name:                 "secret key source rejected as reserved",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			secretData: map[string][]byte{
+				"source": []byte("redis://evil:6379/0"),
+			},
+			expectError: "reserved",
+		},
+		{
+			name:                 "secret key readOnly rejected as reserved",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			secretData: map[string][]byte{
+				"readOnly": []byte("false"),
+			},
+			expectError: "reserved",
+		},
+		{
+			name:                 "secret key mountpoint rejected as reserved",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			secretData: map[string][]byte{
+				"mountpoint": []byte("/etc/hosts"),
+			},
+			expectError: "reserved",
+		},
+		{
+			name:                 "secret key otherOpts rejected as reserved",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			secretData: map[string][]byte{
+				"otherOpts": []byte("cache-size=1"),
+			},
+			expectError: "reserved",
+		},
+
+		// Edge cases
+		{
+			name:                 "agent-identity mode with nil secret",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"fuseType": "juicefs",
+			},
+			secretData:  nil,
+			expectError: "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, "juicefs", req.VolumeContext["fuseType"])
+				assert.Empty(t, req.Secrets)
+			},
+		},
+		{
+			name:                 "empty secret",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			secretData:           map[string][]byte{},
+			expectError:          "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Empty(t, req.Secrets)
+			},
+		},
+		{
+			name:                 "fuseType customfuse is valid",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"fuseType": "customfuse",
+			},
+			expectError: "",
+		},
+		{
+			name:                 "fuseType s3fs is valid",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "s3://my-bucket",
+				"fuseType": "s3fs",
+			},
+			expectError: "",
+		},
+		{
+			// jindo has no shipped entrypoint; a client that validates
+			// without an implementation would fall through to the wrong
+			// entrypoint, so it is not in the allowlist.
+			name:                 "fuseType jindo without implementation rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "oss://bucket",
+				"fuseType": "jindo",
+			},
+			expectError: "unknown fuseType",
+		},
+		{
+			name:                 "safe otherOpts passes validation",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"otherOpts": "cache-size=1024,cache-dir=/ssd-cache,prefetch=1",
+			},
+			expectError: "",
+		},
+
+		// Error: reserved provider keys smuggled inside the option-list
+		// fields (the entrypoint appends them to the -o string after the
+		// provider-composed options, so they would override the validated
+		// url/source/bucket semantics)
+		{
+			name:                 "otherOpts url override rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"otherOpts": "url=http://attacker:9000",
+			},
+			expectError: "reserved for provider-injected",
+		},
+		{
+			name:                 "otherOpts source override rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"otherOpts": "cache-size=1024,source=redis://evil:6379/0",
+			},
+			expectError: "reserved for provider-injected",
+		},
+		{
+			name:                 "otherOpts readOnly override rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"otherOpts": "readOnly=false",
+			},
+			expectError: "reserved for provider-injected",
+		},
+		{
+			// Space-separated options must not hide a reserved key inside
+			// one comma-split token.
+			name:                 "otherOpts space-separated reserved override rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"otherOpts": "cache-size=1024 source=evil",
+			},
+			expectError: "reserved for provider-injected",
+		},
+		{
+			// Mirrors ValidateMountOptions: a keyless entry must not pass
+			// on this path while it is rejected on the pv.Spec.MountOptions
+			// path.
+			name:                 "otherOpts keyless entry rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"otherOpts": "cache-size=1024,=value",
+			},
+			expectError: "empty option key",
+		},
+		{
+			// subdir= follows the official JuiceFS CSI mountOptions
+			// convention but is not supported; point at the path attribute.
+			name:                 "otherOpts subdir option rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"otherOpts": "cache-size=1024,subdir=/my/sub",
+			},
+			expectError: "use the path volumeAttribute",
+		},
+		{
+			name:                 "pv mountOptions subdir option rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:       []string{"subdir=/my/sub"},
+			expectError:          "use the path volumeAttribute",
+		},
+		{
+			name:                 "volumeAttributes mountOptions url override rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":       "redis://host:6379/0",
+				"mountOptions": "url=http://attacker:9000",
+			},
+			expectError: "reserved for provider-injected",
+		},
+		{
+			// capacity is not an option list; an option-like value fails
+			// the shared CapacityPattern format check.
+			name:                 "capacity with option-like value rejected by format check",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":   "redis://host:6379/0",
+				"capacity": "url=x",
+			},
+			expectError: "invalid capacity",
+		},
+		{
+			name:                 "reserved override error masks value",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":    "redis://host:6379/0",
+				"otherOpts": "url=http://attacker:9000",
+			},
+			expectError:           "reserved for provider-injected",
+			expectErrorNotContain: []string{"attacker"},
+		},
+		{
+			name:                 "empty otherOpts and mountOptions pass validation",
+			containerMountTarget: "/mnt",
+			volumeAttributes: map[string]string{
+				"source":       "redis://host:6379/0",
+				"otherOpts":    "",
+				"mountOptions": "",
+			},
+			expectError: "",
+		},
+
+		// Error: PV.Spec.MountOptions -> MountFlags mapping
+		{
+			name:                 "PV mountOptions mapped to VolumeCapability MountFlags",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:       []string{"cache-size=1024", "no-update"},
+			expectError:          "",
+			validateResult: func(t *testing.T, req *csiapi.NodePublishVolumeRequest) {
+				assert.Equal(t, []string{"cache-size=1024", "no-update"},
+					req.VolumeCapability.GetMount().MountFlags)
+			},
+		},
+		{
+			name:                 "PV mountOptions with shell metachar rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:       []string{"opt1; rm -rf /"},
+			expectError:          "invalid shell characters",
+		},
+		{
+			name:                 "empty PV mountOptions passes validation",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:       []string{},
+			expectError:          "",
+		},
+
+		// Error: dangerous environment keys in mountOptions (exported as env
+		// vars by mount-proxy; bash/glibc would act on them)
+		{
+			name:                 "mountOptions BASH_ENV rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:       []string{"BASH_ENV=/tmp/x.sh"},
+			expectError:          "not allowed",
+		},
+		{
+			name:                 "mountOptions LD_PRELOAD rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:       []string{"LD_PRELOAD=/tmp/x.so"},
+			expectError:          "not allowed",
+		},
+		{
+			name:                 "mountOptions PATH rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:       []string{"PATH=/tmp"},
+			expectError:          "not allowed",
+		},
+		{
+			name:                 "bare dangerous key rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:       []string{"IFS"},
+			expectError:          "not allowed",
+		},
+		{
+			name:                 "hyphenated mount option still allowed",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:       []string{"cache-size=1024", "no-update"},
+			expectError:          "",
+		},
+		{
+			name:                 "lowercase dangerous key still allowed",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:       []string{"bash_env=/tmp/x.sh"},
+			expectError:          "",
+		},
+		{
+			name:                  "blocked mount option error masks value",
+			containerMountTarget:  "/mnt",
+			volumeAttributes:      map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:        []string{"BASH_ENV=/tmp/x.sh"},
+			expectError:           "not allowed",
+			expectErrorNotContain: []string{"/tmp/x.sh"},
+		},
+
+		// Error: reserved provider keys in mountOptions (exported as env vars
+		// by mount-proxy; on duplicate keys the last occurrence wins, so they
+		// would override the validated source/url/bucket semantics and can
+		// redirect credentials to an attacker endpoint)
+		{
+			name:                 "mountOptions url override rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:       []string{"url=http://attacker:9000"},
+			expectError:          "reserved for provider-injected",
+		},
+		{
+			name:                 "mountOptions source override rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:       []string{"source=redis://evil:6379/0"},
+			expectError:          "reserved for provider-injected",
+		},
+		{
+			name:                 "mountOptions otherOpts override rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:       []string{"otherOpts=debug"},
+			expectError:          "reserved for provider-injected",
+		},
+		{
+			name:                 "mountOptions readOnly override rejected",
+			containerMountTarget: "/mnt",
+			volumeAttributes:     map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:       []string{"readOnly=false"},
+			expectError:          "reserved for provider-injected",
+		},
+		{
+			name:                  "reserved override error masks value",
+			containerMountTarget:  "/mnt",
+			volumeAttributes:      map[string]string{"source": "redis://host:6379/0"},
+			pvMountOptions:        []string{"url=http://attacker:9000"},
+			expectError:           "reserved for provider-injected",
+			expectErrorNotContain: []string{"attacker"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var pv *corev1.PersistentVolume
+			if !tt.nilPV {
+				csiSpec := &corev1.CSIPersistentVolumeSource{
+					Driver:           "customfuseplugin.csi.openkruise.io",
+					VolumeHandle:     "pv-test-handle",
+					FSType:           tt.csiFSType,
+					VolumeAttributes: tt.volumeAttributes,
+				}
+				if tt.nilCSI {
+					csiSpec = nil
+				}
+				pv = &corev1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{Name: "pv-test"},
+					Spec: corev1.PersistentVolumeSpec{
+						AccessModes:  tt.accessModes,
+						MountOptions: tt.pvMountOptions,
+					},
+				}
+				if csiSpec != nil {
+					pv.Spec.PersistentVolumeSource = corev1.PersistentVolumeSource{
+						CSI: csiSpec,
+					}
+				}
+			}
+
+			var secret *corev1.Secret
+			if tt.secretData != nil {
+				secret = &corev1.Secret{
+					Data: tt.secretData,
+				}
+			}
+
+			provider := &CustomFuseMountProvider{}
+			result, err := provider.GenerateCSINodePublishVolumeRequest(
+				context.Background(),
+				tt.containerMountTarget,
+				pv,
+				tt.readOnly,
+				secret,
+			)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				for _, s := range tt.expectErrorNotContain {
+					assert.NotContains(t, err.Error(), s)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, result)
+				if tt.validateResult != nil {
+					tt.validateResult(t, result)
+				}
+			}
+		})
+	}
+}
+
+func TestCustomFuseMountProvider_VolumeIdStability(t *testing.T) {
+	tests := []struct {
+		name         string
+		volumeHandle string
+		want         string
+	}{
+		{"uses VolumeHandle when set", "pv-unique-handle", "pv-unique-handle"},
+		{"falls back to PV name when VolumeHandle is empty", "", "pv-unique"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &CustomFuseMountProvider{}
+			pv := &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "pv-unique"},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							Driver:           "customfuseplugin.csi.openkruise.io",
+							VolumeHandle:     tt.volumeHandle,
+							VolumeAttributes: map[string]string{"source": "redis://host:6379/0"},
+						},
+					},
+				},
+			}
+
+			// Generate two requests and verify the VolumeId is identical,
+			// because the CSI node plugin keys mount state by it.
+			req1, err1 := provider.GenerateCSINodePublishVolumeRequest(context.Background(), "/mnt", pv, false, nil)
+			require.NoError(t, err1)
+			req2, err2 := provider.GenerateCSINodePublishVolumeRequest(context.Background(), "/mnt", pv, false, nil)
+			require.NoError(t, err2)
+
+			assert.Equal(t, tt.want, req1.VolumeId, "VolumeId must be stable per volume")
+			assert.Equal(t, req1.VolumeId, req2.VolumeId, "consecutive mounts must yield the same VolumeId")
+		})
+	}
+}
+
+func TestCustomFuseMountProvider_PassthroughNonCustomfuseKeys(t *testing.T) {
+	// Verify that custom keys beyond the known customfuse spec are preserved
+	// in VolumeContext without filtering.
+	provider := &CustomFuseMountProvider{}
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-custom"},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver:       "customfuseplugin.csi.openkruise.io",
+					VolumeHandle: "pv-custom-handle",
+					VolumeAttributes: map[string]string{
+						"source":      "redis://host:6379/0",
+						"custom-key1": "value1",
+						"custom-key2": "value2",
+					},
+				},
+			},
+		},
+	}
+
+	req, err := provider.GenerateCSINodePublishVolumeRequest(context.Background(), "/mnt", pv, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "value1", req.VolumeContext["custom-key1"])
+	assert.Equal(t, "value2", req.VolumeContext["custom-key2"])
+}
+
+// TestCustomFuseMountProvider_DoesNotMutatePV verifies the AGENTS.md
+// invariant that provider validation and request generation never modify the
+// input PersistentVolume: the fuseType default must land in the cloned
+// VolumeContext, never in the original PV's volume attributes.
+func TestCustomFuseMountProvider_DoesNotMutatePV(t *testing.T) {
+	provider := &CustomFuseMountProvider{}
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-mutation"},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver:       "customfuseplugin.csi.openkruise.io",
+					VolumeHandle: "pv-mutation-handle",
+					VolumeAttributes: map[string]string{
+						"source": "redis://host:6379/0",
+					},
+				},
+			},
+		},
+	}
+
+	req, err := provider.GenerateCSINodePublishVolumeRequest(context.Background(), "/mnt", pv, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "customfuse", req.VolumeContext["fuseType"])
+
+	assert.Len(t, pv.Spec.CSI.VolumeAttributes, 1)
+	assert.NotContains(t, pv.Spec.CSI.VolumeAttributes, "fuseType")
+	assert.Equal(t, "redis://host:6379/0", pv.Spec.CSI.VolumeAttributes["source"])
+}
+
+// TestCustomFuseMountProvider_ProtoRoundtrip verifies that the generated
+// NodePublishVolumeRequest survives the full serialization pipeline used
+// by CSIMountHandler: proto.Marshal → base64 encode → base64 decode →
+// proto.Unmarshal. No fields should be lost or corrupted in transit.
+func TestCustomFuseMountProvider_ProtoRoundtrip(t *testing.T) {
+	provider := &CustomFuseMountProvider{}
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-roundtrip"},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver:       "customfuseplugin.csi.openkruise.io",
+					VolumeHandle: "pv-roundtrip-handle",
+					VolumeAttributes: map[string]string{
+						"source":    "redis://redis:6379/0",
+						"fuseType":  "juicefs",
+						"bucket":    "ml-datasets",
+						"url":       "https://s3.amazonaws.com",
+						"path":      "/user-123",
+						"capacity":  "100Gi",
+						"otherOpts": "cache-size=1024",
+					},
+				},
+			},
+		},
+	}
+	secret := &corev1.Secret{
+		Data: map[string][]byte{
+			"token":      []byte("test-token-value"),
+			"access_key": []byte("AKID-TEST"),
+			"secret_key": []byte("SECRET-TEST"),
+		},
+	}
+
+	original, err := provider.GenerateCSINodePublishVolumeRequest(
+		context.Background(), "/workspace/data", pv, true, secret,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, original)
+
+	// Simulate CSIMountHandler: proto.Marshal → base64 encode.
+	marshaled, err := proto.Marshal(original)
+	require.NoError(t, err)
+	encoded := base64.StdEncoding.EncodeToString(marshaled)
+
+	// Simulate sandbox-storage: base64 decode → proto.Unmarshal.
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+	restored := &csiapi.NodePublishVolumeRequest{}
+	err = proto.Unmarshal(decoded, restored)
+	require.NoError(t, err)
+
+	// Verify all fields survive the round-trip.
+	assert.Equal(t, original.VolumeId, restored.VolumeId)
+	assert.Equal(t, original.TargetPath, restored.TargetPath)
+	assert.Equal(t, original.Readonly, restored.Readonly)
+	assert.Equal(t, original.VolumeCapability.GetMount().FsType, restored.VolumeCapability.GetMount().FsType)
+	assert.Equal(t, original.VolumeContext["source"], restored.VolumeContext["source"])
+	assert.Equal(t, original.VolumeContext["fuseType"], restored.VolumeContext["fuseType"])
+	assert.Equal(t, original.VolumeContext["bucket"], restored.VolumeContext["bucket"])
+	assert.Equal(t, original.VolumeContext["url"], restored.VolumeContext["url"])
+	assert.Equal(t, original.VolumeContext["path"], restored.VolumeContext["path"])
+	assert.Equal(t, original.VolumeContext["capacity"], restored.VolumeContext["capacity"])
+	assert.Equal(t, original.VolumeContext["otherOpts"], restored.VolumeContext["otherOpts"])
+	assert.Equal(t, original.Secrets["token"], restored.Secrets["token"])
+	assert.Equal(t, original.Secrets["access_key"], restored.Secrets["access_key"])
+	assert.Equal(t, original.Secrets["secret_key"], restored.Secrets["secret_key"])
+}

--- a/pkg/agent-runtime/storages/utils.go
+++ b/pkg/agent-runtime/storages/utils.go
@@ -17,8 +17,8 @@ limitations under the License.
 package storages
 
 import (
-	"math/rand"
-	"time"
+	"math/rand/v2"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -26,24 +26,42 @@ import (
 const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
 
 func generateRandomString(length int) string {
-	rand.Seed(time.Now().UnixNano())
+	// math/rand/v2's global source is seeded automatically and is safe
+	// for concurrent use; the deprecated rand.Seed re-seed per call
+	// could produce identical sequences when calls land in the same
+	// nanosecond.
 	b := make([]byte, length)
 	for i := range b {
-		b[i] = charset[rand.Intn(len(charset))] // #nosec G404 -- non-security random for temp names
+		b[i] = charset[rand.IntN(len(charset))] // #nosec G404 -- non-security random for temp names
 	}
 	return string(b)
 }
 
+// IsPureReadOnly reports whether the volume is read-only by its access
+// modes. Any writable mode (ReadWriteOnce/Many/OncePod) makes the volume
+// writable; otherwise a non-empty mode list is treated as read-only so that
+// an unknown future mode defaults to the conservative direction instead of
+// silently weakening to writable. An empty mode list (no declaration) stays
+// writable, matching the mount request's own readOnly flag as the only
+// signal.
 func IsPureReadOnly(accessModes []corev1.PersistentVolumeAccessMode) bool {
+	if len(accessModes) == 0 {
+		return false
+	}
 	for _, mode := range accessModes {
-		if mode == corev1.ReadWriteOnce || mode == corev1.ReadWriteMany || mode == corev1.ReadWriteOncePod {
+		switch mode {
+		case corev1.ReadWriteOnce, corev1.ReadWriteMany, corev1.ReadWriteOncePod:
 			return false
+		case corev1.ReadOnlyMany:
+			// known read-only mode
+		default:
+			// Unknown mode: keep the conservative read-only default.
 		}
 	}
-	for _, mode := range accessModes {
-		if mode == corev1.ReadOnlyMany {
-			return true
-		}
-	}
-	return false
+	return true
+}
+
+// hasAccessMode reports whether the PV declares the given access mode.
+func hasAccessMode(pv *corev1.PersistentVolume, mode corev1.PersistentVolumeAccessMode) bool {
+	return slices.Contains(pv.Spec.AccessModes, mode)
 }

--- a/pkg/agent-runtime/storages/utils_test.go
+++ b/pkg/agent-runtime/storages/utils_test.go
@@ -69,6 +69,16 @@ func TestIsPureReadOnly(t *testing.T) {
 			accessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany},
 			expected:    true,
 		},
+		{
+			name:        "unknown access mode defaults to read-only",
+			accessModes: []corev1.PersistentVolumeAccessMode{"UnknownFutureMode"},
+			expected:    true,
+		},
+		{
+			name:        "unknown mode mixed with writable mode is writable",
+			accessModes: []corev1.PersistentVolumeAccessMode{"UnknownFutureMode", corev1.ReadWriteOnce},
+			expected:    false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

  ## I. Describe what this PR does
  Adds the control-plane CustomFuseMountProvider
  (customfuseplugin.csi.openkruise.io), registered via
  DYNAMIC_STORAGE_DRIVER_LIST. Validates PV volumeAttributes and the referenced
  Secret against customfusevalidate, derives read-only mode from the CSI request
  and PV access modes, and composes the NodePublishVolumeRequest forwarded to
  the sandbox-side node server.

  ## II. Does this PR fix one issue?
  NONE. Part 3/7 of the customfuse provider PR series (docs: #855).

  ## III. Describe how to verify it
  go test ./pkg/agent-runtime/storages/ -count=1

  ## IV. Special notes for reviews
  Depends on PR2 (customfusevalidate) — merge that first; this PR's diff will
  shrink to its own files once it merges.
