### PR TITLE
fix(controller): use TLS for upgrade hooks

### DIFF
--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -82,6 +82,8 @@ type commonControl struct {
 type ResumeFunc func(ctx context.Context, args EnsureFuncArgs) error
 
 func NewCommonControl(args SandboxControlArgs) SandboxControl {
+	lifecycleHookFunc := NewLifecycleHookFunc(args.RuntimeTLSBundle)
+
 	initializer := &defaultSandboxInitializer{
 		client:          args.Client,
 		apiReader:       args.APIReader,
@@ -96,12 +98,12 @@ func NewCommonControl(args SandboxControlArgs) SandboxControl {
 		rateLimiter:          args.RateLimiter,
 		checkpointControl:    args.CheckpointControl,
 		podControl:           args.PodControl,
-		lifecycleHookFunc:    ExecuteLifecycleHook,
+		lifecycleHookFunc:    lifecycleHookFunc,
 		initializer:          initializer,
 		recycleControl:       NewSandboxRecycleControl(args.Client, args.Recorder, args.RecycleConfig),
 		syncStatusFromPod:    defaultSyncStatusFromPod,
 	}
-	control.upgradeControl = NewUpgradeControl(args.Client, args.CheckpointControl, args.PodControl, args.Recorder, ExecuteLifecycleHook, initializer, control.syncStatusFromPod, control.handleResume)
+	control.upgradeControl = NewUpgradeControl(args.Client, args.CheckpointControl, args.PodControl, args.Recorder, lifecycleHookFunc, initializer, control.syncStatusFromPod, control.handleResume)
 	return control
 }
 

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -2831,7 +2831,7 @@ func TestCommonControl_performRecreateUpgrade_PodTerminating(t *testing.T) {
 		podControl:           podCtrl,
 		checkpointControl:    checkpointCtrl,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), ExecuteLifecycleHook, initializer, defaultSyncStatusFromPod, nil),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultSyncStatusFromPod, nil),
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2892,7 +2892,7 @@ func TestCommonControl_performRecreateUpgrade_NewPodNotReady(t *testing.T) {
 		podControl:           podCtrl,
 		checkpointControl:    checkpointCtrl,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), ExecuteLifecycleHook, initializer, defaultSyncStatusFromPod, nil),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultSyncStatusFromPod, nil),
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -3137,7 +3137,7 @@ func TestCommonControl_performRecreateUpgrade_PodReadyFalse(t *testing.T) {
 		podControl:           podCtrl,
 		checkpointControl:    checkpointCtrl,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), ExecuteLifecycleHook, initializer, defaultSyncStatusFromPod, nil),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultSyncStatusFromPod, nil),
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -3588,7 +3588,7 @@ func TestCommonControl_performRecreateUpgrade_InitializerPath(t *testing.T) {
 				podControl:           podCtrl,
 				checkpointControl:    checkpointCtrl,
 				initializer:          initializer,
-				upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), ExecuteLifecycleHook, initializer, defaultSyncStatusFromPod, nil),
+				upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultSyncStatusFromPod, nil),
 			}
 
 			newStatus := &agentsv1alpha1.SandboxStatus{

--- a/pkg/controller/sandbox/core/lifecycle_handler.go
+++ b/pkg/controller/sandbox/core/lifecycle_handler.go
@@ -30,31 +30,36 @@ import (
 // LifecycleHookFunc is the function type for executing lifecycle hooks.
 type LifecycleHookFunc func(ctx context.Context, box *agentsv1alpha1.Sandbox, action *agentsv1alpha1.UpgradeAction) (exitCode int32, stdout, stderr string, err error)
 
-// ExecuteLifecycleHook executes an upgrade action inside the sandbox pod via envd.
-// It uses the shared RunCommandWithRuntime from pkg/utils/runtime.
-//
-// It is currently the one controller path that still reaches the runtime over
-// plaintext HTTP: it forwards no runtime.Option, so even a sandbox advertising
-// the runtime TLS capability is contacted on the plain runtime port, while the
-// initializer paths (/init handshake, CSI re-mount, security token) already ride
-// the transport resolved for the sandbox.
-//
-// TODO: resolve the sandbox transport via runtime.TransportOptionsFor once the
-// upgrade/recycle flows carry the runtime TLS bundle, mirroring the
-// claim/clone/post-resume flows (see PR #734). The bundle already reaches this
-// package as SandboxControlArgs.RuntimeTLSBundle, so the missing piece is
-// threading it through LifecycleHookFunc. The runtime URL gate below must be
-// revisited together with it: it is a plaintext-only readiness signal, whereas
-// the TLS transport addresses the runtime by its certificate hostname and dials
-// the sandbox Pod IP.
+var runCommandWithRuntimeFunc = agentsruntime.RunCommandWithRuntime
+
+// NewLifecycleHookFunc binds the runtime TLS bundle to the lifecycle hook path
+// so upgrade hooks use the same transport decision as the other controller
+// runtime clients.
+func NewLifecycleHookFunc(tlsBundle *agentsruntime.TLSBundle) LifecycleHookFunc {
+	return func(ctx context.Context, box *agentsv1alpha1.Sandbox, action *agentsv1alpha1.UpgradeAction) (exitCode int32, stdout, stderr string, err error) {
+		return executeLifecycleHook(ctx, box, action, tlsBundle)
+	}
+}
+
+// ExecuteLifecycleHook is the legacy plaintext-compatible entry point kept for
+// direct callers and tests that do not supply a runtime TLS bundle.
 func ExecuteLifecycleHook(ctx context.Context, box *agentsv1alpha1.Sandbox, action *agentsv1alpha1.UpgradeAction) (exitCode int32, stdout, stderr string, err error) {
+	return executeLifecycleHook(ctx, box, action, nil)
+}
+
+// executeLifecycleHook executes an upgrade action inside the sandbox pod via
+// envd, resolving the runtime transport from the sandbox capability stamp.
+func executeLifecycleHook(ctx context.Context, box *agentsv1alpha1.Sandbox, action *agentsv1alpha1.UpgradeAction,
+	tlsBundle *agentsruntime.TLSBundle) (exitCode int32, stdout, stderr string, err error) {
 	if action == nil || action.Exec == nil || len(action.Exec.Command) == 0 {
 		return 0, "", "", nil
 	}
 
-	// Check runtime URL availability
-	runtimeURL := agentsruntime.GetRuntimeURL(box)
-	if runtimeURL == "" {
+	rtOpts, err := agentsruntime.TransportOptionsFor(box, tlsBundle)
+	if err != nil {
+		return -1, "", "", err
+	}
+	if len(rtOpts) == 0 && agentsruntime.GetRuntimeURL(box) == "" {
 		return -1, "", "", fmt.Errorf("runtime URL not found on sandbox %s/%s", box.Namespace, box.Name)
 	}
 
@@ -75,7 +80,7 @@ func ExecuteLifecycleHook(ctx context.Context, box *agentsv1alpha1.Sandbox, acti
 		// Lifecycle hook commands run as root, matching the historical behavior
 		// of the shared runtime process client.
 		AuthUser: "root",
-	})
+	}, rtOpts...)
 	if err != nil {
 		return -1, strings.Join(result.Stdout, ""), strings.Join(result.Stderr, ""), err
 	}

--- a/pkg/controller/sandbox/core/lifecycle_handler.go
+++ b/pkg/controller/sandbox/core/lifecycle_handler.go
@@ -30,8 +30,6 @@ import (
 // LifecycleHookFunc is the function type for executing lifecycle hooks.
 type LifecycleHookFunc func(ctx context.Context, box *agentsv1alpha1.Sandbox, action *agentsv1alpha1.UpgradeAction) (exitCode int32, stdout, stderr string, err error)
 
-var runCommandWithRuntimeFunc = agentsruntime.RunCommandWithRuntime
-
 // NewLifecycleHookFunc binds the runtime TLS bundle to the lifecycle hook path
 // so upgrade hooks use the same transport decision as the other controller
 // runtime clients.

--- a/pkg/controller/sandbox/core/lifecycle_handler.go
+++ b/pkg/controller/sandbox/core/lifecycle_handler.go
@@ -39,12 +39,6 @@ func NewLifecycleHookFunc(tlsBundle *agentsruntime.TLSBundle) LifecycleHookFunc 
 	}
 }
 
