### PR TITLE
fix(sandbox): classify unschedulable startup failures

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -605,6 +605,7 @@ const (
 	SandboxReadyReasonUpgrading            = "Upgrading"
 	SandboxReadyReasonStartContainerFailed = "StartContainerFailed"
 	SandboxReadyReasonPodCreateFailed      = "PodCreateFailed"
+	SandboxReadyReasonUnschedulable        = "Unschedulable"
 
 	// SandboxConditionInplaceUpdate Reason
 	SandboxInplaceUpdateReasonInplaceUpdating = "InplaceUpdating"

--- a/api/v1alpha1/sandboxset_types.go
+++ b/api/v1alpha1/sandboxset_types.go
@@ -145,10 +145,10 @@ type SandboxSetScaleStrategy struct {
 	// the base (equivalent to 100%, i.e. no cap). Scale-down is unaffected.
 	//
 	// The physical scale-up budget is charged by startup blockers: sandboxes
-	// whose Ready condition is False with reason PodCreateFailed or
-	// StartContainerFailed, sandboxes stuck in Creating/ResourcePending past the
-	// configured --max-pending-timeout, and sandbox creations that have been
-	// issued but are not yet observed by the controller (they release their slot
+	// whose Ready condition is False with reason PodCreateFailed,
+	// StartContainerFailed, or Unschedulable, sandboxes stuck in
+	// Creating/ResourcePending past the configured --max-pending-timeout, and
+	// sandbox creations that have been issued but are not yet observed by the controller (they release their slot
 	// once observed as healthy Creating sandboxes). Healthy observed Creating
 	// sandboxes do NOT count against the budget.
 	//

--- a/config/crd/bases/agents.kruise.io_sandboxsets.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxsets.yaml
@@ -418,10 +418,10 @@ spec:
                       the base (equivalent to 100%, i.e. no cap). Scale-down is unaffected.
 
                       The physical scale-up budget is charged by startup blockers: sandboxes
-                      whose Ready condition is False with reason PodCreateFailed or
-                      StartContainerFailed, sandboxes stuck in Creating/ResourcePending past the
-                      configured --max-pending-timeout, and sandbox creations that have been
-                      issued but are not yet observed by the controller (they release their slot
+                      whose Ready condition is False with reason PodCreateFailed,
+                      StartContainerFailed, or Unschedulable, sandboxes stuck in
+                      Creating/ResourcePending past the configured --max-pending-timeout, and
+                      sandbox creations that have been issued but are not yet observed by the controller (they release their slot
                       once observed as healthy Creating sandboxes). Healthy observed Creating
                       sandboxes do NOT count against the budget.
 

--- a/pkg/cache/tasks_test.go
+++ b/pkg/cache/tasks_test.go
@@ -147,6 +147,29 @@ func TestNewSandboxWaitReadyTask_StartContainerFailed_ReturnsError(t *testing.T)
 	assert.Contains(t, err.Error(), agentsv1alpha1.SandboxReadyReasonStartContainerFailed)
 }
 
+func TestNewSandboxWaitReadyTask_Unschedulable_ReturnsError(t *testing.T) {
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sbx-wait-unschedulable", Generation: 1},
+		Status: agentsv1alpha1.SandboxStatus{
+			ObservedGeneration: 1,
+			Conditions: []metav1.Condition{
+				{
+					Type:    string(agentsv1alpha1.SandboxConditionReady),
+					Status:  metav1.ConditionFalse,
+					Reason:  agentsv1alpha1.SandboxReadyReasonUnschedulable,
+					Message: "insufficient CPU",
+				},
+			},
+		},
+	}
+	c, _, err := cachetest.NewTestCache(t, sbx)
+	require.NoError(t, err)
+	task := c.NewSandboxWaitReadyTask(context.Background(), sbx)
+	err = task.Wait(100 * time.Millisecond)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), agentsv1alpha1.SandboxReadyReasonUnschedulable)
+}
+
 func TestNewSandboxWaitReadyTask_PodCreateFailed_ReturnsError(t *testing.T) {
 	sbx := &agentsv1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sbx-wait-3", Generation: 1},

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -254,12 +254,17 @@ func defaultSyncStatusFromPod(
 			cond.Message = pCond.Message
 		}
 	}
