### PR TITLE
feat(controller): emit CommitRunning and CommitSucceeded events for Commit lifecycle

### DIFF
--- a/pkg/controller/commit/commit_controller.go
+++ b/pkg/controller/commit/commit_controller.go
@@ -213,11 +213,29 @@ func (r *CommitReconciler) handleCommitPending(ctx context.Context, args *core.E
 		r.Recorder.Eventf(commit, corev1.EventTypeWarning, "PodNotFound", "Target pod %s not found or deleting", commit.Spec.PodName)
 		return ctrl.Result{}, r.updateCommitStatus(ctx, *args.NewStatus, commit)
 	}
-	return r.ensureAndApply(ctx, args, control.EnsureCommitRunning)
+	result, err := r.ensureAndApply(ctx, args, control.EnsureCommitRunning)
+	// Emit only after the transition is persisted: on a failed status update
+	// the retry re-enters this handler and emits then. Events are best-effort.
+	if err == nil && args.NewStatus.Phase == agentsv1alpha1.CommitPhaseRunning {
+		r.Recorder.Eventf(commit, corev1.EventTypeNormal, "CommitRunning",
+			"Commit Job started for pod %s", commit.Spec.PodName)
+	}
+	return result, err
 }
 
 func (r *CommitReconciler) handleCommitRunning(ctx context.Context, args *core.EnsureFuncArgs, control core.CommitControl) (ctrl.Result, error) {
-	return r.ensureAndApply(ctx, args, control.EnsureCommitUpdated)
+	result, err := r.ensureAndApply(ctx, args, control.EnsureCommitUpdated)
+	// Terminal phases are skipped in Reconcile, so these fire once per
+	// Running -> Succeeded/Failed transition.
+	if err == nil && args.NewStatus.Phase == agentsv1alpha1.CommitPhaseSucceeded {
+		r.Recorder.Eventf(args.Commit, corev1.EventTypeNormal, "CommitSucceeded",
+			"Commit completed successfully, image %s pushed", args.Commit.Spec.Image)
+	}
+	if err == nil && args.NewStatus.Phase == agentsv1alpha1.CommitPhaseFailed {
+		r.Recorder.Eventf(args.Commit, corev1.EventTypeWarning, "CommitFailed",
+			"Commit job failed for pod %s", args.Commit.Spec.PodName)
+	}
+	return result, err
 }
 
 // ensureAndApply calls the given ensure function, then applies the resulting status.

--- a/pkg/controller/commit/commit_controller_test.go
+++ b/pkg/controller/commit/commit_controller_test.go
@@ -19,6 +19,7 @@ package commit
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -631,5 +632,165 @@ func TestGetControl_AnnotationModeEmptyValue(t *testing.T) {
 	}
 	if ctrl != mock {
 		t.Error("expected default common control when annotation value is empty")
+	}
+}
+
+// drainEvents collects all buffered events from the reconciler's fake recorder.
+func drainEvents(r *CommitReconciler) []string {
+	recorder, ok := r.Recorder.(*record.FakeRecorder)
+	if !ok {
+		return nil
+	}
+	var events []string
+	for {
+		select {
+		case e := <-recorder.Events:
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
+}
+
+func TestReconcile_CommitPhasePending_EmitsCommitRunningEvent(t *testing.T) {
+	commit := newCommit("test-commit", "default", agentsv1alpha1.CommitPhasePending)
+	commit.Finalizers = []string{agentsv1alpha1.CommitFinalizer}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	r, mock := newTestReconciler(commit, pod)
+	mock.setPhaseOnRunning = agentsv1alpha1.CommitPhaseRunning
+
+	_, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-commit", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, e := range drainEvents(r) {
+		if strings.Contains(e, "Normal CommitRunning") && strings.Contains(e, "test-pod") {
+			return
+		}
+	}
+	t.Error("expected CommitRunning event for pod test-pod, got none")
+}
+
+func TestReconcile_CommitPhasePending_NoEventWhenPhaseUnchanged(t *testing.T) {
+	commit := newCommit("test-commit", "default", agentsv1alpha1.CommitPhasePending)
+	commit.Finalizers = []string{agentsv1alpha1.CommitFinalizer}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	r, _ := newTestReconciler(commit, pod)
+	// EnsureCommitRunning succeeds but phase stays Pending (e.g. waiting on
+	// expectations) — no transition, no event.
+
+	_, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-commit", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if events := drainEvents(r); len(events) != 0 {
+		t.Errorf("expected no events when phase stays Pending, got %v", events)
+	}
+}
+
+func TestReconcile_CommitPhasePending_NoEventOnError(t *testing.T) {
+	commit := newCommit("test-commit", "default", agentsv1alpha1.CommitPhasePending)
+	commit.Finalizers = []string{agentsv1alpha1.CommitFinalizer}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	r, mock := newTestReconciler(commit, pod)
+	mock.ensureRunningErr = fmt.Errorf("job creation failed")
+	mock.setPhaseOnRunning = agentsv1alpha1.CommitPhaseRunning
+
+	_, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-commit", Namespace: "default"},
+	})
+	if err == nil {
+		t.Fatal("expected error when EnsureCommitRunning fails")
+	}
+
+	if events := drainEvents(r); len(events) != 0 {
+		t.Errorf("expected no events when ensure fails, got %v", events)
+	}
+}
+
+func TestReconcile_CommitPhaseRunning_EmitsCommitSucceededEvent(t *testing.T) {
+	commit := newCommit("test-commit", "default", agentsv1alpha1.CommitPhaseRunning)
+	commit.Finalizers = []string{agentsv1alpha1.CommitFinalizer}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	r, mock := newTestReconciler(commit, pod)
+	mock.setPhaseOnUpdated = agentsv1alpha1.CommitPhaseSucceeded
+
+	_, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-commit", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, e := range drainEvents(r) {
+		if strings.Contains(e, "Normal CommitSucceeded") && strings.Contains(e, commit.Spec.Image) {
+			return
+		}
+	}
+	t.Errorf("expected CommitSucceeded event for image %s, got none", commit.Spec.Image)
+}
+
+func TestReconcile_CommitPhaseRunning_EmitsCommitFailedEvent(t *testing.T) {
+	commit := newCommit("test-commit", "default", agentsv1alpha1.CommitPhaseRunning)
+	commit.Finalizers = []string{agentsv1alpha1.CommitFinalizer}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	r, mock := newTestReconciler(commit, pod)
+	mock.setPhaseOnUpdated = agentsv1alpha1.CommitPhaseFailed
+
+	_, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-commit", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, e := range drainEvents(r) {
+		if strings.Contains(e, "Warning CommitFailed") && strings.Contains(e, "test-pod") {
+			return
+		}
+	}
+	t.Error("expected CommitFailed event for pod test-pod, got none")
+}
+
+func TestReconcile_CommitPhaseRunning_NoEventWhenPhaseUnchanged(t *testing.T) {
+	commit := newCommit("test-commit", "default", agentsv1alpha1.CommitPhaseRunning)
+	commit.Finalizers = []string{agentsv1alpha1.CommitFinalizer}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	r, _ := newTestReconciler(commit, pod)
+	// Job still running: phase stays Running, no event expected.
+
+	_, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-commit", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if events := drainEvents(r); len(events) != 0 {
+		t.Errorf("expected no events when phase stays Running, got %v", events)
 	}
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The Commit controller currently only emits Warning events on edge failure paths (`PodNotFound`, `JobGenerationFailed`, `JobNotFound`). Lifecycle transitions are invisible: a user watching `kubectl describe commit` cannot tell when the commit Job actually started, when the image was successfully pushed, or when the job failed.

