### PR TITLE
feat(customfuse): register customfuse provider in the storage CLI

### DIFF
--- a/pkg/agent-runtime/storage-cli/storage/customfuse_provider.go
+++ b/pkg/agent-runtime/storage-cli/storage/customfuse_provider.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+// CustomFuseDriver is the CSI driver name of the generic FUSE plugin. The
+// mount-proxy component originates from the alibaba-cloud-csi-driver
+// customfuse feature, but the driver is community-owned under the
+// openkruise.io prefix. It MUST match both the directory under CsiSocketDir
+// created by the csi-sidecar and the driver name used by the control-plane
+// storage registration.
+const CustomFuseDriver = "customfuseplugin.csi.openkruise.io"
+
+// customFuseSubDir is the sub-directory under the mount root that hosts the
+// per-volume mount point for the customfuse driver.
+const customFuseSubDir = "customfuse"
+
+// customFuseProvider forwards NodePublishVolume to the csi-sidecar's CSI
+// node server over the standard per-driver unix socket. The sidecar performs
+// the actual FUSE mount via mount-proxy and the driver entrypoint.
+type customFuseProvider struct{}
+
+func init() {
+	Register(&customFuseProvider{})
+}
+
+func (p *customFuseProvider) Driver() string {
+	return CustomFuseDriver
+}
+
+func (p *customFuseProvider) SubDir() string {
+	return customFuseSubDir
+}
+
+// Validate checks the routing fields required to forward a publish request
+// to the sidecar — and nothing more. Deep option validation (source,
+// fuseType whitelist, credential separation) is done by the control-plane
+// CustomFuseMountProvider at claim time; the sidecar CSI node server
+// repeats the environment-key checks (Secret keys and mount flags) as
+// defense in depth, and the FUSE entrypoint re-validates shell safety of
+// the values it interpolates.
+func (p *customFuseProvider) Validate(req csi.NodePublishVolumeRequest) error {
+	if req.VolumeId == "" {
+		return fmt.Errorf("volumeId is required")
+	}
+	if req.TargetPath == "" {
+		return fmt.Errorf("targetPath is required")
+	}
+	return nil
+}
+
+// Mount forwards the request to the sidecar CSI node server via
+// RunNodePublishVolume (see csi_runner.go). debug enables printing the
+// credential-bearing publish context and must never be enabled in
+// production.
+func (p *customFuseProvider) Mount(ctx context.Context, req csi.NodePublishVolumeRequest, debug bool) error {
+	return RunNodePublishVolume(ctx, p.Driver(), req, debug)
+}
+
+// Unmount is not implemented yet; the sandbox teardown removes the mount
+// point together with the sandbox.
+func (p *customFuseProvider) Unmount(ctx context.Context, req csi.NodePublishVolumeRequest) error {
+	return nil
+}

--- a/pkg/agent-runtime/storage-cli/storage/customfuse_provider_test.go
+++ b/pkg/agent-runtime/storage-cli/storage/customfuse_provider_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"io"
+	"path"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCustomFuseProviderRegistration verifies the provider self-registers in
+// init() under the documented driver name, so the storage CLI can look it up
+// without an explicit wiring change.
+func TestCustomFuseProviderRegistration(t *testing.T) {
+	resetRegistryForTesting()
+	defer resetRegistryForTesting()
+
+	p := &customFuseProvider{}
+	Register(p)
+
+	assert.Equal(t, CustomFuseDriver, p.Driver())
+	assert.Equal(t, "customfuse", p.SubDir())
+
+	got, ok := Lookup(CustomFuseDriver)
+	assert.True(t, ok, "provider must be registered under the customfuse driver name")
+	assert.Equal(t, p, got)
+	assert.Contains(t, Drivers(), CustomFuseDriver)
+}
+
+func TestCustomFuseProviderValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		req         csi.NodePublishVolumeRequest
+		expectError string
+	}{
+		{
+			name: "valid request passes",
+			req: csi.NodePublishVolumeRequest{
+				VolumeId:   "vol-1",
+				TargetPath: "/workspace/data",
+			},
+		},
+		{
+			name: "missing volumeId is rejected",
+			req: csi.NodePublishVolumeRequest{
+				TargetPath: "/workspace/data",
+			},
+			expectError: "volumeId is required",
+		},
+		{
+			name: "missing targetPath is rejected",
+			req: csi.NodePublishVolumeRequest{
+				VolumeId: "vol-1",
+			},
+			expectError: "targetPath is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &customFuseProvider{}
+			err := p.Validate(tt.req)
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+			}
+		})
+	}
+}
+
+// TestCustomFuseProviderMountForwardsToSocket verifies Mount routes through
+// RunNodePublishVolume against the standard per-driver socket layout.
+func TestCustomFuseProviderMountForwardsToSocket(t *testing.T) {
+	p := &customFuseProvider{}
+
+	tests := []struct {
+		name    string
+		factory func(socketPath string) (csi.NodeClient, io.Closer, error)
+		expect  string
+	}{
+		{
+			name: "success forwards to csi.sock under driver directory",
+			factory: func(socketPath string) (csi.NodeClient, io.Closer, error) {
+				assert.Equal(t, path.Join(CsiSocketDir, CustomFuseDriver, CsiSocketFile), socketPath)
+				return &fakeNodeClient{resp: &csi.NodePublishVolumeResponse{}}, &nopCloser{}, nil
+			},
+		},
+		{
+			name: "rpc error propagates",
+			factory: func(_ string) (csi.NodeClient, io.Closer, error) {
+				return &fakeNodeClient{err: context.DeadlineExceeded}, &nopCloser{}, nil
+			},
+			expect: "NodePublishVolume failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withClientFactory(t, tt.factory)
+			err := p.Mount(context.Background(), csi.NodePublishVolumeRequest{VolumeId: "vol-1"}, false)
+			if tt.expect == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expect)
+			}
+		})
+	}
+}
+
+func TestCustomFuseProviderUnmountNotImplemented(t *testing.T) {
+	p := &customFuseProvider{}
+	assert.NoError(t, p.Unmount(context.Background(), csi.NodePublishVolumeRequest{}))
+}


### PR DESCRIPTION
Registers customfuseplugin.csi.openkruise.io in the sandbox storage CLI so mount requests dial the per-driver unix socket served by the csi-sidecar node server, with the mount target relocated to <mount-root>/customfuse/<md5(user-path)>. The debug flag that prints the credential-bearing publish context remains CLI-opt-in only.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

## I. Describe what this PR does

  Registers customfuseplugin.csi.openkruise.io in the sandbox storage CLI so
  mount requests dial the per-driver unix socket served by the csi-sidecar node
    server, with the mount target relocated to
    `/run/csi/mount-root/customfuse/<md5(user-path)>`. The debug flag that prints the
  credential-bearing publish context remains CLI-opt-in only.

## II. Does this PR fix one issue?

  NONE. Part 5/7 of the customfuse provider PR series (docs: #855).

## III. Describe how to verify it

  go test ./pkg/agent-runtime/storage-cli/storage/ -count=1

## IV. Special notes for reviews

  Standalone.