### PR TITLE
fix(runtime): honor refresh and retry before process start

### DIFF
--- a/pkg/utils/runtime/process.go
+++ b/pkg/utils/runtime/process.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
@@ -131,38 +132,79 @@ func RunCommandWithRuntime(ctx context.Context, args RunCmdFuncArgs, rtOpts ...O
 func (p *processAPI) Run(ctx context.Context, req RunCommandRequest) (RunCommandResult, error) {
 	sbx, processConfig, timeout := p.r.sbx, req.ProcessConfig, req.Timeout
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx)).V(utils.DebugLogLevel)
-	// The process RPC shares the transport decision with every other capability
-	// group; runtimeGRPCHTTPClient stays the plaintext client so the existing
-	// test seam keeps working.
-	base, httpClient, err := p.r.resolveTransport(sbx, runtimeGRPCHTTPClient)
-	if err != nil {
-		return RunCommandResult{}, err
-	}
-	client := processconnect.NewProcessClient(
-		httpClient,
-		base,
-		connect.WithGRPC(),
-	)
-
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	clientContext, callInfo := connect.NewClientContext(ctxWithTimeout)
-	callInfo.RequestHeader().Set(accessTokenHeader, utils.GetAccessToken(sbx))
-	// The Basic user credential is caller-supplied: it is sent only when
-	// req.AuthUser expresses a user identity for the runtime to resolve.
-	if req.AuthUser != "" {
-		callInfo.RequestHeader().Set("Authorization", basicAuthHeader(req.AuthUser))
-	}
+	// The process RPC shares the transport decision with every other capability
+	// group; runtimeGRPCHTTPClient stays the plaintext client so the existing
+	// test seam keeps working. Like the JSON runtime helpers, the start step is
+	// retried against refreshed sandbox snapshots until the overall call timeout
+	// expires. Once the stream starts successfully we do not replay it: the
+	// remote process may already exist, so retrying past that point could
+	// duplicate execution.
+	var (
+		firstEvent *process.ProcessEvent
+		stream     *connect.ServerStreamForClient[process.StartResponse]
+		attempt    int
+	)
+	err := retry.OnError(p.r.backoff, retriableProcessStartError(ctxWithTimeout), func() error {
+		attempt++
+		if p.r.refreshFn != nil {
+			updated, err := p.r.refreshFn(ctxWithTimeout)
+			if err != nil {
+				return fmt.Errorf("failed to refresh sandbox before starting runtime process: %w", err)
+			}
+			if updated != nil {
+				sbx = updated
+			}
+		}
 
-	startReq := connect.NewRequest(&process.StartRequest{
-		Process: processConfig,
-		Tag:     nil,
-		Pty:     nil,
-		Stdin:   nil,
+		base, httpClient, err := p.r.resolveTransport(sbx, runtimeGRPCHTTPClient)
+		if err != nil {
+			return err
+		}
+		client := processconnect.NewProcessClient(httpClient, base, connect.WithGRPC())
+
+		clientContext, callInfo := connect.NewClientContext(ctxWithTimeout)
+		callInfo.RequestHeader().Set(accessTokenHeader, utils.GetAccessToken(sbx))
+		// The Basic user credential is caller-supplied: it is sent only when
+		// req.AuthUser expresses a user identity for the runtime to resolve.
+		if req.AuthUser != "" {
+			callInfo.RequestHeader().Set("Authorization", basicAuthHeader(req.AuthUser))
+		}
+
+		startReq := connect.NewRequest(&process.StartRequest{
+			Process: processConfig,
+			Tag:     nil,
+			Pty:     nil,
+			Stdin:   nil,
+		})
+		streamCandidate, err := client.Start(clientContext, startReq)
+		if err != nil {
+			log.Info("runtime process start attempt failed",
+				append(p.r.transportLogValues(sbx), "attempt", attempt, "err", err.Error())...)
+			return err
+		}
+		if !streamCandidate.Receive() {
+			err = streamCandidate.Err()
+			if err != nil {
+				log.Info("runtime process start attempt failed",
+					append(p.r.transportLogValues(sbx), "attempt", attempt, "err", err.Error())...)
+				if closeErr := streamCandidate.Close(); closeErr != nil {
+					log.Error(closeErr, "failed to close stream after start failure")
+				}
+				return err
+			}
+		} else {
+			firstEvent = streamCandidate.Msg().Event
+		}
+		stream = streamCandidate
+		return nil
 	})
-	stream, err := client.Start(clientContext, startReq)
 	if err != nil {
 		return RunCommandResult{}, err
+	}
+	if stream == nil {
+		return RunCommandResult{}, fmt.Errorf("runtime process start returned no stream")
 	}
 	defer func() {
 		if err := stream.Close(); err != nil {
@@ -175,33 +217,66 @@ func (p *processAPI) Run(ctx context.Context, req RunCommandRequest) (RunCommand
 	var result RunCommandResult
 	start := time.Now()
 	log.Info("receiving messages", "timeout", timeout)
+	applyProcessEvent(&result, firstEvent)
 	for stream.Receive() {
-		event := stream.Msg().Event
-		switch evt := event.Event.(type) {
-		case *process.ProcessEvent_Start:
-			pid := evt.Start.Pid
-			result.PID = pid
-		case *process.ProcessEvent_Data:
-			switch data := evt.Data.Output.(type) {
-			case *process.ProcessEvent_DataEvent_Stdout:
-				result.Stdout = append(result.Stdout, string(data.Stdout))
-			case *process.ProcessEvent_DataEvent_Stderr:
-				result.Stderr = append(result.Stderr, string(data.Stderr))
-			}
-
-		case *process.ProcessEvent_End:
-			result.ExitCode = evt.End.ExitCode
-			result.Exited = evt.End.Exited
-			if evt.End.Error != nil {
-				result.Error = fmt.Errorf("process error: %s", *evt.End.Error)
-			}
-
-		default: // ProcessEvent_Keepalive
-			continue
-		}
+		applyProcessEvent(&result, stream.Msg().Event)
 	}
 	log.Info("all messages are received", "cost", time.Since(start), "result", result)
 	return result, errors.Join(result.Error, stream.Err())
+}
+
+func applyProcessEvent(result *RunCommandResult, event *process.ProcessEvent) {
+	if result == nil || event == nil {
+		return
+	}
+	switch evt := event.Event.(type) {
+	case *process.ProcessEvent_Start:
+		result.PID = evt.Start.Pid
+	case *process.ProcessEvent_Data:
+		switch data := evt.Data.Output.(type) {
+		case *process.ProcessEvent_DataEvent_Stdout:
+			result.Stdout = append(result.Stdout, string(data.Stdout))
+		case *process.ProcessEvent_DataEvent_Stderr:
+			result.Stderr = append(result.Stderr, string(data.Stderr))
+		}
+	case *process.ProcessEvent_End:
+		result.ExitCode = evt.End.ExitCode
+		result.Exited = evt.End.Exited
+		if evt.End.Error != nil {
+			result.Error = fmt.Errorf("process error: %s", *evt.End.Error)
+		}
+	}
+}
+
+// retriableProcessStartError mirrors the JSON runtime helper policy for the
+// start phase of a process stream: stop on caller cancellation, treat clear
+// client-side connect codes as permanent, and retry everything else
+// (transport, unresolved endpoint, refresh failure, unavailable/internal).
+func retriableProcessStartError(ctx context.Context) func(error) bool {
+	return func(err error) bool {
+		if err == nil {
+			return false
+		}
+		if ctx.Err() != nil {
+			return false
+		}
+		var connectErr *connect.Error
+		if errors.As(err, &connectErr) {
+			switch connectErr.Code() {
+			case connect.CodeCanceled,
+				connect.CodeInvalidArgument,
+				connect.CodeNotFound,
+				connect.CodeAlreadyExists,
+				connect.CodePermissionDenied,
+				connect.CodeFailedPrecondition,
+				connect.CodeUnauthenticated,
+				connect.CodeOutOfRange,
+				connect.CodeUnimplemented:
+				return false
+			}
+		}
+		return true
+	}
 }
 
 // ChmodFileOnRuntime executes `chmod <mode> <filePath>` inside the sandbox runtime

--- a/pkg/utils/runtime/runtime_test.go
+++ b/pkg/utils/runtime/runtime_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 
 	"github.com/openkruise/agents/pkg/utils"
@@ -426,7 +428,7 @@ func TestRunCommandWithRuntime_NoRuntimeURL(t *testing.T) {
 		Timeout:       5 * time.Second,
 	}
 
-	result, err := RunCommandWithRuntime(context.Background(), args)
+	result, err := RunCommandWithRuntime(context.Background(), args, WithRetry(wait.Backoff{Steps: 1}))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "runtime url not found on sandbox")
 	assert.Equal(t, RunCommandResult{}, result)
@@ -513,7 +515,7 @@ func TestRunCommandWithRuntime_ServerError(t *testing.T) {
 
 	_, err := RunCommandWithRuntime(context.Background(), RunCmdFuncArgs{
 		Sbx: sbx, ProcessConfig: &process.ProcessConfig{Cmd: "test"}, Timeout: 5 * time.Second,
-	})
+	}, WithRetry(wait.Backoff{Steps: 1}))
 	assert.Error(t, err)
 }
 
@@ -547,6 +549,74 @@ func TestRunCommandWithRuntime_ContextTimeout(t *testing.T) {
 		Sbx: sbx, ProcessConfig: &process.ProcessConfig{Cmd: "sleep"}, Timeout: 100 * time.Millisecond,
 	})
 	assert.Error(t, err)
