### PR TITLE
fix(sandbox): wait for active checkpoints before pause

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -621,9 +621,11 @@ const (
 	SandboxUpgradingReasonSucceeded         = "Succeeded"
 
 	// SandboxConditionPaused Reason
-	SandboxPausedReasonPending              = "Pending"
-	SandboxPausedReasonImageChanged         = "ImageChanged"
-	SandboxPausedReasonCheckpointInProgress = "CheckpointInProgress"
+	SandboxPausedReasonPending      = "Pending"
+	SandboxPausedReasonImageChanged = "ImageChanged"
+	// SandboxPausedReasonWaitingForExistingCheckpoint indicates that pause is blocked by a Checkpoint created outside the pause flow.
+	SandboxPausedReasonWaitingForExistingCheckpoint = "WaitingForExistingCheckpoint"
+	// SandboxPausedReasonCheckpointCreating indicates that the pause flow is creating its own Checkpoint.
 	SandboxPausedReasonCheckpointCreating   = "CheckpointCreating"
 	SandboxPausedReasonCheckpointSucceeded  = "CheckpointSucceeded"
 	SandboxPausedReasonCheckpointFailed     = "CheckpointFailed"

--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -623,6 +623,7 @@ const (
 	// SandboxConditionPaused Reason
 	SandboxPausedReasonPending              = "Pending"
 	SandboxPausedReasonImageChanged         = "ImageChanged"
+	SandboxPausedReasonCheckpointInProgress = "CheckpointInProgress"
 	SandboxPausedReasonCheckpointCreating   = "CheckpointCreating"
 	SandboxPausedReasonCheckpointSucceeded  = "CheckpointSucceeded"
 	SandboxPausedReasonCheckpointFailed     = "CheckpointFailed"

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"reflect"
+	"sort"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -482,10 +483,15 @@ func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.En
 	if err := r.List(ctx, checkpoints,
 		client.InNamespace(box.Namespace),
 		client.MatchingFields{fieldindex.IndexNameForCheckpointSandboxName: box.Name},
-		client.UnsafeDisableDeepCopy,
 	); err != nil {
 		return false, fmt.Errorf("failed to list checkpoints for sandbox %s/%s: %w", box.Namespace, box.Name, err)
 	}
+	sort.Slice(checkpoints.Items, func(i, j int) bool {
+		if checkpoints.Items[i].CreationTimestamp.Equal(&checkpoints.Items[j].CreationTimestamp) {
+			return checkpoints.Items[i].Name < checkpoints.Items[j].Name
+		}
+		return checkpoints.Items[j].CreationTimestamp.Before(&checkpoints.Items[i].CreationTimestamp)
+	})
 
 	now := time.Now()
 	var blockingCheckpoint *agentsv1alpha1.Checkpoint
@@ -503,11 +509,8 @@ func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.En
 				"age", now.Sub(checkpoint.CreationTimestamp.Time))
 			continue
 		}
-		if blockingCheckpoint == nil ||
-			checkpoint.CreationTimestamp.Before(&blockingCheckpoint.CreationTimestamp) ||
-			(checkpoint.CreationTimestamp.Equal(&blockingCheckpoint.CreationTimestamp) && checkpoint.Name < blockingCheckpoint.Name) {
-			blockingCheckpoint = checkpoint
-		}
+		blockingCheckpoint = checkpoint
+		break
 	}
 	if blockingCheckpoint != nil {
 		phase := string(blockingCheckpoint.Status.Phase)

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sandbox
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"flag"
@@ -509,20 +510,10 @@ func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.En
 	var blockingCheckpoint *agentsv1alpha1.Checkpoint
 	if len(activeCheckpoints) > 0 {
 		blockingCheckpoint = slices.MaxFunc(activeCheckpoints, func(a, b *agentsv1alpha1.Checkpoint) int {
-			if a.CreationTimestamp.Equal(&b.CreationTimestamp) {
-				switch {
-				case a.Name < b.Name:
-					return 1
-				case a.Name > b.Name:
-					return -1
-				default:
-					return 0
-				}
-			}
-			if a.CreationTimestamp.Before(&b.CreationTimestamp) {
-				return -1
-			}
-			return 1
+			return cmp.Or(
+				a.CreationTimestamp.Time.Compare(b.CreationTimestamp.Time),
+				cmp.Compare(b.Name, a.Name),
+			)
 		})
 	}
 	if blockingCheckpoint != nil {
@@ -538,8 +529,8 @@ func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.En
 		if recordEvent && r.recorder != nil {
 			r.recorder.Event(box, corev1.EventTypeNormal, agentsv1alpha1.SandboxPausedReasonWaitingForExistingCheckpoint, message)
 		}
-		klog.Warningf("Wait for in-progress checkpoint before pause: sandbox=%s, checkpoint=%s, phase=%s",
-			klog.KObj(box), klog.KObj(blockingCheckpoint), blockingCheckpoint.Status.Phase)
+		logger.Info("Wait for in-progress checkpoint before pause",
+			"checkpoint", klog.KObj(blockingCheckpoint), "phase", blockingCheckpoint.Status.Phase)
 		return true, nil
 	}
 	// Restore the initial pause state once no in-progress checkpoint blocks the

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -86,12 +86,12 @@ var (
 )
 
 const (
-	eventReasonSandboxTerminating  = "SandboxTerminating"
+	eventReasonSandboxTerminating   = "SandboxTerminating"
 	eventReasonCheckpointInProgress = "CheckpointInProgress"
-	minimumPendingTimeout            = 15 * time.Second
-	maximumPendingTimeout            = 3590 * time.Second
-	checkpointCreationWaitTimeout    = 5 * time.Minute
-	checkpointWaitRequeueInterval    = 5 * time.Second
+	minimumPendingTimeout           = 15 * time.Second
+	maximumPendingTimeout           = 3590 * time.Second
+	checkpointCreationWaitTimeout   = 5 * time.Minute
+	checkpointWaitRequeueInterval   = 5 * time.Second
 )
 
 // MaxPendingTimeout returns the normalized process-wide Sandbox Pending timeout.

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -22,7 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"reflect"
-	"sort"
+	"slices"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -483,18 +483,12 @@ func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.En
 	if err := r.List(ctx, checkpoints,
 		client.InNamespace(box.Namespace),
 		client.MatchingFields{fieldindex.IndexNameForCheckpointSandboxName: box.Name},
+		client.UnsafeDisableDeepCopy,
 	); err != nil {
 		return false, fmt.Errorf("failed to list checkpoints for sandbox %s/%s: %w", box.Namespace, box.Name, err)
 	}
-	sort.Slice(checkpoints.Items, func(i, j int) bool {
-		if checkpoints.Items[i].CreationTimestamp.Equal(&checkpoints.Items[j].CreationTimestamp) {
-			return checkpoints.Items[i].Name < checkpoints.Items[j].Name
-		}
-		return checkpoints.Items[j].CreationTimestamp.Before(&checkpoints.Items[i].CreationTimestamp)
-	})
-
 	now := time.Now()
-	var blockingCheckpoint *agentsv1alpha1.Checkpoint
+	activeCheckpoints := make([]*agentsv1alpha1.Checkpoint, 0, len(checkpoints.Items))
 	for i := range checkpoints.Items {
 		checkpoint := &checkpoints.Items[i]
 		if !checkpoint.DeletionTimestamp.IsZero() ||
@@ -509,8 +503,27 @@ func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.En
 				"age", now.Sub(checkpoint.CreationTimestamp.Time))
 			continue
 		}
