### PR TITLE
feat(customfuse): add sidecar images, entrypoints, and PV/Secret exam…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts are executed directly by the kernel inside containers:
+# a CRLF shebang line ("#!/bin/bash\r") makes exec fail with
+# "no such file or directory". Force LF regardless of core.autocrlf.
+*.sh text eol=lf

--- a/pkg/sidecar/juicefs/Dockerfile
+++ b/pkg/sidecar/juicefs/Dockerfile
@@ -1,0 +1,74 @@
+# Stage 1: build mount-proxy-server from alibaba-cloud-csi-driver source
+# (the customfuse feature on PR #1722). The repository is cloned inside the
+# build instead of relying on a local --build-context; override
+# CSI_DRIVER_REPO with a mirror when GitHub is not directly reachable.
+# IMAGE_PREFIX overrides the Docker Hub prefix for environments without
+# direct Docker Hub access (e.g. docker.1panel.live).
+ARG IMAGE_PREFIX=docker.io
+ARG CSI_DRIVER_REPO=https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver.git
+# The ref to fetch from CSI_DRIVER_REPO. pull/1722/head is GitHub's PR ref;
+# when overriding CSI_DRIVER_REPO with a mirror, also override this: most
+# mirrors do not expose PR refs (and the PR's source branch lives on
+# the author's fork), so use a branch or commit the mirror carries.
+ARG CSI_DRIVER_REF=pull/1722/head
+# CSI_DRIVER_SHA pins pr-1722's head; override with --build-arg when the
+# branch advances (after verifying compatibility). The original pin
+# (d45ddfa) was force-pushed out of pr-1722's history, so the build fails
+# loudly instead of trusting the moving branch.
+ARG CSI_DRIVER_SHA=baf1dca5269965c1ee04ec900a0ba5de4f310f8e
+# GOPROXY defaults to a mainland mirror; override with --build-arg
+# for environments with other reachable proxies.
+ARG GOPROXY=https://goproxy.cn,direct
+# pr-1722's go.mod requires go >= 1.26.0; the sidecar stage below uses
+# 1.26 as well because this repo's go.mod requires >= 1.25.9.
+FROM ${IMAGE_PREFIX}/golang:1.26 AS builder-proxy
+ARG CSI_DRIVER_REPO
+ARG CSI_DRIVER_REF
+ARG CSI_DRIVER_SHA
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+WORKDIR /src
+# Fetch PR #1722's head and verify the pinned commit; the build fails
+# loudly if the branch has advanced (the pin must be re-verified and
+# updated deliberately).
+RUN git init . &&     git remote add origin "${CSI_DRIVER_REPO}" &&     git fetch --depth 1 origin "${CSI_DRIVER_REF}" &&     git checkout FETCH_HEAD &&     test "$(git rev-parse HEAD)" = "${CSI_DRIVER_SHA}" ||         { echo "ERROR: checkout does not match CSI_DRIVER_SHA (did the pinned ref advance?)" >&2; exit 1; } &&     CGO_ENABLED=0 go build -o /out/csi-mount-proxy-server ./cmd/mount-proxy-server
+
+# Stage 2: build csi-sidecar-customfuse (CSI node server) from agents source.
+# Build context must be the repository root.
+# !!! Run the build from the repository root, e.g.:
+# !!! docker buildx build -f pkg/sidecar/juicefs/Dockerfile -t <image> .
+# !!! (Stage 1 clones the pinned csi-driver commit from GitHub itself.)
+# go.mod requires go >= 1.25.9; the 1.26 image satisfies it and matches the
+# builder-proxy stage above.
+FROM ${IMAGE_PREFIX}/golang:1.26 AS builder-sidecar
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+COPY go.mod go.sum ./
+COPY cmd/csi-sidecar-customfuse ./cmd/csi-sidecar-customfuse
+COPY pkg/agent-runtime/customfusesidecar ./pkg/agent-runtime/customfusesidecar
+# customfusesidecar imports customfusevalidate; omit it and the build
+# fails. Keep this COPY set in sync with the packages customfusesidecar
+# imports whenever a new in-repo dependency is added.
+COPY pkg/agent-runtime/customfusevalidate ./pkg/agent-runtime/customfusevalidate
+RUN CGO_ENABLED=0 go build -o /out/csi-sidecar-customfuse ./cmd/csi-sidecar-customfuse
+
+# Stage 3: JuiceFS client + both binaries + entrypoint
+# Pinned by digest (Debian 12, bash 5.2.15 — start.sh requires bash >= 5.1
+# for wait -n -p). Do not float on :latest: the build must stay
+# reproducible and the upstream image updates JuiceFS client versions.
+FROM ${IMAGE_PREFIX}/juicedata/mount@sha256:ee34645eae22378bfa7e9728210a243b32962971942ce52011cd08497cf38927
+
+COPY --from=builder-proxy /out/csi-mount-proxy-server /usr/local/bin/
+COPY --from=builder-sidecar /out/csi-sidecar-customfuse /usr/local/bin/
+# go build outputs already carry the executable bit; the explicit chmod is
+# belt-and-braces for COPY paths that lose file modes.
+RUN chmod +x /usr/local/bin/csi-mount-proxy-server /usr/local/bin/csi-sidecar-customfuse
+
+# Copy entrypoint (must be /entrypoint.sh — mount-proxy looks for this path)
+COPY pkg/sidecar/juicefs/entrypoint-juicefs.sh /entrypoint.sh
+# start.sh runs both processes: mount-proxy-server (mounter.sock) and the
+# CSI node server (csi.sock).
+COPY pkg/sidecar/start.sh /start.sh
+RUN chmod +x /entrypoint.sh /start.sh
+
+ENTRYPOINT ["/start.sh"]

