### PR TITLE
fix(sandbox-gateway): keep the UUID baseline when JWT auth is enabled

### DIFF
--- a/.github/workflows/e2e-sandbox-gateway-security.yaml
+++ b/.github/workflows/e2e-sandbox-gateway-security.yaml
@@ -37,8 +37,19 @@ jobs:
             test_file: test/e2b/test_gateway_auth.py
           - name: JWT auth
             profile: jwt-auth
-            marker: jwt_auth
+            marker: jwt_auth and not jwt_auth_no_baseline
             test_file: test/e2b/test_gateway_jwt_auth.py
+            jwt: true
+            enable_auth: 'true'
+          # Covers upgrading straight from an unauthenticated gateway to JWT: the
+          # UUID baseline stays off, so routes without the opt-in annotation must
+          # keep admitting their existing traffic.
+          - name: JWT auth without UUID baseline
+            profile: jwt-auth-no-baseline
+            marker: jwt_auth_no_baseline
+            test_file: test/e2b/test_gateway_jwt_auth.py
+            jwt: true
+            enable_auth: 'false'
           - name: Runtime mTLS
             profile: runtime-mtls
             marker: runtime_mtls
@@ -130,7 +141,7 @@ jobs:
           docker rmi ${RUNTIME_MTLS_SERVER_IMG}
 
       - name: Build JWT OIDC test provider image
-        if: matrix.profile == 'jwt-auth'
+        if: matrix.jwt
         run: |
           docker build -t ${JWT_OIDC_PROVIDER_IMG} -f test/e2b/assets/jwt-oidc-provider/Dockerfile .
           kind load docker-image --name=${KIND_CLUSTER_NAME} ${JWT_OIDC_PROVIDER_IMG}
@@ -189,7 +200,7 @@ jobs:
             --from-file=ca.crt="$cert_dir/ca.crt"
 
       - name: Configure JWT OIDC test provider
-        if: matrix.profile == 'jwt-auth'
+        if: matrix.jwt
         run: |
           set -euo pipefail
           identity_dir="$(mktemp -d)"
@@ -238,9 +249,12 @@ jobs:
             kubectl rollout status deployment/sandbox-gateway \
               -n sandbox-system --timeout=5m
           fi
-          if [ "${{ matrix.profile }}" = "jwt-auth" ]; then
+          if [ "${{ matrix.jwt }}" = "true" ]; then
+            # enable-auth is patched independently of enable-jwt-auth so that both
+            # upgrade paths get covered. Enabling the JWT capability must not change
+            # how routes without the opt-in annotation are authenticated.
             kubectl get configmap envoy-config -n sandbox-system -o json \
-              | jq '.data["envoy.yaml"] |= sub("enable-auth: false"; "enable-auth: true") | .data["envoy.yaml"] |= sub("enable-jwt-auth: false"; "enable-jwt-auth: true")' \
+              | jq --arg auth '${{ matrix.enable_auth }}' '.data["envoy.yaml"] |= (sub("enable-auth: false"; "enable-auth: " + $auth) | sub("enable-jwt-auth: false"; "enable-jwt-auth: true"))' \
               | kubectl replace -f -
             kubectl set env deployment/sandbox-gateway -n sandbox-system \
               OIDC_DISCOVERY_URL=https://jwt-e2e-oidc-provider.sandbox-system.svc:8443/.well-known/openid-configuration \
@@ -259,7 +273,7 @@ jobs:
           if [ "${{ matrix.profile }}" = "runtime-mtls" ]; then
             export RUNTIME_MTLS_E2E=true
           fi
-          if [ "${{ matrix.profile }}" = "jwt-auth" ]; then
+          if [ "${{ matrix.jwt }}" = "true" ]; then
             export TRAFFIC_ACCESS_TOKEN_JWT_E2E=true
             export JWT_E2E_TOKEN_COMMAND="kubectl exec -n sandbox-system deployment/jwt-e2e-oidc-provider -- /jwt-oidc-provider issue"
           fi

--- a/docs/proposals/20260713-traffic-access-token-jwt-verification.md
+++ b/docs/proposals/20260713-traffic-access-token-jwt-verification.md
@@ -41,6 +41,8 @@ without the annotation decode `RequireTrafficAuth` as `false`.
 - Keep the request path offline after verifier initialization.
 - Fail closed when a route requires JWT authentication but the JWT capability or
   verifier is unavailable.
+- Keep authentication of routes that have not opted into JWT unchanged when the
+  JWT capability is enabled.
 - Preserve existing UUID authentication when JWT authentication is disabled.
 - Keep configuration and dependencies out of sandbox-manager's controller-only
   feature-gate package.
@@ -60,16 +62,30 @@ without the annotation decode `RequireTrafficAuth` as `false`.
 
 ## Behavioral Contract
 
-Gateway authentication has three valid process modes, combined with a
-route-scoped traffic-auth requirement:
+Gateway authentication has two independent process switches, combined with a
+route-scoped traffic-auth requirement. `enable-auth` governs the routes that
+have not opted in, and `enable-jwt-auth` governs the routes that have. The two
+switches are orthogonal and address disjoint sets of routes:
 
 | `enable-auth` | `enable-jwt-auth` | `RequireTrafficAuth=false` | `RequireTrafficAuth=true` |
 |---|---|---|---|
 | `false` | `false` | Authentication disabled. | Fail closed with `503`. |
 | `true` | `false` | Existing `x-access-token` UUID authentication. | Fail closed with `503`; do not fall back to UUID. |
-| `true` | `true` | Skip gateway authentication and remove the traffic-token header. | Verify the JWT using the traffic-token header. |
+| `false` | `true` | Authentication disabled; remove the traffic-token header. | Verify the JWT using the traffic-token header. |
+| `true` | `true` | Existing `x-access-token` UUID authentication; remove the traffic-token header. | Verify the JWT using the traffic-token header. |
 
