### PR TITLE
fix(controller): prevent internal labels leaking into sandbox pod template

### DIFF
--- a/pkg/controller/sandboxset/utils.go
+++ b/pkg/controller/sandboxset/utils.go
@@ -18,6 +18,7 @@ package sandboxset
 
 import (
 	"context"
+	"maps"
 	"strings"
 	"time"
 
@@ -137,14 +138,18 @@ func NewSandboxFromSandboxSet(sbs *agentsv1alpha1.SandboxSet, refTemplate *agent
 	// source pod template before reading labels/annotations so subsequent
 	// mutations (clearAndInitInnerKeys, internal label writes) never leak
 	// back into the SandboxSet spec or the cached SandboxTemplate.
+	// The metadata maps are cloned (not shared) so that the internal labels
+	// written below land only on the Sandbox metadata: if they shared the Pod
+	// template's maps, they would be persisted into spec.template and thus
+	// propagated onto every Pod created from it.
 	if sbs.Spec.Template != nil {
 		template = sbs.Spec.Template.DeepCopy()
-		inheritedLabels = template.Labels
-		inheritedAnnotations = template.Annotations
+		inheritedLabels = maps.Clone(template.Labels)
+		inheritedAnnotations = maps.Clone(template.Annotations)
 	} else if refTemplate != nil && refTemplate.Spec.Template != nil {
 		templateCopy := refTemplate.Spec.Template.DeepCopy()
-		inheritedLabels = templateCopy.Labels
-		inheritedAnnotations = templateCopy.Annotations
+		inheritedLabels = maps.Clone(templateCopy.Labels)
+		inheritedAnnotations = maps.Clone(templateCopy.Annotations)
 	}
 	sbx := &agentsv1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/sandboxset/utils_test.go
+++ b/pkg/controller/sandboxset/utils_test.go
@@ -774,3 +774,69 @@ func TestClearAndInitInnerKeys(t *testing.T) {
 		})
 	}
 }
+
+// TestNewSandboxFromSandboxSetPodTemplateNotPolluted is a regression test for a
+// map-aliasing bug: the Sandbox metadata labels/annotations must not share maps
+// with spec.template, otherwise the internal labels written onto the metadata
+// (sandbox-pool/sandbox-template/sandbox-claimed, plus the template-hash stamped
+// by createSandbox) leak into the Pod template and propagate onto every Pod.
+func TestNewSandboxFromSandboxSetPodTemplateNotPolluted(t *testing.T) {
+	userLabels := map[string]string{"network-open": "true"}
+	userAnnotations := map[string]string{"team": "platform"}
+	sbs := &agentsv1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-a", Namespace: "default"},
+		Spec: agentsv1alpha1.SandboxSetSpec{
+			Replicas: 1,
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: userLabels, Annotations: userAnnotations},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "nginx"}}},
+				},
+			},
+		},
+	}
+
+	sbx := NewSandboxFromSandboxSet(sbs, nil)
+	// Simulate the internal label write performed by createSandbox afterwards.
+	sbx.Labels[agentsv1alpha1.LabelTemplateHash] = "rev-1"
+
+	// Metadata carries user labels plus internal labels.
+	assert.Equal(t, "true", sbx.Labels["network-open"])
+	assert.Equal(t, "pool-a", sbx.Labels[agentsv1alpha1.LabelSandboxPool])
+	assert.Equal(t, "rev-1", sbx.Labels[agentsv1alpha1.LabelTemplateHash])
+
+	// The Pod template keeps only the user's metadata; internal labels must not
+	// leak into it (and therefore never reach the Pods created from it).
+	assert.Equal(t, userLabels, sbx.Spec.Template.Labels,
+		"internal labels must not leak into spec.template.labels")
+	assert.Equal(t, userAnnotations, sbx.Spec.Template.Annotations,
+		"internal annotations must not leak into spec.template.annotations")
+	// The source SandboxSet spec must stay untouched as well.
+	assert.Equal(t, userLabels, sbs.Spec.Template.Labels)
+
+	// templateRef path: the referenced SandboxTemplate must never be mutated.
+	refLabels := map[string]string{"app": "from-template"}
+	refTemplate := &agentsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-template", Namespace: "default"},
+		Spec: agentsv1alpha1.SandboxTemplateSpec{
+			Template: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: refLabels},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "nginx"}}},
+			},
+		},
+	}
+	sbsRef := &agentsv1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-b", Namespace: "default"},
+		Spec: agentsv1alpha1.SandboxSetSpec{
+			Replicas: 1,
+			EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+				TemplateRef: &agentsv1alpha1.SandboxTemplateRef{Name: "my-template"},
+			},
+		},
+	}
+	sbxRef := NewSandboxFromSandboxSet(sbsRef, refTemplate)
+	sbxRef.Labels[agentsv1alpha1.LabelTemplateHash] = "rev-2"
+	assert.Nil(t, sbxRef.Spec.Template)
+	assert.Equal(t, refLabels, refTemplate.Spec.Template.Labels,
+		"referenced SandboxTemplate must not be mutated")
+}


### PR DESCRIPTION

## Background

Pods created from SandboxSet-managed Sandboxes inconsistently carry the internal pool labels (`agents.kruise.io/sandbox-pool` / `sandbox-template` / `sandbox-claimed` / `template-hash`): sandboxes built from an inline `spec.template` produce Pods **with** those labels, while the `spec.templateRef` path produces Pods **without** them (only user template labels + `created-by` + `pod-template-hash`).

## Root cause

`NewSandboxFromSandboxSet` assigned the pod template's label/annotation maps to the Sandbox **metadata by reference** (`inheritedLabels = template.Labels`, then both `ObjectMeta.Labels` and `Spec.Template.Labels` point at the same map). The internal labels written onto the metadata afterwards — `LabelSandboxPool`, `LabelSandboxTemplate`, `LabelSandboxIsClaimed`, and the `LabelTemplateHash` stamped by `createSandbox` — were therefore persisted into `spec.template.metadata.labels` too. The sandbox controller builds every Pod with `Labels: podTemplate.Labels`, so the internal labels leaked onto the Pods.

The existing deep copy only protected the SandboxSet spec / cached SandboxTemplate (as the comment says); it did not protect the Sandbox's own pod template from its own metadata writes.

## Changes

- `pkg/controller/sandboxset/utils.go`: clone the inherited label/annotation maps (`maps.Clone`) so internal metadata writes never reach `spec.template` or the referenced `SandboxTemplate`.
- `pkg/controller/sandboxset/utils_test.go`: regression test asserting `spec.template` keeps only user-provided labels/annotations on both the inline and `templateRef` paths, and that neither the SandboxSet spec nor the referenced SandboxTemplate is mutated.

## Compatibility

- Only affects newly created Sandbox objects; existing Sandboxes keep their (polluted) templates and hashes, so no spurious rolling update is triggered by upgrading the controller.
- After the fix, Pods no longer carry the internal pool labels — selectors/policies must keep using the Sandbox object's labels (as `SandboxSet.status.selector` already does).

## Tests

- `go test ./pkg/controller/sandboxset/...` ✅
- `go test ./pkg/sandbox-manager/infra/sandboxcr/...` ✅ (claim path consumes `NewSandboxFromSandboxSet`)

