### PR TITLE
fix: unbreak go vet and make build on master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 build: generate fmt vet manifests ## Build manager binary.
-	go build -o bin/agent-sandbox-controller cmd/agent-sandbox-controller/main.go
+	go build -o bin/agent-sandbox-controller ./cmd/agent-sandbox-controller
 
 .PHONY: build-okactl
 build-okactl: ## Build okactl CLI binary.

--- a/pkg/agent-runtime/storage-cli/main.go
+++ b/pkg/agent-runtime/storage-cli/main.go
@@ -88,8 +88,8 @@ func runMount(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to decode CSI request config: %w", err)
 	}
 
-	csiReq := csi.NodePublishVolumeRequest{}
-	if err := proto.Unmarshal(configRaw, &csiReq); err != nil {
+	csiReq := &csi.NodePublishVolumeRequest{}
+	if err := proto.Unmarshal(configRaw, csiReq); err != nil {
 		cmd.Help() // #nosec G104 -- help output error is non-actionable
 		return fmt.Errorf("failed to unmarshal CSI request: %w", err)
 	}
@@ -195,7 +195,7 @@ func main() {
 	}
 }
 
-func validateGeneralParams(csiReq csi.NodePublishVolumeRequest) error {
+func validateGeneralParams(csiReq *csi.NodePublishVolumeRequest) error {
 	if strings.TrimSpace(csiReq.VolumeContext["csi.storage.k8s.io/pod.uid"]) == "" {
 		return fmt.Errorf("Pod UID is required. Use csi.storage.k8s.io/pod.uid setting")
 	}

--- a/pkg/agent-runtime/storage-cli/main_test.go
+++ b/pkg/agent-runtime/storage-cli/main_test.go
@@ -283,8 +283,8 @@ func TestRootCmdExecute_VersionSubcommand(t *testing.T) {
 
 // newCSIRequestWithVolumeContext builds a minimal NodePublishVolumeRequest
 // with the provided volume context; used to drive validateGeneralParams.
-func newCSIRequestWithVolumeContext(ctx map[string]string) csi.NodePublishVolumeRequest {
-	return csi.NodePublishVolumeRequest{VolumeContext: ctx}
+func newCSIRequestWithVolumeContext(ctx map[string]string) *csi.NodePublishVolumeRequest {
+	return &csi.NodePublishVolumeRequest{VolumeContext: ctx}
 }
 
 // captureStdout swaps os.Stdout for the duration of fn and returns the
@@ -348,8 +348,8 @@ func ensureSubcommand(t *testing.T, parent, child *cobra.Command) {
 type fakeProvider struct {
 	driverName string
 	subDir     string
-	validateFn func(csi.NodePublishVolumeRequest) error
-	mountFn    func(context.Context, csi.NodePublishVolumeRequest) error
+	validateFn func(*csi.NodePublishVolumeRequest) error
+	mountFn    func(context.Context, *csi.NodePublishVolumeRequest) error
 }
 
 func (f *fakeProvider) Driver() string { return f.driverName }
@@ -359,19 +359,19 @@ func (f *fakeProvider) SubDir() string {
 	}
 	return "fake"
 }
-func (f *fakeProvider) Validate(req csi.NodePublishVolumeRequest) error {
+func (f *fakeProvider) Validate(req *csi.NodePublishVolumeRequest) error {
 	if f.validateFn != nil {
 		return f.validateFn(req)
 	}
 	return nil
 }
-func (f *fakeProvider) Mount(ctx context.Context, req csi.NodePublishVolumeRequest, debug bool) error {
+func (f *fakeProvider) Mount(ctx context.Context, req *csi.NodePublishVolumeRequest, debug bool) error {
 	if f.mountFn != nil {
 		return f.mountFn(ctx, req)
 	}
 	return nil
 }
-func (f *fakeProvider) Unmount(_ context.Context, _ csi.NodePublishVolumeRequest) error {
+func (f *fakeProvider) Unmount(_ context.Context, _ *csi.NodePublishVolumeRequest) error {
 	return nil
 }
 
@@ -444,7 +444,7 @@ func TestRunMount(t *testing.T) {
 	lookupValidateErr := func(_ string) (storage.Provider, bool) {
 		return &fakeProvider{
 			driverName: fakeDriver,
-			validateFn: func(_ csi.NodePublishVolumeRequest) error {
+			validateFn: func(_ *csi.NodePublishVolumeRequest) error {
 				return fmt.Errorf("validate: secret key missing")
 			},
 		}, true
@@ -452,7 +452,7 @@ func TestRunMount(t *testing.T) {
 	lookupMountErr := func(_ string) (storage.Provider, bool) {
 		return &fakeProvider{
 			driverName: fakeDriver,
-			mountFn: func(_ context.Context, _ csi.NodePublishVolumeRequest) error {
+			mountFn: func(_ context.Context, _ *csi.NodePublishVolumeRequest) error {
 				return fmt.Errorf("mount: socket not found")
 			},
 		}, true
@@ -613,5 +613,3 @@ func TestRunMount_PodUIDFromEnv(t *testing.T) {
 	// POD_UID env fills the missing pod uid so validateGeneralParams passes.
 	assert.NoError(t, runMount(silentCmd()))
 }
-
-

--- a/pkg/agent-runtime/storage-cli/storage/csi_runner.go
+++ b/pkg/agent-runtime/storage-cli/storage/csi_runner.go
@@ -49,7 +49,7 @@ var newClientFn = func(socketPath string) (csi.NodeClient, io.Closer, error) {
 // debug controls whether the full PublishContext (which may contain credentials
 // such as AK/SK or tokens) is included in the log output. Pass true only in
 // non-production environments for troubleshooting.
-func RunNodePublishVolume(ctx context.Context, driver string, req csi.NodePublishVolumeRequest, debug bool) error {
+func RunNodePublishVolume(ctx context.Context, driver string, req *csi.NodePublishVolumeRequest, debug bool) error {
 	socketPath := path.Join(CsiSocketDir, driver, CsiSocketFile)
 	client, closer, err := newClientFn(socketPath)
 	if err != nil {
@@ -71,7 +71,7 @@ func RunNodePublishVolume(ctx context.Context, driver string, req csi.NodePublis
 	defer cancel()
 
 	start := time.Now()
-	resp, err := client.NodePublishVolume(callCtx, &req, grpc.WaitForReady(true))
+	resp, err := client.NodePublishVolume(callCtx, req, grpc.WaitForReady(true))
 	if err != nil {
 		return fmt.Errorf("NodePublishVolume failed for driver %q: %w", driver, err)
 	}

--- a/pkg/agent-runtime/storage-cli/storage/csi_runner_test.go
+++ b/pkg/agent-runtime/storage-cli/storage/csi_runner_test.go
@@ -52,12 +52,12 @@ func (c *nopCloser) Close() error {
 type fakeNodeClient struct {
 	csi.NodeClient
 
-	gotReq  *csi.NodePublishVolumeRequest
-	gotCtx  context.Context
-	resp    *csi.NodePublishVolumeResponse
-	err     error
-	calls   atomic.Int32
-	onCall  func(ctx context.Context)
+	gotReq *csi.NodePublishVolumeRequest
+	gotCtx context.Context
+	resp   *csi.NodePublishVolumeResponse
+	err    error
+	calls  atomic.Int32
+	onCall func(ctx context.Context)
 }
 
 func (f *fakeNodeClient) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest, _ ...grpc.CallOption) (*csi.NodePublishVolumeResponse, error) {
@@ -154,7 +154,7 @@ func TestRunNodePublishVolume(t *testing.T) {
 			ctx, cancel := tt.ctx()
 			defer cancel()
 
-			err := RunNodePublishVolume(ctx, driver, csi.NodePublishVolumeRequest{VolumeId: "vol-1"}, false)
+			err := RunNodePublishVolume(ctx, driver, &csi.NodePublishVolumeRequest{VolumeId: "vol-1"}, false)
 
 			if tt.expectError == "" {
 				assert.NoError(t, err)
@@ -184,7 +184,7 @@ func TestRunNodePublishVolumeAppliesTimeout(t *testing.T) {
 		return fake, &nopCloser{}, nil
 	})
 
-	err := RunNodePublishVolume(context.Background(), "fake.csi.example.com", csi.NodePublishVolumeRequest{}, false)
+	err := RunNodePublishVolume(context.Background(), "fake.csi.example.com", &csi.NodePublishVolumeRequest{}, false)
 	assert.NoError(t, err)
 	assert.Equal(t, int32(1), fake.calls.Load())
 }
@@ -330,7 +330,7 @@ func TestRunNodePublishVolumeBuildsSocketPath(t *testing.T) {
 				return &fakeNodeClient{resp: &csi.NodePublishVolumeResponse{}}, &nopCloser{}, nil
 			})
 
-			err := RunNodePublishVolume(context.Background(), tt.driver, csi.NodePublishVolumeRequest{}, false)
+			err := RunNodePublishVolume(context.Background(), tt.driver, &csi.NodePublishVolumeRequest{}, false)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, seenPath)
 			// Sanity-check the layout: the socket must live under CsiSocketDir.

--- a/pkg/agent-runtime/storage-cli/storage/provider.go
+++ b/pkg/agent-runtime/storage-cli/storage/provider.go
@@ -39,7 +39,7 @@ type Provider interface {
 
 	// Validate checks driver-specific fields on the CSI request before
 	// the mount is attempted. It MUST NOT mutate the request.
-	Validate(req csi.NodePublishVolumeRequest) error
+	Validate(req *csi.NodePublishVolumeRequest) error
 
 	// Mount performs the driver-specific mount. The default open-source
 	// implementation forwards to the CSI plugin via NodePublishVolume; see
@@ -47,9 +47,9 @@ type Provider interface {
 	//
 	// debug controls whether sensitive fields (e.g. PublishContext) are included
 	// in log output. Pass true only in non-production environments.
-	Mount(ctx context.Context, req csi.NodePublishVolumeRequest, debug bool) error
+	Mount(ctx context.Context, req *csi.NodePublishVolumeRequest, debug bool) error
 
 	// Unmount performs the driver-specific unmount. Drivers that have not
 	// implemented unmount yet may return nil.
-	Unmount(ctx context.Context, req csi.NodePublishVolumeRequest) error
+	Unmount(ctx context.Context, req *csi.NodePublishVolumeRequest) error
 }

--- a/pkg/agent-runtime/storage-cli/storage/registry_test.go
+++ b/pkg/agent-runtime/storage-cli/storage/registry_test.go
@@ -31,13 +31,13 @@ type fakeProvider struct {
 	subDir string
 }
 
-func (f *fakeProvider) Driver() string                                          { return f.driver }
-func (f *fakeProvider) SubDir() string                                          { return f.subDir }
-func (f *fakeProvider) Validate(_ csi.NodePublishVolumeRequest) error           { return nil }
-func (f *fakeProvider) Mount(_ context.Context, _ csi.NodePublishVolumeRequest, _ bool) error {
+func (f *fakeProvider) Driver() string                                 { return f.driver }
+func (f *fakeProvider) SubDir() string                                 { return f.subDir }
+func (f *fakeProvider) Validate(_ *csi.NodePublishVolumeRequest) error { return nil }
+func (f *fakeProvider) Mount(_ context.Context, _ *csi.NodePublishVolumeRequest, _ bool) error {
 	return nil
 }
-func (f *fakeProvider) Unmount(_ context.Context, _ csi.NodePublishVolumeRequest) error {
+func (f *fakeProvider) Unmount(_ context.Context, _ *csi.NodePublishVolumeRequest) error {
 	return nil
 }
 

--- a/pkg/agent-runtime/storage-cli/validation_test.go
+++ b/pkg/agent-runtime/storage-cli/validation_test.go
@@ -25,12 +25,12 @@ import (
 func TestValidateGeneralParams(t *testing.T) {
 	tests := []struct {
 		name    string
-		csiReq  csi.NodePublishVolumeRequest
+		csiReq  *csi.NodePublishVolumeRequest
 		wantErr bool
 	}{
 		{
 			name: "valid request with pod uid",
-			csiReq: csi.NodePublishVolumeRequest{
+			csiReq: &csi.NodePublishVolumeRequest{
 				VolumeContext: map[string]string{
 					"csi.storage.k8s.io/pod.uid": "test-pod-uid",
 				},
@@ -39,7 +39,7 @@ func TestValidateGeneralParams(t *testing.T) {
 		},
 		{
 			name: "request without pod uid",
-			csiReq: csi.NodePublishVolumeRequest{
+			csiReq: &csi.NodePublishVolumeRequest{
 				VolumeContext: map[string]string{
 					"csi.storage.k8s.io/pod.uid": "",
 				},
@@ -48,14 +48,14 @@ func TestValidateGeneralParams(t *testing.T) {
 		},
 		{
 			name: "request without pod uid key",
-			csiReq: csi.NodePublishVolumeRequest{
+			csiReq: &csi.NodePublishVolumeRequest{
 				VolumeContext: map[string]string{},
 			},
 			wantErr: true,
 		},
 		{
 			name:    "nil volume context",
-			csiReq:  csi.NodePublishVolumeRequest{},
+			csiReq:  &csi.NodePublishVolumeRequest{},
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
Fixes #905

Two separate things stop `make build` producing a binary on a clean checkout of master. The issue diagnosed the first; the second only becomes visible once the first is fixed.

## 1. go vet fails, and vet gates the build

#876 bumped `container-storage-interface/spec` from v1.9.0 to v1.13.0. In v1.13.0 `csi.NodePublishVolumeRequest` carries a `protoimpl.MessageState`, which embeds a `sync.Mutex`. The storage CLI passes that struct **by value** everywhere, so vet now reports 18 copylocks findings and exits 1:

```
pkg/agent-runtime/storage-cli/storage/csi_runner.go:52:67: RunNodePublishVolume passes lock by value
pkg/agent-runtime/storage-cli/main.go:198:35: validateGeneralParams passes lock by value
...
```

`Makefile:81` and `Makefile:110` both declare `vet` as a prerequisite, so `build` and `test-e2e` stop before doing anything.

Fixed by taking `*csi.NodePublishVolumeRequest` through the `Provider` interface, `RunNodePublishVolume` and `validateGeneralParams`. That is the ordinary way to handle a generated protobuf message, and it removes a real struct copy from the mount path rather than just silencing the check. `main.go` already did `proto.Unmarshal(configRaw, &csiReq)`, so it had the pointer in hand anyway.

No production `Provider` implementations exist outside the test fakes, so the interface change is contained.

## 2. The build target compiles a file, not a package

With vet clean, `make build` gets further and then fails:

```
cmd/agent-sandbox-controller/main.go:367:2: undefined: executeCABindings
```

`executeCABindings` lives in `cmd/agent-sandbox-controller/ca_binding.go`, same package. The target was:

```make
go build -o bin/agent-sandbox-controller cmd/agent-sandbox-controller/main.go
```

Naming a single `.go` file builds only that file, so its siblings are invisible. `go build ./cmd/agent-sandbox-controller/` has always worked, which is why this never showed up in `go build ./...` or in CI.

Changed to build the package. The `build-okactl` target two lines below already uses `./cmd/okactl`, so this makes the two consistent.

## Verification

```
$ go vet ./... ; echo $?
0

$ make build
...
go build -o bin/agent-sandbox-controller ./cmd/agent-sandbox-controller
$ ls -l bin/agent-sandbox-controller
-rwxrwxr-x 1 ... 103290525 ... bin/agent-sandbox-controller
```

`go test ./pkg/agent-runtime/storage-cli/...` passes across all four packages.

37 insertions, 39 deletions. Most of it is the mechanical `csi.NodePublishVolumeRequest` to `*csi.NodePublishVolumeRequest` change in the test fakes.

## One note on scope

`make build` runs `go fmt ./...`, which reformatted four unrelated test files on my machine (`pkg/identity/ca_cert_injector_test.go` and three others, all struct-field alignment). I reverted those rather than fold unrelated churn in here, but they are unformatted on master and something will keep re-flagging them. Worth a separate cleanup.

## Why CI missed it

No workflow runs `go vet`. The `undefined: executeCABindings` case is worse, since it only appears in `make build` and never in `go build ./...`. A CI job that runs `make build` would catch both.