### PR TITLE
fix(sandbox): sync pod status before upgrade initialization

### DIFF
--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -3500,12 +3500,14 @@ func TestCommonControl_EnsureSandboxResumed_InitContainerInconsistent(t *testing
 
 // mockSandboxInitializer is a test double for SandboxInitializer.
 type mockSandboxInitializer struct {
-	err    error
-	called int
+	err               error
+	called            int
+	initializedStatus *agentsv1alpha1.SandboxStatus
 }
 
-func (m *mockSandboxInitializer) Initialize(_ context.Context, _ *agentsv1alpha1.Sandbox, _ *agentsv1alpha1.SandboxStatus) error {
+func (m *mockSandboxInitializer) Initialize(_ context.Context, _ *agentsv1alpha1.Sandbox, newStatus *agentsv1alpha1.SandboxStatus) error {
 	m.called++
+	m.initializedStatus = newStatus.DeepCopy()
 	return m.err
 }
 

--- a/pkg/controller/sandbox/core/upgrade_control.go
+++ b/pkg/controller/sandbox/core/upgrade_control.go
@@ -350,6 +350,10 @@ func (r *UpgradeControl) handleResuming(ctx context.Context, args EnsureFuncArgs
 		klog.InfoS("Waiting for pod ready before initialization", "sandbox", klog.KObj(box))
 		return nil
 	}
+	// Sync status from the resumed pod before Initialize so that runtime
+	// re-init targets the current Pod IP/UID. The resumed pod may differ
+	// from the paused one, and using stale status would leave the upgrade
+	// stuck in Resuming.
 	r.syncStatusFromPod(pod, newStatus, false)
 	// Only initialize the old pod when a PreUpgrade hook is configured.
 	// The Initialize call (runtime re-init, security token, CSI re-mount)

--- a/pkg/controller/sandbox/core/upgrade_control.go
+++ b/pkg/controller/sandbox/core/upgrade_control.go
@@ -350,6 +350,7 @@ func (r *UpgradeControl) handleResuming(ctx context.Context, args EnsureFuncArgs
 		klog.InfoS("Waiting for pod ready before initialization", "sandbox", klog.KObj(box))
 		return nil
 	}
+	r.syncStatusFromPod(pod, newStatus, false)
 	// Only initialize the old pod when a PreUpgrade hook is configured.
 	// The Initialize call (runtime re-init, security token, CSI re-mount)
 	// prepares the old pod for PreUpgrade execution. If no PreUpgrade hook
@@ -361,7 +362,6 @@ func (r *UpgradeControl) handleResuming(ctx context.Context, args EnsureFuncArgs
 			return err
 		}
 	}
-	r.syncStatusFromPod(pod, newStatus, false)
 	// Resume succeeded. Transition to ResumeSucceed and wait for
 	// SandboxUpdateOps to patch the template before proceeding.
 	klog.InfoS("Sandbox resumed successfully, waiting for template patch", "sandbox", klog.KObj(box))

--- a/pkg/controller/sandbox/core/upgrade_control_test.go
+++ b/pkg/controller/sandbox/core/upgrade_control_test.go
@@ -1590,12 +1590,16 @@ func TestEnsureSandboxUpgraded_Resuming(t *testing.T) {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = agentsv1alpha1.AddToScheme(scheme)
 	now := metav1.Now()
+	oldPodIP := "10.0.0.1"
+	newPodIP := "10.0.0.2"
+	newPodUID := types.UID("new-pod-uid")
 
 	readyPod := func() *corev1.Pod {
 		return &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-sandbox",
 				Namespace: "default",
+				UID:       newPodUID,
 				Labels: map[string]string{
 					agentsv1alpha1.PodLabelTemplateHash: "old-revision",
 				},
@@ -1608,7 +1612,7 @@ func TestEnsureSandboxUpgraded_Resuming(t *testing.T) {
 			},
 			Status: corev1.PodStatus{
 				Phase: corev1.PodRunning,
-				PodIP: "10.0.0.1",
+				PodIP: newPodIP,
 				Conditions: []corev1.PodCondition{
 					{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: now},
 				},
@@ -1797,7 +1801,12 @@ func TestEnsureSandboxUpgraded_Resuming(t *testing.T) {
 			pod:  readyPod(),
 			box:  boxWithPreUpgrade(),
 			existingStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxUpgrading,
+				Phase:     agentsv1alpha1.SandboxUpgrading,
+				SandboxIp: oldPodIP,
+				PodInfo: agentsv1alpha1.PodInfo{
+					PodIP:  oldPodIP,
+					PodUID: types.UID("old-pod-uid"),
+				},
 				Conditions: []metav1.Condition{
 					resumingCond,
 					pausedTrueCond,
@@ -1816,7 +1825,12 @@ func TestEnsureSandboxUpgraded_Resuming(t *testing.T) {
 			pod:  readyPod(),
 			box:  boxWithPreUpgrade(),
 			existingStatus: &agentsv1alpha1.SandboxStatus{
-				Phase: agentsv1alpha1.SandboxUpgrading,
+				Phase:     agentsv1alpha1.SandboxUpgrading,
+				SandboxIp: oldPodIP,
+				PodInfo: agentsv1alpha1.PodInfo{
+					PodIP:  oldPodIP,
+					PodUID: types.UID("old-pod-uid"),
+				},
 				Conditions: []metav1.Condition{
 					resumingCond,
 					pausedTrueCond,
@@ -1876,8 +1890,20 @@ func TestEnsureSandboxUpgraded_Resuming(t *testing.T) {
 				t.Error("expected resumeFunc NOT to be called, but it was")
 			}
 
-			if tt.expectInitCalled && init.called == 0 {
-				t.Error("expected Initialize to be called, but it was not")
+			if tt.expectInitCalled {
+				if init.called == 0 {
+					t.Error("expected Initialize to be called, but it was not")
+				}
+				if init.initializedStatus == nil {
+					t.Error("expected Initialize to receive sandbox status")
+				} else {
+					assert.Equal(t, newPodIP, init.initializedStatus.SandboxIp)
+					assert.Equal(t, newPodIP, init.initializedStatus.PodInfo.PodIP)
+					assert.Equal(t, newPodUID, init.initializedStatus.PodInfo.PodUID)
+				}
+				assert.Equal(t, newPodIP, newStatus.SandboxIp)
+				assert.Equal(t, newPodIP, newStatus.PodInfo.PodIP)
+				assert.Equal(t, newPodUID, newStatus.PodInfo.PodUID)
 			}
 			if !tt.expectInitCalled && init.called > 0 {
 				t.Error("expected Initialize NOT to be called, but it was")

--- a/pkg/controller/sandbox/core/upgrade_control_test.go
+++ b/pkg/controller/sandbox/core/upgrade_control_test.go
@@ -1897,13 +1897,13 @@ func TestEnsureSandboxUpgraded_Resuming(t *testing.T) {
 				if init.initializedStatus == nil {
 					t.Error("expected Initialize to receive sandbox status")
 				} else {
-					assert.Equal(t, newPodIP, init.initializedStatus.SandboxIp)
-					assert.Equal(t, newPodIP, init.initializedStatus.PodInfo.PodIP)
-					assert.Equal(t, newPodUID, init.initializedStatus.PodInfo.PodUID)
+					assert.Equal(t, newPodIP, init.initializedStatus.SandboxIp, "SandboxIp passed to Initialize")
+					assert.Equal(t, newPodIP, init.initializedStatus.PodInfo.PodIP, "PodInfo.PodIP passed to Initialize")
+					assert.Equal(t, newPodUID, init.initializedStatus.PodInfo.PodUID, "PodInfo.PodUID passed to Initialize")
 				}
-				assert.Equal(t, newPodIP, newStatus.SandboxIp)
-				assert.Equal(t, newPodIP, newStatus.PodInfo.PodIP)
-				assert.Equal(t, newPodUID, newStatus.PodInfo.PodUID)
+				assert.Equal(t, newPodIP, newStatus.SandboxIp, "SandboxIp in newStatus")
+				assert.Equal(t, newPodIP, newStatus.PodInfo.PodIP, "PodInfo.PodIP in newStatus")
+				assert.Equal(t, newPodUID, newStatus.PodInfo.PodUID, "PodInfo.PodUID in newStatus")
 			}
 			if !tt.expectInitCalled && init.called > 0 {
 				t.Error("expected Initialize NOT to be called, but it was")


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Syncs the resumed Pod status before running upgrade initialization.

For a paused Sandbox undergoing a Recreate upgrade with a PreUpgrade hook, the resumed Pod may have a different IP. Previously, initialization used the stale Pod information from Sandbox status, causing runtime `/init` requests to target the old Pod IP and leaving the upgrade stuck in Resuming.

This change updates SandboxIp and PodInfo from the Ready Pod before calling Initialize. It also adds regression coverage for the new Pod IP and UID, including the initialization failure path.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

```bash
GOTOOLCHAIN=go1.26.3 go test -mod=mod ./pkg/controller/sandbox/core -run '^TestEnsureSandboxUpgraded_Resuming$' -count=1
```

### Ⅳ. Special notes for reviews

Please verify the ordering in handleResuming and the status retained when Initialize returns an error.
