### PR TITLE
fix(api): reject unsupported ip persistent content

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -56,7 +56,7 @@ type SandboxSpec struct {
 	// +optional
 	PauseStrategy *PauseStrategy `json:"pauseStrategy,omitempty"`
 
-	// PersistentContents indicates resume pod with persistent content, Enum: ip, memory, filesystem
+	// PersistentContents indicates resume pod with persistent content, Enum: memory, filesystem
 	// +listType=atomic
 	PersistentContents []string `json:"persistentContents,omitempty"`
 
@@ -412,7 +412,6 @@ type UpgradeAction struct {
 }
 
 const (
-	PersistentContentIp         string = "ip"
 	PersistentContentMemory     string = "memory"
 	PersistentContentFilesystem string = "filesystem"
 )

--- a/api/v1alpha1/sandboxset_types.go
+++ b/api/v1alpha1/sandboxset_types.go
@@ -95,7 +95,7 @@ type SandboxSetSpec struct {
 	// +optional
 	PauseStrategy *PauseStrategy `json:"pauseStrategy,omitempty"`
 
-	// PersistentContents indicates resume pod with persistent content, Enum: ip, memory, filesystem
+	// PersistentContents indicates resume pod with persistent content, Enum: memory, filesystem
 	// +listType=atomic
 	PersistentContents []string `json:"persistentContents,omitempty"`
 

--- a/api/v1alpha1/sandboxtemplate_types.go
+++ b/api/v1alpha1/sandboxtemplate_types.go
@@ -36,7 +36,7 @@ type SandboxTemplateSpec struct {
 	// +optional
 	VolumeClaimTemplates []v1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"`
 
-	// PersistentContents indicates resume pod with persistent content, Enum: ip, memory, filesystem
+	// PersistentContents indicates resume pod with persistent content, Enum: memory, filesystem
 	// +listType=atomic
 	PersistentContents []string `json:"persistentContents,omitempty"`
 

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -124,7 +124,7 @@ func main() {
 	flag.BoolVar(&allowPrivileged, "allow-privileged", true, "If true, allow privileged containers. It will only work if api-server is also"+
 		"started with --allow-privileged=true.")
 	flag.StringVar(&defaultPersistentContents, "default-persistent-contents", "", "Default persistent state configuration for sandbox, "+
-		"supporting three states: ip, memory, and filesystem. Format: comma-separated, e.g.: memory,filesystem")
+		"supporting two states: memory and filesystem. Format: comma-separated, e.g.: memory,filesystem")
 	flag.StringVar(&metricLabelsAllowlist, "metric-labels-allowlist", "",
 		"Comma-separated list of Sandbox label keys to expose as sandbox_labels metric labels (e.g., app,env,version)")
 	flag.StringVar(&runtimeClientCertDir, "runtime-client-cert-dir", "",

--- a/config/crd/bases/agents.kruise.io_sandboxes.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxes.yaml
@@ -268,7 +268,7 @@ spec:
                 type: boolean
               persistentContents:
                 description: 'PersistentContents indicates resume pod with persistent
-                  content, Enum: ip, memory, filesystem'
+                  content, Enum: memory, filesystem'
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/agents.kruise.io_sandboxsets.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxsets.yaml
@@ -198,7 +198,7 @@ spec:
                 type: object
               persistentContents:
                 description: 'PersistentContents indicates resume pod with persistent
-                  content, Enum: ip, memory, filesystem'
+                  content, Enum: memory, filesystem'
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/agents.kruise.io_sandboxtemplates.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxtemplates.yaml
@@ -176,7 +176,7 @@ spec:
                 type: object
               persistentContents:
                 description: 'PersistentContents indicates resume pod with persistent
-                  content, Enum: ip, memory, filesystem'
+                  content, Enum: memory, filesystem'
                 items:
                   type: string
                 type: array

--- a/pkg/controller/sandbox/core/checkpoint_test.go
+++ b/pkg/controller/sandbox/core/checkpoint_test.go
@@ -567,11 +567,6 @@ func TestCheckpointContentsForPause(t *testing.T) {
 			contents: []string{agentsv1alpha1.PersistentContentMemory},
 			expected: []string{agentsv1alpha1.CheckpointPersistentContentMemory},
 		},
-		{
-			name:     "ip only - not a checkpoint content, podInfo only",
-			contents: []string{agentsv1alpha1.PersistentContentIp},
-			expected: []string{agentsv1alpha1.CheckpointPersistentContentPodInfo},
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controller/sandboxset/revision_test.go
+++ b/pkg/controller/sandboxset/revision_test.go
@@ -121,7 +121,7 @@ func TestReconciler_buildSandboxTemplateSpec(t *testing.T) {
 					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
 						TemplateRef: &v1alpha1.SandboxTemplateRef{Name: "tpl-a"},
 					},
-					PersistentContents: []string{"ip"},
+					PersistentContents: []string{"memory"},
 					Runtimes:           []v1alpha1.RuntimeConfig{{Name: "node"}},
 				},
 			},
@@ -136,7 +136,7 @@ func TestReconciler_buildSandboxTemplateSpec(t *testing.T) {
 			verify: func(t *testing.T, spec *v1alpha1.SandboxTemplateSpec) {
 				require.NotNil(t, spec.Template)
 				assert.Equal(t, "img:v1", spec.Template.Spec.Containers[0].Image)
-				assert.Equal(t, []string{"ip"}, spec.PersistentContents)
+				assert.Equal(t, []string{"memory"}, spec.PersistentContents)
 				assert.Len(t, spec.Runtimes, 1)
 				assert.Equal(t, "node", spec.Runtimes[0].Name)
 			},

--- a/pkg/controller/sandboxset/utils_test.go
+++ b/pkg/controller/sandboxset/utils_test.go
@@ -383,7 +383,7 @@ func TestNewSandboxFromSandboxSet(t *testing.T) {
 				},
 				Spec: agentsv1alpha1.SandboxSetSpec{
 					Replicas:           2,
-					PersistentContents: []string{"ip", "memory"},
+					PersistentContents: []string{"filesystem", "memory"},
 					Runtimes: []agentsv1alpha1.RuntimeConfig{
 						{Name: agentsv1alpha1.RuntimeConfigForInjectCsiMount},
 						{Name: agentsv1alpha1.RuntimeConfigForInjectAgentRuntime},
@@ -406,7 +406,7 @@ func TestNewSandboxFromSandboxSet(t *testing.T) {
 				{Name: agentsv1alpha1.RuntimeConfigForInjectAgentRuntime},
 			},
 			expectedTemplateRef:        nil,
-			expectedPersistentContents: []string{"ip", "memory"},
+			expectedPersistentContents: []string{"filesystem", "memory"},
 		},
 		{
 			name: "sandboxset with pauseStrategy",

--- a/pkg/webhook/sandboxset/mutating/sandboxset_defaulter.go
+++ b/pkg/webhook/sandboxset/mutating/sandboxset_defaulter.go
@@ -50,10 +50,9 @@ func SetDefaultPersistentContents(contents string) error {
 	}
 	persistentContents := strings.Split(contents, ",")
 	for _, content := range persistentContents {
-		if content != agentsv1alpha1.PersistentContentIp &&
-			content != agentsv1alpha1.PersistentContentFilesystem &&
+		if content != agentsv1alpha1.PersistentContentFilesystem &&
 			content != agentsv1alpha1.PersistentContentMemory {
-			return fmt.Errorf("default-sandboxset-persistent-contents is invalid and only supports three contents: ip, memory, and filesystem")
+			return fmt.Errorf("default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem")
 		}
 	}
 	defaultPersistentContents = persistentContents

--- a/pkg/webhook/sandboxset/mutating/sandboxset_defaulter_test.go
+++ b/pkg/webhook/sandboxset/mutating/sandboxset_defaulter_test.go
@@ -591,6 +591,8 @@ func deepCopyPodTemplateSpec(template *corev1.PodTemplateSpec) *corev1.PodTempla
 }
 
 func TestSetDefaultPersistentContents(t *testing.T) {
+	const invalidContentsErr = "default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem"
+
 	tests := []struct {
 		name     string
 		contents string
@@ -602,7 +604,7 @@ func TestSetDefaultPersistentContents(t *testing.T) {
 			name:     "invalid single content - ip",
 			contents: "ip",
 			wantErr:  true,
-			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem",
+			errorMsg: invalidContentsErr,
 		},
 		{
 			name:     "valid single content - filesystem",
@@ -617,34 +619,22 @@ func TestSetDefaultPersistentContents(t *testing.T) {
 			expected: []string{"memory"},
 		},
 		{
-			name:     "invalid multiple contents - ip,filesystem",
+			name:     "valid multiple contents",
+			contents: "memory,filesystem",
+			wantErr:  false,
+			expected: []string{"memory", "filesystem"},
+		},
+		{
+			name:     "invalid mixed contents - ip,filesystem",
 			contents: "ip,filesystem",
 			wantErr:  true,
-			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem",
-		},
-		{
-			name:     "invalid multiple contents - ip,memory",
-			contents: "ip,memory",
-			wantErr:  true,
-			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem",
-		},
-		{
-			name:     "invalid all three contents",
-			contents: "ip,filesystem,memory",
-			wantErr:  true,
-			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem",
+			errorMsg: invalidContentsErr,
 		},
 		{
 			name:     "invalid content - unknown",
 			contents: "unknown",
 			wantErr:  true,
-			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem",
-		},
-		{
-			name:     "invalid mixed contents - ip,invalid,filesystem",
-			contents: "ip,invalid,filesystem",
-			wantErr:  true,
-			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem",
+			errorMsg: invalidContentsErr,
 		},
 		{
 			name:     "empty string - should be allowed (no defaults)",
@@ -654,9 +644,9 @@ func TestSetDefaultPersistentContents(t *testing.T) {
 		},
 		{
 			name:     "invalid content with spaces",
-			contents: "ip, filesystem",
+			contents: "memory, filesystem",
 			wantErr:  true,
-			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem",
+			errorMsg: invalidContentsErr,
 		},
 	}
 
@@ -696,6 +686,31 @@ func TestSetDefaultPersistentContents(t *testing.T) {
 	}
 }
 
+func newPersistentContentsSandboxSet(contents []string) *v1alpha1.SandboxSet {
+	return &v1alpha1.SandboxSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sbs",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.SandboxSetSpec{
+			Replicas: 3,
+			EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
+				Template: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "nginx:latest",
+							},
+						},
+					},
+				},
+			},
+			PersistentContents: contents,
+		},
+	}
+}
+
 func TestSandboxSetDefaulter_HandleWithPersistentContents(t *testing.T) {
 	err := v1alpha1.AddToScheme(scheme.Scheme)
 	require.NoError(t, err)
@@ -710,29 +725,8 @@ func TestSandboxSetDefaulter_HandleWithPersistentContents(t *testing.T) {
 		expectedContents         []string
 	}{
 		{
-			name: "Create with empty PersistentContents and default set - should apply defaults",
-			sandboxSet: &v1alpha1.SandboxSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-sbs",
-					Namespace: "default",
-				},
-				Spec: v1alpha1.SandboxSetSpec{
-					Replicas: 3,
-					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
-						Template: &corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name:  "test-container",
-										Image: "nginx:latest",
-									},
-								},
-							},
-						},
-					},
-					PersistentContents: []string{}, // Empty
-				},
-			},
+			name:                     "Create with empty PersistentContents and default set - should apply defaults",
+			sandboxSet:               newPersistentContentsSandboxSet([]string{}),
 			defaultPersistentContent: "memory,filesystem",
 			operation:                admissionv1.Create,
 			expectAllow:              true,
