### PR TITLE
fix(webhook): patch PoolAutoscaler webhook service

### DIFF
--- a/config/webhook/patch_manifests.yaml
+++ b/config/webhook/patch_manifests.yaml
@@ -49,6 +49,11 @@ webhooks:
       service:
         name: sandbox-controller-manager-webhook-service
         namespace: sandbox-system
+  - name: v-pa.kb.io
+    clientConfig:
+      service:
+        name: sandbox-controller-manager-webhook-service
+        namespace: sandbox-system
   - name: v-suo.kb.io
     clientConfig:
       service:


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Adds the missing service override for the PoolAutoscaler validating webhook
(`v-pa.kb.io`) in the webhook manifest patch.

This makes the deployed webhook configuration target
`sandbox-controller-manager-webhook-service` in `sandbox-system` while
retaining the generated validation path, rules, and policies.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run `kubectl kustomize config/default`.
2. Confirm `v-pa.kb.io` appears once in the rendered
   `ValidatingWebhookConfiguration`.
3. Confirm its service is
   `sandbox-controller-manager-webhook-service` in `sandbox-system`, with
   path `/validate-poolautoscaler`.

### Ⅳ. Special notes for reviews

- The patch overrides only the service name and namespace; webhook behavior
  remains owned by the generated manifest.
