### PR TITLE
refactor(controller): generalize Pod status synchronization

### DIFF
--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -73,16 +73,7 @@ type commonControl struct {
 	initializer          SandboxInitializer
 	recycleControl       *SandboxRecycleControl
 	upgradeControl       *UpgradeControl
-	syncStatusFromPod    func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, options podStatusSyncOptions)
-}
-
-// podStatusSyncOptions controls which parts of a Pod status are synchronized
-// and optionally carries a backend-specific Pending failure projection.
-type podStatusSyncOptions struct {
-	SyncPodInfo            bool
-	SyncReadyCondition     bool
-	PendingReadyCondition  *metav1.Condition
-	OwnsPendingReadyReason func(string) bool
+	syncStatusFromPod    func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool)
 }
 
 // ResumeFunc resumes a paused sandbox: creates the pod if missing and sets
@@ -112,7 +103,9 @@ func NewCommonControl(args SandboxControlArgs) SandboxControl {
 		lifecycleHookFunc:    lifecycleHookFunc,
 		initializer:          initializer,
 		recycleControl:       NewSandboxRecycleControl(args.Client, args.Recorder, args.RecycleConfig),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
+		syncStatusFromPod: func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool) {
+			defaultSyncStatusFromPod(pod, newStatus, syncReadyCondition, classifyStartupFailure)
+		},
 	}
 	control.upgradeControl = NewUpgradeControl(args.Client, args.CheckpointControl, args.PodControl, args.Recorder, lifecycleHookFunc, initializer, control.syncStatusFromPod, control.handleResume)
 	return control
@@ -147,10 +140,9 @@ func (r *commonControl) EnsureSandboxRunning(ctx context.Context, args EnsureFun
 		return 0, nil
 	}
 
-	// pod status running
+	r.syncStatusFromPod(pod, newStatus, true)
 	if pod.Status.Phase == corev1.PodRunning {
 		newStatus.Phase = agentsv1alpha1.SandboxRunning
-		r.syncStatusFromPod(pod, newStatus, podStatusSyncOptions{SyncPodInfo: true, SyncReadyCondition: true})
 		return 0, nil
 	}
 
@@ -207,40 +199,40 @@ func (r *commonControl) EnsureSandboxUpdated(ctx context.Context, args EnsureFun
 		return err
 	}
 
-	r.syncStatusFromPod(pod, newStatus, podStatusSyncOptions{SyncPodInfo: true, SyncReadyCondition: true})
+	r.syncStatusFromPod(pod, newStatus, true)
 	return nil
 }
 
 // defaultSyncStatusFromPod is the default implementation of syncStatusFromPod.
-// It applies an optional Pending failure projection before synchronizing the
-// requested Pod fields and Ready condition.
-func defaultSyncStatusFromPod(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, options podStatusSyncOptions) {
-	if options.PendingReadyCondition != nil {
-		utils.SetSandboxCondition(newStatus, *options.PendingReadyCondition)
-		return
+// It synchronizes Pod identity and, when requested, normalizes Ready failures
+// through the controller-specific startup failure normalizer.
+func defaultSyncStatusFromPod(
+	pod *corev1.Pod,
+	newStatus *agentsv1alpha1.SandboxStatus,
+	syncReadyCondition bool,
+	normalizePodStartupFailure func(*corev1.Pod) (reason, message string, failed bool),
+) {
+	newStatus.NodeName = pod.Spec.NodeName
+	newStatus.SandboxIp = pod.Status.PodIP
+	newStatus.PodInfo = agentsv1alpha1.PodInfo{
+		PodIP:    pod.Status.PodIP,
+		NodeName: pod.Spec.NodeName,
+		PodUID:   pod.UID,
 	}
-	// if no pending condition, need to clear
-	condition := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady))
-	if condition != nil && condition.Status == metav1.ConditionFalse &&
-		options.OwnsPendingReadyReason != nil && options.OwnsPendingReadyReason(condition.Reason) {
-		condition.Reason = agentsv1alpha1.SandboxReadyReasonPodReady
-		condition.Message = ""
-		utils.SetSandboxCondition(newStatus, *condition)
-	}
-	if options.SyncPodInfo {
-		newStatus.NodeName = pod.Spec.NodeName
-		newStatus.SandboxIp = pod.Status.PodIP
-		newStatus.PodInfo = agentsv1alpha1.PodInfo{
-			PodIP:    pod.Status.PodIP,
-			NodeName: pod.Spec.NodeName,
-			PodUID:   pod.UID,
-		}
-	}
-	if !options.SyncReadyCondition {
+	if !syncReadyCondition {
 		return
 	}
 	pCond := utils.GetPodCondition(&pod.Status, corev1.PodReady)
 	cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady))