-// ExecuteLifecycleHook is the legacy plaintext-compatible entry point kept for
-// direct callers and tests that do not supply a runtime TLS bundle.
-func ExecuteLifecycleHook(ctx context.Context, box *agentsv1alpha1.Sandbox, action *agentsv1alpha1.UpgradeAction) (exitCode int32, stdout, stderr string, err error) {
-	return executeLifecycleHook(ctx, box, action, nil)
-}
-
 // executeLifecycleHook executes an upgrade action inside the sandbox pod via
 // envd, resolving the runtime transport from the sandbox capability stamp.
 func executeLifecycleHook(ctx context.Context, box *agentsv1alpha1.Sandbox, action *agentsv1alpha1.UpgradeAction,
@@ -57,8 +51,13 @@ func executeLifecycleHook(ctx context.Context, box *agentsv1alpha1.Sandbox, acti
 	if err != nil {
 		return -1, "", "", err
 	}
+	// Readiness gates per transport: plaintext is addressed by the runtime URL
+	// (with a Pod-IP fallback), while TLS dials the Pod IP directly.
 	if len(rtOpts) == 0 && agentsruntime.GetRuntimeURL(box) == "" {
 		return -1, "", "", fmt.Errorf("runtime URL not found on sandbox %s/%s", box.Namespace, box.Name)
+	}
+	if len(rtOpts) > 0 && box.Status.PodInfo.PodIP == "" {
+		return -1, "", "", fmt.Errorf("pod IP not ready on sandbox %s/%s", box.Namespace, box.Name)
 	}
 
 	// Determine timeout

--- a/pkg/controller/sandbox/core/lifecycle_handler_test.go
+++ b/pkg/controller/sandbox/core/lifecycle_handler_test.go
@@ -40,7 +40,8 @@ func newTestSandbox(annotations map[string]string, sandboxIP string) *agentsv1al
 	}
 }
 