-		blockingCheckpoint = checkpoint
-		break
+		activeCheckpoints = append(activeCheckpoints, checkpoint)
+	}
+
+	var blockingCheckpoint *agentsv1alpha1.Checkpoint
+	if len(activeCheckpoints) > 0 {
+		blockingCheckpoint = slices.MaxFunc(activeCheckpoints, func(a, b *agentsv1alpha1.Checkpoint) int {
+			if a.CreationTimestamp.Equal(&b.CreationTimestamp) {
+				switch {
+				case a.Name < b.Name:
+					return 1
+				case a.Name > b.Name:
+					return -1
+				default:
+					return 0
+				}
+			}
+			if a.CreationTimestamp.Before(&b.CreationTimestamp) {
+				return -1
+			}
+			return 1
+		})
 	}
 	if blockingCheckpoint != nil {
 		phase := string(blockingCheckpoint.Status.Phase)

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -48,6 +48,7 @@ import (
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
+	"github.com/openkruise/agents/pkg/utils/fieldindex"
 	runtimeclient "github.com/openkruise/agents/pkg/utils/runtime"
 	timeoututils "github.com/openkruise/agents/pkg/utils/timeout"
 
@@ -85,9 +86,12 @@ var (
 )
 
 const (
-	eventReasonSandboxTerminating = "SandboxTerminating"
-	minimumPendingTimeout         = 15 * time.Second
-	maximumPendingTimeout         = 3590 * time.Second
+	eventReasonSandboxTerminating  = "SandboxTerminating"
+	eventReasonCheckpointInProgress = "CheckpointInProgress"
+	minimumPendingTimeout            = 15 * time.Second
+	maximumPendingTimeout            = 3590 * time.Second
+	checkpointCreationWaitTimeout    = 5 * time.Minute
+	checkpointWaitRequeueInterval    = 5 * time.Second
 )
 
 // MaxPendingTimeout returns the normalized process-wide Sandbox Pending timeout.
@@ -368,15 +372,21 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 		tracing.EndSpan(ctx, span, err)
 	case agentsv1alpha1.SandboxPaused:
 		ctx, span := tracing.StartControllerSpan(ctx, tracing.SpanControllerEnsureSandboxPaused)
-		err = r.preparePausedPhase(ctx, args)
-		if err != nil {
-			tracing.EndSpan(ctx, span, err)
-			return reconcile.Result{}, err
+		waitForCheckpoint, prepareErr := r.preparePausedPhase(ctx, args)
+		if prepareErr != nil {
+			tracing.EndSpan(ctx, span, prepareErr)
+			return reconcile.Result{}, prepareErr
 		}
-		// EnsureSandboxPaused is called unconditionally: it drives the pause
-		// state machine to completion (Paused reaches Status=True only after
-		// the pod is fully deleted) and is idempotent once the pause has
-		// finished.
+		if waitForCheckpoint {
+			if requeueAfter == 0 || checkpointWaitRequeueInterval < requeueAfter {
+				requeueAfter = checkpointWaitRequeueInterval
+			}
+			tracing.EndSpan(ctx, span, nil)
+			break
+		}
+		// Once the pre-pause checkpoint gate clears, EnsureSandboxPaused drives
+		// the pause state machine to completion (Paused reaches Status=True only
+		// after the pod is fully deleted) and is idempotent once pause finishes.
 		err = r.getControl(args.Pod).EnsureSandboxPaused(ctx, args)
 		tracing.EndSpan(ctx, span, err)
 	case agentsv1alpha1.SandboxResuming:
@@ -428,9 +438,11 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 	return ctrl.Result{RequeueAfter: requeueAfter}, r.updateSandboxStatus(ctx, *newStatus, box)
 }
 
-// preparePausedPhase initializes the Paused condition and sets Ready to false
-// before delegating to the control-specific EnsureSandboxPaused logic.
-func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.EnsureFuncArgs) error {
+// preparePausedPhase initializes the Paused condition, waits for a recent
+// in-progress Checkpoint, and sets Ready to false before delegating to the
+// control-specific EnsureSandboxPaused logic. The boolean result reports
+// whether the pause flow must wait before invoking EnsureSandboxPaused.
+func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.EnsureFuncArgs) (bool, error) {
 	box, newStatus := args.Box, args.NewStatus
 	cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
 	if cond == nil {
@@ -438,7 +450,7 @@ func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.En
 		// controller-mediated cleanup if the sandbox is deleted while paused.
 		if !controllerutil.ContainsFinalizer(box, core.SandboxFinalizer) {
 			if _, err := utils.PatchFinalizer(ctx, r.Client, box, utils.AddFinalizerOpType, core.SandboxFinalizer); err != nil {
-				return fmt.Errorf("failed to add finalizer for paused sandbox: %w", err)
+				return false, fmt.Errorf("failed to add finalizer for paused sandbox: %w", err)
 			}
 			klog.FromContext(ctx).Info("Add finalizer for paused sandbox", "sandbox", klog.KObj(box))
 		}
@@ -458,7 +470,58 @@ func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.En
 		utils.SetSandboxCondition(newStatus, *rCond)
 		klog.FromContext(ctx).Info("The paused phase sets condition ready to false", "sandbox", klog.KObj(box))
 	}
-	return nil
+
+	// Only gate the initial pause entry. Once this controller starts its own
+	// checkpoint, CheckpointControl is responsible for driving that checkpoint.
+	if cond.Status != metav1.ConditionFalse || cond.Reason != agentsv1alpha1.SandboxPausedReasonPending {
+		return false, nil
+	}
+	checkpoints := &agentsv1alpha1.CheckpointList{}
+	if err := r.List(ctx, checkpoints,
+		client.InNamespace(box.Namespace),
+		client.MatchingFields{fieldindex.IndexNameForCheckpointSandboxName: box.Name},
+		client.UnsafeDisableDeepCopy,
+	); err != nil {
+		return false, fmt.Errorf("failed to list checkpoints for sandbox %s/%s: %w", box.Namespace, box.Name, err)
+	}
+
+	now := time.Now()
+	for i := range checkpoints.Items {
+		checkpoint := &checkpoints.Items[i]
+		if !checkpoint.DeletionTimestamp.IsZero() ||
+			(checkpoint.Status.Phase != "" &&
+				checkpoint.Status.Phase != agentsv1alpha1.CheckpointPending &&
+				checkpoint.Status.Phase != agentsv1alpha1.CheckpointCreating) {
+			continue
+		}
+		if !checkpoint.CreationTimestamp.IsZero() && now.Sub(checkpoint.CreationTimestamp.Time) > checkpointCreationWaitTimeout {
+			klog.FromContext(ctx).Info("Ignore timed-out in-progress checkpoint before pause",
+				"sandbox", klog.KObj(box), "checkpoint", klog.KObj(checkpoint), "phase", checkpoint.Status.Phase,
+				"age", now.Sub(checkpoint.CreationTimestamp.Time))
+			continue
+		}
+		phase := string(checkpoint.Status.Phase)
+		if phase == "" {
+			phase = "<empty>"
+		}
+		message := fmt.Sprintf("Pause is waiting for existing checkpoint %s to complete (phase: %s)", checkpoint.Name, phase)
+		recordEvent := cond.Message != message
+		cond.Message = message
+		utils.SetSandboxCondition(newStatus, *cond)
+		if recordEvent && r.recorder != nil {
+			r.recorder.Event(box, corev1.EventTypeNormal, eventReasonCheckpointInProgress, message)
+		}
+		klog.FromContext(ctx).Info("Wait for in-progress checkpoint before pause",
+			"sandbox", klog.KObj(box), "checkpoint", klog.KObj(checkpoint), "phase", checkpoint.Status.Phase)
+		return true, nil
+	}
+	// Clear the temporary wait message once no in-progress checkpoint blocks
+	// the pause flow, so the next pause step can report its own status.
+	if cond.Message != "" {
+		cond.Message = ""
+		utils.SetSandboxCondition(newStatus, *cond)
+	}
+	return false, nil
 }
 
 // finalizeResumePhase performs the common cleanup once a resume succeeds,

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -86,12 +86,11 @@ var (
 )
 
 const (
-	eventReasonSandboxTerminating   = "SandboxTerminating"
-	eventReasonCheckpointInProgress = "CheckpointInProgress"
-	minimumPendingTimeout           = 15 * time.Second
-	maximumPendingTimeout           = 3590 * time.Second
-	checkpointCreationWaitTimeout   = 5 * time.Minute
-	checkpointWaitRequeueInterval   = 5 * time.Second
+	eventReasonSandboxTerminating = "SandboxTerminating"
+	minimumPendingTimeout         = 15 * time.Second
+	maximumPendingTimeout         = 3590 * time.Second
+	checkpointCreationWaitTimeout = 5 * time.Minute
+	checkpointWaitRequeueInterval = 5 * time.Second
 )
 
 // MaxPendingTimeout returns the normalized process-wide Sandbox Pending timeout.
@@ -444,6 +443,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 // whether the pause flow must wait before invoking EnsureSandboxPaused.
 func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.EnsureFuncArgs) (bool, error) {
 	box, newStatus := args.Box, args.NewStatus
+	logger := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(box))
 	cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
 	if cond == nil {
 		// Add finalizer on first entry into paused state to ensure
@@ -452,7 +452,7 @@ func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.En
 			if _, err := utils.PatchFinalizer(ctx, r.Client, box, utils.AddFinalizerOpType, core.SandboxFinalizer); err != nil {
 				return false, fmt.Errorf("failed to add finalizer for paused sandbox: %w", err)
 			}
-			klog.FromContext(ctx).Info("Add finalizer for paused sandbox", "sandbox", klog.KObj(box))
+			logger.Info("Add finalizer for paused sandbox")
 		}
 		cond = &metav1.Condition{
 			Type:               string(agentsv1alpha1.SandboxConditionPaused),
@@ -461,19 +461,21 @@ func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.En
 			LastTransitionTime: metav1.Now(),
 		}
 		utils.SetSandboxCondition(newStatus, *cond)
