### PR TITLE
fix(runtime): honor refresh and retry in files write

### DIFF
--- a/pkg/utils/runtime/filesystem.go
+++ b/pkg/utils/runtime/filesystem.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
@@ -228,13 +229,8 @@ func (f *filesystemAPI) Write(ctx context.Context, req WriteFileRequest) (WriteF
 	}
 	sbx := f.r.sbx
 	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx)).V(utils.DebugLogLevel)
-
-	// The multipart write shares the transport decision with every other
-	// capability group; runtimeFilesHTTPClient stays the plaintext client so the
-	// existing test seam keeps working.
-	base, httpClient, err := f.r.resolveTransport(sbx, runtimeFilesHTTPClient)
-	if err != nil {
-		return WriteFileResult{}, err
+	if f.r.tlsEnabled && f.r.tlsConfigErr != nil {
+		return WriteFileResult{}, fmt.Errorf("invalid runtime TLS configuration: %w", f.r.tlsConfigErr)
 	}
 
 	username := req.Username
@@ -250,57 +246,119 @@ func (f *filesystemAPI) Write(ctx context.Context, req WriteFileRequest) (WriteF
 	if err != nil {
 		return WriteFileResult{}, err
 	}
+	payload := append([]byte(nil), body.Bytes()...)
 
-	endpoint := buildRuntimeFilesEndpoint(base, req.FilePath, username)
 	reqCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, endpoint, body)
-	if err != nil {
-		return WriteFileResult{}, fmt.Errorf("failed to build runtime files write request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", contentType)
-	if accessToken := utils.GetAccessToken(sbx); accessToken != "" {
-		httpReq.Header.Set(accessTokenHeader, accessToken)
-	}
-	// The Basic user credential is caller-supplied: it is sent only when
-	// req.AuthUser expresses a user identity for the runtime to resolve.
-	if req.AuthUser != "" {
-		httpReq.Header.Set("Authorization", basicAuthHeader(req.AuthUser))
-	}
-
-	start := time.Now()
-	log.Info("writing file to runtime via files API",
-		"filePath", req.FilePath,
-		"endpoint", endpoint)
-
-	resp, err := httpClient.Do(httpReq)
-	if err != nil {
-		return WriteFileResult{}, fmt.Errorf("failed to call runtime files API: %w", err)
-	}
-	defer func() {
-		// Drain and close to enable connection reuse.
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-	}()
-
-	result := WriteFileResult{StatusCode: resp.StatusCode}
-	if resp.StatusCode >= http.StatusBadRequest {
-		// Read up to 1 KiB of the response body to surface the runtime-side error reason
-		// without unbounded memory usage. The status code alone already classifies the
-		// failure, so a mid-body read error only degrades the diagnostic message.
-		bodyBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<10))
-		reason := strings.TrimSpace(string(bodyBytes))
-		if reason == "" && readErr != nil {
-			reason = fmt.Sprintf("failed to read error response body: %v", readErr)
+	result := WriteFileResult{}
+	attempt := 0
+	shouldRetry := retriableRuntimeError(reqCtx)
+	var lastRetriableErr error
+	err = wait.ExponentialBackoffWithContext(reqCtx, f.r.backoff, func(context.Context) (bool, error) {
+		attempt++
+		if f.r.refreshFn != nil {
+			updated, err := f.r.refreshFn(reqCtx)
+			if err != nil {
+				err = fmt.Errorf("failed to refresh sandbox before runtime files write: %w", err)
+				if shouldRetry(err) {
+					lastRetriableErr = err
+					return false, nil
+				}
+				return false, err
+			}
+			if updated != nil {
+				sbx = updated
+			}
 		}
-		return result, fmt.Errorf("runtime files API returned status %d: %s",
-			resp.StatusCode, reason)
-	}
 
-	log.Info("file written to runtime successfully (overwrite)",
-		"filePath", req.FilePath,
-		"statusCode", resp.StatusCode,
-		"cost", time.Since(start))
+		// The multipart write shares the transport decision with every other
+		// capability group; runtimeFilesHTTPClient stays the plaintext client so the
+		// existing test seam keeps working.
+		base, httpClient, err := f.r.resolveTransport(sbx, runtimeFilesHTTPClient)
+		if err != nil {
+			if shouldRetry(err) {
+				lastRetriableErr = err
+				return false, nil
+			}
+			return false, err
+		}
+		endpoint := buildRuntimeFilesEndpoint(base, req.FilePath, username)
+
+		httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, endpoint, bytes.NewReader(payload))
+		if err != nil {
+			return false, fmt.Errorf("failed to build runtime files write request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", contentType)
+		if accessToken := utils.GetAccessToken(sbx); accessToken != "" {
+			httpReq.Header.Set(accessTokenHeader, accessToken)
+		}
+		// The Basic user credential is caller-supplied: it is sent only when
+		// req.AuthUser expresses a user identity for the runtime to resolve.
+		if req.AuthUser != "" {
+			httpReq.Header.Set("Authorization", basicAuthHeader(req.AuthUser))
+		}
+
+		attemptValues := append(f.r.transportLogValues(sbx),
+			"filePath", req.FilePath, "requestURL", endpoint, "attempt", attempt)
+		start := time.Now()
+		log.Info("writing file to runtime via files API", attemptValues...)
+
+		resp, err := httpClient.Do(httpReq)
+		if err != nil {
+			err = fmt.Errorf("failed to call runtime files API: %w", err)
+			if shouldRetry(err) {
+				lastRetriableErr = err
+				return false, nil
+			}
+			return false, err
+		}
+		defer func() {
+			// Drain and close to enable connection reuse.
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}()
+		if err := reqCtx.Err(); err != nil {
+			return false, fmt.Errorf("failed to call runtime files API: %w", err)
+		}
+
+		result.StatusCode = resp.StatusCode
+		if resp.StatusCode >= http.StatusBadRequest {
+			// Read up to 1 KiB of the response body to surface the runtime-side error reason
+			// without unbounded memory usage. The status code alone already classifies the
+			// failure, so a mid-body read error only degrades the diagnostic message.
+			bodyBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<10))
+			reason := strings.TrimSpace(string(bodyBytes))
+			if reason == "" && readErr != nil {
+				reason = fmt.Sprintf("failed to read error response body: %v", readErr)
+			}
+			err = &APIError{
+				Path:       "/files",
+				StatusCode: resp.StatusCode,
+				Message:    reason,
+			}
+			if shouldRetry(err) {
+				lastRetriableErr = err
+				return false, nil
+			}
+			return false, err
+		}
+
+		log.Info("file written to runtime successfully (overwrite)",
+			append(attemptValues, "statusCode", resp.StatusCode, "cost", time.Since(start))...)
+		return true, nil
+	})
+	if wait.Interrupted(err) && lastRetriableErr != nil {
+		err = lastRetriableErr
+	}
+	if err != nil {
+		var apiErr *APIError
+		if errors.As(err, &apiErr) {
+			result.StatusCode = apiErr.StatusCode
+			return result, fmt.Errorf("runtime files API returned status %d: %s",
+				apiErr.StatusCode, apiErr.Message)
+		}
+		return result, err
+	}
 	return result, nil
 }
 