-func TestExecuteLifecycleHook(t *testing.T) {
+func TestLifecycleHookFunc_NilBundle(t *testing.T) {
+	hookFunc := NewLifecycleHookFunc(nil)
 	tests := []struct {
 		name             string
 		box              *agentsv1alpha1.Sandbox
@@ -140,16 +141,16 @@ func TestExecuteLifecycleHook(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			exitCode, stdout, stderr, err := ExecuteLifecycleHook(ctx, tt.box, tt.hook)
+			exitCode, stdout, stderr, err := hookFunc(ctx, tt.box, tt.hook)
 
 			if exitCode != tt.expectedExitCode {
-				t.Errorf("ExecuteLifecycleHook() exitCode = %d, want %d", exitCode, tt.expectedExitCode)
+				t.Errorf("lifecycle hook exitCode = %d, want %d", exitCode, tt.expectedExitCode)
 			}
 			if stdout != tt.expectedStdout {
-				t.Errorf("ExecuteLifecycleHook() stdout = %q, want %q", stdout, tt.expectedStdout)
+				t.Errorf("lifecycle hook stdout = %q, want %q", stdout, tt.expectedStdout)
 			}
 			if stderr != tt.expectedStderr {
-				t.Errorf("ExecuteLifecycleHook() stderr = %q, want %q", stderr, tt.expectedStderr)
+				t.Errorf("lifecycle hook stderr = %q, want %q", stderr, tt.expectedStderr)
 			}
 			if tt.expectError && err == nil {
 				t.Error("Expected error but got none")
@@ -158,32 +159,58 @@ func TestExecuteLifecycleHook(t *testing.T) {
 				t.Errorf("Unexpected error: %v", err)
 			}
 			if tt.expectedErr != "" && err != nil && err.Error() != tt.expectedErr {
-				t.Fatalf("ExecuteLifecycleHook() error = %q, want %q", err.Error(), tt.expectedErr)
+				t.Fatalf("lifecycle hook error = %q, want %q", err.Error(), tt.expectedErr)
 			}
 		})
 	}
 }
 
 func TestNewLifecycleHookFunc_UsesRuntimeTLSBundle(t *testing.T) {
-	box := newTestSandbox(map[string]string{
-		agentsv1alpha1.AnnotationRuntimeTLSPort: "49984",
-	}, "")
-	hookFunc := NewLifecycleHookFunc(&agentsruntime.TLSBundle{})
+	tests := []struct {
+		name        string
+		box         *agentsv1alpha1.Sandbox
+		expectedErr string
+	}{
+		{
+			name: "configured bundle reaches TLS transport validation",
+			box: func() *agentsv1alpha1.Sandbox {
+				box := newTestSandbox(map[string]string{
+					agentsv1alpha1.AnnotationRuntimeTLSPort: "49984",
+				}, "")
+				box.Status.PodInfo.PodIP = "10.0.0.1"
+				return box
+			}(),
+			expectedErr: "invalid runtime TLS configuration: runtime TLS CA bundle is required",
+		},
+		{
+			name: "pod IP not ready returns readiness error",
+			box: newTestSandbox(map[string]string{
+				agentsv1alpha1.AnnotationRuntimeTLSPort: "49984",
+			}, ""),
+			expectedErr: "pod IP not ready on sandbox default/test-sandbox",
+		},
+	}
 
-	exitCode, stdout, stderr, err := hookFunc(context.Background(), box, &agentsv1alpha1.UpgradeAction{
-		Exec: &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "echo tls"}},
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hookFunc := NewLifecycleHookFunc(&agentsruntime.TLSBundle{})
 
-	if exitCode != -1 {
-		t.Fatalf("hook exitCode = %d, want -1", exitCode)
-	}
-	if stdout != "" || stderr != "" {
-		t.Fatalf("hook output = stdout %q stderr %q, want empty output", stdout, stderr)
-	}
-	if err == nil {
-		t.Fatal("expected error but got nil")
-	}
-	if err.Error() != "invalid runtime TLS configuration: runtime TLS CA bundle is required" {
-		t.Fatalf("hook error = %q, want invalid TLS bundle error", err.Error())
+			exitCode, stdout, stderr, err := hookFunc(context.Background(), tt.box, &agentsv1alpha1.UpgradeAction{
+				Exec: &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "echo tls"}},
+			})
+
+			if exitCode != -1 {
+				t.Fatalf("hook exitCode = %d, want -1", exitCode)
+			}
+			if stdout != "" || stderr != "" {
+				t.Fatalf("hook output = stdout %q stderr %q, want empty output", stdout, stderr)
+			}
+			if err == nil {
+				t.Fatal("expected error but got nil")
+			}
+			if err.Error() != tt.expectedErr {
+				t.Fatalf("hook error = %q, want %q", err.Error(), tt.expectedErr)
+			}
+		})
 	}
 }

