### PR TITLE
fix(e2b): restart failed Code Interpreter startup

### DIFF
--- a/test/e2b/assets/sandboxset-code-interpreter-0.yaml
+++ b/test/e2b/assets/sandboxset-code-interpreter-0.yaml
@@ -44,6 +44,14 @@ spec:
             initialDelaySeconds: 1
             periodSeconds: 2
             timeoutSeconds: 1
+          livenessProbe:
+            failureThreshold: 20
+            httpGet:
+              path: /health
+              port: 49999
+            initialDelaySeconds: 60
+            periodSeconds: 2
+            timeoutSeconds: 1
           readinessProbe:
             failureThreshold: 20
             httpGet:

--- a/test/e2b/assets/sandboxset-code-interpreter.yaml
+++ b/test/e2b/assets/sandboxset-code-interpreter.yaml
@@ -44,6 +44,14 @@ spec:
             initialDelaySeconds: 1
             periodSeconds: 2
             timeoutSeconds: 1
+          livenessProbe:
+            failureThreshold: 20
+            httpGet:
+              path: /health
+              port: 49999
+            initialDelaySeconds: 60
+            periodSeconds: 2
+            timeoutSeconds: 1
           readinessProbe:
             failureThreshold: 20
             httpGet:

--- a/test/e2b/assets/sandboxset-quota-nostock.yaml
+++ b/test/e2b/assets/sandboxset-quota-nostock.yaml
@@ -51,6 +51,14 @@ spec:
             initialDelaySeconds: 1
             periodSeconds: 2
             timeoutSeconds: 1
+          livenessProbe:
+            failureThreshold: 20
+            httpGet:
+              path: /health
+              port: 49999
+            initialDelaySeconds: 60
+            periodSeconds: 2
+            timeoutSeconds: 1
           readinessProbe:
             failureThreshold: 20
             httpGet:

--- a/test/e2b/assets/sandboxset-quota-small.yaml
+++ b/test/e2b/assets/sandboxset-quota-small.yaml
@@ -51,6 +51,14 @@ spec:
             initialDelaySeconds: 1
             periodSeconds: 2
             timeoutSeconds: 1
+          livenessProbe:
+            failureThreshold: 20
+            httpGet:
+              path: /health
+              port: 49999
+            initialDelaySeconds: 60
+            periodSeconds: 2
+            timeoutSeconds: 1
           readinessProbe:
             failureThreshold: 20
             httpGet:


### PR DESCRIPTION
## Description:

Add an application liveness probe to every E2E Code Interpreter SandboxSet.

When Code Interpreter Uvicorn exits while creating its default Jupyter context, Jupyter remains the sandbox container's PID 1. Existing templates probe runtime startup on `:49983` and use `:49999/health` only for readiness. A failed Uvicorn startup therefore leaves the pod `1/2 Running` forever: readiness failures do not restart containers.

This PR probes `:49999/health` for liveness after a 60 second startup grace period. Twenty failed checks at two-second intervals make kubelet restart the sandbox container, giving a transient bootstrap failure another startup attempt. The change is applied consistently to the `code-interpreter`, `code-interpreter-0`, `quota-small`, and `quota-nostock` E2E templates.

Closes #908.

### Validation Tests run:

- [x] `kubectl apply --dry-run=server -f test/e2b/assets/sandboxset-code-interpreter.yaml -f test/e2b/assets/sandboxset-code-interpreter-0.yaml -f test/e2b/assets/sandboxset-quota-small.yaml -f test/e2b/assets/sandboxset-quota-nostock.yaml`
- [x] Local kind E2E setup: applied changed templates; `code-interpreter` reached `4/4` and `quota-small` reached `8/8` available replicas.
- [x] Local kind failure injection: terminated one live Uvicorn child; kubelet reported `Container sandbox failed liveness probe, will be restarted`, then pod recovered with `restarts=1 ready=true`.
- [x] `git diff --check`

## Notes:

- Scope is intentionally limited to E2E Code Interpreter templates.
- This does not change the external `code-interpreter:v1.6` image. It prevents its failed Uvicorn child from leaving an unrecoverable pod.