### PR TITLE
chore(workflows): harden GitHub Actions against zizmor and Scorecard findings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout Actions Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Check spelling with custom config file
         uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1.48.0
         with:
@@ -50,6 +52,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           submodules: true
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
@@ -59,8 +62,8 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-${{ github.ref }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-${{ github.ref }}-
       - name: Code generate
         run: |
           make generate
@@ -76,7 +79,7 @@ jobs:
           # unrelated pull request.
           only-new-issues: true
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # master
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -93,6 +96,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           submodules: true
       - name: Fetch History
         run: git fetch --prune --unshallow
@@ -104,8 +108,8 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-${{ github.ref }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-${{ github.ref }}-
       - name: Run Unit Tests
         run: |
           make test
@@ -117,4 +121,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
-          file: cover.out
+          files: cover.out

--- a/.github/workflows/docker-image-agent-runtime.yml
+++ b/.github/workflows/docker-image-agent-runtime.yml
@@ -11,15 +11,19 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      RUNTIME_IMG: openkruise/agent-runtime:${{ github.ref_name }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.HUB_KRUISE }}
@@ -27,7 +31,7 @@ jobs:
         run: |
           docker buildx create --use --platform=linux/amd64,linux/arm64,linux/ppc64le --name multi-platform-builder
           docker buildx ls
-          RUNTIME_IMG=openkruise/agent-runtime:${{ github.ref_name }} make docker-buildx-runtime
+          make docker-buildx-runtime
       - name: Push the Docker image
         run: |
-          RUNTIME_IMG=openkruise/agent-runtime:${{ github.ref_name }} make docker-pushx-runtime
+          make docker-pushx-runtime

--- a/.github/workflows/docker-image-agent-sandbox-controller.yml
+++ b/.github/workflows/docker-image-agent-sandbox-controller.yml
@@ -11,15 +11,19 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      CONTROLLER_IMG: openkruise/agent-sandbox-controller:${{ github.ref_name }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.HUB_KRUISE }}
@@ -27,7 +31,7 @@ jobs:
         run: |
           docker buildx create --use --platform=linux/amd64,linux/arm64,linux/ppc64le --name multi-platform-builder
           docker buildx ls
-          CONTROLLER_IMG=openkruise/agent-sandbox-controller:${{ github.ref_name }} make docker-buildx-controller
+          make docker-buildx-controller
       - name: Push the Docker image
         run: |
-          CONTROLLER_IMG=openkruise/agent-sandbox-controller:${{ github.ref_name }} make docker-pushx-controller
+          make docker-pushx-controller

--- a/.github/workflows/docker-image-commit-job.yml
+++ b/.github/workflows/docker-image-commit-job.yml
@@ -11,15 +11,19 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      COMMIT_JOB_IMG: openkruise/commit-job:${{ github.ref_name }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.HUB_KRUISE }}
@@ -29,5 +33,5 @@ jobs:
           docker buildx build --platform=linux/amd64,linux/arm64 \
             -f dockerfiles/commit-job.Dockerfile \
             --build-arg NERDCTL_BRANCH=v2.0.0 \
-            -t openkruise/commit-job:${{ github.ref_name }} \
+            -t "$COMMIT_JOB_IMG" \
             --push .

--- a/.github/workflows/docker-image-sandbox-gateway.yml
+++ b/.github/workflows/docker-image-sandbox-gateway.yml
@@ -11,15 +11,19 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      GATEWAY_IMG: openkruise/sandbox-gateway:${{ github.ref_name }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.HUB_KRUISE }}
@@ -27,7 +31,7 @@ jobs:
         run: |
           docker buildx create --use --platform=linux/amd64,linux/arm64,linux/ppc64le --name multi-platform-builder
           docker buildx ls
-          GATEWAY_IMG=openkruise/sandbox-gateway:${{ github.ref_name }} make docker-buildx-sandbox-gateway
+          make docker-buildx-sandbox-gateway
       - name: Push the Docker image
         run: |
-          GATEWAY_IMG=openkruise/sandbox-gateway:${{ github.ref_name }} make docker-pushx-sandbox-gateway
+          make docker-pushx-sandbox-gateway

--- a/.github/workflows/docker-image-sandbox-manager.yml
+++ b/.github/workflows/docker-image-sandbox-manager.yml
@@ -11,15 +11,19 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      MANAGER_IMG: openkruise/sandbox-manager:${{ github.ref_name }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.HUB_KRUISE }}
@@ -27,7 +31,7 @@ jobs:
         run: |
           docker buildx create --use --platform=linux/amd64,linux/arm64,linux/ppc64le --name multi-platform-builder
           docker buildx ls
-          MANAGER_IMG=openkruise/sandbox-manager:${{ github.ref_name }} make docker-buildx-manager
+          make docker-buildx-manager
       - name: Push the Docker image
         run: |
-          MANAGER_IMG=openkruise/sandbox-manager:${{ github.ref_name }} make docker-pushx-manager
+          make docker-pushx-manager

