### PR TITLE
feat(customfuse): add sandbox-side CSI node server and binary

### DIFF
--- a/cmd/csi-sidecar-customfuse/main.go
+++ b/cmd/csi-sidecar-customfuse/main.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// csi-sidecar-customfuse runs the CSI node server for the generic FUSE
+// driver inside the sandbox csi-sidecar container. It listens on the
+// per-driver socket that the storage CLI dials, and forwards mount requests
+// to mount-proxy-server (which runs the FUSE entrypoint).
+package main
+
+import (
+	"flag"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/openkruise/agents/pkg/agent-runtime/customfusesidecar"
+	"google.golang.org/grpc"
+	"k8s.io/klog/v2"
+)
+
+var (
+	csiSocketPath = flag.String("csi-socket", "/var/run/csi/sockets/customfuseplugin.csi.openkruise.io/csi.sock",
+		"path of the CSI node server socket that the storage CLI dials")
+	proxySocketPath = flag.String("proxy-socket", "/var/run/csi/mounter.sock",
+		"path of the mount-proxy-server socket")
+)
+
+func main() {
+	klog.InitFlags(flag.CommandLine)
+	flag.Parse()
+
+	if err := run(); err != nil {
+		klog.ErrorS(err, "csi-sidecar-customfuse exited with error")
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if err := os.MkdirAll(filepath.Dir(*csiSocketPath), 0o750); err != nil {
+		return err
+	}
+	// A stale socket from a previous run would make Listen fail with
+	// EADDRINUSE. The mount namespace is fresh per sandbox, so removing any
+	// pre-existing file is safe.
+	if err := os.Remove(*csiSocketPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	lis, err := net.Listen("unix", *csiSocketPath)
+	if err != nil {
+		return err
+	}
+	// Remove the socket file on exit; the startup Remove above stays as
+	// the fallback for an unclean previous exit. Registered BEFORE
+	// lis.Close so that, under defer's LIFO order, the listener is
+	// closed first and the file removed second.
+	defer func() {
+		if err := os.Remove(*csiSocketPath); err != nil && !os.IsNotExist(err) {
+			klog.ErrorS(err, "failed to remove socket", "socket", *csiSocketPath)
+		}
+	}()
+	defer lis.Close()
+	// The storage CLI dials this socket as root on the host (same UID 0),
+	// so owner-only permissions do not break it, and they keep sandbox
+	// processes that can reach the file from talking to the node server
+	// directly — defense in depth on top of request re-validation.
+	if err := os.Chmod(*csiSocketPath, 0o600); err != nil {
+		return err
+	}
+
+	// Register the signal handler before starting to serve so a SIGTERM
+	// arriving in the startup window takes the graceful path instead of
+	// the default action.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	srv := grpc.NewServer()
+	csi.RegisterNodeServer(srv, customfusesidecar.NewNodeServer(*proxySocketPath))
+	klog.InfoS("csi-sidecar-customfuse listening", "socket", *csiSocketPath, "proxy", *proxySocketPath)
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- srv.Serve(lis)
+	}()
+
+	select {
+	case sig := <-sigCh:
+		klog.InfoS("received signal, draining gRPC server", "signal", sig.String())
+	case err := <-serveErr:
+		// Serve failed before shutdown; report through the normal error
+		// path so deferred cleanup runs.
+		return err
+	}
+
+	// GracefulStop waits for in-flight RPCs to finish; bound the wait so
+	// a stuck RPC cannot stall container shutdown. The shutdown timers
+	// nest: this 8s bound sits below start.sh's 10-second SIGKILL
+	// escalation, which sits below the pod's terminationGracePeriodSeconds
+	// (the SandboxSet template must set it to >= 30s — a shorter window
+	// would let kubelet SIGKILL cut the flush short; see the pv.yaml
+	// prerequisites). All timers run from the same TERM, so this process
+	// normally exits on its own terms first.
+	stopped := make(chan struct{})
+	go func() {
+		srv.GracefulStop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+		// GracefulStop is done; Serve returns right after it. Reading
+		// the error keeps every exit path uniform and waits until the
+		// listener is fully released.
+		if err := <-serveErr; err != nil {
+			klog.ErrorS(err, "gRPC server returned error after graceful stop")
+		}
+	case err := <-serveErr:
+		// Serve returned unexpectedly while draining: stop and exit
+		// instead of waiting out the grace window.
+		if err != nil {
+			klog.ErrorS(err, "gRPC server failed while draining")
+		}
+		srv.Stop()
+	case sig := <-sigCh:
+		// A second signal while draining: stop immediately instead of
+		// waiting out the full grace window.
+		klog.InfoS("second signal received, forcing stop", "signal", sig.String())
+		srv.Stop()
+		<-serveErr
+	case <-time.After(8 * time.Second):
+		klog.InfoS("GracefulStop timed out, forcing stop")
+		srv.Stop()
+		// Stop makes Serve return; wait for it so the listener is fully
+		// released before the process exits.
+		<-serveErr
+	}
+	return nil
+}

--- a/pkg/agent-runtime/customfusesidecar/nodeserver.go
+++ b/pkg/agent-runtime/customfusesidecar/nodeserver.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customfusesidecar
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
+
+	"github.com/openkruise/agents/pkg/agent-runtime/customfusevalidate"
+)
+
+// proxyMounter is the mount-proxy client surface used by the node server.
+type proxyMounter interface {
+	Mount(ctx context.Context, req *proxyMountRequest) error
+}
+
+// newProxyClientFn is the indirection used by the node server to obtain a
+// proxy client. It is a package variable so tests can substitute a fake
+// without binding to a real unix socket. Production code MUST NOT reassign
+// it.
+var newProxyClientFn = func(socketPath string) proxyMounter {
+	return newProxyClient(socketPath)
+}
+
+// nodeServer implements csi.NodeServer for the customfuse driver inside the
+// sandbox sidecar. It mounts directly on the target path (no global mount +
+// bind), because the target already lives inside the sandbox mount namespace.
+type nodeServer struct {
+	csi.UnimplementedNodeServer
+
+	locks         *volumeLocks
+	proxySockPath string
+}
+
+// NewNodeServer returns a NodeServer that forwards mount requests to the
+// mount-proxy-server listening on proxySockPath.
+func NewNodeServer(proxySockPath string) csi.NodeServer {
+	return &nodeServer{
+		locks:         newVolumeLocks(),
+		proxySockPath: proxySockPath,
+	}
+}
+
+func (ns *nodeServer) NodeGetCapabilities(_ context.Context, _ *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
+	// No STAGE_UNSTAGE capability: staging is a no-op here and volumes are
+	// published directly on the target path (the target already lives in
+	// the sandbox mount namespace). Declaring the capability would invite
+	// standard CSI consumers to drive a staging flow that this server does
+	// not implement — and, matching CSI conventions, undeclared RPCs
+	// return Unimplemented via the embedded UnimplementedNodeServer.
+	return &csi.NodeGetCapabilitiesResponse{}, nil
+}
+
+func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	if req.GetVolumeId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "volume id is required")
+	}
+	// volume_capability is required by the CSI spec; reject a missing one
+	// instead of falling through with default mount semantics.
+	if req.GetVolumeCapability() == nil {
+		return nil, status.Error(codes.InvalidArgument, "volume capability is required")
+	}
+	if !ns.locks.TryAcquire(req.GetVolumeId()) {
+		return nil, status.Errorf(codes.Aborted, "There is already an operation for %s", req.GetVolumeId())
+	}
+	defer ns.locks.Release(req.GetVolumeId())
+
+	targetPath := req.GetTargetPath()
+	if err := validateTargetPath(targetPath); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// All validation runs before any filesystem mutation so a rejected
+	// request leaves no empty directories behind.
+	opts, err := parseOptions(req)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse options: %v", err)
+	}
+	if opts.Source == "" {
+		return nil, status.Error(codes.InvalidArgument, "source is required (via source, or bucket with optional path)")
+	}
+	if err := precheckAuthConfig(opts); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "auth config error: %v", err)
+	}
+
+	// The provider validates Secret keys and mount flags on the control-plane
+	// path, but the per-driver unix socket is reachable from inside the
+	// sandbox, so requests can arrive without passing through the provider.
+	// mount-proxy exports every Secret entry and mount flag as an environment
+	// variable of the same name into the entrypoint shell; repeat the checks
+	// here because the entrypoint's own unset of dangerous keys happens too
+	// late for its starting shell (bash sources BASH_ENV before the script
+	// body, the loader consumes LD_PRELOAD before that).
+	if err := customfusevalidate.ValidateSecrets(req.GetSecrets()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid secret: %v", err)
+	}
+	// VolumeContext keys are checked with the same blocked-key logic the
+	// provider applies: mount-proxy does not export them today, but a
+	// future revision might.
+	for key := range req.GetVolumeContext() {
+		if customfusevalidate.IsBlockedEnvKey(key) {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid volume context key %q: it would be exported as a dangerous environment variable", key)
+		}
+	}
+	// The merged mount options are validated as a whole: opts.MountOptions
+	// carries both volumeAttributes.mountOptions entries (parsed by
+	// parseOptions) and VolumeCapability.MountFlags, and every entry becomes
+	// one env var in the entrypoint — a dangerous key smuggled through
+	// volumeAttributes.mountOptions must be caught here too.
+	if err := customfusevalidate.ValidateMountOptions(opts.MountOptions); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid mount option: %v", err)
+	}
+	// otherOpts travels as a single env var (one string), so run it through
+	// the same option-list check: ValidateMountOptions splits on the shared
+	// separator set and applies the same key-level rejections (empty key,
+	// blocked env keys, reserved, subdir, credential) the provider applies
+	// to its option lists. This keeps the direct-socket path symmetric with
+	// the control plane.
+	if opts.OtherOpts != "" {
+		if err := customfusevalidate.ValidateMountOptions([]string{opts.OtherOpts}); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid otherOpts: %v", err)
+		}
+	}
+	if volCap := req.GetVolumeCapability(); volCap != nil {
+		switch {
+		case volCap.GetMount() != nil:
+		case volCap.GetBlock() != nil:
+			return nil, status.Error(codes.InvalidArgument, "block volumes are not supported")
+		default:
+			// CSI requires one of Mount or Block; a request carrying neither
+			// is malformed and must not fall through to the mount path.
+			return nil, status.Error(codes.InvalidArgument, "volume capability must specify mount or block access type")
+		}
+		// CSI requires a concrete access mode; UNKNOWN (nil or unset) must
+		// not silently derive default read-write semantics.
+		if volCap.GetAccessMode().GetMode() == csi.VolumeCapability_AccessMode_UNKNOWN {
+			return nil, status.Error(codes.InvalidArgument, "volume capability must specify an access mode")
+		}
+	}
+
+	// In the standard CSI flow the kubelet creates the target path before
+	// calling NodePublishVolume; the storage CLI does not, so create it here.
+	if err := os.MkdirAll(targetPath, 0o750); err != nil {
+		klog.ErrorS(err, "failed to create target path", "volume", req.GetVolumeId(), "target", targetPath)
+		return nil, status.Errorf(codes.Internal, "failed to create target path: %v", err)
+	}
+	// MkdirAll follows symlinks in existing ancestors; resolve the created
+	// path and re-check the prefix so a symlink planted inside the mount
+	// root cannot redirect the mount outside it. The check closes the
+	// pre-request window; between this resolution and the mount(2) inside
+	// mount-proxy a same-pod process that can write to mount-root could
+	// still swap in a symlink, but the impact is limited to shadowing
+	// sidecar paths with the caller's own volume content (a mount outside
+	// mount-root does not propagate out of the sidecar). Skipped on
+	// Windows hosts (unit tests): EvalSymlinks returns host-style paths
+	// there, and the real sandbox always runs Linux.
+	if runtime.GOOS != "windows" {
+		resolved, err := filepath.EvalSymlinks(targetPath)
+		if err != nil {
+			klog.ErrorS(err, "failed to resolve target path", "volume", req.GetVolumeId(), "target", targetPath)
+			return nil, status.Errorf(codes.Internal, "failed to resolve target path: %v", err)
+		}
+		if !strings.HasPrefix(resolved, mountRootPrefix) {
+			_ = os.Remove(targetPath)
+			return nil, status.Errorf(codes.InvalidArgument, "target path %q resolves outside the mount root %s", targetPath, mountRootPrefix)
+		}
+	}
+
+	client := newProxyClientFn(ns.proxySockPath)
+	if err := client.Mount(ctx, &proxyMountRequest{
+		Source:  opts.Source,
+		Target:  targetPath,
+		Fstype:  customFuseFsType,
+		Options: opts.makeMountOptions(),
+		Secrets: req.GetSecrets(),
+		// VolumeID is part of the mount-proxy protocol (metrics paths and
+		// log correlation); forward the CSI request's volume id instead of
+		// leaving the field empty.
+		VolumeID: req.GetVolumeId(),
+	}); err != nil {
+		klog.ErrorS(err, "mount-proxy mount failed", "volume", req.GetVolumeId(), "target", targetPath)
+		// Leave no residue behind: MkdirAll above created the target; remove
+		// it again unless a mount already landed there (Remove then fails
+		// with EBUSY, which is fine).
+		_ = os.Remove(targetPath)
+		return nil, status.Errorf(codes.Internal, "mount-proxy failed: %v", err)
+	}
+
+	return &csi.NodePublishVolumeResponse{}, nil
+}
+
+func (ns *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+	if req.GetVolumeId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "volume id is required")
+	}
+	if !ns.locks.TryAcquire(req.GetVolumeId()) {
+		return nil, status.Errorf(codes.Aborted, "There is already an operation for %s", req.GetVolumeId())
+	}
+	defer ns.locks.Release(req.GetVolumeId())
+
+	// Unmounting is handled by the sandbox teardown: the mount namespace is
+	// discarded together with the sandbox, so there is nothing to clean up
+	// here. Accept the request to keep the CSI protocol happy.
+	return &csi.NodeUnpublishVolumeResponse{}, nil
+}
+
+// mountRootPrefix is the sandbox-wide directory that hosts every per-volume
+// mount point. The storage CLI relocates the user-visible target to
+// <mount-root>/<driver>/<md5> before calling NodePublishVolume, so a request
+// whose target resolves outside it can only come from a direct socket caller
+// trying to shadow arbitrary sidecar paths. A var, not a const, so tests can
+// point it at a temporary directory; production code MUST NOT modify it.
+var mountRootPrefix = "/run/csi/mount-root/"
+
+// validateTargetPath rejects empty, relative, null-byte-bearing, or
+// mount-root-escaping target paths before they reach the entrypoint.
+func validateTargetPath(targetPath string) error {
+	if strings.TrimSpace(targetPath) == "" {
+		return fmt.Errorf("target path is empty")
+	}
+	// path.IsAbs uses POSIX semantics, which is what the sandbox container
+	// sees; filepath.IsAbs would treat "/..." as relative on Windows hosts.
+	if !path.IsAbs(targetPath) {
+		return fmt.Errorf("target path %q is not an absolute path", targetPath)
+	}
+	if strings.ContainsRune(targetPath, '\x00') {
+		return fmt.Errorf("target path contains a null byte")
+	}
+	// path.Clean resolves ".." segments; the cleaned path must stay under the
+	// mount root so a malicious request cannot mount over arbitrary sidecar
+	// directories (e.g. "/run/../etc/x" -> "/etc/x"). The trailing slash in
+	// mountRootPrefix is load-bearing: Clean strips it from the candidate,
+	// so the bare mount root itself ("/run/csi/mount-root/") fails the
+	// HasPrefix check and is rejected as a mount target.
+	cleaned := path.Clean(targetPath)
+	if !strings.HasPrefix(cleaned, mountRootPrefix) {
+		return fmt.Errorf("target path %q is outside the mount root %s", targetPath, mountRootPrefix)
+	}
+	return nil
+}
+
+// volumeLocks serializes operations per volume id. TryAcquire fails instead
+// of blocking so a concurrent request on the same volume is rejected fast.
+type volumeLocks struct {
+	mu    sync.Mutex
+	holds map[string]struct{}
+}
+
+func newVolumeLocks() *volumeLocks {
+	return &volumeLocks{holds: map[string]struct{}{}}
+}
+
+func (l *volumeLocks) TryAcquire(id string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, ok := l.holds[id]; ok {
+		return false
+	}
+	l.holds[id] = struct{}{}
+	return true
+}
+
+func (l *volumeLocks) Release(id string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.holds, id)
+}