-		klog.FromContext(ctx).Info("Paused condition initialized", "sandbox", klog.KObj(box))
+		logger.Info("Paused condition initialized")
 	}
 	// The paused phase sets condition ready to false.
 	if rCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady)); rCond != nil && rCond.Status == metav1.ConditionTrue {
 		rCond.Status = metav1.ConditionFalse
 		rCond.LastTransitionTime = metav1.Now()
 		utils.SetSandboxCondition(newStatus, *rCond)
-		klog.FromContext(ctx).Info("The paused phase sets condition ready to false", "sandbox", klog.KObj(box))
+		logger.Info("The paused phase sets condition ready to false")
 	}
 
 	// Only gate the initial pause entry. Once this controller starts its own
 	// checkpoint, CheckpointControl is responsible for driving that checkpoint.
-	if cond.Status != metav1.ConditionFalse || cond.Reason != agentsv1alpha1.SandboxPausedReasonPending {
+	if cond.Status != metav1.ConditionFalse ||
+		(cond.Reason != agentsv1alpha1.SandboxPausedReasonPending &&
+			cond.Reason != agentsv1alpha1.SandboxPausedReasonCheckpointInProgress) {
 		return false, nil
 	}
 	checkpoints := &agentsv1alpha1.CheckpointList{}
@@ -486,6 +488,7 @@ func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.En
 	}
 
 	now := time.Now()
+	var blockingCheckpoint *agentsv1alpha1.Checkpoint
 	for i := range checkpoints.Items {
 		checkpoint := &checkpoints.Items[i]
 		if !checkpoint.DeletionTimestamp.IsZero() ||
@@ -495,29 +498,38 @@ func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.En
 			continue
 		}
 		if !checkpoint.CreationTimestamp.IsZero() && now.Sub(checkpoint.CreationTimestamp.Time) > checkpointCreationWaitTimeout {
-			klog.FromContext(ctx).Info("Ignore timed-out in-progress checkpoint before pause",
-				"sandbox", klog.KObj(box), "checkpoint", klog.KObj(checkpoint), "phase", checkpoint.Status.Phase,
+			logger.Info("Ignore timed-out in-progress checkpoint before pause",
+				"checkpoint", klog.KObj(checkpoint), "phase", checkpoint.Status.Phase,
 				"age", now.Sub(checkpoint.CreationTimestamp.Time))
 			continue
 		}
-		phase := string(checkpoint.Status.Phase)
+		if blockingCheckpoint == nil ||
+			checkpoint.CreationTimestamp.Before(&blockingCheckpoint.CreationTimestamp) ||
+			(checkpoint.CreationTimestamp.Equal(&blockingCheckpoint.CreationTimestamp) && checkpoint.Name < blockingCheckpoint.Name) {
+			blockingCheckpoint = checkpoint
+		}
+	}
+	if blockingCheckpoint != nil {
+		phase := string(blockingCheckpoint.Status.Phase)
 		if phase == "" {
 			phase = "<empty>"
 		}
-		message := fmt.Sprintf("Pause is waiting for existing checkpoint %s to complete (phase: %s)", checkpoint.Name, phase)
-		recordEvent := cond.Message != message
+		message := fmt.Sprintf("Pause is waiting for existing checkpoint %s to complete (phase: %s)", blockingCheckpoint.Name, phase)
+		recordEvent := cond.Reason != agentsv1alpha1.SandboxPausedReasonCheckpointInProgress || cond.Message != message
+		cond.Reason = agentsv1alpha1.SandboxPausedReasonCheckpointInProgress
 		cond.Message = message
 		utils.SetSandboxCondition(newStatus, *cond)
 		if recordEvent && r.recorder != nil {
-			r.recorder.Event(box, corev1.EventTypeNormal, eventReasonCheckpointInProgress, message)
+			r.recorder.Event(box, corev1.EventTypeNormal, agentsv1alpha1.SandboxPausedReasonCheckpointInProgress, message)
 		}
-		klog.FromContext(ctx).Info("Wait for in-progress checkpoint before pause",
-			"sandbox", klog.KObj(box), "checkpoint", klog.KObj(checkpoint), "phase", checkpoint.Status.Phase)
+		logger.Info("Wait for in-progress checkpoint before pause",
+			"checkpoint", klog.KObj(blockingCheckpoint), "phase", blockingCheckpoint.Status.Phase)
 		return true, nil
 	}
-	// Clear the temporary wait message once no in-progress checkpoint blocks
-	// the pause flow, so the next pause step can report its own status.
-	if cond.Message != "" {
+	// Restore the initial pause state once no in-progress checkpoint blocks the
+	// flow, so CheckpointControl can start and report its own checkpoint state.
+	if cond.Reason == agentsv1alpha1.SandboxPausedReasonCheckpointInProgress || cond.Message != "" {
+		cond.Reason = agentsv1alpha1.SandboxPausedReasonPending
 		cond.Message = ""
 		utils.SetSandboxCondition(newStatus, *cond)
 	}

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -476,7 +476,7 @@ func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.En
 	// checkpoint, CheckpointControl is responsible for driving that checkpoint.
 	if cond.Status != metav1.ConditionFalse ||
 		(cond.Reason != agentsv1alpha1.SandboxPausedReasonPending &&
-			cond.Reason != agentsv1alpha1.SandboxPausedReasonCheckpointInProgress) {
+			cond.Reason != agentsv1alpha1.SandboxPausedReasonWaitingForExistingCheckpoint) {
 		return false, nil
 	}
 	checkpoints := &agentsv1alpha1.CheckpointList{}
@@ -518,20 +518,20 @@ func (r *SandboxReconciler) preparePausedPhase(ctx context.Context, args core.En
 			phase = "<empty>"
 		}
 		message := fmt.Sprintf("Pause is waiting for existing checkpoint %s to complete (phase: %s)", blockingCheckpoint.Name, phase)
-		recordEvent := cond.Reason != agentsv1alpha1.SandboxPausedReasonCheckpointInProgress || cond.Message != message
-		cond.Reason = agentsv1alpha1.SandboxPausedReasonCheckpointInProgress
+		recordEvent := cond.Reason != agentsv1alpha1.SandboxPausedReasonWaitingForExistingCheckpoint || cond.Message != message
+		cond.Reason = agentsv1alpha1.SandboxPausedReasonWaitingForExistingCheckpoint
 		cond.Message = message
 		utils.SetSandboxCondition(newStatus, *cond)
 		if recordEvent && r.recorder != nil {
-			r.recorder.Event(box, corev1.EventTypeNormal, agentsv1alpha1.SandboxPausedReasonCheckpointInProgress, message)
+			r.recorder.Event(box, corev1.EventTypeNormal, agentsv1alpha1.SandboxPausedReasonWaitingForExistingCheckpoint, message)
 		}
-		logger.Info("Wait for in-progress checkpoint before pause",
-			"checkpoint", klog.KObj(blockingCheckpoint), "phase", blockingCheckpoint.Status.Phase)
+		klog.Warningf("Wait for in-progress checkpoint before pause: sandbox=%s, checkpoint=%s, phase=%s",
+			klog.KObj(box), klog.KObj(blockingCheckpoint), blockingCheckpoint.Status.Phase)
 		return true, nil
 	}
 	// Restore the initial pause state once no in-progress checkpoint blocks the
 	// flow, so CheckpointControl can start and report its own checkpoint state.