-`enable-jwt-auth=true` with `enable-auth=false` is invalid configuration.
+The invariant behind the table is that enabling `enable-jwt-auth` never changes
+the `RequireTrafficAuth=false` column. This makes both upgrade paths compatible
+by construction. A deployment already on UUID keeps protecting its existing
+Sandboxes, which would otherwise lose all gateway protection. A deployment with
+authentication disabled keeps admitting its existing traffic, which would
+otherwise start receiving `401` because every Sandbox with an agent-runtime
+carries a generated runtime access token regardless of the gateway
+configuration.
+
+The traffic-token header is removed from every request whenever JWT mode is
+active. On a route that has not opted in the header carries no meaning, so it
+must not leak into the workload.
 
 `RequireTrafficAuth` is derived from the Sandbox annotation and propagated in
 the internal Route model. Only the exact lowercase value `"true"` enables it;
@@ -160,8 +176,8 @@ Envoy filter fields:
 
 | Field | Default | Description |
 |---|---|---|
-| `enable-auth` | `false` | Enables gateway authentication. |
-| `enable-jwt-auth` | `false` | Initializes the process-wide JWT capability. Requires `enable-auth`. |
+| `enable-auth` | `false` | Enables UUID authentication for routes that have not opted into JWT. |
+| `enable-jwt-auth` | `false` | Initializes the process-wide JWT capability. Independent of `enable-auth`. |
 | `traffic-access-token-header` | `e2b-traffic-access-token` | Header carrying the compact JWT. |
 
 Gateway environment variables:
@@ -227,8 +243,15 @@ pointed at the sandbox-gateway ServiceAccount.
 
 - Authentication remains disabled by default in the shipped ConfigMap.
 - Existing UUID mode has unchanged request and response behavior.
-- In JWT mode, routes without the opt-in annotation skip gateway UUID and JWT
-  validation. Operators must account for this when migrating from UUID mode.
+- In JWT mode, routes without the opt-in annotation are authenticated exactly as
+  they would be with JWT mode off. Upgrading from UUID mode keeps the UUID
+  baseline for existing Sandboxes, and upgrading from an unauthenticated
+  deployment keeps admitting existing traffic without validating
+  `x-access-token`.
+- Operators who want the UUID baseline while adopting JWT must keep or set
+  `enable-auth: true`. Turning `enable-auth` on for the first time is a
+  behavioral change for existing clients, independent of JWT, because they must
+  then send the Sandbox runtime access token.
 - Gateways must be upgraded before operators create annotated routes because old
   gateway versions ignore `RequireTrafficAuth`.
 - Sandbox-manager APIs and Sandbox claim/clone behavior are unchanged.
@@ -262,15 +285,25 @@ Unit tests cover:
   cancellation, idempotency, and concurrent readers.
 - Filter configuration, UUID compatibility, JWT success/failure, unavailable
   verifier, route mismatch, custom headers, and header removal.
+- The full switch matrix on routes that have not opted into JWT, covering that
+  JWT mode neither drops the UUID baseline nor introduces validation when
+  `enable-auth` is off.
 - Health and readiness handlers.
 
 The JWT E2E profile uses a local HTTPS OIDC discovery/JWKS provider and covers:
 
 - The in-cluster test issuer minting a token for the created Sandbox ID/UID.
-- An unannotated Sandbox route succeeding without a traffic JWT in JWT mode.
+- An unannotated Sandbox route still enforcing the UUID baseline in JWT mode,
+  succeeding with the Sandbox runtime access token and returning `401` for a
+  mismatched one.
 - A valid JWT and the Sandbox runtime access token succeeding together.
 - Missing, malformed, and expired JWTs returning `403`.
 - A token issued for Sandbox A being rejected for Sandbox B.
+
+A second JWT E2E profile keeps `enable-auth` off while `enable-jwt-auth` is on,
+covering the upgrade straight from an unauthenticated gateway. It asserts that an
+unannotated Sandbox route stays reachable with a mismatched or absent runtime
+access token, while the annotated route keeps enforcing JWT verification.
 
 ## Alternatives
 
@@ -292,4 +325,7 @@ verification is preferred for the initial implementation.
 - [x] 2026-07-15: Finalized the initial ID/UID-only binding and static JWKS scope.
 - [x] 2026-07-15: Added OIDC verifier, asynchronous manager, filter integration,
   readiness, RBAC, and unit/E2E coverage.
+- [x] 2026-08-25: Decoupled `enable-auth` and `enable-jwt-auth` so that enabling
+  the JWT capability never changes how routes without the opt-in annotation are
+  authenticated.
 - [ ] Community review and follow-up design for key/token rotation.

