### PR TITLE
feat(skill): add sync-charts skill for CRD, webhook, RBAC, and identity resource synchronization

### DIFF
--- a/.qoder/skills/sync-charts/SKILL.md
+++ b/.qoder/skills/sync-charts/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: sync-charts
+description: Use when syncing OpenKruise Agents controller or sandbox-manager manifests from config/ into the openkruise/charts next directories, or when investigating drift between those sources.
+---
+
+# Sync Agents Charts
+
+Keep `config/` as the source of truth, but preserve Helm-only logic in the charts checkout. This skill updates only unreleased `next/` content; it never cuts a release.
+
+## Boundaries
+
+- Work in a clean agents checkout and a clean charts checkout. Modify only `versions/kruise-agents-sandbox-{controller,manager}/next/**` in charts.
+- Do not edit `config/crd/`, `templates/agentio/crds.yaml`, a released version directory, `Chart.yaml`, `values.yaml`, or `charts/` pointer files.
+- Copy CRDs byte-for-byte only. Splice RBAC and webhook entries into the existing Helm templates; preserve every `{{ ... }}`, conditional, chart-only resource, and extra permission unless the user approves its removal.
+- Manager has no webhook template. Do not create one.
+
+## Preflight and Source Refresh
+
+Set `CHARTS_REPO` to the charts checkout, then verify the required tools and clean trees:
+
+```bash
+for tool in helm yq gh python3 yamllint; do command -v "$tool" >/dev/null || exit 1; done
+python3 -c 'import yaml'
+test -x ./bin/kustomize || make kustomize
+test -z "$(git status --porcelain -- config)"
+
+test -z "$(git -C "$CHARTS_REPO" status --porcelain)"
+test -d "$CHARTS_REPO/versions/kruise-agents-sandbox-controller/next"
+test -d "$CHARTS_REPO/versions/kruise-agents-sandbox-manager/next"
+```
+
+Stop if either tree is dirty. Refresh generated manifests without manually editing them:
+
+```bash
+make manifests
+test -z "$(git status --porcelain -- config)"
+```
+
+If `config/` changed, stop and resolve or commit that source change in the agents repository before syncing charts.
+
+Create a charts branch from its current `origin/master` only after preflight:
+
+```bash
+git -C "$CHARTS_REPO" fetch origin master
+git -C "$CHARTS_REPO" switch -c "sync/agents-config-$(date +%F)" origin/master
+```
+
+## CRDs
+
+Run the checker before changing charts:
+
+```bash
+python3 .qoder/skills/sync-charts/scripts/chart_drift.py \
+  --charts-repo "$CHARTS_REPO" --aspect crd
+```
+
+The checker follows only `config/crd/kustomization.yaml`. In check mode, it reports every mapped drift even when an unmapped resource exists; with `--apply-crds`, an unmapped resource exits `3` before any copy or drift report. Exit `0` means every source CRD is mapped and byte-identical, `1` means mapped drift when no resource is unmapped, `2` means the source or charts-checkout configuration is invalid or incomplete, and `3` means at least one resource has no chart mapping.
+
+| Source resource | Chart target |
+| --- | --- |
+| `checkpoints`, `commits`, `poolautoscalers`, `sandboxclaims`, `sandboxes`, `sandboxsets`, `sandboxtemplates`, `sandboxupdateops` | `versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_<name>.yaml` |
+| `trafficpolicies` | `versions/kruise-agents-sandbox-manager/next/files/agentio/trafficpolicy-crd.yaml` |
+
+If a future resource in `config/crd/kustomization.yaml` has no chart mapping, the checker exits `3` and blocks every `--apply-crds` copy, including mapped resources. Never manually perform a partial copy while that block exists, and never treat it as a time-pressure fast path: ask the user whether the charts should ship the new resource. Add an explicit `CHART_SPEC` mapping and update its test coverage in a separate reviewed skill change before retrying; do not make that policy decision inside a chart-sync PR. `--component` does not bypass this safeguard.
+
+Once every kustomization resource is mapped, copy and recheck with:
+
+```bash
+python3 .qoder/skills/sync-charts/scripts/chart_drift.py \
+  --charts-repo "$CHARTS_REPO" --aspect crd --apply-crds
+python3 .qoder/skills/sync-charts/scripts/chart_drift.py \
+  --charts-repo "$CHARTS_REPO" --aspect crd
+```
+
+## Webhook and RBAC Splices
+
+Render the complete source overlay; never copy `config/webhook/manifests.yaml` directly because `patch_manifests.yaml` changes service references:
+
+```bash
+./bin/kustomize build config/default > /tmp/agents-default.yaml
+```
+
+Hand-merge the rendered `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` into `versions/kruise-agents-sandbox-controller/next/templates/webhook.yaml`. Keep the chart's service name and replace the rendered fixed namespace with `{{ include "sandbox-controller.namespace" . }}`. Preserve template syntax and chart-specific names.
+
+Hand-splice the `v-pa.kb.io` validating webhook into `versions/kruise-agents-sandbox-controller/next/templates/webhook.yaml` as well, keeping the chart service name and the templated namespace. Its entry must stay source-equivalent: `path: /validate-poolautoscaler`, `failurePolicy: Fail`, operations `CREATE` and `UPDATE`, `apiGroups: agents.kruise.io`, `apiVersions: v1alpha1`, resource `poolautoscalers`, `admissionReviewVersions` `v1` and `v1beta1`, and `sideEffects: None`.
+
+After rendering the controller chart, compare the allowed webhook entries (`md-sbs.kb.io`, `md-sbt.kb.io`, `v-sbs.kb.io`, `v-sbt.kb.io`, `v-pa.kb.io`, `v-pod-delete.kb.io`, `v-pod-eviction.kb.io`, and `v-suo.kb.io`) in both outputs. For every entry, rules, paths, policies, selectors, admission-review versions, and side effects must match. For every chart entry, `{{ include "sandbox-controller.namespace" . }}` resolves to `sandbox-system` and is equivalent to the source fixed namespace. The seven source-patched entries must also retain their patched service names. The source overlay does not patch `v-pa.kb.io`'s service reference, so retain the controller chart service name for that entry instead.
+
+```bash
+helm template sandbox-controller \
+  "$CHARTS_REPO/versions/kruise-agents-sandbox-controller/next" \
+  --namespace sandbox-system > /tmp/controller-chart.yaml
+yq 'select(.kind == "MutatingWebhookConfiguration" or .kind == "ValidatingWebhookConfiguration")' /tmp/agents-default.yaml
+yq 'select(.kind == "MutatingWebhookConfiguration" or .kind == "ValidatingWebhookConfiguration")' /tmp/controller-chart.yaml
+```
+
+Compare source `rules:` blocks and add missing rules only:
+
+| Source | Helm target | Rules to splice |
+| --- | --- | --- |
+| `config/rbac/role.yaml` | controller `templates/rbac.yaml` | `controller-role` ClusterRole and namespaced Role |
+| `config/rbac/leader_election_role.yaml` | controller `templates/rbac.yaml` | leader-election Role |
+| `config/sandbox-manager/rbac.yaml` | manager `templates/rbac.yaml` | manager ClusterRole and secret Role |
+| `config/sandbox-gateway/rbac.yaml` | manager `templates/rbac.yaml` | gateway ClusterRole |
+
+Do not replace ServiceAccounts, bindings, metadata, or Helm conditionals. Do not remove source-independent chart permissions. Leave commented metrics/sample RBAC and `config/sandbox-gateway/jwt-auth-rbac.yaml` untouched.
+
+## Verification and PR
+
+Render both charts before committing:
+
+```bash
+helm template sandbox-controller \
+  "$CHARTS_REPO/versions/kruise-agents-sandbox-controller/next" \
+  --namespace sandbox-system
+helm template sandbox-manager \
+  "$CHARTS_REPO/versions/kruise-agents-sandbox-manager/next" \
+  --namespace sandbox-system \
+  --set ingress.className=nginx --set e2b.adminApiKey=x
+yamllint -c "$CHARTS_REPO/.github/configs/lintconf.yaml" \
+  "$CHARTS_REPO/versions/kruise-agents-sandbox-controller/next" \
+  "$CHARTS_REPO/versions/kruise-agents-sandbox-manager/next"
+git -C "$CHARTS_REPO" status --short
+```
+
+The checker verifies CRDs only; webhook parity requires the rendered comparison above and RBAC splices require manual source-to-template review. The final checker run must report no `DRIFT` and exit `0`, which requires every source CRD to be mapped and byte-identical; any `UNMAPPED` exit `3` marks a blocking unmapped resource, not a successful sync.
+
+Commit with sign-off and create a charts PR that states the agents source SHA, the initial/final drift output, and CRD-upgrade impact. Do not change chart versions or release pointers in this PR.