--- a/pkg/agent-runtime/customfusesidecar/nodeserver_test.go
+++ b/pkg/agent-runtime/customfusesidecar/nodeserver_test.go
@@ -1,0 +1,464 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customfusesidecar
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeProxyMounter records the forwarded request and returns a configurable
+// error.
+type fakeProxyMounter struct {
+	gotReq *proxyMountRequest
+	err    error
+}
+
+func (f *fakeProxyMounter) Mount(_ context.Context, req *proxyMountRequest) error {
+	f.gotReq = req
+	return f.err
+}
+
+// withProxyClientFactory swaps newProxyClientFn for the duration of fn.
+func withProxyClientFactory(t *testing.T, factory func(socketPath string) proxyMounter) {
+	t.Helper()
+	orig := newProxyClientFn
+	newProxyClientFn = factory
+	t.Cleanup(func() { newProxyClientFn = orig })
+}
+
+// withTempMountRoot points mountRootPrefix at a temporary directory for the
+// duration of the test, so filesystem-mutating tests never touch the real
+// /run path (the CI runner is unprivileged there). On Windows the temp dir
+// carries a drive prefix, which validateTargetPath rejects under its POSIX
+// path.IsAbs semantics; stripping the volume name keeps the path
+// POSIX-absolute while still resolving to the same physical directory.
+func withTempMountRoot(t *testing.T) {
+	t.Helper()
+	dir := filepath.ToSlash(t.TempDir())
+	if vol := filepath.VolumeName(t.TempDir()); vol != "" {
+		dir = strings.TrimPrefix(dir, vol)
+	}
+	// path.Clean collapses a doubled leading slash, which would break the
+	// HasPrefix comparison in validateTargetPath; keep exactly one.
+	if !strings.HasPrefix(dir, "/") {
+		dir = "/" + dir
+	}
+	mountRootPrefix = dir + "/mount-root" + "/"
+	t.Cleanup(func() { mountRootPrefix = "/run/csi/mount-root/" })
+}
+
+func TestValidateTargetPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		targetPath  string
+		expectError string
+	}{
+		{name: "absolute path passes", targetPath: "/run/csi/mount-root/customfuse/abc123"},
+		{name: "nested absolute path passes", targetPath: "/run/csi/mount-root/customfuse/abc123/sub"},
+		{name: "empty path is rejected", targetPath: "", expectError: "empty"},
+		{name: "whitespace path is rejected", targetPath: "   ", expectError: "empty"},
+		{name: "relative path is rejected", targetPath: "workspace/data", expectError: "not an absolute path"},
+		{name: "null byte is rejected", targetPath: "/run/csi/mount-root/x\x00y", expectError: "null byte"},
+		{name: "path outside mount root is rejected", targetPath: "/workspace/data", expectError: "outside the mount root"},
+		{name: "path outside mount root with dotdot is rejected", targetPath: "/run/../etc/passwd", expectError: "outside the mount root"},
+		{name: "dotdot escape from mount root is rejected", targetPath: "/run/csi/mount-root/../customfuse/x", expectError: "outside the mount root"},
+		{name: "mount root itself is rejected", targetPath: "/run/csi/mount-root", expectError: "outside the mount root"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTargetPath(tt.targetPath)
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			}
+		})
+	}
+}
+
+func TestNodePublishVolume(t *testing.T) {
+	// Set up the temporary mount root BEFORE building validReq: the target
+	// path expressions capture mountRootPrefix at construction time, so
+	// overriding it later would leave the request pointing at /run/csi.
+	withTempMountRoot(t)
+
+	validReq := &csi.NodePublishVolumeRequest{
+		VolumeId:   "vol-1",
+		TargetPath: mountRootPrefix + "customfuse/vol-1",
+		VolumeContext: map[string]string{
+			"source":   "redis://redis-cluster:6379/0",
+			"fuseType": "juicefs",
+			"bucket":   "ml-datasets",
+		},
+		Secrets: map[string]string{"token": "secret-token"},
+		VolumeCapability: &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{FsType: "juicefs"},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+			},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		req        *csi.NodePublishVolumeRequest
+		proxyErr   error
+		expectCode codes.Code
+		assertReq  func(t *testing.T, got *proxyMountRequest)
+	}{
+		{
+			name: "success forwards mount request",
+			req:  validReq,
+			assertReq: func(t *testing.T, got *proxyMountRequest) {
+				require.NotNil(t, got)
+				assert.Equal(t, "vol-1", got.VolumeID)
+				assert.Equal(t, "redis://redis-cluster:6379/0", got.Source)
+				assert.Equal(t, mountRootPrefix+"customfuse/vol-1", got.Target)
+				assert.Equal(t, customFuseFsType, got.Fstype)
+				assert.Equal(t, []string{"bucket=ml-datasets"}, got.Options)
+				assert.Equal(t, map[string]string{"token": "secret-token"}, got.Secrets)
+			},
+		},
+		{
+			name: "missing volume capability is invalid argument",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:   "vol-1",
+				TargetPath: mountRootPrefix + "customfuse/vol-1",
+				VolumeContext: map[string]string{
+					"source": "redis://h:6379/0",
+				},
+			},
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			// Symmetry with the provider: a reserved key smuggled through
+			// otherOpts must be rejected on the direct-socket path too.
+			name: "otherOpts reserved key rejected",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:   "vol-1",
+				TargetPath: mountRootPrefix + "customfuse/vol-1",
+				VolumeContext: map[string]string{
+					"source":    "redis://h:6379/0",
+					"otherOpts": "cache-size=1024,url=http://attacker:9000",
+				},
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+					},
+				},
+			},
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			name:       "proxy error maps to internal",
+			req:        validReq,
+			proxyErr:   errors.New("entrypoint exited: boom"),
+			expectCode: codes.Internal,
+		},
+		{
+			name:       "empty target path is invalid argument",
+			req:        &csi.NodePublishVolumeRequest{VolumeId: "vol-1"},
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			name:       "empty volume id is invalid argument",
+			req:        &csi.NodePublishVolumeRequest{TargetPath: "/run/csi/mount-root/customfuse/vol-1"},
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			name: "block volume capability rejected",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:   "vol-1",
+				TargetPath: mountRootPrefix + "customfuse/vol-1",
+				VolumeContext: map[string]string{
+					"source": "redis://h:6379/0",
+				},
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Block{
+						Block: &csi.VolumeCapability_BlockVolume{},
+					},
+				},
+			},
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			name: "volume context BASH_ENV key rejected",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:   "vol-1",
+				TargetPath: mountRootPrefix + "customfuse/vol-1",
+				VolumeContext: map[string]string{
+					"source":   "redis://h:6379/0",
+					"BASH_ENV": "/tmp/x.sh",
+				},
+			},
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			// A dangerous key smuggled through volumeAttributes.mountOptions
+			// entries must be caught by the merged MountOptions validation.
+			name: "volume attributes mountOptions dangerous key rejected",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:   "vol-1",
+				TargetPath: mountRootPrefix + "customfuse/vol-1",
+				VolumeContext: map[string]string{
+					"source":       "redis://h:6379/0",
+					"mountOptions": "cache-size=1024 BASH_ENV=/tmp/x.sh",
+				},
+			},
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			name: "invalid capacity is invalid argument",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:      "vol-1",
+				TargetPath:    "/run/csi/mount-root/customfuse/vol-1",
+				VolumeContext: map[string]string{"capacity": "bad"},
+			},
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			name: "unsupported authType is invalid argument",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:      "vol-1",
+				TargetPath:    "/run/csi/mount-root/customfuse/vol-1",
+				VolumeContext: map[string]string{"source": "redis://h:6379/0", "authType": "rrsa"},
+			},
+			expectCode: codes.InvalidArgument,
+		},
+
+		// Attack surface: the unix socket is reachable from inside the
+		// sandbox, so Secrets and MountFlags can arrive without passing
+		// through the control-plane provider. mount-proxy exports each entry
+		// as an env var of the same name into the entrypoint shell; the
+		// entrypoint's own unset runs too late for its starting shell
+		// (BASH_ENV is sourced at bash startup, LD_PRELOAD at exec time), so
+		// the node server must reject them here.
+		{
+			name: "secret BASH_ENV rejected",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:   "vol-1",
+				TargetPath: mountRootPrefix + "customfuse/vol-1",
+				Secrets:    map[string]string{"BASH_ENV": "/tmp/x.sh"},
+			},
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			name: "secret LD_PRELOAD rejected",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:   "vol-1",
+				TargetPath: mountRootPrefix + "customfuse/vol-1",
+				Secrets:    map[string]string{"LD_PRELOAD": "/tmp/x.so"},
+			},
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			name: "secret reserved source key rejected",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:   "vol-1",
+				TargetPath: mountRootPrefix + "customfuse/vol-1",
+				Secrets:    map[string]string{"source": "redis://evil:6379/0"},
+			},
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			name: "secret invalid key name rejected",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:   "vol-1",
+				TargetPath: mountRootPrefix + "customfuse/vol-1",
+				Secrets:    map[string]string{"access-key": "AKID"},
+			},
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			name: "mount flag BASH_ENV rejected",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:   "vol-1",
+				TargetPath: mountRootPrefix + "customfuse/vol-1",
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{
+							MountFlags: []string{"BASH_ENV=/tmp/x.sh"},
+						},
+					},
+				},
+			},
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			name: "mount flag reserved url key rejected",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:   "vol-1",
+				TargetPath: mountRootPrefix + "customfuse/vol-1",
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{
+							MountFlags: []string{"url=http://attacker:9000"},
+						},
+					},
+				},
+			},
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			name: "safe mount flags forwarded",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:   "vol-1",
+				TargetPath: mountRootPrefix + "customfuse/vol-1",
+				VolumeContext: map[string]string{
+					"source": "redis://h:6379/0",
+				},
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{
+							MountFlags: []string{"cache-size=1024"},
+						},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+					},
+				},
+			},
+			assertReq: func(t *testing.T, got *proxyMountRequest) {
+				require.NotNil(t, got)
+				assert.Contains(t, got.Options, "cache-size=1024")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeProxyMounter{err: tt.proxyErr}
+			withProxyClientFactory(t, func(socketPath string) proxyMounter {
+				assert.Equal(t, "/var/run/csi/mounter.sock", socketPath)
+				return fake
+			})
+
+			ns := NewNodeServer("/var/run/csi/mounter.sock")
+			_, err := ns.NodePublishVolume(context.Background(), tt.req)
+
+			if tt.expectCode != 0 {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectCode, status.Code(err))
+				return
+			}
+			require.NoError(t, err)
+			if tt.assertReq != nil {
+				tt.assertReq(t, fake.gotReq)
+			}
+		})
+	}
+}
+
+// TestNodePublishVolumeSerializesConcurrentRequests verifies the per-volume
+// lock rejects a second in-flight request for the same volume.
+func TestNodePublishVolumeSerializesConcurrentRequests(t *testing.T) {
+	blocked := make(chan struct{})
+	unblock := make(chan struct{})
+	fake := &fakeProxyMounter{
+		err: nil,
+	}
+	orig := newProxyClientFn
+	newProxyClientFn = func(_ string) proxyMounter {
+		return &blockingMounter{inner: fake, blocked: blocked, unblock: unblock}
+	}
+	defer func() { newProxyClientFn = orig }()
+
+	withTempMountRoot(t)
+
+	ns := NewNodeServer("/var/run/csi/mounter.sock")
+	req := &csi.NodePublishVolumeRequest{
+		VolumeId:   "vol-lock",
+		TargetPath: mountRootPrefix + "customfuse/vol-1",
+		VolumeContext: map[string]string{
+			"source": "redis://h:6379/0",
+		},
+		VolumeCapability: &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+			},
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, err := ns.NodePublishVolume(context.Background(), req)
+		if err != nil {
+			t.Logf("first call failed early: %v", err)
+		}
+	}()
+	<-blocked // first request holds the lock
+
+	_, err := ns.NodePublishVolume(context.Background(), req)
+	require.Error(t, err)
+	assert.Equal(t, codes.Aborted, status.Code(err))
+
+	close(unblock)
+	<-done
+}
+
+type blockingMounter struct {
+	inner   *fakeProxyMounter
+	blocked chan struct{}
+	unblock chan struct{}
+}
+
+func (b *blockingMounter) Mount(ctx context.Context, req *proxyMountRequest) error {
+	close(b.blocked)
+	<-b.unblock
+	return b.inner.Mount(ctx, req)
+}
+
+func TestNodeUnpublishVolumeAccepted(t *testing.T) {
+	ns := NewNodeServer("/var/run/csi/mounter.sock")
+	resp, err := ns.NodeUnpublishVolume(context.Background(), &csi.NodeUnpublishVolumeRequest{
+		VolumeId:   "vol-1",
+		TargetPath: mountRootPrefix + "customfuse/vol-1",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestNodeGetCapabilities(t *testing.T) {
+	ns := NewNodeServer("/var/run/csi/mounter.sock")
+	resp, err := ns.NodeGetCapabilities(context.Background(), &csi.NodeGetCapabilitiesRequest{})
+	require.NoError(t, err)
+	// Staging is a no-op here and volumes are published directly on the
+	// target path; declaring STAGE_UNSTAGE would invite standard CSI
+	// consumers to drive a flow this server does not implement.
+	assert.Empty(t, resp.Capabilities)
+}

--- a/pkg/agent-runtime/customfusesidecar/options.go
+++ b/pkg/agent-runtime/customfusesidecar/options.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customfusesidecar
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+
+	"github.com/openkruise/agents/pkg/agent-runtime/customfusevalidate"
+)
+
+// fuseOptions are the parsed volume attributes of a customfuse volume.
+// Field semantics follow the alibaba-cloud-csi-driver customfuse driver so
+// entrypoints written for it behave identically here.
+type fuseOptions struct {
+	// Source is the mount source passed to the FUSE entrypoint as $source.
+	// Its business format is opaque to the CSI side — a JuiceFS META-URL
+	// (e.g. "redis://host:6379/1"), an OSS-style bucket:path, ... — but it
+	// is still constrained to the shared SafeForwardPattern character set.
+	Source string
+	// Bucket is the object storage bucket name, passed as $bucket.
+	Bucket string
+	// URL is the object storage endpoint, passed as $url.
+	URL string
+	// OtherOpts originates from volumeAttributes.otherOpts, passed as a
+	// single $otherOpts string that the entrypoint splits and appends to
+	// -o. mountOptions entries (from volumeAttributes.mountOptions or
+	// pv.Spec.MountOptions) become one env var each instead — a different
+	// transport, not a drop-in equivalent.
+	OtherOpts string
+	// Path is the sub-path within the volume, passed as $path.
+	Path string
+	// ReadOnly is derived from the CSI readOnly flag or the volume access
+	// mode, passed as $readOnly to the entrypoint.
+	ReadOnly bool
+	// FuseType identifies the FUSE client (e.g. "juicefs", "s3fs").
+	// Defaults to "customfuse" when unset. Validated against the shared
+	// AllowedFuseTypes allowlist.
+	FuseType string
+	// MountOptions combines volumeAttributes.mountOptions entries (split
+	// by parseOptions) and pv.Spec.MountOptions (via
+	// VolumeCapability.Mount.MountFlags). Each entry is a "key=value" or
+	// bare "key" string, passed as env var $key in the entrypoint.
+	MountOptions []string
+	// AuthType selects the authentication method. Only the default (empty)
+	// is supported, which passes Secret entries directly as env vars.
+	AuthType string
+	// Capacity is the volume quota passed as $capacity to the entrypoint.
+	// Validated against customfusevalidate.CapacityPattern: a plain integer
+	// or an integer with Ti/TiB, Gi/GiB, Mi/MiB, Ki/KiB units, both
+	// branches bounded to 15 digits — the same set the JuiceFS entrypoint
+	// accepts.
+	Capacity string
+	// StorageType is the object storage backend passed as $storageType to the
+	// entrypoint (e.g. "s3", "oss", "minio"). Only the JuiceFS entrypoint
+	// consumes it, during format.
+	StorageType string
+}
+
+// customFuseFsType is the fsType reported to mount-proxy; it selects the
+// customfuse driver there.
+const customFuseFsType = "customfuse"
+
+// parseOptions converts a NodePublishVolumeRequest into fuseOptions. Keys in
+// VolumeContext are matched case-insensitively after trimming.
+func parseOptions(req *csi.NodePublishVolumeRequest) (*fuseOptions, error) {
+	opts := &fuseOptions{
+		FuseType: customFuseFsType,
+	}
+
+	if err := applyVolumeContext(opts, req.GetVolumeContext()); err != nil {
+		return nil, err
+	}
+	if err := applyVolumeCapability(opts, req.GetVolumeCapability()); err != nil {
+		return nil, err
+	}
+	// The allowlist check runs after the FsType override so a value that
+	// arrives via VolumeCapability.Mount.FsType is validated too.
+	if opts.FuseType != "" && !customfusevalidate.AllowedFuseTypes[strings.ToLower(opts.FuseType)] {
+		return nil, fmt.Errorf("unknown fuseType %q", customfusevalidate.MaskOptionValues(opts.FuseType))
+	}
+	if req.GetReadonly() {
+		opts.ReadOnly = true
+	}
+	synthesizeSource(opts)
+	if err := validateForwardedFields(opts); err != nil {
+		return nil, err
+	}
+	return opts, nil
+}
+
+// applyVolumeContext merges the request's VolumeContext keys into opts.
+// Multiple case variants of the same key are rejected when their values
+// differ: the provider does the same, and a direct socket caller must
+// not get a mount whose source depends on map iteration order.
+func applyVolumeContext(opts *fuseOptions, volCtx map[string]string) error {
+	seen := map[string]string{}
+	for k, v := range volCtx {
+		key := strings.TrimSpace(strings.ToLower(k))
+		if key == "" {
+			continue
+		}
+		value := strings.TrimSpace(v)
+		if value == "" {
+			continue
+		}
+		if existing, ok := seen[key]; ok {
+			if existing != value {
+				return fmt.Errorf("conflicting values for %q: %q and %q", key, customfusevalidate.MaskOptionValues(existing), customfusevalidate.MaskOptionValues(value))
+			}
+			continue
+		}
+		seen[key] = value
+		switch key {
+		case "source":
+			opts.Source = value
+		case "bucket":
+			opts.Bucket = value
+		case "path":
+			opts.Path = value
+		case "url":
+			opts.URL = value
+		case "otheropts":
+			opts.OtherOpts = value
+		case "mountoptions":
+			// Same option-list semantics as pv.Spec.MountOptions; split on
+			// the separator set the provider's ValidateMountOptions uses so
+			// each entry becomes one env var in the entrypoint.
+			opts.MountOptions = append(opts.MountOptions, strings.FieldsFunc(value, func(r rune) bool { return r == ',' || r == ' ' || r == '	' })...)
+		case "fusetype":
+			opts.FuseType = value
+		case "authtype":
+			opts.AuthType = value
+		case "capacity":
+			if !customfusevalidate.CapacityPattern.MatchString(value) {
+				return fmt.Errorf("invalid capacity %q: must be a plain integer or one of Ti/TiB, Gi/GiB, Mi/MiB, Ki/KiB units (e.g. 100, 100Gi)", customfusevalidate.MaskOptionValues(value))
+			}
+			opts.Capacity = value
+		case "storagetype":
+			opts.StorageType = value
+		}
+	}
+	return nil
+}
+
+// applyVolumeCapability merges the CSI volume capability into opts.
+func applyVolumeCapability(opts *fuseOptions, volCap *csi.VolumeCapability) error {
+	if volCap == nil {
+		return nil
+	}
+	if mount := volCap.GetMount(); mount != nil {
+		if mount.FsType != "" {
+			// Case-insensitive like the provider's cross-check: a
+			// casing-only difference is not a conflict.
+			if opts.FuseType != customFuseFsType && !strings.EqualFold(opts.FuseType, mount.FsType) {
+				return fmt.Errorf("fuseType %q from volumeAttributes conflicts with fsType %q from PV spec", opts.FuseType, mount.FsType)
+			}
+			opts.FuseType = mount.FsType
+		}
+		// Empty flags are dropped for parity with the volumeAttributes
+		// mountOptions path, where FieldsFunc filters them out.
+		for _, f := range mount.MountFlags {
+			if strings.TrimSpace(f) != "" {
+				opts.MountOptions = append(opts.MountOptions, f)
+			}
+		}
+	}
+	switch volCap.GetAccessMode().GetMode() {
+	case csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY:
+		opts.ReadOnly = true
+	}
+	return nil
+}
+
+// synthesizeSource derives the mount source from bucket (with optional path)
+// when no explicit source was given.
+func synthesizeSource(opts *fuseOptions) {
+	if opts.Source == "" && opts.Bucket != "" {
+		if opts.Path != "" {
+			opts.Source = opts.Bucket + ":" + opts.Path
+		} else {
+			opts.Source = opts.Bucket
+		}
+	}
+}
+
+// validateForwardedFields enforces the shared character set and
+// shell-metachar checks on the fields forwarded to the entrypoint, mirroring
+// the control-plane provider's defense in depth.
+func validateForwardedFields(opts *fuseOptions) error {
+	for _, field := range []struct{ name, value string }{
+		{"source", opts.Source}, {"bucket", opts.Bucket}, {"path", opts.Path},
+		{"url", opts.URL}, {"storageType", opts.StorageType},
+	} {
+		if field.value != "" && !customfusevalidate.SafeForwardPattern.MatchString(field.value) {
+			return fmt.Errorf("%s contains invalid characters: %q", field.name, customfusevalidate.MaskOptionValues(field.value))
+		}
+	}
+	for _, field := range []struct{ name, value string }{
+		{"otherOpts", opts.OtherOpts}, {"capacity", opts.Capacity},
+	} {
+		if customfusevalidate.HasShellMetachar(field.value) {
+			return fmt.Errorf("%s contains invalid shell characters: %q", field.name, customfusevalidate.MaskOptionValues(field.value))
+		}
+	}
+	return nil
+}
+
+// precheckAuthConfig validates the auth configuration before mounting.
+// Only the default auth type (Secret passthrough) is supported.
+func precheckAuthConfig(opts *fuseOptions) error {
+	if opts.AuthType != "" {
+		return fmt.Errorf("unsupported authType %q; only default (secret passthrough) is currently supported", opts.AuthType)
+	}
+	return nil
+}
+
+// makeMountOptions serializes volume attributes as key=value pairs carried
+// through the mount-proxy protocol. mount-proxy maps them to env vars for
+// the entrypoint. Source is passed separately via proxyMountRequest.Source.
+func (o *fuseOptions) makeMountOptions() []string {
+	var opts []string
+	if o.Bucket != "" {
+		opts = append(opts, "bucket="+o.Bucket)
+	}
+	if o.URL != "" {
+		opts = append(opts, "url="+o.URL)
+	}
+	if o.Path != "" {
+		opts = append(opts, "path="+o.Path)
+	}
+	if o.OtherOpts != "" {
+		opts = append(opts, "otherOpts="+o.OtherOpts)
+	}
+	if o.Capacity != "" {
+		opts = append(opts, "capacity="+o.Capacity)
+	}
+	if o.StorageType != "" {
+		opts = append(opts, "storageType="+o.StorageType)
+	}
+	opts = append(opts, o.MountOptions...)
+	// readOnly is appended last so a conflicting entry in pv.Spec.MountOptions
+	// (e.g. "readOnly=false") cannot weaken the read-only semantics derived
+	// from the CSI request: mount-proxy builds the entrypoint env from this
+	// slice in order, and in a duplicate-key env the last occurrence wins.
+	if o.ReadOnly {
+		opts = append(opts, "readOnly=true")
+	}
+	return opts
+}
+
+// The capacity validation lives in customfusevalidate.CapacityPattern so
+// the provider and the node server share one regexp.

--- a/pkg/agent-runtime/customfusesidecar/options_test.go
+++ b/pkg/agent-runtime/customfusesidecar/options_test.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customfusesidecar
+
+import (
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOptions(t *testing.T) {
+	tests := []struct {
+		name                  string
+		req                   *csi.NodePublishVolumeRequest
+		want                  fuseOptions
+		expectError           string
+		expectErrorNotContain []string
+	}{
+		{
+			name: "full attribute set is parsed",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext: map[string]string{
+					"source":      "redis://redis-cluster:6379/0",
+					"bucket":      "ml-datasets",
+					"url":         "https://s3.amazonaws.com",
+					"path":        "/user-123",
+					"otherOpts":   "cache-size=1024",
+					"fuseType":    "juicefs",
+					"capacity":    "100Gi",
+					"storageType": "oss",
+					"readOnly":    "true",
+					"fuseExtra1":  "ignored",
+				},
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+					},
+				},
+				Readonly: true,
+			},
+			want: fuseOptions{
+				Source:       "redis://redis-cluster:6379/0",
+				Bucket:       "ml-datasets",
+				URL:          "https://s3.amazonaws.com",
+				Path:         "/user-123",
+				OtherOpts:    "cache-size=1024",
+				FuseType:     "juicefs",
+				Capacity:     "100Gi",
+				StorageType:  "oss",
+				ReadOnly:     true,
+				AuthType:     "",
+				MountOptions: nil,
+			},
+		},
+		{
+			name: "keys are matched case-insensitively and trimmed",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext: map[string]string{
+					"  Source  ": "  redis://h:6379/1  ",
+					"FUSETYPE":   "JUICEfs",
+				},
+			},
+			want: fuseOptions{
+				Source:   "redis://h:6379/1",
+				FuseType: "JUICEfs",
+			},
+		},
+		{
+			name: "empty values are skipped",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext: map[string]string{
+					"source":   "",
+					"bucket":   "",
+					"fuseType": " ",
+				},
+			},
+			want: fuseOptions{FuseType: customFuseFsType},
+		},
+		{
+			name: "default fuseType is customfuse",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext: map[string]string{"source": "redis://h:6379/0"},
+			},
+			want: fuseOptions{
+				Source:   "redis://h:6379/0",
+				FuseType: customFuseFsType,
+			},
+		},
+		{
+			name: "mountFlags become mount options",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{
+							FsType:     "juicefs",
+							MountFlags: []string{"cache-size=1024", "foreground"},
+						},
+					},
+				},
+			},
+			want: fuseOptions{
+				FuseType:     "juicefs",
+				MountOptions: []string{"cache-size=1024", "foreground"},
+			},
+		},
+		{
+			name: "fsType from mount capability overrides default",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext: map[string]string{"source": "s3://b"},
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{FsType: "s3fs"},
+					},
+				},
+			},
+			want: fuseOptions{
+				Source:   "s3://b",
+				FuseType: "s3fs",
+			},
+		},
+		{
+			name: "conflicting fuseType and fsType are rejected",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext: map[string]string{"fuseType": "juicefs"},
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{FsType: "s3fs"},
+					},
+				},
+			},
+			expectError: "conflicts with fsType",
+		},
+		{
+			name: "read-only access mode sets ReadOnly",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+					},
+				},
+			},
+			want: fuseOptions{FuseType: customFuseFsType, ReadOnly: true},
+		},
+		{
+			name: "bucket and path synthesize source",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext: map[string]string{"bucket": "bkt", "path": "/sub"},
+			},
+			want: fuseOptions{
+				Bucket:   "bkt",
+				Path:     "/sub",
+				Source:   "bkt:/sub",
+				FuseType: customFuseFsType,
+			},
+		},
+		{
+			name: "bucket alone synthesizes source",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext: map[string]string{"bucket": "bkt"},
+			},
+			want: fuseOptions{
+				Bucket:   "bkt",
+				Source:   "bkt",
+				FuseType: customFuseFsType,
+			},
+		},
+		{
+			name: "capacity with units is validated",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext: map[string]string{"capacity": "not-a-quantity"},
+			},
+			expectError: "invalid capacity",
+		},
+		{
+			name: "plain integer capacity passes through",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext: map[string]string{"capacity": "100"},
+			},
+			want: fuseOptions{FuseType: customFuseFsType, Capacity: "100"},
+		},
+		{
+			name: "storageType key is case-insensitive",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext: map[string]string{"STORAGETYPE": "MINIO"},
+			},
+			want: fuseOptions{FuseType: customFuseFsType, StorageType: "MINIO"},
+		},
+		{
+			name: "source with shell metachar rejected",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext: map[string]string{"source": "redis://host:6379/0;rm -rf /"},
+			},
+			expectError: "source contains invalid characters",
+		},
+		{
+			// bucket alone synthesizes source, so the character-set check
+			// fires on the synthesized source value.
+			name: "bucket with shell metachar rejected via synthesized source",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext: map[string]string{"bucket": "bkt$(whoami)"},
+			},
+			expectError: "source contains invalid characters",
+		},
+		{
+			name:                  "capacity quantity error masks credential-like value",
+			req:                   &csi.NodePublishVolumeRequest{VolumeContext: map[string]string{"capacity": "token=xyz"}},
+			expectError:           "invalid capacity",
+			expectErrorNotContain: []string{"xyz"},
+		},
+		{
+			name:        "conflicting case variants of the same key rejected",
+			req:         &csi.NodePublishVolumeRequest{VolumeContext: map[string]string{"source": "redis://h:6379/0", "Source": "redis://h:6379/1"}},
+			expectError: "conflicting values",
+		},
+		{
+			name:        "fractional capacity rejected",
+			req:         &csi.NodePublishVolumeRequest{VolumeContext: map[string]string{"capacity": "1.5"}},
+			expectError: "invalid capacity",
+		},
+		{
+			name:        "quantity-style capacity outside entrypoint units rejected",
+			req:         &csi.NodePublishVolumeRequest{VolumeContext: map[string]string{"capacity": "100m"}},
+			expectError: "invalid capacity",
+		},
+		{
+			name: "KiB capacity accepted",
+			req:  &csi.NodePublishVolumeRequest{VolumeContext: map[string]string{"capacity": "500Ki"}},
+			want: fuseOptions{FuseType: customFuseFsType, Capacity: "500Ki"},
+		},
+		{
+			name:        "unknown fuseType rejected",
+			req:         &csi.NodePublishVolumeRequest{VolumeContext: map[string]string{"fuseType": "evil"}},
+			expectError: "unknown fuseType",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseOptions(tt.req)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				for _, s := range tt.expectErrorNotContain {
+					assert.NotContains(t, err.Error(), s)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, *got)
+		})
+	}
+}
+
+func TestPrecheckAuthConfig(t *testing.T) {
+	assert.NoError(t, precheckAuthConfig(&fuseOptions{AuthType: ""}))
+	err := precheckAuthConfig(&fuseOptions{AuthType: "rrsa"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported authType")
+}
+
+func TestMakeMountOptions(t *testing.T) {
+	opts := &fuseOptions{
+		Bucket:       "bkt",
+		URL:          "https://s3",
+		Path:         "/sub",
+		ReadOnly:     true,
+		OtherOpts:    "cache-size=1024",
+		Capacity:     "100Gi",
+		StorageType:  "oss",
+		MountOptions: []string{"foreground"},
+	}
+	assert.Equal(t, []string{
+		"bucket=bkt",
+		"url=https://s3",
+		"path=/sub",
+		"otherOpts=cache-size=1024",
+		"capacity=100Gi",
+		"storageType=oss",
+		"foreground",
+		"readOnly=true",
+	}, opts.makeMountOptions())
+
+	empty := &fuseOptions{}
+	assert.Empty(t, empty.makeMountOptions())
+}
+
+func TestMakeMountOptionsReadOnlyWins(t *testing.T) {
+	// A conflicting readOnly=false in pv.Spec.MountOptions must not weaken
+	// the read-only semantics: mount-proxy builds the entrypoint env in
+	// slice order and the last duplicate key wins, so readOnly=true is
+	// emitted after the MountOptions entries.
+	opts := &fuseOptions{
+		ReadOnly:     true,
+		MountOptions: []string{"readOnly=false", "no-update"},
+	}
+	assert.Equal(t, []string{
+		"readOnly=false",
+		"no-update",
+		"readOnly=true",
+	}, opts.makeMountOptions())
+
+	writable := &fuseOptions{
+		MountOptions: []string{"readOnly=true"},
+	}
+	assert.Equal(t, []string{"readOnly=true"}, writable.makeMountOptions())
+}

--- a/pkg/agent-runtime/customfusesidecar/proxy.go
+++ b/pkg/agent-runtime/customfusesidecar/proxy.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package customfusesidecar implements the CSI node server that runs inside
+// the csi-sidecar container of a sandbox pod. It receives NodePublishVolume
+// requests from the storage CLI over the per-driver unix socket and forwards
+// them to mount-proxy-server, which executes the FUSE entrypoint.
+//
+// The wire protocol (JSON over a unix socket, newline-terminated) mirrors the
+// alibaba-cloud-csi-driver mount-proxy protocol so that the sidecar can talk
+// to an unmodified mount-proxy-server binary.
+package customfusesidecar
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+const (
+	// proxyMessageEnd terminates each JSON frame on the socket.
+	proxyMessageEnd = '\n'
+	// proxyTimeout is the upper bound for one proxy RPC. The mount-proxy
+	// server itself runs the entrypoint with a 30s handle timeout, so the
+	// client deadline must be longer than that.
+	proxyTimeout = 35 * time.Second
+)
+
+// maxProxyMsgSize bounds a single proxy request/response (256MB, same
+// upper bound as the mount-proxy server). A var, not a const, so tests can
+// shrink it instead of allocating a 256MB payload. Production code MUST NOT
+// modify it.
+var maxProxyMsgSize = 1 << 28
+
+type proxyMethod string
+
+const (
+	proxyMount proxyMethod = "mount"
+	proxyPing  proxyMethod = "ping"
+)
+
+type proxyRequest struct {
+	Header proxyHeader `json:"header"`
+	Body   any         `json:"body,omitempty"`
+}
+
+type proxyHeader struct {
+	Method proxyMethod `json:"method,omitempty"`
+}
+
+type proxyResponse struct {
+	Seq   int64  `json:"seq,omitempty"`
+	Error string `json:"error,omitempty"`
+}
+
+type proxyMountRequest struct {
+	Source      string            `json:"source,omitempty"`
+	Target      string            `json:"target,omitempty"`
+	Fstype      string            `json:"fstype,omitempty"`
+	Options     []string          `json:"options,omitempty"`
+	MountFlags  []string          `json:"mountFlags,omitempty"`
+	Secrets     map[string]string `json:"secrets,omitempty"`
+	MetricsPath string            `json:"metricsPath,omitempty"`
+	VolumeID    string            `json:"volumeID,omitempty"`
+}
+
+// proxyDoRequestFn is the indirection used by proxyClient.Mount to issue a
+// request. It is a package variable so tests can substitute a fake without
+// binding to a real unix socket. Production code MUST NOT reassign it.
+var proxyDoRequestFn = func(c *proxyClient, ctx context.Context, req *proxyRequest) (*proxyResponse, error) {
+	return c.doRequest(ctx, req)
+}
+
+// proxyClient talks to a mount-proxy-server over its unix socket.
+type proxyClient struct {
+	raddr   net.UnixAddr
+	timeout time.Duration
+}
+
+func newProxyClient(socketPath string) *proxyClient {
+	return &proxyClient{
+		raddr:   net.UnixAddr{Name: socketPath, Net: "unix"},
+		timeout: proxyTimeout,
+	}
+}
+
+// Mount sends a mount request and returns an error carrying the server-side
+// failure message, if any.
+func (c *proxyClient) Mount(ctx context.Context, req *proxyMountRequest) error {
+	resp, err := proxyDoRequestFn(c, ctx, &proxyRequest{
+		Header: proxyHeader{Method: proxyMount},
+		Body:   req,
+	})
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return errors.New(resp.Error)
+	}
+	return nil
+}
+
+func (c *proxyClient) doRequest(ctx context.Context, req *proxyRequest) (*proxyResponse, error) {
+	// One deadline bounds the whole RPC — connection establishment and the
+	// request/response exchange — so the total wait never exceeds
+	// c.timeout. The dial uses the same context: a unix connect can block
+	// when the server's listen backlog is full, and a separate Dialer
+	// timeout would add up with the deadline below, doubling the worst
+	// case.
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", c.raddr.Name)
+	if err != nil {
+		return nil, fmt.Errorf("dial mount proxy %s: %w", c.raddr.Name, err)
+	}
+	defer conn.Close()
+
+	deadline, ok := ctx.Deadline()
+	if ok {
+		if err := conn.SetDeadline(deadline); err != nil {
+			return nil, fmt.Errorf("set deadline: %w", err)
+		}
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("encode proxy request: %w", err)
+	}
+	if _, err := conn.Write(append(data, proxyMessageEnd)); err != nil {
+		return nil, fmt.Errorf("send proxy request: %w", err)
+	}
+
+	var resp proxyResponse
+	if err := readProxyMsg(conn, &resp); err != nil {
+		return nil, fmt.Errorf("read proxy response: %w", err)
+	}
+	return &resp, nil
+}
+
+// readProxyMsg decodes one JSON message and verifies that a message-end byte
+// follows, mirroring the mount-proxy server's framing.
+func readProxyMsg(r io.Reader, msg any) error {
+	lr := io.LimitedReader{R: r, N: int64(maxProxyMsgSize)}
+	dec := json.NewDecoder(&lr)
+	if err := dec.Decode(msg); err != nil {
+		if lr.N <= 0 {
+			return errors.New("proxy message too large")
+		}
+		return fmt.Errorf("decode proxy message: %w", err)
+	}
+
+	var p [32]byte
+	n, err := io.MultiReader(dec.Buffered(), &lr).Read(p[:])
+	if err != nil {
+		return fmt.Errorf("read proxy message end: %w", err)
+	}
+	// The frame must end with exactly one message-end byte; anything more is
+	// a protocol violation that would desynchronize the request/response
+	// pairing on this connection.
+	if n != 1 || p[0] != proxyMessageEnd {
+		return errors.New("missing message end after proxy message")
+	}
+	return nil
+}

--- a/pkg/agent-runtime/customfusesidecar/proxy_test.go
+++ b/pkg/agent-runtime/customfusesidecar/proxy_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customfusesidecar
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadProxyMsg(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		want        proxyResponse
+		expectError string
+	}{
+		{
+			name:  "valid message with terminator",
+			input: `{"seq":7,"error":""}` + string(proxyMessageEnd),
+			want:  proxyResponse{Seq: 7},
+		},
+		{
+			name:  "error message decodes",
+			input: `{"error":"mount failed"}` + string(proxyMessageEnd),
+			want:  proxyResponse{Error: "mount failed"},
+		},
+		{
+			name:        "missing terminator is rejected",
+			input:       `{"seq":1}`,
+			expectError: "read proxy message end",
+		},
+		{
+			name:        "malformed json is rejected",
+			input:       `{broken` + string(proxyMessageEnd),
+			expectError: "decode proxy message",
+		},
+		{
+			name:        "empty input is rejected",
+			input:       "",
+			expectError: "decode proxy message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got proxyResponse
+			err := readProxyMsg(strings.NewReader(tt.input), &got)
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestReadProxyMsgOversize(t *testing.T) {
+	// A valid JSON frame whose payload exceeds maxProxyMsgSize exhausts the
+	// LimitedReader during decoding and must be rejected with a size error.
+	// Shrink the limit so the payload stays small instead of allocating a
+	// 256MB string.
+	old := maxProxyMsgSize
+	maxProxyMsgSize = 1 << 10
+	t.Cleanup(func() { maxProxyMsgSize = old })
+
+	big := `{"seq":1,"error":"` + strings.Repeat("x", maxProxyMsgSize) + `"}`
+	var got proxyResponse
+	err := readProxyMsg(bytes.NewReader([]byte(big)), &got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too large")
+}
+
+func TestProxyMountPropagatesServerError(t *testing.T) {
+	// Mount must surface the server-side error message so the node server can
+	// map it to a CSI status code.
+	orig := proxyDoRequestFn
+	proxyDoRequestFn = func(_ *proxyClient, _ context.Context, _ *proxyRequest) (*proxyResponse, error) {
+		return &proxyResponse{Error: "entrypoint exited: boom"}, nil
+	}
+	defer func() { proxyDoRequestFn = orig }()
+
+	client := newProxyClient("/var/run/csi/mounter.sock")
+	err := client.Mount(context.Background(), &proxyMountRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "entrypoint exited: boom")
+}

--- a/pkg/agent-runtime/customfusevalidate/validate.go
+++ b/pkg/agent-runtime/customfusevalidate/validate.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package customfusevalidate holds the security checks shared between the
+// control-plane CustomFuseMountProvider and the sandbox-side CSI node server.
+// Both ends must reject the same inputs because mount-proxy exports every
+// Secret entry and mount flag as an environment variable of the same name
+// into the entrypoint shell: the provider validates the PV+Secret path, and
+// the node server repeats the checks for requests that reach it directly
+// over the per-driver unix socket without passing through the provider.
+package customfusevalidate
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// secretKeyPattern matches Secret keys that can be exported as environment
+// variables. The customfuse contract maps every Secret key to an env var of
+// the same name consumed by the entrypoint, and bash cannot reference names
+// with dashes ($access-key expands as $access plus the literal "-key").
+var secretKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// blockedMountOptionKeys are mount options that would become environment
+// variables with code-execution or command-redirection side effects once
+// mount-proxy exports them to the entrypoint shell: bash sources BASH_ENV at
+// startup, glibc loads LD_PRELOAD, PATH redirects command lookup, and
+// IFS/PS4/SHELLOPTS alter shell behavior. These keys are rejected outright.
+// The match is exact: bash and glibc read only the canonical uppercase names,
+// so lowercase variants are harmless and stay allowed.
+var blockedMountOptionKeys = map[string]bool{
+	"BASH_ENV": true, "ENV": true, "BASHOPTS": true, "SHELLOPTS": true,
+	"PROMPT_COMMAND": true, "PS4": true, "IFS": true, "BASH_XTRACEFD": true,
+	"LD_PRELOAD": true, "LD_LIBRARY_PATH": true, "LD_AUDIT": true,
+	"LD_BIND_NOW": true, "LD_DEBUG": true, "GLIBC_TUNABLES": true,
+	"PATH": true, "CDPATH": true, "HISTFILE": true,
+}
+
+// reservedSecretKeys are Secret keys that would overwrite the environment
+// variables the provider itself injects for the entrypoint: mount-proxy
+// exports every Secret entry verbatim and in a duplicate-key env the last
+// occurrence wins, so a Secret key like "source" would replace the validated
+// mount source, "readOnly" would weaken the read-only semantics derived from
+// the CSI request, and "mountpoint" would redirect the mount target.
+// Credentials never legitimately share names with these reserved keys.
+var reservedSecretKeys = map[string]bool{
+	"source": true, "readOnly": true, "mountpoint": true,
+	"bucket": true, "url": true, "path": true, "otherOpts": true,
+	"capacity": true, "fuseType": true, "authType": true,
+	"storageType": true,
+}
+
+// optionValuePattern matches key=value pairs in option strings (e.g.
+// "cache-size=1024") so that error messages can mask the value part, which
+// may carry credential material. The key is any run of non-separator
+// characters, possibly empty so a malformed "=secret" input is masked
+// too: a narrow key charset would leave "x.y=Secret" unmasked and leak
+// the value into error logs. Values are masked up to the next separator:
+// a value containing a comma is an invalid mount option (comma is the
+// option separator), and masking past the comma would swallow the
+// following option from the error message entirely.
+var optionValuePattern = regexp.MustCompile(`([^=,;\s]*)=([^,;\s]*)`)
+
+// HasShellMetachar returns true when s contains characters that could be
+// interpreted by a shell: ; | & ` $ ( ) \r \n \x00 and the escape
+// character \ which can change how a later character is parsed.
+func HasShellMetachar(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		switch c {
+		case ';', '|', '&', '`', '$', '(', ')', '\\', '\r', '\n', '\x00':
+			return true
+		}
+	}
+	return false
+}
+
+// SafeForwardPattern matches values made only of characters that are safe
+// to forward to the sidecar entrypoint: metadata URLs (redis://host:6379/0,
+// s3://bucket, redis://[::1]:6379/0) and plain identifiers. It is shared by
+// the control-plane provider and the sandbox-side node server so both ends
+// reject the same inputs; the allowlist approach (rather than a denylist)
+// keeps every future entrypoint safe even when it forgets to quote.
+var SafeForwardPattern = regexp.MustCompile(`^[A-Za-z0-9_\-:/@.%\[\]]+$`)
+
+// AllowedFuseTypes is the allowlist of FUSE client identifiers shared by
+// the control-plane provider and the sandbox-side node server. Only clients
+// with a shipped entrypoint belong here; "customfuse" is the default
+// sentinel for "no client specified" (injected by the provider when neither
+// fuseType nor CSI fsType is set), not a client type.
+var AllowedFuseTypes = map[string]bool{
+	"juicefs":    true,
+	"s3fs":       true,
+	"customfuse": true,
+}
+
+// CapacityPattern mirrors the JuiceFS entrypoint's accepted capacity forms:
+// a plain integer or an integer with Ti/TiB, Gi/GiB, Mi/MiB, Ki/KiB units.
+// It is shared by the control-plane provider and the sandbox-side node
+// server so a value accepted at the control plane never fails later in the
+// entrypoint. Both branches carry the 15-digit bound: unit-bearing values
+// are multiplied in bash arithmetic, which must stay inside 64-bit range,
+// and absurdly large plain integers are rejected early instead of failing
+// quota set at mount time with only a warning.
+var CapacityPattern = regexp.MustCompile(`^([0-9]{1,15}(TiB|Ti|GiB|Gi|MiB|Mi|KiB|Ki)|[0-9]{1,15})$`)
+
+// MaskOptionValues masks the value of every key=value pair in an option
+// string so error messages never echo potential credential material.
+func MaskOptionValues(s string) string {
+	return optionValuePattern.ReplaceAllString(s, "${1}=***")
+}
+
+// ValidateSecretData validates every entry of a Secret's Data map: the key
+// must be a valid environment variable name, must not be a dangerous
+// environment key, must not be a reserved provider key, and the value must
+// be single-line. A value containing a newline would inject extra lines into
+// the s3fs credential file.
+func ValidateSecretData(data map[string][]byte) error {
+	for key, value := range data {
+		if err := validateSecretEntry(key, string(value)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateSecrets validates every entry of a CSI request's Secrets map, which
+// is how the sandbox-side node server receives Secret material.
+func ValidateSecrets(secrets map[string]string) error {
+	for key, value := range secrets {
+		if err := validateSecretEntry(key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSecretEntry(key, value string) error {
+	if err := ValidateEnvKeyName(key); err != nil {
+		return fmt.Errorf("secret key %v", err)
+	}
+	if reservedSecretKeys[key] {
+		return fmt.Errorf("secret key %q is reserved for provider-injected environment variables and must not be overridden", key)
+	}
+	// NUL is rejected along with newlines: environment values are C
+	// strings, so an embedded NUL would truncate the variable at execve
+	// time or make the exec fail outright. A tab is rejected too: the
+	// s3fs credential file is parsed as access_key:secret_key pairs and
+	// an embedded tab would corrupt that parsing.
+	if strings.ContainsAny(value, "\n\r\x00\t") {
+		return fmt.Errorf("secret %q must not contain a newline, tab or NUL byte", key)
+	}
+	return nil
+}
+
+// ValidateEnvKeyName checks a single key that may be exported as an
+// environment variable to the entrypoint: it must be a valid variable name
+// of a sane length and must not be one of the dangerous keys bash or glibc
+// would act on.
+func ValidateEnvKeyName(key string) error {
+	if !secretKeyPattern.MatchString(key) {
+		return fmt.Errorf("%q is not a valid environment variable name", key)
+	}
+	if len(key) > 256 {
+		return fmt.Errorf("environment variable name is too long (%d bytes)", len(key))
+	}
+	if blockedMountOptionKeys[key] {
+		return fmt.Errorf("%q is not allowed: it would be exported as a dangerous environment variable to the entrypoint", key)
+	}
+	return nil
+}
+
+// IsBlockedEnvKey reports whether key is one of the dangerous environment
+// variables bash or glibc would act on. Used for VolumeContext keys on the
+// control plane, where an invalid variable name is harmless (bash cannot
+// reference it) but a dangerous exact-name key would take effect if
+// mount-proxy ever starts exporting VolumeContext keys as environment
+// variables — defense in depth.
+func IsBlockedEnvKey(key string) bool {
+	return blockedMountOptionKeys[key]
+}
+
+// IsReservedKey reports whether key is a provider-injected environment name
+// that callers must not override through mount options or Secret keys.
+func IsReservedKey(key string) bool {
+	return reservedSecretKeys[key]
+}
+
+// credentialKeys lists key names that denote credential material and must
+// not appear in volumeAttributes or in mount-option sub-keys. Credentials
+// belong in a Kubernetes Secret referenced by the PV's
+// NodePublishSecretRef, never in plain-text PV fields or option lists.
+// The list is a best-effort guard against common mistakes; the security
+// boundary is the Secret mechanism itself.
+var credentialKeys = []string{
+	"token", "accessKeyId", "accessKeySecret", "passphrase", "password", "passwd",
+	"access-key", "secret-key", "access_key", "secret_key", "ak", "sk", "secret",
+	"securityToken", "sessionToken", "authToken",
+}
+
+// IsCredentialKey reports whether key names a credential, matched
+// case-insensitively. Mount-option sub-keys that look like credentials
+// (e.g. "token=xxx" inside otherOpts) must be rejected rather than let
+// the value travel into mount options and logs.
+func IsCredentialKey(key string) bool {
+	for _, credKey := range credentialKeys {
+		if strings.EqualFold(key, credKey) {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateMountOptions checks every mount option entry (pv.Spec.MountOptions
+// on the control plane, VolumeCapability.MountFlags on the node server). Each
+// entry becomes one environment variable in the entrypoint, so shell
+// metacharacters are rejected and entries whose keys are dangerous
+// environment variables or provider-reserved keys are denied outright.
+func ValidateMountOptions(opts []string) error {
+	for _, opt := range opts {
+		if HasShellMetachar(opt) {
+			return fmt.Errorf("mount option %q contains invalid shell characters", MaskOptionValues(opt))
+		}
+		// Entries are split on space, tab and comma, mirroring the
+		// entrypoint's option-list parsing: a comma-only split would let
+		// "cache-size=1024 BASH_ENV=x" hide a dangerous key inside one
+		// token. FieldsFunc also drops empty fields, so a whitespace
+		// padded key (" BASH_ENV=x") cannot dodge the exact match either.
+		for _, entry := range strings.FieldsFunc(opt, func(r rune) bool { return r == ',' || r == ' ' || r == '\t' }) {
+			key, _, _ := strings.Cut(entry, "=")
+			// A keyless "=value" entry is malformed and would dodge the
+			// key-based checks below ("" is neither blocked nor reserved).
+			if key == "" {
+				return fmt.Errorf("mount option %q is not allowed: empty option key", MaskOptionValues(opt))
+			}
+			// subdir= follows the official JuiceFS CSI mountOptions
+			// convention, but this driver mounts sub-directories via the
+			// path volumeAttribute; a subdir option would reach the
+			// client's -o string and be rejected or silently ignored.
+			// Exact match only, consistent with the case-sensitive option
+			// checks: the client treats option keys case-sensitively.
+			if key == "subdir" {
+				return fmt.Errorf("mount option %q is not supported: use the path volumeAttribute to mount a sub-directory", MaskOptionValues(opt))
+			}
+			if blockedMountOptionKeys[key] {
+				return fmt.Errorf("mount option %q is not allowed: it would be exported as a dangerous environment variable to the entrypoint", MaskOptionValues(opt))
+			}
+			if reservedSecretKeys[key] {
+				return fmt.Errorf("mount option %q is reserved for provider-injected mount semantics and must not be overridden", MaskOptionValues(opt))
+			}
+			if IsCredentialKey(key) {
+				return fmt.Errorf("mount option %q must not carry credential material, put it in Secret instead", MaskOptionValues(opt))
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/agent-runtime/customfusevalidate/validate_test.go
+++ b/pkg/agent-runtime/customfusevalidate/validate_test.go
@@ -1,0 +1,267 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customfusevalidate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateSecrets(t *testing.T) {
+	tests := []struct {
+		name        string
+		secrets     map[string]string
+		expectError string
+	}{
+		{name: "nil secrets pass", secrets: nil, expectError: ""},
+		{name: "empty secrets pass", secrets: map[string]string{}, expectError: ""},
+		{
+			name:        "credential keys pass",
+			secrets:     map[string]string{"access_key": "AKID", "secret_key": "SK", "token": "tok"},
+			expectError: "",
+		},
+		{
+			name:        "key with dash rejected",
+			secrets:     map[string]string{"access-key": "AKID"},
+			expectError: "not a valid environment variable name",
+		},
+		{
+			name:        "key with leading digit rejected",
+			secrets:     map[string]string{"1secret": "v"},
+			expectError: "not a valid environment variable name",
+		},
+		{
+			name:        "BASH_ENV rejected",
+			secrets:     map[string]string{"BASH_ENV": "/tmp/x.sh"},
+			expectError: "not allowed",
+		},
+		{
+			name:        "LD_PRELOAD rejected",
+			secrets:     map[string]string{"LD_PRELOAD": "/tmp/x.so"},
+			expectError: "not allowed",
+		},
+		{
+			name:        "IFS rejected",
+			secrets:     map[string]string{"IFS": ":"},
+			expectError: "not allowed",
+		},
+		{
+			name:        "reserved source key rejected",
+			secrets:     map[string]string{"source": "redis://evil:6379/0"},
+			expectError: "reserved",
+		},
+		{
+			name:        "reserved readOnly key rejected",
+			secrets:     map[string]string{"readOnly": "false"},
+			expectError: "reserved",
+		},
+		{
+			name:        "reserved url key rejected",
+			secrets:     map[string]string{"url": "http://attacker:9000"},
+			expectError: "reserved",
+		},
+		{
+			name:        "reserved storageType key rejected",
+			secrets:     map[string]string{"storageType": "oss"},
+			expectError: "reserved",
+		},
+		{
+			name:        "newline value rejected",
+			secrets:     map[string]string{"access_key": "AK\nID"},
+			expectError: "must not contain a newline",
+		},
+		{
+			name:        "carriage return value rejected",
+			secrets:     map[string]string{"access_key": "AK\rID"},
+			expectError: "must not contain a newline",
+		},
+		{
+			name:        "NUL byte value rejected",
+			secrets:     map[string]string{"access_key": "AK\x00ID"},
+			expectError: "must not contain a newline, tab or NUL byte",
+		},
+		{
+			name:        "tab value rejected",
+			secrets:     map[string]string{"access_key": "AK\tID"},
+			expectError: "must not contain a newline, tab or NUL byte",
+		},
+		{
+			name:        "lowercase dangerous key stays allowed",
+			secrets:     map[string]string{"bash_env": "/tmp/x.sh"},
+			expectError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSecrets(tt.secrets)
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			}
+		})
+	}
+}
+
+func TestValidateSecretData(t *testing.T) {
+	err := ValidateSecretData(map[string][]byte{
+		"access_key": []byte("AKID"),
+		"secret_key": []byte("SK\nline2"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must not contain a newline")
+
+	assert.NoError(t, ValidateSecretData(nil))
+}
+
+func TestValidateEnvKeyName(t *testing.T) {
+	tests := []struct {
+		name        string
+		key         string
+		expectError string
+	}{
+		{name: "plain name passes", key: "access_key", expectError: ""},
+		{name: "name with dash rejected", key: "access-key", expectError: "not a valid environment variable name"},
+		{name: "name with leading digit rejected", key: "1key", expectError: "not a valid environment variable name"},
+		{name: "BASH_ENV rejected", key: "BASH_ENV", expectError: "not allowed"},
+		{name: "LD_PRELOAD rejected", key: "LD_PRELOAD", expectError: "not allowed"},
+		{name: "lowercase dangerous key passes", key: "bash_env", expectError: ""},
+		{name: "overlong key rejected", key: strings.Repeat("a", 300), expectError: "too long"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateEnvKeyName(tt.key)
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			}
+		})
+	}
+}
+
+func TestIsBlockedEnvKey(t *testing.T) {
+	for _, key := range []string{"BASH_ENV", "LD_PRELOAD", "IFS", "PATH"} {
+		assert.True(t, IsBlockedEnvKey(key), "expected %q to be blocked", key)
+	}
+	for _, key := range []string{"bash_env", "access_key", "custom-key", ""} {
+		assert.False(t, IsBlockedEnvKey(key), "expected %q not to be blocked", key)
+	}
+}
+
+func TestValidateMountOptions(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        []string
+		expectError string
+	}{
+		{name: "nil options pass", opts: nil, expectError: ""},
+		{name: "safe options pass", opts: []string{"cache-size=1024", "no-update"}, expectError: ""},
+		{name: "shell metachar rejected", opts: []string{"opt; rm -rf /"}, expectError: "invalid shell characters"},
+		{name: "BASH_ENV rejected", opts: []string{"BASH_ENV=/tmp/x.sh"}, expectError: "not allowed"},
+		{name: "LD_PRELOAD rejected", opts: []string{"LD_PRELOAD=/tmp/x.so"}, expectError: "not allowed"},
+		{name: "PATH rejected", opts: []string{"PATH=/tmp"}, expectError: "not allowed"},
+		{name: "space-padded dangerous key rejected", opts: []string{"  BASH_ENV=/tmp/x.sh"}, expectError: "not allowed"},
+		{name: "tab-padded reserved key rejected", opts: []string{"\tsource=redis://evil:6379/0"}, expectError: "reserved"},
+		{name: "bare dangerous key rejected", opts: []string{"IFS"}, expectError: "not allowed"},
+		{name: "reserved url rejected", opts: []string{"url=http://attacker:9000"}, expectError: "reserved"},
+		{name: "reserved source rejected", opts: []string{"source=redis://evil:6379/0"}, expectError: "reserved"},
+		{name: "reserved readOnly rejected", opts: []string{"readOnly=false"}, expectError: "reserved"},
+		{name: "subdir option rejected with path hint", opts: []string{"subdir=/my/sub/dir"}, expectError: "use the path volumeAttribute"},
+		{name: "case variant of subdir stays allowed", opts: []string{"Subdir=/my/sub/dir"}, expectError: ""},
+		{name: "space-separated entry hiding reserved key rejected", opts: []string{"cache-size=1024 source=evil"}, expectError: "reserved"},
+		{name: "space-separated entry hiding dangerous key rejected", opts: []string{"cache-size=1024 BASH_ENV=/tmp/x.sh"}, expectError: "not allowed"},
+		{name: "keyless entry rejected", opts: []string{"=value"}, expectError: "empty option key"},
+		{name: "bare flag without equals stays allowed", opts: []string{"allow_other"}, expectError: ""},
+		{name: "credential-like sub-key rejected", opts: []string{"cache-size=1024,token=xxx"}, expectError: "must not carry credential material"},
+		{name: "password sub-key rejected", opts: []string{"password=secret"}, expectError: "must not carry credential material"},
+		{
+			name:        "blocked option error masks value",
+			opts:        []string{"BASH_ENV=/tmp/x.sh"},
+			expectError: "not allowed",
+		},
+		{
+			name:        "lowercase dangerous key stays allowed",
+			opts:        []string{"bash_env=/tmp/x.sh"},
+			expectError: "",
+		},
+		{
+			name:        "case variant of reserved key stays allowed",
+			opts:        []string{"Url=http://attacker:9000"},
+			expectError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMountOptions(tt.opts)
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			}
+		})
+	}
+}
+
+func TestBlockedOptionErrorMasksValue(t *testing.T) {
+	err := ValidateMountOptions([]string{"BASH_ENV=/tmp/x.sh"})
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "/tmp/x.sh")
+}
+
+func TestIsReservedKey(t *testing.T) {
+	for _, key := range []string{"source", "readOnly", "mountpoint", "bucket", "url", "path", "otherOpts", "capacity", "fuseType", "authType", "storageType"} {
+		assert.True(t, IsReservedKey(key), "expected %q to be reserved", key)
+	}
+	for _, key := range []string{"Url", "URL", "SOURCE", "access_key", "token", "cache-size", "no-update", ""} {
+		assert.False(t, IsReservedKey(key), "expected %q not to be reserved", key)
+	}
+}
+
+func TestHasShellMetachar(t *testing.T) {
+	for _, c := range []string{";", "|", "&", "`", "$", "(", ")", "\\", "\r", "\n", "\x00"} {
+		assert.True(t, HasShellMetachar("a"+c+"b"), "expected metachar %q", c)
+	}
+	for _, s := range []string{"", "cache-size=1024", "http://host:9000", "a b", "a<b>c", "a'b\"c"} {
+		assert.False(t, HasShellMetachar(s), "expected no metachar in %q", s)
+	}
+}
+
+func TestMaskOptionValues(t *testing.T) {
+	assert.Equal(t, "passwd_file=***,allow_other", MaskOptionValues("passwd_file=/tmp/x,allow_other"))
+	assert.Equal(t, "opt1; x", MaskOptionValues("opt1; x"))
+	// Keys containing characters outside [A-Za-z0-9_-] must be masked too,
+	// or their values would leak into error messages.
+	assert.Equal(t, "x.y=***,allow_other", MaskOptionValues("x.y=Secret,allow_other"))
+	assert.Equal(t, "x.y=*** BASH_ENV=***", MaskOptionValues("x.y=Secret BASH_ENV=/evil"))
+	// Values are masked up to the next separator. A value containing a
+	// comma is an invalid mount option; masking past the comma would
+	// swallow the following option from the error message, so the mask
+	// stops at the boundary.
+	assert.Equal(t, "cache-size=***,no-update", MaskOptionValues("cache-size=1024,no-update"))
+	assert.Equal(t, "cache-dir=***,b", MaskOptionValues("cache-dir=/path/a,b"))
+	// Malformed keyless input ("=secret") is masked as well.
+	assert.Equal(t, "=***", MaskOptionValues("=secret"))
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

  Ⅰ. Describe what this PR does
  Adds csi-sidecar-customfuse: the sandbox-side CSI node server that listens on
  the per-driver unix socket and forwards NodePublishVolume to
  mount-proxy-server. Re-validates requests that bypass the control plane
  (secret keys, blocked env keys, mount options, fuse-type allowlist,
  mount-root-contained target path with symlink re-resolution), and drains gRPC
  for up to 8s on SIGTERM (nested below the supervisor's 10s SIGKILL escalation).

  Ⅱ. Does this pull request fix one issue?
  NONE. Part 4/7 of the customfuse provider PR series (docs: #855).

  Ⅲ. Describe how to verify it
  go test ./pkg/agent-runtime/customfusesidecar/ -count=1

  Ⅳ. Special notes for reviews
  Depends on PR2 (customfusevalidate).