+	reason, message, failed := "", "", false
+	if normalizePodStartupFailure != nil {
+		reason, message, failed = normalizePodStartupFailure(pod)
+	}
+	// Keep ordinary Pending Pods condition-free. Unclassified startup delays
+	// remain governed by the SandboxSet ResourcePending timeout.
+	if cond == nil && pCond == nil && !failed {
+		return
+	}
 	if cond == nil {
 		cond = &metav1.Condition{
 			Type:               string(agentsv1alpha1.SandboxConditionReady),
@@ -257,23 +249,19 @@ func defaultSyncStatusFromPod(pod *corev1.Pod, newStatus *agentsv1alpha1.Sandbox
 			cond.Reason = agentsv1alpha1.SandboxReadyReasonPodReady
 			cond.Message = ""
 		} else {
-			// Still not Ready: keep any previously recorded Reason so we do
-			// not erase a classification that has not been superseded. Sync
-			// the latest kubelet-level message for operator visibility, and
-			// classifyStartupFailure below may overwrite Reason if it now
-			// matches a definitive failure.
+			// Preserve non-startup failure reasons until they are superseded by
+			// the normalizer or the Pod becomes Ready.
 			cond.Message = pCond.Message
 		}
 	}
-	// Only classify explicit container startup failures. Other Waiting reasons
-	// are left to kubelet retries and the SandboxSet ResourcePending timeout.
-	// A previously recorded failure reason is kept until the Ready status
-	// flips to True (handled above), so we do not erase the classification
-	// speculatively while the pod is still not Ready.
 	if cond.Status == metav1.ConditionFalse {
-		if reason, message, failed := classifyStartupFailure(pod); failed {
+		if failed {
 			cond.Reason = reason
 			cond.Message = message
+		} else if cond.Reason == agentsv1alpha1.SandboxReadyReasonStartContainerFailed {
+			// Only the normalizer-owned startup failure is cleared on recovery.
+			cond.Reason = agentsv1alpha1.SandboxReadyReasonPodReady
+			cond.Message = ""
 		}
 	}
 	utils.SetSandboxCondition(newStatus, *cond)
@@ -292,7 +280,7 @@ func (r *commonControl) EnsureSandboxResumed(ctx context.Context, args EnsureFun
 	resumedCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionResumed))
 	if pod != nil && resumedCond != nil && resumedCond.Status == metav1.ConditionTrue {
 		newStatus.Phase = agentsv1alpha1.SandboxRunning
-		r.syncStatusFromPod(pod, newStatus, podStatusSyncOptions{SyncPodInfo: true})
+		r.syncStatusFromPod(pod, newStatus, false)
 	}
 	return nil
 }

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -73,7 +73,16 @@ type commonControl struct {
 	initializer          SandboxInitializer
 	recycleControl       *SandboxRecycleControl
 	upgradeControl       *UpgradeControl
-	syncStatusFromPod    func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool)
+	syncStatusFromPod    func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, options podStatusSyncOptions)
+}
+
+// podStatusSyncOptions controls which parts of a Pod status are synchronized
+// and optionally carries a backend-specific Pending failure projection.
+type podStatusSyncOptions struct {
+	SyncPodInfo            bool
+	SyncReadyCondition     bool
+	PendingReadyCondition  *metav1.Condition
+	OwnsPendingReadyReason func(string) bool
 }
 
 // ResumeFunc resumes a paused sandbox: creates the pod if missing and sets