--- a/.qoder/skills/sync-charts/SKILL.md
+++ b/.qoder/skills/sync-charts/SKILL.md
@@ -103,7 +103,48 @@ Compare source `rules:` blocks and add missing rules only:
 | `config/sandbox-manager/rbac.yaml` | manager `templates/rbac.yaml` | manager ClusterRole and secret Role |
 | `config/sandbox-gateway/rbac.yaml` | manager `templates/rbac.yaml` | gateway ClusterRole |
 
-Do not replace ServiceAccounts, bindings, metadata, or Helm conditionals. Do not remove source-independent chart permissions. Leave commented metrics/sample RBAC and `config/sandbox-gateway/jwt-auth-rbac.yaml` untouched.
+## Identity Resources
+
+Synchronize ServiceAccounts and RoleBinding/ClusterRoleBinding resources by hand-splicing source-defined behavior into the existing Helm templates. Do not byte-copy these resources: preserve `{{ ... }}`, chart names, the chart's existing namespace helper, chart-only labels and annotations, conditional blocks, and source-independent resources. Do not compare literal chart names: Helm generates chart names for every target. For controller sources, `config/default/kustomization.yaml` also applies `namePrefix: sandbox-` and `namespace: sandbox-system`; raw `subjects[].namespace: system` is a pre-render input, so inspect subjects only in the rendered default overlay.
+
+| Source | Helm target | Fields to synchronize |
+| --- | --- | --- |
+| `config/rbac/service_account.yaml` | controller `templates/rbac.yaml` | controller ServiceAccount presence and source-defined labels |
+| `config/rbac/role_binding.yaml` | controller `templates/rbac.yaml` | controller ClusterRoleBinding and RoleBinding `roleRef` and `subjects` |
+| `config/rbac/leader_election_role_binding.yaml` | controller `templates/rbac.yaml` | leader-election RoleBinding `roleRef` and `subjects` |
+| `config/sandbox-manager/serviceaccount.yaml` | manager `templates/rbac.yaml` | manager ServiceAccount presence, source-defined labels, and `automountServiceAccountToken` |
+| `config/sandbox-manager/rbac.yaml` | manager `templates/rbac.yaml` | manager ClusterRoleBinding and secrets RoleBinding `roleRef` and `subjects` |
+| `config/sandbox-gateway/serviceaccount.yaml` | manager `templates/rbac.yaml` | gateway ServiceAccount presence and source-defined labels |
+| `config/sandbox-gateway/rbac.yaml` | manager `templates/rbac.yaml` | gateway ClusterRoleBinding `roleRef` and `subjects` |
+
+Merge source labels additively, excluding `app.kubernetes.io/managed-by: kustomize`; that Kustomize bookkeeping label must not enter a Helm template. Retain chart-managed labels and annotations, so do not require literal equality of complete label sets. On conflict, chart-managed standard `app.kubernetes.io/*` keys win; add only source labels that the chart does not already manage. Keep the chart's name and namespace helpers in ServiceAccount references.
+
+After rendering with `--namespace sandbox-system`, verify that each synchronized ServiceAccount exists and that every synchronized non-templated field, including `automountServiceAccountToken`, is source-equivalent. Each source-rendered binding in the table must have exactly one chart counterpart of the same kind; a missing or duplicate counterpart is drift. For every matched binding, compare roleRef `apiGroup` and `kind`, then verify that its rendered role name identifies the rendered source role counterpart. The controller ClusterRoleBinding and RoleBinding share names, so pair bindings by kind before comparing; a name match alone does not identify the counterpart. Pair roleRef targets by kind as well, because the source ClusterRole and Role share their rendered name. Each `subjects` entry for a ServiceAccount must retain `kind: ServiceAccount`, name the rendered chart ServiceAccount, and resolve through the chart's existing namespace helper to `sandbox-system`. Do not remove source-independent chart permissions, commented metrics/sample RBAC, or resources from optional overlays that are not included by `config/sandbox-gateway/kustomization.yaml`: `config/sandbox-gateway/jwt-auth-rbac.yaml` and `config/sandbox-gateway-runtime-mtls/rbac.yaml` are not drift when absent from the base rendered source.
+
+Render the source resources and compare them against their chart output:
+
+```bash
+./bin/kustomize build config/default > /tmp/agents-default.yaml
+./bin/kustomize build config/sandbox-manager > /tmp/agents-manager.yaml
+./bin/kustomize build config/sandbox-gateway > /tmp/agents-gateway.yaml
+helm template sandbox-controller \
+  "$CHARTS_REPO/versions/kruise-agents-sandbox-controller/next" \
+  --namespace sandbox-system > /tmp/controller-chart.yaml
+helm template sandbox-manager \
+  "$CHARTS_REPO/versions/kruise-agents-sandbox-manager/next" \
+  --namespace sandbox-system \
+  --set ingress.className=nginx --set e2b.adminApiKey=x > /tmp/manager-chart.yaml
+```
+
+Before accepting `/tmp/manager-chart.yaml`, inspect the manager templates for gateway conditionals. If a chart value gates gateway identity resources, render again with that value enabled and use that output for the gateway comparison; never treat a value-gated absence as parity.
+
+```bash
+yq 'select(.kind == "ServiceAccount" or .kind == "RoleBinding" or .kind == "ClusterRoleBinding")' /tmp/agents-default.yaml
+yq 'select(.kind == "ServiceAccount" or .kind == "RoleBinding" or .kind == "ClusterRoleBinding")' /tmp/agents-manager.yaml
+yq 'select(.kind == "ServiceAccount" or .kind == "RoleBinding" or .kind == "ClusterRoleBinding")' /tmp/agents-gateway.yaml
+yq 'select(.kind == "ServiceAccount" or .kind == "RoleBinding" or .kind == "ClusterRoleBinding")' /tmp/controller-chart.yaml
+yq 'select(.kind == "ServiceAccount" or .kind == "RoleBinding" or .kind == "ClusterRoleBinding")' /tmp/manager-chart.yaml
+```
 
 ## Verification and PR
 