@@ -740,29 +734,8 @@ func TestSandboxSetDefaulter_HandleWithPersistentContents(t *testing.T) {
 			expectedContents:         []string{"memory", "filesystem"},
 		},
 		{
-			name: "Create with nil PersistentContents and default set - should apply defaults",
-			sandboxSet: &v1alpha1.SandboxSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-sbs",
-					Namespace: "default",
-				},
-				Spec: v1alpha1.SandboxSetSpec{
-					Replicas: 3,
-					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
-						Template: &corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name:  "test-container",
-										Image: "nginx:latest",
-									},
-								},
-							},
-						},
-					},
-					PersistentContents: nil, // Nil
-				},
-			},
+			name:                     "Create with nil PersistentContents and default set - should apply defaults",
+			sandboxSet:               newPersistentContentsSandboxSet(nil),
 			defaultPersistentContent: "memory",
 			operation:                admissionv1.Create,
 			expectAllow:              true,
@@ -770,29 +743,8 @@ func TestSandboxSetDefaulter_HandleWithPersistentContents(t *testing.T) {
 			expectedContents:         []string{"memory"},
 		},
 		{
-			name: "Create with existing PersistentContents - should not override",
-			sandboxSet: &v1alpha1.SandboxSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-sbs",
-					Namespace: "default",
-				},
-				Spec: v1alpha1.SandboxSetSpec{
-					Replicas: 3,
-					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
-						Template: &corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name:  "test-container",
-										Image: "nginx:latest",
-									},
-								},
-							},
-						},
-					},
-					PersistentContents: []string{"memory"}, // Already set
-				},
-			},
+			name:                     "Create with existing PersistentContents - should not override",
+			sandboxSet:               newPersistentContentsSandboxSet([]string{"memory"}),
 			defaultPersistentContent: "filesystem,memory",
 			operation:                admissionv1.Create,
 			expectAllow:              true,