--- a/pkg/utils/runtime/runtime_test.go
+++ b/pkg/utils/runtime/runtime_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 
 	"github.com/openkruise/agents/pkg/utils"
@@ -649,7 +651,7 @@ func TestWriteFileWithRuntime_InputValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := WriteFileWithRuntime(context.Background(), tt.args)
+			res, err := WriteFileWithRuntime(context.Background(), tt.args, WithRetry(wait.Backoff{Steps: 1}))
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectError)
 			assert.Equal(t, 0, res.StatusCode, "no HTTP call should be made on input validation failure")
@@ -756,7 +758,7 @@ func TestWriteFileWithRuntime_HTTPInteractions(t *testing.T) {
 				AuthUser: tt.authUser,
 			}
 
-			res, err := WriteFileWithRuntime(context.Background(), args)
+			res, err := WriteFileWithRuntime(context.Background(), args, WithRetry(wait.Backoff{Steps: 1}))
 
 			if tt.expectError == "" {
 				require.NoError(t, err)
@@ -798,7 +800,7 @@ func TestWriteFileWithRuntime_TransportError(t *testing.T) {
 	sbx := newWriteFileSandbox(server.URL, "runtime-token")
 	args := WriteFileArgs{Sbx: sbx, FilePath: "/tmp/x", Content: []byte("x")}
 
-	res, err := WriteFileWithRuntime(context.Background(), args)
+	res, err := WriteFileWithRuntime(context.Background(), args, WithRetry(wait.Backoff{Steps: 1}))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to call runtime files API")
 	assert.Equal(t, 0, res.StatusCode)
@@ -826,11 +828,72 @@ func TestWriteFileWithRuntime_ContextTimeout(t *testing.T) {
 	}
 
 	start := time.Now()
-	res, err := WriteFileWithRuntime(context.Background(), args)
+	res, err := WriteFileWithRuntime(context.Background(), args, WithRetry(wait.Backoff{Steps: 1}))
 	assert.Less(t, time.Since(start), 1500*time.Millisecond, "timeout should fire well before the server replies")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to call runtime files API")
 	assert.Equal(t, 0, res.StatusCode)
+}
+
+func TestWriteFileWithRuntime_RefreshResolvesRuntimeURL(t *testing.T) {
+	var calls, refreshes int32
+	captured := &capturedFilesRequest{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		captured.query = r.URL.Query()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notReady := newWriteFileSandbox("", "runtime-token")
+	ready := newWriteFileSandbox(server.URL, "runtime-token")
+
+	res, err := WriteFileWithRuntime(context.Background(), WriteFileArgs{
+		Sbx:      notReady,
+		FilePath: "/tmp/token",
+		Content:  []byte("payload"),
+		AuthUser: "root",
+	}, WithRetry(fastBackoff), WithRefresh(func(context.Context) (*agentsv1alpha1.Sandbox, error) {
+		if atomic.AddInt32(&refreshes, 1) == 1 {
+			return notReady, nil
+		}
+		return ready, nil
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&refreshes),
+		"the runtime URL should be re-resolved after the first not-ready attempt")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"the files API should only be called after refresh resolves the runtime URL")
+	assert.Equal(t, http.MethodPost, captured.method)
+	assert.Equal(t, "/files", captured.path)
+	assert.Equal(t, "/tmp/token", captured.query.Get("path"))
+}
+
+func TestWriteFileWithRuntime_RetriesTransientServerError(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("runtime warming up"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	res, err := WriteFileWithRuntime(context.Background(), WriteFileArgs{
+		Sbx:      newWriteFileSandbox(server.URL, "runtime-token"),
+		FilePath: "/tmp/token",
+		Content:  []byte("payload"),
+		AuthUser: "root",
+	}, WithRetry(fastBackoff))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls),
+		"a transient runtime files error should be retried")
 }
 
 // TestWriteFileWithRuntime_HonorsLargeArgsTimeout regression-tests the contract that


### PR DESCRIPTION
## Description:

Honor runtime refresh and retry in the multipart files write path.

Before this change, `FilesystemAPI.Write` resolved transport once from the bound sandbox and sent a single multipart `/files` request. As a result, a caller-provided `WithRefresh` hook could not surface a newly stamped runtime URL or TLS transport, and transient transport or HTTP 5xx failures ignored the configured `WithRetry` policy.

This PR keeps the existing outward `/files` error behavior, but refreshes the sandbox before each attempt, rebuilds the request from a cached multipart payload, and adds regression tests for the missing-runtime-URL refresh path and a transient 500 response.

### Validation Tests run:

- [x] `go test ./pkg/utils/runtime -run 'TestWriteFileWithRuntime_RefreshResolvesRuntimeURL|TestWriteFileWithRuntime_RetriesTransientServerError' -count=1 -v`
- [x] `go test ./pkg/utils/runtime -run 'TestWriteFileWithRuntime_(InputValidation|HTTPInteractions|TransportError|HonorsLargeArgsTimeout|RefreshResolvesRuntimeURL|RetriesTransientServerError)|TestTLSMode_CapabilityGroupsUseRuntimeTLS|TestTLSMode_CapabilityGroupsRejectInvalidBundle' -count=1`

## Notes:

- Scope is intentionally limited to `FilesystemAPI.Write`.
- `ListDir` and `Remove` are left for a follow up PR if needed.
