### PR TITLE
fix(poolautoscaler): reject when policy cannot reach min replicas

### DIFF
--- a/docs/proposals/20260106-sandboxset-autoscaler.md
+++ b/docs/proposals/20260106-sandboxset-autoscaler.md
@@ -707,6 +707,52 @@ spec:
 - **Upper Watermark (Scale-Down Trigger)**: `Current Replicas × (70% + 10%) = Current Replicas × 80%` (rounded up)
 - **Dead Zone**: Between lower and upper watermarks, no scaling occurs
 
+**Scale-Down Reachability**: The webhook rejects a capacity policy that cannot
+guarantee an idle pool will scale down to `minReplicas`. It checks the final scale-down
+step: when the pool has one more replica than `minReplicas`, the upper watermark must be
+no greater than `minReplicas`. For example, when `minReplicas` is 1, the pool must be able
+to scale from 2 replicas to 1, so its upper watermark at 2 replicas must be at most 1.
+Formally, for a percentage target `p%` and percentage tolerance `q%` (including the default
+`10%`), the final scale-down step is reachable when
+`ceil((minReplicas + 1) × (p + q) / 100) ≤ minReplicas`, equivalently
+`p + q ≤ 100 × minReplicas / (minReplicas + 1)`. For an absolute target `T` and resolved
+absolute tolerance `D`, it is reachable when `T + D ≤ minReplicas`. A percentage target
+with an absolute tolerance is evaluated at `minReplicas + 1` replicas.
+The validation error reports the calculated upper watermark and the required maximum.
+Lower `targetAvailable` or `tolerance` to make that final scale-down step possible; use an
+absolute target with `tolerance: 0` when a fixed warm-pool size is required.
+
+**Configuration Examples**:
+
+| `minReplicas` | `targetAvailable` | `tolerance` | Final-step evaluation | Result |
+|---:|---|---|---|---|
+| 1 | `"40%"` | omitted (default `"10%"`) | At 2 replicas, upper watermark is 1 | Accepted; can scale from 2 to 1 |
+| 1 | `"50%"` | omitted (default `"10%"`) | At 2 replicas, upper watermark is 2 | Rejected; 2 is not above the upper watermark |
+| 1 | `1` | `0` | At 2 replicas, upper watermark is 1 | Accepted; preserves one idle Sandbox |
+| 1 | `1` | omitted (default `"10%"`) | At 2 replicas, upper watermark is 2 | Rejected; default tolerance rounds up to one |
+| 4 | `"70%"` | `"10%"` | At 5 replicas, upper watermark is 4 | Accepted; can scale from 5 to 4 |
+
+For example, this percentage policy can shrink to one replica:
+
+```yaml
+spec:
+  minReplicas: 1
+  maxReplicas: 50
+  capacityPolicy:
+    targetAvailable: "40%"
+```
+
+This policy is rejected because its default tolerance makes the upper watermark 2 when
+the pool has 2 replicas:
+
+```yaml
+spec:
+  minReplicas: 1
+  maxReplicas: 50
+  capacityPolicy:
+    targetAvailable: "50%"
+```
+
 **Empty-Pool Prevention**: For percentage-based `targetAvailable`, `minReplicas` must be at
 least 1 (enforced by webhook) to ensure the pool can bootstrap. The percentage base is the
 current observed pool size (`avgReplicas`). With `minReplicas >= 1`, the SandboxSet always has

--- a/pkg/webhook/poolautoscaler/validating/poolautoscaler_validate.go
+++ b/pkg/webhook/poolautoscaler/validating/poolautoscaler_validate.go
@@ -113,6 +113,7 @@ func validatePoolAutoscalerSpec(spec agentsv1alpha1.PoolAutoscalerSpec, fldPath 
 			errList = append(errList, field.Invalid(fldPath.Child("minReplicas"), spec.MinReplicas,
 				"percentage targetAvailable requires minReplicas >= 1 to prevent empty-pool deadlock"))
 		}
+		errList = append(errList, validateScaleDownReachability(spec, fldPath)...)
 	}
 
 	// An autoscaler without any scaling policy is a misconfiguration: bounds
@@ -198,6 +199,56 @@ func validateCapacityPolicy(policy *agentsv1alpha1.CapacityPolicy, maxReplicas i
 	}
 
 	return errList