@@ -800,29 +752,8 @@ func TestSandboxSetDefaulter_HandleWithPersistentContents(t *testing.T) {
 			expectedContents:         []string{"memory"}, // Should remain unchanged
 		},
 		{
-			name: "Update operation with empty PersistentContents - should not apply defaults",
-			sandboxSet: &v1alpha1.SandboxSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-sbs",
-					Namespace: "default",
-				},
-				Spec: v1alpha1.SandboxSetSpec{
-					Replicas: 3,
-					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
-						Template: &corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name:  "test-container",
-										Image: "nginx:latest",
-									},
-								},
-							},
-						},
-					},
-					PersistentContents: []string{}, // Empty
-				},
-			},
+			name:                     "Update operation with empty PersistentContents - should not apply defaults",
+			sandboxSet:               newPersistentContentsSandboxSet([]string{}),
 			defaultPersistentContent: "memory,filesystem",
 			operation:                admissionv1.Update,
 			expectAllow:              true,
@@ -830,29 +761,8 @@ func TestSandboxSetDefaulter_HandleWithPersistentContents(t *testing.T) {
 			expectedContents:         []string{}, // Should remain empty on Update
 		},
 		{
-			name: "Create with no default set - should not apply defaults",
-			sandboxSet: &v1alpha1.SandboxSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-sbs",
-					Namespace: "default",
-				},
-				Spec: v1alpha1.SandboxSetSpec{
-					Replicas: 3,
-					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
-						Template: &corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name:  "test-container",
-										Image: "nginx:latest",
-									},
-								},
-							},
-						},
-					},
-					PersistentContents: []string{}, // Empty
-				},
-			},
+			name:                     "Create with no default set - should not apply defaults",
+			sandboxSet:               newPersistentContentsSandboxSet([]string{}),
 			defaultPersistentContent: "", // No default
 			operation:                admissionv1.Create,
 			expectAllow:              true,

