### PR TITLE
fix(controller): use TLS for recycle writes

### DIFF
--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -82,6 +82,11 @@ type commonControl struct {
 type ResumeFunc func(ctx context.Context, args EnsureFuncArgs) error
 
 func NewCommonControl(args SandboxControlArgs) SandboxControl {
+	recycleConfig := args.RecycleConfig
+	if recycleConfig.RuntimeTLSBundle == nil {
+		recycleConfig.RuntimeTLSBundle = args.RuntimeTLSBundle
+	}
+
 	initializer := &defaultSandboxInitializer{
 		client:          args.Client,
 		apiReader:       args.APIReader,
@@ -98,7 +103,7 @@ func NewCommonControl(args SandboxControlArgs) SandboxControl {
 		podControl:           args.PodControl,
 		lifecycleHookFunc:    ExecuteLifecycleHook,
 		initializer:          initializer,
-		recycleControl:       NewSandboxRecycleControl(args.Client, args.Recorder, args.RecycleConfig),
+		recycleControl:       NewSandboxRecycleControl(args.Client, args.Recorder, recycleConfig),
 		syncStatusFromPod:    defaultSyncStatusFromPod,
 	}
 	control.upgradeControl = NewUpgradeControl(args.Client, args.CheckpointControl, args.PodControl, args.Recorder, ExecuteLifecycleHook, initializer, control.syncStatusFromPod, control.handleResume)

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openkruise/agents/pkg/utils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
 	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
+	runtimeclient "github.com/openkruise/agents/pkg/utils/runtime"
 	"github.com/openkruise/agents/pkg/utils/sidecarutils"
 )
 
@@ -2382,6 +2383,27 @@ func TestNewCommonControl(t *testing.T) {
 	if args.NewStatus.Phase != agentsv1alpha1.SandboxFailed {
 		t.Errorf("Expected phase Failed, got %s", args.NewStatus.Phase)
 	}
+}
+
+func TestNewCommonControl_ForwardsRuntimeTLSBundle(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	bundle := &runtimeclient.TLSBundle{CABundle: []byte("test-ca")}
+
+	control := NewCommonControl(SandboxControlArgs{
+		Client:           fakeClient,
+		Recorder:         record.NewFakeRecorder(10),
+		RateLimiter:      NewRateLimiter(),
+		RuntimeTLSBundle: bundle,
+	})
+	require.NotNil(t, control)
+
+	cc, ok := control.(*commonControl)
+	require.True(t, ok, "NewCommonControl should return *commonControl")
+	assert.Same(t, bundle, cc.recycleControl.config.RuntimeTLSBundle, "recycle control must receive runtime TLS bundle")
 }
 
 func TestCommonControl_EnsureSandboxUpdated_InplaceNotDone(t *testing.T) {

--- a/pkg/controller/sandbox/core/interface.go
+++ b/pkg/controller/sandbox/core/interface.go
@@ -100,6 +100,10 @@ type SandboxRecycleConfig struct {
 	Timeout              time.Duration
 	GracePeriod          time.Duration
 	FailureShutdownGrace time.Duration
+	// RuntimeTLSBundle is the client TLS bundle for reaching TLS-capable
+	// agent-runtimes during recycle-side runtime calls (for example the CSI
+	// reset-signal write). Nil keeps the legacy plaintext recycle paths.
+	RuntimeTLSBundle *runtimeclient.TLSBundle
 	// CSIResetSignalDir is the directory inside the sandbox where a reset signal
 	// file is written before recycle when the sandbox carries CSI mounts, so that a
 	// stopping csi-sidecar can detect it during prestop/SIGTERM and unmount stale

--- a/pkg/controller/sandbox/core/recycle.go
+++ b/pkg/controller/sandbox/core/recycle.go
@@ -182,6 +182,10 @@ func (r *SandboxRecycleControl) ensureCSIResetSignal(ctx context.Context, box *a
 	if r.config.CSIResetSignalDir == "" {
 		return fmt.Errorf("sandbox carries CSI mounts but csi-reset-signal-dir is not configured")
 	}
+	rtOpts, err := agentsruntime.TransportOptionsFor(box, r.config.RuntimeTLSBundle)
+	if err != nil {
+		return err
+	}
 
 	resetFile := path.Join(r.config.CSIResetSignalDir, r.config.CSIResetSignalFileName)
 	var lastErr error
@@ -198,7 +202,7 @@ func (r *SandboxRecycleControl) ensureCSIResetSignal(ctx context.Context, box *a
 			// The reset signal file lives in a root-owned directory, so the
 			// runtime must resolve the write to the root user.
 			AuthUser: "root",
-		})
+		}, rtOpts...)
 		if lastErr == nil {
 			klog.FromContext(ctx).Info("Wrote CSI reset signal for recycle", "sandbox", klog.KObj(box), "file", resetFile, "attempt", attempt)
 			return nil

--- a/pkg/controller/sandbox/core/recycle_test.go
+++ b/pkg/controller/sandbox/core/recycle_test.go
@@ -2097,7 +2097,9 @@ func TestEnsureCSIResetSignal(t *testing.T) {
 		cancelCtx    bool
 		failTimes    int // number of leading write attempts that fail before succeeding
 		writeErr     error
+		runtimeTLS   *agentsruntime.TLSBundle
 		wantCalls    int
+		wantOptCount int
 		wantFilePath string
 		expectError  string
 	}{
@@ -2122,6 +2124,7 @@ func TestEnsureCSIResetSignal(t *testing.T) {
 			fileName:     "reset",
 			box:          sandboxWithCSI(),
 			wantCalls:    1,
+			wantOptCount: 0,
 			wantFilePath: "/var/run/csi-reset/reset",
 		},
 		{
@@ -2130,7 +2133,22 @@ func TestEnsureCSIResetSignal(t *testing.T) {
 			fileName:     "unmount",
 			box:          sandboxWithCSI(),
 			wantCalls:    1,
+			wantOptCount: 0,
 			wantFilePath: "/var/run/csi-reset/unmount",
+		},
+		{
+			name:     "runtime TLS sandbox forwards transport opts to write path",
+			dir:      "/var/run/csi-reset",
+			fileName: "reset",
+			box: func() *agentsv1alpha1.Sandbox {
+				sbx := sandboxWithCSI()
+				sbx.Annotations[agentsv1alpha1.AnnotationRuntimeTLSPort] = "49984"
+				return sbx
+			}(),
+			runtimeTLS:   &agentsruntime.TLSBundle{CABundle: []byte("ca")},
+			wantCalls:    1,
+			wantOptCount: 2,
+			wantFilePath: "/var/run/csi-reset/reset",
 		},
 		{
 			name:         "success after retries",
@@ -2140,16 +2158,18 @@ func TestEnsureCSIResetSignal(t *testing.T) {
 			failTimes:    2,
 			writeErr:     fmt.Errorf("runtime unavailable"),
 			wantCalls:    3,
+			wantOptCount: 0,
 			wantFilePath: "/var/run/csi-reset/reset",
 		},
 		{
-			name:        "failure after exhausting retries",
-			dir:         "/var/run/csi-reset",
-			box:         sandboxWithCSI(),
-			failTimes:   csiResetSignalMaxRetries,
-			writeErr:    fmt.Errorf("runtime unavailable"),
-			wantCalls:   csiResetSignalMaxRetries,
-			expectError: "runtime unavailable",
+			name:         "failure after exhausting retries",
+			dir:          "/var/run/csi-reset",
+			box:          sandboxWithCSI(),
+			failTimes:    csiResetSignalMaxRetries,
+			writeErr:     fmt.Errorf("runtime unavailable"),
+			wantCalls:    csiResetSignalMaxRetries,
+			wantOptCount: 0,
+			expectError:  "runtime unavailable",
 		},
 		{
 			name:        "canceled context returns before writing",
@@ -2159,6 +2179,17 @@ func TestEnsureCSIResetSignal(t *testing.T) {
 			wantCalls:   0,
 			expectError: "context canceled",
 		},
+		{
+			name: "runtime TLS sandbox without client bundle fails before plaintext write",
+			dir:  "/var/run/csi-reset",
+			box: func() *agentsv1alpha1.Sandbox {
+				sbx := sandboxWithCSI()
+				sbx.Annotations[agentsv1alpha1.AnnotationRuntimeTLSPort] = "49984"
+				return sbx
+			}(),
+			wantCalls:   0,
+			expectError: "no client TLS bundle is configured",
+		},
 	}
 
 	for _, tt := range tests {
@@ -2166,11 +2197,13 @@ func TestEnsureCSIResetSignal(t *testing.T) {
 			var calls int
 			var gotPath string
 			var gotContent []byte
+			var gotOptCount int
 			writeRuntimeFileFunc = func(_ context.Context, args agentsruntime.WriteFileArgs,
-				_ ...agentsruntime.Option) (agentsruntime.WriteFileResult, error) {
+				opts ...agentsruntime.Option) (agentsruntime.WriteFileResult, error) {
 				calls++
 				gotPath = args.FilePath
 				gotContent = args.Content
+				gotOptCount = len(opts)
 				if calls <= tt.failTimes {
 					return agentsruntime.WriteFileResult{}, tt.writeErr
 				}
@@ -2184,10 +2217,15 @@ func TestEnsureCSIResetSignal(t *testing.T) {
 				cancel()
 			}
 
-			control := &SandboxRecycleControl{config: SandboxRecycleConfig{CSIResetSignalDir: tt.dir, CSIResetSignalFileName: tt.fileName}}
+			control := &SandboxRecycleControl{config: SandboxRecycleConfig{
+				RuntimeTLSBundle:       tt.runtimeTLS,
+				CSIResetSignalDir:      tt.dir,
+				CSIResetSignalFileName: tt.fileName,
+			}}
 			err := control.ensureCSIResetSignal(ctx, tt.box)
 
 			assert.Equal(t, tt.wantCalls, calls)
+			assert.Equal(t, tt.wantOptCount, gotOptCount)
 			if tt.wantFilePath != "" {
 				assert.Equal(t, tt.wantFilePath, gotPath)
 				assert.Empty(t, gotContent, "reset signal file must be an empty marker")


### PR DESCRIPTION
## Description:

Thread runtime TLS through recycle CSI reset signal writes.

Before this change, `ensureCSIResetSignal` called `WriteFileWithRuntime` without the transport resolved by `runtime.TransportOptionsFor`. As a result, a sandbox advertising the runtime TLS capability was silently downgraded to plaintext during recycle.

This PR keeps the legacy plaintext behavior for non-TLS sandboxes but binds the controller's existing `RuntimeTLSBundle` into the recycle reset signal write path and adds regression tests for the missing-bundle and configured-bundle paths.

### Validation Tests run:

- [x] `go test ./pkg/controller/sandbox/core -run 'TestEnsureCSIResetSignal|TestNewCommonControl_ForwardsRuntimeTLSBundle' -count=1`
- [x] `go test ./pkg/controller/sandbox/core -count=1`
- [x] `go test ./pkg/controller/sandbox/... -count=1`

## Notes:

- Scope is intentionally limited to recycle CSI reset signal writes.
- The upgrade lifecycle hook TLS path is split into separate PR (#886).