@@ -141,7 +150,7 @@ func (r *commonControl) EnsureSandboxRunning(ctx context.Context, args EnsureFun
 	// pod status running
 	if pod.Status.Phase == corev1.PodRunning {
 		newStatus.Phase = agentsv1alpha1.SandboxRunning
-		r.syncStatusFromPod(pod, newStatus, true)
+		r.syncStatusFromPod(pod, newStatus, podStatusSyncOptions{SyncPodInfo: true, SyncReadyCondition: true})
 		return 0, nil
 	}
 
@@ -198,22 +207,36 @@ func (r *commonControl) EnsureSandboxUpdated(ctx context.Context, args EnsureFun
 		return err
 	}
 
-	r.syncStatusFromPod(pod, newStatus, true)
+	r.syncStatusFromPod(pod, newStatus, podStatusSyncOptions{SyncPodInfo: true, SyncReadyCondition: true})
 	return nil
 }
 
 // defaultSyncStatusFromPod is the default implementation of syncStatusFromPod.
-// It syncs sandbox status from pod info and, when syncReadyCondition is true, also
-// syncs the Ready condition and detects container startup failures.
-func defaultSyncStatusFromPod(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool) {
-	newStatus.NodeName = pod.Spec.NodeName
-	newStatus.SandboxIp = pod.Status.PodIP
-	newStatus.PodInfo = agentsv1alpha1.PodInfo{
-		PodIP:    pod.Status.PodIP,
-		NodeName: pod.Spec.NodeName,
-		PodUID:   pod.UID,
+// It applies an optional Pending failure projection before synchronizing the
+// requested Pod fields and Ready condition.
+func defaultSyncStatusFromPod(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, options podStatusSyncOptions) {
+	if options.PendingReadyCondition != nil {
+		utils.SetSandboxCondition(newStatus, *options.PendingReadyCondition)
+		return
 	}
-	if !syncReadyCondition {
+	// if no pending condition, need to clear
+	condition := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady))
+	if condition != nil && condition.Status == metav1.ConditionFalse &&
+		options.OwnsPendingReadyReason != nil && options.OwnsPendingReadyReason(condition.Reason) {
+		condition.Reason = agentsv1alpha1.SandboxReadyReasonPodReady
+		condition.Message = ""
+		utils.SetSandboxCondition(newStatus, *condition)
+	}
+	if options.SyncPodInfo {
+		newStatus.NodeName = pod.Spec.NodeName
+		newStatus.SandboxIp = pod.Status.PodIP
+		newStatus.PodInfo = agentsv1alpha1.PodInfo{
+			PodIP:    pod.Status.PodIP,
+			NodeName: pod.Spec.NodeName,
+			PodUID:   pod.UID,
+		}
+	}
+	if !options.SyncReadyCondition {
 		return
 	}
 	pCond := utils.GetPodCondition(&pod.Status, corev1.PodReady)
@@ -269,7 +292,7 @@ func (r *commonControl) EnsureSandboxResumed(ctx context.Context, args EnsureFun
 	resumedCond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionResumed))
 	if pod != nil && resumedCond != nil && resumedCond.Status == metav1.ConditionTrue {
 		newStatus.Phase = agentsv1alpha1.SandboxRunning
-		r.syncStatusFromPod(pod, newStatus, false)
+		r.syncStatusFromPod(pod, newStatus, podStatusSyncOptions{SyncPodInfo: true})
 	}
 	return nil
 }

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -42,6 +42,10 @@ import (
 	"github.com/openkruise/agents/pkg/utils/sidecarutils"
 )
 