--- a/.github/workflows/e2e-1.32.yaml
+++ b/.github/workflows/e2e-1.32.yaml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           submodules: true
       - name: Setup Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0

--- a/.github/workflows/e2e-e2b-2.24.0.yaml
+++ b/.github/workflows/e2e-e2b-2.24.0.yaml
@@ -38,6 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           submodules: true
       - name: Setup Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
@@ -52,7 +53,7 @@ jobs:
           version: ${{ env.KIND_VERSION }}
 
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/e2e-e2b-2.8.1.yaml
+++ b/.github/workflows/e2e-e2b-2.8.1.yaml
@@ -38,6 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           submodules: true
       - name: Setup Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0

--- a/.github/workflows/e2e-e2b-latest.yaml
+++ b/.github/workflows/e2e-e2b-latest.yaml
@@ -56,6 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           submodules: true
       - name: Setup Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
@@ -70,7 +71,7 @@ jobs:
           version: ${{ env.KIND_VERSION }}
 
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/e2e-e2b-mysql-latest.yaml
+++ b/.github/workflows/e2e-e2b-mysql-latest.yaml
@@ -42,6 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           submodules: true
       - name: Setup Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
@@ -56,7 +57,7 @@ jobs:
           version: ${{ env.KIND_VERSION }}
 
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/e2e-okactl.yaml
+++ b/.github/workflows/e2e-okactl.yaml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           submodules: true
       - name: Setup Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0

--- a/.github/workflows/e2e-sandbox-gateway-security.yaml
+++ b/.github/workflows/e2e-sandbox-gateway-security.yaml
@@ -58,6 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           submodules: true
       - name: Setup Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
@@ -72,7 +73,7 @@ jobs:
           version: ${{ env.KIND_VERSION }}
 
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/e2e-tracing.yaml
+++ b/.github/workflows/e2e-tracing.yaml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           submodules: true
       - name: Setup Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0

--- a/.github/workflows/e2e-upgrade-1.32.yaml
+++ b/.github/workflows/e2e-upgrade-1.32.yaml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           submodules: true
       - name: Setup Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -19,6 +19,8 @@ jobs:
     name: Check for unapproved licenses
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Hardens the GitHub Actions workflows against the zizmor and OpenSSF
Scorecard code-scanning alerts (follow-up to #918 which addressed the
Go-code alerts).

Changes across 16 workflow files:

- **Pin third-party actions to full commit SHAs** — replaces mutable
  `@v4` / `@main` / `@master` tags on `docker/setup-qemu-action`,
  `docker/setup-buildx-action`, `docker/login-action`,
  `jlumbroso/free-disk-space`, and `aquasecurity/trivy-action` with
  immutable 40-char SHAs plus a trailing `# tag` comment for
  readability. Mitigates `zizmor/unpinned-uses` and
  `zizmor/ref-version-mismatch`.
- **Add `persist-credentials: false`** to every `actions/checkout`
  step. Prevents `GITHUB_TOKEN` from leaking into the cached
  `.git/config` and addresses `zizmor/artipacked` and
  `zizmor/cache-poisoning`.
- **Defuse template injection** in the five `docker-image-*.yml`
  workflows by moving `github.ref_name` out of inline `run:` blocks
  into job-level `env:` and referencing it as a shell variable.
  Mitigates `zizmor/template-injection`.
- **Scope the Go module cache key by `github.ref`** in `ci.yaml` so
  PR caches cannot pollute the `master` cache. Mitigates
  `zizmor/cache-poisoning`.
- **Pin `trivy-action` to the v0.36.0 release SHA** (was tracking
  the moving `master` branch).
- **Rename codecov `file:` to `files:`** to use the documented key
  name for `codecov/codecov-action@v7`.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

1. Run `python3 -c 'import yaml, glob; [yaml.safe_load(open(f)) for f in glob.glob(".github/workflows/*.y*ml")]'`
   — every workflow parses cleanly.
2. Confirm that the pinned SHAs match the tags annotated on each
   action's repository (e.g.
   `docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a`
   is the commit tagged `v4`).
3. Check that `ghcr.io` / Docker Hub image builds still succeed on
   the `workflow_dispatch` docker-image workflows after merge.

### Ⅳ. Special notes for reviews

- `zizmor/adhoc-packages` in `license.yml` (the `gem install
  license_finder` step) is intentionally not fixed — installing a
  pinned gem at runtime is an acceptable pattern and fixing it
  requires a vendored image that is out of scope here.
- The `zizmor/cache-poisoning` alerts on the e2e workflows are not
  addressed because those workflows do not use `actions/cache` and
  rely on their own docker image caching; the alerts appear to be
  false positives.
- `permissions: read-all` at the workflow level in `ci.yaml` is
  already the most restrictive setting; the job-level
  `security-events: write` and `pull-requests: read` are required
  by `golangci-lint-action` and `trivy-action` respectively.
- OpenSSF Scorecard repo-level settings (branch protection,
  CII badge, etc.) are admin-only and cannot be addressed through
  code changes.