-	if cond.Reason == agentsv1alpha1.SandboxPausedReasonCheckpointInProgress || cond.Message != "" {
+	if cond.Reason == agentsv1alpha1.SandboxPausedReasonWaitingForExistingCheckpoint || cond.Message != "" {
 		cond.Reason = agentsv1alpha1.SandboxPausedReasonPending
 		cond.Message = ""
 		utils.SetSandboxCondition(newStatus, *cond)

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
+	"github.com/openkruise/agents/pkg/utils/fieldindex"
 	"github.com/openkruise/agents/pkg/utils/timeout"
 )
 
@@ -785,7 +786,9 @@ func TestSandboxReconciler_Reconcile(t *testing.T) {
 				objects = append(objects, tt.pod)
 			}
 			fakeRecorder := record.NewFakeRecorder(100)
-			client := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&agentsv1alpha1.Sandbox{}).WithObjects(objects...).Build()
+			client := fake.NewClientBuilder().WithScheme(scheme).
+				WithIndex(&agentsv1alpha1.Checkpoint{}, fieldindex.IndexNameForCheckpointSandboxName, fieldindex.CheckpointSandboxNameIndexFunc).
+				WithStatusSubresource(&agentsv1alpha1.Sandbox{}).WithObjects(objects...).Build()
 			rl := core.NewRateLimiter()
 			reconciler := &SandboxReconciler{
 				Client: client,
@@ -1410,19 +1413,160 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		finalizers     []string
-		conditions     []metav1.Condition
-		injectPatchErr bool
-		wantErr        bool
-		wantFinalizer  bool
-		wantPaused     metav1.Condition
-		wantReady      *metav1.Condition
+		name                            string
+		finalizers                      []string
+		conditions                      []metav1.Condition
+		checkpointPhase                 *agentsv1alpha1.CheckpointPhase
+		checkpointAge                   time.Duration
+		checkpointPodName               bool
+		checkpointDeleting              bool
+		checkpointZeroCreationTimestamp bool
+		disableRecorder                 bool
+		injectPatchErr                  bool
+		injectListErr                   bool
+		wantErr                         bool
+		wantWait                        bool
+		wantEvent                       bool
+		wantFinalizer                   bool
+		wantPaused                      metav1.Condition
+		wantMessage                     string
+		wantReady                       *metav1.Condition
 	}{
 		{
 			name:          "initializes paused condition and adds finalizer",
 			wantFinalizer: true,
 			wantPaused:    pausedPending,
+		},
+		{
+			name:              "waits for recent pending checkpoint by pod name",
+			finalizers:        []string{core.SandboxFinalizer},
+			checkpointPhase:   ptr.To(agentsv1alpha1.CheckpointPending),
+			checkpointAge:     time.Minute,
+			checkpointPodName: true,
+			wantWait:          true,
+			wantEvent:         true,
+			wantFinalizer:     true,
+			wantPaused:        pausedPending,
+			wantMessage:       "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Pending)",
+		},
+		{
+			name:            "waits for recent creating checkpoint by sandbox name",
+			finalizers:      []string{core.SandboxFinalizer},
+			checkpointPhase: ptr.To(agentsv1alpha1.CheckpointCreating),
+			checkpointAge:   time.Minute,
+			wantWait:        true,
+			wantEvent:       true,
+			wantFinalizer:   true,
+			wantPaused:      pausedPending,
+			wantMessage:     "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Creating)",
+		},
+		{
+			name:            "waits for checkpoint with empty phase",
+			finalizers:      []string{core.SandboxFinalizer},
+			checkpointPhase: ptr.To(agentsv1alpha1.CheckpointPhase("")),
+			checkpointAge:   time.Minute,
+			wantWait:        true,
+			wantEvent:       true,
+			wantFinalizer:   true,
+			wantPaused:      pausedPending,
+			wantMessage:     "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: <empty>)",
+		},
+		{
+			name:                            "waits when checkpoint creation timestamp is absent",
+			finalizers:                      []string{core.SandboxFinalizer},
+			checkpointPhase:                 ptr.To(agentsv1alpha1.CheckpointCreating),
+			checkpointZeroCreationTimestamp: true,
+			wantWait:                        true,
+			wantEvent:                       true,
+			wantFinalizer:                   true,
+			wantPaused:                      pausedPending,
+			wantMessage:                     "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Creating)",
+		},
+		{
+			name:            "waits without event recorder",
+			finalizers:      []string{core.SandboxFinalizer},
+			checkpointPhase: ptr.To(agentsv1alpha1.CheckpointPending),
+			checkpointAge:   time.Minute,
+			disableRecorder: true,
+			wantWait:        true,
+			wantFinalizer:   true,
+			wantPaused:      pausedPending,
+			wantMessage:     "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Pending)",
+		},
+		{
+			name:            "ignores creating checkpoint older than timeout",
+			finalizers:      []string{core.SandboxFinalizer},
+			checkpointPhase: ptr.To(agentsv1alpha1.CheckpointCreating),
+			checkpointAge:   checkpointCreationWaitTimeout + time.Second,
+			wantFinalizer:   true,
+			wantPaused:      pausedPending,
+		},
+		{
+			name:               "ignores deleting checkpoint",
+			finalizers:         []string{core.SandboxFinalizer},
+			checkpointPhase:    ptr.To(agentsv1alpha1.CheckpointCreating),
+			checkpointAge:      time.Minute,
+			checkpointDeleting: true,
+			wantFinalizer:      true,
+			wantPaused:         pausedPending,
+		},
+		{
+			name:            "ignores succeeded checkpoint",
+			finalizers:      []string{core.SandboxFinalizer},
+			checkpointPhase: ptr.To(agentsv1alpha1.CheckpointSucceeded),
+			checkpointAge:   time.Minute,
+			wantFinalizer:   true,
+			wantPaused:      pausedPending,
+		},
+		{
+			name:            "ignores failed checkpoint",
+			finalizers:      []string{core.SandboxFinalizer},
+			checkpointPhase: ptr.To(agentsv1alpha1.CheckpointFailed),
+			checkpointAge:   time.Minute,
+			wantFinalizer:   true,
+			wantPaused:      pausedPending,
+		},
+		{
+			name:            "ignores terminating checkpoint",
+			finalizers:      []string{core.SandboxFinalizer},
+			checkpointPhase: ptr.To(agentsv1alpha1.CheckpointTerminating),
+			checkpointAge:   time.Minute,
+			wantFinalizer:   true,
+			wantPaused:      pausedPending,
+		},
+		{
+			name:       "clears temporary checkpoint wait message when gate clears",
+			finalizers: []string{core.SandboxFinalizer},
+			conditions: []metav1.Condition{{
+				Type:    string(agentsv1alpha1.SandboxConditionPaused),
+				Status:  metav1.ConditionFalse,
+				Reason:  agentsv1alpha1.SandboxPausedReasonPending,
+				Message: "Pause is waiting for existing checkpoint old-checkpoint to complete (phase: Creating)",
+			}},
+			wantFinalizer: true,
+			wantPaused:    pausedPending,
+		},
+		{
+			name:       "does not gate checkpoint already managed by pause control",
+			finalizers: []string{core.SandboxFinalizer},
+			conditions: []metav1.Condition{{
+				Type:   string(agentsv1alpha1.SandboxConditionPaused),
+				Status: metav1.ConditionFalse,
+				Reason: agentsv1alpha1.SandboxPausedReasonCheckpointCreating,
+			}},
+			checkpointPhase: ptr.To(agentsv1alpha1.CheckpointCreating),
+			checkpointAge:   time.Minute,
+			wantFinalizer:   true,
+			wantPaused: metav1.Condition{
+				Status: metav1.ConditionFalse,
+				Reason: agentsv1alpha1.SandboxPausedReasonCheckpointCreating,
+			},
+		},
+		{
+			name:          "checkpoint list error propagates with sandbox context",
+			finalizers:    []string{core.SandboxFinalizer},
+			injectListErr: true,
+			wantErr:       true,
 		},
 		{
 			name:       "existing finalizer skips patch and flips ready to false",
@@ -1484,29 +1628,80 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 					Conditions: tt.conditions,
 				},
 			}