--- a/pkg/sidecar/juicefs/entrypoint-juicefs.sh
+++ b/pkg/sidecar/juicefs/entrypoint-juicefs.sh
@@ -1,0 +1,382 @@
+#!/bin/bash
+set -e
+
+# Defense in depth: mount-proxy exports every Secret entry as an environment
+# variable of the same name, so a Secret key could smuggle a code-execution
+# env var (BASH_ENV, LD_PRELOAD, ...) into this shell. The provider rejects
+# these keys, but clear them here too so a future relaxation cannot silently
+# reintroduce the attack. PATH is reset to the image default because an
+# injected PATH would shadow command lookup.
+unset BASH_ENV ENV BASHOPTS SHELLOPTS PROMPT_COMMAND PS4 IFS BASH_XTRACEFD \
+      LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT LD_BIND_NOW LD_DEBUG \
+      GLIBC_TUNABLES CDPATH HISTFILE 2>/dev/null || true
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# JuiceFS entrypoint for OpenKruise customfuse csi-sidecar
+#
+# Environment variables injected by mount-proxy-server from CSI request:
+#   $source       — JuiceFS META-URL (e.g. redis://redis-cluster:6379/0)
+#   $mountpoint   — target mount path inside the sandbox
+#   $token        — JuiceFS token (from Secret, if present)
+#   $access_key   — object storage access key (from Secret)
+#   $secret_key   — object storage secret key (from Secret)
+#   $bucket       — object storage bucket name
+#   $url          — object storage URL
+#   $storageType  — object storage type ("s3" default, "oss", "minio", ...)
+#   $path         — sub-path under the volume root
+#   $capacity     — volume capacity quota (e.g. "100Gi")
+#   $readOnly     — "true" or "false"
+#   $otherOpts    — extra options from PV.Spec.VolumeAttributes
+
+# Log masking
+# META-URLs may embed credentials (redis://user:pass@host), never echo them.
+# The second pattern covers userinfo without a scheme (user:pass@host),
+# which the provider's charset check lets through.
+mask_source() {
+    printf '%s' "$1" | sed -E -e 's|(://)[^ ]*@|\1***@|' -e 's|([^ /:@]+:)[^ /@]*@|\1***@|'
+}
+
+# Shell injection prevention
+validate_opts() {
+    for opt in "$@"; do
+        if [[ "$opt" =~ [\;\|\&\`\$\(\)$'\n'$'\r'\\] ]]; then
+            echo "ERROR: invalid character in option: $opt" >&2
+            exit 1
+        fi
+    done
+}
+
+# Defense in depth: the provider and node server validate source, but this
+# entrypoint must stay safe even if a request bypasses them. The character
+# set mirrors the provider's safeForwardPattern exactly.
+if [ -z "$source" ]; then
+    echo "ERROR: source is required" >&2
+    exit 1
+fi
+if [[ ! "$source" =~ ^[][A-Za-z0-9_:/@.%-]+$ ]]; then
+    echo "ERROR: source contains invalid characters" >&2
+    exit 1
+fi
+
+# url is validated unconditionally (not only inside the format branch):
+# the field must be well-formed even when the token-only path does not
+# use it, and future code paths can rely on it being clean.
+if [ -n "$url" ] && [[ ! "$url" =~ ^[][A-Za-z0-9_:/@.%-]+$ ]]; then
+    echo "ERROR: url contains invalid characters" >&2
+    exit 1
+fi
+if [ -n "$otherOpts" ]; then
+    # Split on space, tab and comma — the same separator set the
+    # provider's ValidateMountOptions uses — so a debug option embedded
+    # after any separator ("cache-size=1024,debug" or
+    # "allow_other<TAB>debug") cannot dodge the checks below. Empty
+    # fields from consecutive separators ("a,,b") are dropped so they
+    # cannot reach -o.
+    IFS=$' ,\t' read -ra _RAW_OPTS <<< "$otherOpts"
+    _OPTS=()
+    for _o in "${_RAW_OPTS[@]}"; do
+        [ -n "$_o" ] && _OPTS+=("$_o")
+    done
+    validate_opts "${_OPTS[@]}"
+    # Debug options make the FUSE client print full request details —
+    # including Authorization signatures and credential material — to
+    # stderr, which mount-proxy forwards to logs. A volume never
+    # legitimately needs them, so deny them outright.
+    # background is denied for a different reason: it daemonizes the
+    # client, so this shell would reap an exited parent, exit 0, and the
+    # TERM trap below would no longer exist — the flush-on-unmount
+    # guarantee would silently vanish.
+    for _opt in "${_OPTS[@]}"; do
+        case "${_opt%%=*}" in
+            curldbg|dbg|dbglevel|debug|verbose)
+                echo "ERROR: debug option $_opt is not allowed (would leak credentials into logs)" >&2
+                exit 1 ;;
+            background)
+                echo "ERROR: background option is not allowed (defeats TERM unmount persistence)" >&2
+                exit 1 ;;
+        esac
+    done
+    # Rebuild the sanitized option string so the -o line carries exactly
+    # what was validated, with empty fields gone.
+    otherOpts=$(IFS=,; printf '%s' "${_OPTS[*]}")
+fi
+
+# 1. Auth
+# Token mode: authenticate with JuiceFS token
+# Static AK/SK mode: authenticate via --access-key/--secret-key in juicefs format
+FORMAT_ARGS=()
+
+if [ -n "$token" ]; then
+    export JFS_TOKEN="$token"
+fi
+
+if [ -n "$access_key" ] && [ -n "$secret_key" ]; then
+    FORMAT_ARGS+=(--access-key="$access_key" --secret-key="$secret_key")
+elif [ -n "$access_key" ] || [ -n "$secret_key" ]; then
+    # Half a credential pair silently skips format and fails at mount
+    # time with no clue; fail loudly instead.
+    echo "ERROR: access_key and secret_key must be provided together" >&2
+    exit 1
+fi
+
+# 2. Format (first-time only, safe to re-run)
+# juicefs requires the object storage parameters when formatting a new
+# volume; they arrive from PV volumeAttributes as $bucket/$url/$storageType.
+# $name is the JuiceFS file system name; like the official CSI driver, it
+# arrives via the Secret (any non-reserved Secret key is exported as an
+# env var of the same name). It customizes the format-time volume name:
+# one META-URL database holds exactly one volume (a second format on the
+# same database fails), and mount infers the name from the database, so
+# the name is not passed to the mount command.
+_JFS_NAME="${name:-myjfs}"
+if [[ ! "$_JFS_NAME" =~ ^[A-Za-z0-9_-]+$ ]]; then
+    echo "ERROR: name contains invalid characters" >&2
+    exit 1
+fi
+if [ ${#FORMAT_ARGS[@]} -gt 0 ]; then
+    if [ -z "$bucket" ]; then
+        echo "ERROR: bucket is required for object storage format" >&2
+        exit 1
+    fi
+    # Same character set the provider enforces for forwarded fields; the
+    # values go to juicefs format as argv, but a malformed bucket must
+    # fail here with a readable error instead of confusing the client.
+    if [[ ! "$bucket" =~ ^[][A-Za-z0-9_:/@.%-]+$ ]]; then
+        echo "ERROR: bucket contains invalid characters" >&2
+        exit 1
+    fi
+    # MinIO is S3-compatible; JuiceFS does not accept "minio" as a
+    # --storage value.
+    _storageType="${storageType:-s3}"
+    [ "$_storageType" = "minio" ] && _storageType="s3"
+    if [[ ! "$_storageType" =~ ^[A-Za-z0-9_-]+$ ]]; then
+        echo "ERROR: storageType contains invalid characters" >&2
+        exit 1
+    fi
+    # juicefs format has no --endpoint option: a self-hosted S3-compatible
+    # endpoint is passed as part of --bucket in URL form
+    # (http://host:port/bucket). Verified against the real client.
+    if [ -n "$url" ]; then
+        # ${url%/} strips a trailing slash so "http://host:9000/" does not
+        # become "http://host:9000//bucket" in the URL-form --bucket.
+        FORMAT_ARGS+=(--storage="$_storageType" --bucket="${url%/}/${bucket}")
+    else
+        FORMAT_ARGS+=(--storage="$_storageType" --bucket="$bucket")
+    fi
+    # $format_options carries extra juicefs format arguments as a
+    # comma-separated key=value list (e.g. "trash-days=1,block-size=4096"),
+    # mirroring the official CSI driver's Secret field (snake_case because
+    # Secret keys become environment variables). Every entry becomes one
+    # --key=value argv argument; keys that would override the
+    # provider-composed format flags are denied.
+    if [ -n "$format_options" ]; then
+        IFS=, read -ra _FOPTS <<< "$format_options"
+        for _opt in "${_FOPTS[@]}"; do
+            [ -n "\$_opt" ] || continue
+            [[ "\$_opt" == *=* ]] || { echo "ERROR: format_options entry must be key=value: \$_opt" >&2; exit 1; }
+            _fkey="${_opt%%=*}"
+            _fval="${_opt#*=}"
+            [[ "$_fkey" =~ ^[A-Za-z0-9][A-Za-z0-9_-]*$ ]] || { echo "ERROR: invalid format_options key: \$_opt" >&2; exit 1; }
+            [[ "$_fval" =~ ^[A-Za-z0-9_./%+-]*$ ]] || { echo "ERROR: invalid format_options value: \$_opt" >&2; exit 1; }
+            case "$_fkey" in
+                access-key|secret-key|storage|bucket)
+                    echo "ERROR: format_options must not override provider-composed format flags: $_fkey" >&2
+                    exit 1 ;;
+            esac
+            FORMAT_ARGS+=(--"$_fkey=$_fval")
+        done
+    fi
+    echo "Formatting volume: $(mask_source "$source") name=$_JFS_NAME storage=$_storageType bucket=$bucket"
+    # juicefs format 1.4.1 replays the configuration idempotently on an
+    # existing volume (verified empirically: a re-run succeeds), so the
+    # normal path never fails here. The fallback below still guards the
+    # failure case: treat it as "already formatted" only when the error
+    # says so or the volume is actually reachable, so a genuine format
+    # failure (bad credentials, bad bucket) stays fatal instead of being
+    # masked. Bad AK/SK cannot hide here: mounting authenticates via token
+    # only, and the AK/SK pair participates solely in format — a volume
+    # that exists implies the format failure was "already formatted", not a
+    # credential error. The error-text check comes first because
+    # `juicefs status` may itself need authentication and fail on a
+    # perfectly healthy existing volume.
+    if ! _fmt_err=$(juicefs format "${FORMAT_ARGS[@]}" "$source" "$_JFS_NAME" 2>&1); then
+        if grep -qi "already" <<< "$_fmt_err"; then
+            echo "WARNING: volume already formatted; continuing"
+        elif juicefs status "$source" >/dev/null 2>&1; then
+            echo "WARNING: format failed but volume already exists; continuing"
+        else
+            # Mask credential material before echoing: the error output
+            # may replay the full command line including --access-key and
+            # --secret-key values, and the source/endpoint may embed
+            # credentials (redis://user:pass@..., http://user:pass@...).
+            _fmt_err=$(printf '%s' "$_fmt_err" | sed -E -e 's|(--access-key=)[^ ]*|\1***|' -e 's|(--secret-key=)[^ ]*|\1***|')
+            _fmt_err=$(mask_source "$_fmt_err")
+            echo "ERROR: juicefs format failed: $_fmt_err" >&2
+            exit 1
+        fi
+    fi
+fi
+
+# 3. Credential cleanup
+# access_key/secret_key were consumed by format; the raw token env is no
+# longer needed. JFS_TOKEN stays: mount.juicefs authenticates with it and
+# is not passed --token on the command line, so clearing it here would
+# break the token-only mount path entirely.
+_HAS_AUTH=0
+if [ -n "$token" ] || { [ -n "$access_key" ] && [ -n "$secret_key" ]; }; then
+    _HAS_AUTH=1
+fi
+unset access_key secret_key token
+
+# 4. Build mount options
+# JuiceFS 1.x runs in the foreground by default (no -d), and the 1.4.1
+# client no longer accepts the legacy "foreground" and "no-update" options
+# — both are passed through to fusermount3, which rejects them. User
+# options come FIRST so provider-injected options win under the last-wins
+# duplicate parsing: a user-supplied rw must not weaken the read-only
+# semantics derived from the CSI request. (Under a first-wins parser this
+# ordering is a no-op.)
+MOUNT_OPTS=""
+[ -n "$otherOpts" ] && MOUNT_OPTS="${otherOpts}"
+
+# Read-only
+[ "$readOnly" = "true" ] && MOUNT_OPTS="${MOUNT_OPTS}${MOUNT_OPTS:+,}ro"
+
+# 5. Set quota (optional)
+if [ -n "$capacity" ]; then
+    # The numeric prefix must be a plain non-negative integer in every
+    # unit branch; a negative value must not reach quota set. The 15-digit
+    # bound mirrors the shared CapacityPattern so a bypassed request cannot
+    # push an out-of-range value into the unit arithmetic below.
+    _cap_num=${capacity%%[A-Za-z]*}
+    if [[ ! "$_cap_num" =~ ^[0-9]{1,15}$ ]]; then
+        echo "ERROR: invalid capacity: $capacity" >&2
+        exit 1
+    fi
+    case "$capacity" in
+        # Fractional values never reach here: the numeric-prefix check
+        # above rejects them ("1.5" is not ^[0-9]+$).
+        *TiB|*Ti) capacity=$(( ${capacity%%[A-Za-z]*} * 1024 )) ;;
+        *GiB|*Gi) capacity=${capacity%%[A-Za-z]*} ;;
+        # Round up: a sub-GiB quota like 500Mi must not become 0.
+        *MiB|*Mi) capacity=$(( (${capacity%%[A-Za-z]*} + 1023) / 1024 )) ;;
+        # Round up: a sub-GiB quota must not become 0.
+        *KiB|*Ki) capacity=$(( (${capacity%%[A-Za-z]*} + 1048575) / 1048576 )) ;;
+        *[A-Za-z]*)
+            echo "ERROR: unsupported capacity unit: $capacity" >&2
+            exit 1 ;;
+        *)
+            # Plain integer without a unit: juicefs quota set interprets
+            # --capacity in GiB. Reject anything that is not digits so a
+            # negative or malformed value cannot reach quota set; the
+            # 15-digit bound mirrors the shared CapacityPattern so an
+            # absurdly large value fails fast instead of erroring inside
+            # quota set at mount time.
+            if [[ ! "$capacity" =~ ^[0-9]{1,15}$ ]]; then
+                echo "ERROR: invalid capacity: $capacity" >&2
+                exit 1
+            fi
+            ;;
+    esac
+    echo "Setting JuiceFS quota: capacity=${capacity}GiB"
+    if ! juicefs quota set "$source" --path / --capacity "$capacity"; then
+        echo "WARNING: juicefs quota set failed; mounting without quota" >&2
+    fi
+fi
+
+# 6. Mount
+# $path mounts a sub-directory as the volume root via --subdir. It is passed
+# as an argv argument, never interpolated into -o, so it has no shell
+# injection surface; its character set is already enforced by the provider.
+# The checks below are defense in depth for requests that bypassed the
+# provider: metacharacters are rejected and parent traversal is denied.
+MOUNT_ARGS=()
+if [ -n "$path" ]; then
+    if [[ ! "$path" =~ ^[][A-Za-z0-9_:/@.%-]+$ ]]; then
+        echo "ERROR: path contains invalid characters" >&2
+        exit 1
+    fi
+    # Same strictness as mountpoint: empty segments would pass through
+    # to --subdir as "a//b" and rely on the client to normalize them.
+    if [[ "$path" == *//* ]]; then
+        echo "ERROR: path must not contain empty path segments" >&2
+        exit 1
+    fi
+    # Split on "/" exactly (IFS as a read prefix does not leak into the
+    # rest of the script) so ".." segments are caught without relying on
+    # unquoted word splitting.
+    IFS=/ read -ra _segs <<< "$path"
+    for _seg in "${_segs[@]}"; do
+        [ "$_seg" = ".." ] && { echo "ERROR: path must not traverse to the parent directory" >&2; exit 1; }
+    done
+    # --subdir expects a path relative to the volume root; strip every
+    # leading slash the PV may carry ("//shared" -> "shared"). "/" alone
+    # means the root itself: omit --subdir entirely.
+    _subdir="$path"
+    while [[ "$_subdir" == /* ]]; do _subdir="${_subdir#/}"; done
+    # "." means the volume root itself — same treatment as "/" (omit
+    # --subdir entirely) instead of relying on the client to normalize.
+    if [ -n "$_subdir" ] && [ "$_subdir" != "." ]; then
+        MOUNT_ARGS+=(--subdir="$_subdir")
+    fi
+fi
+if [ -z "$mountpoint" ]; then
+    echo "ERROR: mountpoint is required" >&2
+    exit 1
+fi
+# Defense in depth matching the provider's validateMountTarget: the
+# mountpoint must be an absolute path of safe characters without parent
+# traversal or empty segments, even for requests that bypassed the
+# provider. The character set mirrors mountPathPattern exactly (path
+# characters only — no URL characters like : @ % [ ]).
+if [[ ! "$mountpoint" =~ ^/[A-Za-z0-9_./-]+$ ]]; then
+    echo "ERROR: mountpoint must be an absolute path with safe characters" >&2
+    exit 1
+fi
+if [[ "$mountpoint" == *//* ]]; then
+    echo "ERROR: mountpoint must not contain empty path segments" >&2
+    exit 1
+fi
+IFS=/ read -ra _segs <<< "$mountpoint"
+for _seg in "${_segs[@]}"; do
+    [ "$_seg" = ".." ] && { echo "ERROR: mountpoint must not traverse to the parent directory" >&2; exit 1; }
+done
+# The On-Demand Volume Mounting doc requires the mount target to be an
+# empty directory; mounting over a non-empty one hides its content and
+# fails in the CSI flow. Create the directory (the client also would) and
+# refuse to proceed if anything is already in it.
+mkdir -p "$mountpoint"
+if [ -n "$(ls -A "$mountpoint" 2>/dev/null)" ]; then
+    echo "ERROR: mountpoint $mountpoint must be an empty directory" >&2
+    exit 1
+fi
+if [ "$_HAS_AUTH" != 1 ]; then
+    echo "WARNING: mounting without token or AK/SK; it will fail unless the metadata engine requires no authentication" >&2
+fi
+
+# The log line masks option values: otherOpts may carry credential-like
+# key=value pairs (the provider rejects credential keys, but a request
+# that bypassed it must not leak them into logs either).
+_MOUNT_OPTS_LOG=$(printf '%s' "$MOUNT_OPTS" | sed -E 's|([^, =]+=)[^, ]*|\1***|g')
+echo "Mounting JuiceFS: source=$(mask_source "$source") mountpoint=$mountpoint options=$_MOUNT_OPTS_LOG subdir=${_subdir:-/}"
+# The client runs in the background instead of exec so this shell can
+# translate TERM into a proper unmount. mount-proxy (and start.sh) send
+# SIGTERM to stop the mount, but JuiceFS buffers writes and a bare TERM
+# kills the client without flushing — data written in the last seconds is
+# lost. umount triggers the flush; only then is the client killed.
+# The explicit `juicefs mount` subcommand is used instead of the
+# mount.juicefs symlink: the symlink dispatches on argv[0], which bash
+# does not preserve for backgrounded commands.
+if [ -n "$MOUNT_OPTS" ]; then
+    juicefs mount "$source" "$mountpoint" -o "$MOUNT_OPTS" "${MOUNT_ARGS[@]}" &
+else
+    juicefs mount "$source" "$mountpoint" "${MOUNT_ARGS[@]}" &
+fi
+JFPID=$!
+# Every command carries || true: errexit is in effect inside traps, and one
+# failing step (umount AND fusermount both fail, wait returning 143 after
+# the kill) must not abort the trap before kill/exit run — that would leave
+# the client orphaned and skip the exit-0 handshake with mount-proxy.
+trap 'umount "$mountpoint" 2>/dev/null || fusermount -u "$mountpoint" 2>/dev/null || true; kill $JFPID 2>/dev/null || true; wait $JFPID 2>/dev/null || true; exit 0' TERM INT
+wait $JFPID
+exit $?

--- a/pkg/sidecar/juicefs/pv.yaml
+++ b/pkg/sidecar/juicefs/pv.yaml
@@ -1,0 +1,105 @@
+# OpenKruise CustomFuse PersistentVolume Example
+# This PV uses the customfuse CSI driver with JuiceFS as FUSE client.
+#
+# Prerequisites:
+#   1. csi-sidecar-customfuse container in SandboxSet template
+#      (set terminationGracePeriodSeconds >= 30 there: the JuiceFS
+#      client buffers writes and umount needs time to flush them,
+#      and the internal supervisor timers assume that window)
+#   2. Redis (metadata engine) + S3-compatible storage (MinIO/OSS/etc.);
+#      the ml-datasets bucket below must already exist (format fails otherwise) and
+#      the Redis database number must match the actual deployment
+#   3. Secret with JuiceFS credentials (see secret.yaml)
+#   4. TODO: replace the example hosts, bucket and db with your environment,
+#      and the Secret credentials (see secret.yaml)
+#   5. The SandboxClaim's mountPath must be an empty directory in the
+#      sandbox container (On-Demand Volume Mounting doc requirement)
+#
+# Production note: run Redis with AOF persistence enabled
+# (--appendonly yes). Without it JuiceFS logs a warning and Redis
+# metadata can be lost if Redis is not shut down properly.
+#
+# Parameters:
+#   source       — JuiceFS META-URL (redis://host:port/db). Object-storage
+#                  credentials belong in the Secret, never here; if the
+#                  metadata engine itself needs authentication, userinfo in
+#                  the META-URL (redis://user:pass@host) is the JuiceFS-
+#                  native form and is masked in logs.
+#   fuseType     — FUSE client type. When set it must match CSI fsType
+#                  (a mismatch is rejected); when omitted, fsType is
+#                  used. Only when neither is set does the provider
+#                  inject the "customfuse" default. Both sources pass the
+#                  fuseType allowlist. This example sets both to "juicefs"
+#                  explicitly.
+#                  The file system name itself comes from the Secret key
+#                  "name" (defaults to "myjfs"), matching the official
+#                  JuiceFS CSI driver convention.
+#   bucket       — S3 bucket name. Required when the Secret carries an
+#                  AK/SK pair (the format step needs it); omittable in
+#                  token-only mode, which skips format entirely.
+#   url          — (optional) S3 endpoint URL; required for self-hosted
+#                  object storage (MinIO/OSS/Ceph RGW), omit only for AWS S3
+#                  (except AWS regions that require an explicit endpoint,
+#                  e.g. China regions). Must include the scheme (http:// or
+#                  https:// host:port); never embed credentials in it.
+#   storageType  — (optional) object storage type (default "s3"; "oss", ...).
+#                  Passed through as juicefs format --storage; "minio" is
+#                  mapped to "s3" (S3-compatible). A typo fails at format.
+#   path         — (optional) sub-path mounted as the volume root (--subdir).
+#                  Unlike the official JuiceFS CSI driver's mountOptions
+#                  subdir= form, the sub-directory is NOT auto-created here:
+#                  it must already exist in the file system (mount fails
+#                  otherwise). Use this field instead of putting subdir=
+#                  into otherOpts — subdir is a client flag, not a FUSE
+#                  option, so -o subdir=... would be rejected or ignored.
+#   capacity     — (optional) capacity quota (e.g. "100Gi"); a plain
+#                  integer is interpreted as GiB by juicefs quota set, and
+#                  the numeric part is bounded to 15 digits. Independent of
+#                  spec.capacity.storage above, which is informational
+#                  only — the quota is enforced via `juicefs quota set`
+#   otherOpts    — (optional) extra FUSE mount options, space, comma or
+#                  tab separated; option values must not contain
+#                  spaces, commas or tabs
+#
+# Note: pv.spec.mountOptions is not consumed by the entrypoint (each entry
+# would become a separate env var that the script does not read); put extra
+# mount options in volumeAttributes.otherOpts instead. The entries are
+# still validated by the provider (dangerous or reserved keys are
+# rejected at claim time); debug and background options are rejected by
+# the entrypoint at mount time.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: juicefs-imagenet
+spec:
+  capacity:
+    storage: 1Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  # volumeMode/storageClassName match the On-Demand Volume Mounting doc
+  # example; the empty storageClassName keeps a default StorageClass from
+  # taking over semantics for this manually created PV.
+  volumeMode: Filesystem
+  storageClassName: ""
+  csi:
+    driver: customfuseplugin.csi.openkruise.io
+    fsType: juicefs
+    # volumeHandle must be unique cluster-wide; use the PV name itself so
+    # collisions surface as obvious duplicate PV names.
+    volumeHandle: juicefs-imagenet
+    volumeAttributes:
+      source: "redis://redis.sandbox-system:6379/0"
+      fuseType: "juicefs"
+      bucket: "ml-datasets"
+      # url is required for self-hosted object storage (MinIO/OSS/RGW);
+      # delete the line when the bucket lives in AWS S3 itself.
+      url: "http://minio.sandbox-system:9000"
+      # path: "/shared"
+      # capacity: "100Gi"
+      # otherOpts: "cache-size=1024"
+    nodePublishSecretRef:
+      name: juicefs-imagenet-secret
+      # The provider reads the Secret from this namespace; RBAC must grant
+      # it access here even though the PV itself is cluster-scoped.
+      namespace: sandbox-system

--- a/pkg/sidecar/juicefs/secret.yaml
+++ b/pkg/sidecar/juicefs/secret.yaml
@@ -1,0 +1,54 @@
+# JuiceFS Credentials Secret
+# All keys are passed directly as environment variables to the entrypoint
+# script. The entrypoint author controls the env-var schema by naming the
+# Secret keys accordingly.
+#
+# Supported keys for the JuiceFS entrypoint (entrypoint-juicefs.sh):
+#   token       — JuiceFS authentication token (optional); authenticates
+#                 the mount of an existing file system (JFS_TOKEN).
+#                 Mainly for JuiceFS Cloud Service or metadata engines
+#                 that require authentication — unauthenticated
+#                 self-hosted engines (e.g. plain Redis) need no token.
+#   access_key  — object storage access key ID; used only when formatting a
+#                 new file system (juicefs format --access-key)
+#   secret_key  — object storage access key secret; used with access_key
+#   name        — JuiceFS file system name (optional; defaults to "myjfs").
+#                 Set it explicitly to format the file system with a
+#                 custom name, like the official CSI driver's name field.
+#   format_options — extra juicefs format arguments (optional), comma-separated
+#                 key=value pairs, e.g. "trash-days=1,block-size=4096".
+#                 Mirrors the official CSI driver's format-options Secret
+#                 field (snake_case: Secret keys become environment
+#                 variables, so dashes are not allowed).
+#
+# token and access_key/secret_key serve different roles and may coexist:
+# token authenticates the mount, the AK/SK pair is written into the file
+# system metadata during the one-time format step.
+#
+# IMPORTANT: providing the AK/SK pair always triggers the format branch
+# (idempotent on an existing volume, but noisy). If the volume is already
+# formatted and only needs mounting, provide token alone and omit the
+# AK/SK pair: the entrypoint skips the format step entirely when no AK/SK
+# is present.
+#
+# Unrecognized keys that are valid env names, not blocked env keys
+# (BASH_ENV, LD_PRELOAD, ...) and not reserved provider keys (source, url,
+# readOnly, ...) are passed to the entrypoint as env vars. Keys must be
+# valid environment variable names ([A-Za-z_][A-Za-z0-9_]*): bash cannot
+# reference names with dashes, so dash-containing keys are rejected by the
+# CustomFuseMountProvider before the request is generated.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: juicefs-imagenet-secret
+  namespace: sandbox-system
+type: Opaque
+# All values below are placeholders: replace them with real credentials
+# (token from the JuiceFS Cloud Service console; AK/SK from your object
+# storage provider). Values must be
+# single-line: newlines, tabs and NUL are rejected by the provider.
+# Restrict RBAC on this Secret: it carries high-privilege credentials.
+stringData:
+  token: "<JUICEFS_TOKEN>"
+  access_key: "<ACCESS_KEY>"
+  secret_key: "<SECRET_KEY>"

--- a/pkg/sidecar/s3fs/Dockerfile
+++ b/pkg/sidecar/s3fs/Dockerfile
@@ -1,0 +1,87 @@
+# Stage 1: build mount-proxy-server from alibaba-cloud-csi-driver source
+# (the customfuse feature on PR #1722). The repository is cloned inside the
+# build instead of relying on a local --build-context; override
+# CSI_DRIVER_REPO with a mirror when GitHub is not directly reachable.
+# IMAGE_PREFIX overrides the Docker Hub prefix for environments without
+# direct Docker Hub access (e.g. docker.1panel.live).
+ARG IMAGE_PREFIX=docker.io
+ARG CSI_DRIVER_REPO=https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver.git
+# The ref to fetch from CSI_DRIVER_REPO. pull/1722/head is GitHub's PR ref;
+# when overriding CSI_DRIVER_REPO with a mirror, also override this: most
+# mirrors do not expose PR refs (and the PR's source branch lives on
+# the author's fork), so use a branch or commit the mirror carries.
+ARG CSI_DRIVER_REF=pull/1722/head
+# CSI_DRIVER_SHA pins pr-1722's head; override with --build-arg when the
+# branch advances (after verifying compatibility). The original pin
+# (d45ddfa) was force-pushed out of pr-1722's history, so the build fails
+# loudly instead of trusting the moving branch.
+ARG CSI_DRIVER_SHA=baf1dca5269965c1ee04ec900a0ba5de4f310f8e
+# GOPROXY defaults to a mainland mirror; override with --build-arg
+# for environments with other reachable proxies.
+ARG GOPROXY=https://goproxy.cn,direct
+# pr-1722's go.mod requires go >= 1.26.0; the sidecar stage below uses
+# 1.26 as well because this repo's go.mod requires >= 1.25.9.
+FROM ${IMAGE_PREFIX}/golang:1.26 AS builder-proxy
+ARG CSI_DRIVER_REPO
+ARG CSI_DRIVER_REF
+ARG CSI_DRIVER_SHA
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+WORKDIR /src
+# Fetch PR #1722's head and verify the pinned commit; the build fails
+# loudly if the branch has advanced (the pin must be re-verified and
+# updated deliberately).
+RUN git init . &&     git remote add origin "${CSI_DRIVER_REPO}" &&     git fetch --depth 1 origin "${CSI_DRIVER_REF}" &&     git checkout FETCH_HEAD &&     test "$(git rev-parse HEAD)" = "${CSI_DRIVER_SHA}" ||         { echo "ERROR: checkout does not match CSI_DRIVER_SHA (did the pinned ref advance?)" >&2; exit 1; } &&     CGO_ENABLED=0 go build -o /out/csi-mount-proxy-server ./cmd/mount-proxy-server
+
+# Stage 2: build csi-sidecar-customfuse (CSI node server) from agents source.
+# Build context must be the repository root.
+# !!! Run the build from the repository root, e.g.:
+# !!! docker buildx build -f pkg/sidecar/s3fs/Dockerfile -t <image> .
+# !!! (Stage 1 clones the pinned csi-driver commit from GitHub itself.)
+# go.mod requires go >= 1.25.9; the 1.26 image satisfies it and matches the
+# builder-proxy stage above.
+FROM ${IMAGE_PREFIX}/golang:1.26 AS builder-sidecar
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+COPY go.mod go.sum ./
+COPY cmd/csi-sidecar-customfuse ./cmd/csi-sidecar-customfuse
+COPY pkg/agent-runtime/customfusesidecar ./pkg/agent-runtime/customfusesidecar
+# customfusesidecar imports customfusevalidate; omit it and the build
+# fails. Keep this COPY set in sync with the packages customfusesidecar
+# imports whenever a new in-repo dependency is added.
+COPY pkg/agent-runtime/customfusevalidate ./pkg/agent-runtime/customfusevalidate
+RUN CGO_ENABLED=0 go build -o /out/csi-sidecar-customfuse ./cmd/csi-sidecar-customfuse
+
+# Stage 3: s3fs FUSE client + both binaries + entrypoint
+# Pinned by digest for reproducible builds, mirroring the juicefs
+# Dockerfile; do not float on the :22.04 tag. The digest is amd64-only.
+FROM ${IMAGE_PREFIX}/ubuntu:22.04@sha256:3c3de9608507804525ff4303874525760ea36d62606e8105f515adaa761b80cb
+
+# Use Aliyun mirror so apt works without direct access to archive.ubuntu.com.
+# s3fs is version-pinned: the base image digest fixes the initial state
+# but apt would otherwise install whatever the repo currently carries.
+RUN sed -i -e 's|archive.ubuntu.com|mirrors.aliyun.com|g' -e 's|security.ubuntu.com|mirrors.aliyun.com|g' /etc/apt/sources.list && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        s3fs=1.90-1 fuse3 ca-certificates && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+# allow_other: s3fs requires explicit opt-in in fuse.conf.
+# The container runs as root so this is belt-and-braces. printf (not echo
+# >>) so the entry still parses if the packaged file lacked a trailing
+# newline.
+RUN printf '\nuser_allow_other\n' >> /etc/fuse.conf
+
+COPY --from=builder-proxy /out/csi-mount-proxy-server /usr/local/bin/
+COPY --from=builder-sidecar /out/csi-sidecar-customfuse /usr/local/bin/
+# go build outputs already carry the executable bit; the explicit chmod is
+# belt-and-braces for COPY paths that lose file modes.
+RUN chmod +x /usr/local/bin/csi-mount-proxy-server /usr/local/bin/csi-sidecar-customfuse
+
+# Copy entrypoint (must be /entrypoint.sh — mount-proxy looks for this path)
+COPY pkg/sidecar/s3fs/entrypoint-s3fs.sh /entrypoint.sh
+# start.sh runs both processes: mount-proxy-server (mounter.sock) and the
+# CSI node server (csi.sock).
+COPY pkg/sidecar/start.sh /start.sh
+RUN chmod +x /entrypoint.sh /start.sh
+
+ENTRYPOINT ["/start.sh"]

--- a/pkg/sidecar/s3fs/entrypoint-s3fs.sh
+++ b/pkg/sidecar/s3fs/entrypoint-s3fs.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+set -e
+
+# Defense in depth: mount-proxy exports every Secret entry as an environment
+# variable of the same name, so a Secret key could smuggle a code-execution
+# env var (BASH_ENV, LD_PRELOAD, ...) into this shell. The provider rejects
+# these keys, but clear them here too so a future relaxation cannot silently
+# reintroduce the attack. PATH is reset to the image default because an
+# injected PATH would shadow command lookup.
+unset BASH_ENV ENV BASHOPTS SHELLOPTS PROMPT_COMMAND PS4 IFS BASH_XTRACEFD \
+      LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT LD_BIND_NOW LD_DEBUG \
+      GLIBC_TUNABLES CDPATH HISTFILE 2>/dev/null || true
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# s3fs entrypoint for OpenKruise customfuse csi-sidecar
+#
+# Environment variables injected by mount-proxy-server from CSI request:
+#   $source       — S3 bucket to mount ("s3://ml-datasets" or bare bucket name)
+#   $url          — S3-compatible endpoint URL (MinIO, Alibaba OSS, Ceph RGW, ...)
+#   $mountpoint   — target mount path inside the sandbox
+#   $access_key   — object storage access key (from Secret)
+#   $secret_key   — object storage secret key (from Secret)
+#   $readOnly     — "true" or "false"
+#   $otherOpts    — extra options from PV.Spec.VolumeAttributes
+#   $path         — rejected: only the bucket root is mounted
+#
+# Unlike the JuiceFS entrypoint there is no format step and no metadata
+# engine: s3fs mounts an S3 bucket directly. Only the bucket root is
+# mounted; sub-bucket prefixes are not supported.
+
+# Credentials may be embedded in endpoint URLs (http://user:pass@host),
+# never echo them.
+mask_url() {
+    # The second pattern covers userinfo without a scheme (user:pass@host),
+    # which the bucket charset allows through.
+    printf '%s' "$1" | sed -E -e 's|(://)[^ ]*@|\1***@|' -e 's|([^ /:@]+:)[^ /@]*@|\1***@|'
+}
+
+# Shell injection prevention
+validate_opts() {
+    for opt in "$@"; do
+        if [[ "$opt" =~ [\;\|\&\`\$\(\)$'\n'$'\r'\\] ]]; then
+            echo "ERROR: invalid character in option: $opt" >&2
+            exit 1
+        fi
+    done
+}
+if [ -n "$otherOpts" ]; then
+    # Split on space, tab and comma — the same separator set the
+    # provider's ValidateMountOptions uses — so a debug option embedded
+    # after any separator cannot dodge the checks below. Empty fields
+    # from consecutive separators ("a,,b") are dropped so they cannot
+    # reach -o.
+    IFS=$' ,\t' read -ra _RAW_OPTS <<< "$otherOpts"
+    _OPTS=()
+    for _o in "${_RAW_OPTS[@]}"; do
+        [ -n "$_o" ] && _OPTS+=("$_o")
+    done
+    validate_opts "${_OPTS[@]}"
+    # Debug options make s3fs print full HTTP headers — including the
+    # Authorization signature — to stderr, which mount-proxy forwards to
+    # logs. A volume never legitimately needs them, so deny them outright.
+    for _opt in "${_OPTS[@]}"; do
+        # A keyless "=value" entry is malformed and must not reach -o;
+        # the provider rejects it too, this mirrors that check.
+        case "$_opt" in
+            =*) echo "ERROR: empty option key in otherOpts" >&2; exit 1 ;;
+        esac
+        case "${_opt%%=*}" in
+            curldbg|dbg|dbglevel|debug|verbose)
+                echo "ERROR: debug option $_opt is not allowed (would leak credentials into logs)" >&2
+                exit 1 ;;
+            background)
+                echo "ERROR: background option is not allowed (the client must stay in the foreground for TERM propagation)" >&2
+                exit 1 ;;
+        esac
+    done
+    # Rebuild the sanitized option string so the -o line carries exactly
+    # what was validated, with empty fields gone.
+    otherOpts=$(IFS=,; printf '%s' "${_OPTS[*]}")
+fi
+
+# 1. Validate all inputs before any credential material is written to disk
+# 1a. Credentials are required for s3fs
+if [ -z "$access_key" ] || [ -z "$secret_key" ]; then
+    echo "ERROR: access_key and secret_key are required for s3fs" >&2
+    exit 1
+fi
+
+# 1a2. A newline in either credential would inject an extra line into the
+# s3fs passwd file, silently corrupting authentication; a tab, colon or
+# space would break the accesskey:secretkey field split. NUL cannot reach a
+# shell variable (it terminates the C string at execve), so it is not
+# checked here.
+case "$access_key$secret_key" in
+    *$'\n'*|*$'\r'*|*$'\t'*|*:*|*' '*)
+        echo "ERROR: credentials must not contain newlines, tabs, spaces or colons" >&2
+        exit 1 ;;
+esac
+
+# 1b. source must be "s3://bucket" or a bare bucket name. Any other URL
+# form (redis://, http://user:pass@host, ...) is not an S3 bucket and may
+# embed credentials that would leak into logs or the mount attempt.
+case "$source" in
+    s3://*) ;; # canonical form
+    *://*)
+        echo "ERROR: source must be 's3://bucket' or a bare bucket name: $(mask_url "$source")" >&2
+        exit 1 ;;
+esac
+
+# 1b2. The provider may forward a path volumeAttribute for the generic
+# driver, but this entrypoint mounts only the bucket root. Reject it
+# loudly instead of silently mounting the root while the user asked for
+# a sub-directory.
+if [ -n "$path" ]; then
+    echo "ERROR: path is not supported by the s3fs entrypoint (only the bucket root is mounted)" >&2
+    exit 1
+fi
+
+# 1c. Resolve the bucket name: "s3://bucket" or a bare bucket name
+BUCKET="${source#s3://}"
+BUCKET="${BUCKET%/}"
+if [ -z "$BUCKET" ]; then
+    echo "ERROR: source must name an S3 bucket (e.g. s3://ml-datasets)" >&2
+    exit 1
+fi
+# Only the bucket root is mounted; a prefix like "s3://bucket/sub" must
+# be rejected instead of being passed to s3fs as a bucket name.
+case "$BUCKET" in
+    */*)
+        echo "ERROR: sub-bucket prefixes are not supported (only the bucket root is mounted): $(mask_url "$BUCKET")" >&2
+        exit 1 ;;
+esac
+# Same character set the provider enforces for forwarded fields, so a
+# bare bucket name stays safe even for requests that bypassed it.
+if [[ ! "$BUCKET" =~ ^[][A-Za-z0-9_:/@.%-]+$ ]]; then
+    echo "ERROR: bucket name contains invalid characters: $(mask_url "$BUCKET")" >&2
+    exit 1
+fi
+
+# 1d. mountpoint is injected by mount-proxy; guard against a missing value
+# so the failure is readable instead of an s3fs usage message. The path
+# checks mirror the provider's validateMountTarget, matching the JuiceFS
+# entrypoint's defense in depth.
+if [ -z "$mountpoint" ]; then
+    echo "ERROR: mountpoint is empty" >&2
+    exit 1
+fi
+if [[ ! "$mountpoint" =~ ^/[A-Za-z0-9_./-]+$ ]]; then
+    echo "ERROR: mountpoint must be an absolute path with safe characters" >&2
+    exit 1
+fi
+if [[ "$mountpoint" == *//* ]]; then
+    echo "ERROR: mountpoint must not contain empty path segments" >&2
+    exit 1
+fi
+IFS=/ read -ra _segs <<< "$mountpoint"
+for _seg in "${_segs[@]}"; do
+    [ "$_seg" = ".." ] && { echo "ERROR: mountpoint must not traverse to the parent directory" >&2; exit 1; }
+done
+# The On-Demand Volume Mounting doc requires the mount target to be an
+# empty directory; mounting over a non-empty one hides its content and
+# fails in the CSI flow. Create the directory (the client also would) and
+# refuse to proceed if anything is already in it.
+mkdir -p "$mountpoint"
+if [ -n "$(ls -A "$mountpoint" 2>/dev/null)" ]; then
+    echo "ERROR: mountpoint $mountpoint must be an empty directory" >&2
+    exit 1
+fi
+
+# 1e. url is embedded into the comma-separated -o options, so any
+# character outside the provider's forwarded-field set — a comma would
+# split options, whitespace would break parsing — is rejected up front.
+if [ -n "$url" ] && [[ ! "$url" =~ ^[][A-Za-z0-9_:/@.%-]+$ ]]; then
+    echo "ERROR: url contains invalid characters: $(mask_url "$url")" >&2
+    exit 1
+fi
+
+# 2. s3fs reads credentials from a passwd file in "accesskey:secretkey"
+# format. The file stays for the mount's lifetime (s3fs may re-read it on
+# reload); it lives in the container's private /tmp and disappears on
+# restart.
+umask 077
+# The file lives for the container's lifetime: the script execs s3fs below,
+# so an EXIT trap would never run — the credential file disappears when the
+# container (and its /tmp) is torn down with the sandbox.
+PASSWD_FILE="$(mktemp)"
+printf '%s:%s\n' "$access_key" "$secret_key" > "$PASSWD_FILE"
+
+# 3. Build mount options
+# s3fs stays in foreground via -f below so mount-proxy can track the process.
+# (The `foreground` option is rejected by newer libfuse, do not add it back.)
+# allow_other: let business containers access the mount
+# use_path_request_style: required by MinIO and other IP-addressed endpoints
+# User options come FIRST so provider-injected options win under the
+# last-wins duplicate parsing s3fs uses: a user-supplied passwd_file or
+# rw must not override the provider's credential file or read-only
+# semantics. (Under a first-wins parser this ordering is a no-op.)
+MOUNT_OPTS=""
+[ -n "$otherOpts" ] && MOUNT_OPTS="${otherOpts},"
+MOUNT_OPTS="${MOUNT_OPTS}passwd_file=${PASSWD_FILE},allow_other"
+
+# Endpoint. use_path_request_style is required by MinIO and other
+# IP-addressed endpoints, but must NOT be forced for AWS S3 itself:
+# newer buckets reject path-style requests, so it is only added together
+# with a self-hosted url.
+[ -n "$url" ] && MOUNT_OPTS="${MOUNT_OPTS},use_path_request_style,url=${url}"
+
+# Read-only
+[ "${readOnly,,}" = "true" ] && MOUNT_OPTS="${MOUNT_OPTS},ro"
+
+# 4. Mount
+URL_LOG=""
+[ -n "$url" ] && URL_LOG=" url=$(mask_url "$url")"
+# Bucket is masked as a final line of defense even though source was
+# validated above, in case a future validation change relaxes the charset.
+echo "Mounting s3fs: bucket=$(mask_url "$BUCKET")${URL_LOG} mountpoint=$mountpoint"
+exec s3fs "$BUCKET" "$mountpoint" -o "$MOUNT_OPTS" -f

--- a/pkg/sidecar/s3fs/pv.yaml
+++ b/pkg/sidecar/s3fs/pv.yaml
@@ -1,0 +1,85 @@
+# OpenKruise CustomFuse s3fs PersistentVolume Example
+# This PV uses the customfuse CSI driver with s3fs as FUSE client,
+# mounting an S3 bucket directly (no metadata engine, no format step).
+#
+# Prerequisites:
+#   1. csi-sidecar container with the s3fs binary in the SandboxSet template
+#      (set terminationGracePeriodSeconds >= 30 there: the internal
+#      supervisor escalation timer assumes that window)
+#   2. S3-compatible object storage reachable from the sandbox
+#      (MinIO in-cluster, Alibaba OSS, Ceph RGW, COS, OBS, ...) —
+#      switching backends only changes url + the Secret credentials;
+#      the ml-datasets bucket must already exist (mount fails otherwise)
+#   3. Secret with s3fs credentials (see secret.yaml)
+#   4. TODO: replace the example bucket and hosts with your environment,
+#      and the Secret credentials (see secret.yaml)
+#   5. The SandboxClaim's mountPath must be an empty directory in the
+#      sandbox container (On-Demand Volume Mounting doc requirement)
+#
+# Parameters:
+#   source    — S3 bucket ("s3://ml-datasets" or bare "ml-datasets")
+#   fuseType  — FUSE client type (optional). When set it must match CSI
+#               fsType below (a mismatch is rejected by the provider);
+#               when omitted, fsType is used. Both sources pass the
+#               fuseType allowlist.
+#   url       — (optional) S3 endpoint URL, required for MinIO/OSS/RGW,
+#               omit for AWS S3 (except AWS regions that require an
+#               explicit endpoint, e.g. China regions; path-style requests
+#               are not forced there); must include the scheme (http:// or
+#               https:// host:port) and must not embed credentials. Use
+#               https:// outside the cluster-internal network.
+#   path      — not supported: s3fs mounts only the bucket root (setting
+#               it is rejected by the entrypoint; a subdir= entry in
+#               otherOpts is rejected by the provider at claim time)
+#   otherOpts — (optional) extra s3fs mount options, space, comma or tab
+#               separated; option values must not contain spaces, commas
+#               or tabs
+#
+# Note: s3fs has no capacity-quota concept, so the capacity below is
+# informational only (unlike the JuiceFS entrypoint's quota support).
+# A storageType volumeAttribute is ignored by the s3fs entrypoint (only
+# the JuiceFS format step consumes it), but the provider still validates
+# its character set — an invalid value is rejected at claim time.
+# s3fs also provides no file locking and only weak cross-node consistency,
+# so ReadWriteMany is best-effort.
+#
+# pv.spec.mountOptions is not consumed by the entrypoint (each entry would
+# become a separate env var that the script does not read); put extra mount
+# options in volumeAttributes.otherOpts instead. Keys that bash or glibc
+# act on (BASH_ENV, LD_PRELOAD, PATH, ...) are rejected by the provider at
+# claim time; debug and background options are rejected by the entrypoint
+# at mount time.
+#
+# otherOpts must not contain shell metacharacters; debug options
+# (curldbg, dbg, dbglevel, debug, verbose — they would print signed
+# request headers into logs) and background (the client must stay in the
+# foreground for TERM propagation) are rejected by the entrypoint.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: s3fs-dataset
+spec:
+  capacity:
+    storage: 1Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  # volumeMode/storageClassName match the On-Demand Volume Mounting doc
+  # example; the empty storageClassName keeps a default StorageClass from
+  # taking over semantics for this manually created PV.
+  volumeMode: Filesystem
+  storageClassName: ""
+  csi:
+    driver: customfuseplugin.csi.openkruise.io
+    fsType: s3fs
+    volumeHandle: s3fs-dataset
+    volumeAttributes:
+      source: "s3://ml-datasets"
+      fuseType: "s3fs"
+      url: "http://minio.sandbox-system:9000"
+      # otherOpts: "multipart_size=64,multipart_copy_size=512"
+    nodePublishSecretRef:
+      name: s3fs-secret
+      # The provider reads the Secret from this namespace; RBAC must grant
+      # it access here even though the PV itself is cluster-scoped.
+      namespace: sandbox-system

--- a/pkg/sidecar/s3fs/secret.yaml
+++ b/pkg/sidecar/s3fs/secret.yaml
@@ -1,0 +1,26 @@
+# s3fs Credentials Secret
+# Keys are passed as environment variables to the entrypoint; both are
+# required by entrypoint-s3fs.sh. Keys must be valid environment variable
+# names ([A-Za-z_][A-Za-z0-9_]*), enforced by the CustomFuseMountProvider:
+# dash-containing keys (access-key), blocked env keys (BASH_ENV,
+# LD_PRELOAD, ...) and reserved provider keys (source, url, ...) are all
+# rejected. s3fs supports access-key authentication only; there is no
+# token mode (unlike JuiceFS Cloud).
+#
+# All values below are placeholders: replace them with real credentials
+# from your S3-compatible object storage provider. Values must be
+# single-line and must not contain newlines, tabs, colons, spaces or
+# NUL: the passwd file is parsed as access_key:secret_key, so those
+# characters would break the field split.
+#
+# Restrict RBAC on this Secret: it carries long-lived object-storage
+# credentials. The namespace must match the PV's nodePublishSecretRef.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3fs-secret
+  namespace: sandbox-system
+type: Opaque
+stringData:
+  access_key: "<ACCESS_KEY>"
+  secret_key: "<SECRET_KEY>"

--- a/pkg/sidecar/start.sh
+++ b/pkg/sidecar/start.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Starts both processes of the csi-sidecar-customfuse image:
+#   - csi-mount-proxy-server: listens on /var/run/csi/mounter.sock, runs
+#     /entrypoint.sh for each mount (s3fs/juicefs FUSE mount)
+#   - csi-sidecar-customfuse: CSI node server listening on the per-driver
+#     csi.sock, forwards NodePublishVolume to mount-proxy-server
+#
+# The image runs as root (no USER directive), so /var/run/csi is always
+# writable; if the image is ever converted to a non-root user, an explicit
+# volume mount or directory pre-creation becomes necessary here.
+#
+# Supervision requires bash >= 5.1 for wait -n -p, which blocks until a
+# child exits, reaps it, and reports which PID was reaped: there is no
+# zombie window, so no kill -0 guesswork is needed. Both runtime base
+# images provide this: ubuntu:22.04 ships bash 5.1 and juicedata/mount
+# ships bash 5.x. Do not switch the base images to CentOS 7 (bash 4.2)
+# or Alpine (no bash); the version check below makes such a change fail
+# loudly instead of misbehaving.
+set -e
+if [ "${BASH_VERSINFO[0]}" -lt 5 ] || { [ "${BASH_VERSINFO[0]}" -eq 5 ] && [ "${BASH_VERSINFO[1]}" -lt 1 ]; }; then
+    echo "start.sh requires bash >= 5.1 for wait -n -p" >&2
+    exit 1
+fi
+mkdir -p /var/run/csi
+csi-mount-proxy-server --driver=customfuse &
+MPID=$!
+csi-sidecar-customfuse &
+SPID=$!
+TERMINATING=0
+MAIN_PID=$BASHPID
+# Forward termination signals to both children. The order does not
+# matter: the node server's drain may fail in-flight forwards (the
+# container is going away anyway), and mount-proxy's FUSE umount does
+# not depend on the node server being alive — the mount namespace
+# disappears with the container either way. The BASHPID guard makes
+# the handler a no-op in subshells: a freshly forked subshell inherits
+# this trap until it installs its own, and letting it re-kill MPID/SPID
+# would be harmless but sloppy (and wrong if a PID got reused).
+trap 'if [ "$BASHPID" = "$MAIN_PID" ]; then TERMINATING=1; kill $MPID $SPID 2>/dev/null || true; fi' TERM INT
+
+# arm_kill sends TERM and arms a 10-second SIGKILL escalation. The timer
+# subshell reaps its own sleep child on TERM, so no orphaned process or
+# zombie survives. All wait calls stay at the top level: in bash 5.1,
+# wait executed inside a function can miss the SIGCHLD of a child that
+# died just after kill and then block until the next SIGCHLD arrives
+# (the timer's, 10 seconds later), stalling shutdown by the full grace
+# period. The timer PID travels back through the TIMER_PID global.
+arm_kill() {
+    _pid=$1
+    kill $_pid 2>/dev/null || true
+    # Separate kill from the caller's wait with a short sleep. bash 5.1
+    # can miss a SIGCHLD that lands between kill and wait, which would
+    # stall the next wait until the timer's SIGCHLD arrives 10 seconds
+    # later. The sleep is also a fork+wait cycle that drains an already
+    # pending SIGCHLD. A child that exits after this window is safe: a
+    # SIGCHLD arriving while a wait is already blocked is handled
+    # normally, as the main wait -n -p above demonstrates. The || true
+    # keeps set -e from aborting when a second TERM interrupts the
+    # sleep mid-run (the trap has already recorded TERMINATING).
+    sleep 0.5 || true
+    ( trap 'if [ -n "$SL" ]; then kill $SL 2>/dev/null; wait $SL 2>/dev/null; fi; exit 0' TERM
+      sleep 10 &
+      SL=$!
+      wait $SL && kill -9 $_pid 2>/dev/null ) &
+    TIMER_PID=$!
+    # The timer subshell failed to fork (or died instantly). An empty
+    # TIMER_PID makes timer_running report false, which sends the
+    # caller into the immediate kill -9 branch.
+    timer_running || TIMER_PID=""
+}
+
+# cancel_timer stops the armed escalation timer without waiting on it
+# (all waits stay at the top level, see arm_kill). TERM alone is not
+# enough: a subshell that has not yet installed its own trap inherits
+# the parent shell's trap, whose handler returns and lets the subshell
+# run out the full 10 seconds. The SIGKILL fallback after a short
+# grace closes that window; in the rare window case it can leave the
+# timer's own sleep child running for up to 10 seconds, which is
+# harmless — the container is exiting and the sleep dies on its own.
+cancel_timer() {
+    # An empty TIMER_PID means arm_kill failed to fork the timer; there
+    # is nothing to cancel.
+    [ -n "$TIMER_PID" ] || return 0
+    kill $TIMER_PID 2>/dev/null || true
+    sleep 0.05 || true
+    if timer_running; then
+        kill -9 $TIMER_PID 2>/dev/null || true
+    fi
+}
+
+# timer_running reports whether the escalation timer is still live. It
+# reads /proc instead of using kill -0, which reports success for a
+# zombie and would make a dead timer look alive (that in turn would
+# send the caller into a wait that can never be satisfied if the
+# target ignores TERM). The state and parent-PID fields are checked
+# together: after the timer dies and the shell reaps it, a busy sibling
+# (e.g. the target's own children) can reuse the freed PID within
+# milliseconds, and a bare state check would mistake the new process
+# for a live timer. read is a shell builtin, so this introduces no
+# fork and no wait.
+timer_running() {
+    local _stat _rest
+    [ -n "$TIMER_PID" ] || return 1
+    IFS= read -r _stat 2>/dev/null < "/proc/$TIMER_PID/stat" || return 1
+    _rest=${_stat##*) }
+    [ "${_rest%% *}" != "Z" ] || return 1
+    _rest=${_rest#* }
+    [ "${_rest%% *}" = "$MAIN_PID" ]
+}
+
+# Block until either child exits, then stop the other and propagate the
+# exit status. The -p report names the reaped child exactly, so a child
+# that crashed at the same moment as its sibling is handled by the right
+# branch. If mount-proxy dies first, the whole container fails so
+# Kubernetes rebuilds the sandbox instead of silently degrading into
+# "all new mounts fail". The if-context keeps set -e from treating a
+# non-zero wait (child crash, or a wait interrupted by the TERM trap) as
+# a fatal shell error before the cleanup below can run.
+if wait -n -p REAPED $MPID $SPID; then
+    FIRST_STATUS=0
+else
+    FIRST_STATUS=$?
+fi
+if [ "$REAPED" = "$MPID" ]; then
+    # The proxy exited first. A start failure is already reported by the
+    # shell ("command not found"); anything else is an unexpected crash.
+    # If the TERM trap interrupted the wait above, REAPED may be unset;
+    # falling into the branch below is still correct — both branches
+    # exit 0 under TERMINATING.
+    [ $TERMINATING -eq 0 ] && echo "csi-mount-proxy-server exited unexpectedly (status $FIRST_STATUS)" >&2
+    arm_kill $SPID
+    if timer_running; then
+        wait $SPID 2>/dev/null || true
+    else
+        # The escalation timer failed to start: kill -9 directly so the
+        # wait below cannot block forever on a TERM-ignoring child
+        # (kubelet's grace-period SIGKILL would eventually reap the
+        # container, but explicit escalation keeps shutdown within it).
+        kill -9 $SPID 2>/dev/null || true
+        wait $SPID 2>/dev/null || true
+    fi
+    cancel_timer
+    # A guarded wait: with an empty TIMER_PID (fork failure), a bare
+    # `wait` would wait for every remaining background job — including
+    # the orphaned timer sleep — and delay shutdown by up to 10s.
+    [ -n "$TIMER_PID" ] && wait $TIMER_PID 2>/dev/null || true
+    if [ $TERMINATING -eq 1 ]; then
+        exit 0
+    fi
+    exit $FIRST_STATUS
+fi
+# The node server exited, on its own or through the termination trap.
+arm_kill $MPID
+if timer_running; then
+    wait $MPID 2>/dev/null || true
+else
+    kill -9 $MPID 2>/dev/null || true
+    wait $MPID 2>/dev/null || true
+fi
+cancel_timer
+[ -n "$TIMER_PID" ] && wait $TIMER_PID 2>/dev/null || true
+if [ $TERMINATING -eq 1 ]; then
+    exit 0
+fi
+exit $FIRST_STATUS


### PR DESCRIPTION
…ples

Adds the JuiceFS and s3fs sidecar images: multi-stage Dockerfiles that pin the mount-proxy source (alibaba-cloud-csi-driver PR #1722) to a verified commit with a fail-loud SHA check, per-driver entrypoint scripts with shell hardening and credential masking, the two-process supervisor (start.sh) with TERM-forwarding and a 10s SIGKILL escalation nested below the pod grace period, and complete PV/Secret examples. .gitattributes forces LF for the shell scripts (a CRLF shebang breaks exec).

The image README is submitted as a separate docs PR.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

## I. Describe what this PR does

  Adds the JuiceFS and s3fs sidecar images: multi-stage Dockerfiles that pin the
  mount-proxy source (alibaba-cloud-csi-driver PR #1722) to a verified commit
  with a fail-loud SHA check, per-driver entrypoint scripts with shell hardening
  and credential masking, the two-process supervisor (start.sh) with
  TERM-forwarding and a 10s SIGKILL escalation, complete PV/Secret examples, and
  .gitattributes LF enforcement for the shell scripts.

## II. Does this PR fix one issue?

  NONE. Part 6/7 of the customfuse provider PR series (docs: #855).

## III. Describe how to verify it

  NONE (scripts syntax-checked with bash -n; images built and verified
  end-to-end in a cluster).

## IV. Special notes for reviews

  The image README is PR #855.