--- a/pkg/controller/sandbox/core/lifecycle_handler_test.go
+++ b/pkg/controller/sandbox/core/lifecycle_handler_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	agentsruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
 func newTestSandbox(annotations map[string]string, sandboxIP string) *agentsv1alpha1.Sandbox {
@@ -47,6 +48,7 @@ func TestExecuteLifecycleHook(t *testing.T) {
 		expectedExitCode int32
 		expectedStdout   string
 		expectedStderr   string
+		expectedErr      string
 		expectError      bool
 	}{
 		{
@@ -74,6 +76,21 @@ func TestExecuteLifecycleHook(t *testing.T) {
 			expectedExitCode: -1,
 			expectedStdout:   "",
 			expectedStderr:   "",
+			expectedErr:      "runtime URL not found on sandbox default/test-sandbox",
+			expectError:      true,
+		},
+		{
+			name: "runtime TLS sandbox without client bundle returns TLS transport error",
+			box: newTestSandbox(map[string]string{
+				agentsv1alpha1.AnnotationRuntimeTLSPort: "49984",
+			}, ""),
+			hook: &agentsv1alpha1.UpgradeAction{
+				Exec: &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "echo tls"}},
+			},
+			expectedExitCode: -1,
+			expectedStdout:   "",
+			expectedStderr:   "",
+			expectedErr:      "sandbox default/test-sandbox advertises runtime TLS port 49984 but no client TLS bundle is configured",
 			expectError:      true,
 		},
 		{
@@ -140,6 +157,33 @@ func TestExecuteLifecycleHook(t *testing.T) {
 			if !tt.expectError && err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}
+			if tt.expectedErr != "" && err != nil && err.Error() != tt.expectedErr {
+				t.Fatalf("ExecuteLifecycleHook() error = %q, want %q", err.Error(), tt.expectedErr)
+			}
 		})
+	}
+}
+
+func TestNewLifecycleHookFunc_UsesRuntimeTLSBundle(t *testing.T) {
+	box := newTestSandbox(map[string]string{
+		agentsv1alpha1.AnnotationRuntimeTLSPort: "49984",
+	}, "")
+	hookFunc := NewLifecycleHookFunc(&agentsruntime.TLSBundle{})
+
+	exitCode, stdout, stderr, err := hookFunc(context.Background(), box, &agentsv1alpha1.UpgradeAction{
+		Exec: &corev1.ExecAction{Command: []string{"/bin/bash", "-c", "echo tls"}},
+	})
+
+	if exitCode != -1 {
+		t.Fatalf("hook exitCode = %d, want -1", exitCode)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("hook output = stdout %q stderr %q, want empty output", stdout, stderr)
+	}
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+	if err.Error() != "invalid runtime TLS configuration: runtime TLS CA bundle is required" {
+		t.Fatalf("hook error = %q, want invalid TLS bundle error", err.Error())
 	}
 }


### PR DESCRIPTION
## Description:

Thread runtime TLS through upgrade lifecycle hook execution.

Before this change, lifecycle hooks called `RunCommandWithRuntime` without the transport resolved by `runtime.TransportOptionsFor`, and they still gated execution on plaintext `GetRuntimeURL`. As a result, a sandbox advertising the runtime TLS capability could not execute upgrade hooks over the TLS path and failed before the TLS transport had a chance to resolve.

This PR keeps the legacy plaintext behavior for non-TLS sandboxes, but binds the controller's existing `RuntimeTLSBundle` into lifecycle hook execution and adds regression tests for the missing-bundle and configured-bundle paths.

### Validation Tests run:

- [x] `go test ./pkg/controller/sandbox/core -run 'TestExecuteLifecycleHook|TestNewLifecycleHookFunc_UsesRuntimeTLSBundle' -count=1`
- [x] `go test ./pkg/controller/sandbox/core -count=1`
- [x] `go test ./pkg/controller/sandbox/... -count=1`

## Notes:

- Scope is intentionally limited to upgrade lifecycle hooks.
- The recycle CSI reset signal TLS path is split into a separate follow up PR (#888).