-			builder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(box)
-			if tt.injectPatchErr {
-				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
-					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-						return fmt.Errorf("injected patch failure")
+			testObjects := []client.Object{box}
+			if tt.checkpointPhase != nil {
+				checkpoint := &agentsv1alpha1.Checkpoint{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "existing-checkpoint",
+						Namespace: box.Namespace,
 					},
-				})
+					Status: agentsv1alpha1.CheckpointStatus{Phase: *tt.checkpointPhase},
+				}
+				if !tt.checkpointZeroCreationTimestamp {
+					checkpoint.CreationTimestamp = metav1.NewTime(time.Now().Add(-tt.checkpointAge))
+				}
+				if tt.checkpointDeleting {
+					checkpoint.DeletionTimestamp = ptr.To(metav1.Now())
+					checkpoint.Finalizers = []string{"test-finalizer"}
+				}
+				if tt.checkpointPodName {
+					checkpoint.Spec.PodName = &box.Name
+				} else {
+					checkpoint.Spec.SandboxName = &box.Name
+				}
+				testObjects = append(testObjects, checkpoint)
+			}
+			builder := fake.NewClientBuilder().WithScheme(scheme).
+				WithIndex(&agentsv1alpha1.Checkpoint{}, fieldindex.IndexNameForCheckpointSandboxName, fieldindex.CheckpointSandboxNameIndexFunc).
+				WithObjects(testObjects...)
+			interceptorFuncs := interceptor.Funcs{}
+			if tt.injectPatchErr {
+				interceptorFuncs.Patch = func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					return fmt.Errorf("injected patch failure")
+				}
+			}
+			if tt.injectListErr {
+				interceptorFuncs.List = func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					return fmt.Errorf("injected list failure")
+				}
+			}
+			if tt.injectPatchErr || tt.injectListErr {
+				builder = builder.WithInterceptorFuncs(interceptorFuncs)
 			}
 			fakeClient := builder.Build()
-			reconciler := &SandboxReconciler{Client: fakeClient}
+			recorder := record.NewFakeRecorder(10)
+			reconciler := &SandboxReconciler{Client: fakeClient, recorder: recorder}
+			if tt.disableRecorder {
+				reconciler.recorder = nil
+			}
 
 			newStatus := box.Status.DeepCopy()
-			err := reconciler.preparePausedPhase(context.Background(), core.EnsureFuncArgs{Box: box, NewStatus: newStatus})
+			wait, err := reconciler.preparePausedPhase(context.Background(), core.EnsureFuncArgs{Box: box, NewStatus: newStatus})
 			if tt.wantErr {
 				require.Error(t, err)
+				if tt.injectListErr {
+					assert.ErrorContains(t, err, "failed to list checkpoints for sandbox default/paused-sandbox")
+					assert.ErrorContains(t, err, "injected list failure")
+				}
 				return
 			}
 			require.NoError(t, err)
+			assert.Equal(t, tt.wantWait, wait)
 
 			paused := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionPaused))
 			require.NotNil(t, paused)
 			assert.Equal(t, tt.wantPaused.Status, paused.Status)
 			assert.Equal(t, tt.wantPaused.Reason, paused.Reason)
+			assert.Equal(t, tt.wantMessage, paused.Message)
+			if tt.wantEvent {
+				assertSandboxRecorderEvent(t, recorder, corev1.EventTypeNormal+" "+eventReasonCheckpointInProgress, paused.Message)
+				wait, err = reconciler.preparePausedPhase(context.Background(), core.EnsureFuncArgs{Box: box, NewStatus: newStatus})
+				require.NoError(t, err)
+				assert.True(t, wait)
+				assertNoSandboxRecorderEvent(t, recorder)
+			} else {
+				assertNoSandboxRecorderEvent(t, recorder)
+			}
 
 			if tt.wantReady != nil {
 				ready := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady))
@@ -1520,6 +1715,125 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 				require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "paused-sandbox"}, updated))
 				assert.Contains(t, updated.Finalizers, core.SandboxFinalizer)
 			}
+		})
+	}
+}
+
+func TestSandboxReconciler_ReconcileWaitsForInProgressCheckpoint(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, agentsv1alpha1.AddToScheme(scheme))
+
+	tests := []struct {
+		name          string
+		shutdownAfter *time.Duration
+	}{
+		{
+			name: "requeues after checkpoint polling interval without another timer",
+		},
+		{
+			name:          "checkpoint polling interval wins over later timer",
+			shutdownAfter: ptr.To(time.Minute),
+		},
+		{
+			name:          "earlier timer wins over checkpoint polling interval",
+			shutdownAfter: ptr.To(2 * time.Second),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			box := &agentsv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "paused-sandbox",
+					Namespace:  "default",
+					Finalizers: []string{core.SandboxFinalizer},
+				},
+				Spec: agentsv1alpha1.SandboxSpec{
+					Paused: true,
+					EmbeddedSandboxTemplate: agentsv1alpha1.EmbeddedSandboxTemplate{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "busybox"}}},
+						},
+					},
+				},
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxPaused,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(agentsv1alpha1.SandboxConditionPaused),
+							Status: metav1.ConditionFalse,
+							Reason: agentsv1alpha1.SandboxPausedReasonPending,
+						},
+						{
+							Type:   string(agentsv1alpha1.SandboxConditionReady),
+							Status: metav1.ConditionTrue,
+							Reason: "SandboxReady",
+						},
+					},
+				},
+			}
+			if tt.shutdownAfter != nil {
+				box.Spec.ShutdownTime = ptr.To(metav1.NewTime(time.Now().Add(*tt.shutdownAfter)))
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: box.Name, Namespace: box.Namespace},
+				Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+			}
+			checkpoint := &agentsv1alpha1.Checkpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "existing-checkpoint",
+					Namespace:         box.Namespace,
+					CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute)),
+				},
+				Spec: agentsv1alpha1.CheckpointSpec{PodName: &box.Name},
+				Status: agentsv1alpha1.CheckpointStatus{
+					Phase: agentsv1alpha1.CheckpointCreating,
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+				WithStatusSubresource(&agentsv1alpha1.Sandbox{}).
+				WithIndex(&agentsv1alpha1.Checkpoint{}, fieldindex.IndexNameForCheckpointSandboxName, fieldindex.CheckpointSandboxNameIndexFunc).
+				WithObjects(box, pod, checkpoint).
+				Build()
+			recorder := record.NewFakeRecorder(10)
+			reconciler := &SandboxReconciler{
+				Client:   fakeClient,
+				Scheme:   scheme,
+				recorder: recorder,
+				// A nil control map makes this test fail immediately if the checkpoint
+				// gate accidentally delegates to EnsureSandboxPaused.
+				controls: nil,
+			}
+
+			startedAt := time.Now()
+			result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Namespace: box.Namespace, Name: box.Name},
+			})
+			require.NoError(t, err)
+			if tt.shutdownAfter == nil || *tt.shutdownAfter > checkpointWaitRequeueInterval {
+				assert.Equal(t, checkpointWaitRequeueInterval, result.RequeueAfter)
+			} else {
+				assert.Positive(t, result.RequeueAfter)
+				assert.LessOrEqual(t, result.RequeueAfter, *tt.shutdownAfter)
+				assert.GreaterOrEqual(t, result.RequeueAfter, *tt.shutdownAfter-time.Since(startedAt)-time.Second)
+			}
+
+			updatedBox := &agentsv1alpha1.Sandbox{}
+			require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(box), updatedBox))
+			paused := utils.GetSandboxCondition(&updatedBox.Status, string(agentsv1alpha1.SandboxConditionPaused))
+			require.NotNil(t, paused)
+			assert.Equal(t, metav1.ConditionFalse, paused.Status)
+			assert.Equal(t, agentsv1alpha1.SandboxPausedReasonPending, paused.Reason)
+			assert.Equal(t, "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Creating)", paused.Message)
+			ready := utils.GetSandboxCondition(&updatedBox.Status, string(agentsv1alpha1.SandboxConditionReady))
+			require.NotNil(t, ready)
+			assert.Equal(t, metav1.ConditionFalse, ready.Status)
+
+			remainingPod := &corev1.Pod{}
+			require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(pod), remainingPod))
+			assertSandboxRecorderEvent(t, recorder, corev1.EventTypeNormal+" "+eventReasonCheckpointInProgress, paused.Message)
+			assertNoSandboxRecorderEvent(t, recorder)
 		})
 	}
 }

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -1406,10 +1406,20 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 		Status: metav1.ConditionFalse,
 		Reason: agentsv1alpha1.SandboxPausedReasonPending,
 	}
