### PR TITLE
fix(quota): correct breaker halfOpen comment and add concurrent test

### DIFF
--- a/pkg/sandbox-manager/quota/breaker.go
+++ b/pkg/sandbox-manager/quota/breaker.go
@@ -115,7 +115,7 @@ func (b *BreakerBackend) beforeCall() error {
 	if !b.openedUntil.IsZero() {
 		// 1. breaker is open but may be about to close
 		if b.halfOpen {
-			// 3. the probe acquire failed, breaker stays open
+			// 3. a probe acquire is already in-flight; fail-fast concurrent callers to prevent thundering herd
 			return ErrBackendUnavailable
 		}
 		// 2.1. allow only one probe acquire to check recovery

--- a/pkg/sandbox-manager/quota/breaker_test.go
+++ b/pkg/sandbox-manager/quota/breaker_test.go
@@ -141,6 +141,36 @@ func TestBreaker(t *testing.T) {
 		require.ErrorIs(t, b.Cleanup(ctx, "K"), ErrBackendUnavailable)
 		require.Equal(t, 2, backend.cleanupCalls)
 	})
+
+	t.Run("concurrent caller during in-flight probe gets ErrBackendUnavailable without touching inner", func(t *testing.T) {
+		ready := make(chan struct{})
+		done := make(chan struct{})
+
+		inner := &blockingBackend{ready: ready, done: done, acquireErr: errors.New("dial tcp"), blockOnCall: 2}
+		b := NewBreakerBackend(inner, 1, 30*time.Second)
+		clk := &breakerTestClock{t: time.Unix(0, 0)}
+		b.now = clk.now
+
+		ctx := context.Background()
+
+		// Trip the breaker
+		require.ErrorIs(t, b.Acquire(ctx, AcquireParams{User: "K", LockString: "l0"}), ErrBackendUnavailable)
+		require.Equal(t, 1, inner.acquireCalls)
+
+		// Advance past openedUntil so a probe is allowed
+		clk.t = clk.t.Add(31 * time.Second)
+
+		// Goroutine A: probe - will block until we signal
+		go func() { _ = b.Acquire(ctx, AcquireParams{User: "K", LockString: "probe"}) }()
+		<-ready // probe is now in-flight (halfOpen == true, inner.calls == 2)
+
+		// Goroutine B: races while probe is still in-flight
+		err := b.Acquire(ctx, AcquireParams{User: "K", LockString: "concurrent"})
+		require.ErrorIs(t, err, ErrBackendUnavailable, "concurrent caller must fail-fast while probe is in-flight")
+		require.Equal(t, 2, inner.acquireCalls, "inner must not be called by the concurrent caller")
+
+		close(done) // unblock the probe
+	})
 }
 
 func TestBreakerAcquireAfterInnerPanicDoesNotStayHalfOpen(t *testing.T) {
@@ -219,4 +249,37 @@ func (b *breakerTestBackend) ListEntries(context.Context, string) (map[string]En
 func (b *breakerTestBackend) Cleanup(context.Context, string) error {
 	b.cleanupCalls++
 	return b.cleanupErr
+}
+
+type blockingBackend struct {
+	acquireErr   error
+	acquireCalls int
+	ready        chan struct{}
+	done         chan struct{}
+	blockOnCall  int
+}
+
+func (b *blockingBackend) Acquire(context.Context, AcquireParams) error {
+	b.acquireCalls++
+	if b.acquireCalls == b.blockOnCall {
+		if b.ready != nil {
+			close(b.ready)
+		}
+		if b.done != nil {
+			<-b.done
+		}
+	}
+	return b.acquireErr
+}
+
+func (b *blockingBackend) Release(context.Context, string, string) error {
+	return nil
+}
+
+func (b *blockingBackend) ListEntries(context.Context, string) (map[string]Entry, error) {
+	return nil, nil
+}
+
+func (b *blockingBackend) Cleanup(context.Context, string) error {
+	return nil
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

This PR corrects a factually wrong comment in `BreakerBackend.beforeCall()` that misrepresents the state machine, and introduces a missing concurrent unit test to cover this specific race condition.

**Context:**
In `pkg/sandbox-manager/quota/breaker.go` line 118, the comment described the `halfOpen == true` state as: `// 3. the probe acquire failed, breaker stays open`. 

This is incorrect. When `beforeCall()` executes the `halfOpen == true` branch, it means **a probe acquire is currently in-flight** in another goroutine, not that it has failed. The actual failure path is handled asynchronously inside `afterCall()`, which re-opens the breaker.

**Changes:**
1. **Comment Fix:** Updated the comment in `breaker.go` to accurately describe the fail-fast thundering herd protection.
2. **Missing Test Added:** Added a new test `concurrent caller during in-flight probe gets ErrBackendUnavailable without touching inner` to `breaker_test.go`. This test uses a new `blockingBackend` to intentionally pause the probe mid-flight and ensure that a concurrent caller correctly fails-fast with `ErrBackendUnavailable` without incrementing the inner backend call count.

### Ⅱ. Does this pull request fix one issue?
fixes #897

### Ⅲ. Describe how to verify it

1. Review the logic trace in `breaker.go` to confirm the comment change aligns with the `afterCall()` state transitions.
2. Run the newly added test suite to verify the race condition is properly protected against:
   ```bash
   go test -v -run TestBreaker ./pkg/sandbox-manager/quota