--- a/pkg/sandbox-gateway/filter/config.go
+++ b/pkg/sandbox-gateway/filter/config.go
@@ -55,10 +55,17 @@ type Config struct {
 	HostHeaderName string `json:"host-header-name,omitempty"`
 	// DefaultPort is the default port if not specified
 	DefaultPort string `json:"default-port,omitempty"`
-	// EnableAuth enables access token authentication when set to true.
-	// When disabled (default), the gateway skips token validation for backward compatibility.
+	// EnableAuth enables the UUID access-token baseline for routes that have not
+	// opted into JWT enforcement. When disabled (default), those routes skip token
+	// validation for backward compatibility.
 	EnableAuth bool `json:"enable-auth,omitempty"`
-	// EnableJWTAuth switches enabled gateway authentication from UUID to JWT.
+	// EnableJWTAuth initializes the process-wide JWT capability, which enforces
+	// JWT verification on the routes that opt in through the Sandbox annotation.
+	// It is independent of EnableAuth: the two switches govern disjoint sets of
+	// routes, so enabling JWT never changes how a non-opted-in route is
+	// authenticated. That keeps both migration paths compatible: a deployment
+	// already on UUID keeps its baseline, and a deployment with authentication
+	// off keeps letting existing traffic through.
 	EnableJWTAuth bool `json:"enable-jwt-auth,omitempty"`
 	// TrafficAccessTokenHeader is the request header carrying the traffic access JWT.
 	TrafficAccessTokenHeader string `json:"traffic-access-token-header,omitempty"`
@@ -79,9 +86,6 @@ func DefaultConfig() *Config {
 
 // Validate checks configuration validity
 func (c *Config) Validate() error {
-	if c.EnableJWTAuth && !c.EnableAuth {
-		return fmt.Errorf("enable-jwt-auth requires enable-auth")
-	}
 	headerName := c.GetTrafficAccessTokenHeader()
 	if !httpguts.ValidHeaderFieldName(headerName) || strings.HasPrefix(headerName, ":") {
 		return fmt.Errorf("traffic-access-token-header %q is not a valid HTTP header name", headerName)

--- a/pkg/sandbox-gateway/filter/config_test.go
+++ b/pkg/sandbox-gateway/filter/config_test.go
@@ -189,7 +189,7 @@ func TestConfigValidateJWT(t *testing.T) {
 		expectError string
 	}{
 		{name: "JWT mode", cfg: Config{EnableAuth: true, EnableJWTAuth: true}},
-		{name: "JWT requires auth", cfg: Config{EnableJWTAuth: true}, expectError: "requires enable-auth"},
+		{name: "JWT without the UUID baseline", cfg: Config{EnableJWTAuth: true}},
 		{name: "custom header", cfg: Config{EnableAuth: true, EnableJWTAuth: true, TrafficAccessTokenHeader: "X-Custom-JWT"}},
 		{name: "invalid header", cfg: Config{EnableAuth: true, EnableJWTAuth: true, TrafficAccessTokenHeader: "bad header"}, expectError: "not a valid HTTP header"},
 		{name: "runtime token conflict", cfg: Config{EnableAuth: true, EnableJWTAuth: true, TrafficAccessTokenHeader: "X-Access-Token"}, expectError: "must differ"},
@@ -252,11 +252,12 @@ func TestConfigParserJWT(t *testing.T) {
 			expectHeader:     DefaultTrafficAccessTokenHeader,
 		},
 		{
-			name:         "JWT requires authentication",
-			values:       map[string]any{"enable-jwt-auth": true},
-			manager:      &fakeJWTAuthManager{},
-			expectError:  "requires enable-auth",
-			expectHeader: DefaultTrafficAccessTokenHeader,
+			name:             "JWT without the UUID baseline",
+			values:           map[string]any{"enable-jwt-auth": true},
+			manager:          &fakeJWTAuthManager{},
+			expectConfigured: []bool{true},
+			expectJWT:        true,
+			expectHeader:     DefaultTrafficAccessTokenHeader,
 		},
 		{
 			name:        "missing manager",

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -161,9 +161,15 @@ func (f *sandboxFilter) authenticate(header api.RequestHeaderMap, route sandboxr
 		}
 		return f.authenticateJWT(header, route)
 	}
+	// A route that has not opted into JWT enforcement is authenticated by the
+	// EnableAuth baseline below, exactly as it would be with JWT mode off. The two
+	// switches govern disjoint sets of routes, so enabling JWT neither exposes a
+	// route that UUID mode protected nor starts rejecting traffic that an
+	// unauthenticated deployment allowed. The traffic token is still stripped here
+	// because it carries no meaning for a non-opted-in route and must not leak into
+	// the workload.
 	if f.config.EnableJWTAuth {
 		header.Del(f.config.GetTrafficAccessTokenHeader())
-		return api.Continue
 	}
 	if !f.config.EnableAuth {
 		return api.Continue

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -165,9 +165,13 @@ func (f *sandboxFilter) authenticate(header api.RequestHeaderMap, route sandboxr
 	// EnableAuth baseline below, exactly as it would be with JWT mode off. The two
 	// switches govern disjoint sets of routes, so enabling JWT neither exposes a
 	// route that UUID mode protected nor starts rejecting traffic that an
-	// unauthenticated deployment allowed. The traffic token is still stripped here
-	// because it carries no meaning for a non-opted-in route and must not leak into
-	// the workload.
+	// unauthenticated deployment allowed.
+	//
+	// Stripping the traffic token is scoped to JWT mode rather than unconditional:
+	// only a gateway that verifies these tokens owns the header, so only it can
+	// claim the one arriving here is meaningless. With the capability off the
+	// gateway never reads that header and forwards it untouched, so a workload must
+	// not treat it as gateway-asserted identity.
 	if f.config.EnableJWTAuth {
 		header.Del(f.config.GetTrafficAccessTokenHeader())
 	}

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -784,11 +784,15 @@ func TestFilterFactory(t *testing.T) {
 	assert.NotNil(t, sf.adapter)
 }
 
-// TestDecodeHeadersAccessTokenAuth tests access token authentication logic
+// TestDecodeHeadersAccessTokenAuth tests access token authentication logic for
+// routes that have not opted into JWT enforcement. Because EnableAuth and
+// EnableJWTAuth govern disjoint sets of routes, these routes must be
+// authenticated identically whether or not JWT mode is active.
 func TestDecodeHeadersAccessTokenAuth(t *testing.T) {
 	tests := []struct {
 		name                string
 		disableAuth         bool
+		enableJWTAuth       bool
 		useKruisePath       bool
 		routeAccessToken    string
 		requestToken        string
@@ -869,6 +873,49 @@ func TestDecodeHeadersAccessTokenAuth(t *testing.T) {
 			expectedStatusCode:  401,
 			expectedReplyDetail: "unauthorized",
 		},
+		{
+			// Migrating a UUID deployment to JWT must not drop the baseline.
+			name:             "JWT mode keeps the UUID baseline",
+			enableJWTAuth:    true,
+			routeAccessToken: "secret-token-123",
+			requestToken:     "secret-token-123",
+			setTokenHeader:   true,
+			expectedStatus:   api.Continue,
+			expectLocalReply: false,
+		},
+		{
+			name:                "JWT mode rejects a mismatched UUID token",
+			enableJWTAuth:       true,
+			routeAccessToken:    "secret-token-123",
+			requestToken:        "wrong-token",
+			setTokenHeader:      true,
+			expectedStatus:      api.LocalReply,
+			expectLocalReply:    true,
+			expectedStatusCode:  401,
+			expectedReplyDetail: "unauthorized",
+		},
+		{
+			// Migrating an unauthenticated deployment straight to JWT must not
+			// start validating traffic that was previously allowed through, even
+			// though every Sandbox carries a runtime access token annotation.
+			name:             "JWT mode without the baseline ignores a mismatched token",
+			disableAuth:      true,
+			enableJWTAuth:    true,
+			routeAccessToken: "secret-token-123",
+			requestToken:     "wrong-token",
+			setTokenHeader:   true,
+			expectedStatus:   api.Continue,
+			expectLocalReply: false,
+		},
+		{
+			name:             "JWT mode without the baseline allows a missing token",
+			disableAuth:      true,
+			enableJWTAuth:    true,
+			routeAccessToken: "secret-token-123",
+			setTokenHeader:   false,
+			expectedStatus:   api.Continue,
+			expectLocalReply: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -883,7 +930,15 @@ func TestDecodeHeadersAccessTokenAuth(t *testing.T) {
 
 			cfg := DefaultConfig()
 			cfg.EnableAuth = !tt.disableAuth
-			filter, mockCallbacks := newTestFilter(cfg)
+			cfg.EnableJWTAuth = tt.enableJWTAuth
+			var manager JWTAuthManager
+			if tt.enableJWTAuth {
+				// The manager exposes no verifier, so a regression that routed these
+				// requests through JWT verification would surface as a 503 instead of
+				// silently passing.
+				manager = &fakeJWTAuthManager{}
+			}
+			filter, mockCallbacks := newTestFilterWithDeps(cfg, defaultTestAdapter(), manager)
 
 			var header api.RequestHeaderMap
 			if tt.useKruisePath {
@@ -894,11 +949,16 @@ func TestDecodeHeadersAccessTokenAuth(t *testing.T) {
 			if tt.setTokenHeader {
 				header.Set("x-access-token", tt.requestToken)
 			}
+			header.Set(DefaultTrafficAccessTokenHeader, "unused-jwt")
 
 			status := filter.DecodeHeaders(header, true)
 
 			assert.Equal(t, tt.expectedStatus, status)
 			assert.Equal(t, tt.expectLocalReply, mockCallbacks.decoderCallbacks.sendLocalReplyCalled)
+			// The traffic token is meaningless on a non-opted-in route, so JWT mode
+			// must strip it before the request reaches the workload.
+			_, trafficTokenPresent := header.Get(DefaultTrafficAccessTokenHeader)
+			assert.Equal(t, !tt.enableJWTAuth, trafficTokenPresent)
 			if tt.expectLocalReply {
 				assert.Equal(t, tt.expectedStatusCode, mockCallbacks.decoderCallbacks.replyStatusCode)
 				assert.Equal(t, tt.expectedReplyDetail, mockCallbacks.decoderCallbacks.replyDetails)
@@ -932,7 +992,7 @@ func TestDecodeHeadersJWTAuthentication(t *testing.T) {
 		skipRouteAuth    bool
 	}{
 		{
-			name:             "route without JWT requirement skips verification",
+			name:             "route without JWT requirement skips JWT verification",
 			managerState:     "missing",
 			requestJWT:       "unused-jwt",
 			expectStatus:     api.Continue,

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -955,8 +955,9 @@ func TestDecodeHeadersAccessTokenAuth(t *testing.T) {
 
 			assert.Equal(t, tt.expectedStatus, status)
 			assert.Equal(t, tt.expectLocalReply, mockCallbacks.decoderCallbacks.sendLocalReplyCalled)
-			// The traffic token is meaningless on a non-opted-in route, so JWT mode
-			// must strip it before the request reaches the workload.
+			// JWT mode owns the traffic token header and strips the one a client sent
+			// for a non-opted-in route. With the capability off the gateway does not
+			// read that header, so it reaches the workload untouched.
 			_, trafficTokenPresent := header.Get(DefaultTrafficAccessTokenHeader)
 			assert.Equal(t, !tt.enableJWTAuth, trafficTokenPresent)
 			if tt.expectLocalReply {

--- a/test/e2b/gateway_utils.py
+++ b/test/e2b/gateway_utils.py
@@ -2,8 +2,52 @@
 
 import json
 import subprocess
+import time
+
+import requests
 
 from utils import resolve_sandbox_cr
+
+
+# The port agent-runtime listens on. agent-runtime authenticates x-access-token
+# on its own, so a rejection observed here cannot be attributed to the gateway.
+RUNTIME_PORT = 49983
+# A port served by the sandbox workload itself. Nothing behind it inspects
+# credentials, so a 200 carrying WORKLOAD_RESPONSE_BODY is positive proof that a
+# request traversed the gateway, and any 4xx/5xx can only have come from the
+# gateway. Kept distinct from the 8080 used by the WebSocket case so both
+# servers can coexist inside one sandbox.
+WORKLOAD_PORT = 8081
+WORKLOAD_RESPONSE_BODY = "gateway-workload-ok"
+TRAFFIC_ACCESS_TOKEN_HEADER = "E2B-Traffic-Access-Token"
+
+_WORKLOAD_SERVER_PATH = "/tmp/gateway_workload_server.py"
+_WORKLOAD_READY_PATH = "/tmp/gateway-workload-ready"
+_WORKLOAD_SERVER = f'''
+import http.server
+
+BODY = {WORKLOAD_RESPONSE_BODY!r}.encode()
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(BODY)))
+        self.end_headers()
+        self.wfile.write(BODY)
+
+    def log_message(self, *args):
+        pass
+
+
+server = http.server.HTTPServer(("0.0.0.0", {WORKLOAD_PORT}), Handler)
+# Binding already succeeded here, so the readiness marker cannot race ahead of
+# the listening socket.
+with open({_WORKLOAD_READY_PATH!r}, "w"):
+    pass
+server.serve_forever()
+'''
 
 
 def get_sandbox_resource(sandbox_id: str) -> dict:
@@ -30,3 +74,83 @@ def get_sandbox_access_token(sandbox_id: str) -> str:
 def get_sandbox_uid(sandbox_id: str) -> str:
     """Return the immutable Sandbox UID."""
     return get_sandbox_resource(sandbox_id)["metadata"]["uid"]
+
+
+def start_workload_server(sandbox) -> None:
+    """Serve WORKLOAD_RESPONSE_BODY on WORKLOAD_PORT inside the sandbox.
+
+    The caller must pass a client that can already reach the sandbox through the
+    gateway; for a JWT opt-in Sandbox that means a client carrying a valid
+    traffic token. Waiting on the readiness marker keeps the first gateway
+    request from racing the listener startup.
+    """
+    sandbox.files.write(_WORKLOAD_SERVER_PATH, _WORKLOAD_SERVER)
+    sandbox.commands.run(f"python3 {_WORKLOAD_SERVER_PATH}", background=True)
+    sandbox.commands.run(
+        f"for i in $(seq 1 100); do test -f {_WORKLOAD_READY_PATH} && exit 0; "
+        "sleep 0.1; done; exit 1"
+    )
+
+
+def gateway_request(
+    config,
+    sandbox_id,
+    runtime_access_token=None,
+    traffic_access_token=None,
+    port=RUNTIME_PORT,
+):
+    """Send a header-routed request through the gateway to one sandbox port."""
+    headers = {
+        "e2b-sandbox-id": sandbox_id,
+        "e2b-sandbox-port": str(port),
+    }
+    if runtime_access_token is not None:
+        headers["x-access-token"] = runtime_access_token
+    if traffic_access_token is not None:
+        headers[TRAFFIC_ACCESS_TOKEN_HEADER] = traffic_access_token
+    return requests.get(f"{config.gateway_url}/", headers=headers, timeout=10)
+
+
+def gateway_request_eventually(
+    config,
+    sandbox_id,
+    runtime_access_token=None,
+    traffic_access_token=None,
+    port=RUNTIME_PORT,
+    timeout=30,
+):
+    """Poll the gateway until the route stops reporting itself as unusable.
+
+    502 and 503 cover every state in which no usable route is installed yet: a
+    registry miss, a registry that is still starting, and a Sandbox whose
+    projected state is not running. That last case is what makes polling on
+    these two codes sufficient rather than arbitrary: a warm-pool Sandbox is
+    owned by its SandboxSet until it is claimed, which projects to Available (or
+    Creating) instead of Running, and the gateway rejects those with 502 before
+    authentication runs. Claiming clears the owner reference and writes the
+    runtime access token in a single update, so any other status proves the
+    route in effect is the post-claim one, with its access token and traffic-auth
+    flag already populated.
+    """
+    deadline = time.monotonic() + timeout
+    response = None
+    while time.monotonic() < deadline:
+        response = gateway_request(
+            config, sandbox_id, runtime_access_token, traffic_access_token, port
+        )
+        if response.status_code not in (502, 503):
+            return response
+        time.sleep(0.5)
+    raise AssertionError(
+        f"gateway route was not ready for {sandbox_id} on port {port}: "
+        f"{response.status_code if response is not None else 'no response'} "
+        f"{response.text if response is not None else ''}"
+    )
+
+
+def assert_workload_reached(response) -> None:
+    """Assert a response was produced by the workload, not by the gateway."""
+    assert response.status_code == 200, (
+        f"expected the workload's 200, got {response.status_code}: {response.text}"
+    )
+    assert response.text == WORKLOAD_RESPONSE_BODY, response.text

--- a/test/e2b/pytest.ini
+++ b/test/e2b/pytest.ini
@@ -10,6 +10,7 @@ markers =
     gateway_routing: sandbox-gateway routing tests using the default authentication mode
     gateway_uuid_auth: sandbox-gateway UUID authentication tests
     jwt_auth: sandbox-gateway JWT authentication tests requiring a dedicated OIDC provider
+    jwt_auth_no_baseline: sandbox-gateway JWT authentication tests requiring the UUID baseline to be disabled
     runtime_mtls: sandbox-gateway Runtime mTLS tests requiring dedicated certificates and backend
     flaky: tests with known transient issues (rerun on failure)
     slow: long-running tests

--- a/test/e2b/test_gateway_auth.py
+++ b/test/e2b/test_gateway_auth.py
@@ -6,7 +6,14 @@ import pytest
 import requests
 from e2b_code_interpreter import Sandbox
 
-from gateway_utils import get_sandbox_access_token
+from gateway_utils import (
+    WORKLOAD_PORT,
+    assert_workload_reached,
+    gateway_request,
+    gateway_request_eventually,
+    get_sandbox_access_token,
+    start_workload_server,
+)
 
 logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.gateway_uuid_auth
@@ -79,3 +86,49 @@ def test_gateway_uuid_auth(sandbox_context, config):
     assert host_valid_response.status_code not in (401, 502, 503), (
         f"Gateway rejected valid UUID token via host routing: {host_valid_response.status_code}"
     )
+
+    # Repeat the matrix on a port served by the workload instead of
+    # agent-runtime. agent-runtime authenticates x-access-token on its own, so a
+    # 401 on the runtime port cannot be attributed to the gateway; on this port
+    # nothing else authenticates, so the rejections below are unambiguously the
+    # gateway's and a 200 with the fixed body proves end-to-end reach.
+    start_workload_server(sandbox)
+    assert_workload_reached(
+        gateway_request_eventually(
+            config, sandbox_id, access_token, None, port=WORKLOAD_PORT
+        )
+    )
+
+    workload_missing = gateway_request(
+        config, sandbox_id, None, None, port=WORKLOAD_PORT
+    )
+    assert workload_missing.status_code == 401, (
+        f"Expected 401 without UUID token on the workload port, "
+        f"got {workload_missing.status_code}: {workload_missing.text}"
+    )
+
+    workload_invalid = gateway_request(
+        config, sandbox_id, "wrong-token-value", None, port=WORKLOAD_PORT
+    )
+    assert workload_invalid.status_code == 401, (
+        f"Expected 401 with invalid UUID token on the workload port, "
+        f"got {workload_invalid.status_code}: {workload_invalid.text}"
+    )
+
+    workload_host = f"{WORKLOAD_PORT}-{sandbox_id}.{config.e2b_domain}"
+    workload_host_missing = requests.get(
+        f"{config.gateway_url}/",
+        headers={"Host": workload_host},
+        timeout=10,
+    )
+    assert workload_host_missing.status_code == 401, (
+        f"Expected 401 without UUID token via host routing on the workload port, "
+        f"got {workload_host_missing.status_code}"
+    )
+
+    workload_host_valid = requests.get(
+        f"{config.gateway_url}/",
+        headers={"Host": workload_host, "X-Access-Token": access_token},
+        timeout=10,
+    )
+    assert_workload_reached(workload_host_valid)

--- a/test/e2b/test_gateway_jwt_auth.py
+++ b/test/e2b/test_gateway_jwt_auth.py
@@ -8,21 +8,29 @@ import subprocess
 import time
 
 import pytest
-import requests
 from e2b import PtySize
 from e2b_code_interpreter import Sandbox
 from kruise_agents.patch_traffic_token import patch_traffic_access_token
 from websocket import WebSocketBadStatusException, create_connection
 
-from gateway_utils import get_sandbox_access_token, get_sandbox_uid
+from gateway_utils import (
+    TRAFFIC_ACCESS_TOKEN_HEADER,
+    WORKLOAD_PORT,
+    assert_workload_reached,
+    gateway_request,
+    gateway_request_eventually,
+    get_sandbox_access_token,
+    get_sandbox_uid,
+    start_workload_server,
+)
 
 
 TOKEN_COMMAND = os.environ.get("JWT_E2E_TOKEN_COMMAND", "")
 JWT_AUTH_METADATA_KEY = "security.agents.kruise.io/enable-jwt-auth"
-TRAFFIC_ACCESS_TOKEN_HEADER = "E2B-Traffic-Access-Token"
 # The gateway's own local reply for a failed UUID check. agent-runtime also
-# authenticates x-access-token on its own, so the body is the only way to tell
-# which layer rejected a request.
+# authenticates x-access-token on its own, so on the runtime port the body is the
+# only way to tell which layer rejected a request. Assertions that need an
+# unambiguous answer use WORKLOAD_PORT instead.
 GATEWAY_UNAUTHORIZED_BODY = "unauthorized: invalid or missing access token"
 WEBSOCKET_PORT = 8080
 WEBSOCKET_SERVER = r'''
@@ -131,39 +139,6 @@ def gateway_websocket_url(config) -> str:
     return config.gateway_url.replace("http://", "ws://", 1)
 
 
-def gateway_request(
-    config, sandbox_id, runtime_access_token, traffic_access_token=None
-):
-    headers = {
-        "e2b-sandbox-id": sandbox_id,
-        "e2b-sandbox-port": "49983",
-    }
-    if runtime_access_token is not None:
-        headers["x-access-token"] = runtime_access_token
-    if traffic_access_token is not None:
-        headers[TRAFFIC_ACCESS_TOKEN_HEADER] = traffic_access_token
-    return requests.get(f"{config.gateway_url}/", headers=headers, timeout=10)
-
-
-def gateway_request_eventually(
-    config, sandbox_id, runtime_access_token, traffic_access_token
-):
-    deadline = time.monotonic() + 30
-    response = None
-    while time.monotonic() < deadline:
-        response = gateway_request(
-            config, sandbox_id, runtime_access_token, traffic_access_token
-        )
-        if response.status_code not in (502, 503):
-            return response
-        time.sleep(0.5)
-    raise AssertionError(
-        f"gateway route was not ready for {sandbox_id}: "
-        f"{response.status_code if response is not None else 'no response'} "
-        f"{response.text if response is not None else ''}"
-    )
-
-
 def test_gateway_traffic_access_token_jwt(sandbox_context, config):
     """Verify route-selective JWT authentication and token validation."""
     first: Sandbox = sandbox_context.add(
@@ -214,6 +189,28 @@ def test_gateway_traffic_access_token_jwt(sandbox_context, config):
         public_wrong_token.text
     )
 
+    # Repeat the baseline column on a port served by the workload instead of
+    # agent-runtime. Nothing there authenticates, so the rejections below are
+    # unambiguously the gateway's and the acceptance proves end-to-end reach.
+    start_workload_server(public)
+    assert_workload_reached(
+        gateway_request_eventually(
+            config,
+            public.sandbox_id,
+            public_runtime_token,
+            None,
+            port=WORKLOAD_PORT,
+        )
+    )
+    public_workload_wrong = gateway_request(
+        config, public.sandbox_id, "wrong-runtime-token", None, port=WORKLOAD_PORT
+    )
+    assert public_workload_wrong.status_code == 401, public_workload_wrong.text
+    public_workload_absent = gateway_request(
+        config, public.sandbox_id, None, None, port=WORKLOAD_PORT
+    )
+    assert public_workload_absent.status_code == 401, public_workload_absent.text
+
     valid = gateway_request_eventually(
         config, first.sandbox_id, first_runtime_token, first_token
     )
@@ -226,6 +223,30 @@ def test_gateway_traffic_access_token_jwt(sandbox_context, config):
         config, first.sandbox_id, first_runtime_token, "not-a-jwt"
     )
     assert malformed.status_code == 403, malformed.text
+
+    # The opted-in column on the workload port. Reaching the sandbox to start the
+    # listener already requires a valid traffic token, so rebuild the client with
+    # one first.
+    start_workload_server(sandbox_client_with_traffic_jwt(first, first_token))
+    assert_workload_reached(
+        gateway_request_eventually(
+            config,
+            first.sandbox_id,
+            first_runtime_token,
+            first_token,
+            port=WORKLOAD_PORT,
+        )
+    )
+    first_workload_missing = gateway_request(
+        config, first.sandbox_id, first_runtime_token, None, port=WORKLOAD_PORT
+    )
+    assert first_workload_missing.status_code == 403, first_workload_missing.text
+    first_workload_malformed = gateway_request(
+        config, first.sandbox_id, first_runtime_token, "not-a-jwt", port=WORKLOAD_PORT
+    )
+    assert first_workload_malformed.status_code == 403, (
+        first_workload_malformed.text
+    )
 
     expired_token = issue_traffic_access_token(
         first.sandbox_id, get_sandbox_uid(first.sandbox_id), expired=True
@@ -287,9 +308,27 @@ def test_gateway_traffic_access_token_jwt_without_uuid_baseline(
     assert public_response.status_code in (200, 404), public_response.text
 
     # Every Sandbox carries a generated runtime access token, so a gateway that
-    # started validating it here would break clients that never sent one. Assert
-    # on the gateway's own rejection body because agent-runtime may still answer
-    # 401 for its own reasons.
+    # started validating it here would break clients that never sent one. Prove
+    # the request reaches the workload rather than merely missing one rejection
+    # body: on WORKLOAD_PORT nothing authenticates, so a 200 carrying the fixed
+    # body rules out both a revived UUID check (401) and JWT enforcement leaking
+    # onto a route that never opted in (403).
+    start_workload_server(public)
+    assert_workload_reached(
+        gateway_request_eventually(
+            config,
+            public.sandbox_id,
+            "wrong-runtime-token",
+            None,
+            port=WORKLOAD_PORT,
+        )
+    )
+    assert_workload_reached(
+        gateway_request(config, public.sandbox_id, None, None, port=WORKLOAD_PORT)
+    )
+
+    # The runtime port cannot distinguish the two layers, so it only gets the
+    # weaker check that the gateway's own rejection body is absent.
     wrong_runtime_token = gateway_request(
         config, public.sandbox_id, "wrong-runtime-token", None
     )
@@ -315,6 +354,39 @@ def test_gateway_traffic_access_token_jwt_without_uuid_baseline(
         config, protected.sandbox_id, protected_runtime_token, "not-a-jwt"
     )
     assert malformed.status_code == 403, malformed.text
+
+    start_workload_server(
+        sandbox_client_with_traffic_jwt(protected, protected_token)
+    )
+    assert_workload_reached(
+        gateway_request_eventually(
+            config,
+            protected.sandbox_id,
+            protected_runtime_token,
+            protected_token,
+            port=WORKLOAD_PORT,
+        )
+    )
+    protected_workload_missing = gateway_request(
+        config,
+        protected.sandbox_id,
+        protected_runtime_token,
+        None,
+        port=WORKLOAD_PORT,
+    )
+    assert protected_workload_missing.status_code == 403, (
+        protected_workload_missing.text
+    )
+    protected_workload_malformed = gateway_request(
+        config,
+        protected.sandbox_id,
+        protected_runtime_token,
+        "not-a-jwt",
+        port=WORKLOAD_PORT,
+    )
+    assert protected_workload_malformed.status_code == 403, (
+        protected_workload_malformed.text
+    )
 
 
 def test_gateway_traffic_access_token_jwt_with_e2b_sdk(sandbox_context, config):

--- a/test/e2b/test_gateway_jwt_auth.py
+++ b/test/e2b/test_gateway_jwt_auth.py
@@ -20,6 +20,10 @@ from gateway_utils import get_sandbox_access_token, get_sandbox_uid
 TOKEN_COMMAND = os.environ.get("JWT_E2E_TOKEN_COMMAND", "")
 JWT_AUTH_METADATA_KEY = "security.agents.kruise.io/enable-jwt-auth"
 TRAFFIC_ACCESS_TOKEN_HEADER = "E2B-Traffic-Access-Token"
+# The gateway's own local reply for a failed UUID check. agent-runtime also
+# authenticates x-access-token on its own, so the body is the only way to tell
+# which layer rejected a request.
+GATEWAY_UNAUTHORIZED_BODY = "unauthorized: invalid or missing access token"
 WEBSOCKET_PORT = 8080
 WEBSOCKET_SERVER = r'''
 import base64
@@ -133,8 +137,9 @@ def gateway_request(
     headers = {
         "e2b-sandbox-id": sandbox_id,
         "e2b-sandbox-port": "49983",
-        "x-access-token": runtime_access_token,
     }
+    if runtime_access_token is not None:
+        headers["x-access-token"] = runtime_access_token
     if traffic_access_token is not None:
         headers[TRAFFIC_ACCESS_TOKEN_HEADER] = traffic_access_token
     return requests.get(f"{config.gateway_url}/", headers=headers, timeout=10)
@@ -199,6 +204,16 @@ def test_gateway_traffic_access_token_jwt(sandbox_context, config):
     )
     assert public_response.status_code in (200, 404), public_response.text
 
+    # A Sandbox that has not opted into JWT keeps the UUID baseline, so enabling
+    # JWT mode must not leave it unprotected.
+    public_wrong_token = gateway_request(
+        config, public.sandbox_id, "wrong-runtime-token", None
+    )
+    assert public_wrong_token.status_code == 401, public_wrong_token.text
+    assert GATEWAY_UNAUTHORIZED_BODY in public_wrong_token.text, (
+        public_wrong_token.text
+    )
+
     valid = gateway_request_eventually(
         config, first.sandbox_id, first_runtime_token, first_token
     )
@@ -229,6 +244,77 @@ def test_gateway_traffic_access_token_jwt(sandbox_context, config):
         config, second.sandbox_id, second_runtime_token, first_token
     )
     assert replayed.status_code == 403, replayed.text
+
+
+@pytest.mark.jwt_auth_no_baseline
+def test_gateway_traffic_access_token_jwt_without_uuid_baseline(
+    sandbox_context, config
+):
+    """Verify JWT enforcement while the UUID baseline stays disabled.
+
+    Covers upgrading a gateway that never had authentication enabled straight to
+    JWT mode. Routes without the opt-in annotation must keep admitting the
+    traffic they admitted before, while annotated routes stay fail closed.
+    """
+    protected: Sandbox = sandbox_context.add(
+        Sandbox.create(
+            template=config.templates.code_interpreter,
+            timeout=120,
+            metadata={JWT_AUTH_METADATA_KEY: "true"},
+            headers={"x-request-id": sandbox_context.request_id},
+        )
+    )
+    public: Sandbox = sandbox_context.add(
+        Sandbox.create(
+            template=config.templates.code_interpreter,
+            timeout=120,
+            headers={"x-request-id": sandbox_context.request_id},
+        )
+    )
+    protected_token = issue_traffic_access_token(
+        protected.sandbox_id, get_sandbox_uid(protected.sandbox_id)
+    )
+    protected_runtime_token = get_sandbox_access_token(protected.sandbox_id)
+    public_runtime_token = get_sandbox_access_token(public.sandbox_id)
+    assert protected_runtime_token, (
+        "protected Sandbox is missing its runtime access token"
+    )
+    assert public_runtime_token, "public Sandbox is missing its runtime access token"
+
+    public_response = gateway_request_eventually(
+        config, public.sandbox_id, public_runtime_token, None
+    )
+    assert public_response.status_code in (200, 404), public_response.text
+
+    # Every Sandbox carries a generated runtime access token, so a gateway that
+    # started validating it here would break clients that never sent one. Assert
+    # on the gateway's own rejection body because agent-runtime may still answer
+    # 401 for its own reasons.
+    wrong_runtime_token = gateway_request(
+        config, public.sandbox_id, "wrong-runtime-token", None
+    )
+    assert GATEWAY_UNAUTHORIZED_BODY not in wrong_runtime_token.text, (
+        wrong_runtime_token.text
+    )
+
+    absent_runtime_token = gateway_request(config, public.sandbox_id, None, None)
+    assert GATEWAY_UNAUTHORIZED_BODY not in absent_runtime_token.text, (
+        absent_runtime_token.text
+    )
+
+    # The opted-in column is unaffected by the disabled baseline.
+    valid = gateway_request_eventually(
+        config, protected.sandbox_id, protected_runtime_token, protected_token
+    )
+    assert valid.status_code in (200, 404), valid.text
+
+    missing = gateway_request(config, protected.sandbox_id, protected_runtime_token)
+    assert missing.status_code == 403, missing.text
+
+    malformed = gateway_request(
+        config, protected.sandbox_id, protected_runtime_token, "not-a-jwt"
+    )
+    assert malformed.status_code == 403, malformed.text
 
 
 def test_gateway_traffic_access_token_jwt_with_e2b_sdk(sandbox_context, config):


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

`enable-jwt-auth` required `enable-auth`, and once JWT mode was on the gateway
skipped authentication entirely for every route that had not opted in through
the `security.agents.kruise.io/enable-jwt-auth` annotation. That coupling broke
both upgrade paths:

- **UUID → JWT**: an existing Sandbox has no opt-in annotation, so it lost all
  gateway protection the moment JWT mode was enabled. Its UUID token in the
  `agents.kruise.io/runtime-access-token` annotation stopped being checked.
- **no auth → JWT**: config validation rejected this combination, forcing the
  operator to turn on `enable-auth` at the same time. Every Sandbox with an
  agent-runtime carries a generated runtime access token regardless of gateway
  configuration, so that immediately started returning `401` to clients that had
  never sent one.

This PR makes the two switches orthogonal, governing disjoint sets of routes:

| `enable-auth` | `enable-jwt-auth` | `RequireTrafficAuth=false` | `RequireTrafficAuth=true` |
|---|---|---|---|
| `false` | `false` | Authentication disabled. | Fail closed with `503`. |
| `true` | `false` | UUID `x-access-token`. | Fail closed with `503`. |
| `false` | `true` | Authentication disabled. | Verify the JWT. |
| `true` | `true` | UUID `x-access-token`. | Verify the JWT. |

The invariant is that enabling `enable-jwt-auth` never changes the
`RequireTrafficAuth=false` column, which makes both upgrade paths compatible by
construction. The traffic-token header is still stripped on non-opted-in routes
because it carries no meaning there and must not leak into the workload.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. `go test ./pkg/sandbox-gateway/... -count=1`
2. `TestDecodeHeadersAccessTokenAuth` now drives all four switch combinations on
   a non-opted-in route. The JWT cases install a manager with no verifier, so a
   regression that routed those requests through JWT verification surfaces as a
   `503` instead of silently passing.
3. `TestConfigValidateJWT` / `TestConfigParserJWT` accept `enable-jwt-auth`
   without `enable-auth`.
4. E2E, two profiles over the same test file:
   - `jwt-auth` (`enable-auth=true`, `enable-jwt-auth=true`) additionally asserts
     that a non-opted-in route returns `401` for a mismatched runtime token.
   - `jwt-auth-no-baseline` (`enable-auth=false`, `enable-jwt-auth=true`) is new
     and asserts a non-opted-in route stays reachable with a mismatched or absent
     runtime token, while the annotated route still enforces JWT.

### Ⅳ. Special notes for reviews

- The behavioral change is confined to `authenticate()` in
  `pkg/sandbox-gateway/filter/filter.go`: JWT mode no longer returns early for a
  non-opted-in route, it only strips the traffic-token header and then falls
  through to the `enable-auth` baseline.
- Worth a close look: removing the `enable-jwt-auth requires enable-auth`
  validation in `config.go` is what enables the third matrix row. The guard in
  `authenticate()` is deliberately `!f.config.EnableAuth` and not
  `!EnableAuth && !EnableJWTAuth` — the latter would re-break the
  "no auth → JWT" path by validating tokens that were never validated before.
- Both directions were reverse-verified: temporarily restoring the early
  `return api.Continue` fails the mismatched-UUID case, and temporarily widening
  the guard fails the two no-baseline cases.
- `test/e2b/test_gateway_jwt_auth.py` asserts on the gateway's own local-reply
  body rather than the status code alone, because agent-runtime also
  authenticates `x-access-token` and would otherwise be indistinguishable from a
  gateway rejection.