@@ -123,6 +164,6 @@ yamllint -c "$CHARTS_REPO/.github/configs/lintconf.yaml" \
 git -C "$CHARTS_REPO" status --short
 ```
 
-The checker verifies CRDs only; webhook parity requires the rendered comparison above and RBAC splices require manual source-to-template review. The final checker run must report no `DRIFT` and exit `0`, which requires every source CRD to be mapped and byte-identical; any `UNMAPPED` exit `3` marks a blocking unmapped resource, not a successful sync.
+The checker verifies CRDs only; webhook parity requires the rendered comparison above and RBAC splices require manual source-to-template review. Identity resources require manual source-to-rendered review. The final checker run must report no `DRIFT` and exit `0`, which requires every source CRD to be mapped and byte-identical; any `UNMAPPED` exit `3` marks a blocking unmapped resource, not a successful sync.
 
 Commit with sign-off and create a charts PR that states the agents source SHA, the initial/final drift output, and CRD-upgrade impact. Do not change chart versions or release pointers in this PR.

--- a/.qoder/skills/sync-charts/SKILL.md
+++ b/.qoder/skills/sync-charts/SKILL.md
@@ -59,7 +59,7 @@ The checker follows only `config/crd/kustomization.yaml`. In check mode, it repo
 | Source resource | Chart target |
 | --- | --- |
 | `checkpoints`, `commits`, `poolautoscalers`, `sandboxclaims`, `sandboxes`, `sandboxsets`, `sandboxtemplates`, `sandboxupdateops` | `versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_<name>.yaml` |
-| `trafficpolicies` | `versions/kruise-agents-sandbox-manager/next/files/agentio/trafficpolicy-crd.yaml` |
+| `trafficpolicies`, `globaltrafficpolicies`, `securityprofiles`, `globalsecurityprofiles` | `versions/kruise-agents-sandbox-manager/next/files/agentio/<singular>-crd.yaml` |
 
 If a future resource in `config/crd/kustomization.yaml` has no chart mapping, the checker exits `3` and blocks every `--apply-crds` copy, including mapped resources. Never manually perform a partial copy while that block exists, and never treat it as a time-pressure fast path: ask the user whether the charts should ship the new resource. Add an explicit `CHART_SPEC` mapping and update its test coverage in a separate reviewed skill change before retrying; do not make that policy decision inside a chart-sync PR. `--component` does not bypass this safeguard.
 
@@ -84,7 +84,7 @@ Hand-merge the rendered `MutatingWebhookConfiguration` and `ValidatingWebhookCon
 
 Hand-splice the `v-pa.kb.io` validating webhook into `versions/kruise-agents-sandbox-controller/next/templates/webhook.yaml` as well, keeping the chart service name and the templated namespace. Its entry must stay source-equivalent: `path: /validate-poolautoscaler`, `failurePolicy: Fail`, operations `CREATE` and `UPDATE`, `apiGroups: agents.kruise.io`, `apiVersions: v1alpha1`, resource `poolautoscalers`, `admissionReviewVersions` `v1` and `v1beta1`, and `sideEffects: None`.
 