--- a/pkg/webhook/sandboxset/mutating/sandboxset_defaulter_test.go
+++ b/pkg/webhook/sandboxset/mutating/sandboxset_defaulter_test.go
@@ -599,10 +599,10 @@ func TestSetDefaultPersistentContents(t *testing.T) {
 		errorMsg string
 	}{
 		{
-			name:     "valid single content - ip",
+			name:     "invalid single content - ip",
 			contents: "ip",
-			wantErr:  false,
-			expected: []string{"ip"},
+			wantErr:  true,
+			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem",
 		},
 		{
 			name:     "valid single content - filesystem",
@@ -617,34 +617,34 @@ func TestSetDefaultPersistentContents(t *testing.T) {
 			expected: []string{"memory"},
 		},
 		{
-			name:     "valid multiple contents - ip,filesystem",
+			name:     "invalid multiple contents - ip,filesystem",
 			contents: "ip,filesystem",
-			wantErr:  false,
-			expected: []string{"ip", "filesystem"},
+			wantErr:  true,
+			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem",
 		},
 		{
-			name:     "valid multiple contents - ip,memory",
+			name:     "invalid multiple contents - ip,memory",
 			contents: "ip,memory",
-			wantErr:  false,
-			expected: []string{"ip", "memory"},
+			wantErr:  true,
+			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem",
 		},
 		{
-			name:     "valid all three contents",
+			name:     "invalid all three contents",
 			contents: "ip,filesystem,memory",
-			wantErr:  false,
-			expected: []string{"ip", "filesystem", "memory"},
+			wantErr:  true,
+			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem",
 		},
 		{
 			name:     "invalid content - unknown",
 			contents: "unknown",
 			wantErr:  true,
-			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports three contents: ip, memory, and filesystem",
+			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem",
 		},
 		{
 			name:     "invalid mixed contents - ip,invalid,filesystem",
 			contents: "ip,invalid,filesystem",
 			wantErr:  true,
-			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports three contents: ip, memory, and filesystem",
+			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem",
 		},
 		{
 			name:     "empty string - should be allowed (no defaults)",
@@ -656,7 +656,7 @@ func TestSetDefaultPersistentContents(t *testing.T) {
 			name:     "invalid content with spaces",
 			contents: "ip, filesystem",
 			wantErr:  true,
-			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports three contents: ip, memory, and filesystem",
+			errorMsg: "default-sandboxset-persistent-contents is invalid and only supports two contents: memory and filesystem",
 		},
 	}
 
@@ -733,11 +733,11 @@ func TestSandboxSetDefaulter_HandleWithPersistentContents(t *testing.T) {
 					PersistentContents: []string{}, // Empty
 				},
 			},
-			defaultPersistentContent: "ip,filesystem",
+			defaultPersistentContent: "memory,filesystem",
 			operation:                admissionv1.Create,
 			expectAllow:              true,
 			expectPatch:              true,
-			expectedContents:         []string{"ip", "filesystem"},
+			expectedContents:         []string{"memory", "filesystem"},
 		},
 		{
 			name: "Create with nil PersistentContents and default set - should apply defaults",
@@ -790,14 +790,14 @@ func TestSandboxSetDefaulter_HandleWithPersistentContents(t *testing.T) {
 							},
 						},
 					},