+func defaultCommonSyncStatusFromPod(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool) {
+	defaultSyncStatusFromPod(pod, newStatus, syncReadyCondition, classifyStartupFailure)
+}
+
 func TestCommonControl_EnsureSandboxRunning(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
@@ -331,7 +335,7 @@ func TestCommonControl_EnsureSandboxRunning(t *testing.T) {
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				rateLimiter:          rl,
 				podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-				syncStatusFromPod:    defaultSyncStatusFromPod,
+				syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 			}
 
 			requeue, err := control.EnsureSandboxRunning(context.TODO(), tt.args)
@@ -526,7 +530,7 @@ func TestCommonControl_EnsureSandboxUpdated(t *testing.T) {
 				recorder:             record.NewFakeRecorder(10),
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fc, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-				syncStatusFromPod:    defaultSyncStatusFromPod,
+				syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 			}
 
 			err := control.EnsureSandboxUpdated(context.TODO(), tt.args)
@@ -721,7 +725,7 @@ func TestCommonControl_EnsureSandboxUpdated_InitializePath(t *testing.T) {
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fc, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				initializer:          tt.initializer,
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-				syncStatusFromPod:    defaultSyncStatusFromPod,
+				syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 			}
 
 			newStatus := &agentsv1alpha1.SandboxStatus{
@@ -957,7 +961,7 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 				recorder:             record.NewFakeRecorder(10),
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fc, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-				syncStatusFromPod:    defaultSyncStatusFromPod,
+				syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 				checkpointControl:    NewCheckpointControl(fc, record.NewFakeRecorder(10)),
 			}
 
@@ -1420,7 +1424,7 @@ func TestCommonControl_EnsureSandboxResumed(t *testing.T) {
 				initializer:          init,
 				checkpointControl:    NewCheckpointControl(fc, record.NewFakeRecorder(10)),
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-				syncStatusFromPod:    defaultSyncStatusFromPod,
+				syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 			}
 
 			err := control.EnsureSandboxResumed(context.TODO(), tt.args)
@@ -1547,7 +1551,7 @@ func TestCommonControl_EnsureSandboxTerminated(t *testing.T) {
 				recorder:             record.NewFakeRecorder(10),
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fc, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-				syncStatusFromPod:    defaultSyncStatusFromPod,
+				syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 			}
 
 			err := control.EnsureSandboxTerminated(context.TODO(), tt.args)
@@ -2427,7 +2431,7 @@ func TestCommonControl_EnsureSandboxUpdated_InplaceNotDone(t *testing.T) {
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
+		syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2475,7 +2479,7 @@ func TestCommonControl_EnsureSandboxResumed_TerminatingPod(t *testing.T) {
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
+		syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2517,7 +2521,7 @@ func TestCommonControl_EnsureSandboxResumed_SetResumedCondition(t *testing.T) {
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
+		syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2569,7 +2573,7 @@ func TestCommonControl_EnsureSandboxResumed_LegacyBackfill(t *testing.T) {
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
 		checkpointControl:    NewCheckpointControl(fakeClient, record.NewFakeRecorder(10)),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
+		syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 	}
 
 	tests := []struct {
@@ -2732,7 +2736,7 @@ func TestCommonControl_EnsureSandboxTerminated_PodNotExist_NoFinalizer(t *testin
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
+		syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 	}
 
 	err := control.EnsureSandboxTerminated(context.TODO(), EnsureFuncArgs{Pod: nil, Box: box, NewStatus: &agentsv1alpha1.SandboxStatus{}})
@@ -2760,7 +2764,7 @@ func TestCommonControl_EnsureSandboxPaused_AlreadyPaused(t *testing.T) {
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
+		syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2831,7 +2835,7 @@ func TestCommonControl_performRecreateUpgrade_PodTerminating(t *testing.T) {
 		podControl:           podCtrl,
 		checkpointControl:    checkpointCtrl,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultSyncStatusFromPod, nil),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultCommonSyncStatusFromPod, nil),
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2892,7 +2896,7 @@ func TestCommonControl_performRecreateUpgrade_NewPodNotReady(t *testing.T) {
 		podControl:           podCtrl,
 		checkpointControl:    checkpointCtrl,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultSyncStatusFromPod, nil),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultCommonSyncStatusFromPod, nil),
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -3137,7 +3141,7 @@ func TestCommonControl_performRecreateUpgrade_PodReadyFalse(t *testing.T) {
 		podControl:           podCtrl,
 		checkpointControl:    checkpointCtrl,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultSyncStatusFromPod, nil),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultCommonSyncStatusFromPod, nil),
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -3440,7 +3444,7 @@ func TestCommonControl_EnsureSandboxResumed_InitContainerInconsistent(t *testing
 				initializer:          &mockSandboxInitializer{err: nil},
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
 				checkpointControl:    NewCheckpointControl(fc, record.NewFakeRecorder(10)),
-				syncStatusFromPod:    defaultSyncStatusFromPod,
+				syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 			}
 
 			newStatus := &agentsv1alpha1.SandboxStatus{
@@ -3590,7 +3594,7 @@ func TestCommonControl_performRecreateUpgrade_InitializerPath(t *testing.T) {
 				podControl:           podCtrl,
 				checkpointControl:    checkpointCtrl,
 				initializer:          initializer,
-				upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultSyncStatusFromPod, nil),
+				upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultCommonSyncStatusFromPod, nil),
 			}
 
 			newStatus := &agentsv1alpha1.SandboxStatus{
@@ -3615,110 +3619,4 @@ func TestCommonControl_performRecreateUpgrade_InitializerPath(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestDefaultSyncStatusFromPodPendingProjection(t *testing.T) {
-	now := metav1.NewTime(time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC))
-	projected := metav1.Condition{
-		Type:               string(agentsv1alpha1.SandboxConditionReady),
-		Status:             metav1.ConditionFalse,
-		Reason:             "ProjectedFailure",
-		Message:            "projected pending failure",
-		LastTransitionTime: now,
-	}
-	ownedFailure := projected
-	tests := []struct {
-		name          string
-		pod           *corev1.Pod
-		status        agentsv1alpha1.SandboxStatus
-		wantCondition *metav1.Condition
-		wantNodeName  string
-	}{
-		{
-			name: "pending pod applies projection",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"project-failure": "true"}},
-				Spec:       corev1.PodSpec{NodeName: "should-not-sync"},
-				Status:     corev1.PodStatus{Phase: corev1.PodPending, PodIP: "10.0.0.1"},
-			},
-			wantCondition: &projected,
-		},
-		{
-			name:   "missing projection clears owned failure",
-			pod:    &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodPending}},
-			status: agentsv1alpha1.SandboxStatus{Conditions: []metav1.Condition{ownedFailure}},
-			wantCondition: &metav1.Condition{
-				Type:               string(agentsv1alpha1.SandboxConditionReady),
-				Status:             metav1.ConditionFalse,
-				Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
-				LastTransitionTime: now,
-			},
-		},
-		{
-			name:   "absent pod clears owned failure",
-			status: agentsv1alpha1.SandboxStatus{Conditions: []metav1.Condition{ownedFailure}},
-			wantCondition: &metav1.Condition{
-				Type:               string(agentsv1alpha1.SandboxConditionReady),
-				Status:             metav1.ConditionFalse,
-				Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
-				LastTransitionTime: now,
-			},
-		},
-		{
-			name: "unowned failure is preserved",
-			status: agentsv1alpha1.SandboxStatus{Conditions: []metav1.Condition{{
-				Type:               string(agentsv1alpha1.SandboxConditionReady),
-				Status:             metav1.ConditionFalse,
-				Reason:             agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
-				Message:            "image pull failed",
-				LastTransitionTime: now,
-			}}},
-			wantCondition: &metav1.Condition{
-				Type:               string(agentsv1alpha1.SandboxConditionReady),
-				Status:             metav1.ConditionFalse,
-				Reason:             agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
-				Message:            "image pull failed",
-				LastTransitionTime: now,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			status := tt.status.DeepCopy()
-			options := podStatusSyncOptions{
-				OwnsPendingReadyReason: func(reason string) bool {
-					return reason == projected.Reason
-				},
-			}
-			if tt.pod != nil && tt.pod.Annotations["project-failure"] == "true" {
-				options.PendingReadyCondition = &projected
-			}
-			defaultSyncStatusFromPod(tt.pod, status, options)
-			assert.Equal(t, tt.wantCondition, utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionReady)))
-			assert.Equal(t, tt.wantNodeName, status.NodeName)
-		})
-	}
-}
-
-func TestDefaultSyncStatusFromPodSyncReadyWithoutPodInfo(t *testing.T) {
-	pod := &corev1.Pod{
-		Spec: corev1.PodSpec{NodeName: "should-not-sync"},
-		Status: corev1.PodStatus{
-			PodIP: "10.0.0.1",
-			Conditions: []corev1.PodCondition{{
-				Type:   corev1.PodReady,
-				Status: corev1.ConditionTrue,
-			}},
-		},
-	}
-	status := &agentsv1alpha1.SandboxStatus{}
-
-	defaultSyncStatusFromPod(pod, status, podStatusSyncOptions{SyncReadyCondition: true})
-
-	assert.Empty(t, status.NodeName)
-	assert.Empty(t, status.SandboxIp)
-	assert.Empty(t, status.PodInfo.PodUID)
-	readyCondition := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionReady))
-	assert.NotNil(t, readyCondition)
-	assert.Equal(t, metav1.ConditionTrue, readyCondition.Status)
 }

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -3616,3 +3616,109 @@ func TestCommonControl_performRecreateUpgrade_InitializerPath(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultSyncStatusFromPodPendingProjection(t *testing.T) {
+	now := metav1.NewTime(time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC))
+	projected := metav1.Condition{
+		Type:               string(agentsv1alpha1.SandboxConditionReady),
+		Status:             metav1.ConditionFalse,
+		Reason:             "ProjectedFailure",
+		Message:            "projected pending failure",
+		LastTransitionTime: now,
+	}
+	ownedFailure := projected
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		status        agentsv1alpha1.SandboxStatus
+		wantCondition *metav1.Condition
+		wantNodeName  string
+	}{
+		{
+			name: "pending pod applies projection",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"project-failure": "true"}},
+				Spec:       corev1.PodSpec{NodeName: "should-not-sync"},
+				Status:     corev1.PodStatus{Phase: corev1.PodPending, PodIP: "10.0.0.1"},
+			},
+			wantCondition: &projected,
+		},
+		{
+			name:   "missing projection clears owned failure",
+			pod:    &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodPending}},
+			status: agentsv1alpha1.SandboxStatus{Conditions: []metav1.Condition{ownedFailure}},
+			wantCondition: &metav1.Condition{
+				Type:               string(agentsv1alpha1.SandboxConditionReady),
+				Status:             metav1.ConditionFalse,
+				Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
+				LastTransitionTime: now,
+			},
+		},
+		{
+			name:   "absent pod clears owned failure",
+			status: agentsv1alpha1.SandboxStatus{Conditions: []metav1.Condition{ownedFailure}},
+			wantCondition: &metav1.Condition{
+				Type:               string(agentsv1alpha1.SandboxConditionReady),
+				Status:             metav1.ConditionFalse,
+				Reason:             agentsv1alpha1.SandboxReadyReasonPodReady,
+				LastTransitionTime: now,
+			},
+		},
+		{
+			name: "unowned failure is preserved",
+			status: agentsv1alpha1.SandboxStatus{Conditions: []metav1.Condition{{
+				Type:               string(agentsv1alpha1.SandboxConditionReady),
+				Status:             metav1.ConditionFalse,
+				Reason:             agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
+				Message:            "image pull failed",
+				LastTransitionTime: now,
+			}}},
+			wantCondition: &metav1.Condition{
+				Type:               string(agentsv1alpha1.SandboxConditionReady),
+				Status:             metav1.ConditionFalse,
+				Reason:             agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
+				Message:            "image pull failed",
+				LastTransitionTime: now,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status := tt.status.DeepCopy()
+			options := podStatusSyncOptions{
+				OwnsPendingReadyReason: func(reason string) bool {
+					return reason == projected.Reason
+				},
+			}
+			if tt.pod != nil && tt.pod.Annotations["project-failure"] == "true" {
+				options.PendingReadyCondition = &projected
+			}
+			defaultSyncStatusFromPod(tt.pod, status, options)
+			assert.Equal(t, tt.wantCondition, utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionReady)))
+			assert.Equal(t, tt.wantNodeName, status.NodeName)
+		})
+	}
+}
+
+func TestDefaultSyncStatusFromPodSyncReadyWithoutPodInfo(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{NodeName: "should-not-sync"},
+		Status: corev1.PodStatus{
+			PodIP: "10.0.0.1",
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	status := &agentsv1alpha1.SandboxStatus{}
+
+	defaultSyncStatusFromPod(pod, status, podStatusSyncOptions{SyncReadyCondition: true})
+
+	assert.Empty(t, status.NodeName)
+	assert.Empty(t, status.SandboxIp)
+	assert.Empty(t, status.PodInfo.PodUID)
+	readyCondition := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionReady))
+	assert.NotNil(t, readyCondition)
+	assert.Equal(t, metav1.ConditionTrue, readyCondition.Status)
+}

