### PR TITLE
fix(crd): register securityprofiles, globalsecurityprofiles and globaltrafficpolicies CRDs in kustomization

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -4,13 +4,16 @@
 resources:
 - bases/agents.kruise.io_checkpoints.yaml
 - bases/agents.kruise.io_commits.yaml
+- bases/agents.kruise.io_globalsecurityprofiles.yaml
+- bases/agents.kruise.io_globaltrafficpolicies.yaml
+- bases/agents.kruise.io_poolautoscalers.yaml
+- bases/agents.kruise.io_sandboxclaims.yaml
 - bases/agents.kruise.io_sandboxes.yaml
 - bases/agents.kruise.io_sandboxsets.yaml
-- bases/agents.kruise.io_sandboxclaims.yaml
 - bases/agents.kruise.io_sandboxtemplates.yaml
 - bases/agents.kruise.io_sandboxupdateops.yaml
+- bases/agents.kruise.io_securityprofiles.yaml
 - bases/agents.kruise.io_trafficpolicies.yaml
-- bases/agents.kruise.io_poolautoscalers.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patches:


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

The CRD base files for `securityprofiles`, `globalsecurityprofiles`, and
`globaltrafficpolicies` were generated alongside the other CRDs (in
`config/crd/bases/`) but never registered in
`config/crd/kustomization.yaml`. As a result, any kustomize build that
pulls in the `crd` package — including `config/default` — silently
omits these three CRDs from the rendered manifests.

This PR adds the three entries to `resources:` in
`config/crd/kustomization.yaml` so that these CRDs are installed and
updated together with the rest of the CRD set. The resources list is
also sorted alphabetically to keep future additions easy to scan.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run `kustomize build config/default` before and after this change,
   and confirm that `CustomResourceDefinition` objects for
   `securityprofiles`, `globalsecurityprofiles`, and
   `globaltrafficpolicies` now appear in the output.
2. Apply the rendered manifests to a test cluster and verify that
   `kubectl get crd` lists:
     - `securityprofiles.agents.kruise.io`
     - `globalsecurityprofiles.agents.kruise.io`
     - `globaltrafficpolicies.agents.kruise.io`

### Ⅳ. Special notes for reviews

- Only `config/crd/kustomization.yaml` is modified; no generated CRD
  YAML under `config/crd/bases/` is touched.
- `config/default/kustomization.yaml` already references the whole
  `../crd` package, so the new CRDs are picked up automatically by
  downstream kustomize builds without further changes.