+	pausedCheckpointInProgress := metav1.Condition{
+		Type:   string(agentsv1alpha1.SandboxConditionPaused),
+		Status: metav1.ConditionFalse,
+		Reason: agentsv1alpha1.SandboxPausedReasonCheckpointInProgress,
+	}
 	pausedCompleted := metav1.Condition{
 		Type:   string(agentsv1alpha1.SandboxConditionPaused),
 		Status: metav1.ConditionTrue,
 		Reason: agentsv1alpha1.SandboxPausedReasonStopPauseSucceed,
+	}
+	type additionalCheckpoint struct {
+		name  string
+		phase agentsv1alpha1.CheckpointPhase
+		age   time.Duration
 	}
 
 	tests := []struct {
@@ -1421,6 +1431,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 		checkpointPodName               bool
 		checkpointDeleting              bool
 		checkpointZeroCreationTimestamp bool
+		additionalCheckpoints           []additionalCheckpoint
 		disableRecorder                 bool
 		injectPatchErr                  bool
 		injectListErr                   bool
@@ -1446,7 +1457,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			wantWait:          true,
 			wantEvent:         true,
 			wantFinalizer:     true,
-			wantPaused:        pausedPending,
+			wantPaused:        pausedCheckpointInProgress,
 			wantMessage:       "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Pending)",
 		},
 		{
@@ -1457,7 +1468,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			wantWait:        true,
 			wantEvent:       true,
 			wantFinalizer:   true,
-			wantPaused:      pausedPending,
+			wantPaused:      pausedCheckpointInProgress,
 			wantMessage:     "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Creating)",
 		},
 		{
@@ -1468,7 +1479,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			wantWait:        true,
 			wantEvent:       true,
 			wantFinalizer:   true,
-			wantPaused:      pausedPending,
+			wantPaused:      pausedCheckpointInProgress,
 			wantMessage:     "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: <empty>)",
 		},
 		{
@@ -1479,7 +1490,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			wantWait:                        true,
 			wantEvent:                       true,
 			wantFinalizer:                   true,
-			wantPaused:                      pausedPending,
+			wantPaused:                      pausedCheckpointInProgress,
 			wantMessage:                     "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Creating)",
 		},
 		{
@@ -1490,8 +1501,36 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			disableRecorder: true,
 			wantWait:        true,
 			wantFinalizer:   true,
-			wantPaused:      pausedPending,
+			wantPaused:      pausedCheckpointInProgress,
 			wantMessage:     "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Pending)",
+		},
+		{
+			name:            "selects oldest active checkpoint deterministically",
+			finalizers:      []string{core.SandboxFinalizer},
+			checkpointPhase: ptr.To(agentsv1alpha1.CheckpointCreating),
+			checkpointAge:   time.Minute,
+			additionalCheckpoints: []additionalCheckpoint{
+				{name: "older-checkpoint", phase: agentsv1alpha1.CheckpointPending, age: 2 * time.Minute},
+			},
+			wantWait:      true,
+			wantEvent:     true,
+			wantFinalizer: true,
+			wantPaused:    pausedCheckpointInProgress,
+			wantMessage:   "Pause is waiting for existing checkpoint older-checkpoint to complete (phase: Pending)",
+		},
+		{
+			name:            "uses checkpoint name to break creation timestamp ties",
+			finalizers:      []string{core.SandboxFinalizer},
+			checkpointPhase: ptr.To(agentsv1alpha1.CheckpointCreating),
+			checkpointAge:   time.Minute,
+			additionalCheckpoints: []additionalCheckpoint{
+				{name: "a-checkpoint", phase: agentsv1alpha1.CheckpointPending, age: time.Minute},
+			},
+			wantWait:      true,
+			wantEvent:     true,
+			wantFinalizer: true,
+			wantPaused:    pausedCheckpointInProgress,
+			wantMessage:   "Pause is waiting for existing checkpoint a-checkpoint to complete (phase: Pending)",
 		},
 		{
 			name:            "ignores creating checkpoint older than timeout",
@@ -1540,7 +1579,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			conditions: []metav1.Condition{{
 				Type:    string(agentsv1alpha1.SandboxConditionPaused),
 				Status:  metav1.ConditionFalse,
-				Reason:  agentsv1alpha1.SandboxPausedReasonPending,
+				Reason:  agentsv1alpha1.SandboxPausedReasonCheckpointInProgress,
 				Message: "Pause is waiting for existing checkpoint old-checkpoint to complete (phase: Creating)",
 			}},
 			wantFinalizer: true,
@@ -1630,6 +1669,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			}
 			testObjects := []client.Object{box}
 			if tt.checkpointPhase != nil {
+				checkpointCreationTimestamp := metav1.NewTime(time.Now().Add(-tt.checkpointAge))
 				checkpoint := &agentsv1alpha1.Checkpoint{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "existing-checkpoint",
@@ -1638,7 +1678,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 					Status: agentsv1alpha1.CheckpointStatus{Phase: *tt.checkpointPhase},
 				}
 				if !tt.checkpointZeroCreationTimestamp {
-					checkpoint.CreationTimestamp = metav1.NewTime(time.Now().Add(-tt.checkpointAge))
+					checkpoint.CreationTimestamp = checkpointCreationTimestamp
 				}
 				if tt.checkpointDeleting {
 					checkpoint.DeletionTimestamp = ptr.To(metav1.Now())
@@ -1650,6 +1690,21 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 					checkpoint.Spec.SandboxName = &box.Name
 				}
 				testObjects = append(testObjects, checkpoint)
+				for _, additional := range tt.additionalCheckpoints {
+					creationTimestamp := metav1.NewTime(time.Now().Add(-additional.age))
+					if additional.age == tt.checkpointAge {
+						creationTimestamp = checkpointCreationTimestamp
+					}
+					testObjects = append(testObjects, &agentsv1alpha1.Checkpoint{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              additional.name,
+							Namespace:         box.Namespace,
+							CreationTimestamp: creationTimestamp,
+						},
+						Spec:   agentsv1alpha1.CheckpointSpec{SandboxName: &box.Name},
+						Status: agentsv1alpha1.CheckpointStatus{Phase: additional.phase},
+					})
+				}
 			}
 			builder := fake.NewClientBuilder().WithScheme(scheme).
 				WithIndex(&agentsv1alpha1.Checkpoint{}, fieldindex.IndexNameForCheckpointSandboxName, fieldindex.CheckpointSandboxNameIndexFunc).