--- a/pkg/controller/sandbox/core/pod_failure_test.go
+++ b/pkg/controller/sandbox/core/pod_failure_test.go
@@ -167,11 +167,11 @@ func TestDefaultSyncStatusFromPodStartupFailure(t *testing.T) {
 			expectMessage: "kubelet message",
 		},
 		{
-			name:           "transient reason keeps prior startup failure",
+			name:           "transient reason clears prior startup failure",
 			waitingReason:  "ContainerCreating",
 			previousReason: agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
-			expectReason:   agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
-			expectMessage:  "previous failure",
+			expectReason:   agentsv1alpha1.SandboxReadyReasonPodReady,
+			expectMessage:  "",
 		},
 		{
 			name:           "existing pod keeps prior pod create failure",
@@ -227,7 +227,7 @@ func TestDefaultSyncStatusFromPodStartupFailure(t *testing.T) {
 				Message: "previous failure",
 			}}}
 
-			defaultSyncStatusFromPod(pod, status, podStatusSyncOptions{SyncPodInfo: true, SyncReadyCondition: true})
+			defaultSyncStatusFromPod(pod, status, true, classifyStartupFailure)
 
 			condition := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionReady))
 			assert.Equal(t, tt.expectReason, condition.Reason)

--- a/pkg/controller/sandbox/core/pod_failure_test.go
+++ b/pkg/controller/sandbox/core/pod_failure_test.go
@@ -227,7 +227,7 @@ func TestDefaultSyncStatusFromPodStartupFailure(t *testing.T) {
 				Message: "previous failure",
 			}}}
 