+}
+
+// validateScaleDownReachability rejects a capacity policy that cannot scale an
+// idle pool through its final transition to minReplicas.
+func validateScaleDownReachability(spec agentsv1alpha1.PoolAutoscalerSpec, fldPath *field.Path) field.ErrorList {
+	if spec.CapacityPolicy == nil || spec.MinReplicas < 0 || spec.MinReplicas >= spec.MaxReplicas {
+		return nil
+	}
+
+	min := int64(spec.MinReplicas)
+	nextReplicaCount := min + 1
+	upperWatermark := capacityPolicyUpperWatermark(spec.CapacityPolicy, nextReplicaCount)
+	if upperWatermark <= min {
+		return nil
+	}
+
+	return field.ErrorList{field.Invalid(fldPath.Child("capacityPolicy"), "",
+		fmt.Sprintf("cannot scale down to minReplicas %d: with %d replicas, the upper watermark is %d but must be at most %d; please lower targetAvailable or tolerance", min, nextReplicaCount, upperWatermark, min))}
+}
+
+func capacityPolicyUpperWatermark(policy *agentsv1alpha1.CapacityPolicy, replicaCount int64) int64 {
+	target := policy.TargetAvailable
+	tolerance := intstr.FromString("10%")
+	if policy.Tolerance != nil {
+		tolerance = *policy.Tolerance
+	}
+
+	if target.Type == intstr.Int {
+		targetValue := int64(target.IntVal)
+		return targetValue + resolveWebhookTolerance(tolerance, targetValue)
+	}
+	if target.Type == intstr.String {
+		targetPercent := int64(parseWebhookPercent(target))
+		if tolerance.Type == intstr.String {
+			return ceilWebhookPercent(replicaCount, targetPercent+int64(parseWebhookPercent(tolerance)))
+		}
+		return ceilWebhookPercent(replicaCount, targetPercent) + int64(tolerance.IntVal)
+	}
+	return 0
+}
+
+func resolveWebhookTolerance(tolerance intstr.IntOrString, target int64) int64 {
+	if tolerance.Type == intstr.Int {
+		return int64(tolerance.IntVal)
+	}
+	return ceilWebhookPercent(target, int64(parseWebhookPercent(tolerance)))
+}
+
+func ceilWebhookPercent(value, percent int64) int64 {
+	return (value*percent + 99) / 100
 }
 
 // validateIntOrPercent validates an IntOrString value used as an absolute count

--- a/pkg/webhook/poolautoscaler/validating/poolautoscaler_validate_test.go
+++ b/pkg/webhook/poolautoscaler/validating/poolautoscaler_validate_test.go
@@ -52,7 +52,7 @@ func TestValidatePoolAutoscalerSpec(t *testing.T) {
 				MaxReplicas: 50,
 				MinReplicas: 5,
 				CapacityPolicy: &agentsv1alpha1.CapacityPolicy{
-					TargetAvailable: intstr.FromInt32(10),
+					TargetAvailable: intstr.FromInt32(4),
 				},
 			},
 			expectError: "",
@@ -149,11 +149,12 @@ func TestValidatePoolAutoscalerSpec(t *testing.T) {
 					Name: "my-pool",
 				},
 				MaxReplicas: 50,
+				MinReplicas: 10,
 				CronPolicies: []agentsv1alpha1.CronScalingPolicy{
 					{Name: "up", Schedule: "0 8 * * *", TargetReplicas: 20},
 				},
 				CapacityPolicy: &agentsv1alpha1.CapacityPolicy{
-					TargetAvailable: intstr.FromInt32(10),
+					TargetAvailable: intstr.FromInt32(9),
 				},
 			},
 			expectError: "",
@@ -260,6 +261,7 @@ func TestValidatePoolAutoscalerSpec(t *testing.T) {
 					Name: "my-pool",
 				},
 				MaxReplicas: 50,