+	if failed && cond.Status != metav1.ConditionFalse {
+		cond.Status = metav1.ConditionFalse
+		cond.LastTransitionTime = metav1.Now()
+	}
 	if cond.Status == metav1.ConditionFalse {
 		if failed {
 			cond.Reason = reason
 			cond.Message = message
-		} else if cond.Reason == agentsv1alpha1.SandboxReadyReasonStartContainerFailed {
-			// Only the normalizer-owned startup failure is cleared on recovery.
+		} else if cond.Reason == agentsv1alpha1.SandboxReadyReasonStartContainerFailed ||
+			cond.Reason == agentsv1alpha1.SandboxReadyReasonUnschedulable {
+			// Only normalizer-owned startup failures are cleared on recovery.
 			cond.Reason = agentsv1alpha1.SandboxReadyReasonPodReady
 			cond.Message = ""
 		}

--- a/pkg/controller/sandbox/core/pod_failure.go
+++ b/pkg/controller/sandbox/core/pod_failure.go
@@ -54,10 +54,10 @@ const (
 //
 // The first hit wins, and init containers are checked before app containers
 // since they run first and block the app containers just as definitively.
-// The returned reason is always SandboxReadyReasonStartContainerFailed to
-// preserve the existing downstream contract (SandboxSet ScalingLimited,
-// wait-ready task, claim short-circuit all key off this single reason). The
-// returned message carries the originating pod- or container-level detail
+// Container startup failures return SandboxReadyReasonStartContainerFailed,
+// while scheduler capacity failures return SandboxReadyReasonUnschedulable.
+// Both reasons are recognized as startup failures by downstream consumers.
+// The returned message carries the originating pod- or container-level detail
 // for diagnostics.
 //
 // If no definitive failure is present, failed is false and callers must leave
@@ -82,7 +82,7 @@ func classifyStartupFailure(pod *corev1.Pod) (reason, message string, failed boo
 			continue
 		}
 		if c.Status == corev1.ConditionFalse && c.Reason == corev1.PodReasonUnschedulable {
-			return agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
+			return agentsv1alpha1.SandboxReadyReasonUnschedulable,
 				c.Message,
 				true
 		}

--- a/pkg/controller/sandbox/core/pod_failure_test.go
+++ b/pkg/controller/sandbox/core/pod_failure_test.go
@@ -42,6 +42,7 @@ func TestClassifyStartupFailure(t *testing.T) {
 		name          string
 		pod           *corev1.Pod
 		failed        bool
+		expectReason  string
 		expectMessage string
 	}{
 		{name: "nil pod"},
@@ -102,7 +103,8 @@ func TestClassifyStartupFailure(t *testing.T) {
 				Reason:  corev1.PodReasonUnschedulable,
 				Message: "kubelet message",
 			}}}},