-			defaultSyncStatusFromPod(pod, status, true)
+			defaultSyncStatusFromPod(pod, status, podStatusSyncOptions{SyncPodInfo: true, SyncReadyCondition: true})
 
 			condition := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionReady))
 			assert.Equal(t, tt.expectReason, condition.Reason)

--- a/pkg/controller/sandbox/core/upgrade_control.go
+++ b/pkg/controller/sandbox/core/upgrade_control.go
@@ -55,7 +55,7 @@ type UpgradeControl struct {
 	recorder          record.EventRecorder
 	lifecycleHookFunc LifecycleHookFunc
 	initializer       SandboxInitializer
-	syncStatusFromPod func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, options podStatusSyncOptions)
+	syncStatusFromPod func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool)
 	resumeFunc        ResumeFunc
 }
 
@@ -70,7 +70,7 @@ func NewUpgradeControl(
 	recorder record.EventRecorder,
 	lifecycleHookFunc LifecycleHookFunc,
 	initializer SandboxInitializer,
-	syncStatusFromPod func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, options podStatusSyncOptions),
+	syncStatusFromPod func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool),
 	resumeFunc ResumeFunc,
 ) *UpgradeControl {
 	return &UpgradeControl{
@@ -354,7 +354,7 @@ func (r *UpgradeControl) handleResuming(ctx context.Context, args EnsureFuncArgs
 	// re-init targets the current Pod IP/UID. The resumed pod may differ
 	// from the paused one, and using stale status would leave the upgrade
 	// stuck in Resuming.
-	r.syncStatusFromPod(pod, newStatus, podStatusSyncOptions{SyncPodInfo: true})
+	r.syncStatusFromPod(pod, newStatus, false)
 	// Only initialize the old pod when a PreUpgrade hook is configured.
 	// The Initialize call (runtime re-init, security token, CSI re-mount)
 	// prepares the old pod for PreUpgrade execution. If no PreUpgrade hook
@@ -483,7 +483,7 @@ func (r *UpgradeControl) performRecreateUpgrade(ctx context.Context, args Ensure
 		return false, nil
 	}
 
-	r.syncStatusFromPod(pod, newStatus, podStatusSyncOptions{SyncPodInfo: true})
+	r.syncStatusFromPod(pod, newStatus, false)
 
 	// Step 4: Perform post-recreate-upgrade initialization (re-init runtime, re-mount CSI).
 	if err := r.initializer.Initialize(ctx, box, newStatus); err != nil {

--- a/pkg/controller/sandbox/core/upgrade_control.go
+++ b/pkg/controller/sandbox/core/upgrade_control.go
@@ -55,7 +55,7 @@ type UpgradeControl struct {
 	recorder          record.EventRecorder
 	lifecycleHookFunc LifecycleHookFunc
 	initializer       SandboxInitializer
-	syncStatusFromPod func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool)
+	syncStatusFromPod func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, options podStatusSyncOptions)
 	resumeFunc        ResumeFunc
 }
 
@@ -70,7 +70,7 @@ func NewUpgradeControl(
 	recorder record.EventRecorder,
 	lifecycleHookFunc LifecycleHookFunc,
 	initializer SandboxInitializer,
-	syncStatusFromPod func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool),
+	syncStatusFromPod func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, options podStatusSyncOptions),
 	resumeFunc ResumeFunc,
 ) *UpgradeControl {
 	return &UpgradeControl{
@@ -354,7 +354,7 @@ func (r *UpgradeControl) handleResuming(ctx context.Context, args EnsureFuncArgs
 	// re-init targets the current Pod IP/UID. The resumed pod may differ
 	// from the paused one, and using stale status would leave the upgrade
 	// stuck in Resuming.
-	r.syncStatusFromPod(pod, newStatus, false)
+	r.syncStatusFromPod(pod, newStatus, podStatusSyncOptions{SyncPodInfo: true})
 	// Only initialize the old pod when a PreUpgrade hook is configured.
 	// The Initialize call (runtime re-init, security token, CSI re-mount)
 	// prepares the old pod for PreUpgrade execution. If no PreUpgrade hook
@@ -483,7 +483,7 @@ func (r *UpgradeControl) performRecreateUpgrade(ctx context.Context, args Ensure
 		return false, nil
 	}
 
-	r.syncStatusFromPod(pod, newStatus, false)
+	r.syncStatusFromPod(pod, newStatus, podStatusSyncOptions{SyncPodInfo: true})
 
 	// Step 4: Perform post-recreate-upgrade initialization (re-init runtime, re-mount CSI).
 	if err := r.initializer.Initialize(ctx, box, newStatus); err != nil {

--- a/pkg/controller/sandbox/core/upgrade_control_test.go
+++ b/pkg/controller/sandbox/core/upgrade_control_test.go
@@ -126,7 +126,7 @@ func newTestCommonControl(hookFunc LifecycleHookFunc, objects ...client.Object) 
 		podControl:           podCtrl,
 		lifecycleHookFunc:    hookFunc,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(100), hookFunc, initializer, defaultSyncStatusFromPod, nil),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(100), hookFunc, initializer, defaultCommonSyncStatusFromPod, nil),
 	}
 }
 