-					PersistentContents: []string{"ip"}, // Already set
+					PersistentContents: []string{"memory"}, // Already set
 				},
 			},
-			defaultPersistentContent: "ip,filesystem,memory",
+			defaultPersistentContent: "filesystem,memory",
 			operation:                admissionv1.Create,
 			expectAllow:              true,
-			expectPatch:              true,           // Still patch for AutomountServiceAccountToken
-			expectedContents:         []string{"ip"}, // Should remain unchanged
+			expectPatch:              true,               // Still patch for AutomountServiceAccountToken
+			expectedContents:         []string{"memory"}, // Should remain unchanged
 		},
 		{
 			name: "Update operation with empty PersistentContents - should not apply defaults",
@@ -823,7 +823,7 @@ func TestSandboxSetDefaulter_HandleWithPersistentContents(t *testing.T) {
 					PersistentContents: []string{}, // Empty
 				},
 			},
-			defaultPersistentContent: "ip,filesystem",
+			defaultPersistentContent: "memory,filesystem",
 			operation:                admissionv1.Update,
 			expectAllow:              true,
 			expectPatch:              true,       // Patch for AutomountServiceAccountToken


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Rejects the unsupported `ip` value for sandbox persistent contents.

- removes the unused `PersistentContentIp` API constant
- updates Sandbox, SandboxSet, and SandboxTemplate persistentContents comments and generated CRD descriptions to list only `memory` and `filesystem`
- updates the controller flag help text and SandboxSet default persistent contents validation to reject `ip`
- updates regression tests and replaces test fixtures that used `ip` as a valid sample value

### Ⅱ. Does this pull request fix one issue?

fixes #813

### Ⅲ. Describe how to verify it

```bash
GOCACHE=/private/tmp/go-build-issue-813 GOPATH=/private/tmp/go-issue-813 GOMODCACHE=/private/tmp/go-issue-813/pkg/mod make generate manifests
GOCACHE=/private/tmp/go-build-issue-813 GOPATH=/private/tmp/go-issue-813 GOMODCACHE=/private/tmp/go-issue-813/pkg/mod go test ./api/... ./pkg/webhook/sandboxset/mutating ./pkg/controller/sandbox/core ./pkg/controller/sandboxset -count=1
GOCACHE=/private/tmp/go-build-issue-813 GOPATH=/private/tmp/go-issue-813 GOMODCACHE=/private/tmp/go-issue-813/pkg/mod go test ./cmd/agent-sandbox-controller -run '^$' -count=1
```

### Ⅳ. Special notes for reviews

This intentionally does not change the separate behavior where an unrecognized `sandbox.spec.persistentContents` entry can fall through to a podInfo-only checkpoint. This PR only removes the stale `ip` vocabulary from the public/default validation boundary.