This PR emits events on the lifecycle transitions:

- **CommitRunning** (Normal) — the commit Job has been created and the Commit entered `Running`. Message: `Commit Job started for pod <podName>`.
- **CommitSucceeded** (Normal) — the commit Job completed and the image was pushed. Message: `Commit completed successfully, image <image> pushed`.
- **CommitFailed** (Warning) — the commit Job completed unsuccessfully (e.g. registry push rejected, non-zero exit). Message: `Commit job failed for pod <podName>`. This covers the previously-invisible job-failure path; `JobNotFound` and `JobGenerationFailed` keep their own specific Warning events.

Implementation notes:

- Events are emitted only after the phase transition is **successfully persisted** (`err == nil` from `ensureAndApply`). If the status update fails, the phase stays put in the API server, so the retry re-enters the same handler and emits then. Events are best-effort observability signals.
- Emission cannot repeat across reconciles: after Pending→Running the next reconcile is routed to `handleCommitRunning`, and terminal phases (Succeeded/Failed) are short-circuited in `Reconcile`.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how you did it

Unit tests cover all paths:
- `TestReconcile_CommitPhasePending_EmitsCommitRunningEvent` — Pending→Running emits `CommitRunning`
- `TestReconcile_CommitPhaseRunning_EmitsCommitSucceededEvent` — Running→Succeeded emits `CommitSucceeded`
- `TestReconcile_CommitPhaseRunning_EmitsCommitFailedEvent` — Running→Failed emits `CommitFailed`
- `TestReconcile_CommitPhasePending_NoEventWhenPhaseUnchanged` / `TestReconcile_CommitPhaseRunning_NoEventWhenPhaseUnchanged` — no event while the phase stays put
- `TestReconcile_CommitPhasePending_NoEventOnError` — no event when the ensure function errors

### Ⅳ. Describe how to verify it

```bash
go test ./pkg/controller/commit/... -count=1
```

On a live cluster, `kubectl describe commit <name>` now shows:

```
Events:
  Type    Reason           Age   From               Message
  ----    ------           ----  ----               -------
  Normal  CommitRunning    5s    commit-controller  Commit Job started for pod my-sandbox-pod
  Normal  CommitSucceeded  83s   commit-controller  Commit completed successfully, image registry.example.com/env:v1 pushed
```

or on failure:

```
  Warning CommitFailed     83s   commit-controller  Commit job failed for pod my-sandbox-pod
```

### Ⅴ. Special notes for reviews

- No behavioral change beyond the `Recorder.Eventf` calls; status flow, requeue and error handling are untouched.
- `core` RBAC for events already exists (`+kubebuilder:rbac:groups=core,resources=events,verbs=create`).
- The `CommitFailed` event is added per review feedback to make the lifecycle symmetric (thanks @furykerry); the `JobNotFound` path will show both its specific event and `CommitFailed`.