@@ -897,7 +897,7 @@ func newTestCommonControlWithCheckpointIndex(hookFunc LifecycleHookFunc, objects
 		podControl:           podCtrl,
 		lifecycleHookFunc:    hookFunc,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(100), hookFunc, initializer, defaultSyncStatusFromPod, nil),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(100), hookFunc, initializer, defaultCommonSyncStatusFromPod, nil),
 	}
 }
 
@@ -1717,7 +1717,7 @@ func TestEnsureSandboxUpgraded_Resuming(t *testing.T) {
 			}
 			return nil
 		}
-		return NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(100), mockLifecycleHookFunc(0, "", "", nil), initializer, defaultSyncStatusFromPod, resumeFn), initializer
+		return NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(100), mockLifecycleHookFunc(0, "", "", nil), initializer, defaultCommonSyncStatusFromPod, resumeFn), initializer
 	}
 
 	tests := []struct {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Generalizes Pod status synchronization by replacing the Ready-only boolean with explicit synchronization options.

- Separates Pod identity/IP synchronization from Ready-condition synchronization.
- Adds an optional, backend-provided Pending Ready-condition projection and scoped cleanup for conditions owned by that projection.
- Keeps upgrade resume and recreate paths limited to Pod identity/IP synchronization.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

```bash
go test ./pkg/controller/sandbox/core -run 'Test(DefaultSyncStatusFromPodPendingProjection|DefaultSyncStatusFromPodSyncReadyWithoutPodInfo|CommonControl_EnsureSandbox(Running|Updated|Resumed)|PodFailure|EnsureSandboxUpgraded|PerformRecreateUpgrade_ContainerStatuses)' -count=1
```

### Ⅳ. Special notes for reviews

- `PendingReadyCondition` and `OwnsPendingReadyReason` provide a generic extension point for backend-specific Pending failures without adding provider dependencies to the common controller.
- Cleanup is limited to the caller-owned Ready reason, preserving unrelated startup failures.
