### PR TITLE
fix(network): format IPv6 upstream addresses

### DIFF
--- a/pkg/proxy/ext_proc.go
+++ b/pkg/proxy/ext_proc.go
@@ -22,7 +22,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -136,7 +138,7 @@ func (s *Server) handleRequestHeaders(requestHeaders *extProcPb.ProcessingReques
 	}
 	// An adapter can set "x-envoy-original-dst-host" header to force route the request to a specific destination
 	if _, ok := extraHeaders[OrigDstHeader]; !ok {
-		extraHeaders[OrigDstHeader] = fmt.Sprintf("%s:%d", route.IP, sandboxPort)
+		extraHeaders[OrigDstHeader] = net.JoinHostPort(route.IP, strconv.Itoa(sandboxPort))
 	}
 
 	return s.logAndCreateDstResponse(requestHeaders.RequestHeaders, extraHeaders, log)

--- a/pkg/proxy/ext_proc_test.go
+++ b/pkg/proxy/ext_proc_test.go
@@ -174,6 +174,56 @@ func TestServer_Process(t *testing.T) {
 			},
 		},
 		{
+			name: "IPv6 sandbox upstream uses bracketed host port",
+			setupRoutes: []sandboxroute.Route{
+				{ID: "sandbox-ipv6", IP: "2001:db8::1", Owner: "user1"},
+			},
+			adapter: &testRequestAdapter{
+				isSandboxRequest: true,
+				mapResult: mapResult{
+					sandboxID:   "sandbox-ipv6",
+					sandboxPort: 49999,
+				},
+				entry: "127.0.0.1:8080",
+			},
+			requests: []*extProcPb.ProcessingRequest{
+				{
+					Request: &extProcPb.ProcessingRequest_RequestHeaders{
+						RequestHeaders: &extProcPb.HttpHeaders{
+							Headers: &corev3.HeaderMap{
+								Headers: []*corev3.HeaderValue{
+									{Key: ":scheme", RawValue: []byte("http")},
+									{Key: ":authority", RawValue: []byte("localhost:9002")},
+									{Key: ":path", RawValue: []byte("/sandbox")},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+			expectResp: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_RequestHeaders{
+						RequestHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										{
+											Header: &corev3.HeaderValue{
+												Key:      "x-envoy-original-dst-host",
+												RawValue: []byte("[2001:db8::1]:49999"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:        "non-sandbox",
 			setupRoutes: []sandboxroute.Route{},
 			adapter: &testRequestAdapter{

--- a/pkg/proxy/routes_test.go
+++ b/pkg/proxy/routes_test.go
@@ -344,6 +344,25 @@ func TestSyncRouteWithPeers_TwoNodes_Success(t *testing.T) {
 	assert.Equal(t, route.ID, peer2.getReceived()[0].ID)
 }
 
+func TestSyncRouteWithPeers_IPv6Peer(t *testing.T) {
+	peer := newRecordingPeer()
+	defer peer.close()
+
+	const peerIP = "fd11:1111:1111::10"
+	overridePeerTransport(t, map[string]string{
+		net.JoinHostPort(peerIP, fmt.Sprint(refresh.DefaultPort)): peer.server.URL[7:],
+	}, 5*time.Second)
+
+	s := newTestServer(newMockPeers(peers.Peer{IP: peerIP, Name: "node-v6"}))
+	route := testProxyRoute("sb-v6", "fd11:1111:1111::20", "1")
+	require.NoError(t, s.SyncRouteWithPeers(t.Context(), route))
+
+	require.Eventually(t, func() bool {
+		return len(peer.getReceived()) == 1
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, route.ID, peer.getReceived()[0].ID)
+}
+
 func TestSyncRouteWithPeers_TwoNodes_OneFails(t *testing.T) {
 	// peer1 is a real server; peer2 points to a non-existent address
 	peer1 := newRecordingPeer()

--- a/pkg/proxy/utils.go
+++ b/pkg/proxy/utils.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -49,7 +50,8 @@ func requestPeer(ctx context.Context, method, ip, path string, body []byte) erro
 	if len(body) > 0 {
 		buf = bytes.NewReader(body)
 	}
-	request, err := http.NewRequestWithContext(ctx, method, fmt.Sprintf("http://%s:%d%s", ip, refresh.DefaultPort, path), buf)
+	peerAddress := net.JoinHostPort(ip, fmt.Sprint(refresh.DefaultPort))
+	request, err := http.NewRequestWithContext(ctx, method, fmt.Sprintf("http://%s%s", peerAddress, path), buf)
 	if err != nil {
 		return err
 	}

--- a/pkg/proxy/utils.go
+++ b/pkg/proxy/utils.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/openkruise/agents/pkg/sandboxroute/refresh"
@@ -50,7 +51,7 @@ func requestPeer(ctx context.Context, method, ip, path string, body []byte) erro
 	if len(body) > 0 {
 		buf = bytes.NewReader(body)
 	}
-	peerAddress := net.JoinHostPort(ip, fmt.Sprint(refresh.DefaultPort))
+	peerAddress := net.JoinHostPort(ip, strconv.Itoa(refresh.DefaultPort))
 	request, err := http.NewRequestWithContext(ctx, method, fmt.Sprintf("http://%s%s", peerAddress, path), buf)
 	if err != nil {
 		return err

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -20,7 +20,8 @@ import (
 	"context"
 	"crypto/subtle"
 	"errors"
-	"fmt"
+	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -198,7 +199,7 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 // apply identical overrides so a request that triggered a wake continues
 // exactly like a request that arrived on a Running sandbox.
 func (f *sandboxFilter) applyUpstreamOverrides(route sandboxroute.Route, sandboxPort int) {
-	upstreamHost := fmt.Sprintf("%s:%d", route.IP, sandboxPort)
+	upstreamHost := net.JoinHostPort(route.IP, strconv.Itoa(sandboxPort))
 	f.callbacks.StreamInfo().DynamicMetadata().Set("envoy.lb.original_dst", "host", upstreamHost)
 	if f.config.EnableRuntimeMTLS && sandboxPort == utils.RuntimePort {
 		f.callbacks.StreamInfo().DynamicMetadata().Set(runtimeMTLSMetadataNamespace, runtimeMTLSMetadataKey, true)

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -503,7 +503,7 @@ func TestDecodeHeadersExtractionVectors(t *testing.T) {
 				return newSandboxHeader("default--ipv6-sandbox")
 			},
 			endStream: true,
-			wantHost:  "2001:db8::1:49983",
+			wantHost:  "[2001:db8::1]:49983",
 		},
 		{
 			name:   "IPv6 upstream via host header",
@@ -512,7 +512,7 @@ func TestDecodeHeadersExtractionVectors(t *testing.T) {
 				return newHostHeader("8080-default--ipv6-sandbox.example.com")
 			},
 			endStream: true,
-			wantHost:  "2001:db8::1:8080",
+			wantHost:  "[2001:db8::1]:8080",
 		},
 		{
 			name:   "kruise custom protocol rewrites the path",

--- a/pkg/utils/proxyutils/default.go
+++ b/pkg/utils/proxyutils/default.go
@@ -21,7 +21,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 
 	"k8s.io/klog/v2"
 
@@ -37,7 +39,8 @@ func requestSandbox(ctx context.Context, s *agentsv1alpha1.Sandbox, method, path
 	if s.Status.Phase != agentsv1alpha1.SandboxRunning {
 		return nil, errors.New("sandbox is not running")
 	}
-	url := fmt.Sprintf("http://%s:%d%s", s.Status.PodInfo.PodIP, port, path)
+	sandboxAddress := net.JoinHostPort(s.Status.PodInfo.PodIP, strconv.Itoa(port))
+	url := "http://" + sandboxAddress + path
 	r, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)

--- a/pkg/utils/proxyutils/default.go
+++ b/pkg/utils/proxyutils/default.go
@@ -40,7 +40,7 @@ func requestSandbox(ctx context.Context, s *agentsv1alpha1.Sandbox, method, path
 		return nil, errors.New("sandbox is not running")
 	}
 	sandboxAddress := net.JoinHostPort(s.Status.PodInfo.PodIP, strconv.Itoa(port))
-	url := "http://" + sandboxAddress + path
+	url := fmt.Sprintf("http://%s%s", sandboxAddress, path)
 	r, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)

--- a/pkg/utils/proxyutils/default_test.go
+++ b/pkg/utils/proxyutils/default_test.go
@@ -18,6 +18,8 @@ package proxyutils
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"testing"
@@ -43,13 +45,37 @@ func TestRequestSandbox(t *testing.T) {
 	require.NoError(t, err)
 	port, _ := strconv.Atoi(portStr)
 
+	var (
+		ipv6Port       int
+		ipv6SkipReason string
+	)
+	ipv6Listener, ipv6Err := net.Listen("tcp6", "[::1]:0")
+	if ipv6Err != nil {
+		ipv6SkipReason = "IPv6 loopback is unavailable: " + ipv6Err.Error()
+	} else {
+		ipv6Server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		ipv6Server.Listener = ipv6Listener
+		ipv6Server.Start()
+		defer ipv6Server.Close()
+
+		_, ipv6PortStr, splitErr := net.SplitHostPort(ipv6Server.Listener.Addr().String())
+		require.NoError(t, splitErr)
+		ipv6Port, err = strconv.Atoi(ipv6PortStr)
+		require.NoError(t, err)
+	}
+
 	tests := []struct {
-		name    string
-		sandbox *v1alpha1.Sandbox
-		wantErr bool
+		name       string
+		sandbox    *v1alpha1.Sandbox
+		port       int
+		skipReason string
+		wantErr    bool
 	}{
 		{
 			name: "running sandbox",
+			port: port,
 			sandbox: &v1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "running-sandbox",
@@ -70,7 +96,25 @@ func TestRequestSandbox(t *testing.T) {
 			},
 		},
 		{
+			name:       "running sandbox with IPv6 PodIP",
+			port:       ipv6Port,
+			skipReason: ipv6SkipReason,
+			sandbox: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "running-ipv6-sandbox",
+					Namespace: "default",
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase: v1alpha1.SandboxRunning,
+					PodInfo: v1alpha1.PodInfo{
+						PodIP: "::1",
+					},
+				},
+			},
+		},
+		{
 			name: "paused sandbox",
+			port: port,
 			sandbox: &v1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "running-sandbox",
@@ -95,7 +139,10 @@ func TestRequestSandbox(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := requestSandbox(t.Context(), tt.sandbox, "GET", "/", port, nil)
+			if tt.skipReason != "" {
+				t.Skip(tt.skipReason)
+			}
+			_, err := requestSandbox(t.Context(), tt.sandbox, "GET", "/", tt.port, nil)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/utils/runtime/runtime.go
+++ b/pkg/utils/runtime/runtime.go
@@ -20,7 +20,8 @@ package runtime
 
 import (
 	"context"
-	"fmt"
+	"net"
+	"strconv"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/utils"
@@ -56,5 +57,5 @@ func GetRuntimeURL(sbx *agentsv1alpha1.Sandbox) string {
 	if ip == "" {
 		return ""
 	}
-	return fmt.Sprintf("http://%s:%d", ip, utils.RuntimePort)
+	return "http://" + net.JoinHostPort(ip, strconv.Itoa(utils.RuntimePort))
 }

--- a/pkg/utils/runtime/runtime_test.go
+++ b/pkg/utils/runtime/runtime_test.go
@@ -1018,6 +1018,18 @@ func TestGetRuntimeURL(t *testing.T) {
 			expected: fmt.Sprintf("http://10.0.0.1:%d", utils.RuntimePort),
 		},
 		{
+			name: "no annotation but IPv6 PodIP present falls back to bracketed ip:port",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+					PodInfo: agentsv1alpha1.PodInfo{
+						PodIP: "2001:db8::1",
+					},
+				},
+			},
+			expected: fmt.Sprintf("http://[2001:db8::1]:%d", utils.RuntimePort),
+		},
+		{
 			name: "empty annotation value falls back to ip:port",
 			sandbox: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
  ### Ⅰ. Describe what this PR does

  This PR fixes ambiguous IPv6 host-port formatting in the sandbox traffic data
  plane.

  It uses `net.JoinHostPort` in the following address-construction paths:

  - `pkg/proxy/ext_proc.go`: Envoy `x-envoy-original-dst-host` values.
  - `pkg/proxy/utils.go`: sandbox-manager peer refresh HTTP URLs.
  - `pkg/sandbox-gateway/filter/filter.go`: Envoy `envoy.lb.original_dst`
    metadata.
  - `pkg/utils/runtime/runtime.go`: agent-runtime fallback URLs derived from the
    Sandbox Pod IP.
  - `pkg/utils/proxyutils/default.go`: direct HTTP requests to a Sandbox Pod IP.

  For example, an IPv6 destination is now formatted as `[2001:db8::1]:49999`
  instead of `2001:db8::1:49999`.

  IPv4 behavior remains unchanged. This PR does not change route synchronization,
  retry, concurrency, TLS authority, or memberlist behavior.

  ### Ⅱ. Does this pull request fix one issue?

  NONE

  ### Ⅲ. Describe how to verify it

  The full unit-test suite passes with Go 1.25.9:

  ```text
  GOTOOLCHAIN=go1.25.9 make test

  This runs all pkg/... tests with race detection and coverage.

  Focused tests also pass:

  go test ./pkg/proxy ./pkg/sandbox-gateway/filter \
    ./pkg/utils/runtime ./pkg/utils/proxyutils -count=1

  The tests cover:

  - IPv6 ext-proc original destinations.
  - IPv6 peer refresh HTTP requests.
  - IPv6 sandbox-gateway destinations from sandbox and host headers.
  - IPv6 agent-runtime fallback URLs.
  - Direct requests to an IPv6 Sandbox Pod using a real IPv6 loopback server.
  - Existing IPv4 behavior.

  ### Ⅳ. Special notes for reviews

  This change is limited to host-port formatting at the five affected
  address-construction paths listed above. Memberlist IPv6 handling remains
  intentionally excluded.