### PR TITLE
Use an unexported key type for e2b request context values

### DIFF
--- a/pkg/servers/e2b/api_key_test.go
+++ b/pkg/servers/e2b/api_key_test.go
@@ -539,7 +539,7 @@ func TestCreateAPIKeyPermissionMiddleware(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := NewRequest(t, nil, tt.request, nil, tt.user)
-			ctx := context.WithValue(logs.NewContext(), "user", tt.user)
+			ctx := context.WithValue(logs.NewContext(), userContextKey, tt.user)
 			ctx, apiError := controller.CheckCreateAPIKeyPermission(ctx, req)
 			if tt.expectError != "" {
 				require.NotNil(t, apiError)
@@ -633,7 +633,7 @@ func TestDeleteAPIKeyPermissionMiddleware(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := NewRequest(t, nil, nil, map[string]string{"apiKeyID": tt.targetID}, tt.user)
-			ctx := context.WithValue(logs.NewContext(), "user", tt.user)
+			ctx := context.WithValue(logs.NewContext(), userContextKey, tt.user)
 			ctx, apiError := controller.CheckDeleteAPIKeyPermission(ctx, req)
 			if tt.expectMiddlewareError {
 				require.NotNil(t, apiError)

--- a/pkg/servers/e2b/core_test.go
+++ b/pkg/servers/e2b/core_test.go
@@ -455,7 +455,7 @@ func NewRequest(t *testing.T, query map[string]string, body any, pathValues map[
 			req.SetPathValue(k, v)
 		}
 	}
-	return req.WithContext(context.WithValue(req.Context(), "user", user))
+	return req.WithContext(context.WithValue(req.Context(), userContextKey, user))
 }
 
 func GetSbsOwnerReference(sbs *agentsv1alpha1.SandboxSet) []metav1.OwnerReference {

--- a/pkg/servers/e2b/network_test.go
+++ b/pkg/servers/e2b/network_test.go
@@ -428,7 +428,7 @@ func TestUpdateSandboxNetwork_InvalidBody(t *testing.T) {
 		strings.NewReader("invalid json"))
 	require.NoError(t, err)
 	req.SetPathValue("sandboxID", "non-existent--sandbox")
-	req = req.WithContext(context.WithValue(req.Context(), "user", user))
+	req = req.WithContext(context.WithValue(req.Context(), userContextKey, user))
 
 	resp, apiErr := controller.UpdateSandboxNetwork(req)
 	require.NotNil(t, apiErr)

--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -173,13 +173,18 @@ func (sc *Controller) CheckApiKey(ctx context.Context, r *http.Request) (context
 		}
 	}
 	ctx = klog.NewContext(ctx, logger.WithValues("user", user.Name))
-	ctx = context.WithValue(ctx, "user", user)
+	ctx = context.WithValue(ctx, userContextKey, user)
 	return ctx, nil
 }
 
+// contextKey is an unexported type for context keys defined in this package,
+// so they cannot collide with keys set by other packages on the same request.
+type contextKey string
+
 const (
-	newAPIKeyRequestContextKey = "newAPIKeyRequest"
-	targetAPIKeyContextKey     = "targetAPIKey"
+	userContextKey             contextKey = "user"
+	newAPIKeyRequestContextKey contextKey = "newAPIKeyRequest"
+	targetAPIKeyContextKey     contextKey = "targetAPIKey"
 )
 
 func (sc *Controller) CheckCreateAPIKeyPermission(ctx context.Context, r *http.Request) (context.Context, *web.ApiError) {
@@ -312,7 +317,7 @@ func (sc *Controller) validateTeamNamespace(ctx context.Context, teamName string
 }
 
 func GetUserFromContext(ctx context.Context) *models.CreatedTeamAPIKey {
-	value := ctx.Value("user")
+	value := ctx.Value(userContextKey)
 	user, ok := value.(*models.CreatedTeamAPIKey)
 	if !ok {
 		return nil

--- a/pkg/servers/e2b/routes_test.go
+++ b/pkg/servers/e2b/routes_test.go
@@ -473,7 +473,7 @@ func TestGetUserFromContext(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			if tt.ctxValue != nil {
-				ctx = context.WithValue(ctx, "user", tt.ctxValue)
+				ctx = context.WithValue(ctx, userContextKey, tt.ctxValue)
 			}
 
 			user := GetUserFromContext(ctx)

--- a/pkg/servers/e2b/traffic_token_test.go
+++ b/pkg/servers/e2b/traffic_token_test.go
@@ -88,7 +88,7 @@ func TestRefreshTrafficAccessToken(t *testing.T) {
 
 	request := httptest.NewRequest(http.MethodPost, "/sandboxes/"+sandboxID+"/traffic-access-token", nil)
 	request.SetPathValue("sandboxID", sandboxID)
-	request = request.WithContext(context.WithValue(request.Context(), "user", &models.CreatedTeamAPIKey{ID: keys.AdminKeyID, Team: models.AdminTeam()}))
+	request = request.WithContext(context.WithValue(request.Context(), userContextKey, &models.CreatedTeamAPIKey{ID: keys.AdminKeyID, Team: models.AdminTeam()}))
 	response, apiErr := controller.RefreshTrafficAccessToken(request)
 	require.Nil(t, apiErr)
 	require.NotNil(t, response.Body)


### PR DESCRIPTION
`routes.go` stores the authenticated user under a bare string key:

```go
ctx = context.WithValue(ctx, "user", user)
...
func GetUserFromContext(ctx context.Context) *models.CreatedTeamAPIKey {
	value := ctx.Value("user")
	user, ok := value.(*models.CreatedTeamAPIKey)
```

and the two API key constants are untyped strings, so they land in the same namespace:

```go
const (
	newAPIKeyRequestContextKey = "newAPIKeyRequest"
	targetAPIKeyContextKey     = "targetAPIKey"
)
```

`context.WithValue`'s documentation asks for a key type that is not a built-in, because every package sharing a request shares one key space. `"user"` is a name auth and logging middleware pick very often, so it is the realistic collision here rather than a theoretical one.

The failure is quiet rather than loud: `GetUserFromContext` type-asserts the value it finds, so a foreign value stored under `"user"` makes it return `nil`, and the request reads as unauthenticated instead of erroring.

`pkg/tracing/propagator.go:72` already does this correctly with `type rootSpanContextKey struct{}`, so this brings `pkg/servers/e2b` in line with the pattern the repo already uses rather than introducing a new one.

The tests changed because they set `"user"` by string, and that is worth pointing at: once the production code uses `contextKey("user")`, the string `"user"` is a genuinely different key and the tests fail. That failure is the isolation the change buys.

staticcheck flags all three as SA1029.

Verified: `go build ./...` passes, `gofmt -l` clean, SA1029 gone from the package under `GOOS=linux` and `GOOS=darwin`, and `go test ./pkg/servers/e2b/...` is green.

One note in case you see it in CI: `TestConnectSandbox` in `pause_resume_test.go` failed once for me at line 502 and passed on re-run, on both this branch and an unmodified checkout. It looks timing-dependent around the `go UpdateSandboxWhen(...)` goroutine and is unrelated to this change.