### PR TITLE
docs(poolautoscaler): update lifecycle-aware scaling proposal

### DIFF
--- a/docs/proposals/20260106-sandboxset-autoscaler.md
+++ b/docs/proposals/20260106-sandboxset-autoscaler.md
@@ -47,7 +47,9 @@ superseded-by:
             - [Policy Combination and Precedence](#policy-combination-and-precedence)
             - [Observation Window and Sampling Configuration](#observation-window-and-sampling-configuration)
             - [Lifecycle-Aware Scale-Up Flow Control](#lifecycle-aware-scale-up-flow-control)
-            - [Pending Sandbox Timeout Observability](#pending-sandbox-timeout-observability)
+                - [Component Interaction State Machine](#component-interaction-state-machine)
+            - [SandboxSet Scale-Up Readiness](#sandboxset-scale-up-readiness)
+            - [SandboxSet Scaling Limitation](#sandboxset-scaling-limitation)
             - [Cron Policy Maintenance Window Support](#cron-policy-maintenance-window-support)
             - [One-to-One Relationship Between Warm Pool and Autoscaler](#one-to-one-relationship-between-warm-pool-and-autoscaler)
         - [Risks and Mitigations](#risks-and-mitigations)
@@ -90,10 +92,11 @@ This enhancement adds two complementary autoscaling policy types:
 ensuring sufficient idle capacity while preventing over-provisioning
 
 The autoscaler integrates seamlessly with `SandboxSet`, providing operators with fine-grained
-control over resource pool capacity while reducing operational overhead. Target growth is limited
-by Sandboxes that remain Pending beyond the configured timeout and, for repeated capacity-driven
-increases, by observed claim progress. SandboxSet independently limits actual creation concurrency,
-allowing healthy high-throughput replenishment to continue without growing an unused pool.
+control over resource pool capacity while reducing operational overhead. PoolAutoscaler decides the
+desired target without interpreting `maxUnavailable`; SandboxSet independently limits actual creation
+concurrency and publishes whether the current scale-up generation has made Available progress. This
+allows healthy high-throughput replenishment to continue without repeatedly increasing the target
+while execution is stalled.
 This enhancement addresses critical requirements for latency-sensitive agent workloads that require
 predictable startup performance and efficient resource utilization.
 
@@ -467,10 +470,16 @@ published incrementally during initial reconciliation.
 
 ##### SandboxSet Lifecycle Status and Scale Safety
 
-`SandboxSet.spec.replicas` remains the desired number of **unclaimed** Sandboxes. Creation flow
-control and abnormal target-growth control use separate derived values without adding API fields.
+`SandboxSet.spec.replicas` remains the desired number of **unclaimed** Sandboxes. Responsibilities
+are split across three logical controllers without adding a replica-count API field:
 
-SandboxSet retains its existing creation-concurrency calculation:
+- Sandbox controller manages one Sandbox and reports its lifecycle state.
+- SandboxSet controller executes `spec.replicas`, owns `maxUnavailable`, and publishes execution
+  progress through the existing `status.conditions` field.
+- PoolAutoscaler computes desired capacity and consumes SandboxSet status; it does not list
+  Sandboxes or interpret `maxUnavailable`.
+
+SandboxSet retains its existing in-flight calculation:
 
 ```
 inFlightUnavailable = max(status.replicas - status.availableReplicas, 0)
@@ -478,22 +487,40 @@ inFlightUnavailable = max(status.replicas - status.availableReplicas, 0)
 
 `status.replicas` includes Creating and Available Sandboxes. Existing expectation accounting also
 includes successful create requests that are not visible through the informer yet (`dirtyCreate`).
-Consequently, `inFlightUnavailable` represents observed Creating Sandboxes plus `dirtyCreate`, and
-SandboxSet uses it to consume `spec.scaleStrategy.maxUnavailable` while creating the replicas already
-declared in `spec.replicas`.
+Consequently, `inFlightUnavailable` represents observed Creating Sandboxes plus `dirtyCreate`.
+SandboxSet resolves `spec.scaleStrategy.maxUnavailable` and uses the result solely to limit physical
+create operations. An absent value preserves the existing unlimited scale-up behavior; absolute
+values are used directly, percentages are rounded up, and invalid values are rejected by admission.
 
-PoolAutoscaler separately derives `timedOutPending` by listing Sandboxes still owned by the target
-SandboxSet and counting only those whose state reason is `ResourcePending` and whose age has reached
-the component-level Pending timeout. Fresh Pending Sandboxes and `dirtyCreate` do not count as
-timed-out failures. PoolAutoscaler uses this value to limit how quickly it raises the desired target,
-so a healthy stream of newly created Sandboxes can continue growing the pool.
+To prevent a large desired-target jump from immediately enlarging percentage-based creation
+concurrency, SandboxSet resolves percentage `maxUnavailable` against observed pool size rather than
+the new desired target:
 
-`status.observedGeneration` confirms that SandboxSet has observed the previous desired size.
-PoolAutoscaler also keeps an in-memory claim sequence for each target SandboxSet. After a successful
-capacity-driven scale-up, at least one subsequent claim must be observed before another
-capacity-driven scale-up is admitted. Sampling history, cooldown timestamps, claim-gate state, and
-other derived scaling state stay in controller memory. No additional persistent progress or
-per-Sandbox tracking fields are introduced.
+```
+executionBase = max(status.replicas, 1)
+maxConcurrent = resolve(spec.scaleStrategy.maxUnavailable,
+                        executionBase, default=unlimited)
+createHeadroom = max(maxConcurrent - inFlightUnavailable, 0)
+```
+
+SandboxSet publishes two orthogonal conditions. `ScaleUpReady` is the per-generation execution
+handshake: after a desired-target increase, it remains `False` until SandboxSet observes at least one
+owned Sandbox become Available. The Available transition is recorded by the Sandbox event handler,
+so a Sandbox that is claimed immediately after becoming Available still counts as progress even when
+the net `availableReplicas` value does not increase. The condition is reset for the next target
+generation.
+
+`ScalingLimited` reports whether one or more owned Sandboxes are currently blocked from starting.
+It becomes `True` immediately when an owned Sandbox reports an existing startup-failure reason, or
+when an otherwise inconclusive Pending Sandbox exceeds the controller-wide startup timeout. It is
+not sticky and returns to `False` when no blocker remains. This reuses
+`SandboxSet.status.conditions`; blocker counts and object lists are derived during reconciliation and
+are not persisted as new status fields.
+
+PoolAutoscaler uses `status.observedGeneration`, `ScaleUpReady`, and `ScalingLimited` as the execution
+handshake. It does not inspect claims, Pending age, Pod status, or per-Sandbox UIDs itself. Sampling
+history, cooldown timestamps, and the short-lived Available-transition observation stay in controller
+memory; only the aggregate conditions are persisted.
 
 When a Sandbox is claimed, it leaves the warm pool. SandboxSet replenishes the unclaimed pool
 according to `spec.replicas`, but PoolAutoscaler does not continue tracking the claimed Sandbox and
@@ -660,18 +687,17 @@ scale-up condition unreachable.
 
 - With one unclaimed and available Sandbox, `targetAvailable=10`, and `tolerance=5`,
   available capacity is below the lower watermark. The policy recommendation is
-  `1 + (10 - 1) = 10`, while lifecycle-aware scale-up admits only the creation credit
-  currently available. With the default concurrency, the pool grows one successful
-  Sandbox at a time until the target is restored.
+  `1 + (10 - 1) = 10`. PoolAutoscaler may publish that target, while SandboxSet applies its own
+  creation concurrency and reports Available progress through `ScaleUpReady`.
 - Claiming a Sandbox removes it from the unclaimed pool and SandboxSet replenishes toward
   `spec.replicas`. Absolute targets remain fixed; claimed Sandboxes do not change the
   configured target value.
 - With 30 unclaimed and available Sandboxes and a full observation window, available capacity
   exceeds the upper watermark. The policy recommendation is `30 - (30 - 10) = 10`.
 
-Scale-up is deliberately separated into recommendation and admission: the capacity policy may
-recommend the full deficit, but the lifecycle gate releases only bounded creation credit. Scale-down
-uses the averaged observation window and waits for the previous reduction to converge.
+Scale-up is deliberately separated into recommendation and execution: CapacityPolicy computes the
+desired target, while SandboxSet independently bounds physical creation and publishes progress.
+Scale-down uses the averaged observation window and waits for the previous reduction to converge.
 
 ###### Percentage-Based Watermark Configuration
 
@@ -779,7 +805,11 @@ avgReplicas  = sum(status.replicas) / sampleCount
 ```
 
 Scale-up can act on the current sample immediately. Scale-down requires a full observation window
-to avoid reducing capacity from incomplete history after startup or controller restart.
+to avoid reducing capacity from incomplete history after startup or controller restart. After a
+capacity-driven target increase, the same observation window is also the maximum quiet period before
+PoolAutoscaler re-evaluates scale-up. An owned Sandbox becoming Available triggers earlier
+re-evaluation. Window expiry is only a timer signal: it does not classify the scale-up or any Sandbox
+as failed.
 
 **Integration with Scaling Cooldowns**:
 
@@ -792,147 +822,224 @@ The observation window smooths raw lifecycle status. The direction-specific
 
 #### Lifecycle-Aware Scale-Up Flow Control
 
-Target growth and actual Sandbox creation have different safety requirements. Treating every fresh
-Pending Sandbox as a PoolAutoscaler blocker can starve growth under sustained demand: each Sandbox
-may become Available and be claimed immediately while its replacement keeps one creation slot
-continuously occupied. The design therefore separates two values:
+Target selection and target execution belong to different layers. PoolAutoscaler computes
+`policyDesired`; SandboxSet controller owns `maxUnavailable`, actual create concurrency, and
+execution progress. PoolAutoscaler therefore never resolves `maxUnavailable`, counts Pending
+Sandboxes, or derives target-growth headroom.
 
-```
-inFlightUnavailable = max(status.replicas - status.availableReplicas, 0)
-timedOutPending      = count(owned ResourcePending Sandboxes with age >= pendingTimeout)
-```
+For each SandboxSet generation, SandboxSet controller performs the following flow:
 
-`inFlightUnavailable` includes observed Creating Sandboxes and expectation-accounted `dirtyCreate`
-operations. SandboxSet uses it to limit actual create operations under `maxUnavailable` while
-converging toward the already declared `spec.replicas`.
-
-`timedOutPending` includes only observable Sandbox objects that have remained `ResourcePending`
-beyond the component-level timeout. It excludes fresh Pending Sandboxes, other Creating reasons,
-claimed Sandboxes, and `dirtyCreate`, which has no Sandbox object or `creationTimestamp` to inspect.
-PoolAutoscaler uses this value as an abnormal-creation budget when increasing the desired target.
-It computes the value directly from the owned Sandbox list and never parses the count from a
-Condition message.
-
-PoolAutoscaler first evaluates cron or capacity policy and clamps the result to `minReplicas` and
-`maxReplicas`. Every requested increase, including a cron target, passes through the same
-timed-out-Pending gate. Cron targets bypass the direction-specific cooldown and the consumption-
-progress gate because they express an explicit scheduled pool size rather than inferred demand.
-Bounds enforcement likewise remains independent of consumption progress.
-
-Before increasing `SandboxSet.spec.replicas`, PoolAutoscaler requires:
-
-1. `status.observedGeneration >= metadata.generation`, ensuring SandboxSet has observed the
-   previous desired size.
-2. Remaining abnormal-creation budget under `spec.scaleStrategy.maxUnavailable`.
-3. For a capacity-driven increase following another capacity-driven increase, at least one Sandbox
-   claim observed after the previous successful target update.
-
-The claim signal is derived without a new API field. A Sandbox update counts when the old object was
-controlled by the target SandboxSet and the new object has `agents.kruise.io/sandbox-claimed=true`
-and is no longer controlled by that SandboxSet. The controller records a monotonically increasing
-claim sequence per SandboxSet in memory. Immediately after a capacity-driven target update succeeds,
-it snapshots the current sequence as the baseline for the next scale-up. The next increase is
-admitted only when the current sequence exceeds the baseline. Sandbox deletion, readiness
-transition, and replenishment creation do not advance this sequence.
-
-```
-maxConcurrent  = resolve(spec.scaleStrategy.maxUnavailable,
-                         spec.replicas, default=1)
-timedOutPending = count(owned ResourcePending Sandboxes
-                        where now - creationTimestamp >= pendingTimeout)
-targetGrowthHeadroom = max(maxConcurrent - timedOutPending, 0)
-allowed          = min(policyDesired, spec.replicas + targetGrowthHeadroom)
-```
-
-`maxUnavailable` may be an absolute value or a percentage. A percentage is resolved against the
-current `spec.replicas` and rounded up; an absent, invalid, or less-than-one result falls back to
-one. SandboxSet and PoolAutoscaler use this same resolved value, including the default, for their
-respective creation-concurrency and abnormal-target-growth decisions. `allowed > spec.replicas`,
-rather than merely `allowed > 0`, means that the failure budget permits an increase. A capacity-
-driven increase is applied only when the consumption-progress gate is also open.
-
-For example, with `maxConcurrent=2` and one timed-out Pending Sandbox, `targetGrowthHeadroom=1`, so
-PoolAutoscaler may increase `spec.replicas` by one. When `timedOutPending` reaches two, target growth
-stops. This budget is recalculated after SandboxSet observes each target generation, so one persistent
-timed-out Sandbox still permits gradual growth when other Sandboxes are created successfully and
-claimed immediately.
-
-Fresh Pending Sandboxes do not consume `targetGrowthHeadroom`. They still consume
-`inFlightUnavailable`, so SandboxSet defers the corresponding physical creates whenever its actual
-creation concurrency reaches `maxUnavailable`. PoolAutoscaler may therefore build desired backlog
-without causing SandboxSet to exceed its creation concurrency, but only one bounded capacity-driven
-increment is admitted per observed claim. This prevents repeated reconciliation from growing an
-unused pool while preserving continued growth under claim-and-replenish traffic. The two lifecycle
-values must not be added, because timed-out Pending Sandboxes are already part of
-`inFlightUnavailable`.
-
-The first capacity-driven increase is admitted without prior claim progress. After that update, a
-new policy recommendation alone is insufficient: if no Sandbox has been claimed, the target stays
-unchanged even when sampling, cooldown, generation, and failure-budget checks pass. One claim opens
-the gate for one subsequent bounded increase, which records a new baseline and closes the gate
-again. The claim does not need to identify a Sandbox created by the immediately preceding increment;
-its purpose is to prove continued pool consumption after that target update.
-
-No progress token or pending target is persisted. Claim sequence and gate state are intentionally
-process-local; restart continuity is outside this proposal. The target patch uses optimistic locking,
-and normal reconciliation recalculates the desired value and retries after conflicts. Observation
-samples and cooldown state are also in memory.
-
-#### Pending Sandbox Timeout Observability
-
-A fresh Pending Sandbox consumes SandboxSet's actual creation budget but not PoolAutoscaler's
-abnormal-creation budget. This allows the desired pool to keep growing when Sandboxes become
-Available and are claimed immediately under sustained demand. Once a Pending Sandbox reaches the
-timeout, it contributes to `timedOutPending`; target growth slows by one slot for each such Sandbox
-and stops when `timedOutPending >= maxConcurrent`.
-
-SandboxSet reports the same timeout state through its existing `status.conditions` field. This adds
-no new CRD field and does not change deletion or replacement behavior. PoolAutoscaler calculates
-`timedOutPending` from Sandbox objects rather than parsing the Condition message.
-
-The timeout is configured once for the controller component rather than per SandboxSet:
-
-```
---sandboxset-pending-timeout=1m
-```
-
-The default is one minute. The controller checks only Sandboxes that are still owned by the
-SandboxSet and for which `GetSandboxState` returns `SandboxStateCreating` with reason
-`ResourcePending`. Other Creating reasons, Dead reasons such as `ResourceFailed`, and claimed
-Sandboxes are outside this timeout signal.
-
-Pending duration is measured from the Sandbox `creationTimestamp`. If at least one Sandbox exceeds
-the timeout, SandboxSet publishes:
+1. Observe the new desired target and set `ScaleUpReady=False` with reason `WaitingForAvailable`.
+2. Continue creating toward `spec.replicas` while `createHeadroom > 0`.
+3. When `inFlightUnavailable >= maxConcurrent`, stop issuing create requests and set reason
+   `MaxUnavailableReached`. This is normal flow control, not a failure.
+4. When any owned Sandbox transitions from Creating to Available, set `ScaleUpReady=True` with reason
+   `AvailableProgressObserved` for that generation. This `True` result is sticky for the generation;
+   immediately refilling the released create slot and reaching `maxUnavailable` again does not erase
+   the observed progress. When no scale-up is outstanding, publish `ScaleUpReady=True` with reason
+   `Reconciled`.
+5. Independently aggregate existing Sandbox startup-failure reasons and publish
+   `ScalingLimited=True/StartupBlocked` when at least one owned Sandbox reports one of them or exceeds
+   the Pending startup timeout. SandboxSet may continue reconciling the already-declared target within
+   `maxUnavailable`, but the condition prevents PoolAutoscaler from raising the target again until all
+   blockers clear.
 
 ```yaml
 status:
   conditions:
-    - type: Degraded
-      status: "True"
-      reason: ResourcePendingTimeout
-      message: "2 Sandboxes have remained ResourcePending longer than 1m; oldest is sandbox-xxx"
-```
-
-When no owned Sandbox exceeds the timeout, the condition is cleared semantically:
-
-```yaml
-status:
-  conditions:
-    - type: Degraded
+    - type: ScaleUpReady
       status: "False"
-      reason: ResourcePendingResolved
-      message: "No Sandbox exceeds the ResourcePending timeout"
+      reason: MaxUnavailableReached
+      observedGeneration: 12
+      message: "Waiting for in-flight Sandboxes to become Available"
 ```
 
-`LastTransitionTime` changes only when the condition status changes. `ObservedGeneration` is set to
-the current SandboxSet generation. The message contains the total timed-out count and the oldest
-Sandbox name, but no UID list is persisted. A Warning event is emitted only when the condition
-transitions to `True`, avoiding an event on every reconciliation.
+After progress:
 
-A Pending Sandbox may produce no watch event at the deadline. The controller must therefore compute
-the earliest remaining timeout among owned `ResourcePending` Sandboxes and set `RequeueAfter` to
-that deadline. Because timeout state is derived from `creationTimestamp`, it is reconstructed after a
-controller restart without additional persistent state.
+```yaml
+status:
+  conditions:
+    - type: ScaleUpReady
+      status: "True"
+      reason: AvailableProgressObserved
+      observedGeneration: 12
+      message: "Available progress was observed for the current scale-up generation"
+```
+
+`LastTransitionTime` changes only when condition status changes. `reason` and `message` are for
+observability; PoolAutoscaler does not parse them. Its admission check uses only condition type,
+status, and `observedGeneration`.
+
+##### Component Interaction State Machine
+
+```mermaid
+flowchart TD
+    subgraph PA["PoolAutoscaler"]
+        PA_Evaluate["Evaluating<br/>Compute policyDesired"]
+        PA_WaitGeneration["WaitingForGeneration"]
+        PA_WaitProgress["WaitingForProgress"]
+        PA_WaitLimited["WaitingForScalingRecovery"]
+        PA_Update["UpdateTarget<br/>Patch spec.replicas"]
+        PA_Keep["KeepCurrentTarget"]
+    end
+
+    subgraph SS["SandboxSet Controller"]
+        SS_Reconciled["Reconciled<br/>ScaleUpReady=True"]
+        SS_NewGeneration["NewGenerationObserved<br/>ScaleUpReady=False<br/>WaitingForAvailable"]
+        SS_Creating["Creating<br/>Apply createHeadroom"]
+        SS_Limited["CreationLimited<br/>ScaleUpReady=False<br/>MaxUnavailableReached"]
+        SS_Blocked["StartupBlocked<br/>ScalingLimited=True"]
+        SS_Progress["ProgressObserved<br/>ScaleUpReady=True<br/>AvailableProgressObserved"]
+    end
+
+    subgraph SB["Sandbox Controller / Sandbox"]
+        SB_Pending["Creating / Pending"]
+        SB_Available["Available"]
+        SB_Claimed["Claimed<br/>Leaves warm pool"]
+    end
+
+    PA_Evaluate -->|"policyDesired <= spec.replicas"| PA_Keep
+    PA_Evaluate -->|"generation not observed"| PA_WaitGeneration
+    PA_Evaluate -->|"ScalingLimited is not current False"| PA_WaitLimited
+    PA_Evaluate -->|"ScaleUpReady=False"| PA_WaitProgress
+    PA_Evaluate -->|"both gates open and desired is larger"| PA_Update
+
+    PA_Update -->|"new target generation"| SS_NewGeneration
+    SS_NewGeneration --> SS_Creating
+    SS_Creating -->|"create Sandbox"| SB_Pending
+    SS_Creating -->|"inFlightUnavailable >= maxConcurrent"| SS_Limited
+
+    SB_Pending -->|"Creating to Available"| SB_Available
+    SB_Pending -->|"existing Sandbox failure reason or Pending timeout"| SS_Blocked
+    SB_Available -->|"record progress for generation"| SS_Progress
+    SB_Available -->|"may be claimed immediately"| SB_Claimed
+
+    SS_Progress -->|"condition update event"| PA_Evaluate
+    SS_Progress -->|"current target eventually reconciles"| SS_Reconciled
+    SS_Reconciled -->|"condition update event"| PA_Evaluate
+
+    PA_WaitGeneration -->|"observedGeneration updated"| PA_Evaluate
+    PA_WaitLimited -->|"ScalingLimited=False"| PA_Evaluate
+    PA_WaitProgress -->|"Available progress event"| PA_Evaluate
+    PA_WaitProgress -->|"observation window expires"| PA_Evaluate
+
+    SS_Limited -->|"Sandbox becomes Available"| SS_Progress
+    SS_Limited -->|"no Available progress"| SS_Limited
+    SS_Blocked -->|"blocker clears"| SS_Creating
+    SS_Blocked -->|"condition update event"| PA_WaitLimited
+```
+
+The key handshake is per SandboxSet generation:
+
+```text
+PoolAutoscaler updates target
+→ SandboxSet observes the generation and sets ScaleUpReady=False
+→ SandboxSet creates within maxUnavailable
+→ one Sandbox becomes Available
+→ SandboxSet sets ScaleUpReady=True for that generation
+→ PoolAutoscaler may evaluate the next capacity-driven increase
+```
+
+An observation-window expiry returns PoolAutoscaler to `Evaluating`, but it does not change
+`ScaleUpReady` or clear `ScalingLimited`; therefore it cannot bypass a stalled or explicitly blocked
+execution layer. A Sandbox that is claimed immediately follows the `Available` transition first, so
+the progress signal is preserved.
+
+Before a capacity-driven increase, PoolAutoscaler requires:
+
+1. `SandboxSet.status.observedGeneration >= SandboxSet.metadata.generation`.
+2. `ScalingLimited=False` for the current SandboxSet generation.
+3. `ScaleUpReady=True` for the current SandboxSet generation.
+4. A freshly recomputed Capacity recommendation greater than current `spec.replicas`.
+5. The scale-up cooldown, when configured, to have elapsed.
+
+The initial bounds-enforcement action may bootstrap `minReplicas` without prior Available progress or
+prior `ScalingLimited=False`, so an empty pool can establish observable startup state. Cron targets
+represent explicit scheduled intent and bypass the Available-progress wait and capacity cooldown, but
+not `ScalingLimited=True`; SandboxSet always applies its physical creation limit. Capacity-driven
+increases use both aggregate conditions.
+
+After PoolAutoscaler updates the target, it waits until an Available transition, a condition change,
+or the observation window requests another reconciliation. It then reads fresh SandboxSet status and
+recomputes the Capacity recommendation. Window expiry does not open either gate by itself: if
+`ScaleUpReady` remains `False` or current-generation `ScalingLimited=False` is not present,
+PoolAutoscaler keeps the target unchanged. If progress is observed but available capacity has already
+recovered, the fresh recommendation also keeps the target unchanged.
+
+This separates two cases without tracking claims:
+
+- Sustained demand: a Sandbox may become Available and be claimed immediately; the transition opens
+  the execution handshake even if net `availableReplicas` remains unchanged.
+- No demand: newly created Sandboxes remain Available, so the current sample recovers toward the
+  configured watermark and CapacityPolicy stops recommending further growth.
+
+No failure budget, claim sequence, pending target, or persisted blocker counter is introduced.
+Pending age is evaluated only by SandboxSet for the aggregate `ScalingLimited` condition;
+PoolAutoscaler never calculates a timed-out Pending count. Controller restart may lose an unpersisted
+Available transition before the condition update; the conservative result is to wait for later
+progress rather than over-scale. The target patch continues to use optimistic locking and is
+recalculated after conflicts.
+
+#### SandboxSet Scale-Up Readiness
+
+`ScaleUpReady` describes whether the execution layer has demonstrated progress for the current
+generation. It does not declare success or failure of individual Sandboxes. In particular, reaching
+`maxUnavailable` or waiting longer than one observation window is not a failure condition.
+
+SandboxSet continues reconciling and refreshing the condition whenever Sandbox lifecycle events,
+expectation observations, or target-generation changes occur. When no watch event arrives,
+PoolAutoscaler's observation-window requeue provides periodic re-evaluation, but it does not classify
+startup timeout or clear either condition.
+
+The condition uses the existing `SandboxSet.status.conditions` field, so no new status counter is
+required. Operators can observe a long-lived `ScaleUpReady=False` and its `LastTransitionTime`, while
+automation relies on the structured condition fields rather than parsing the human-readable message.
+
+#### SandboxSet Scaling Limitation
+
+`ScalingLimited` is an orthogonal, current-state condition. It reports that one or more owned
+Sandboxes cannot currently complete startup; unlike `ScaleUpReady`, it is not a sticky progress
+record. SandboxSet derives it only from existing owned Sandbox state and does not watch or interpret
+Pod lifecycle directly. This version recognizes only failure reasons already published by the
+Sandbox controller:
+
+- `Timeout`: an owned Sandbox remains `ResourcePending` longer than the controller-wide
+  `--sandboxset-pending-timeout`, which defaults to one minute.
+- `Failed`: an owned Sandbox already reports a startup failure through its existing `Ready=False`
+  condition. Current `PodCreateFailed` and `StartContainerFailed` reasons both contribute to this one
+  aggregate category; SandboxSet does not expose separate counts for them.
+
+This design does not change Sandbox controller behavior and does not add `PodUnschedulable`,
+`ContainerStartupBlocked`, a Pod waiting-reason allowlist, or any other Sandbox condition reason.
+SandboxSet consumes existing startup-failure reasons exactly as they are currently published, but
+maps all of them to the single aggregate category `Failed`. States not already classified as failures
+by Sandbox controller remain ordinary Creating/Pending states and are reported only after the Pending
+timeout. Terminal Sandbox handling remains unchanged and is not reimplemented by this condition.
+
+When one or more blockers exist, SandboxSet publishes:
+
+```yaml
+status:
+  conditions:
+    - type: ScalingLimited
+      status: "True"
+      reason: StartupBlocked
+      observedGeneration: 12
+      message: "3 Sandboxes are blocked from starting: Timeout=2, Failed=1"
+```
+
+When all blockers clear, it publishes `ScalingLimited=False/ScalingAllowed`. Counts and a bounded
+summary of reasons belong only in `message`, Events, logs, and metrics; no UID list or counter is
+added to the API. `LastTransitionTime` changes only when status changes. The earliest incomplete
+Pending deadline supplies `RequeueAfter`, so timeout detection works without Pod events and is
+reconstructed from `creationTimestamp` after restart. A Warning Event is emitted only on transition
+to `True`.
+
+`ScalingLimited=True` does not delete or replace Sandboxes and does not stop SandboxSet from
+reconciling its already-declared target within `maxUnavailable`. It only prevents PoolAutoscaler from
+publishing another scale-up target. Scale-down remains allowed. Capacity and Cron scale-up both honor
+this condition; the initial `minReplicas` bootstrap may still establish the first target so startup
+state can be observed.
 
 #### Cron Policy Maintenance Window Support
 
@@ -1043,8 +1150,9 @@ scaling operations. This can occur due to:
     - Check for logical inconsistencies such as `minReplicas > maxReplicas`
     - Require `minReplicas >= 1` for percentage capacity targets
 - *Explicit Policy Precedence*: Triggered cron targets take precedence when cron and capacity policies coexist
-- *Separated Lifecycle Limits*: Let SandboxSet use `inFlightUnavailable`, including `dirtyCreate`, to constrain actual creation concurrency; let PoolAutoscaler use `timedOutPending` to reduce target-growth headroom without blocking healthy high-throughput replenishment
-- *Consumption Progress Gate*: After the first capacity-driven increase, require a subsequent claim before admitting another increase, preventing stale low-availability samples from repeatedly growing an unused pool
+- *Separated Responsibilities*: Let SandboxSet resolve `maxUnavailable`, account for `dirtyCreate`, limit actual create concurrency, and publish `ScaleUpReady` plus `ScalingLimited`; let PoolAutoscaler consume only those aggregate conditions
+- *Progress-Gated Capacity Scaling*: Require Available progress for the current SandboxSet generation before another capacity-driven target increase, and use the observation window only to schedule re-evaluation
+- *Blocked-Startup Gate*: Aggregate all existing Sandbox startup-failure reasons into one `Failed` category immediately, and inconclusive Pending stalls after the one-minute controller timeout; block further target growth without introducing new Sandbox failure types
 - *Reasonable Default Values*: Provide sensible defaults that prevent extreme behavior:
     - Default stabilization windows and cooldown periods
     - Default tolerance values that prevent over-reaction
@@ -1250,17 +1358,20 @@ the CRD definition and the controller implementation.
 - Test stabilization window logic for scale-up and scale-down
 - Test tolerance calculation and application
 - Test bounds enforcement (minReplicas, maxReplicas)
-- Test SandboxSet creation concurrency uses `inFlightUnavailable`, including expectation-accounted `dirtyCreate`
-- Test PoolAutoscaler target growth uses `timedOutPending` and excludes fresh Pending and `dirtyCreate`
-- Test `timedOutPending < maxUnavailable` permits only the remaining failure headroom and equality blocks target growth
-- Test sustained claim-and-replenish traffic can grow the desired pool while fresh Pending Sandboxes remain
-- Test the first capacity-driven increase needs no prior claim, while the next increase is blocked until a claim is observed
-- Test each observed claim admits at most one subsequent bounded capacity-driven increase
-- Test readiness transitions, deletions, and replenishment creates do not satisfy the consumption-progress gate
-- Test cron targets and bounds enforcement bypass the consumption-progress gate but retain lifecycle safety checks
-- Test Pending timeout condition filtering by `ResourcePending`, default one-minute deadline, and recovery
-- Test timeout-driven requeue and transition-only Warning events
-- Test in-memory sampling, cooldown, and claim-gate state behavior within one controller process
+- Test SandboxSet resolves `maxUnavailable` and limits creation with `inFlightUnavailable`, including expectation-accounted `dirtyCreate`
+- Test percentage `maxUnavailable` uses observed pool size as the execution base, not a newly enlarged desired target
+- Test `ScaleUpReady=False` while waiting for Available progress and when `maxUnavailable` is reached
+- Test a Creating-to-Available transition sets `ScaleUpReady=True` for the current generation
+- Test an immediately claimed Sandbox still records Available progress even when net `availableReplicas` does not increase
+- Test `ScalingLimited=True/StartupBlocked` aggregation into exactly two categories: `Failed` for all existing Sandbox startup-failure reasons and `Timeout` for Pending beyond the deadline
+- Test other Creating/Pending states remain unclassified before the timeout and the condition clears when all blockers resolve
+- Test timeout requeue, restart reconstruction from `creationTimestamp`, aggregate reason messages, and transition-only Warning Events
+- Test PoolAutoscaler does not inspect `maxUnavailable`, Pending counts, Pod status, or Sandbox objects, and SandboxSet does not interpret Pod lifecycle directly
+- Test Capacity scale-up requires current-generation `ScaleUpReady=True`, current-generation `ScalingLimited=False`, and a freshly recomputed recommendation
+- Test Capacity and Cron scale-up stop while `ScalingLimited` is True, Unknown, missing, or stale, while scale-down and initial `minReplicas` bootstrap retain their defined behavior
+- Test observation-window expiry re-evaluates scale-up but does not mark failure, bypass `ScaleUpReady=False`, or clear `ScalingLimited=True`
+- Test Cron targets bypass Available-progress waiting and cooldown but require current-generation `ScalingLimited=False`; test that initial bounds bootstrap can establish `minReplicas` while SandboxSet retains physical creation limits
+- Test in-memory sampling, cooldown, and Available-transition observation within one controller process
 - Test PoolAutoscaler ignores claimed Sandboxes after they leave the warm pool
 
 **Reconciliation Tests**:
@@ -1312,4 +1423,5 @@ the CRD definition and the controller implementation.
 
 - [x] 06/01/2026: Initial proposal draft created
 - [x] 26/08/2026: Lifecycle-aware scale-up design refined to reuse existing API status and in-memory sampling
-- [x] 27/08/2026: Separated actual creation concurrency from timed-out-Pending target-growth control
+- [x] 27/08/2026: Separated PoolAutoscaler target decisions from SandboxSet creation control through an Available-progress handshake
+- [x] 27/08/2026: Added the orthogonal `ScalingLimited` condition with `Failed` and `Timeout` aggregate categories

--- a/docs/proposals/20260106-sandboxset-autoscaler.md
+++ b/docs/proposals/20260106-sandboxset-autoscaler.md
@@ -5,7 +5,7 @@ authors:
 reviewers:
   - "@furykerry"
 creation-date: 2026-01-06
-last-updated: 2026-01-15
+last-updated: 2026-08-26
 status: implementable
 see-also:
 replaces:
@@ -34,6 +34,7 @@ superseded-by:
                     - [Cron-based Policy](#cron-based-policy)
                     - [Capacity Availability Policy](#capacity-availability-policy)
                 - [Status](#Status)
+                - [SandboxSet Lifecycle Status and Scale Safety](#sandboxset-lifecycle-status-and-scale-safety)
             - [Metrics](#Metrics)
                 - [Reconciliation Metrics](#reconciliation-metrics)
             - [User Configuration Examples](#user-configuration-examples)
@@ -43,8 +44,10 @@ superseded-by:
                     - [Absolute Value Watermark Configuration](#absolute-value-watermark-configuration)
                     - [Percentage-Based Watermark Configuration](#percentage-based-watermark-configuration)
         - [Implementation Details/Notes/Constraints](#implementation-detailsnotesconstraints)
-            - [Policy Combination Limitations](#policy-combination-limitations)
+            - [Policy Combination and Precedence](#policy-combination-and-precedence)
             - [Observation Window and Sampling Configuration](#observation-window-and-sampling-configuration)
+            - [Lifecycle-Aware Scale-Up Flow Control](#lifecycle-aware-scale-up-flow-control)
+            - [Sandbox Creation Failure Handling](#sandbox-creation-failure-handling)
             - [Cron Policy Maintenance Window Support](#cron-policy-maintenance-window-support)
             - [One-to-One Relationship Between Warm Pool and Autoscaler](#one-to-one-relationship-between-warm-pool-and-autoscaler)
         - [Risks and Mitigations](#risks-and-mitigations)
@@ -87,7 +90,9 @@ This enhancement adds two complementary autoscaling policy types:
 ensuring sufficient idle capacity while preventing over-provisioning
 
 The autoscaler integrates seamlessly with `SandboxSet`, providing operators with fine-grained
-control over resource pool capacity while reducing operational overhead. This enhancement addresses
+control over resource pool capacity while reducing operational overhead. Scale-up is coordinated
+with observed Sandbox creation progress, and SandboxSet applies timeout and failure circuit-breaker
+protection so unavailable infrastructure cannot cause unbounded creation attempts. This enhancement addresses
 critical requirements for latency-sensitive agent workloads that require predictable startup performance
 and efficient resource utilization.
 
@@ -146,8 +151,7 @@ Cluster-level node scaling is handled by the cluster autoscaler and is out of sc
 that could conflict with `SandboxSet` scaling policies. This proposal does not address coordination
 between HPA and `PoolAutoscaler` for now and will be extended in the future based on usage scenarios
 and user feedback.
-- **Multi-policy combination**: Currently, cron-based and capacity-based policies cannot be used simultaneously.
-Future enhancements may support policy composition with clear precedence rules.
+- **Policy precedence**: Capacity and cron policies may coexist. A cron policy that triggers for the current schedule takes precedence over the capacity recommendation.
 - **Maintenance window support**: Cron-based policies do not currently support maintenance window configuration.
 This will be added based on user requirements and feedback.
 
@@ -197,8 +201,7 @@ The API is designed following Kubernetes best practices, with clear separation b
 **Key Design Principles**:
 - **One autoscaler per target**: Each `SandboxSet` can be managed by at most one `PoolAutoscaler`
 to prevent conflicts
-- **Policy exclusivity**: Cron-based and capacity-based policies are mutually exclusive
-to ensure predictable behavior
+- **Policy precedence**: When cron and capacity policies coexist, a cron policy triggered for the current schedule overrides the capacity recommendation
 - **Bounds enforcement**: All scaling operations respect `minReplicas` and `maxReplicas` constraints
 - **Status transparency**: Rich status information enables observability and debugging
 
@@ -234,7 +237,7 @@ type PoolAutoscalerSpec struct {
 	// MinReplicas is the lower limit for the number of replicas to which the autoscaler
 	// can scale down.
 	// It defaults to 0 pods.
-	MinReplicas *int32
+	MinReplicas int32
 
 	// CronPolicies is a list of potential cron scaling policies which can be used during scaling.
 	// +optional
@@ -244,10 +247,10 @@ type PoolAutoscalerSpec struct {
 	// +optional
 	CapacityPolicy *CapacityPolicy
 
-	// This flag tells the controller to suspend subsequent executions
+	// Suspend tells the controller to suspend subsequent executions.
 	// Defaults to false.
 	// +optional
-	Suspend bool
+	Suspend *bool
 }
 
 // CronScalingPolicy defines the cron-based scaling configuration for the resource pool.
@@ -277,12 +280,14 @@ type CronScalingPolicy struct {
 	Schedule string
 	// TargetReplicas is the desired replicas.
 	// +required
-	TargetReplicas *int32
+	TargetReplicas int32
 }
 
 // CapacityPolicy defines the capacity configuration of the target resource pool.
 type CapacityPolicy struct {
 	// TargetAvailable is the desired available replicas.
+	// It can be an absolute number or a percentage of the observed unclaimed
+	// and used capacity. Percentage targets require minReplicas >= 1.
 	// +required
 	TargetAvailable intstr.IntOrString
 	// Tolerance is the tolerance between the watermark and desired
@@ -300,12 +305,12 @@ type CapacityPolicy struct {
 }
 
 type CapacityScalingRules struct {
-	// StabilizationWindowSeconds is the number of seconds for which past recommendations should be
-	// considered while scaling up or scaling down.
+	// StabilizationWindowSeconds is the cooldown period after any scale action before
+	// a scale in this direction is allowed.
 	// StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
 	// If not set, use the default values:
-	// - For scale up: 0 (i.e. no stabilization is done).
-	// - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+	// - For scale up: 0 (i.e. no cooldown is applied).
+	// - For scale down: 300 (i.e. the cooldown is 300 seconds long).
 	// +optional
 	StabilizationWindowSeconds *int32
 }
@@ -323,25 +328,50 @@ type PoolAutoscalerStatus struct {
 
 	// CurrentReplicas is current number of replicas of pods managed by this autoscaler,
 	// as last seen by the autoscaler.
+	// It is optional in the CRD schema so target progress can be persisted before
+	// the first complete status snapshot.
+	// +optional
 	CurrentReplicas int32
 
 	// DesiredReplicas is the desired number of replicas of pods managed by this autoscaler,
 	// as last calculated by the autoscaler.
+	// It is optional in the CRD schema so target progress can be persisted before
+	// the first complete status snapshot.
+	// +optional
 	DesiredReplicas int32
-	// This flag tells the controller to suspend subsequent executions
+
+	// Suspended indicates whether the autoscaler is currently suspended.
 	// Defaults to false.
 	// +optional
 	Suspended bool
-	// Policy execution status.
+
+	// AppliedCronPolicies is the execution status of cron policies.
+	// +optional
 	AppliedCronPolicies []CronScalingPolicyStatus
+
 	// CurrentCapacity is the last read state of the capacity used by this autoscaler.
-	// +listType=atomic
 	// +optional
 	CurrentCapacity CapacityStatus
 
+	// ObservedAvailableTransitionCount is the target SandboxSet availability
+	// progress already consumed by scale-up flow control.
+	// +optional
+	ObservedAvailableTransitionCount int64
+
+	// ObservedScaleTargetUID associates progress and reservations with one
+	// concrete SandboxSet instance, including delete-and-recreate scenarios.
+	// +optional
+	ObservedScaleTargetUID types.UID
+
+	// ReservedReplicas is a durable scale-up target reserved before patching
+	// SandboxSet.spec.replicas.
+	// +optional
+	ReservedReplicas *int32
+
 	// Conditions is the set of conditions required for this autoscaler to scale its target,
 	// and indicates whether those conditions are met.
-	Conditions []PoolAutoscalerCondition
+	// +optional
+	Conditions []metav1.Condition
 }
 
 type CronScalingPolicyStatus struct {
@@ -430,11 +460,13 @@ that the cluster maintains a safe level of available resources.
 
 | Field                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                            | Use Cases                                                                                                                                                                                                                                                                                                                                                                                                                    | Validation                                                                                                                                                                                                                           |
 |--------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **stabilizationWindowSeconds** | The number of seconds for which past recommendations should be considered while scaling up or scaling down. This creates a stabilization window that prevents flapping by choosing the safest value from recent recommendations instead of applying the latest recommendation immediately. For scale-up, it selects the minimum recommendation from the window. For scale-down, it selects the maximum recommendation from the window. | 1. *Prevent flapping*: Smooth the scaling by using a stabilization window to avoid rapid scaling oscillations.<br/>2. *Conservative scale-down*: Use longer stabilization windows for scale-down to prevent premature reduction during temporary decrease in the rate of resource consumption.<br/>3. *Aggressive scale-up*: Use shorter or zero stabilization windows for scale-up to respond quickly to traffic increases. | 1. *Optional field*: Can be omitted. If not specified, uses the default values:<br/> - For scale up: 0 (no stabilization).<br/> - For scale-down: 300 seconds (5min).<br/> 2. *Range validation*: must be >= 0 and <= 3600 (1 hour). |
+| **stabilizationWindowSeconds** | Cooldown period for a scaling direction. The first scaling action is immediate; after any scale action, a subsequent action in this direction must wait until the configured period has elapsed. | 1. *Prevent flapping*: Delay repeated or opposite-direction scaling after a recent action.<br/>2. *Conservative scale-down*: Use a longer scale-down cooldown to avoid premature reduction.<br/>3. *Responsive scale-up*: Use zero or a short scale-up cooldown. | 1. *Optional field*: defaults to 0 seconds for scale-up and 300 seconds for scale-down.<br/>2. *Range*: 0 through 3600 seconds. |
 
-Available capacity can be configured using absolute values or percentage.
-The percentage is defined relative to the current replica count of the resource pool,
-enabling proportional scaling that adapts to pool size changes.
+Available capacity can be configured using an absolute value or a percentage.
+For percentage policies, the base is the observed unclaimed pool capacity plus claimed
+running or paused sandboxes (`avgReplicas + avgUsed`). This keeps claimed demand in the
+calculation even though `SandboxSet.spec.replicas` continues to represent only unclaimed
+creating and available capacity.
 
 ##### Status
 
@@ -447,7 +479,45 @@ enabling proportional scaling that adapts to pool size changes.
 | **suspended**           | Whether the autoscaler controller has suspend subsequent policy executions. When `true`, the controller will not sync the policy. when `false`, the policy synced normally.                                                                                                                                                |
 | **appliedCronPolicies** | Cron policy execution status.                                                                                                                                                                                                                                                                                              |
 | **currentCapacity**     | The current number of available capacity managed by this autoscaler, as last seen by the autoscaler. This represents the actual current available capacity of the target warming pool that the autoscaler is managing.                                                                                                     |
-| **condition**           | The set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met. This is an array of PoolAutoscalerCondition objects, each representing a specific condition type with its status, reason and message.                                                       |
+| **observedAvailableTransitionCount** | The cumulative SandboxSet availability progress already consumed by scale-up flow control. |
+| **observedScaleTargetUID** | The UID of the concrete SandboxSet instance associated with progress and any pending reservation. A UID change resets stale progress. |
+| **reservedReplicas** | A durable pending scale-up target recorded before patching the SandboxSet, allowing an idempotent retry if the target patch or final status update fails. |
+| **conditions**          | The set of conditions required for this autoscaler to scale its target, including whether scaling is active, possible, or limited. |
+
+`currentReplicas` and `desiredReplicas` are optional in the CRD schema. This permits the
+controller to persist target identity and progress during the first reconciliation before a
+complete status snapshot exists.
+
+##### SandboxSet Lifecycle Status and Scale Safety
+
+`SandboxSet.spec.replicas` remains the desired number of **unclaimed** sandboxes. Claimed
+sandboxes no longer count toward that desired pool size, but the controller continues to
+observe their source pool identity for capacity accounting and successful creation progress.
+
+The following `SandboxSet` fields provide protocol-neutral lifecycle signals to the autoscaler:
+
+| Field | Description |
+|-------|-------------|
+| `spec.scaleStrategy.maxUnavailable` | Maximum concurrent unavailable capacity allowed during scale-up. It also defines the default scale-up credit available to PoolAutoscaler; the effective minimum is one. |
+| `spec.scaleStrategy.maxFailureThreshold` | Consecutive failed creation attempts that open the scale-up circuit breaker. Defaults to 3; 0 disables the breaker. |
+| `spec.scaleStrategy.creatingTimeout` | Maximum time a Sandbox may remain Creating before it is treated as stuck. Defaults to 10 minutes. |
+| `status.creatingReplicas` | Unclaimed Sandboxes still being created, including create operations not yet observed by the informer. |
+| `status.usedReplicas` | Claimed Running or Paused Sandboxes attributed to this SandboxSet. |
+| `status.availableTransitionCount` | Cumulative count of distinct Sandboxes that reached a usable state, including Sandboxes claimed before a periodic availability sample. |
+| `status.availabilityTrackingInitialized` | Indicates that the durable usable-Sandbox UID checkpoint has been initialized. |
+| `status.observedUsableSandboxUIDs` | UID checkpoint used to recover availability-transition accounting after controller restart. |
+| `status.failedReplicas` | Consecutive creation failures currently counted by the circuit breaker. |
+| `status.failedSandboxUIDs` | UID checkpoint that prevents duplicate failure accounting across reconciliation and restart. |
+| `status.lastFailureTime` | Time of the latest newly observed creation failure, used to schedule a half-open retry. |
+| `status.conditions[type=ScaleUpLimited]` | Reports whether SandboxSet scale-up is blocked by the failure circuit breaker. |
+
+When a Sandbox is claimed, its SandboxSet owner reference is removed so the pool can
+replenish unclaimed capacity. Before removal, the claim path preserves both the source pool
+name and UID in internal labels. The SandboxSet controller observes only claimed Running or
+Paused Sandboxes through those labels; they contribute to `usedReplicas` and availability
+progress, but never to pool replica counts, garbage collection, failure accounting, or rolling
+updates. The source UID prevents a newly created SandboxSet with the same name from adopting
+historical state.
 
 #### Metrics
 
@@ -491,6 +561,20 @@ Metrics follow Prometheus conventions and are compatible with standard Kubernete
 - Identify slow reconciliations
 - Track performance degradation
 - Set SLOs for reconciliation latency
+
+`sandboxset_sandboxes_failed_total`
+
+**Type**: Counter
+
+**Description**: Cumulative number of distinct Sandbox creation failures observed for a
+SandboxSet. Failures are deduplicated by Sandbox UID.
+
+`sandboxset_scale_up_limited`
+
+**Type**: Gauge
+
+**Description**: Whether SandboxSet scale-up is blocked by the failure circuit breaker
+(`1` for blocked, `0` for allowed).
 
 #### User Configuration Examples
 
@@ -587,91 +671,59 @@ spec:
     - When available resources exceed 15, the autoscaler scales down to optimize resource usage
 - **Dead Zone**: Between 5 and 15, no scaling occurs (prevents oscillation)
 
-**Scaling Behavior Timeline**:
+**Mixed Configuration (Absolute Target with Percentage Tolerance)**:
 
-| Time | Event              | Replica Count | Available Resources | Used Resources | Autoscaler Decision Logic                                                                                               |
-|------|--------------------|---------------|---------------------|----------------|-------------------------------------------------------------------------------------------------------------------------|
-| t0   | Initial State      | 1             | 1                   | 0              | No Action: Available (1) is within dead zone [5, 15]                                                                    |
-| t1   | Autoscaler Sync    | 10            | 10                  | 0              | **Scale Up**: Available (1) < Lower Watermark (5). Target: 10 available → Scale to 10 replicas                          |
-| t2   | Resources Consumed | 10            | 0                   | 10             | No Action: Autoscaler not yet synchronized                                                                              |
-| t3   | Autoscaler Sync    | 20            | 10                  | 10             | **Scale Up**: Available (0) < Lower Watermark (5). Target: 10 available → Scale to 20 replicas (10 used + 10 available) |
-| t4   | Resources Consumed | 20            | 0                   | 20             | No Action: Autoscaler not yet synchronized                                                                              |
-| t5   | Autoscaler Sync    | 30            | 10                  | 20             | **Scale Up**: Available (0) < Lower Watermark (5). Target: 10 available → Scale to 30 replicas (20 used + 10 available) |
-| t6   | Resources Released | 30            | 30                  | 0              | No Action: Autoscaler not yet synchronized                                                                              |
-| t7   | Autoscaler Sync    | 10            | 10                  | 0              | **Scale Down**: Available (30) > Upper Watermark (15). Target: 10 available → Scale to 10 replicas                      |
+When `targetAvailable` is an absolute number and `tolerance` is a percentage
+(including the default `10%`), the percentage tolerance is resolved against the
+resolved target, not the pool size:
 
-**Detailed Timeline Explanation**:
-
-**t0 - Initial State**: The resource pool starts with 1 replica,
-all of which are available. The autoscaler evaluates the current state: available resources (1)
-are below the lower watermark (5), but since this is the initial state
-and the autoscaler hasn't synchronized yet, no action is taken immediately.
-
-**t1 - First Autoscaler Sync**: The autoscaler synchronizes and detects
-that available resources (1) are below the lower watermark threshold (5).
-It calculates the required replica count to maintain the target available capacity (10).
-Since there are no used resources, it scales the pool to 10 replicas,
-achieving the target of 10 available resources.
-
-**t2 - Resource Consumption**: All 10 idle resources are consumed by workloads.
-The autoscaler has not yet synchronized, so no scaling action occurs.
-The system now has 10 replicas in use and 0 available.
-
-**t3 - Second Autoscaler Sync**: The autoscaler synchronizes and detects
-that available resources (0) are below the lower watermark (5).
-To restore the target available capacity (10) while maintaining the 10 currently used resources,
-it scales up to 20 replicas (10 used + 10 available).
-
-**t4 - Continued Resource Consumption**: Another 10 idle resources are consumed.
-The autoscaler has not yet synchronized, so no scaling action occurs.
-The system now has 20 replicas in use and 0 available.
-
-**t5 - Third Autoscaler Sync**: The autoscaler synchronizes
-and detects that available resources (0) are still below the lower watermark (5).
-To restore the target available capacity (10) while maintaining the 20 currently used resources,
-it scales up to 30 replicas (20 used + 10 available).
-
-**t6 - Resource Release**: All 30 previously used resources are released back to the resource pool.
-The system now has 30 available resources and 0 used resources.
-The autoscaler has not yet synchronized, so no scaling action occurs.
-
-**t7 - Scale-Down Sync**: The autoscaler synchronizes and detects
-that available resources (30) exceed the upper watermark (15).
-To optimize resource usage while maintaining the target available capacity (10),
-it scales down to 10 replicas, resulting in 10 available resources.
-
-**Visual Representation**:
 ```
-30 |                       ●    ●○
-   |
-20 |
-   |
-15 |              ●   ●        ───── Upper Watermark
-   |
-   |
-10 |   ●○    ●    ○        ○         ●○  ───── Target Available
-   |
-   |
- 5 |         ───── Lower Watermark
-   |
-   |●○
- 0 |         ○         ○
-   +----+----+----+----+----+----+----+----+----+----+
-   t0   t1   t2   t3   t4   t5   t6   t7
-
-Legend:
-● = Replica Count
-○ = Available Resources
+target = targetAvailable                    (e.g. 5)
+tol    = ceil(target * tolerancePercent / 100)   (e.g. ceil(5 * 10 / 100) = 1)
+lower  = max(target - tol, 0)               (e.g. 4)
+upper  = target + tol                       (e.g. 6)
 ```
+
+Anchoring the percentage tolerance to the target keeps the dead zone
+proportional to the configured capacity target. Anchoring it to the pool size
+instead would widen the dead zone as the pool grows and, whenever the resolved
+tolerance exceeded the target, clamp the lower watermark to 0 and make the
+scale-up condition unreachable.
+
+**Scaling Examples**:
+
+- With one unclaimed and available Sandbox, `targetAvailable=10`, and `tolerance=5`,
+  available capacity is below the lower watermark. The policy recommendation is
+  `1 + (10 - 1) = 10`, while lifecycle-aware scale-up admits only the creation credit
+  currently available. With the default concurrency, the pool grows one successful
+  Sandbox at a time until the target is restored.
+- Claiming a Sandbox removes it from the unclaimed pool and SandboxSet replenishes toward
+  `spec.replicas`. Absolute targets remain fixed; claimed Sandboxes do not change the
+  configured target value.
+- With 30 unclaimed and available Sandboxes, a full observation window, and no used
+  Sandboxes, available capacity exceeds the upper watermark. The policy recommendation is
+  `30 - (30 - 10) = 10`.
+
+Scale-up is deliberately separated into recommendation and admission: the capacity policy may
+recommend the full deficit, but the lifecycle gate releases only bounded creation credit. Scale-down
+uses the averaged observation window and waits for the previous reduction to converge.
 
 ###### Percentage-Based Watermark Configuration
 
-For dynamic workloads where pool size varies significantly,
-percentage-based watermarks provide fully adaptive scaling
-that maintains proportional idle capacity across all pool sizes.
-When all watermarks (target, scale-up tolerance, and scale-down tolerance)
-are configured as percentages, they scale proportionally together,
-ensuring uniform scaling behavior regardless of pool scale.
+For dynamic workloads where pool size varies significantly, percentage-based watermarks maintain
+available capacity as a proportion of total observed demand. The base includes both the unclaimed
+pool and claimed Running or Paused Sandboxes:
+
+```
+base   = avgReplicas + avgUsed
+target = ceil(base × targetPercent)
+lower  = ceil(base × (targetPercent - tolerancePercent))
+upper  = ceil(base × (targetPercent + tolerancePercent))
+```
+
+`avgReplicas` is the observed unclaimed pool (`Creating + Available`), while `avgUsed` preserves
+claimed demand after ownership leaves the SandboxSet. Combining the percentages before rounding
+avoids different results caused by independently rounded target and tolerance values.
 
 **Configuration Example**:
 ```yaml
@@ -682,169 +734,52 @@ spec:
 ```
 
 **Watermark Calculation (Dynamic)**:
-- **Target Available**: `Current Replicas × 70%` (rounded up)
-- **Lower Watermark (Scale-Up Trigger)**: `Current Replicas × (70% - 10%) = Current Replicas × 60%` (rounded up)
-- **Upper Watermark (Scale-Down Trigger)**: `Current Replicas × (70% + 10%) = Current Replicas × 80%` (rounded up)
-- **Dead Zone**: Between lower and upper watermarks, no scaling occurs
+- **Target Available**: `ceil((avgReplicas + avgUsed) × 70%)`
+- **Lower Watermark (Scale-Up Trigger)**: `ceil((avgReplicas + avgUsed) × 60%)`
+- **Upper Watermark (Scale-Down Trigger)**: `ceil((avgReplicas + avgUsed) × 80%)`
+- **Dead Zone**: No scaling occurs while average available capacity is within `[lower, upper]`
 
-**Scaling Behavior Timeline with Percentage-Based Watermarks**:
+**Empty-Pool Prevention**: For percentage-based `targetAvailable`, `minReplicas` must be at
+least 1 (enforced by webhook). Bounds enforcement seeds the first unclaimed Sandbox; percentage
+watermarks are then calculated from observed capacity. The autoscaler does not use
+`maxReplicas` as the bootstrap base.
 
-| Time | Event              | Replica Count | Available Resources | Used Resources | Watermark Calculation                                                   | Autoscaler Decision                                                                                                      |
-|------|--------------------|---------------|---------------------|----------------|-------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| t0   | Initial State      | 4             | 4                   | 0              | Target: 4×70%↑=3<br/>Lower: 4×60%↑=3<br/>Upper: 4×80%↑=4                | **No Action**: Available (4) equals upper watermark (4), within acceptable range                                         |
-| t1   | Resources Consumed | 4             | 0                   | 4              | -                                                                       | No Action: Autoscaler not yet synchronized                                                                               |
-| t2   | Autoscaler Sync    | 7             | 3                   | 4              | Target: 4×70%↑=3<br/>Lower: 4×60%↑=3<br/>Current: 0                     | **Scale Up**: Available (0) < Lower Watermark (3). Target: 3 available → Scale to 7 replicas (4 used + 3 available)      |
-| t3   | Resources Consumed | 7             | 0                   | 7              | -                                                                       | No Action: Autoscaler not yet synchronized                                                                               |
-| t4   | Autoscaler Sync    | 12            | 5                   | 7              | Target: 7×70%↑=5<br/>Lower: 7×60%↑=5<br/>Current: 0                     | **Scale Up**: Available (0) < Lower Watermark (5). Target: 5 available → Scale to 12 replicas (7 used + 5 available)     |
-| t5   | Resources Consumed | 12            | 0                   | 12             | -                                                                       | No Action: Autoscaler not yet synchronized                                                                               |
-| t6   | Autoscaler Sync    | 21            | 9                   | 12             | Target: 12×70%↑=9<br/>Lower: 12×60%↑=8<br/>Current: 0                   | **Scale Up**: Available (0) < Lower Watermark (8). Target: 9 available → Scale to 21 replicas (12 used + 9 available)    |
-| t7   | Resources Consumed | 21            | 0                   | 21             | -                                                                       | No Action: Autoscaler not yet synchronized                                                                               |
-| t8   | Autoscaler Sync    | 36            | 15                  | 21             | Target: 21×70%↑=15<br/>Lower: 21×60%↑=13<br/>Current: 0                 | **Scale Up**: Available (0) < Lower Watermark (13). Target: 15 available → Scale to 36 replicas (21 used + 15 available) |
-| t9   | Resources Released | 36            | 36                  | 0              | -                                                                       | No Action: Autoscaler not yet synchronized                                                                               |
-| t10  | Autoscaler Sync    | 26            | 26                  | 0              | Target: 36×70%↑=26<br/>Upper: 36×80%↑=29<br/>Current: 36                | **Scale Down**: Available (36) > Upper Watermark (29). Target: 26 available → Scale to 26 replicas                       |
-| t11  | Autoscaler Sync    | 19            | 19                  | 0              | Target: 26×70%↑=19<br/>Upper: 26×80%↑=21<br/>Current: 26                | **Scale Down**: Available (26) > Upper Watermark (21). Target: 19 available → Scale to 19 replicas                       |
-| t12  | Autoscaler Sync    | 14            | 14                  | 0              | Target: 19×70%↑=14<br/>Upper: 19×80%↑=16<br/>Current: 19                | **Scale Down**: Available (19) > Upper Watermark (16). Target: 14 available → Scale to 14 replicas                       |
-| t13  | Autoscaler Sync    | 10            | 10                  | 0              | Target: 14×70%↑=10<br/>Upper: 14×80%↑=12<br/>Current: 14                | **Scale Down**: Available (14) > Upper Watermark (12). Target: 10 available → Scale to 10 replicas                       |
-| t14  | Autoscaler Sync    | 7             | 7                   | 0              | Target: 10×70%↑=7<br/>Upper: 10×80%↑=8<br/>Current: 10                  | **Scale Down**: Available (10) > Upper Watermark (8). Target: 7 available → Scale to 7 replicas                          |
-| t15  | Autoscaler Sync    | 5             | 5                   | 0              | Target: 7×70%↑=5<br/>Upper: 7×80%↑=6<br/>Current: 7                     | **Scale Down**: Available (7) > Upper Watermark (6). Target: 5 available → Scale to 5 replicas                           |
-| t16  | Autoscaler Sync    | 4             | 4                   | 0              | Target: 5×70%↑=4<br/>Upper: 5×80%↑=4<br/>Current: 5                     | **Scale Down**: Available (5) > Upper Watermark (4). Target: 4 available → Scale to 4 replicas                           |
-| t17  | Final State        | 4             | 4                   | 0              | Target: 4×70%↑=3<br/>Lower: 4×60%↑=3<br/>Upper: 4×80%↑=4<br/>Current: 4 | **No Action**: Available (4) equals upper watermark (4), within acceptable range. Pool reaches steady state              |
+**Scale Calculation**:
 
-
-**Detailed Timeline Explanation for Percentage-Based Configuration**:
-
-**t0 - Initial State**: The resource pool starts with 4 replicas, all available.
-The autoscaler calculates watermarks:
-- Target Available: `4 × 70% = 2.8 → 3` (rounded up)
-- Lower Watermark: `4 × (70% - 10%) = 4 × 60% = 2.4 → 3` (rounded up)
-- Upper Watermark: `4 × (70% + 10%) = 4 × 80% = 3.2 → 4` (rounded up)
-- Current Available: 4
-
-Since available resources (4) equal the upper watermark (4),
-the pool is at the maximum acceptable idle capacity.
-No scaling action is required as the pool is within the dead zone [3, 4].
-
-**t1 - Resource Consumption**: All 4 instances are consumed by workloads.
-The autoscaler has not yet synchronized, so no scaling action occurs.
-
-**t2 - First Scale-Up**: The autoscaler synchronizes and evaluates:
-- Current Available: 0
-- Lower Watermark: `4 × 60% = 3` (rounded up)
-- Target Available: `4 × 80% = 4` (rounded up)
-
-Since available (0) < lower watermark (3), the autoscaler scales up.
-To achieve the target of 3 available resources while maintaining 4 used resources,
-it scales to 7 replicas (4 used + 3 available).
-
-**t3 - Continued Consumption**: All 7 instances are now consumed.
-The autoscaler has not yet synchronized.
-
-**t4 - Second Scale-Up**: The autoscaler recalculates watermarks based on current replica count (7):
-- Target Available: `7 × 70% = 4.9 → 5` (rounded up)
-- Lower Watermark: `7 × 60% = 4.2 → 5` (rounded up)
-- Current Available: 0
-
-Since available (0) < lower watermark (5), the autoscaler scales up to 12 replicas (7 used + 5 available).
-
-**t5-t8 - Progressive Scale-Up**: The pattern continues as resources are consumed.
-Each autoscaler sync recalculates watermarks based on the current replica count,
-ensuring the target available capacity grows proportionally with pool size.
-By t8, the pool has scaled to 36 replicas with 15 available resources (maintaining the 70% target).
-
-**t9 - Resource Release**: All 36 previously used resources are released,
-resulting in 36 available resources and 0 used resources.
-
-**t10-t16 - Progressive Scale-Down**: The autoscaler begins scaling down to optimize resource usage.
-At each sync, it recalculates watermarks based on the current replica count.
-Since available resources exceed the upper watermark at each step,
-the autoscaler scales down to restore the target available capacity.
-The scale-down process is gradual (36 → 26 → 19 → 14 → 10 → 7 → 5 → 4),
-ensuring stability and preventing sudden capacity drops that could impact future availability.
-Each step maintains the proportional idle ratio while respecting the upper watermark threshold.
-
-**t17 - Steady State**: The pool reaches a steady state at 4 replicas with 4 available resources.
-The autoscaler calculates:
-- Target Available: `4 × 70% = 2.8 → 3` (rounded up)
-- Lower Watermark: `4 × 60% = 2.4 → 3` (rounded up)
-- Upper Watermark: `4 × 80% = 3.2 → 4` (rounded up)
-- Current Available: 3
-
-Since available (4) equals the upper watermark (4),
-the pool is at the maximum acceptable idle capacity for this pool size.
-The pool has reached a stable state where it maintains the target idle ratio
-while respecting the upper bound, and no further scaling is needed.
-
-**Visual Timeline - Percentage-Based Watermarks**:
 ```
-36 |                                      ●   ●○
-   |
-30 |
-   |
-   |                                               ●○
-   |                            ●    ●
-20 |
-   |                                                     ●○
-15 |                                      ○
-   |                                                          ●○
-12 |                   ●   ●
-   |
-10 |                                                               ●○
-   |                            ○
- 8 |
- 7 |         ●    ●                                                     ●○
-   |
- 5 |                   ○                                                     ●○
-   |
- 4 |●○  ●                                                                         ●○   ●○
-   |
- 3 |         ○
-   |
- 0 |    ○         ○         ○         ○
-   +----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
-   t0   t1   t2   t3   t4   t5   t6   t7   t8   t9   t10 t11  t12  t13  t14  t15  t16  t17
-
-Legend:
-● = Replica Count
-○ = Idle Resources
+scale up:   desired = avgReplicas + max(target - avgAvailable, 1)
+scale down: desired = avgReplicas - (avgAvailable - target)
+final:      desired is clamped to [minReplicas, maxReplicas]
 ```
 
-**Key Observations from the Timeline**:
-1. **Proportional Growth**: As the pool grows from 4 to 36 replicas,
-both the target available capacity and watermark thresholds grow proportionally
-- Target: 3 (at 4 replicas) → 21 (at 36 replicas), maintaining ~70% ratio
-- Lower: 3 (at 4 replicas) → 13 (at 36 replicas), maintaining ~60% ratio
-- Upper: 4 (at 4 replicas) → 29 (at 36 replicas), maintaining ~80% ratio
+A percentage target is self-relative. If every unclaimed Sandbox is idle, repeated scale-down
+may continue as the base shrinks until the upper watermark is no longer exceeded or
+`minReplicas` is reached. For example, with `targetAvailable: "30%"`, default `10%` tolerance,
+and `minReplicas: 1`, an idle pool can move from 8 to 3 and then from 3 to 1:
 
-This maintains consistent proportional relationships across all scales.
+| Step | `avgReplicas` | `avgAvailable` | Target | Upper | Decision |
+|------|----------------|----------------|--------|-------|----------|
+| Initial | 8 | 8 | `ceil(8×30%)=3` | `ceil(8×40%)=4` | Scale to `8-(8-3)=3` |
+| After convergence | 3 | 3 | `ceil(3×30%)=1` | `ceil(3×40%)=2` | Scale to `3-(3-1)=1` |
+| Steady state | 1 | 1 | 1 | 1 | No action |
 
-2. **Fully Dynamic Watermarks**: All watermarks (target, lower, upper) scale proportionally with pool size,
-ensuring uniform scaling behavior regardless of pool scale.
-This provides predictable and consistent behavior across different workload sizes.
+This behavior is appropriate for proportional idle capacity. An operator that requires a fixed
+number of idle Sandboxes should configure an absolute `targetAvailable` instead.
 
-3. **Adaptive Scaling**: The watermark thresholds adjust dynamically based on current pool size,
-ensuring appropriate scaling triggers at all scales.
-The percentage-based approach eliminates the need for manual threshold adjustments as the pool grows or shrinks.
-
-4. **Gradual Scale-Down**: The scale-down process is gradual
-(36 → 26 → 19 → 14 → 10 → 7 → 5 → 4), with each step triggered when available resources exceed
-the dynamically calculated upper watermark. This prevents sudden capacity drops that could impact availability.
-
-5. **Steady State**: The pool eventually reaches a minimal steady state (4 replicas)
-where available resources equal the upper watermark,
-maintaining the target idle ratio while respecting the upper bound.
+Claimed capacity remains in the percentage base. For example, if four Sandboxes are claimed,
+`avgUsed=4` continues to represent that demand even after their owner references are removed.
+The autoscaler therefore replenishes idle capacity rather than interpreting claims as a smaller
+pool. A Sandbox that becomes Ready and is claimed between two sampling points still increments
+`availableTransitionCount`, so healthy Ready-to-Claim traffic supplies scale-up progress even
+when sampled `availableReplicas` remains low.
 
 ### Implementation Details/Notes/Constraints
 
-#### Policy Combination Limitations
+#### Policy Combination and Precedence
 
-Currently, the autoscaler does not support simultaneous configuration of cron-based policies and
-capacity-based policies. This limitation exists to avoid potential conflicts and ensure
-predictable scaling behavior. The autoscaler will prioritize one policy type when both are configured,
-which may lead to unexpected scaling results.
-
-*Future Enhancement*: Support for combining cron-based and capacity-based policies will be added
-based on product requirements and user feedback. The implementation will include conflict
-resolution mechanisms and clear precedence rules to ensure consistent and predictable autoscaling behavior.
+Cron and capacity policies may be configured together. Capacity policy provides the normal
+continuous recommendation. When a cron schedule triggers, its explicit target takes precedence
+for that reconciliation. Every result is still clamped to `minReplicas` and `maxReplicas`.
 
 #### Observation Window and Sampling Configuration
 
@@ -864,46 +799,89 @@ multiple samples collected within the observation window.
 
 **Configuration Parameters**:
 
-The autoscaler exposes the following configuration parameters:
+The controller exposes the observation window and sampling interval as process flags:
 
-- **Observation Window Duration** (`observationWindowSeconds`):
-The total time window over which samples are collected and aggregated
-    - **Default**: 60 seconds
-    - **Range**: 30-300 seconds
-    - **Purpose**: Determines how much historical data is considered for scaling decisions
+- `--poolautoscaler-observation-window-seconds` defaults to 30 seconds.
+- `--poolautoscaler-sampling-interval-seconds` defaults to 5 seconds.
 
-- **Sampling Interval** (`samplingIntervalSeconds`): The time interval between consecutive sampling operations
-    - **Default**: 15 seconds
-    - **Range**: 5-30 seconds
-    - **Purpose**: Controls the frequency of resource state queries
+Both values must be positive and the observation window must not be shorter than the sampling
+interval. Invalid combinations fall back to the defaults.
 
 **Metric Value Determination Within Observation Window**:
 
-The autoscaler collects multiple samples of resource state
-(available replicas, total replicas) over the observation window and
-aggregates them to determine the final value used for scaling decisions.
-The autoscaler supports Average (Mean) aggregation methods to
-determine the final metric value from samples within the observation window:
+The autoscaler collects samples of available, unclaimed, and used replicas and averages each
+value over the observation window:
 
 ```
-Final Available = sum(availableReplicas from all samples) / number of samples
+avgAvailable = sum(availableReplicas) / sampleCount
+avgReplicas  = sum(status.replicas) / sampleCount
+avgUsed      = sum(usedReplicas) / sampleCount
 ```
-- **Use Case**: General purpose, smooths out temporary fluctuations
-- **Advantage**: Provides stable, representative value
 
-**Integration with Stabilization Windows**:
+Scale-up can act on the current sample immediately. Scale-down requires a full observation window
+to avoid reducing capacity from incomplete history after startup or controller restart.
 
-The observation window is separate from but complementary to stabilization windows used in scaling policies:
+**Integration with Scaling Cooldowns**:
 
-- **Observation Window**: Determines **when** and **how** samples are collected
-    - Collects raw resource state samples
-    - Aggregates samples to determine current metric value
-    - Provides input to scaling decision algorithm
+The observation window smooths raw lifecycle status. The direction-specific
+`stabilizationWindowSeconds` fields implement cooldowns rather than recommendation history:
 
-- **Stabilization Window**: Determines **how** past recommendations are considered
-    - Operates on scaling recommendations (not raw samples)
-    - Selects conservative recommendation from historical recommendations
-    - Applied after observation window aggregation
+- The first scaling action is immediate.
+- After any scale action, a scale in a direction is blocked until that direction's cooldown expires.
+- Cron-triggered targets bypass the cooldown because they represent explicit scheduled intent.
+
+#### Lifecycle-Aware Scale-Up Flow Control
+
+A low `availableReplicas` value is ambiguous: Sandboxes may be stuck Creating, or healthy
+Sandboxes may become Ready and be claimed before the next sample. PoolAutoscaler therefore uses
+explicit SandboxSet lifecycle status instead of inferring creation from `spec.replicas - available`.
+
+Before any scale-up, including bounds, cron, and capacity recommendations, the controller requires:
+
+1. `ScaleUpLimited` is not `True` on the target SandboxSet.
+2. `status.observedGeneration >= metadata.generation`.
+3. Creation credit is available.
+
+Creation credit is calculated as:
+
+```
+maxConcurrent = resolve(spec.scaleStrategy.maxUnavailable, default=1)
+headroom      = max(maxConcurrent - status.creatingReplicas, 0)
+progress      = max(status.availableTransitionCount
+                    - pa.status.observedAvailableTransitionCount, 0)
+credit        = min(max(headroom, progress), maxConcurrent)
+allowed       = min(policyDesired, spec.replicas + credit)
+```
+
+Consequently, a Sandbox that remains Pending consumes the default single creation slot and
+prevents repeated scale-up. A Sandbox that reaches a usable state creates progress credit even
+if it is claimed immediately, allowing healthy demand-driven replenishment to continue.
+
+Before patching `SandboxSet.spec.replicas`, PoolAutoscaler persists both the consumed transition
+count and `reservedReplicas`. The SandboxSet patch uses optimistic locking. If the target patch
+fails, the reservation remains and is retried idempotently; once the target reaches the reserved
+value, the reservation is cleared. `observedScaleTargetUID` scopes this state to one SandboxSet
+instance and resets it after same-name recreation.
+
+#### Sandbox Creation Failure Handling
+
+SandboxSet prevents repeated failed creation from exhausting cluster resources:
+
+- A Pending Sandbox is considered stuck after `creatingTimeout` from its creation time. For a
+  Running but not Ready Sandbox, the timeout starts from the Ready condition's latest transition.
+- The controller schedules reconciliation at the earliest creating-timeout deadline, so cleanup
+  does not depend on another watch event.
+- Only `ResourceFailed` Sandboxes and timed-out Creating Sandboxes count as failed creation
+  attempts. Each Sandbox UID is counted once.
+- Failure count and UID checkpoints are persisted before failed Sandboxes are deleted, allowing
+  recovery after controller restart.
+- At `maxFailureThreshold`, SandboxSet sets `ScaleUpLimited=True` and blocks ordinary scale-up.
+- After a one-minute cooldown, the controller permits one half-open probe when no Sandbox is
+  already Creating. A successful usable transition clears the failure history and closes the breaker.
+- If deletion of a stuck Sandbox fails, reconciliation returns without creating its replacement.
+
+Both `maxFailureThreshold` and `creatingTimeout` reject negative values. Setting
+`maxFailureThreshold: 0` disables the circuit breaker.
 
 #### Cron Policy Maintenance Window Support
 
@@ -954,7 +932,7 @@ storage resources, which can be amplified in large-scale clusters with many auto
     - Limit the number of cron policy per autoscaler
 - *Optimized Algorithms*: Implement efficient algorithms that avoid unnecessary recalculations:
     - Cache cron schedule evaluations
-    - Use incremental updates for recommendation history
+    - Bound and prune capacity samples to the configured observation window
     - Optimize memory usage through efficient data structures
 - *Resource Monitoring*: Provide metrics to monitor controller resource consumption and
   alert when thresholds are exceeded
@@ -988,18 +966,18 @@ scaling operations. This can occur due to:
     - High watermark: Threshold that must be exceeded before scaling down
     - Low watermark: Threshold that must be crossed before scaling up
     - Prevents oscillation around a single threshold value
-- **Stabilization Windows**: Implement stabilization windows to:
-    - Collect multiple recommendations over a time period
-    - Select the most conservative recommendation to prevent flapping
-    - Provide separate stabilization windows for scale-up and scale-down
+- **Scaling Cooldowns**: Apply direction-specific cooldowns after scale actions:
+    - Default to immediate scale-up and a 300-second scale-down cooldown
+    - Requeue when the relevant cooldown expires
+    - Let explicit cron targets bypass capacity-policy cooldowns
 
 #### Extreme Behavior from Invalid Configuration Combinations
 
-*Risk*: Invalid or conflicting parameter combinations can lead to extreme scaling behavior, such as:
-- Simultaneous configuration of conflicting policies (e.g., cron and capacity-based) without clear precedence
-- Parameter values that result in excessive scaling (e.g., very high scale-up percentages)
+**Risk**: Invalid configuration or unavailable Sandbox infrastructure can lead to extreme scaling behavior, such as:
+- Ambiguous precedence when cron and capacity policies are combined
+- Parameter values that result in excessive scaling
 - Missing bounds that allow scaling beyond cluster capacity
-- Invalid cron expressions that cause unexpected scheduling behavior
+- Repeated Sandbox creation attempts while earlier Sandboxes remain Pending or fail
 
 *Impact*:
 - Unpredictable scaling behavior that violates user expectations
@@ -1010,12 +988,11 @@ scaling operations. This can occur due to:
 *Mitigation*:
 - *API Validation*: Implement comprehensive API validation to prevent invalid configurations:
     - Validate cron expression syntax at API admission time
-    - Reject conflicting policy combinations (e.g., cron and capacity-based policies together)
-    - Validate parameter ranges (e.g., min/max replicas, scaling percentages)
-    - Check for logical inconsistencies (e.g., minReplicas > maxReplicas)
-- *Restricted API Combinations*: Enforce restrictions on how policies can be combined:
-    - Only allow one policy type per autoscaler (cron OR capacity-based, not both)
-    - Prevent mutually exclusive configurations
+    - Validate parameter ranges, including replica bounds, percentages, failure threshold, and creating timeout
+    - Check for logical inconsistencies such as `minReplicas > maxReplicas`
+    - Require `minReplicas >= 1` for percentage capacity targets
+- *Explicit Policy Precedence*: Triggered cron targets take precedence when cron and capacity policies coexist
+- *Lifecycle-Aware Limits*: Gate scale-up by observed creation progress and stop repeated failures with the SandboxSet circuit breaker
 - *Reasonable Default Values*: Provide sensible defaults that prevent extreme behavior:
     - Default stabilization windows and cooldown periods
     - Default tolerance values that prevent over-reaction
@@ -1213,7 +1190,7 @@ the CRD definition and the controller implementation.
 - Test cron expression parsing and validation
 - Verify capacity policy validation (targetAvailable, tolerance, stabilization windows)
 - Test one-to-one relationship enforcement (rejecting multiple autoscalers for same target)
-- Validate policy combination restrictions (cron vs. capacity-based)
+- Validate cron and capacity policy precedence
 
 **Controller Logic Tests**:
 - Test cron policy evaluation and scheduling
@@ -1221,7 +1198,13 @@ the CRD definition and the controller implementation.
 - Test stabilization window logic for scale-up and scale-down
 - Test tolerance calculation and application
 - Test bounds enforcement (minReplicas, maxReplicas)
-- Test suspend flag behavior
+- Test scale-up gating by `creatingReplicas`, generation observation, and `ScaleUpLimited`
+- Test Ready-to-Claim transition credit and percentage bases that include used Sandboxes
+- Test durable scale-up reservations, optimistic-lock conflicts, and target UID replacement
+- Test SandboxSet failure UID deduplication, restart recovery, half-open probes, and successful reset
+- Test creating timeout cleanup and timeout-driven requeue for Pending and Running-not-ready Sandboxes
+- Test claimed Sandbox source tracking without including claimed objects in pool GC or rolling updates
+- Test optional initial PoolAutoscaler status persistence
 
 **Reconciliation Tests**:
 - Test reconciliation with various policy configurations
@@ -1240,7 +1223,7 @@ the CRD definition and the controller implementation.
 **Policy Interaction Tests**:
 - Test cron policy execution timing
 - Test capacity policy evaluation during resource consumption/release
-- Test policy precedence when both types are configured (should be rejected)
+- Test policy precedence when cron and capacity policies are both configured
 
 **Status and Observability Tests**:
 - Verify status fields are updated correctly
@@ -1260,7 +1243,7 @@ the CRD definition and the controller implementation.
 **Scalability Tests**:
 - Test controller performance with 100+ PoolAutoscaler resources
 - Test reconciliation latency under load
-- Test memory consumption with large recommendation histories
+- Test memory consumption with large observation windows
 - Test cron schedule evaluation performance
 
 **Stress Tests**:
@@ -1270,5 +1253,5 @@ the CRD definition and the controller implementation.
 
 ## Implementation History
 
-- [ ] 06/01/2026: Initial proposals draft created
-- [ ] 15/01/2026: Proposal reviewed and approved
+- [x] 06/01/2026: Initial proposal draft created
+- [x] 26/08/2026: Lifecycle-aware scale-up, durable progress tracking, and Sandbox creation failure protection implemented

--- a/docs/proposals/20260106-sandboxset-autoscaler.md
+++ b/docs/proposals/20260106-sandboxset-autoscaler.md
@@ -47,7 +47,7 @@ superseded-by:
             - [Policy Combination and Precedence](#policy-combination-and-precedence)
             - [Observation Window and Sampling Configuration](#observation-window-and-sampling-configuration)
             - [Lifecycle-Aware Scale-Up Flow Control](#lifecycle-aware-scale-up-flow-control)
-            - [Sandbox Creation Failure Handling](#sandbox-creation-failure-handling)
+            - [Pending Sandbox Timeout Observability](#pending-sandbox-timeout-observability)
             - [Cron Policy Maintenance Window Support](#cron-policy-maintenance-window-support)
             - [One-to-One Relationship Between Warm Pool and Autoscaler](#one-to-one-relationship-between-warm-pool-and-autoscaler)
         - [Risks and Mitigations](#risks-and-mitigations)
@@ -91,10 +91,10 @@ ensuring sufficient idle capacity while preventing over-provisioning
 
 The autoscaler integrates seamlessly with `SandboxSet`, providing operators with fine-grained
 control over resource pool capacity while reducing operational overhead. Scale-up is coordinated
-with observed Sandbox creation progress, and SandboxSet applies timeout and failure circuit-breaker
-protection so unavailable infrastructure cannot cause unbounded creation attempts. This enhancement addresses
-critical requirements for latency-sensitive agent workloads that require predictable startup performance
-and efficient resource utilization.
+with the number of Sandboxes still being created, preventing repeated increases while previous
+creation requests have not converged. This enhancement addresses critical requirements for
+latency-sensitive agent workloads that require predictable startup performance and efficient
+resource utilization.
 
 ## Motivation
 
@@ -287,7 +287,7 @@ type CronScalingPolicy struct {
 type CapacityPolicy struct {
 	// TargetAvailable is the desired available replicas.
 	// It can be an absolute number or a percentage of the observed unclaimed
-	// and used capacity. Percentage targets require minReplicas >= 1.
+	// pool capacity. Percentage targets require minReplicas >= 1.
 	// +required
 	TargetAvailable intstr.IntOrString
 	// Tolerance is the tolerance between the watermark and desired
@@ -328,15 +328,11 @@ type PoolAutoscalerStatus struct {
 
 	// CurrentReplicas is current number of replicas of pods managed by this autoscaler,
 	// as last seen by the autoscaler.
-	// It is optional in the CRD schema so target progress can be persisted before
-	// the first complete status snapshot.
 	// +optional
 	CurrentReplicas int32
 
 	// DesiredReplicas is the desired number of replicas of pods managed by this autoscaler,
 	// as last calculated by the autoscaler.
-	// It is optional in the CRD schema so target progress can be persisted before
-	// the first complete status snapshot.
 	// +optional
 	DesiredReplicas int32
 
@@ -352,21 +348,6 @@ type PoolAutoscalerStatus struct {
 	// CurrentCapacity is the last read state of the capacity used by this autoscaler.
 	// +optional
 	CurrentCapacity CapacityStatus
-
-	// ObservedAvailableTransitionCount is the target SandboxSet availability
-	// progress already consumed by scale-up flow control.
-	// +optional
-	ObservedAvailableTransitionCount int64
-
-	// ObservedScaleTargetUID associates progress and reservations with one
-	// concrete SandboxSet instance, including delete-and-recreate scenarios.
-	// +optional
-	ObservedScaleTargetUID types.UID
-
-	// ReservedReplicas is a durable scale-up target reserved before patching
-	// SandboxSet.spec.replicas.
-	// +optional
-	ReservedReplicas *int32
 
 	// Conditions is the set of conditions required for this autoscaler to scale its target,
 	// and indicates whether those conditions are met.
@@ -463,10 +444,9 @@ that the cluster maintains a safe level of available resources.
 | **stabilizationWindowSeconds** | Cooldown period for a scaling direction. The first scaling action is immediate; after any scale action, a subsequent action in this direction must wait until the configured period has elapsed. | 1. *Prevent flapping*: Delay repeated or opposite-direction scaling after a recent action.<br/>2. *Conservative scale-down*: Use a longer scale-down cooldown to avoid premature reduction.<br/>3. *Responsive scale-up*: Use zero or a short scale-up cooldown. | 1. *Optional field*: defaults to 0 seconds for scale-up and 300 seconds for scale-down.<br/>2. *Range*: 0 through 3600 seconds. |
 
 Available capacity can be configured using an absolute value or a percentage.
-For percentage policies, the base is the observed unclaimed pool capacity plus claimed
-running or paused sandboxes (`avgReplicas + avgUsed`). This keeps claimed demand in the
-calculation even though `SandboxSet.spec.replicas` continues to represent only unclaimed
-creating and available capacity.
+For percentage policies, the base is the observed unclaimed pool capacity (`avgReplicas`).
+Claimed Sandboxes leave the warm pool and are outside the scope of this proposal; they are not
+tracked for percentage calculation or later pool reuse.
 
 ##### Status
 
@@ -479,45 +459,33 @@ creating and available capacity.
 | **suspended**           | Whether the autoscaler controller has suspend subsequent policy executions. When `true`, the controller will not sync the policy. when `false`, the policy synced normally.                                                                                                                                                |
 | **appliedCronPolicies** | Cron policy execution status.                                                                                                                                                                                                                                                                                              |
 | **currentCapacity**     | The current number of available capacity managed by this autoscaler, as last seen by the autoscaler. This represents the actual current available capacity of the target warming pool that the autoscaler is managing.                                                                                                     |
-| **observedAvailableTransitionCount** | The cumulative SandboxSet availability progress already consumed by scale-up flow control. |
-| **observedScaleTargetUID** | The UID of the concrete SandboxSet instance associated with progress and any pending reservation. A UID change resets stale progress. |
-| **reservedReplicas** | A durable pending scale-up target recorded before patching the SandboxSet, allowing an idempotent retry if the target patch or final status update fails. |
 | **conditions**          | The set of conditions required for this autoscaler to scale its target, including whether scaling is active, possible, or limited. |
 
-`currentReplicas` and `desiredReplicas` are optional in the CRD schema. This permits the
-controller to persist target identity and progress during the first reconciliation before a
-complete status snapshot exists.
+`currentReplicas` and `desiredReplicas` remain optional in the CRD schema so status can be
+published incrementally during initial reconciliation.
 
 ##### SandboxSet Lifecycle Status and Scale Safety
 
-`SandboxSet.spec.replicas` remains the desired number of **unclaimed** sandboxes. Claimed
-sandboxes no longer count toward that desired pool size, but the controller continues to
-observe their source pool identity for capacity accounting and successful creation progress.
+`SandboxSet.spec.replicas` remains the desired number of **unclaimed** Sandboxes. PoolAutoscaler
+uses the existing `SandboxSet` status fields without adding a dedicated creating-replica field:
 
-The following `SandboxSet` fields provide protocol-neutral lifecycle signals to the autoscaler:
+```
+unavailableReplicas = max(status.replicas - status.availableReplicas, 0)
+```
 
-| Field | Description |
-|-------|-------------|
-| `spec.scaleStrategy.maxUnavailable` | Maximum concurrent unavailable capacity allowed during scale-up. It also defines the default scale-up credit available to PoolAutoscaler; the effective minimum is one. |
-| `spec.scaleStrategy.maxFailureThreshold` | Consecutive failed creation attempts that open the scale-up circuit breaker. Defaults to 3; 0 disables the breaker. |
-| `spec.scaleStrategy.creatingTimeout` | Maximum time a Sandbox may remain Creating before it is treated as stuck. Defaults to 10 minutes. |
-| `status.creatingReplicas` | Unclaimed Sandboxes still being created, including create operations not yet observed by the informer. |
-| `status.usedReplicas` | Claimed Running or Paused Sandboxes attributed to this SandboxSet. |
-| `status.availableTransitionCount` | Cumulative count of distinct Sandboxes that reached a usable state, including Sandboxes claimed before a periodic availability sample. |
-| `status.availabilityTrackingInitialized` | Indicates that the durable usable-Sandbox UID checkpoint has been initialized. |
-| `status.observedUsableSandboxUIDs` | UID checkpoint used to recover availability-transition accounting after controller restart. |
-| `status.failedReplicas` | Consecutive creation failures currently counted by the circuit breaker. |
-| `status.failedSandboxUIDs` | UID checkpoint that prevents duplicate failure accounting across reconciliation and restart. |
-| `status.lastFailureTime` | Time of the latest newly observed creation failure, used to schedule a half-open retry. |
-| `status.conditions[type=ScaleUpLimited]` | Reports whether SandboxSet scale-up is blocked by the failure circuit breaker. |
+This derivation requires `status.replicas` to represent the observed unclaimed pool and to include
+Creating and Available Sandboxes. SandboxSet's existing expectation accounting must also include
+create operations that have been submitted but are not visible through the informer yet. This keeps
+cache delay from exposing false creation headroom without expanding the public API.
 
-When a Sandbox is claimed, its SandboxSet owner reference is removed so the pool can
-replenish unclaimed capacity. Before removal, the claim path preserves both the source pool
-name and UID in internal labels. The SandboxSet controller observes only claimed Running or
-Paused Sandboxes through those labels; they contribute to `usedReplicas` and availability
-progress, but never to pool replica counts, garbage collection, failure accounting, or rolling
-updates. The source UID prevents a newly created SandboxSet with the same name from adopting
-historical state.
+`status.observedGeneration` confirms that SandboxSet has observed the previous desired size.
+Sampling history, cooldown timestamps, and derived scaling state stay in controller memory and
+start empty after controller restart. No additional persistent progress or per-Sandbox tracking
+fields are introduced.
+
+When a Sandbox is claimed, it leaves the warm pool. SandboxSet replenishes the unclaimed pool
+according to `spec.replicas`, but PoolAutoscaler does not continue tracking the claimed Sandbox and
+does not support returning it to the pool in this version.
 
 #### Metrics
 
@@ -561,20 +529,6 @@ Metrics follow Prometheus conventions and are compatible with standard Kubernete
 - Identify slow reconciliations
 - Track performance degradation
 - Set SLOs for reconciliation latency
-
-`sandboxset_sandboxes_failed_total`
-
-**Type**: Counter
-
-**Description**: Cumulative number of distinct Sandbox creation failures observed for a
-SandboxSet. Failures are deduplicated by Sandbox UID.
-
-`sandboxset_scale_up_limited`
-
-**Type**: Gauge
-
-**Description**: Whether SandboxSet scale-up is blocked by the failure circuit breaker
-(`1` for blocked, `0` for allowed).
 
 #### User Configuration Examples
 
@@ -700,9 +654,8 @@ scale-up condition unreachable.
 - Claiming a Sandbox removes it from the unclaimed pool and SandboxSet replenishes toward
   `spec.replicas`. Absolute targets remain fixed; claimed Sandboxes do not change the
   configured target value.
-- With 30 unclaimed and available Sandboxes, a full observation window, and no used
-  Sandboxes, available capacity exceeds the upper watermark. The policy recommendation is
-  `30 - (30 - 10) = 10`.
+- With 30 unclaimed and available Sandboxes and a full observation window, available capacity
+  exceeds the upper watermark. The policy recommendation is `30 - (30 - 10) = 10`.
 
 Scale-up is deliberately separated into recommendation and admission: the capacity policy may
 recommend the full deficit, but the lifecycle gate releases only bounded creation credit. Scale-down
@@ -711,19 +664,18 @@ uses the averaged observation window and waits for the previous reduction to con
 ###### Percentage-Based Watermark Configuration
 
 For dynamic workloads where pool size varies significantly, percentage-based watermarks maintain
-available capacity as a proportion of total observed demand. The base includes both the unclaimed
-pool and claimed Running or Paused Sandboxes:
+available capacity as a proportion of the observed unclaimed pool:
 
 ```
-base   = avgReplicas + avgUsed
+base   = avgReplicas
 target = ceil(base × targetPercent)
 lower  = ceil(base × (targetPercent - tolerancePercent))
 upper  = ceil(base × (targetPercent + tolerancePercent))
 ```
 
-`avgReplicas` is the observed unclaimed pool (`Creating + Available`), while `avgUsed` preserves
-claimed demand after ownership leaves the SandboxSet. Combining the percentages before rounding
-avoids different results caused by independently rounded target and tolerance values.
+`avgReplicas` is the observed unclaimed pool (`Creating + Available`). Claimed Sandboxes are
+outside this version's autoscaling model. Combining the percentages before rounding avoids
+different results caused by independently rounded target and tolerance values.
 
 **Configuration Example**:
 ```yaml
@@ -734,9 +686,9 @@ spec:
 ```
 
 **Watermark Calculation (Dynamic)**:
-- **Target Available**: `ceil((avgReplicas + avgUsed) × 70%)`
-- **Lower Watermark (Scale-Up Trigger)**: `ceil((avgReplicas + avgUsed) × 60%)`
-- **Upper Watermark (Scale-Down Trigger)**: `ceil((avgReplicas + avgUsed) × 80%)`
+- **Target Available**: `ceil(avgReplicas × 70%)`
+- **Lower Watermark (Scale-Up Trigger)**: `ceil(avgReplicas × 60%)`
+- **Upper Watermark (Scale-Down Trigger)**: `ceil(avgReplicas × 80%)`
 - **Dead Zone**: No scaling occurs while average available capacity is within `[lower, upper]`
 
 **Empty-Pool Prevention**: For percentage-based `targetAvailable`, `minReplicas` must be at
@@ -766,12 +718,9 @@ and `minReplicas: 1`, an idle pool can move from 8 to 3 and then from 3 to 1:
 This behavior is appropriate for proportional idle capacity. An operator that requires a fixed
 number of idle Sandboxes should configure an absolute `targetAvailable` instead.
 
-Claimed capacity remains in the percentage base. For example, if four Sandboxes are claimed,
-`avgUsed=4` continues to represent that demand even after their owner references are removed.
-The autoscaler therefore replenishes idle capacity rather than interpreting claims as a smaller
-pool. A Sandbox that becomes Ready and is claimed between two sampling points still increments
-`availableTransitionCount`, so healthy Ready-to-Claim traffic supplies scale-up progress even
-when sampled `availableReplicas` remains low.
+Claimed Sandboxes are intentionally outside the percentage base. A claim reduces the observed
+unclaimed pool, and SandboxSet replenishes toward `spec.replicas`; PoolAutoscaler does not retain
+per-claim history or model reuse of claimed Sandboxes.
 
 ### Implementation Details/Notes/Constraints
 
@@ -809,13 +758,12 @@ interval. Invalid combinations fall back to the defaults.
 
 **Metric Value Determination Within Observation Window**:
 
-The autoscaler collects samples of available, unclaimed, and used replicas and averages each
+The autoscaler collects samples of available and unclaimed replicas and averages each
 value over the observation window:
 
 ```
 avgAvailable = sum(availableReplicas) / sampleCount
 avgReplicas  = sum(status.replicas) / sampleCount
-avgUsed      = sum(usedReplicas) / sampleCount
 ```
 
 Scale-up can act on the current sample immediately. Scale-down requires a full observation window
@@ -832,56 +780,101 @@ The observation window smooths raw lifecycle status. The direction-specific
 
 #### Lifecycle-Aware Scale-Up Flow Control
 
-A low `availableReplicas` value is ambiguous: Sandboxes may be stuck Creating, or healthy
-Sandboxes may become Ready and be claimed before the next sample. PoolAutoscaler therefore uses
-explicit SandboxSet lifecycle status instead of inferring creation from `spec.replicas - available`.
-
-Before any scale-up, including bounds, cron, and capacity recommendations, the controller requires:
-
-1. `ScaleUpLimited` is not `True` on the target SandboxSet.
-2. `status.observedGeneration >= metadata.generation`.
-3. Creation credit is available.
-
-Creation credit is calculated as:
+A low `availableReplicas` value is ambiguous: capacity may have been consumed, or existing
+Sandboxes may still be in creation. PoolAutoscaler derives current unavailability from existing
+SandboxSet status instead of adding another lifecycle field:
 
 ```
-maxConcurrent = resolve(spec.scaleStrategy.maxUnavailable, default=1)
-headroom      = max(maxConcurrent - status.creatingReplicas, 0)
-progress      = max(status.availableTransitionCount
-                    - pa.status.observedAvailableTransitionCount, 0)
-credit        = min(max(headroom, progress), maxConcurrent)
-allowed       = min(policyDesired, spec.replicas + credit)
+unavailableReplicas = max(status.replicas - status.availableReplicas, 0)
 ```
 
-Consequently, a Sandbox that remains Pending consumes the default single creation slot and
-prevents repeated scale-up. A Sandbox that reaches a usable state creates progress credit even
-if it is claimed immediately, allowing healthy demand-driven replenishment to continue.
+This is intentionally conservative: every observed unclaimed Sandbox that is not Available consumes
+the creation budget. Sandbox failure handling remains unchanged and outside this proposal.
 
-Before patching `SandboxSet.spec.replicas`, PoolAutoscaler persists both the consumed transition
-count and `reservedReplicas`. The SandboxSet patch uses optimistic locking. If the target patch
-fails, the reservation remains and is retried idempotently; once the target reaches the reserved
-value, the reservation is cleared. `observedScaleTargetUID` scopes this state to one SandboxSet
-instance and resets it after same-name recreation.
+PoolAutoscaler first evaluates cron or capacity policy and clamps the result to `minReplicas` and
+`maxReplicas`. Every requested increase, including a cron target, then passes through the same
+lifecycle safety gate. Cron targets bypass only the direction-specific cooldown.
 
-#### Sandbox Creation Failure Handling
+Before increasing `SandboxSet.spec.replicas`, PoolAutoscaler requires:
 
-SandboxSet prevents repeated failed creation from exhausting cluster resources:
+1. `status.observedGeneration >= metadata.generation`, ensuring SandboxSet has observed the
+   previous desired size.
+2. Available creation headroom under `spec.scaleStrategy.maxUnavailable`.
 
-- A Pending Sandbox is considered stuck after `creatingTimeout` from its creation time. For a
-  Running but not Ready Sandbox, the timeout starts from the Ready condition's latest transition.
-- The controller schedules reconciliation at the earliest creating-timeout deadline, so cleanup
-  does not depend on another watch event.
-- Only `ResourceFailed` Sandboxes and timed-out Creating Sandboxes count as failed creation
-  attempts. Each Sandbox UID is counted once.
-- Failure count and UID checkpoints are persisted before failed Sandboxes are deleted, allowing
-  recovery after controller restart.
-- At `maxFailureThreshold`, SandboxSet sets `ScaleUpLimited=True` and blocks ordinary scale-up.
-- After a one-minute cooldown, the controller permits one half-open probe when no Sandbox is
-  already Creating. A successful usable transition clears the failure history and closes the breaker.
-- If deletion of a stuck Sandbox fails, reconciliation returns without creating its replacement.
+```
+maxConcurrent      = resolve(spec.scaleStrategy.maxUnavailable,
+                             spec.replicas, default=1)
+unavailableReplicas = max(status.replicas - status.availableReplicas, 0)
+headroom            = max(maxConcurrent - unavailableReplicas, 0)
+allowed             = min(policyDesired, spec.replicas + headroom)
+```
 
-Both `maxFailureThreshold` and `creatingTimeout` reject negative values. Setting
-`maxFailureThreshold: 0` disables the circuit breaker.
+`maxUnavailable` may be an absolute value or a percentage. A percentage is resolved against the
+current `spec.replicas` and rounded up; an absent, invalid, or less-than-one result falls back to
+one. `allowed > spec.replicas`, rather than merely `allowed > 0`, means that this reconciliation
+may increase the target.
+
+An unclaimed Sandbox that has not become Available continues to consume the creation budget.
+PoolAutoscaler therefore cannot repeatedly increase the desired size while earlier creation
+requests remain in flight. Once it becomes Available, `unavailableReplicas` decreases and a later
+reconciliation may admit additional scale-up.
+
+No progress token or pending target is persisted. The target patch uses optimistic locking, and
+normal reconciliation recalculates the desired value and retries after conflicts or controller
+restart. Observation samples and cooldown state are also in memory; losing them may temporarily
+reduce stabilization after restart but does not alter the declared pool size.
+
+#### Pending Sandbox Timeout Observability
+
+A Pending Sandbox already consumes the `maxUnavailable` budget through
+`status.replicas - status.availableReplicas`, so it naturally prevents unbounded scale-up. However,
+the original behavior exposes no status explaining why the pool has stopped progressing. SandboxSet
+therefore reports long-running Pending Sandboxes through its existing `status.conditions` field.
+This adds no new CRD field and does not change deletion, replacement, or PoolAutoscaler decisions.
+
+The timeout is configured once for the controller component rather than per SandboxSet:
+
+```
+--sandboxset-pending-timeout=1m
+```
+
+The default is one minute. The controller checks only Sandboxes that are still owned by the
+SandboxSet and for which `GetSandboxState` returns `SandboxStateCreating` with reason
+`ResourcePending`. Other Creating reasons, Dead reasons such as `ResourceFailed`, and claimed
+Sandboxes are outside this timeout signal.
+
+Pending duration is measured from the Sandbox `creationTimestamp`. If at least one Sandbox exceeds
+the timeout, SandboxSet publishes:
+
+```yaml
+status:
+  conditions:
+    - type: Degraded
+      status: "True"
+      reason: ResourcePendingTimeout
+      message: "2 Sandboxes have remained ResourcePending longer than 1m; oldest is sandbox-xxx"
+```
+
+When no owned Sandbox exceeds the timeout, the condition is cleared semantically:
+
+```yaml
+status:
+  conditions:
+    - type: Degraded
+      status: "False"
+      reason: ResourcePendingResolved
+      message: "No Sandbox exceeds the ResourcePending timeout"
+```
+
+`LastTransitionTime` changes only when the condition status changes. `ObservedGeneration` is set to
+the current SandboxSet generation. The message contains the total timed-out count and the oldest
+Sandbox name, but no UID list is persisted. A Warning event is emitted only when the condition
+transitions to `True`, avoiding an event on every reconciliation.
+
+A Pending Sandbox may produce no watch event at the deadline. The controller must therefore compute
+the earliest remaining timeout among owned `ResourcePending` Sandboxes and set `RequeueAfter` to
+that deadline. Because timeout state is derived from `creationTimestamp`, it is reconstructed after a
+controller restart without additional persistent state.
 
 #### Cron Policy Maintenance Window Support
 
@@ -914,9 +907,9 @@ prevent conflicts, and maintain system stability.
 
 *Risk*: The introduction of multiple scaling policies (cron-based and capacity-based) increases
 the computational complexity of the autoscaler controller. The controller needs to evaluate
-multiple policy types, calculate scaling recommendations, maintain historical state for
-stabilization windows, and process cron schedules. This requires additional memory and
-storage resources, which can be amplified in large-scale clusters with many autoscaler instances.
+multiple policy types, calculate scaling recommendations, maintain in-memory historical state for
+observation windows, and process cron schedules. This requires additional CPU and memory,
+which can be amplified in large-scale clusters with many autoscaler instances.
 
 *Impact*:
 - Increased CPU usage for policy evaluation and calculation
@@ -977,7 +970,7 @@ scaling operations. This can occur due to:
 - Ambiguous precedence when cron and capacity policies are combined
 - Parameter values that result in excessive scaling
 - Missing bounds that allow scaling beyond cluster capacity
-- Repeated Sandbox creation attempts while earlier Sandboxes remain Pending or fail
+- Repeated scale-up while existing Sandbox creation is still in flight
 
 *Impact*:
 - Unpredictable scaling behavior that violates user expectations
@@ -988,11 +981,11 @@ scaling operations. This can occur due to:
 *Mitigation*:
 - *API Validation*: Implement comprehensive API validation to prevent invalid configurations:
     - Validate cron expression syntax at API admission time
-    - Validate parameter ranges, including replica bounds, percentages, failure threshold, and creating timeout
+    - Validate parameter ranges, including replica bounds and percentages
     - Check for logical inconsistencies such as `minReplicas > maxReplicas`
     - Require `minReplicas >= 1` for percentage capacity targets
 - *Explicit Policy Precedence*: Triggered cron targets take precedence when cron and capacity policies coexist
-- *Lifecycle-Aware Limits*: Gate scale-up by observed creation progress and stop repeated failures with the SandboxSet circuit breaker
+- *Lifecycle-Aware Limits*: Gate every requested increase by observed generation and the unavailable count derived from existing SandboxSet status, keeping unavailable Sandboxes within the `maxUnavailable` budget
 - *Reasonable Default Values*: Provide sensible defaults that prevent extreme behavior:
     - Default stabilization windows and cooldown periods
     - Default tolerance values that prevent over-reaction
@@ -1198,13 +1191,11 @@ the CRD definition and the controller implementation.
 - Test stabilization window logic for scale-up and scale-down
 - Test tolerance calculation and application
 - Test bounds enforcement (minReplicas, maxReplicas)
-- Test scale-up gating by `creatingReplicas`, generation observation, and `ScaleUpLimited`
-- Test Ready-to-Claim transition credit and percentage bases that include used Sandboxes
-- Test durable scale-up reservations, optimistic-lock conflicts, and target UID replacement
-- Test SandboxSet failure UID deduplication, restart recovery, half-open probes, and successful reset
-- Test creating timeout cleanup and timeout-driven requeue for Pending and Running-not-ready Sandboxes
-- Test claimed Sandbox source tracking without including claimed objects in pool GC or rolling updates
-- Test optional initial PoolAutoscaler status persistence
+- Test scale-up gating by derived unavailable replicas, generation observation, and `maxUnavailable`
+- Test Pending timeout condition filtering by `ResourcePending`, default one-minute deadline, and recovery
+- Test timeout-driven requeue and transition-only Warning events
+- Test in-memory sampling and cooldown reset behavior after controller restart
+- Test PoolAutoscaler ignores claimed Sandboxes after they leave the warm pool
 
 **Reconciliation Tests**:
 - Test reconciliation with various policy configurations
@@ -1254,4 +1245,4 @@ the CRD definition and the controller implementation.
 ## Implementation History
 
 - [x] 06/01/2026: Initial proposal draft created
-- [x] 26/08/2026: Lifecycle-aware scale-up, durable progress tracking, and Sandbox creation failure protection implemented
+- [x] 26/08/2026: Lifecycle-aware scale-up design refined to reuse existing API status and in-memory sampling

--- a/docs/proposals/20260106-sandboxset-autoscaler.md
+++ b/docs/proposals/20260106-sandboxset-autoscaler.md
@@ -91,8 +91,9 @@ ensuring sufficient idle capacity while preventing over-provisioning
 
 The autoscaler integrates seamlessly with `SandboxSet`, providing operators with fine-grained
 control over resource pool capacity while reducing operational overhead. Target growth is limited
-by Sandboxes that remain Pending beyond the configured timeout, while SandboxSet independently
-limits actual creation concurrency, allowing healthy high-throughput replenishment to continue.
+by Sandboxes that remain Pending beyond the configured timeout and, for repeated capacity-driven
+increases, by observed claim progress. SandboxSet independently limits actual creation concurrency,
+allowing healthy high-throughput replenishment to continue without growing an unused pool.
 This enhancement addresses critical requirements for latency-sensitive agent workloads that require
 predictable startup performance and efficient resource utilization.
 
@@ -488,9 +489,11 @@ timed-out failures. PoolAutoscaler uses this value to limit how quickly it raise
 so a healthy stream of newly created Sandboxes can continue growing the pool.
 
 `status.observedGeneration` confirms that SandboxSet has observed the previous desired size.
-Sampling history, cooldown timestamps, and derived scaling state stay in controller memory and
-start empty after controller restart. No additional persistent progress or per-Sandbox tracking
-fields are introduced.
+PoolAutoscaler also keeps an in-memory claim sequence for each target SandboxSet. After a successful
+capacity-driven scale-up, at least one subsequent claim must be observed before another
+capacity-driven scale-up is admitted. Sampling history, cooldown timestamps, claim-gate state, and
+other derived scaling state stay in controller memory. No additional persistent progress or
+per-Sandbox tracking fields are introduced.
 
 When a Sandbox is claimed, it leaves the warm pool. SandboxSet replenishes the unclaimed pool
 according to `spec.replicas`, but PoolAutoscaler does not continue tracking the claimed Sandbox and
@@ -811,46 +814,69 @@ It computes the value directly from the owned Sandbox list and never parses the 
 Condition message.
 
 PoolAutoscaler first evaluates cron or capacity policy and clamps the result to `minReplicas` and
-`maxReplicas`. Every requested increase, including a cron target, then passes through the same
-timed-out-Pending gate. Cron targets bypass only the direction-specific cooldown.
+`maxReplicas`. Every requested increase, including a cron target, passes through the same
+timed-out-Pending gate. Cron targets bypass the direction-specific cooldown and the consumption-
+progress gate because they express an explicit scheduled pool size rather than inferred demand.
+Bounds enforcement likewise remains independent of consumption progress.
 
 Before increasing `SandboxSet.spec.replicas`, PoolAutoscaler requires:
 
 1. `status.observedGeneration >= metadata.generation`, ensuring SandboxSet has observed the
    previous desired size.
 2. Remaining abnormal-creation budget under `spec.scaleStrategy.maxUnavailable`.
+3. For a capacity-driven increase following another capacity-driven increase, at least one Sandbox
+   claim observed after the previous successful target update.
+
+The claim signal is derived without a new API field. A Sandbox update counts when the old object was
+controlled by the target SandboxSet and the new object has `agents.kruise.io/sandbox-claimed=true`
+and is no longer controlled by that SandboxSet. The controller records a monotonically increasing
+claim sequence per SandboxSet in memory. Immediately after a capacity-driven target update succeeds,
+it snapshots the current sequence as the baseline for the next scale-up. The next increase is
+admitted only when the current sequence exceeds the baseline. Sandbox deletion, readiness
+transition, and replenishment creation do not advance this sequence.
 
 ```
 maxConcurrent  = resolve(spec.scaleStrategy.maxUnavailable,
                          spec.replicas, default=1)
 timedOutPending = count(owned ResourcePending Sandboxes
                         where now - creationTimestamp >= pendingTimeout)
-failureHeadroom = max(maxConcurrent - timedOutPending, 0)
-allowed          = min(policyDesired, spec.replicas + failureHeadroom)
+targetGrowthHeadroom = max(maxConcurrent - timedOutPending, 0)
+allowed          = min(policyDesired, spec.replicas + targetGrowthHeadroom)
 ```
 
 `maxUnavailable` may be an absolute value or a percentage. A percentage is resolved against the
 current `spec.replicas` and rounded up; an absent, invalid, or less-than-one result falls back to
 one. SandboxSet and PoolAutoscaler use this same resolved value, including the default, for their
 respective creation-concurrency and abnormal-target-growth decisions. `allowed > spec.replicas`,
-rather than merely `allowed > 0`, means that this reconciliation may increase the target.
+rather than merely `allowed > 0`, means that the failure budget permits an increase. A capacity-
+driven increase is applied only when the consumption-progress gate is also open.
 
-For example, with `maxConcurrent=2` and one timed-out Pending Sandbox, `failureHeadroom=1`, so
+For example, with `maxConcurrent=2` and one timed-out Pending Sandbox, `targetGrowthHeadroom=1`, so
 PoolAutoscaler may increase `spec.replicas` by one. When `timedOutPending` reaches two, target growth
 stops. This budget is recalculated after SandboxSet observes each target generation, so one persistent
 timed-out Sandbox still permits gradual growth when other Sandboxes are created successfully and
 claimed immediately.
 
-Fresh Pending Sandboxes do not consume `failureHeadroom`. They still consume
+Fresh Pending Sandboxes do not consume `targetGrowthHeadroom`. They still consume
 `inFlightUnavailable`, so SandboxSet defers the corresponding physical creates whenever its actual
 creation concurrency reaches `maxUnavailable`. PoolAutoscaler may therefore build desired backlog
-without causing SandboxSet to exceed its creation concurrency. The two values must not be added,
-because timed-out Pending Sandboxes are already part of `inFlightUnavailable`.
+without causing SandboxSet to exceed its creation concurrency, but only one bounded capacity-driven
+increment is admitted per observed claim. This prevents repeated reconciliation from growing an
+unused pool while preserving continued growth under claim-and-replenish traffic. The two lifecycle
+values must not be added, because timed-out Pending Sandboxes are already part of
+`inFlightUnavailable`.
 
-No progress token or pending target is persisted. The target patch uses optimistic locking, and
-normal reconciliation recalculates the desired value and retries after conflicts or controller
-restart. Observation samples and cooldown state are also in memory; losing them may temporarily
-reduce stabilization after restart but does not alter the declared pool size.
+The first capacity-driven increase is admitted without prior claim progress. After that update, a
+new policy recommendation alone is insufficient: if no Sandbox has been claimed, the target stays
+unchanged even when sampling, cooldown, generation, and failure-budget checks pass. One claim opens
+the gate for one subsequent bounded increase, which records a new baseline and closes the gate
+again. The claim does not need to identify a Sandbox created by the immediately preceding increment;
+its purpose is to prove continued pool consumption after that target update.
+
+No progress token or pending target is persisted. Claim sequence and gate state are intentionally
+process-local; restart continuity is outside this proposal. The target patch uses optimistic locking,
+and normal reconciliation recalculates the desired value and retries after conflicts. Observation
+samples and cooldown state are also in memory.
 
 #### Pending Sandbox Timeout Observability
 
@@ -1018,6 +1044,7 @@ scaling operations. This can occur due to:
     - Require `minReplicas >= 1` for percentage capacity targets
 - *Explicit Policy Precedence*: Triggered cron targets take precedence when cron and capacity policies coexist
 - *Separated Lifecycle Limits*: Let SandboxSet use `inFlightUnavailable`, including `dirtyCreate`, to constrain actual creation concurrency; let PoolAutoscaler use `timedOutPending` to reduce target-growth headroom without blocking healthy high-throughput replenishment
+- *Consumption Progress Gate*: After the first capacity-driven increase, require a subsequent claim before admitting another increase, preventing stale low-availability samples from repeatedly growing an unused pool
 - *Reasonable Default Values*: Provide sensible defaults that prevent extreme behavior:
     - Default stabilization windows and cooldown periods
     - Default tolerance values that prevent over-reaction
@@ -1227,9 +1254,13 @@ the CRD definition and the controller implementation.
 - Test PoolAutoscaler target growth uses `timedOutPending` and excludes fresh Pending and `dirtyCreate`
 - Test `timedOutPending < maxUnavailable` permits only the remaining failure headroom and equality blocks target growth
 - Test sustained claim-and-replenish traffic can grow the desired pool while fresh Pending Sandboxes remain
+- Test the first capacity-driven increase needs no prior claim, while the next increase is blocked until a claim is observed
+- Test each observed claim admits at most one subsequent bounded capacity-driven increase
+- Test readiness transitions, deletions, and replenishment creates do not satisfy the consumption-progress gate
+- Test cron targets and bounds enforcement bypass the consumption-progress gate but retain lifecycle safety checks
 - Test Pending timeout condition filtering by `ResourcePending`, default one-minute deadline, and recovery
 - Test timeout-driven requeue and transition-only Warning events
-- Test in-memory sampling and cooldown reset behavior after controller restart
+- Test in-memory sampling, cooldown, and claim-gate state behavior within one controller process
 - Test PoolAutoscaler ignores claimed Sandboxes after they leave the warm pool
 
 **Reconciliation Tests**:

--- a/docs/proposals/20260106-sandboxset-autoscaler.md
+++ b/docs/proposals/20260106-sandboxset-autoscaler.md
@@ -5,7 +5,7 @@ authors:
 reviewers:
   - "@furykerry"
 creation-date: 2026-01-06
-last-updated: 2026-08-26
+last-updated: 2026-08-27
 status: implementable
 see-also:
 replaces:
@@ -90,11 +90,11 @@ This enhancement adds two complementary autoscaling policy types:
 ensuring sufficient idle capacity while preventing over-provisioning
 
 The autoscaler integrates seamlessly with `SandboxSet`, providing operators with fine-grained
-control over resource pool capacity while reducing operational overhead. Scale-up is coordinated
-with the number of Sandboxes still being created, preventing repeated increases while previous
-creation requests have not converged. This enhancement addresses critical requirements for
-latency-sensitive agent workloads that require predictable startup performance and efficient
-resource utilization.
+control over resource pool capacity while reducing operational overhead. Target growth is limited
+by Sandboxes that remain Pending beyond the configured timeout, while SandboxSet independently
+limits actual creation concurrency, allowing healthy high-throughput replenishment to continue.
+This enhancement addresses critical requirements for latency-sensitive agent workloads that require
+predictable startup performance and efficient resource utilization.
 
 ## Motivation
 
@@ -466,17 +466,26 @@ published incrementally during initial reconciliation.
 
 ##### SandboxSet Lifecycle Status and Scale Safety
 
-`SandboxSet.spec.replicas` remains the desired number of **unclaimed** Sandboxes. PoolAutoscaler
-uses the existing `SandboxSet` status fields without adding a dedicated creating-replica field:
+`SandboxSet.spec.replicas` remains the desired number of **unclaimed** Sandboxes. Creation flow
+control and abnormal target-growth control use separate derived values without adding API fields.
+
+SandboxSet retains its existing creation-concurrency calculation:
 
 ```
-unavailableReplicas = max(status.replicas - status.availableReplicas, 0)
+inFlightUnavailable = max(status.replicas - status.availableReplicas, 0)
 ```
 
-This derivation requires `status.replicas` to represent the observed unclaimed pool and to include
-Creating and Available Sandboxes. SandboxSet's existing expectation accounting must also include
-create operations that have been submitted but are not visible through the informer yet. This keeps
-cache delay from exposing false creation headroom without expanding the public API.
+`status.replicas` includes Creating and Available Sandboxes. Existing expectation accounting also
+includes successful create requests that are not visible through the informer yet (`dirtyCreate`).
+Consequently, `inFlightUnavailable` represents observed Creating Sandboxes plus `dirtyCreate`, and
+SandboxSet uses it to consume `spec.scaleStrategy.maxUnavailable` while creating the replicas already
+declared in `spec.replicas`.
+
+PoolAutoscaler separately derives `timedOutPending` by listing Sandboxes still owned by the target
+SandboxSet and counting only those whose state reason is `ResourcePending` and whose age has reached
+the component-level Pending timeout. Fresh Pending Sandboxes and `dirtyCreate` do not count as
+timed-out failures. PoolAutoscaler uses this value to limit how quickly it raises the desired target,
+so a healthy stream of newly created Sandboxes can continue growing the pool.
 
 `status.observedGeneration` confirms that SandboxSet has observed the previous desired size.
 Sampling history, cooldown timestamps, and derived scaling state stay in controller memory and
@@ -780,44 +789,63 @@ The observation window smooths raw lifecycle status. The direction-specific
 
 #### Lifecycle-Aware Scale-Up Flow Control
 
-A low `availableReplicas` value is ambiguous: capacity may have been consumed, or existing
-Sandboxes may still be in creation. PoolAutoscaler derives current unavailability from existing
-SandboxSet status instead of adding another lifecycle field:
+Target growth and actual Sandbox creation have different safety requirements. Treating every fresh
+Pending Sandbox as a PoolAutoscaler blocker can starve growth under sustained demand: each Sandbox
+may become Available and be claimed immediately while its replacement keeps one creation slot
+continuously occupied. The design therefore separates two values:
 
 ```
-unavailableReplicas = max(status.replicas - status.availableReplicas, 0)
+inFlightUnavailable = max(status.replicas - status.availableReplicas, 0)
+timedOutPending      = count(owned ResourcePending Sandboxes with age >= pendingTimeout)
 ```
 
-This is intentionally conservative: every observed unclaimed Sandbox that is not Available consumes
-the creation budget. Sandbox failure handling remains unchanged and outside this proposal.
+`inFlightUnavailable` includes observed Creating Sandboxes and expectation-accounted `dirtyCreate`
+operations. SandboxSet uses it to limit actual create operations under `maxUnavailable` while
+converging toward the already declared `spec.replicas`.
+
+`timedOutPending` includes only observable Sandbox objects that have remained `ResourcePending`
+beyond the component-level timeout. It excludes fresh Pending Sandboxes, other Creating reasons,
+claimed Sandboxes, and `dirtyCreate`, which has no Sandbox object or `creationTimestamp` to inspect.
+PoolAutoscaler uses this value as an abnormal-creation budget when increasing the desired target.
+It computes the value directly from the owned Sandbox list and never parses the count from a
+Condition message.
 
 PoolAutoscaler first evaluates cron or capacity policy and clamps the result to `minReplicas` and
 `maxReplicas`. Every requested increase, including a cron target, then passes through the same
-lifecycle safety gate. Cron targets bypass only the direction-specific cooldown.
+timed-out-Pending gate. Cron targets bypass only the direction-specific cooldown.
 
 Before increasing `SandboxSet.spec.replicas`, PoolAutoscaler requires:
 
 1. `status.observedGeneration >= metadata.generation`, ensuring SandboxSet has observed the
    previous desired size.
-2. Available creation headroom under `spec.scaleStrategy.maxUnavailable`.
+2. Remaining abnormal-creation budget under `spec.scaleStrategy.maxUnavailable`.
 
 ```
-maxConcurrent      = resolve(spec.scaleStrategy.maxUnavailable,
-                             spec.replicas, default=1)
-unavailableReplicas = max(status.replicas - status.availableReplicas, 0)
-headroom            = max(maxConcurrent - unavailableReplicas, 0)
-allowed             = min(policyDesired, spec.replicas + headroom)
+maxConcurrent  = resolve(spec.scaleStrategy.maxUnavailable,
+                         spec.replicas, default=1)
+timedOutPending = count(owned ResourcePending Sandboxes
+                        where now - creationTimestamp >= pendingTimeout)
+failureHeadroom = max(maxConcurrent - timedOutPending, 0)
+allowed          = min(policyDesired, spec.replicas + failureHeadroom)
 ```
 
 `maxUnavailable` may be an absolute value or a percentage. A percentage is resolved against the
 current `spec.replicas` and rounded up; an absent, invalid, or less-than-one result falls back to
-one. `allowed > spec.replicas`, rather than merely `allowed > 0`, means that this reconciliation
-may increase the target.
+one. SandboxSet and PoolAutoscaler use this same resolved value, including the default, for their
+respective creation-concurrency and abnormal-target-growth decisions. `allowed > spec.replicas`,
+rather than merely `allowed > 0`, means that this reconciliation may increase the target.
 
-An unclaimed Sandbox that has not become Available continues to consume the creation budget.
-PoolAutoscaler therefore cannot repeatedly increase the desired size while earlier creation
-requests remain in flight. Once it becomes Available, `unavailableReplicas` decreases and a later
-reconciliation may admit additional scale-up.
+For example, with `maxConcurrent=2` and one timed-out Pending Sandbox, `failureHeadroom=1`, so
+PoolAutoscaler may increase `spec.replicas` by one. When `timedOutPending` reaches two, target growth
+stops. This budget is recalculated after SandboxSet observes each target generation, so one persistent
+timed-out Sandbox still permits gradual growth when other Sandboxes are created successfully and
+claimed immediately.
+
+Fresh Pending Sandboxes do not consume `failureHeadroom`. They still consume
+`inFlightUnavailable`, so SandboxSet defers the corresponding physical creates whenever its actual
+creation concurrency reaches `maxUnavailable`. PoolAutoscaler may therefore build desired backlog
+without causing SandboxSet to exceed its creation concurrency. The two values must not be added,
+because timed-out Pending Sandboxes are already part of `inFlightUnavailable`.
 
 No progress token or pending target is persisted. The target patch uses optimistic locking, and
 normal reconciliation recalculates the desired value and retries after conflicts or controller
@@ -826,11 +854,15 @@ reduce stabilization after restart but does not alter the declared pool size.
 
 #### Pending Sandbox Timeout Observability
 
-A Pending Sandbox already consumes the `maxUnavailable` budget through
-`status.replicas - status.availableReplicas`, so it naturally prevents unbounded scale-up. However,
-the original behavior exposes no status explaining why the pool has stopped progressing. SandboxSet
-therefore reports long-running Pending Sandboxes through its existing `status.conditions` field.
-This adds no new CRD field and does not change deletion, replacement, or PoolAutoscaler decisions.
+A fresh Pending Sandbox consumes SandboxSet's actual creation budget but not PoolAutoscaler's
+abnormal-creation budget. This allows the desired pool to keep growing when Sandboxes become
+Available and are claimed immediately under sustained demand. Once a Pending Sandbox reaches the
+timeout, it contributes to `timedOutPending`; target growth slows by one slot for each such Sandbox
+and stops when `timedOutPending >= maxConcurrent`.
+
+SandboxSet reports the same timeout state through its existing `status.conditions` field. This adds
+no new CRD field and does not change deletion or replacement behavior. PoolAutoscaler calculates
+`timedOutPending` from Sandbox objects rather than parsing the Condition message.
 
 The timeout is configured once for the controller component rather than per SandboxSet:
 
@@ -985,7 +1017,7 @@ scaling operations. This can occur due to:
     - Check for logical inconsistencies such as `minReplicas > maxReplicas`
     - Require `minReplicas >= 1` for percentage capacity targets
 - *Explicit Policy Precedence*: Triggered cron targets take precedence when cron and capacity policies coexist
-- *Lifecycle-Aware Limits*: Gate every requested increase by observed generation and the unavailable count derived from existing SandboxSet status, keeping unavailable Sandboxes within the `maxUnavailable` budget
+- *Separated Lifecycle Limits*: Let SandboxSet use `inFlightUnavailable`, including `dirtyCreate`, to constrain actual creation concurrency; let PoolAutoscaler use `timedOutPending` to reduce target-growth headroom without blocking healthy high-throughput replenishment
 - *Reasonable Default Values*: Provide sensible defaults that prevent extreme behavior:
     - Default stabilization windows and cooldown periods
     - Default tolerance values that prevent over-reaction
@@ -1191,7 +1223,10 @@ the CRD definition and the controller implementation.
 - Test stabilization window logic for scale-up and scale-down
 - Test tolerance calculation and application
 - Test bounds enforcement (minReplicas, maxReplicas)
-- Test scale-up gating by derived unavailable replicas, generation observation, and `maxUnavailable`
+- Test SandboxSet creation concurrency uses `inFlightUnavailable`, including expectation-accounted `dirtyCreate`
+- Test PoolAutoscaler target growth uses `timedOutPending` and excludes fresh Pending and `dirtyCreate`
+- Test `timedOutPending < maxUnavailable` permits only the remaining failure headroom and equality blocks target growth
+- Test sustained claim-and-replenish traffic can grow the desired pool while fresh Pending Sandboxes remain
 - Test Pending timeout condition filtering by `ResourcePending`, default one-minute deadline, and recovery
 - Test timeout-driven requeue and transition-only Warning events
 - Test in-memory sampling and cooldown reset behavior after controller restart
@@ -1246,3 +1281,4 @@ the CRD definition and the controller implementation.
 
 - [x] 06/01/2026: Initial proposal draft created
 - [x] 26/08/2026: Lifecycle-aware scale-up design refined to reuse existing API status and in-memory sampling
+- [x] 27/08/2026: Separated actual creation concurrency from timed-out-Pending target-growth control

--- a/docs/proposals/20260827-sandboxset-scale-up-execution-coordination.md
+++ b/docs/proposals/20260827-sandboxset-scale-up-execution-coordination.md
@@ -22,12 +22,13 @@ superseded-by:
   - [Goals](#goals)
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
+  - [API Changes](#api-changes)
   - [Controller Responsibilities](#controller-responsibilities)
   - [SandboxSet Creation Limit](#sandboxset-creation-limit)
   - [Scale-Up Cooldown and Derived Pending Timeout](#scale-up-cooldown-and-derived-pending-timeout)
   - [ScalingLimited Condition](#scalinglimited-condition)
   - [PoolAutoscaler Gate](#poolautoscaler-gate)
-  - [User-Visible Behavior](#user-visible-behavior)
+  - [User-Visible Scaling Behavior](#user-visible-scaling-behavior)
   - [State Transitions](#state-transitions)
   - [Observation Window Interaction](#observation-window-interaction)
 - [Risks and Mitigations](#risks-and-mitigations)
@@ -85,6 +86,58 @@ creation concurrency.
 
 ## Proposal
 
+### API Changes
+
+This proposal adds no CRD field or command-line flag. It changes the effective semantics of one
+existing PoolAutoscaler field and adds one structured condition type to the existing SandboxSet
+conditions list.
+
+#### PoolAutoscaler Configuration
+
+`spec.capacityPolicy.scaleUp.stabilizationWindowSeconds` remains the user-facing scale-up cooldown:
+
+- When omitted, the effective default is `35` seconds. The previous design used `0` seconds.
+- The effective minimum is `15` seconds. Any explicit value below `15`, including `0`, remains valid
+  but is normalized to `15` seconds at runtime.
+- Values from `15` through the existing maximum of `3600` seconds are used unchanged.
+- The resolved value applies to both Capacity-driven and Cron-driven target increases.
+
+Pending timeout is internal and adds no API surface. It is calculated as
+`min(resolvedScaleUpCooldown - 5 seconds, 60 seconds)`.
+
+| User configuration | Effective scale-up cooldown | Derived Pending timeout |
+| --- | --- | --- |
+| omitted | 35 seconds | 30 seconds |
+| `0` | 15 seconds | 10 seconds |
+| 10 seconds | 15 seconds | 10 seconds |
+| 15 seconds | 15 seconds | 10 seconds |
+| 30 seconds | 30 seconds | 25 seconds |
+| 65 seconds | 65 seconds | 60 seconds |
+| 120 seconds | 120 seconds | 60 seconds |
+
+Existing PoolAutoscalers require no manifest migration. Omitted values use the new 35-second default;
+explicit values below 15 seconds are normalized to 15 seconds.
+
+#### SandboxSet Condition
+
+The existing `SandboxSet.status.conditions` list gains the `ScalingLimited` condition contract; no
+new status field or blocker counter is added.
+
+| Field | Available budget | Exhausted budget |
+| --- | --- | --- |
+| `type` | `ScalingLimited` | `ScalingLimited` |
+| `status` | `False` | `True` |
+| `reason` | `StartupBudgetAvailable` | `StartupBudgetExhausted` |
+| `observedGeneration` | Current SandboxSet generation | Current SandboxSet generation |
+| `message` | Bounded `Failed` and `Timeout` summary | Bounded `Failed` and `Timeout` summary |
+
+`ScalingLimited=True` means `Failed + Timeout >= startupBudget`. A non-zero blocker count below the
+budget still publishes `False/StartupBudgetAvailable`. Consumers must use the structured condition
+status and reason rather than parse `message`.
+
+There is no `ScaleUpReady` condition or Ready-progress API. Existing Sandbox Ready conditions,
+Events, logs, and metrics remain available for individual startup diagnosis.
+
 ### Controller Responsibilities
 
 Responsibilities are split across the existing controllers:
@@ -130,29 +183,29 @@ create requests until a slot opens, but it is normal flow control rather than a 
 
 The design reuses CapacityPolicy's existing `scaleUp.stabilizationWindowSeconds` as the interval
 between successful target increases, whether the selected target originates from Capacity or Cron.
-Its default changes from zero to 65 seconds. An omitted or explicit zero value resolves to this default
-for backward compatibility. An explicitly configured non-zero value must be greater than the fixed
-five-second safety margin.
+Its effective default is 35 seconds when omitted; the previous design used zero. The effective
+cooldown has a 15-second lower bound: any user-configured value below 15 seconds, including zero, is
+automatically raised to 15 seconds rather than rejected.
 
 Pending timeout is not exposed as a flag or CRD field. Both controllers use one resolver. The derived
 value is capped at 60 seconds:
 
 ```text
 safetyMargin = 5 seconds
+minimumScaleUpCooldown = 15 seconds
 maximumPendingTimeout = 60 seconds
-scaleUpCooldown = resolve(scaleUp.stabilizationWindowSeconds,
-                          defaultWhenNilOrZero=65 seconds)
+configuredCooldown = scaleUp.stabilizationWindowSeconds
+scaleUpCooldown = 35 seconds if configuredCooldown is omitted
+                  else max(configuredCooldown, minimumScaleUpCooldown)
 pendingTimeout = min(scaleUpCooldown - safetyMargin,
                      maximumPendingTimeout)
-
-require scaleUpCooldown > safetyMargin
 ```
 
-The default Pending timeout is therefore 60 seconds. A configured cooldown above 65 seconds does not
+The default Pending timeout is therefore 30 seconds. A configured cooldown above 65 seconds does not
 increase the Pending timeout beyond 60 seconds; it only extends the interval before another scale-up.
 SandboxSet obtains the CapacityPolicy that targets it through the controller cache and uses the same
 resolver; no timeout value is copied into SandboxSet status. If no associated CapacityPolicy is
-available, it uses the 65-second default cooldown and 60-second derived timeout for condition
+available, it uses the 35-second default cooldown and 30-second derived timeout for condition
 calculation.
 
 The safety margin provides an interval in which Pending deadlines can elapse and `ScalingLimited` can
@@ -178,7 +231,7 @@ SandboxSet derives exactly two aggregate categories from existing Sandbox state:
   condition. Existing reasons such as `PodCreateFailed` and `StartContainerFailed` contribute to the
   single aggregate category and are not exposed as separate counts.
 - `Timeout`: an owned Sandbox remains `ResourcePending` longer than the internally derived
-  `pendingTimeout`. With the default 65-second scale-up cooldown, this timeout is 60 seconds.
+  `pendingTimeout`. With the default 35-second scale-up cooldown, this timeout is 30 seconds.
 
 This design does not change Sandbox controller behavior or add Sandbox failure reasons. States that
 are not already classified as failures remain ordinary Creating or Pending states until the timeout.
@@ -290,7 +343,8 @@ function reconcileScaleUp(poolAutoscaler, sandboxSet):
     if desired <= sandboxSet.spec.replicas:
         return keepOrScaleDown(desired)
 
-    cooldown = resolveScaleUpCooldown(defaultWhenNilOrZero=65 seconds)
+    cooldown = resolveScaleUpCooldown(default=35 seconds,
+                                      minimum=15 seconds)
     if now < status.lastScaleTime + cooldown:
         return requeueAt(status.lastScaleTime + cooldown)
 
@@ -326,40 +380,10 @@ scale-down:
     thereby restart the cooldown before a later scale-up
 ```
 
-### User-Visible Behavior
-
-This design changes configuration defaults and scaling timing, but does not add a new CRD field or
-command-line flag.
-
-#### Configuration
-
-- Users continue configuring scale-up delay through
-  `spec.capacityPolicy.scaleUp.stabilizationWindowSeconds`.
-- Its effective default changes from `0` to `65` seconds. An omitted or explicit `0` resolves to 65
-  seconds for compatibility; a non-zero value must be greater than `5` seconds. Values from `1`
-  through `5` are rejected by PoolAutoscaler validation.
-- Pending timeout is not user-configurable. It is derived internally as
-  `min(resolvedScaleUpCooldown - 5 seconds, 60 seconds)`.
-- Existing `spec.scaleStrategy.maxUnavailable` remains the only user-facing startup-concurrency
-  setting. Absolute and percentage values retain their existing resolution behavior.
-
-Examples:
-
-| Scale-up cooldown | Derived Pending timeout |
-| --- | --- |
-| omitted or `0` | 60 seconds |
-| 30 seconds | 25 seconds |
-| 65 seconds | 60 seconds |
-| 120 seconds | 60 seconds |
-
-Existing PoolAutoscalers that omit the field or explicitly store `0` require no manifest migration,
-but after upgrade their successive scale-ups are delayed by 65 seconds instead of occurring without
-a cooldown.
-
-#### Scaling Behavior
+### User-Visible Scaling Behavior
 
 - The first `minReplicas` bootstrap may occur immediately. Each later Capacity or Cron increase waits
-  for the scale-up cooldown.
+  for the resolved scale-up cooldown.
 - A failed or timed-out Sandbox does not by itself stop target growth when startup budget remains.
   Scale-up is blocked only when `Failed + Timeout >= startupBudget`.
 - Healthy sustained demand may continue increasing the target once per cooldown interval. There is no
@@ -367,20 +391,6 @@ a cooldown.
 - SandboxSet still enforces `maxUnavailable` while creating toward the declared target, independently
   of PoolAutoscaler's cooldown.
 - Scale-down remains allowed while scale-up is cooling down or limited.
-
-#### Observability
-
-Users observe startup-budget exhaustion through the existing
-`SandboxSet.status.conditions[type=ScalingLimited]`:
-
-- `False/StartupBudgetAvailable`: another increase may proceed after cooldown if policy still
-  recommends it. This can remain `False` when blocker count is non-zero but below the budget.
-- `True/StartupBudgetExhausted`: PoolAutoscaler keeps the current target unchanged after cooldown.
-- The condition message reports bounded `Failed` and `Timeout` counts for diagnosis. Users do not need
-  to parse the message for automation; automation should rely on condition status and reason.
-
-There is no `ScaleUpReady` condition or Ready-progress status. Existing Sandbox Ready conditions,
-Events, logs, and metrics remain available for investigating individual startup behavior.
 
 ### State Transitions
 
@@ -503,8 +513,8 @@ checks current generation and condition state and recomputes the recommendation.
 
 ### PoolAutoscaler Unit Tests
 
-- Verify the scale-up cooldown defaults to 65 seconds for omitted and explicit zero values, and
-  explicitly configured non-zero values must exceed the five-second safety margin.
+- Verify the scale-up cooldown defaults to 35 seconds when omitted and any explicit value below 15
+  seconds is normalized to 15 seconds without validation failure.
 - Verify every successful Capacity or Cron increase starts the cooldown.
 - Verify failed or conflicted target patches do not start the cooldown.
 - Verify a successful scale-down remains allowed and restarts the interval before a later scale-up.

--- a/docs/proposals/20260827-sandboxset-scale-up-execution-coordination.md
+++ b/docs/proposals/20260827-sandboxset-scale-up-execution-coordination.md
@@ -24,10 +24,10 @@ superseded-by:
 - [Proposal](#proposal)
   - [Controller Responsibilities](#controller-responsibilities)
   - [SandboxSet Creation Limit](#sandboxset-creation-limit)
-  - [In-Memory Ready Progress Tracker](#in-memory-ready-progress-tracker)
-  - [Tracker Lifecycle and Concurrency](#tracker-lifecycle-and-concurrency)
+  - [Scale-Up Cooldown and Derived Pending Timeout](#scale-up-cooldown-and-derived-pending-timeout)
   - [ScalingLimited Condition](#scalinglimited-condition)
   - [PoolAutoscaler Gate](#poolautoscaler-gate)
+  - [User-Visible Behavior](#user-visible-behavior)
   - [State Transitions](#state-transitions)
   - [Observation Window Interaction](#observation-window-interaction)
 - [Risks and Mitigations](#risks-and-mitigations)
@@ -37,19 +37,19 @@ superseded-by:
 
 ## Summary
 
-This proposal defines the execution coordination between PoolAutoscaler, Sandbox controller, and
-SandboxSet during scale-up. PoolAutoscaler remains responsible for selecting a desired capacity
-target, SandboxSet limits physical creation and reports startup blockers through `ScalingLimited`,
-and Sandbox controller records Pending-to-Available progress in a process-local shared tracker.
+This proposal defines the execution coordination between PoolAutoscaler and SandboxSet during
+scale-up. PoolAutoscaler remains responsible for selecting a desired capacity target and enforcing a
+minimum interval between target increases. SandboxSet limits physical creation and reports exhausted
+startup concurrency through `ScalingLimited`.
 
-The tracker prevents repeated target increases when Sandbox creation has made no progress. Recording
-the transition in Sandbox controller also preserves healthy high-throughput replenishment when a
-Sandbox becomes Available and is claimed immediately. `ScalingLimited` reuses
-`SandboxSet.status.conditions`; the progress tracker does not add API fields, replica counters,
-blocker lists, timestamps, or claim-tracking fields.
+No Ready-progress gate, sequence, baseline, timestamp, replica counter, blocker list, or claim-tracking
+field is introduced. The design reuses the existing scale-up cooldown and
+`SandboxSet.status.conditions`.
 
 The PoolAutoscaler policies and capacity calculations are defined in
-[SandboxSet supports autoscaler](./20260106-sandboxset-autoscaler.md).
+[SandboxSet supports autoscaler](./20260106-sandboxset-autoscaler.md). For execution coordination,
+this proposal supersedes that document's Ready-progress handshake, zero default scale-up cooldown,
+and Cron cooldown-bypass behavior.
 
 ## Motivation
 
@@ -60,18 +60,18 @@ If PoolAutoscaler treats every observation-window expiry as permission to increa
 the desired replica count can continue growing without execution progress.
 
 PoolAutoscaler must not duplicate SandboxSet execution logic by interpreting `maxUnavailable`,
-listing Sandboxes, or inspecting Pods. Because PoolAutoscaler and Sandbox controller run in the same
-controller-manager process, Sandbox controller can publish Ready progress through a shared in-memory
-tracker. SandboxSet separately publishes startup blockage as an aggregate condition.
+listing Sandboxes, or inspecting Pods. Instead, each target increase starts a scale-up cooldown that
+is longer than the internally derived Pending timeout. By the end of that cooldown, SandboxSet has
+classified prolonged startup and can report whether blocked Sandboxes have exhausted the configured
+creation concurrency.
 
 ### Goals
 
 - Keep desired-capacity calculation in PoolAutoscaler and physical creation control in SandboxSet.
-- Detect Pending-to-Available progress in Sandbox controller before another capacity-driven target
-  increase.
-- Prevent Capacity and Cron target growth while known startup blockers exist.
-- Aggregate startup blockers without adding new Sandbox failure reasons.
-- Reuse the existing conditions field for blockers and keep Ready progress in process memory.
+- Rate-limit successive target increases with the existing scale-up cooldown.
+- Derive Pending timeout from that cooldown without exposing another user setting.
+- Prevent target growth only when timed-out or failed Sandboxes exhaust `maxUnavailable`.
+- Aggregate startup blockers without adding new Sandbox failure reasons or API fields.
 
 ### Non-Goals
 
@@ -80,27 +80,24 @@ tracker. SandboxSet separately publishes startup blockage as an aggregate condit
 - Adding Pod-derived failure reasons such as `PodUnschedulable` or
   `ContainerStartupBlocked`.
 - Letting PoolAutoscaler calculate Pending age, creation concurrency, or blocker counts.
-- Treating observation-window expiry or `maxUnavailable` saturation as a failure.
-- Persisting or reconstructing an outstanding Ready-progress wait across controller-manager restart.
+- Treating observation-window expiry or `maxUnavailable` saturation by itself as a failure.
+- Tracking individual Ready transitions or reconstructing scale-up progress after restart.
 
 ## Proposal
 
 ### Controller Responsibilities
 
-Responsibilities are split across three controllers running in the same controller-manager process:
+Responsibilities are split across the existing controllers:
 
-- Sandbox controller manages one Sandbox. After successfully persisting a Pending-to-Available
-  transition, it increments a process-local progress sequence for the owning SandboxSet.
-- SandboxSet controller executes `spec.replicas`, owns `maxUnavailable`, and publishes the aggregate
-  `ScalingLimited` condition.
-- PoolAutoscaler computes the desired target, snapshots the progress sequence before increasing the
-  target, and waits for that sequence to advance before another capacity-driven increase. It does
-  not list Sandboxes or Pods and does not interpret `maxUnavailable`.
+- Sandbox controller continues managing individual Sandbox and Pod lifecycle. This proposal adds no
+  Ready-transition tracking or coordination responsibility to it.
+- SandboxSet controller executes `spec.replicas`, owns `maxUnavailable`, derives the Pending timeout,
+  and publishes the aggregate `ScalingLimited` condition.
+- PoolAutoscaler computes the desired target, applies the existing scale-up cooldown, and consumes
+  `ScalingLimited`. It does not list Sandboxes or Pods and does not interpret `maxUnavailable`.
 
-The tracker is keyed by SandboxSet UID, not name, so deletion and recreation of a same-named
-SandboxSet cannot inherit progress. Sampling history, cooldown timestamps, the per-SandboxSet
-progress sequence, and the active scale-up baseline all remain in controller memory. Only
-`ScalingLimited` is persisted as an aggregate condition.
+Sampling history and cooldown timestamps remain in PoolAutoscaler's existing process-local state.
+Only `ScalingLimited` is persisted as an aggregate condition.
 
 ### SandboxSet Creation Limit
 
@@ -129,120 +126,81 @@ createHeadroom = max(maxConcurrent - inFlightUnavailable, 0)
 SandboxSet creates toward `spec.replicas` while `createHeadroom > 0`. Reaching the limit stops new
 create requests until a slot opens, but it is normal flow control rather than a startup failure.
 
-### In-Memory Ready Progress Tracker
+### Scale-Up Cooldown and Derived Pending Timeout
 
-Sandbox controller detects progress by comparing the persisted Sandbox status loaded at the start of
-reconciliation with the newly calculated status. It records progress only after the status patch has
-succeeded and only when both of the following are true:
+The design reuses CapacityPolicy's existing `scaleUp.stabilizationWindowSeconds` as the interval
+between successful target increases, whether the selected target originates from Capacity or Cron.
+Its default changes from zero to 65 seconds. An omitted or explicit zero value resolves to this default
+for backward compatibility. An explicitly configured non-zero value must be greater than the fixed
+five-second safety margin.
 
-1. The old Sandbox state is Creating, including ordinary Pending startup.
-2. The new Sandbox state is Available and the Sandbox has a SandboxSet controller owner reference.
-
-The shared tracker maintains a monotonically increasing sequence for each SandboxSet UID:
-
-```text
-readyProgress[SandboxSetUID] = sequence
-```
-
-Sandbox controller updates it after persisting status:
+Pending timeout is not exposed as a flag or CRD field. Both controllers use one resolver. The derived
+value is capped at 60 seconds:
 
 ```text
-oldState = GetSandboxState(persistedSandbox)
-newState = GetSandboxState(sandboxWithNewStatus)
+safetyMargin = 5 seconds
+maximumPendingTimeout = 60 seconds
+scaleUpCooldown = resolve(scaleUp.stabilizationWindowSeconds,
+                          defaultWhenNilOrZero=65 seconds)
+pendingTimeout = min(scaleUpCooldown - safetyMargin,
+                     maximumPendingTimeout)
 
-if patchSandboxStatus(sandboxWithNewStatus) succeeded:
-    owner = SandboxSetControllerRef(persistedSandbox)
-    if owner exists
-       and oldState == Creating
-       and newState == Available:
-        readyProgress.RecordReady(owner.UID)
+require scaleUpCooldown > safetyMargin
 ```
 
-`RecordReady` is deliberately executed after the status patch. A failed or conflicted status write
-must not produce progress that other controllers cannot observe.
+The default Pending timeout is therefore 60 seconds. A configured cooldown above 65 seconds does not
+increase the Pending timeout beyond 60 seconds; it only extends the interval before another scale-up.
+SandboxSet obtains the CapacityPolicy that targets it through the controller cache and uses the same
+resolver; no timeout value is copied into SandboxSet status. If no associated CapacityPolicy is
+available, it uses the 65-second default cooldown and 60-second derived timeout for condition
+calculation.
 
-PoolAutoscaler logically clears Ready progress before every successful target increase by capturing
-the current sequence as that scale-up's baseline. A later increase is ready only when:
+The safety margin provides an interval in which Pending deadlines can elapse and `ScalingLimited` can
+be published before PoolAutoscaler reaches its next scale-up decision. If publication is delayed, the
+missing or stale condition keeps the gate closed conservatively. Every successful scale action updates
+existing `status.lastScaleTime`; the cooldown gates only later increases. Failed or conflicted target
+patches do not update it. Initial bootstrap may perform the first increase immediately, but that
+increase starts the cooldown. Scale-down remains allowed independently of both scale-up gates.
 
-```text
-readyProgress[SandboxSetUID] > scaleUpBaseline[SandboxSetUID]
-```
-
-A sequence and baseline are used instead of resetting a boolean. This prevents a concurrent Ready
-event from being overwritten by a clear operation. PoolAutoscaler establishes the baseline before
-patching `SandboxSet.spec.replicas`; if the patch fails, it cancels that pending baseline. Every
-successful target increase, including Cron and initial bounds enforcement, establishes a new baseline
-for subsequent capacity-driven scaling.
-
-The tracker records the state transition itself rather than comparing `creationTimestamp`,
-`Ready.LastTransitionTime`, or `PoolAutoscaler.status.lastScaleTime`. It therefore does not depend on
-clock ordering and also accepts an older Pending Sandbox that becomes Available after the target
-increase as valid execution progress.
-
-An already Available Sandbox being claimed does not change its Ready state and does not increment the
-sequence. A newly created Sandbox that becomes Available increments the sequence immediately after
-its status update; a subsequent immediate claim cannot erase that progress. Claim events therefore
-do not require separate handling.
-
-The progress sequence is process-local and intentionally not persisted. After a controller-manager
-restart, no outstanding baseline is restored; the next successful target increase establishes a new
-baseline and normal gating resumes.
-
-### Tracker Lifecycle and Concurrency
-
-The shared tracker exposes atomic operations equivalent to:
-
-```text
-Current(SandboxSetUID) uint64
-RecordReady(SandboxSetUID)
-Delete(SandboxSetUID)
-```
-
-`RecordReady` increments the sequence under synchronization. PoolAutoscaler stores the baseline in
-its existing process-local reconciliation state. Because each SandboxSet can have at most one
-PoolAutoscaler, one Ready event grants at most one later target increase: immediately before that
-increase, PoolAutoscaler replaces the old baseline with the current sequence.
-
-The baseline is captured before patching `spec.replicas`, which defines the start of the new
-observation interval and prevents a concurrent Ready transition from being lost. If the patch fails,
-the pending baseline is discarded. Scale-down clears any outstanding Ready-progress wait because it
-is not gated by startup progress. Tracker state is removed when the SandboxSet or its PoolAutoscaler
-is deleted. Both the sequence and baseline disappear together on process restart.
+This version applies the cooldown to every later increase, including Cron-driven increases. Allowing
+Cron to bypass it would permit another target increase before the derived Pending timeout can report
+blocked execution.
 
 ### ScalingLimited Condition
 
-`ScalingLimited` is an orthogonal current-state condition. It is `True` while one or more owned
-Sandboxes are blocked from completing startup and returns to `False` when all blockers clear. It is
-not sticky.
+`ScalingLimited` is a current-state condition. It is `True` only when failed and timed-out owned
+Sandboxes consume the full startup concurrency budget. It returns to `False` when blocker count falls
+below that budget and is not sticky.
 
 SandboxSet derives exactly two aggregate categories from existing Sandbox state:
 
 - `Failed`: an owned Sandbox reports an existing startup failure through its `Ready=False`
   condition. Existing reasons such as `PodCreateFailed` and `StartContainerFailed` contribute to the
   single aggregate category and are not exposed as separate counts.
-- `Timeout`: an owned Sandbox remains `ResourcePending` longer than
-  `--sandboxset-pending-timeout`, which defaults to one minute.
+- `Timeout`: an owned Sandbox remains `ResourcePending` longer than the internally derived
+  `pendingTimeout`. With the default 65-second scale-up cooldown, this timeout is 60 seconds.
 
 This design does not change Sandbox controller behavior or add Sandbox failure reasons. States that
 are not already classified as failures remain ordinary Creating or Pending states until the timeout.
 SandboxSet derives the counts from its existing owned-Sandbox list and does not inspect Pods.
 
-When blockers exist, SandboxSet publishes:
+When blockers exhaust the startup concurrency budget, SandboxSet publishes:
 
 ```yaml
 status:
   conditions:
     - type: ScalingLimited
       status: "True"
-      reason: StartupBlocked
+      reason: StartupBudgetExhausted
       observedGeneration: 12
-      message: "3 Sandboxes are blocked from starting: Timeout=2, Failed=1"
+      message: "3 of 3 startup slots are blocked: Timeout=2, Failed=1"
 ```
 
-When no blocker remains, it publishes `ScalingLimited=False/ScalingAllowed`. Counts and a bounded
-summary belong only in the condition message, Events, logs, and metrics; no UID list or counter is
-added to the API. `LastTransitionTime` changes only when status changes, and a Warning Event is
-emitted only on transition to `True`.
+When blocker count is below the budget, SandboxSet publishes
+`ScalingLimited=False/StartupBudgetAvailable`, even if one or more blocked Sandboxes remain. Counts
+and a bounded summary belong only in the condition message, Events, logs, and metrics; no UID list or
+counter is added to the API. `LastTransitionTime` changes only when status changes, and a Warning
+Event is emitted only on transition to `True`.
 
 The earliest incomplete Pending deadline supplies `RequeueAfter`. Timeout state is derived from the
 Sandbox `creationTimestamp`, so it can be reconstructed after a controller restart without a
@@ -269,56 +227,72 @@ for sandbox in ownedSandboxes:
         else:
             nextDeadline = min(nextDeadline, deadline)
 
-if failed + timeout > 0:
-    ScalingLimited = True / StartupBlocked
+executionBase = max(status.replicas, 1)
+maxConcurrent = resolve(spec.scaleStrategy.maxUnavailable,
+                        executionBase, default=unlimited)
+startupBudget = max(maxConcurrent, 1) if finite else executionBase
+blocked = failed + timeout
+
+if blocked >= startupBudget:
+    ScalingLimited = True / StartupBudgetExhausted
 else:
-    ScalingLimited = False / ScalingAllowed
+    ScalingLimited = False / StartupBudgetAvailable
 
 requeueAfter = max(nextDeadline - now, 0)
 ```
 
-Only `Failed` and `Timeout` are externally aggregated. `dirtyCreate` participates in creation
-concurrency but is not an observed Sandbox and therefore does not contribute to either blocker count.
+For finite `maxUnavailable`, `startupBudget` is exactly the same resolved value used by physical
+creation control. When `maxUnavailable` is absent, creation remains unlimited and the condition uses
+the current observed pool size as its diagnostic budget; only an entirely blocked observed pool then
+limits another target increase. `startupBudget` is always at least one.
+
+A single failed or timed-out Sandbox therefore does not block another target increase while another
+startup slot remains. `dirtyCreate` participates in `inFlightUnavailable` and creation concurrency,
+but it is not an observed Sandbox and does not contribute to `blocked`.
 
 `ScalingLimited=True` does not delete or replace Sandboxes and does not stop SandboxSet from
 reconciling its already-declared target within `maxUnavailable`. It only prevents PoolAutoscaler from
-publishing another scale-up target.
+publishing another scale-up target after cooldown.
 
 ### PoolAutoscaler Gate
 
-Before a capacity-driven target increase, PoolAutoscaler requires:
+Before a capacity-driven or Cron-driven target increase, PoolAutoscaler requires:
 
-1. `SandboxSet.status.observedGeneration >= SandboxSet.metadata.generation`.
-2. `ScalingLimited=False` for the current SandboxSet generation.
-3. Either no target increase is awaiting progress, or the SandboxSet progress sequence is greater
-   than the baseline captured for the previous target increase.
-4. A freshly recomputed Capacity recommendation greater than current `spec.replicas`.
-5. The scale-up cooldown, when configured, to have elapsed.
+1. The scale-up cooldown started by the previous successful increase to have elapsed.
+2. `SandboxSet.status.observedGeneration >= SandboxSet.metadata.generation`.
+3. `ScalingLimited=False` for the current SandboxSet generation.
+4. A freshly recomputed recommendation greater than current `spec.replicas`.
 
-If `ScalingLimited` is missing, stale, or `Unknown`, the blocker gate remains closed. PoolAutoscaler
-does not parse its reason or message.
+The cooldown is checked before the blocker condition. Because `pendingTimeout` is at least five
+seconds shorter than the cooldown, SandboxSet has an interval to classify prolonged Pending
+Sandboxes and publish the current condition before the next increase is eligible. If
+`ScalingLimited` is missing, stale, or `Unknown` at cooldown expiry, the blocker gate remains closed.
+PoolAutoscaler does not parse its reason, message, counts, or `maxUnavailable`.
 
-The initial bounds-enforcement action may bootstrap `minReplicas` without prior Ready progress or
-prior `ScalingLimited=False`, allowing an empty pool to establish observable startup state. Cron
-targets bypass the previous-progress wait and capacity cooldown because they represent explicit
-scheduled intent, but they still require current-generation `ScalingLimited=False`. Scale-down is not
-blocked by either gate. SandboxSet always applies its physical creation limit.
+The initial bounds-enforcement action may bootstrap `minReplicas` immediately without prior
+`ScalingLimited=False`, allowing an empty pool to establish observable startup state. Its successful
+target patch starts the cooldown. Cron follows the same cooldown and condition gate as Capacity in
+this version. Scale-down is not blocked by either gate, and SandboxSet always applies its physical
+creation limit.
 
-Before any successful target increase, PoolAutoscaler captures the current tracker sequence as the
-new baseline. It then waits for a sequence increment, a `ScalingLimited` condition update, or a
-timer-driven reconciliation. On every evaluation it reads fresh SandboxSet status and recomputes the
-recommendation. If Ready progress has restored available capacity, the recommendation naturally
-keeps the current target. If demand remains high, the advanced sequence allows the next increase.
+At cooldown expiry, PoolAutoscaler reads fresh SandboxSet status and recomputes the recommendation.
+If healthy Sandboxes have restored available capacity, the recommendation naturally keeps the current
+target. If demand remains high and the startup budget is not exhausted, another increase is allowed
+and starts a new cooldown.
 
-The Capacity gate can be expressed as:
+The scale-up gate can be expressed as:
 
 ```text
-function reconcileCapacityScaleUp(poolAutoscaler, sandboxSet):
-    policyDesired = calculateCapacityPolicy()
-    policyDesired = clamp(policyDesired, minReplicas, maxReplicas)
+function reconcileScaleUp(poolAutoscaler, sandboxSet):
+    desired = calculateActivePolicyTarget()
+    desired = clamp(desired, minReplicas, maxReplicas)
 
-    if policyDesired <= sandboxSet.spec.replicas:
-        return keepOrScaleDown(policyDesired)
+    if desired <= sandboxSet.spec.replicas:
+        return keepOrScaleDown(desired)
+
+    cooldown = resolveScaleUpCooldown(defaultWhenNilOrZero=65 seconds)
+    if now < status.lastScaleTime + cooldown:
+        return requeueAt(status.lastScaleTime + cooldown)
 
     if sandboxSet.status.observedGeneration < sandboxSet.metadata.generation:
         return keepCurrentTarget()
@@ -329,45 +303,84 @@ function reconcileCapacityScaleUp(poolAutoscaler, sandboxSet):
        or limited.status != False:
         return keepCurrentTarget()
 
-    baseline, waiting = scaleUpBaseline.Load(sandboxSet.UID)
-    currentSequence = readyProgress.Current(sandboxSet.UID)
-    if waiting and currentSequence <= baseline:
+    refresh sandboxSet and recompute desired
+    if desired <= sandboxSet.spec.replicas:
         return keepCurrentTarget()
 
-    if scaleUpCooldownNotElapsed():
-        return requeueWhenCooldownExpires()
-
-    refresh sandboxSet and recompute policyDesired
-    if policyDesired <= sandboxSet.spec.replicas:
-        return keepCurrentTarget()
-
-    nextBaseline = readyProgress.Current(sandboxSet.UID)
-    if patch sandboxSet.spec.replicas = policyDesired succeeds:
-        scaleUpBaseline.Store(sandboxSet.UID, nextBaseline)
+    if patch sandboxSet.spec.replicas = desired succeeds:
+        update status.lastScaleTime = now
     else:
-        return retryWithoutChangingBaseline()
+        return retryWithoutStartingCooldown()
 ```
 
-The second sequence read immediately before the target patch is important. It consumes all Ready
-progress observed before this target increase and makes only a later transition eligible to unlock
-the next increase.
-
-Cron and initial bootstrap use the following exceptions:
+Exceptions are limited to bootstrap and scale-down:
 
 ```text
-Cron increase:
-    bypass previous-progress wait and capacity cooldown
-    require current ScalingLimited=False
-    capture a new baseline when the target patch succeeds
-
 initial minReplicas bootstrap:
-    may bypass previous-progress and ScalingLimited initialization
-    capture a new baseline when the target patch succeeds
+    may bypass cooldown and ScalingLimited initialization
+    start cooldown when the target patch succeeds
 
 scale-down:
-    never blocked by Ready progress or ScalingLimited
-    clear any outstanding scale-up baseline after a successful patch
+    never blocked by scale-up cooldown or ScalingLimited
+    update the existing lastScaleTime after a successful scale-down
+    thereby restart the cooldown before a later scale-up
 ```
+
+### User-Visible Behavior
+
+This design changes configuration defaults and scaling timing, but does not add a new CRD field or
+command-line flag.
+
+#### Configuration
+
+- Users continue configuring scale-up delay through
+  `spec.capacityPolicy.scaleUp.stabilizationWindowSeconds`.
+- Its effective default changes from `0` to `65` seconds. An omitted or explicit `0` resolves to 65
+  seconds for compatibility; a non-zero value must be greater than `5` seconds. Values from `1`
+  through `5` are rejected by PoolAutoscaler validation.
+- Pending timeout is not user-configurable. It is derived internally as
+  `min(resolvedScaleUpCooldown - 5 seconds, 60 seconds)`.
+- Existing `spec.scaleStrategy.maxUnavailable` remains the only user-facing startup-concurrency
+  setting. Absolute and percentage values retain their existing resolution behavior.
+
+Examples:
+
+| Scale-up cooldown | Derived Pending timeout |
+| --- | --- |
+| omitted or `0` | 60 seconds |
+| 30 seconds | 25 seconds |
+| 65 seconds | 60 seconds |
+| 120 seconds | 60 seconds |
+
+Existing PoolAutoscalers that omit the field or explicitly store `0` require no manifest migration,
+but after upgrade their successive scale-ups are delayed by 65 seconds instead of occurring without
+a cooldown.
+
+#### Scaling Behavior
+
+- The first `minReplicas` bootstrap may occur immediately. Each later Capacity or Cron increase waits
+  for the scale-up cooldown.
+- A failed or timed-out Sandbox does not by itself stop target growth when startup budget remains.
+  Scale-up is blocked only when `Failed + Timeout >= startupBudget`.
+- Healthy sustained demand may continue increasing the target once per cooldown interval. There is no
+  requirement to observe an individual Sandbox Ready transition between increases.
+- SandboxSet still enforces `maxUnavailable` while creating toward the declared target, independently
+  of PoolAutoscaler's cooldown.
+- Scale-down remains allowed while scale-up is cooling down or limited.
+
+#### Observability
+
+Users observe startup-budget exhaustion through the existing
+`SandboxSet.status.conditions[type=ScalingLimited]`:
+
+- `False/StartupBudgetAvailable`: another increase may proceed after cooldown if policy still
+  recommends it. This can remain `False` when blocker count is non-zero but below the budget.
+- `True/StartupBudgetExhausted`: PoolAutoscaler keeps the current target unchanged after cooldown.
+- The condition message reports bounded `Failed` and `Timeout` counts for diagnosis. Users do not need
+  to parse the message for automation; automation should rely on condition status and reason.
+
+There is no `ScaleUpReady` condition or Ready-progress status. Existing Sandbox Ready conditions,
+Events, logs, and metrics remain available for investigating individual startup behavior.
 
 ### State Transitions
 
@@ -376,72 +389,78 @@ The following diagram shows only the new execution-coordination logic:
 ```mermaid
 flowchart LR
     subgraph PA["PoolAutoscaler"]
-        PA_Check["Check progress<br/>and blocker gates"]
-        PA_Begin["Capture baseline<br/>Increase target"]
-        PA_Wait["Keep target<br/>unchanged"]
+        PA_Evaluate["Compute desired target"]
+        PA_Cooldown["Wait for scale-up cooldown"]
+        PA_Check["Check current ScalingLimited"]
+        PA_Update["Increase target<br/>Start cooldown"]
+        PA_Keep["Keep target unchanged"]
     end
 
     subgraph SS["SandboxSet Controller"]
-        SS_Execute["Create within<br/>maxUnavailable"]
-        SS_Blocked["Publish ScalingLimited=True<br/>Failed or Timeout"]
+        SS_Execute["Create within maxUnavailable"]
+        SS_Classify["Classify Failed and Timeout"]
+        SS_Open["Publish ScalingLimited=False<br/>budget available"]
+        SS_Blocked["Publish ScalingLimited=True<br/>budget exhausted"]
     end
 
-    subgraph SB["Sandbox Controller"]
+    subgraph SB["Sandbox Controller / Sandbox"]
         SB_Pending["Creating / Pending"]
-        SB_Ready["Persist Available"]
-        SB_Record["Increment SandboxSet<br/>progress sequence"]
+        SB_Ready["Available"]
+        SB_Failed["Existing startup failure"]
     end
 
-    PA_Check -->|"gates open"| PA_Begin
-    PA_Check -->|"gate closed"| PA_Wait
-    PA_Begin -->|"new target"| SS_Execute
+    PA_Evaluate -->|"increase recommended"| PA_Cooldown
+    PA_Cooldown -->|"not elapsed"| PA_Keep
+    PA_Cooldown -->|"elapsed"| PA_Check
+    PA_Check -->|"current False"| PA_Update
+    PA_Check -->|"missing, stale, Unknown, or True"| PA_Keep
+    PA_Update -->|"new target"| SS_Execute
     SS_Execute -->|"create Sandbox"| SB_Pending
-    SB_Pending -->|"Pending → Available"| SB_Ready
-    SB_Ready --> SB_Record
-    SB_Record -->|"sequence advanced"| PA_Check
-    SB_Pending -->|"Failed or Timeout"| SS_Blocked
-    SS_Blocked -->|"block further increase"| PA_Wait
-    SS_Blocked -->|"all blockers clear"| SS_Execute
-    SS_Blocked -->|"condition update"| PA_Check
+    SB_Pending -->|"startup succeeds"| SB_Ready
+    SB_Pending -->|"timeout"| SS_Classify
+    SB_Failed --> SS_Classify
+    SS_Classify -->|"blocked < startupBudget"| SS_Open
+    SS_Classify -->|"blocked >= startupBudget"| SS_Blocked
+    SS_Open -->|"condition update"| PA_Evaluate
+    SS_Blocked -->|"condition update"| PA_Evaluate
 ```
 
-The in-process handshake is:
+The coordination loop is:
 
 ```text
-PoolAutoscaler captures the current progress sequence and increases the target
+PoolAutoscaler increases the target and starts the scale-up cooldown
 → SandboxSet creates within maxUnavailable
-→ Sandbox controller persists one Pending-to-Available transition
-→ Sandbox controller increments the owning SandboxSet's progress sequence
-→ PoolAutoscaler may evaluate the next capacity-driven increase
+→ SandboxSet classifies Failed and Timeout using the derived Pending timeout
+→ SandboxSet compares Failed + Timeout with the resolved startup budget
+→ after cooldown, PoolAutoscaler increases again only when ScalingLimited=False
 ```
 
 ### Observation Window Interaction
 
 The observation window continues to collect capacity samples as defined by the PoolAutoscaler
-proposal. Its expiry only schedules another evaluation. It does not advance the Ready progress
-sequence, clear `ScalingLimited`, classify a Sandbox as failed, or replace the one-minute Pending
-timeout.
+proposal. Its expiry only schedules another evaluation. It does not end the scale-up cooldown, clear
+`ScalingLimited`, classify a Sandbox as failed, or replace the derived Pending timeout.
 
-A Pending-to-Available transition advances the sequence. PoolAutoscaler's normal sampling requeue
-observes the new value without requiring Sandbox controller to address or enqueue a PoolAutoscaler
-directly. A `ScalingLimited` condition change can trigger earlier re-evaluation through the existing
-SandboxSet watch. PoolAutoscaler checks the current baseline, sequence, SandboxSet generation, and
-condition again before deciding whether to increase the target.
+SandboxSet's timeout `RequeueAfter` and lifecycle watches refresh `ScalingLimited` independently of the
+observation window. A condition change can trigger earlier PoolAutoscaler reconciliation through the
+existing SandboxSet watch, but another increase still waits until cooldown expiry. PoolAutoscaler then
+checks current generation and condition state and recomputes the recommendation.
 
 ## Risks and Mitigations
 
-- **Repeated growth without execution progress**: require the process-local sequence to advance past
-  the previous target increase's baseline.
-- **Lost Ready event while clearing state**: use a monotonically increasing sequence and capture a
-  baseline instead of resetting a boolean.
-- **Growth while startup is blocked**: require current-generation `ScalingLimited=False` for Capacity
-  and Cron increases.
+- **Repeated growth while startup is still unresolved**: enforce a non-zero cooldown after every
+  successful target increase, derive Pending timeout to expire at least five seconds earlier, and cap
+  it at 60 seconds.
+- **Growth after startup concurrency is exhausted**: require current-generation
+  `ScalingLimited=False` for Capacity and Cron increases.
+- **One isolated blocker unnecessarily stops growth**: compare `Failed + Timeout` with the resolved
+  startup budget instead of treating any blocker as sufficient.
 - **Stale blocker observations**: compare `ScalingLimited.observedGeneration` and SandboxSet
   `status.observedGeneration` with `metadata.generation`.
-- **Controller-manager restart**: outstanding progress state is intentionally not reconstructed; the
-  next target increase establishes a new baseline.
-- **API growth and high-cardinality status**: keep Ready progress in memory, reuse
-  `status.conditions` for blockers, and keep object identifiers and counters out of the API.
+- **Controller-manager restart**: reconstruct Pending timeout state from Sandbox
+  `creationTimestamp`; the existing scale timestamp semantics continue to govern cooldown recovery.
+- **API growth and high-cardinality status**: reuse `status.conditions`, derive timeout from existing
+  policy configuration, and keep object identifiers and counters out of the API.
 - **Missed Pending timeout without Pod events**: derive the nearest deadline from
   `creationTimestamp` and set `RequeueAfter`.
 
@@ -451,14 +470,16 @@ condition again before deciding whether to increase the target.
   execution policy and couples target selection to create concurrency.
 - **Let PoolAutoscaler count Pending Sandboxes**: rejected because it requires listing execution
   objects and duplicates SandboxSet lifecycle knowledge.
-- **Persist a `ScaleUpReady` condition**: rejected because PoolAutoscaler and Sandbox controller run
-  in the same process, so short-lived progress can be coordinated without expanding persisted API
-  semantics.
-- **Compare `creationTimestamp` or `Ready.LastTransitionTime` with `lastScaleTime`**: rejected because
-  the timestamps come from different lifecycle stages and potentially different clocks; direct
-  transition observation is unambiguous.
-- **Gate on claim events**: rejected because an already Available Sandbox being claimed is demand, not
-  scale-up execution progress. A new Sandbox records its Ready transition before an immediate claim.
+- **Track Ready progress in memory or in a `ScaleUpReady` condition**: deferred for this version. The
+  cooldown gives SandboxSet enough time to classify blocked execution without adding a Ready-event
+  handshake.
+- **Expose an independent Pending-timeout setting**: rejected because an unsafe combination could let
+  cooldown expire before timeout classification. Deriving it from scale-up cooldown preserves the
+  ordering by construction.
+- **Treat any Failed or Timeout Sandbox as limited**: rejected because an isolated blocker does not
+  exhaust a larger `maxUnavailable` budget.
+- **Let Cron bypass scale-up cooldown**: rejected because it could increase the target before Pending
+  timeout classification completes.
 - **Treat observation-window expiry as progress or failure**: rejected because timer expiry provides
   no evidence about Sandbox startup.
 - **Add detailed Sandbox or Pod failure reasons**: rejected for this version; `ScalingLimited`
@@ -467,48 +488,43 @@ condition again before deciding whether to increase the target.
 
 ## Test Plan
 
-### Sandbox Controller and Tracker Unit Tests
-
-- Verify only Creating-to-Available transitions increment the owning SandboxSet sequence.
-- Verify progress is recorded only after the Sandbox status patch succeeds.
-- Verify an already Available Sandbox being claimed does not increment the sequence.
-- Verify an immediately claimed newly Available Sandbox retains the recorded progress.
-- Verify concurrent baseline capture and Ready updates cannot lose a sequence increment.
-- Verify a failed target patch discards its pending baseline and scale-down clears an outstanding
-  progress wait.
-- Verify tracker entries are isolated by SandboxSet UID and cleaned up when no longer needed.
-
 ### SandboxSet Unit Tests
 
 - Verify absolute and percentage `maxUnavailable` creation limits, including `dirtyCreate`.
+- Verify Pending timeout is `min(resolvedScaleUpCooldown - 5 seconds, 60 seconds)` and defaults to
+  60 seconds.
 - Verify `ScalingLimited` aggregates exactly `Failed` and `Timeout`.
+- Verify `ScalingLimited=True` only when `Failed + Timeout >= startupBudget`.
+- Verify a blocker count below the budget publishes `False/StartupBudgetAvailable`.
+- Verify absent `maxUnavailable` uses observed pool size as the diagnostic budget.
 - Verify other Creating and Pending states remain unclassified before timeout.
-- Verify the condition clears when all blockers resolve.
 - Verify timeout requeue and restart reconstruction from `creationTimestamp`.
 - Verify condition messages are bounded and Warning Events occur only on transition to `True`.
 
 ### PoolAutoscaler Unit Tests
 
-- Verify Capacity increase waits until the sequence advances beyond the previous baseline and
-  requires current-generation `ScalingLimited=False`.
-- Verify baseline capture happens before the target patch and a failed patch cancels the pending
-  baseline.
+- Verify the scale-up cooldown defaults to 65 seconds for omitted and explicit zero values, and
+  explicitly configured non-zero values must exceed the five-second safety margin.
+- Verify every successful Capacity or Cron increase starts the cooldown.
+- Verify failed or conflicted target patches do not start the cooldown.
+- Verify a successful scale-down remains allowed and restarts the interval before a later scale-up.
+- Verify another increase is denied before cooldown expiry regardless of condition updates.
 - Verify Capacity and Cron increases stop for missing, stale, `Unknown`, or `True`
-  `ScalingLimited`.
-- Verify Cron bypasses the previous-progress wait and cooldown but not `ScalingLimited`, and starts a
-  new baseline after increasing the target.
+  `ScalingLimited` after cooldown expiry.
 - Verify initial `minReplicas` bootstrap and scale-down retain their exceptions.
-- Verify observation-window expiry re-evaluates without advancing progress or opening either gate.
+- Verify observation-window expiry re-evaluates without ending cooldown or opening the condition gate.
 - Verify PoolAutoscaler does not inspect `maxUnavailable`, Pending counts, Pods, or Sandboxes.
 
 ### Integration Tests
 
 - Verify healthy sustained demand can increase the target across multiple generations.
 - Verify no-demand replenishment restores available capacity and stops further target growth.
-- Verify startup failure and Pending timeout block further increases and recovery reopens the gate.
+- Verify startup blockers reaching the budget stop further increases after cooldown, and recovery
+  reopens the gate.
+- Verify a blocker count below the startup budget permits sustained-demand growth after cooldown.
 - Verify condition transitions, Events, logs, and metrics provide sufficient diagnostics.
 
 ## Implementation History
 
 - [x] 27/08/2026: Initial execution-coordination proposal extracted from the PoolAutoscaler design.
-- [x] 27/08/2026: Moved Ready progress detection to a process-local Sandbox controller tracker.
+- [x] 27/08/2026: Replaced Ready-progress coordination with cooldown-based startup-budget limiting.

--- a/docs/proposals/20260827-sandboxset-scale-up-execution-coordination.md
+++ b/docs/proposals/20260827-sandboxset-scale-up-execution-coordination.md
@@ -1,0 +1,514 @@
+---
+title: SandboxSet scale-up execution coordination
+authors:
+  - "@sivanzcw"
+reviewers:
+  - "@furykerry"
+creation-date: 2026-08-27
+last-updated: 2026-08-27
+status: implementable
+see-also:
+  - "/docs/proposals/20260106-sandboxset-autoscaler.md"
+replaces:
+superseded-by:
+---
+
+# SandboxSet scale-up execution coordination
+
+## Table of Contents
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [Controller Responsibilities](#controller-responsibilities)
+  - [SandboxSet Creation Limit](#sandboxset-creation-limit)
+  - [In-Memory Ready Progress Tracker](#in-memory-ready-progress-tracker)
+  - [Tracker Lifecycle and Concurrency](#tracker-lifecycle-and-concurrency)
+  - [ScalingLimited Condition](#scalinglimited-condition)
+  - [PoolAutoscaler Gate](#poolautoscaler-gate)
+  - [State Transitions](#state-transitions)
+  - [Observation Window Interaction](#observation-window-interaction)
+- [Risks and Mitigations](#risks-and-mitigations)
+- [Alternatives](#alternatives)
+- [Test Plan](#test-plan)
+- [Implementation History](#implementation-history)
+
+## Summary
+
+This proposal defines the execution coordination between PoolAutoscaler, Sandbox controller, and
+SandboxSet during scale-up. PoolAutoscaler remains responsible for selecting a desired capacity
+target, SandboxSet limits physical creation and reports startup blockers through `ScalingLimited`,
+and Sandbox controller records Pending-to-Available progress in a process-local shared tracker.
+
+The tracker prevents repeated target increases when Sandbox creation has made no progress. Recording
+the transition in Sandbox controller also preserves healthy high-throughput replenishment when a
+Sandbox becomes Available and is claimed immediately. `ScalingLimited` reuses
+`SandboxSet.status.conditions`; the progress tracker does not add API fields, replica counters,
+blocker lists, timestamps, or claim-tracking fields.
+
+The PoolAutoscaler policies and capacity calculations are defined in
+[SandboxSet supports autoscaler](./20260106-sandboxset-autoscaler.md).
+
+## Motivation
+
+Target selection and target execution belong to different controller layers. A capacity policy may
+recommend a much larger target while SandboxSet is still creating Sandboxes under
+`maxUnavailable`, or while startup is blocked by an existing failure or a prolonged Pending state.
+If PoolAutoscaler treats every observation-window expiry as permission to increase the target again,
+the desired replica count can continue growing without execution progress.
+
+PoolAutoscaler must not duplicate SandboxSet execution logic by interpreting `maxUnavailable`,
+listing Sandboxes, or inspecting Pods. Because PoolAutoscaler and Sandbox controller run in the same
+controller-manager process, Sandbox controller can publish Ready progress through a shared in-memory
+tracker. SandboxSet separately publishes startup blockage as an aggregate condition.
+
+### Goals
+
+- Keep desired-capacity calculation in PoolAutoscaler and physical creation control in SandboxSet.
+- Detect Pending-to-Available progress in Sandbox controller before another capacity-driven target
+  increase.
+- Prevent Capacity and Cron target growth while known startup blockers exist.
+- Aggregate startup blockers without adding new Sandbox failure reasons.
+- Reuse the existing conditions field for blockers and keep Ready progress in process memory.
+
+### Non-Goals
+
+- Tracking claimed Sandboxes or returning them to the warm pool.
+- Replacing failed Sandboxes or changing Sandbox restart behavior.
+- Adding Pod-derived failure reasons such as `PodUnschedulable` or
+  `ContainerStartupBlocked`.
+- Letting PoolAutoscaler calculate Pending age, creation concurrency, or blocker counts.
+- Treating observation-window expiry or `maxUnavailable` saturation as a failure.
+- Persisting or reconstructing an outstanding Ready-progress wait across controller-manager restart.
+
+## Proposal
+
+### Controller Responsibilities
+
+Responsibilities are split across three controllers running in the same controller-manager process:
+
+- Sandbox controller manages one Sandbox. After successfully persisting a Pending-to-Available
+  transition, it increments a process-local progress sequence for the owning SandboxSet.
+- SandboxSet controller executes `spec.replicas`, owns `maxUnavailable`, and publishes the aggregate
+  `ScalingLimited` condition.
+- PoolAutoscaler computes the desired target, snapshots the progress sequence before increasing the
+  target, and waits for that sequence to advance before another capacity-driven increase. It does
+  not list Sandboxes or Pods and does not interpret `maxUnavailable`.
+
+The tracker is keyed by SandboxSet UID, not name, so deletion and recreation of a same-named
+SandboxSet cannot inherit progress. Sampling history, cooldown timestamps, the per-SandboxSet
+progress sequence, and the active scale-up baseline all remain in controller memory. Only
+`ScalingLimited` is persisted as an aggregate condition.
+
+### SandboxSet Creation Limit
+
+SandboxSet retains its existing in-flight calculation:
+
+```text
+inFlightUnavailable = max(status.replicas - status.availableReplicas, 0)
+```
+
+`status.replicas` includes Creating and Available Sandboxes. Existing expectation accounting also
+includes successful create requests that are not visible through the informer yet (`dirtyCreate`).
+Therefore, `inFlightUnavailable` represents observed Creating Sandboxes plus `dirtyCreate`.
+
+SandboxSet resolves `spec.scaleStrategy.maxUnavailable` solely to limit physical create operations.
+An absent value preserves unlimited scale-up behavior. Absolute values are used directly;
+percentages are rounded up and resolved against the observed pool size rather than a newly enlarged
+desired target:
+
+```text
+executionBase = max(status.replicas, 1)
+maxConcurrent = resolve(spec.scaleStrategy.maxUnavailable,
+                        executionBase, default=unlimited)
+createHeadroom = max(maxConcurrent - inFlightUnavailable, 0)
+```
+
+SandboxSet creates toward `spec.replicas` while `createHeadroom > 0`. Reaching the limit stops new
+create requests until a slot opens, but it is normal flow control rather than a startup failure.
+
+### In-Memory Ready Progress Tracker
+
+Sandbox controller detects progress by comparing the persisted Sandbox status loaded at the start of
+reconciliation with the newly calculated status. It records progress only after the status patch has
+succeeded and only when both of the following are true:
+
+1. The old Sandbox state is Creating, including ordinary Pending startup.
+2. The new Sandbox state is Available and the Sandbox has a SandboxSet controller owner reference.
+
+The shared tracker maintains a monotonically increasing sequence for each SandboxSet UID:
+
+```text
+readyProgress[SandboxSetUID] = sequence
+```
+
+Sandbox controller updates it after persisting status:
+
+```text
+oldState = GetSandboxState(persistedSandbox)
+newState = GetSandboxState(sandboxWithNewStatus)
+
+if patchSandboxStatus(sandboxWithNewStatus) succeeded:
+    owner = SandboxSetControllerRef(persistedSandbox)
+    if owner exists
+       and oldState == Creating
+       and newState == Available:
+        readyProgress.RecordReady(owner.UID)
+```
+
+`RecordReady` is deliberately executed after the status patch. A failed or conflicted status write
+must not produce progress that other controllers cannot observe.
+
+PoolAutoscaler logically clears Ready progress before every successful target increase by capturing
+the current sequence as that scale-up's baseline. A later increase is ready only when:
+
+```text
+readyProgress[SandboxSetUID] > scaleUpBaseline[SandboxSetUID]
+```
+
+A sequence and baseline are used instead of resetting a boolean. This prevents a concurrent Ready
+event from being overwritten by a clear operation. PoolAutoscaler establishes the baseline before
+patching `SandboxSet.spec.replicas`; if the patch fails, it cancels that pending baseline. Every
+successful target increase, including Cron and initial bounds enforcement, establishes a new baseline
+for subsequent capacity-driven scaling.
+
+The tracker records the state transition itself rather than comparing `creationTimestamp`,
+`Ready.LastTransitionTime`, or `PoolAutoscaler.status.lastScaleTime`. It therefore does not depend on
+clock ordering and also accepts an older Pending Sandbox that becomes Available after the target
+increase as valid execution progress.
+
+An already Available Sandbox being claimed does not change its Ready state and does not increment the
+sequence. A newly created Sandbox that becomes Available increments the sequence immediately after
+its status update; a subsequent immediate claim cannot erase that progress. Claim events therefore
+do not require separate handling.
+
+The progress sequence is process-local and intentionally not persisted. After a controller-manager
+restart, no outstanding baseline is restored; the next successful target increase establishes a new
+baseline and normal gating resumes.
+
+### Tracker Lifecycle and Concurrency
+
+The shared tracker exposes atomic operations equivalent to:
+
+```text
+Current(SandboxSetUID) uint64
+RecordReady(SandboxSetUID)
+Delete(SandboxSetUID)
+```
+
+`RecordReady` increments the sequence under synchronization. PoolAutoscaler stores the baseline in
+its existing process-local reconciliation state. Because each SandboxSet can have at most one
+PoolAutoscaler, one Ready event grants at most one later target increase: immediately before that
+increase, PoolAutoscaler replaces the old baseline with the current sequence.
+
+The baseline is captured before patching `spec.replicas`, which defines the start of the new
+observation interval and prevents a concurrent Ready transition from being lost. If the patch fails,
+the pending baseline is discarded. Scale-down clears any outstanding Ready-progress wait because it
+is not gated by startup progress. Tracker state is removed when the SandboxSet or its PoolAutoscaler
+is deleted. Both the sequence and baseline disappear together on process restart.
+
+### ScalingLimited Condition
+
+`ScalingLimited` is an orthogonal current-state condition. It is `True` while one or more owned
+Sandboxes are blocked from completing startup and returns to `False` when all blockers clear. It is
+not sticky.
+
+SandboxSet derives exactly two aggregate categories from existing Sandbox state:
+
+- `Failed`: an owned Sandbox reports an existing startup failure through its `Ready=False`
+  condition. Existing reasons such as `PodCreateFailed` and `StartContainerFailed` contribute to the
+  single aggregate category and are not exposed as separate counts.
+- `Timeout`: an owned Sandbox remains `ResourcePending` longer than
+  `--sandboxset-pending-timeout`, which defaults to one minute.
+
+This design does not change Sandbox controller behavior or add Sandbox failure reasons. States that
+are not already classified as failures remain ordinary Creating or Pending states until the timeout.
+SandboxSet derives the counts from its existing owned-Sandbox list and does not inspect Pods.
+
+When blockers exist, SandboxSet publishes:
+
+```yaml
+status:
+  conditions:
+    - type: ScalingLimited
+      status: "True"
+      reason: StartupBlocked
+      observedGeneration: 12
+      message: "3 Sandboxes are blocked from starting: Timeout=2, Failed=1"
+```
+
+When no blocker remains, it publishes `ScalingLimited=False/ScalingAllowed`. Counts and a bounded
+summary belong only in the condition message, Events, logs, and metrics; no UID list or counter is
+added to the API. `LastTransitionTime` changes only when status changes, and a Warning Event is
+emitted only on transition to `True`.
+
+The earliest incomplete Pending deadline supplies `RequeueAfter`. Timeout state is derived from the
+Sandbox `creationTimestamp`, so it can be reconstructed after a controller restart without a
+persisted timer.
+
+SandboxSet calculates the aggregate condition during reconciliation:
+
+```text
+failed = 0
+timeout = 0
+nextDeadline = none
+
+for sandbox in ownedSandboxes:
+    if sandbox.Ready == False
+       and sandbox.Ready.reason is an existing startup-failure reason:
+        failed++
+        continue
+
+    if GetSandboxState(sandbox) == Creating
+       and stateReason == ResourcePending:
+        deadline = sandbox.creationTimestamp + pendingTimeout
+        if now >= deadline:
+            timeout++
+        else:
+            nextDeadline = min(nextDeadline, deadline)
+
+if failed + timeout > 0:
+    ScalingLimited = True / StartupBlocked
+else:
+    ScalingLimited = False / ScalingAllowed
+
+requeueAfter = max(nextDeadline - now, 0)
+```
+
+Only `Failed` and `Timeout` are externally aggregated. `dirtyCreate` participates in creation
+concurrency but is not an observed Sandbox and therefore does not contribute to either blocker count.
+
+`ScalingLimited=True` does not delete or replace Sandboxes and does not stop SandboxSet from
+reconciling its already-declared target within `maxUnavailable`. It only prevents PoolAutoscaler from
+publishing another scale-up target.
+
+### PoolAutoscaler Gate
+
+Before a capacity-driven target increase, PoolAutoscaler requires:
+
+1. `SandboxSet.status.observedGeneration >= SandboxSet.metadata.generation`.
+2. `ScalingLimited=False` for the current SandboxSet generation.
+3. Either no target increase is awaiting progress, or the SandboxSet progress sequence is greater
+   than the baseline captured for the previous target increase.
+4. A freshly recomputed Capacity recommendation greater than current `spec.replicas`.
+5. The scale-up cooldown, when configured, to have elapsed.
+
+If `ScalingLimited` is missing, stale, or `Unknown`, the blocker gate remains closed. PoolAutoscaler
+does not parse its reason or message.
+
+The initial bounds-enforcement action may bootstrap `minReplicas` without prior Ready progress or
+prior `ScalingLimited=False`, allowing an empty pool to establish observable startup state. Cron
+targets bypass the previous-progress wait and capacity cooldown because they represent explicit
+scheduled intent, but they still require current-generation `ScalingLimited=False`. Scale-down is not
+blocked by either gate. SandboxSet always applies its physical creation limit.
+
+Before any successful target increase, PoolAutoscaler captures the current tracker sequence as the
+new baseline. It then waits for a sequence increment, a `ScalingLimited` condition update, or a
+timer-driven reconciliation. On every evaluation it reads fresh SandboxSet status and recomputes the
+recommendation. If Ready progress has restored available capacity, the recommendation naturally
+keeps the current target. If demand remains high, the advanced sequence allows the next increase.
+
+The Capacity gate can be expressed as:
+
+```text
+function reconcileCapacityScaleUp(poolAutoscaler, sandboxSet):
+    policyDesired = calculateCapacityPolicy()
+    policyDesired = clamp(policyDesired, minReplicas, maxReplicas)
+
+    if policyDesired <= sandboxSet.spec.replicas:
+        return keepOrScaleDown(policyDesired)
+
+    if sandboxSet.status.observedGeneration < sandboxSet.metadata.generation:
+        return keepCurrentTarget()
+
+    limited = currentCondition(sandboxSet, ScalingLimited)
+    if limited is missing
+       or limited.observedGeneration < sandboxSet.metadata.generation
+       or limited.status != False:
+        return keepCurrentTarget()
+
+    baseline, waiting = scaleUpBaseline.Load(sandboxSet.UID)
+    currentSequence = readyProgress.Current(sandboxSet.UID)
+    if waiting and currentSequence <= baseline:
+        return keepCurrentTarget()
+
+    if scaleUpCooldownNotElapsed():
+        return requeueWhenCooldownExpires()
+
+    refresh sandboxSet and recompute policyDesired
+    if policyDesired <= sandboxSet.spec.replicas:
+        return keepCurrentTarget()
+
+    nextBaseline = readyProgress.Current(sandboxSet.UID)
+    if patch sandboxSet.spec.replicas = policyDesired succeeds:
+        scaleUpBaseline.Store(sandboxSet.UID, nextBaseline)
+    else:
+        return retryWithoutChangingBaseline()
+```
+
+The second sequence read immediately before the target patch is important. It consumes all Ready
+progress observed before this target increase and makes only a later transition eligible to unlock
+the next increase.
+
+Cron and initial bootstrap use the following exceptions:
+
+```text
+Cron increase:
+    bypass previous-progress wait and capacity cooldown
+    require current ScalingLimited=False
+    capture a new baseline when the target patch succeeds
+
+initial minReplicas bootstrap:
+    may bypass previous-progress and ScalingLimited initialization
+    capture a new baseline when the target patch succeeds
+
+scale-down:
+    never blocked by Ready progress or ScalingLimited
+    clear any outstanding scale-up baseline after a successful patch
+```
+
+### State Transitions
+
+The following diagram shows only the new execution-coordination logic:
+
+```mermaid
+flowchart LR
+    subgraph PA["PoolAutoscaler"]
+        PA_Check["Check progress<br/>and blocker gates"]
+        PA_Begin["Capture baseline<br/>Increase target"]
+        PA_Wait["Keep target<br/>unchanged"]
+    end
+
+    subgraph SS["SandboxSet Controller"]
+        SS_Execute["Create within<br/>maxUnavailable"]
+        SS_Blocked["Publish ScalingLimited=True<br/>Failed or Timeout"]
+    end
+
+    subgraph SB["Sandbox Controller"]
+        SB_Pending["Creating / Pending"]
+        SB_Ready["Persist Available"]
+        SB_Record["Increment SandboxSet<br/>progress sequence"]
+    end
+
+    PA_Check -->|"gates open"| PA_Begin
+    PA_Check -->|"gate closed"| PA_Wait
+    PA_Begin -->|"new target"| SS_Execute
+    SS_Execute -->|"create Sandbox"| SB_Pending
+    SB_Pending -->|"Pending → Available"| SB_Ready
+    SB_Ready --> SB_Record
+    SB_Record -->|"sequence advanced"| PA_Check
+    SB_Pending -->|"Failed or Timeout"| SS_Blocked
+    SS_Blocked -->|"block further increase"| PA_Wait
+    SS_Blocked -->|"all blockers clear"| SS_Execute
+    SS_Blocked -->|"condition update"| PA_Check
+```
+
+The in-process handshake is:
+
+```text
+PoolAutoscaler captures the current progress sequence and increases the target
+→ SandboxSet creates within maxUnavailable
+→ Sandbox controller persists one Pending-to-Available transition
+→ Sandbox controller increments the owning SandboxSet's progress sequence
+→ PoolAutoscaler may evaluate the next capacity-driven increase
+```
+
+### Observation Window Interaction
+
+The observation window continues to collect capacity samples as defined by the PoolAutoscaler
+proposal. Its expiry only schedules another evaluation. It does not advance the Ready progress
+sequence, clear `ScalingLimited`, classify a Sandbox as failed, or replace the one-minute Pending
+timeout.
+
+A Pending-to-Available transition advances the sequence. PoolAutoscaler's normal sampling requeue
+observes the new value without requiring Sandbox controller to address or enqueue a PoolAutoscaler
+directly. A `ScalingLimited` condition change can trigger earlier re-evaluation through the existing
+SandboxSet watch. PoolAutoscaler checks the current baseline, sequence, SandboxSet generation, and
+condition again before deciding whether to increase the target.
+
+## Risks and Mitigations
+
+- **Repeated growth without execution progress**: require the process-local sequence to advance past
+  the previous target increase's baseline.
+- **Lost Ready event while clearing state**: use a monotonically increasing sequence and capture a
+  baseline instead of resetting a boolean.
+- **Growth while startup is blocked**: require current-generation `ScalingLimited=False` for Capacity
+  and Cron increases.
+- **Stale blocker observations**: compare `ScalingLimited.observedGeneration` and SandboxSet
+  `status.observedGeneration` with `metadata.generation`.
+- **Controller-manager restart**: outstanding progress state is intentionally not reconstructed; the
+  next target increase establishes a new baseline.
+- **API growth and high-cardinality status**: keep Ready progress in memory, reuse
+  `status.conditions` for blockers, and keep object identifiers and counters out of the API.
+- **Missed Pending timeout without Pod events**: derive the nearest deadline from
+  `creationTimestamp` and set `RequeueAfter`.
+
+## Alternatives
+
+- **Let PoolAutoscaler interpret `maxUnavailable`**: rejected because it duplicates SandboxSet
+  execution policy and couples target selection to create concurrency.
+- **Let PoolAutoscaler count Pending Sandboxes**: rejected because it requires listing execution
+  objects and duplicates SandboxSet lifecycle knowledge.
+- **Persist a `ScaleUpReady` condition**: rejected because PoolAutoscaler and Sandbox controller run
+  in the same process, so short-lived progress can be coordinated without expanding persisted API
+  semantics.
+- **Compare `creationTimestamp` or `Ready.LastTransitionTime` with `lastScaleTime`**: rejected because
+  the timestamps come from different lifecycle stages and potentially different clocks; direct
+  transition observation is unambiguous.
+- **Gate on claim events**: rejected because an already Available Sandbox being claimed is demand, not
+  scale-up execution progress. A new Sandbox records its Ready transition before an immediate claim.
+- **Treat observation-window expiry as progress or failure**: rejected because timer expiry provides
+  no evidence about Sandbox startup.
+- **Add detailed Sandbox or Pod failure reasons**: rejected for this version; `ScalingLimited`
+  consumes only failure reasons already published by Sandbox controller and aggregates them as
+  `Failed`.
+
+## Test Plan
+
+### Sandbox Controller and Tracker Unit Tests
+
+- Verify only Creating-to-Available transitions increment the owning SandboxSet sequence.
+- Verify progress is recorded only after the Sandbox status patch succeeds.
+- Verify an already Available Sandbox being claimed does not increment the sequence.
+- Verify an immediately claimed newly Available Sandbox retains the recorded progress.
+- Verify concurrent baseline capture and Ready updates cannot lose a sequence increment.
+- Verify a failed target patch discards its pending baseline and scale-down clears an outstanding
+  progress wait.
+- Verify tracker entries are isolated by SandboxSet UID and cleaned up when no longer needed.
+
+### SandboxSet Unit Tests
+
+- Verify absolute and percentage `maxUnavailable` creation limits, including `dirtyCreate`.
+- Verify `ScalingLimited` aggregates exactly `Failed` and `Timeout`.
+- Verify other Creating and Pending states remain unclassified before timeout.
+- Verify the condition clears when all blockers resolve.
+- Verify timeout requeue and restart reconstruction from `creationTimestamp`.
+- Verify condition messages are bounded and Warning Events occur only on transition to `True`.
+
+### PoolAutoscaler Unit Tests
+
+- Verify Capacity increase waits until the sequence advances beyond the previous baseline and
+  requires current-generation `ScalingLimited=False`.
+- Verify baseline capture happens before the target patch and a failed patch cancels the pending
+  baseline.
+- Verify Capacity and Cron increases stop for missing, stale, `Unknown`, or `True`
+  `ScalingLimited`.
+- Verify Cron bypasses the previous-progress wait and cooldown but not `ScalingLimited`, and starts a
+  new baseline after increasing the target.
+- Verify initial `minReplicas` bootstrap and scale-down retain their exceptions.
+- Verify observation-window expiry re-evaluates without advancing progress or opening either gate.
+- Verify PoolAutoscaler does not inspect `maxUnavailable`, Pending counts, Pods, or Sandboxes.
+
+### Integration Tests
+
+- Verify healthy sustained demand can increase the target across multiple generations.
+- Verify no-demand replenishment restores available capacity and stops further target growth.
+- Verify startup failure and Pending timeout block further increases and recovery reopens the gate.
+- Verify condition transitions, Events, logs, and metrics provide sufficient diagnostics.
+
+## Implementation History
+
+- [x] 27/08/2026: Initial execution-coordination proposal extracted from the PoolAutoscaler design.
+- [x] 27/08/2026: Moved Ready progress detection to a process-local Sandbox controller tracker.


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Updates the PoolAutoscaler proposal to match the latest lifecycle-aware scaling design developed alongside #625.

- Defines SandboxSet lifecycle status for creating, available, and used Sandboxes.
- Clarifies percentage capacity targets, including used Sandboxes in the calculation base while keeping `spec.replicas` as unclaimed pool capacity.
- Documents scale-up flow control based on creation headroom and observed availability progress.
- Adds durable scale-up reservations, optimistic locking, and target UID scoping.
- Documents creating timeouts and failure circuit-breaker behavior related to #852.
- Aligns policy precedence, cooldown semantics, status fields, metrics, and test coverage with the final design.

### Ⅱ. Does this pull request fix one issue?

NONE

Related to #852.

### Ⅲ. Describe how to verify it

1. Review the rendered Markdown and table of contents.
2. Verify the API examples and scaling formulas against the proposed behavior.
3. Confirm the lifecycle-aware scaling and failure-handling sections are internally consistent.

### Ⅳ. Special notes for reviews

- This PR only updates the proposal document; it does not include controller or API implementation changes.
- The main review focus is the percentage target semantics, lifecycle-aware scale-up credit, durable reservation flow, and failure circuit-breaker behavior.
