### PR TITLE
[Bug]: distinguish unsupported sandbox in-place resize

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -607,9 +607,10 @@ const (
 	SandboxReadyReasonPodCreateFailed      = "PodCreateFailed"
 
 	// SandboxConditionInplaceUpdate Reason
-	SandboxInplaceUpdateReasonInplaceUpdating = "InplaceUpdating"
-	SandboxInplaceUpdateReasonSucceeded       = "Succeeded"
-	SandboxInplaceUpdateReasonFailed          = "Failed"
+	SandboxInplaceUpdateReasonInplaceUpdating   = "InplaceUpdating"
+	SandboxInplaceUpdateReasonSucceeded         = "Succeeded"
+	SandboxInplaceUpdateReasonFailed            = "Failed"
+	SandboxInplaceUpdateReasonUnsupportedResize = "UnsupportedResize"
 
 	// SandboxConditionUpgrading Reason
 	SandboxUpgradingReasonResuming         = "Resuming"

--- a/pkg/cache/tasks_test.go
+++ b/pkg/cache/tasks_test.go
@@ -147,6 +147,34 @@ func TestNewSandboxWaitReadyTask_StartContainerFailed_ReturnsError(t *testing.T)
 	assert.Contains(t, err.Error(), "start container failed")
 }
 
+func TestNewSandboxWaitReadyTask_UnsupportedResize_ReturnsReadyWhenSandboxUsable(t *testing.T) {
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sbx-wait-3", Generation: 1},
+		Status: agentsv1alpha1.SandboxStatus{
+			ObservedGeneration: 1,
+			Phase:              agentsv1alpha1.SandboxRunning,
+			PodInfo:            agentsv1alpha1.PodInfo{PodIP: "10.0.0.3"},
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(agentsv1alpha1.SandboxConditionReady),
+					Status: metav1.ConditionTrue,
+					Reason: agentsv1alpha1.SandboxReadyReasonPodReady,
+				},
+				{
+					Type:    string(agentsv1alpha1.SandboxConditionInplaceUpdate),
+					Status:  metav1.ConditionFalse,
+					Reason:  agentsv1alpha1.SandboxInplaceUpdateReasonUnsupportedResize,
+					Message: "in-place pod resize not supported",
+				},
+			},
+		},
+	}
+	c, _, err := cachetest.NewTestCache(t, sbx)
+	require.NoError(t, err)
+	task := c.NewSandboxWaitReadyTask(context.Background(), sbx)
+	assert.NoError(t, task.Wait(100*time.Millisecond))
+}
+
 func TestNewCheckpointTask_Succeeded(t *testing.T) {
 	cp := &agentsv1alpha1.Checkpoint{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cp-1"},

--- a/pkg/controller/sandbox/core/common_inplace_update_handler.go
+++ b/pkg/controller/sandbox/core/common_inplace_update_handler.go
@@ -225,10 +225,15 @@ func handleInPlaceUpdateCommon(
 	if err != nil {
 		msg := err.Error()
 		handler.GetRecorder().Eventf(box, corev1.EventTypeWarning, "InplaceUpdateFailed", msg)
+		reason := agentsv1alpha1.SandboxInplaceUpdateReasonFailed
+		var resizeErr *inplaceupdate.ResizeNotSupportedError
+		if errors.As(err, &resizeErr) {
+			reason = agentsv1alpha1.SandboxInplaceUpdateReasonUnsupportedResize
+		}
 		utils.SetSandboxCondition(newStatus, metav1.Condition{
 			Type:   string(agentsv1alpha1.SandboxConditionInplaceUpdate),
 			Status: metav1.ConditionFalse,
-			Reason: agentsv1alpha1.SandboxInplaceUpdateReasonFailed,
+			Reason: reason,
 			// We need truncate msg here, K8s API errors can embed full PodSpec diffs that are too verbose for conditions.
 			Message:            utils.TruncateConditionMessage(msg),
 			LastTransitionTime: metav1.Now(),
@@ -237,7 +242,6 @@ func handleInPlaceUpdateCommon(
 		// (K8s 1.33+) and the direct spec patch fallback (K8s 1.27-1.32) fail,
 		// which typically means InPlacePodVerticalScaling is not enabled.
 		// so we need treat this as terminal.
-		var resizeErr *inplaceupdate.ResizeNotSupportedError
 		if errors.As(err, &resizeErr) {
 			return true, nil
 		}
@@ -295,6 +299,7 @@ func isInplaceUpdateTerminal(newStatus *agentsv1alpha1.SandboxStatus) bool {
 	}
 	switch cond.Reason {
 	case agentsv1alpha1.SandboxInplaceUpdateReasonFailed,
+		agentsv1alpha1.SandboxInplaceUpdateReasonUnsupportedResize,
 		agentsv1alpha1.SandboxInplaceUpdateReasonSucceeded:
 		return true
 	}

--- a/pkg/controller/sandbox/core/common_inplace_update_handler_test.go
+++ b/pkg/controller/sandbox/core/common_inplace_update_handler_test.go
@@ -23,13 +23,16 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
@@ -568,6 +571,98 @@ func TestHandleInPlaceUpdateCommon_MemoryDownscaleSkippedAdvisory(t *testing.T) 
 	}
 }
 
+func TestHandleInPlaceUpdateCommon_UnsupportedResizeReason(t *testing.T) {
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = agentsv1alpha1.AddToScheme(scheme)
+
+	oldPodSpec := corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:  "main",
+			Image: "nginx:old",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
+				Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
+			},
+		}},
+	}
+	newPodSpec := corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:  "main",
+			Image: "nginx:old",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+				Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+			},
+		}},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				agentsv1alpha1.PodLabelTemplateHash: "old-revision",
+			},
+		},
+		Spec: oldPodSpec,
+	}
+	box := buildMatchingHashBox("test-sandbox", "default", newPodSpec)
+
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	wrapped := interceptor.NewClient(base, interceptor.Funcs{
+		SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object,
+			patch client.Patch, opts ...client.SubResourcePatchOption) error {
+			if sub == "resize" {
+				return apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, obj.GetName())
+			}
+			return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
+		},
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch,
+			opts ...client.PatchOption) error {
+			data, _ := patch.Data(obj)
+			if !strings.Contains(string(data), `"metadata"`) {
+				return apierrors.NewBadRequest("InPlacePodVerticalScaling feature gate disabled")
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	})
+
+	newStatus := &agentsv1alpha1.SandboxStatus{UpdateRevision: "new-revision"}
+	handler := &MockInPlaceUpdateHandler{
+		control:  inplaceupdate.NewInPlaceUpdateControl(wrapped, inplaceupdate.DefaultGeneratePatchBodyFunc),
+		recorder: createTestRecorder(),
+		logger:   logr.Discard(),
+	}
+
+	result, err := handleInPlaceUpdateCommon(ctx, handler, pod, box, newStatus)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !result {
+		t.Fatal("Expected result true (unsupported resize is terminal), got false")
+	}
+
+	var cond *metav1.Condition
+	for i := range newStatus.Conditions {
+		if newStatus.Conditions[i].Type == string(agentsv1alpha1.SandboxConditionInplaceUpdate) {
+			cond = &newStatus.Conditions[i]
+			break
+		}
+	}
+	if cond == nil {
+		t.Fatal("InplaceUpdate condition not found in status")
+	}
+	if cond.Reason != agentsv1alpha1.SandboxInplaceUpdateReasonUnsupportedResize {
+		t.Errorf("Expected reason %s, got %s", agentsv1alpha1.SandboxInplaceUpdateReasonUnsupportedResize, cond.Reason)
+	}
+	if !strings.Contains(cond.Message, "in-place pod resize not supported") {
+		t.Errorf("Expected unsupported resize message, got %q", cond.Message)
+	}
+}
+
 func TestHandleInPlaceUpdateCommon_ResizeInfeasibleFailFast(t *testing.T) {
 	ctx := context.Background()
 
@@ -741,7 +836,7 @@ func TestHandleInPlaceUpdateCommon_TerminalFailureNotOverwritten(t *testing.T) {
 			{
 				Type:    string(agentsv1alpha1.SandboxConditionInplaceUpdate),
 				Status:  metav1.ConditionFalse,
-				Reason:  agentsv1alpha1.SandboxInplaceUpdateReasonFailed,
+				Reason:  agentsv1alpha1.SandboxInplaceUpdateReasonUnsupportedResize,
 				Message: "in-place pod resize not supported: the server could not find the requested resource",
 			},
 		},
@@ -764,8 +859,8 @@ func TestHandleInPlaceUpdateCommon_TerminalFailureNotOverwritten(t *testing.T) {
 
 	for _, cond := range newStatus.Conditions {
 		if cond.Type == string(agentsv1alpha1.SandboxConditionInplaceUpdate) {
-			if cond.Reason != agentsv1alpha1.SandboxInplaceUpdateReasonFailed {
-				t.Errorf("Expected InplaceUpdate condition to remain Failed, got %s", cond.Reason)
+			if cond.Reason != agentsv1alpha1.SandboxInplaceUpdateReasonUnsupportedResize {
+				t.Errorf("Expected InplaceUpdate condition to remain UnsupportedResize, got %s", cond.Reason)
 			}
 			return
 		}


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

This PR refines Sandbox in-place resource resize failure reporting for clusters where the Pod resize path is not supported.

Before this change, a resize capability mismatch was reported with the same generic condition reason used by other in-place update failures:

```text
InplaceUpdate=False
Reason=Failed
Message=in-place pod resize not supported
```

That message is visible to operators, but the reason is not machine-readable enough to distinguish an unsupported cluster/runtime resize path from other generic in-place update failures.

This PR adds one structured `InplaceUpdate` reason:

- `UnsupportedResize`: the cluster/runtime resize path is not supported.

Other terminal resource resize failures, such as kubelet reporting an infeasible resize after the Pod has moved to the target revision, continue to use the existing `Failed` reason.

The claim wait-ready behavior intentionally remains compatibility-preserving. `NewSandboxWaitReadyTask` only waits while the Sandbox reports `InplaceUpdating`; terminal in-place update failure reasons, including `UnsupportedResize`, fall through to the existing usable-Sandbox readiness check. As a result, this PR improves status classification without changing the current best-effort claim semantics.

Broader API semantics, such as a future `spec.inplaceUpdate.failurePolicy` with `BestEffort`, `Fail`, or `CreateNew`, are tracked in #934 and should be designed separately.

### Ⅱ. Does this pull request fix one issue?

Related to #934

### Ⅲ. Describe how to verify it

```bash
go test ./api/v1alpha1 -count=1
go test ./pkg/cache -run 'TestNewSandboxWaitReadyTask|TestCache_CountActiveSandboxes' -count=1
go test ./pkg/controller/sandbox/core -run 'TestHandleInPlaceUpdateCommon|TestIsInplaceUpdateTerminal' -count=1
go test ./pkg/controller/sandboxclaim/core -run 'Test.*Claim|Test.*Inplace|Test.*buildClaimOptions' -count=1
make generate manifests
```

### Ⅳ. Special notes for reviews

This PR does not introduce a fallback policy and does not make `UnsupportedResize` directly control SandboxClaim success. It only makes the unsupported resize path explicit while preserving the existing best-effort claim behavior.