@@ -1694,7 +1749,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			assert.Equal(t, tt.wantPaused.Reason, paused.Reason)
 			assert.Equal(t, tt.wantMessage, paused.Message)
 			if tt.wantEvent {
-				assertSandboxRecorderEvent(t, recorder, corev1.EventTypeNormal+" "+eventReasonCheckpointInProgress, paused.Message)
+				assertSandboxRecorderEvent(t, recorder, corev1.EventTypeNormal+" "+agentsv1alpha1.SandboxPausedReasonCheckpointInProgress, paused.Message)
 				wait, err = reconciler.preparePausedPhase(context.Background(), core.EnsureFuncArgs{Box: box, NewStatus: newStatus})
 				require.NoError(t, err)
 				assert.True(t, wait)
@@ -1824,7 +1879,7 @@ func TestSandboxReconciler_ReconcileWaitsForInProgressCheckpoint(t *testing.T) {
 			paused := utils.GetSandboxCondition(&updatedBox.Status, string(agentsv1alpha1.SandboxConditionPaused))
 			require.NotNil(t, paused)
 			assert.Equal(t, metav1.ConditionFalse, paused.Status)
-			assert.Equal(t, agentsv1alpha1.SandboxPausedReasonPending, paused.Reason)
+			assert.Equal(t, agentsv1alpha1.SandboxPausedReasonCheckpointInProgress, paused.Reason)
 			assert.Equal(t, "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Creating)", paused.Message)
 			ready := utils.GetSandboxCondition(&updatedBox.Status, string(agentsv1alpha1.SandboxConditionReady))
 			require.NotNil(t, ready)
@@ -1832,7 +1887,7 @@ func TestSandboxReconciler_ReconcileWaitsForInProgressCheckpoint(t *testing.T) {
 
 			remainingPod := &corev1.Pod{}
 			require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(pod), remainingPod))
-			assertSandboxRecorderEvent(t, recorder, corev1.EventTypeNormal+" "+eventReasonCheckpointInProgress, paused.Message)
+			assertSandboxRecorderEvent(t, recorder, corev1.EventTypeNormal+" "+agentsv1alpha1.SandboxPausedReasonCheckpointInProgress, paused.Message)
 			assertNoSandboxRecorderEvent(t, recorder)
 		})
 	}

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -1505,18 +1505,18 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			wantMessage:     "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Pending)",
 		},
 		{
-			name:            "selects oldest active checkpoint deterministically",
+			name:            "selects newest active checkpoint deterministically",
 			finalizers:      []string{core.SandboxFinalizer},
 			checkpointPhase: ptr.To(agentsv1alpha1.CheckpointCreating),
-			checkpointAge:   time.Minute,
+			checkpointAge:   2 * time.Minute,
 			additionalCheckpoints: []additionalCheckpoint{
-				{name: "older-checkpoint", phase: agentsv1alpha1.CheckpointPending, age: 2 * time.Minute},
+				{name: "newer-checkpoint", phase: agentsv1alpha1.CheckpointPending, age: time.Minute},
 			},
 			wantWait:      true,
 			wantEvent:     true,
 			wantFinalizer: true,
 			wantPaused:    pausedCheckpointInProgress,
-			wantMessage:   "Pause is waiting for existing checkpoint older-checkpoint to complete (phase: Pending)",
+			wantMessage:   "Pause is waiting for existing checkpoint newer-checkpoint to complete (phase: Pending)",
 		},
 		{
 			name:            "uses checkpoint name to break creation timestamp ties",

--- a/pkg/controller/sandbox/sandbox_controller_test.go
+++ b/pkg/controller/sandbox/sandbox_controller_test.go
@@ -1406,10 +1406,10 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 		Status: metav1.ConditionFalse,
 		Reason: agentsv1alpha1.SandboxPausedReasonPending,
 	}