-After rendering the controller chart, compare the allowed webhook entries (`md-sbs.kb.io`, `md-sbt.kb.io`, `v-sbs.kb.io`, `v-sbt.kb.io`, `v-pa.kb.io`, `v-pod-delete.kb.io`, `v-pod-eviction.kb.io`, and `v-suo.kb.io`) in both outputs. For every entry, rules, paths, policies, selectors, admission-review versions, and side effects must match. For every chart entry, `{{ include "sandbox-controller.namespace" . }}` resolves to `sandbox-system` and is equivalent to the source fixed namespace. The seven source-patched entries must also retain their patched service names. The source overlay does not patch `v-pa.kb.io`'s service reference, so retain the controller chart service name for that entry instead.
+After rendering the controller chart, compare the allowed webhook entries (`md-sbs.kb.io`, `md-sbt.kb.io`, `v-sbs.kb.io`, `v-sbt.kb.io`, `v-pa.kb.io`, `v-pod-delete.kb.io`, `v-pod-eviction.kb.io`, and `v-suo.kb.io`) in both outputs. For every entry, rules, paths, policies, selectors, admission-review versions, and side effects must match. For every chart entry, `{{ include "sandbox-controller.namespace" . }}` resolves to `sandbox-system` and is equivalent to the source fixed namespace. All eight source-patched entries must also retain their patched service names.
 
 ```bash
 helm template sandbox-controller \

--- a/.qoder/skills/sync-charts/scripts/chart_drift.py
+++ b/.qoder/skills/sync-charts/scripts/chart_drift.py
@@ -54,6 +54,18 @@ CHART_SPEC = {
         "manager",
         Path("versions/kruise-agents-sandbox-manager/next/files/agentio/trafficpolicy-crd.yaml"),
     ),
+    "agents.kruise.io_globaltrafficpolicies.yaml": Target(
+        "manager",
+        Path("versions/kruise-agents-sandbox-manager/next/files/agentio/globaltrafficpolicy-crd.yaml"),
+    ),
+    "agents.kruise.io_securityprofiles.yaml": Target(
+        "manager",
+        Path("versions/kruise-agents-sandbox-manager/next/files/agentio/securityprofile-crd.yaml"),
+    ),
+    "agents.kruise.io_globalsecurityprofiles.yaml": Target(
+        "manager",
+        Path("versions/kruise-agents-sandbox-manager/next/files/agentio/globalsecurityprofile-crd.yaml"),
+    ),
 }
 
 

--- a/.qoder/skills/sync-charts/scripts/chart_drift.py
+++ b/.qoder/skills/sync-charts/scripts/chart_drift.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Check and optionally copy CRDs listed in config/crd/kustomization.yaml."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Target:
+    component: str
+    path: Path
+
+
+CHART_SPEC = {
+    "agents.kruise.io_checkpoints.yaml": Target(
+        "controller",
+        Path("versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_checkpoints.yaml"),
+    ),
+    "agents.kruise.io_commits.yaml": Target(
+        "controller",
+        Path("versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_commits.yaml"),
+    ),
+    "agents.kruise.io_poolautoscalers.yaml": Target(
+        "controller",
+        Path("versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_poolautoscalers.yaml"),
+    ),
+    "agents.kruise.io_sandboxclaims.yaml": Target(
+        "controller",
+        Path("versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxclaims.yaml"),
+    ),
+    "agents.kruise.io_sandboxes.yaml": Target(
+        "controller",
+        Path("versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxes.yaml"),
+    ),
+    "agents.kruise.io_sandboxsets.yaml": Target(
+        "controller",
+        Path("versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxsets.yaml"),
+    ),
+    "agents.kruise.io_sandboxtemplates.yaml": Target(
+        "controller",
+        Path("versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxtemplates.yaml"),
+    ),
+    "agents.kruise.io_sandboxupdateops.yaml": Target(
+        "controller",
+        Path("versions/kruise-agents-sandbox-controller/next/crds/agents.kruise.io_sandboxupdateops.yaml"),
+    ),
+    "agents.kruise.io_trafficpolicies.yaml": Target(
+        "manager",
+        Path("versions/kruise-agents-sandbox-manager/next/files/agentio/trafficpolicy-crd.yaml"),
+    ),
+}
+
+
+class ConfigurationError(Exception):
+    pass
+
+
+def resources(kustomization: Path) -> list[Path]:
+    if not kustomization.is_file():
+        raise ConfigurationError(f"missing kustomization: {kustomization}")
+
+    result: list[Path] = []
+    active = False
+    for line in kustomization.read_text(encoding="utf-8").splitlines():
+        if not active:
+            active = line.strip() == "resources:"
+            continue
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if re.match(r"^[A-Za-z][A-Za-z0-9_-]*:\s*", line):
+            break
+        match = re.match(r"^\s*-\s+([^#]+?)(?:\s+#.*)?$", line)
+        if match:
+            result.append(Path(match.group(1).strip().strip("'\"")))
+
+    if not active:
+        raise ConfigurationError(f"resources key not found: {kustomization}")
+    return result
+
+
+def synchronize(args: argparse.Namespace) -> int:
+    if not args.charts_repo.is_dir():
+        raise ConfigurationError(f"missing charts checkout: {args.charts_repo}")
+    if not (args.charts_repo / "versions").is_dir():
+        raise ConfigurationError(f"missing charts versions directory: {args.charts_repo / 'versions'}")
+
+    crd_dir = args.agents_repo / "config" / "crd"
+    entries: list[tuple[Path, Target]] = []
+    has_unmapped = False
+
+    for resource in resources(crd_dir / "kustomization.yaml"):
+        target = CHART_SPEC.get(resource.name)
+        if target is None:
+            print(f"UNMAPPED crd {resource.name}")
+            has_unmapped = True
+            continue
+        if args.component != "all" and args.component != target.component:
+            continue
+        source = crd_dir / resource
+        if not source.is_file():
+            raise ConfigurationError(f"missing CRD source: {source}")
+        entries.append((source, target))
+
+    if args.apply_crds and has_unmapped:
+        return 3
+
+    if args.apply_crds:
+        for source, target in entries:
+            destination = args.charts_repo / target.path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, destination)
+            print(f"SYNCED crd {target.component} {target.path}")
+
+    has_drift = False
+    for source, target in entries:
+        destination = args.charts_repo / target.path
+        if not destination.is_file():
+            print(f"DRIFT crd {target.component} {target.path} missing")
+            has_drift = True
+        elif source.read_bytes() != destination.read_bytes():
+            print(f"DRIFT crd {target.component} {target.path} content")
+            has_drift = True
+        else:
+            print(f"OK crd {target.component} {target.path}")
+    if has_unmapped:
+        return 3
+    return 1 if has_drift else 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agents-repo", type=Path, default=Path.cwd())
+    parser.add_argument("--charts-repo", type=Path, required=True)
+    parser.add_argument("--component", choices=("all", "controller", "manager"), default="all")
+    parser.add_argument("--aspect", choices=("crd",), default="crd")
+    parser.add_argument("--target", choices=("next",), default="next")
+    parser.add_argument("--apply-crds", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    try:
+        return synchronize(parse_args())
+    except ConfigurationError as error:
+        print(f"ERROR {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.qoder/skills/sync-charts/tests/test_chart_drift.py
+++ b/.qoder/skills/sync-charts/tests/test_chart_drift.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Black-box tests for the sync-charts drift checker."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+CHECKER = SKILL_DIR / "scripts" / "chart_drift.py"
+
+
+class ChartDriftTest(unittest.TestCase):
+    def test_reports_kustomization_crd_without_chart_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            agents_repo = root / "agents"
+            charts_repo = root / "charts"
+            (agents_repo / "config" / "crd" / "bases").mkdir(parents=True)
+            (charts_repo / "versions").mkdir(parents=True)
+            (agents_repo / "config" / "crd" / "kustomization.yaml").write_text(
+                "resources:\n"
+                "- bases/agents.kruise.io_unmappedfixtures.yaml\n",
+                encoding="utf-8",
+            )
+            (
+                agents_repo / "config" / "crd" / "bases" / "agents.kruise.io_unmappedfixtures.yaml"
+            ).write_text(
+                "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(CHECKER),
+                    "--agents-repo",
+                    str(agents_repo),
+                    "--charts-repo",
+                    str(charts_repo),
+                    "--aspect",
+                    "crd",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 3, result.stderr)
+        self.assertIn(
+            "UNMAPPED crd agents.kruise.io_unmappedfixtures.yaml",
+            result.stdout,
+        )
+
+    def test_reports_missing_charts_checkout_as_configuration_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            agents_repo = root / "agents"
+            source = (
+                agents_repo
+                / "config"
+                / "crd"
+                / "bases"
+                / "agents.kruise.io_checkpoints.yaml"
+            )
+            source.parent.mkdir(parents=True)
+            (agents_repo / "config" / "crd" / "kustomization.yaml").write_text(
+                "resources:\n"
+                "- bases/agents.kruise.io_checkpoints.yaml\n",
+                encoding="utf-8",
+            )
+            source.write_text(
+                "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(CHECKER),
+                    "--agents-repo",
+                    str(agents_repo),
+                    "--charts-repo",
+                    str(root / "missing-charts"),
+                    "--aspect",
+                    "crd",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn("ERROR missing charts checkout", result.stderr)
+
+    def test_reports_mapped_drift_alongside_unmapped_crd(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            agents_repo = root / "agents"
+            charts_repo = root / "charts"
+            crd_dir = agents_repo / "config" / "crd"
+            bases_dir = crd_dir / "bases"
+            bases_dir.mkdir(parents=True)
+            (charts_repo / "versions").mkdir(parents=True)
+            (crd_dir / "kustomization.yaml").write_text(
+                "resources:\n"
+                "- bases/agents.kruise.io_unmappedfixtures.yaml\n"
+                "- bases/agents.kruise.io_checkpoints.yaml\n",
+                encoding="utf-8",
+            )
+            (bases_dir / "agents.kruise.io_unmappedfixtures.yaml").write_text(
+                "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\n",
+                encoding="utf-8",
+            )
+            (bases_dir / "agents.kruise.io_checkpoints.yaml").write_text(
+                "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(CHECKER),
+                    "--agents-repo",
+                    str(agents_repo),
+                    "--charts-repo",
+                    str(charts_repo),
+                    "--aspect",
+                    "crd",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 3, result.stderr)
+        self.assertIn("UNMAPPED crd agents.kruise.io_unmappedfixtures.yaml", result.stdout)
+        self.assertIn(
+            "DRIFT crd controller "
+            "versions/kruise-agents-sandbox-controller/next/crds/"
+            "agents.kruise.io_checkpoints.yaml missing",
+            result.stdout,
+        )
+
+    def test_does_not_copy_mapped_crd_when_another_crd_is_unmapped(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            agents_repo = root / "agents"
+            charts_repo = root / "charts"
+            crd_dir = agents_repo / "config" / "crd"
+            bases_dir = crd_dir / "bases"
+            destination = (
+                charts_repo
+                / "versions"
+                / "kruise-agents-sandbox-controller"
+                / "next"
+                / "crds"
+                / "agents.kruise.io_checkpoints.yaml"
+            )
+            bases_dir.mkdir(parents=True)
+            (charts_repo / "versions").mkdir(parents=True)
+            (crd_dir / "kustomization.yaml").write_text(
+                "resources:\n"
+                "- bases/agents.kruise.io_unmappedfixtures.yaml\n"
+                "- bases/agents.kruise.io_checkpoints.yaml\n",
+                encoding="utf-8",
+            )
+            (bases_dir / "agents.kruise.io_unmappedfixtures.yaml").write_text(
+                "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\n",
+                encoding="utf-8",
+            )
+            (bases_dir / "agents.kruise.io_checkpoints.yaml").write_text(
+                "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(CHECKER),
+                    "--agents-repo",
+                    str(agents_repo),
+                    "--charts-repo",
+                    str(charts_repo),
+                    "--aspect",
+                    "crd",
+                    "--apply-crds",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 3, result.stderr)
+        self.assertFalse(destination.exists())
+        self.assertNotIn("SYNCED crd", result.stdout)
+
+    def test_copies_mapped_crd_when_apply_is_requested(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            agents_repo = root / "agents"
+            charts_repo = root / "charts"
+            source = (
+                agents_repo
+                / "config"
+                / "crd"
+                / "bases"
+                / "agents.kruise.io_checkpoints.yaml"
+            )
+            destination = (
+                charts_repo
+                / "versions"
+                / "kruise-agents-sandbox-controller"
+                / "next"
+                / "crds"
+                / "agents.kruise.io_checkpoints.yaml"
+            )
+            source.parent.mkdir(parents=True)
+            destination.parent.mkdir(parents=True)
+            (agents_repo / "config" / "crd" / "kustomization.yaml").write_text(
+                "resources:\n"
+                "- bases/agents.kruise.io_checkpoints.yaml\n",
+                encoding="utf-8",
+            )
+            source.write_bytes(b"apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\n")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(CHECKER),
+                    "--agents-repo",
+                    str(agents_repo),
+                    "--charts-repo",
+                    str(charts_repo),
+                    "--aspect",
+                    "crd",
+                    "--apply-crds",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(destination.read_bytes(), source.read_bytes())
+            self.assertIn("SYNCED crd controller", result.stdout)
+
+    def test_copies_commits_crd_to_controller_chart(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            agents_repo = root / "agents"
+            charts_repo = root / "charts"
+            source = (
+                agents_repo
+                / "config"
+                / "crd"
+                / "bases"
+                / "agents.kruise.io_commits.yaml"
+            )
+            destination = (
+                charts_repo
+                / "versions"
+                / "kruise-agents-sandbox-controller"
+                / "next"
+                / "crds"
+                / "agents.kruise.io_commits.yaml"
+            )
+            source.parent.mkdir(parents=True)
+            (charts_repo / "versions").mkdir(parents=True)
+            (agents_repo / "config" / "crd" / "kustomization.yaml").write_text(
+                "resources:\n"
+                "- bases/agents.kruise.io_commits.yaml\n",
+                encoding="utf-8",
+            )
+            source.write_bytes(
+                b"apiVersion: apiextensions.k8s.io/v1\n"
+                b"kind: CustomResourceDefinition\n"
+                b"metadata:\n"
+                b"  name: commits.agents.kruise.io\n"
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(CHECKER),
+                    "--agents-repo",
+                    str(agents_repo),
+                    "--charts-repo",
+                    str(charts_repo),
+                    "--aspect",
+                    "crd",
+                    "--apply-crds",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(destination.read_bytes(), source.read_bytes())
+            self.assertIn(
+                "SYNCED crd controller "
+                "versions/kruise-agents-sandbox-controller/next/crds/"
+                "agents.kruise.io_commits.yaml",
+                result.stdout,
+            )
+
+    def test_copies_poolautoscalers_crd_to_controller_chart(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            agents_repo = root / "agents"
+            charts_repo = root / "charts"
+            source = (
+                agents_repo
+                / "config"
+                / "crd"
+                / "bases"
+                / "agents.kruise.io_poolautoscalers.yaml"
+            )
+            destination = (
+                charts_repo
+                / "versions"
+                / "kruise-agents-sandbox-controller"
+                / "next"
+                / "crds"
+                / "agents.kruise.io_poolautoscalers.yaml"
+            )
+            source.parent.mkdir(parents=True)
+            (charts_repo / "versions").mkdir(parents=True)
+            (agents_repo / "config" / "crd" / "kustomization.yaml").write_text(
+                "resources:\n"
+                "- bases/agents.kruise.io_poolautoscalers.yaml\n",
+                encoding="utf-8",
+            )
+            source.write_bytes(
+                b"apiVersion: apiextensions.k8s.io/v1\n"
+                b"kind: CustomResourceDefinition\n"
+                b"metadata:\n"
+                b"  name: poolautoscalers.agents.kruise.io\n"
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(CHECKER),
+                    "--agents-repo",
+                    str(agents_repo),
+                    "--charts-repo",
+                    str(charts_repo),
+                    "--aspect",
+                    "crd",
+                    "--apply-crds",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(destination.read_bytes(), source.read_bytes())
+            self.assertIn(
+                "SYNCED crd controller "
+                "versions/kruise-agents-sandbox-controller/next/crds/"
+                "agents.kruise.io_poolautoscalers.yaml",
+                result.stdout,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.qoder/skills/sync-charts/tests/test_chart_drift.py
+++ b/.qoder/skills/sync-charts/tests/test_chart_drift.py
@@ -370,6 +370,67 @@ class ChartDriftTest(unittest.TestCase):
                 result.stdout,
             )
 
+    def test_copies_securityprofiles_crd_to_manager_chart(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            agents_repo = root / "agents"
+            charts_repo = root / "charts"
+            source = (
+                agents_repo
+                / "config"
+                / "crd"
+                / "bases"
+                / "agents.kruise.io_securityprofiles.yaml"
+            )
+            destination = (
+                charts_repo
+                / "versions"
+                / "kruise-agents-sandbox-manager"
+                / "next"
+                / "files"
+                / "agentio"
+                / "securityprofile-crd.yaml"
+            )
+            source.parent.mkdir(parents=True)
+            (charts_repo / "versions").mkdir(parents=True)
+            (agents_repo / "config" / "crd" / "kustomization.yaml").write_text(
+                "resources:\n"
+                "- bases/agents.kruise.io_securityprofiles.yaml\n",
+                encoding="utf-8",
+            )
+            source.write_bytes(
+                b"apiVersion: apiextensions.k8s.io/v1\n"
+                b"kind: CustomResourceDefinition\n"
+                b"metadata:\n"
+                b"  name: securityprofiles.agents.kruise.io\n"
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(CHECKER),
+                    "--agents-repo",
+                    str(agents_repo),
+                    "--charts-repo",
+                    str(charts_repo),
+                    "--aspect",
+                    "crd",
+                    "--apply-crds",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(destination.read_bytes(), source.read_bytes())
+            self.assertIn(
+                "SYNCED crd manager "
+                "versions/kruise-agents-sandbox-manager/next/files/agentio/"
+                "securityprofile-crd.yaml",
+                result.stdout,
+            )
+
     def test_documents_identity_resource_synchronization(self) -> None:
         content = SKILL.read_text(encoding="utf-8")
 

--- a/.qoder/skills/sync-charts/tests/test_chart_drift.py
+++ b/.qoder/skills/sync-charts/tests/test_chart_drift.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 SKILL_DIR = Path(__file__).resolve().parents[1]
 CHECKER = SKILL_DIR / "scripts" / "chart_drift.py"
+SKILL = SKILL_DIR / "SKILL.md"
 
 
 class ChartDriftTest(unittest.TestCase):
@@ -368,6 +369,44 @@ class ChartDriftTest(unittest.TestCase):
                 "agents.kruise.io_poolautoscalers.yaml",
                 result.stdout,
             )
+
+    def test_documents_identity_resource_synchronization(self) -> None:
+        content = SKILL.read_text(encoding="utf-8")
+
+        self.assertIn("## Identity Resources", content)
+        self.assertIn("> /tmp/manager-chart.yaml", content)
+        for requirement in (
+            "controller `templates/rbac.yaml`",
+            "manager `templates/rbac.yaml`",
+            "preserve `{{ ... }}`",
+            "excluding `app.kubernetes.io/managed-by: kustomize`",
+            "chart-managed standard `app.kubernetes.io/*` keys win",
+            "roleRef `apiGroup` and `kind`",
+            "chart's existing namespace helper",
+            "source role counterpart",
+            "source-rendered binding in the table",
+            "exactly one chart counterpart of the same kind",
+            "roleRef targets by kind",
+            "namePrefix: sandbox-",
+            "namespace: sandbox-system",
+            "pair bindings by kind",
+            "config/sandbox-gateway/jwt-auth-rbac.yaml",
+            "config/sandbox-gateway-runtime-mtls/rbac.yaml",
+            "Identity resources require manual source-to-rendered review.",
+        ):
+            with self.subTest(requirement=requirement):
+                self.assertIn(requirement, content)
+        for source in (
+            "config/rbac/service_account.yaml",
+            "config/rbac/role_binding.yaml",
+            "config/rbac/leader_election_role_binding.yaml",
+            "config/sandbox-manager/serviceaccount.yaml",
+            "config/sandbox-manager/rbac.yaml",
+            "config/sandbox-gateway/serviceaccount.yaml",
+            "config/sandbox-gateway/rbac.yaml",
+        ):
+            with self.subTest(source=source):
+                self.assertIn(source, content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Adds a `sync-charts` skill under `.qoder/skills/sync-charts/` that guides
synchronizing controller and manager manifests from `config/` into the
openkruise/charts `next/` directories. The skill covers four areas:

- **CRDs**: A Python drift checker (`chart_drift.py`) that maps every
  `config/crd/kustomization.yaml` resource to its chart target, reports
  drift, and copies byte-for-byte with `--apply-crds`. An unmapped
  resource blocks all copies (exit 3) to prevent partial syncs.
- **Webhooks**: Hand-splice guidance for mutating and validating webhook
  configurations, including `v-pa.kb.io` for PoolAutoscaler, preserving
  chart-templated namespaces and service names.
- **RBAC**: Source-to-template splice rules for ClusterRole and Role
  entries across controller and manager charts.
- **Identity Resources**: ServiceAccount and RoleBinding/ClusterRoleBinding
  synchronization with label merge rules, kind-based pairing for same-named
  bindings, and rendered comparison commands.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run the drift checker tests:
   `python3 .qoder/skills/sync-charts/tests/test_chart_drift.py`
2. Run the checker against a charts checkout:
   `python3 .qoder/skills/sync-charts/scripts/chart_drift.py --charts-repo $CHARTS_REPO --aspect crd`
3. Follow the SKILL.md preflight, CRD, webhook, RBAC, and identity
   resource sections to sync a charts checkout end-to-end.

### Ⅳ. Special notes for reviews

- The checker maps 12 CRDs: 8 controller CRDs to `crds/` and 4 manager
  CRDs (trafficpolicies, globaltrafficpolicies, securityprofiles,
  globalsecurityprofiles) to `files/agentio/<singular>-crd.yaml`.
- Exit codes: 0 = in sync, 1 = mapped drift, 2 = configuration error,
  3 = unmapped resource (blocks all copies).
- The skill never modifies `config/crd/` or released chart versions;
  it targets only `versions/*/next/**`.