+}
+
+func TestRunCommandWithRuntime_RefreshResolvesRuntimeURL(t *testing.T) {
+	var calls, refreshes int32
+	_, ready := newMockRuntimeServer(t, &mockProcessHandler{
+		startFn: func(_ context.Context, _ *connect.Request[process.StartRequest], stream *connect.ServerStream[process.StartResponse]) error {
+			atomic.AddInt32(&calls, 1)
+			if err := stream.Send(&process.StartResponse{Event: &process.ProcessEvent{
+				Event: &process.ProcessEvent_Start{Start: &process.ProcessEvent_StartEvent{Pid: 7}},
+			}}); err != nil {
+				return err
+			}
+			return stream.Send(&process.StartResponse{Event: &process.ProcessEvent{
+				Event: &process.ProcessEvent_End{End: &process.ProcessEvent_EndEvent{ExitCode: 0, Exited: true}},
+			}})
+		},
+	})
+	notReady := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default"},
+	}
+
+	result, err := RunCommandWithRuntime(context.Background(), RunCmdFuncArgs{
+		Sbx:           notReady,
+		ProcessConfig: &process.ProcessConfig{Cmd: "true"},
+		Timeout:       5 * time.Second,
+	}, WithRetry(fastBackoff), WithRefresh(func(context.Context) (*agentsv1alpha1.Sandbox, error) {
+		if atomic.AddInt32(&refreshes, 1) == 1 {
+			return notReady, nil
+		}
+		return ready, nil
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, uint32(7), result.PID)
+	assert.True(t, result.Exited)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&refreshes),
+		"the runtime URL should be re-resolved after the first not-ready attempt")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"the process start RPC should only run after refresh resolves the runtime URL")
+}
+
+func TestRunCommandWithRuntime_RetriesTransientStartError(t *testing.T) {
+	var calls int32
+	_, sbx := newMockRuntimeServer(t, &mockProcessHandler{
+		startFn: func(_ context.Context, _ *connect.Request[process.StartRequest], stream *connect.ServerStream[process.StartResponse]) error {
+			if atomic.AddInt32(&calls, 1) == 1 {
+				return connect.NewError(connect.CodeUnavailable, fmt.Errorf("runtime warming up"))
+			}
+			if err := stream.Send(&process.StartResponse{Event: &process.ProcessEvent{
+				Event: &process.ProcessEvent_Start{Start: &process.ProcessEvent_StartEvent{Pid: 11}},
+			}}); err != nil {
+				return err
+			}
+			return stream.Send(&process.StartResponse{Event: &process.ProcessEvent{
+				Event: &process.ProcessEvent_End{End: &process.ProcessEvent_EndEvent{ExitCode: 0, Exited: true}},
+			}})
+		},
+	})
+
+	result, err := RunCommandWithRuntime(context.Background(), RunCmdFuncArgs{
+		Sbx:           sbx,
+		ProcessConfig: &process.ProcessConfig{Cmd: "true"},
+		Timeout:       5 * time.Second,
+	}, WithRetry(fastBackoff))
+	require.NoError(t, err)
+	assert.Equal(t, uint32(11), result.PID)
+	assert.True(t, result.Exited)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls),
+		"a transient process start error should be retried")
 }
 
 // ------------------ WriteFileWithRuntime ------------------


### PR DESCRIPTION
## Description:

Honor runtime refresh and retry before starting process streams.

Before this change, `ProcessAPI.Run` resolved transport once from the bound sandbox and called `client.Start` directly. As a result, a caller-provided `WithRefresh` hook could not surface a newly stamped runtime URL or TLS transport, and transient start failures ignored the configured `WithRetry` policy.

This PR keeps the existing process behavior after stream startup, but retries only the pre-first-event startup path against refreshed sandbox snapshots. It also adds regression tests for the missing-runtime-URL refresh path and a transient `CodeUnavailable` start failure.

### Validation Tests run:

- [x] `go test ./pkg/utils/runtime -run 'TestRunCommandWithRuntime_RefreshResolvesRuntimeURL|TestRunCommandWithRuntime_RetriesTransientStartError' -count=1 -v`
- [x] `go test ./pkg/utils/runtime -run 'TestRunCommandWithRuntime|TestDoCSIMount|TestChmodFileOnRuntime' -count=1`

## Notes:

- Scope is intentionally limited to `ProcessAPI.Run`.
- No existing issue is linked; this is a direct bugfix PR.
- Retry stays limited to the pre-start path; once the process stream has started, the call is not replayed.