-			failed: true,
+			failed:       true,
+			expectReason: agentsv1alpha1.SandboxReadyReasonUnschedulable,
 		},
 		{
 			name: "scheduler error is transient",
@@ -136,7 +138,11 @@ func TestClassifyStartupFailure(t *testing.T) {
 			reason, message, failed := classifyStartupFailure(tt.pod)
 			assert.Equal(t, tt.failed, failed)
 			if tt.failed {
-				assert.Equal(t, agentsv1alpha1.SandboxReadyReasonStartContainerFailed, reason)
+				expectReason := tt.expectReason
+				if expectReason == "" {
+					expectReason = agentsv1alpha1.SandboxReadyReasonStartContainerFailed
+				}
+				assert.Equal(t, expectReason, reason)
 				if tt.expectMessage != "" {
 					assert.Equal(t, tt.expectMessage, message)
 				} else {
@@ -170,6 +176,13 @@ func TestDefaultSyncStatusFromPodStartupFailure(t *testing.T) {
 			name:           "transient reason clears prior startup failure",
 			waitingReason:  "ContainerCreating",
 			previousReason: agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
+			expectReason:   agentsv1alpha1.SandboxReadyReasonPodReady,
+			expectMessage:  "",
+		},
+		{
+			name:           "transient reason clears prior unschedulable failure",
+			waitingReason:  "ContainerCreating",
+			previousReason: agentsv1alpha1.SandboxReadyReasonUnschedulable,
 			expectReason:   agentsv1alpha1.SandboxReadyReasonPodReady,
 			expectMessage:  "",
 		},

--- a/pkg/controller/sandbox/pod_event_handler.go
+++ b/pkg/controller/sandbox/pod_event_handler.go
@@ -95,6 +95,13 @@ func isActivePodUpdate(oldObj, newObj *corev1.Pod) bool {
 	if !isPodConditionEqual(rCond1, rCond2) {
 		return true
 	}
+	// PodScheduled drives the shared startup-failure normalizer. Observe both
+	// failure and recovery so the Sandbox Ready condition stays current.
+	sCond1 := utils.GetPodCondition(&oldObj.Status, corev1.PodScheduled)
+	sCond2 := utils.GetPodCondition(&newObj.Status, corev1.PodScheduled)
+	if !isPodConditionEqual(sCond1, sCond2) {
+		return true
+	}
 	pCond1 := utils.GetPodCondition(&oldObj.Status, core.PodConditionContainersPaused)
 	pCond2 := utils.GetPodCondition(&newObj.Status, core.PodConditionContainersPaused)
 	if !isPodConditionEqual(pCond1, pCond2) {

--- a/pkg/controller/sandbox/pod_event_handler_test.go
+++ b/pkg/controller/sandbox/pod_event_handler_test.go
@@ -113,6 +113,52 @@ func TestIsActivePodUpdate(t *testing.T) {
 			description: "should return true when pod IP is assigned",
 		},
 		{
+			name: "PodScheduled condition reports unschedulable",
+			oldPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			newPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:    corev1.PodScheduled,
+						Status:  corev1.ConditionFalse,
+						Reason:  corev1.PodReasonUnschedulable,
+						Message: "insufficient CPU",
+					}},
+				},
+			},
+			expected:    true,
+			description: "should return true when PodScheduled reports Unschedulable",
+		},
+		{
+			name: "PodScheduled condition recovers from unschedulable",
+			oldPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:    corev1.PodScheduled,
+						Status:  corev1.ConditionFalse,
+						Reason:  corev1.PodReasonUnschedulable,
+						Message: "insufficient CPU",
+					}},
+				},
+			},
+			newPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			expected:    true,
+			description: "should return true when PodScheduled recovers so the startup failure is cleared",
+		},
+		{
 			name: "PodReady condition status changed from False to True",
 			oldPod: &corev1.Pod{
 				Status: corev1.PodStatus{
@@ -545,7 +591,7 @@ func TestIsActivePodUpdate(t *testing.T) {
 			description: "should return false when all tracked conditions are identical",
 		},
 		{
-			name: "Untracked condition changed - should not trigger update",
+			name: "PodScheduled condition changed - should trigger update",
 			oldPod: &corev1.Pod{
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
@@ -573,13 +619,13 @@ func TestIsActivePodUpdate(t *testing.T) {
 						},
 						{
 							Type:   corev1.PodScheduled,
-							Status: corev1.ConditionFalse, // Changed but not tracked
+							Status: corev1.ConditionFalse,
 						},
 					},
 				},
 			},
-			expected:    false,
-			description: "should return false when only untracked conditions change",
+			expected:    true,
+			description: "should return true when PodScheduled changes",
 		},
 		{
 			name: "Multiple conditions but only tracked ones matter",

--- a/pkg/controller/sandboxset/scaling_limited_test.go
+++ b/pkg/controller/sandboxset/scaling_limited_test.go
@@ -131,6 +131,17 @@ func TestCalculateScalingLimited(t *testing.T) {
 			expectFailed:  1,
 		},
 		{
+			name:           "unschedulable exhausts budget",
+			maxUnavailable: intOrStringPtr(intstr.FromInt(1)),
+			groups: GroupedSandboxes{Creating: []*agentsv1alpha1.Sandbox{
+				newFailed("failed", agentsv1alpha1.SandboxReadyReasonUnschedulable),
+			}},
+			expectStatus:  metav1.ConditionTrue,
+			expectReason:  scalingLimitedReasonBudgetExhausted,
+			expectMessage: "Timeout=0, Failed=1",
+			expectFailed:  1,
+		},
+		{
 			name:                 "configured pending timeout is used",
 			maxUnavailable:       intOrStringPtr(intstr.FromInt(1)),
 			sbxMaxPendingTimeout: 25 * time.Second,

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -1075,15 +1075,15 @@ func sandboxReadyFailureReason(sbx *v1alpha1.Sandbox, state string, readyCond, i
 	if inplaceCond.Reason == v1alpha1.SandboxInplaceUpdateReasonInplaceUpdating {
 		return "inplace update is still in progress"
 	}
-	if sbx.Status.PodInfo.PodIP == "" {
-		return "sandbox has no pod IP"
-	}
 	if utils.IsSandboxStartupFailureReason(readyCond.Reason) {
 		reason := fmt.Sprintf("ready condition reports %s", readyCond.Reason)
 		if readyCond.Message != "" {
 			reason = fmt.Sprintf("%s: %s", reason, readyCond.Message)
 		}
 		return reason
+	}
+	if sbx.Status.PodInfo.PodIP == "" {
+		return "sandbox has no pod IP"
 	}
 	if state != v1alpha1.SandboxStateRunning {
 		return fmt.Sprintf("sandbox state is %s", state)

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -1078,7 +1078,7 @@ func sandboxReadyFailureReason(sbx *v1alpha1.Sandbox, state string, readyCond, i
 	if sbx.Status.PodInfo.PodIP == "" {
 		return "sandbox has no pod IP"
 	}
-	if readyCond.Reason == v1alpha1.SandboxReadyReasonStartContainerFailed {
+	if utils.IsSandboxStartupFailureReason(readyCond.Reason) {
 		reason := fmt.Sprintf("ready condition reports %s", readyCond.Reason)
 		if readyCond.Message != "" {
 			reason = fmt.Sprintf("%s: %s", reason, readyCond.Message)

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -1184,6 +1184,29 @@ func TestSandboxReadyFailureMessage(t *testing.T) {
 			},
 			want: "sandbox default/sbx-1 is not ready before wait timeout: reason=ready condition reports StartContainerFailed: process exited, state=dead, ready=StartContainerFailed",
 		},
+		{
+			name: "ready condition reports unschedulable with message",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "sbx-1",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase:              v1alpha1.SandboxRunning,
+					ObservedGeneration: 1,
+					Conditions: []metav1.Condition{
+						{
+							Type:    string(v1alpha1.SandboxConditionReady),
+							Reason:  v1alpha1.SandboxReadyReasonUnschedulable,
+							Message: "insufficient CPU",
+						},
+					},
+					PodInfo: v1alpha1.PodInfo{PodIP: "1.2.3.4"},
+				},
+			},
+			want: "sandbox default/sbx-1 is not ready before wait timeout: reason=ready condition reports Unschedulable: insufficient CPU, state=dead, ready=Unschedulable",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -1207,6 +1207,28 @@ func TestSandboxReadyFailureMessage(t *testing.T) {
 			},
 			want: "sandbox default/sbx-1 is not ready before wait timeout: reason=ready condition reports Unschedulable: insufficient CPU, state=dead, ready=Unschedulable",
 		},
+		{
+			name: "unschedulable reason reported without pod ip",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "sbx-1",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase:              v1alpha1.SandboxRunning,
+					ObservedGeneration: 1,
+					Conditions: []metav1.Condition{
+						{
+							Type:    string(v1alpha1.SandboxConditionReady),
+							Reason:  v1alpha1.SandboxReadyReasonUnschedulable,
+							Message: "insufficient CPU",
+						},
+					},
+				},
+			},
+			want: "sandbox default/sbx-1 is not ready before wait timeout: reason=ready condition reports Unschedulable: insufficient CPU, state=dead, ready=Unschedulable",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -80,7 +80,8 @@ func GetSandboxCondition(status *agentsv1alpha1.SandboxStatus, condType string) 
 func IsSandboxStartupFailureReason(reason string) bool {
 	switch reason {
 	case agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
-		agentsv1alpha1.SandboxReadyReasonPodCreateFailed:
+		agentsv1alpha1.SandboxReadyReasonPodCreateFailed,
+		agentsv1alpha1.SandboxReadyReasonUnschedulable:
 		return true
 	default:
 		return false

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -2053,6 +2053,11 @@ func TestIsSandboxStartupFailureReason(t *testing.T) {
 			wantFailure: true,
 		},
 		{
+			name:        "unschedulable",
+			reason:      agentsv1alpha1.SandboxReadyReasonUnschedulable,
+			wantFailure: true,
+		},
+		{
 			name:        "pod ready",
 			reason:      agentsv1alpha1.SandboxReadyReasonPodReady,
 			wantFailure: false,


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

- Adds `Unschedulable` as a shared Sandbox Ready failure reason for `PodScheduled=False/Unschedulable`.
- Watches PodScheduled condition changes so scheduling failures and recoveries are reconciled promptly.
- Counts unschedulable sandboxes in the SandboxSet startup budget, fails wait-ready early, and reports the scheduling reason during claim diagnostics.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

- `go test ./pkg/controller/sandbox -run '^TestIsActivePodUpdate$' -count=1`
- `go test ./pkg/controller/sandbox/core -run 'Test(ClassifyStartupFailure|DefaultSyncStatusFromPodStartupFailure)$' -count=1`
- Targeted tests for `pkg/utils`, `pkg/controller/sandboxset`, `pkg/cache`, and `pkg/sandbox-manager/infra/sandboxcr`.

### Ⅳ. Special notes for reviews

- Recovery clears normalizer-owned `Unschedulable` and `StartContainerFailed` reasons, while preserving `PodCreateFailed`.
- CRD documentation is regenerated for the updated startup-budget contract.

---

### Appendix: Incidental Changes

- Regenerated SandboxSet CRD description (`config/crd/bases/agents.kruise.io_sandboxsets.yaml`).