-	pausedCheckpointInProgress := metav1.Condition{
+	pausedWaitingForExistingCheckpoint := metav1.Condition{
 		Type:   string(agentsv1alpha1.SandboxConditionPaused),
 		Status: metav1.ConditionFalse,
-		Reason: agentsv1alpha1.SandboxPausedReasonCheckpointInProgress,
+		Reason: agentsv1alpha1.SandboxPausedReasonWaitingForExistingCheckpoint,
 	}
 	pausedCompleted := metav1.Condition{
 		Type:   string(agentsv1alpha1.SandboxConditionPaused),
@@ -1457,7 +1457,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			wantWait:          true,
 			wantEvent:         true,
 			wantFinalizer:     true,
-			wantPaused:        pausedCheckpointInProgress,
+			wantPaused:        pausedWaitingForExistingCheckpoint,
 			wantMessage:       "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Pending)",
 		},
 		{
@@ -1468,7 +1468,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			wantWait:        true,
 			wantEvent:       true,
 			wantFinalizer:   true,
-			wantPaused:      pausedCheckpointInProgress,
+			wantPaused:      pausedWaitingForExistingCheckpoint,
 			wantMessage:     "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Creating)",
 		},
 		{
@@ -1479,7 +1479,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			wantWait:        true,
 			wantEvent:       true,
 			wantFinalizer:   true,
-			wantPaused:      pausedCheckpointInProgress,
+			wantPaused:      pausedWaitingForExistingCheckpoint,
 			wantMessage:     "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: <empty>)",
 		},
 		{
@@ -1490,7 +1490,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			wantWait:                        true,
 			wantEvent:                       true,
 			wantFinalizer:                   true,
-			wantPaused:                      pausedCheckpointInProgress,
+			wantPaused:                      pausedWaitingForExistingCheckpoint,
 			wantMessage:                     "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Creating)",
 		},
 		{
@@ -1501,7 +1501,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			disableRecorder: true,
 			wantWait:        true,
 			wantFinalizer:   true,
-			wantPaused:      pausedCheckpointInProgress,
+			wantPaused:      pausedWaitingForExistingCheckpoint,
 			wantMessage:     "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Pending)",
 		},
 		{
@@ -1515,7 +1515,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			wantWait:      true,
 			wantEvent:     true,
 			wantFinalizer: true,
-			wantPaused:    pausedCheckpointInProgress,
+			wantPaused:    pausedWaitingForExistingCheckpoint,
 			wantMessage:   "Pause is waiting for existing checkpoint newer-checkpoint to complete (phase: Pending)",
 		},
 		{
@@ -1529,7 +1529,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			wantWait:      true,
 			wantEvent:     true,
 			wantFinalizer: true,
-			wantPaused:    pausedCheckpointInProgress,
+			wantPaused:    pausedWaitingForExistingCheckpoint,
 			wantMessage:   "Pause is waiting for existing checkpoint a-checkpoint to complete (phase: Pending)",
 		},
 		{
@@ -1579,7 +1579,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			conditions: []metav1.Condition{{
 				Type:    string(agentsv1alpha1.SandboxConditionPaused),
 				Status:  metav1.ConditionFalse,
-				Reason:  agentsv1alpha1.SandboxPausedReasonCheckpointInProgress,
+				Reason:  agentsv1alpha1.SandboxPausedReasonWaitingForExistingCheckpoint,
 				Message: "Pause is waiting for existing checkpoint old-checkpoint to complete (phase: Creating)",
 			}},
 			wantFinalizer: true,
@@ -1749,7 +1749,7 @@ func TestSandboxReconciler_preparePausedPhase(t *testing.T) {
 			assert.Equal(t, tt.wantPaused.Reason, paused.Reason)
 			assert.Equal(t, tt.wantMessage, paused.Message)
 			if tt.wantEvent {
-				assertSandboxRecorderEvent(t, recorder, corev1.EventTypeNormal+" "+agentsv1alpha1.SandboxPausedReasonCheckpointInProgress, paused.Message)
+				assertSandboxRecorderEvent(t, recorder, corev1.EventTypeNormal+" "+agentsv1alpha1.SandboxPausedReasonWaitingForExistingCheckpoint, paused.Message)
 				wait, err = reconciler.preparePausedPhase(context.Background(), core.EnsureFuncArgs{Box: box, NewStatus: newStatus})
 				require.NoError(t, err)
 				assert.True(t, wait)
@@ -1879,7 +1879,7 @@ func TestSandboxReconciler_ReconcileWaitsForInProgressCheckpoint(t *testing.T) {
 			paused := utils.GetSandboxCondition(&updatedBox.Status, string(agentsv1alpha1.SandboxConditionPaused))
 			require.NotNil(t, paused)
 			assert.Equal(t, metav1.ConditionFalse, paused.Status)
-			assert.Equal(t, agentsv1alpha1.SandboxPausedReasonCheckpointInProgress, paused.Reason)
+			assert.Equal(t, agentsv1alpha1.SandboxPausedReasonWaitingForExistingCheckpoint, paused.Reason)
 			assert.Equal(t, "Pause is waiting for existing checkpoint existing-checkpoint to complete (phase: Creating)", paused.Message)
 			ready := utils.GetSandboxCondition(&updatedBox.Status, string(agentsv1alpha1.SandboxConditionReady))
 			require.NotNil(t, ready)
@@ -1887,7 +1887,7 @@ func TestSandboxReconciler_ReconcileWaitsForInProgressCheckpoint(t *testing.T) {
 
 			remainingPod := &corev1.Pod{}
 			require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(pod), remainingPod))
-			assertSandboxRecorderEvent(t, recorder, corev1.EventTypeNormal+" "+agentsv1alpha1.SandboxPausedReasonCheckpointInProgress, paused.Message)
+			assertSandboxRecorderEvent(t, recorder, corev1.EventTypeNormal+" "+agentsv1alpha1.SandboxPausedReasonWaitingForExistingCheckpoint, paused.Message)
 			assertNoSandboxRecorderEvent(t, recorder)
 		})
 	}

--- a/pkg/utils/fieldindex/register.go
+++ b/pkg/utils/fieldindex/register.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	IndexNameForOwnerRefUID = "ownerRefUID"
+	IndexNameForOwnerRefUID           = "ownerRefUID"
+	IndexNameForCheckpointSandboxName = "checkpointSandboxName"
 )
 
 var (
@@ -44,6 +45,22 @@ var OwnerIndexFunc = func(obj client.Object) []string {
 		owners = append(owners, string(controller.UID))
 	}
 	return owners
+}
+
+// CheckpointSandboxNameIndexFunc indexes checkpoints by spec.sandboxName,
+// falling back to spec.podName for checkpoints created from a running Pod.
+var CheckpointSandboxNameIndexFunc = func(obj client.Object) []string {
+	checkpoint, ok := obj.(*agentsv1alpha1.Checkpoint)
+	if !ok {
+		return nil
+	}
+	if checkpoint.Spec.SandboxName != nil && *checkpoint.Spec.SandboxName != "" {
+		return []string{*checkpoint.Spec.SandboxName}
+	}
+	if checkpoint.Spec.PodName != nil && *checkpoint.Spec.PodName != "" {
+		return []string{*checkpoint.Spec.PodName}
+	}
+	return nil
 }
 
 var commitUIDIndexFunc = func(obj client.Object) []string {
@@ -66,6 +83,10 @@ func RegisterFieldIndexes(c cache.Cache) error {
 		}
 		// checkpoint ownerReference
 		if err = c.IndexField(context.TODO(), &agentsv1alpha1.Checkpoint{}, IndexNameForOwnerRefUID, OwnerIndexFunc); err != nil {
+			return
+		}
+		// checkpoint sandbox name
+		if err = c.IndexField(context.TODO(), &agentsv1alpha1.Checkpoint{}, IndexNameForCheckpointSandboxName, CheckpointSandboxNameIndexFunc); err != nil {
 			return
 		}
 		// commit job/pod label

--- a/pkg/utils/fieldindex/register_test.go
+++ b/pkg/utils/fieldindex/register_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2025 The Kruise Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldindex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+func TestCheckpointSandboxNameIndexFunc(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{
+			name: "ignores non-checkpoint object",
+			obj:  &corev1.Pod{},
+		},
+		{
+			name: "ignores checkpoint without sandbox or pod name",
+			obj:  &agentsv1alpha1.Checkpoint{},
+		},
+		{
+			name: "ignores empty sandbox and pod names",
+			obj: &agentsv1alpha1.Checkpoint{Spec: agentsv1alpha1.CheckpointSpec{
+				SandboxName: ptr.To(""),
+				PodName:     ptr.To(""),
+			}},
+		},
+		{
+			name: "indexes sandbox name",
+			obj: &agentsv1alpha1.Checkpoint{Spec: agentsv1alpha1.CheckpointSpec{
+				SandboxName: ptr.To("sandbox-a"),
+			}},
+			want: []string{"sandbox-a"},
+		},
+		{
+			name: "falls back to pod name",
+			obj: &agentsv1alpha1.Checkpoint{Spec: agentsv1alpha1.CheckpointSpec{
+				PodName: ptr.To("sandbox-from-pod"),
+			}},
+			want: []string{"sandbox-from-pod"},
+		},
+		{
+			name: "falls back to pod name when sandbox name is empty",
+			obj: &agentsv1alpha1.Checkpoint{Spec: agentsv1alpha1.CheckpointSpec{
+				SandboxName: ptr.To(""),
+				PodName:     ptr.To("sandbox-from-pod"),
+			}},
+			want: []string{"sandbox-from-pod"},
+		},
+		{
+			name: "prefers sandbox name when both names are set",
+			obj: &agentsv1alpha1.Checkpoint{Spec: agentsv1alpha1.CheckpointSpec{
+				SandboxName: ptr.To("sandbox-a"),
+				PodName:     ptr.To("pod-a"),
+			}},
+			want: []string{"sandbox-a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CheckpointSandboxNameIndexFunc(tt.obj))
+		})
+	}
+}

--- a/test/e2e/sandbox_test.go
+++ b/test/e2e/sandbox_test.go
@@ -86,6 +86,16 @@ var _ = Describe("Sandbox", func() {
 
 	Context("creation and pending phase", func() {
 		It("should create sandbox and transition to running phase", func() {
+			// Keep the pod unready briefly so the observable Pending phase cannot be
+			// skipped when the node already has the test image cached.
+			sandbox.Spec.Template.Spec.Containers[0].ReadinessProbe = &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					Exec: &corev1.ExecAction{Command: []string{"sh", "-c", "exit 0"}},
+				},
+				InitialDelaySeconds: 5,
+				PeriodSeconds:       1,
+			}
+
 			By("Creating a new Sandbox")
 			Expect(k8sClient.Create(ctx, sandbox)).To(Succeed())
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Prevents Sandbox pause from racing with an existing Checkpoint:

- Indexes Checkpoints by `spec.sandboxName`, falling back to `spec.podName`
- Waits for checkpoints in empty, Pending, or Creating phase before pausing
- Stops waiting after five minutes without deleting the Checkpoint
- Requeues every five seconds while blocked
- Reports the blocking Checkpoint through the Paused condition and a deduplicated Normal event
- Adds unit coverage for checkpoint states, timeout handling, indexing, event deduplication, and reconcile requeue behavior

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

Run:

`go test ./pkg/controller/sandbox ./pkg/utils/fieldindex`

The tests were not run locally because the vendored dependency requires Go 1.26.3, while the available local toolchain is Go 1.25.9.

### Ⅳ. Special notes for reviews

- The gate only applies while the Paused condition is `False` with reason `Pending`, avoiding interference with checkpoints created by the pause controller itself.
- External Checkpoints may not have a Sandbox owner reference, so the controller uses a five-second requeue interval.
- Checkpoints older than five minutes, deleting checkpoints, and completed checkpoints do not block pause.