+				MinReplicas: 11,
 				CapacityPolicy: &agentsv1alpha1.CapacityPolicy{
 					TargetAvailable: intstr.FromInt32(10),
 					ScaleUp: &agentsv1alpha1.CapacityScalingRules{
@@ -280,6 +282,7 @@ func TestValidatePoolAutoscalerSpec(t *testing.T) {
 					Name: "my-pool",
 				},
 				MaxReplicas: 50,
+				MinReplicas: 11,
 				CapacityPolicy: &agentsv1alpha1.CapacityPolicy{
 					TargetAvailable: intstr.FromInt32(10),
 					ScaleUp: &agentsv1alpha1.CapacityScalingRules{
@@ -337,6 +340,7 @@ func TestValidatePoolAutoscalerSpec(t *testing.T) {
 					Name: "my-pool",
 				},
 				MaxReplicas: 10,
+				MinReplicas: 10,
 				CapacityPolicy: &agentsv1alpha1.CapacityPolicy{
 					TargetAvailable: intstr.FromInt32(10),
 				},
@@ -351,7 +355,7 @@ func TestValidatePoolAutoscalerSpec(t *testing.T) {
 					Name: "my-pool",
 				},
 				MaxReplicas: 10,
-				MinReplicas: 1,
+				MinReplicas: 4,
 				CapacityPolicy: &agentsv1alpha1.CapacityPolicy{
 					TargetAvailable: intstr.FromString("70%"),
 				},
@@ -383,7 +387,7 @@ func TestValidatePoolAutoscalerSpec(t *testing.T) {
 				MaxReplicas: 10,
 				MinReplicas: 1,
 				CapacityPolicy: &agentsv1alpha1.CapacityPolicy{
-					TargetAvailable: intstr.FromString("50%"),
+					TargetAvailable: intstr.FromString("40%"),
 				},
 			},
 			expectError: "",
@@ -398,7 +402,7 @@ func TestValidatePoolAutoscalerSpec(t *testing.T) {
 				MaxReplicas: 10,
 				MinReplicas: 0,
 				CapacityPolicy: &agentsv1alpha1.CapacityPolicy{
-					TargetAvailable: intstr.FromInt32(5),
+					TargetAvailable: intstr.FromInt32(0),
 				},
 			},
 			expectError: "",
@@ -486,6 +490,7 @@ func TestValidatePoolAutoscalerSpec(t *testing.T) {
 					Name: "my-pool",
 				},
 				MaxReplicas: 50,
+				MinReplicas: 15,
 				CapacityPolicy: &agentsv1alpha1.CapacityPolicy{
 					TargetAvailable: intstr.FromInt32(10),
 					Tolerance:       intOrStrPtr(intstr.FromString("50%")),
@@ -494,14 +499,14 @@ func TestValidatePoolAutoscalerSpec(t *testing.T) {
 			expectError: "",
 		},
 		{
-			name: "percentage target with absolute tolerance - not statically rejected",
+			name: "percentage target with absolute tolerance - valid when the final scale-down is reachable",
 			spec: agentsv1alpha1.PoolAutoscalerSpec{
 				ScaleTargetRef: agentsv1alpha1.CrossVersionObjectReference{
 					Kind: "SandboxSet",
 					Name: "my-pool",
 				},
 				MaxReplicas: 50,
-				MinReplicas: 1,
+				MinReplicas: 15,
 				CapacityPolicy: &agentsv1alpha1.CapacityPolicy{
 					TargetAvailable: intstr.FromString("30%"),
 					Tolerance:       intOrStrPtr(intstr.FromInt32(10)),
@@ -517,7 +522,7 @@ func TestValidatePoolAutoscalerSpec(t *testing.T) {
 					Name: "my-pool",
 				},
 				MaxReplicas: 50,
-				MinReplicas: 1,
+				MinReplicas: 4,
 				CapacityPolicy: &agentsv1alpha1.CapacityPolicy{
 					TargetAvailable: intstr.FromString("70%"),
 					Tolerance:       intOrStrPtr(intstr.FromString("10%")),
@@ -651,19 +656,25 @@ func TestHandle(t *testing.T) {
 	_ = clientgoscheme.AddToScheme(scheme)
 	decoder := admission.NewDecoder(scheme)
 
-	validPA := &agentsv1alpha1.PoolAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-pa", Namespace: "default"},
-		Spec: agentsv1alpha1.PoolAutoscalerSpec{
-			ScaleTargetRef: agentsv1alpha1.CrossVersionObjectReference{
-				Kind: "SandboxSet",
-				Name: "test-sbs",
+	newPoolAutoscaler := func(target intstr.IntOrString, tolerance *intstr.IntOrString, minReplicas, maxReplicas int32) *agentsv1alpha1.PoolAutoscaler {
+		return &agentsv1alpha1.PoolAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pa", Namespace: "default"},
+			Spec: agentsv1alpha1.PoolAutoscalerSpec{
+				ScaleTargetRef: agentsv1alpha1.CrossVersionObjectReference{
+					Kind: "SandboxSet",
+					Name: "test-sbs",
+				},
+				MinReplicas: minReplicas,
+				MaxReplicas: maxReplicas,
+				CapacityPolicy: &agentsv1alpha1.CapacityPolicy{
+					TargetAvailable: target,
+					Tolerance:       tolerance,
+				},
 			},
-			MaxReplicas: 50,
-			CapacityPolicy: &agentsv1alpha1.CapacityPolicy{
-				TargetAvailable: intstr.FromInt32(10),
-			},
-		},
+		}
 	}
+
+	validPA := newPoolAutoscaler(intstr.FromInt32(1), intOrStrPtr(intstr.FromInt32(0)), 1, 50)
 
 	invalidPA := &agentsv1alpha1.PoolAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pa", Namespace: "default"},
@@ -682,10 +693,54 @@ func TestHandle(t *testing.T) {
 		rawBytes      []byte // if non-nil, use these raw bytes instead of encoding pa
 		expectAllowed bool
 		expectCode    int32 // 0 means do not check
+		expectMessage string
 	}{
 		{
-			name:          "valid PoolAutoscaler - allowed",
+			name:          "valid PoolAutoscaler - allowed without warning",
 			pa:            validPA,
+			expectAllowed: true,
+		},
+		{
+			name:          "percentage target 100 - denied because final scale-down is unreachable",
+			pa:            newPoolAutoscaler(intstr.FromString("100%"), nil, 1, 50),
+			expectAllowed: false,
+			expectCode:    422,
+			expectMessage: "with 2 replicas, the upper watermark is 3 but must be at most 1",
+		},
+		{
+			name:          "percentage target 99 - denied because final scale-down is unreachable",
+			pa:            newPoolAutoscaler(intstr.FromString("99%"), nil, 1, 50),
+			expectAllowed: false,
+			expectCode:    422,
+			expectMessage: "with 2 replicas, the upper watermark is 3 but must be at most 1",
+		},
+		{
+			name:          "percentage target 40 with tolerance 10 - allowed without warning",
+			pa:            newPoolAutoscaler(intstr.FromString("40%"), intOrStrPtr(intstr.FromString("10%")), 1, 50),
+			expectAllowed: true,
+		},
+		{
+			name:          "absolute target 1 with default tolerance - denied because final scale-down is unreachable",
+			pa:            newPoolAutoscaler(intstr.FromInt32(1), nil, 1, 50),
+			expectAllowed: false,
+			expectCode:    422,
+			expectMessage: "with 2 replicas, the upper watermark is 2 but must be at most 1",
+		},
+		{
+			name:          "percentage target with absolute tolerance - allowed without warning",
+			pa:            newPoolAutoscaler(intstr.FromString("50%"), intOrStrPtr(intstr.FromInt32(0)), 1, 50),
+			expectAllowed: true,
+		},
+		{
+			name:          "percentage target with absolute tolerance - denied because final scale-down is unreachable",
+			pa:            newPoolAutoscaler(intstr.FromString("50%"), intOrStrPtr(intstr.FromInt32(1)), 1, 50),
+			expectAllowed: false,
+			expectCode:    422,
+			expectMessage: "with 2 replicas, the upper watermark is 2 but must be at most 1",
+		},
+		{
+			name:          "fixed pool - allowed without warning",
+			pa:            newPoolAutoscaler(intstr.FromString("100%"), nil, 5, 5),
 			expectAllowed: true,
 		},
 		{
@@ -729,9 +784,14 @@ func TestHandle(t *testing.T) {
 
 			resp := h.Handle(context.Background(), req)
 			assert.Equal(t, tt.expectAllowed, resp.Allowed)
+			assert.Empty(t, resp.Warnings)
 			if tt.expectCode != 0 {
 				require.NotNil(t, resp.Result)
 				assert.Equal(t, tt.expectCode, resp.Result.Code)
+			}
+			if tt.expectMessage != "" {
+				require.NotNil(t, resp.Result)
+				assert.Contains(t, resp.Result.Message, tt.expectMessage)
 			}
 		})
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Rejects (HTTP 422) PoolAutoscaler capacity policies that cannot scale an idle pool down to `minReplicas`, instead of only returning an admission warning that users may never see.

The check evaluates the upper watermark at `minReplicas + 1` replicas with the same rounding and default-tolerance semantics as the controller, so validation matches runtime behavior.

The error message explains the final scale-down step concretely instead of exposing the percentage formula:

```
cannot scale down to minReplicas 1: with 2 replicas, the upper watermark is 3 but must be at most 1; please lower targetAvailable or tolerance
```

Also updates the proposal with the plain-language rule, the equivalent formulas, and accepted/rejected configuration examples.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

```bash
go test -mod=readonly ./pkg/webhook/poolautoscaler/validating -count=1
```

- `targetAvailable: "100%"` / `"99%"` with `minReplicas: 1` are rejected with 422.
- `targetAvailable: "40%"` (default tolerance) with `minReplicas: 1` is accepted.
- `targetAvailable: 1` with `tolerance: 0` is accepted.
- The rejection message reports the calculated upper watermark and the required maximum.

### Ⅳ. Special notes for reviews

- **Behavior change**: previously these configurations only produced an admission warning; they are now rejected on create/update (`failurePolicy=fail`). Existing PoolAutoscalers with such policies must be corrected before their next update.
- The webhook reuses the controller's watermark semantics (combine percentages before rounding up, default tolerance `10%`), keeping validation and runtime consistent.
- No API schema, controller watermark, or cooldown changes.
