### PR TITLE
chore(skill): drop Deployment from sync-charts manifests drift check

### DIFF
--- a/.qoder/skills/sync-charts/SKILL.md
+++ b/.qoder/skills/sync-charts/SKILL.md
@@ -10,7 +10,7 @@ Keep `config/` as the source of truth, but preserve Helm-only logic in the chart
 ## Boundaries
 
 - Work in a clean agents checkout and a clean charts checkout. Modify only `versions/kruise-agents-sandbox-{controller,manager}/next/**` in charts.
-- Do not edit `config/crd/`, `templates/agentio/crds.yaml`, a released version directory, `Chart.yaml`, `values.yaml`, or `charts/` pointer files.
+- Do not edit `config/crd/`, `templates/agentio/crds.yaml`, a released version directory, `Chart.yaml`, or `charts/` pointer files. Edit `values.yaml` only to update existing default values so source-defined behavior renders correctly; do not add new value keys or restructure values.
 - Copy CRDs byte-for-byte only. Splice RBAC and webhook entries into the existing Helm templates; preserve every `{{ ... }}`, conditional, chart-only resource, and extra permission unless the user approves its removal.
 - Manager has no webhook template. Do not create one.
 
@@ -102,22 +102,24 @@ The checker renders each source overlay with kustomize (`./bin/kustomize`, falli
 | gateway | `config/sandbox-gateway` | Service | `sandbox-gateway` | manager `templates/service.yaml` (document 1) |
 | gateway | `config/sandbox-gateway` | ConfigMap | `envoy-config` | manager `templates/gateway-envoy-config.yaml` |
 
-The comparison never checks `metadata.name` or `metadata.namespace`, and it ignores chart-managed metadata (`helm.sh/chart`, `helm.sh/resource-policy`, and the `app.kubernetes.io/{managed-by,instance,version,part-of,component}` labels); differences in those show up as `HELM_ONLY`. Deployment manifests, Namespace templates, and the controller's `configuration` ConfigMap are out of scope by design: Deployments are not synchronized by this checker, the controller chart provides no configmap template, and namespaces belong to the deployment environment. RBAC, ServiceAccount, and webhook documents from the same overlays are handled by the webhook, RBAC, and identity sections instead and are silently skipped here.
+The comparison never checks `metadata.name` or `metadata.namespace`, and it ignores chart-managed metadata (`helm.sh/chart`, `helm.sh/resource-policy`, and the `app.kubernetes.io/{managed-by,instance,version,part-of,component}` labels). For value differences the checker also reads the raw chart template file and reports the finding as `TEMPLATED` when the affected field is rendered through a `{{ ... }}` expression or a `{{- range ... }}` block. Deployment manifests, Namespace templates, and the controller's `configuration` ConfigMap are out of scope by design: Deployments are not synchronized by this checker, the controller chart provides no configmap template, and namespaces belong to the deployment environment. RBAC, ServiceAccount, and webhook documents from the same overlays are handled by the webhook, RBAC, and identity sections instead and are silently skipped here.
 
 Output categories:
 
 - `OK` — every compared field is source-equivalent.
 - `DRIFT` — source-defined behavior is missing or different in the chart; hand-splice it into the template.
+- `TEMPLATED` — a value difference on a field the chart renders through a `{{ ... }}` template; resolve it by updating the existing `values.yaml` default so the template stays in place.
 - `HELM_ONLY` — chart-only content driven by chart values or Helm rendering (extra ports, extra labels); usually retain it.
 - `MISSING` — a mapped chart template file does not exist.
 - `UNMAPPED` — a source manifest of a managed kind in a rendered overlay has no mapping entry.
 
-Exit codes match the CRD aspect: `0` clean, `1` drift or missing, `2` configuration or render error, `3` unmapped source manifest.
+Exit codes match the CRD aspect: `0` clean, `1` drift (including `TEMPLATED`) or missing, `2` configuration or render error, `3` unmapped source manifest.
 
-Sync policy when splicing a `DRIFT` finding into a chart template:
+Sync policy when resolving a `DRIFT` or `TEMPLATED` finding in a chart template:
 
-- **Do not modify resource metadata.** `metadata.labels`, `metadata.annotations`, and every other metadata field are left as the chart renders them; do not copy source metadata into the template.
-- **Never replace a `{{ ... }}` template with a concrete source value.** When the chart already renders a `spec`, `data`, or `stringData` field through a template expression, keep the template even when the source carries a concrete value; do not substitute the source literal in its place.
+- **Preserve chart-managed metadata, but add source-defined labels/annotations the chart does not already generate.** The checker ignores chart-managed labels/annotations (`helm.sh/chart`, `helm.sh/resource-policy`, and the `app.kubernetes.io/{managed-by,instance,version,part-of,component}` labels); every other source label/annotation must be present in the rendered chart. Add them after the chart helper block (for example, after `{{- include "sandbox-controller.labels" . | nindent 4 }}`) instead of replacing chart-generated labels. Do not copy `metadata.name`, `metadata.namespace`, or any chart-managed field.
+- **Keep `{{ ... }}` templates; fix values-driven drift by updating `values.yaml` defaults first.** When a DRIFT is caused by a chart value (for example, `.Values.controller.extProcMaxConcurrency`) rendering to a different value than the source, update the existing default in `values.yaml` so the template stays in place. Replace a template with a concrete source value only when no value-driven path exists and the source requires a specific literal.
+- **Match source order for indexed lists; append chart-only entries at the end.** The checker compares `Ingress` rules and `Service` ports by index. Reorder source-derived entries in the template to match the rendered source order, then append chart-only entries after them.
 
 Preserve every `{{ ... }}`, chart helper, conditional, and chart-only addition while applying a fix. `HELM_ONLY` findings describe intentional chart behavior; review them but do not delete chart content to silence them. `MISSING` and `UNMAPPED` are blockers, exactly like the CRD unmapped block: ask the user whether the charts should ship the affected resource, and add the explicit `MANIFEST_SPEC` mapping plus its test coverage in a separate reviewed skill change rather than deciding policy inside a chart-sync PR.
 
@@ -213,6 +215,8 @@ yamllint -c "$CHARTS_REPO/.github/configs/lintconf.yaml" \
 git -C "$CHARTS_REPO" status --short
 ```
 
-The CRD and deployment-manifest checks are automated; webhook parity requires the rendered comparison above and RBAC splices require manual source-to-template review. Identity resources require manual source-to-rendered review. The final CRD checker run must report no `DRIFT` and exit `0`, which requires every source CRD to be mapped and byte-identical; any `UNMAPPED` exit `3` marks a blocking unmapped resource, not a successful sync. The final manifests run must report no `DRIFT`, `MISSING`, or `UNMAPPED`; `HELM_ONLY` findings may legitimately remain.
+Before committing, review `git -C "$CHARTS_REPO" diff` for template regressions: a hunk that removes a `{{ ... }}` expression or a `{{- range ... }}` block and replaces it with literals violates the sync policy unless no value-driven path exists and the source requires a specific literal; restore the template and update the `values.yaml` default instead. The checker cannot catch this retroactively, because a hardcoded value that matches the source renders identically.
+
+The CRD and deployment-manifest checks are automated; webhook parity requires the rendered comparison above and RBAC splices require manual source-to-template review. Identity resources require manual source-to-rendered review. The final CRD checker run must report no `DRIFT` and exit `0`, which requires every source CRD to be mapped and byte-identical; any `UNMAPPED` exit `3` marks a blocking unmapped resource, not a successful sync. The final manifests run must report no `DRIFT`, `TEMPLATED`, `MISSING`, or `UNMAPPED`; `HELM_ONLY` findings may legitimately remain.
 
 Commit with sign-off and create a charts PR that states the agents source SHA, the initial/final drift output, and CRD-upgrade impact. Do not change chart versions or release pointers in this PR.

--- a/.qoder/skills/sync-charts/SKILL.md
+++ b/.qoder/skills/sync-charts/SKILL.md
@@ -114,7 +114,13 @@ Output categories:
 
 Exit codes match the CRD aspect: `0` clean, `1` drift or missing, `2` configuration or render error, `3` unmapped source manifest.
 
-Fix every `DRIFT` by hand-editing the mapped chart template: add or correct only the source-defined fields the finding names while preserving `{{ ... }}`, chart helpers, conditionals, and chart-only additions. `HELM_ONLY` findings describe intentional chart behavior; review them but do not delete chart content to silence them. `MISSING` and `UNMAPPED` are blockers, exactly like the CRD unmapped block: ask the user whether the charts should ship the affected resource, and add the explicit `MANIFEST_SPEC` mapping plus its test coverage in a separate reviewed skill change rather than deciding policy inside a chart-sync PR.
+Sync policy when splicing a `DRIFT` finding into a chart template:
+
+- **Do not modify resource metadata.** `metadata.labels`, `metadata.annotations`, and every other metadata field are left as the chart renders them; do not copy source metadata into the template.
+- **Spec: append only.** On `spec` (and on `data` / `stringData` for ConfigMap and Secret), only add a new field or append a new entry to a list or map. Do not change the value of an existing field.
+- **Never replace a `{{ ... }}` template with a concrete source value.** When the chart already renders a field through a template expression, keep the template even when the source carries a concrete value; do not substitute the source literal in its place.
+
+Preserve every `{{ ... }}`, chart helper, conditional, and chart-only addition while applying a fix. `HELM_ONLY` findings describe intentional chart behavior; review them but do not delete chart content to silence them. `MISSING` and `UNMAPPED` are blockers, exactly like the CRD unmapped block: ask the user whether the charts should ship the affected resource, and add the explicit `MANIFEST_SPEC` mapping plus its test coverage in a separate reviewed skill change rather than deciding policy inside a chart-sync PR.
 
 ## Webhook and RBAC Splices
 

--- a/.qoder/skills/sync-charts/SKILL.md
+++ b/.qoder/skills/sync-charts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-charts
-description: Use when syncing OpenKruise Agents controller or sandbox-manager manifests from config/ into the openkruise/charts next directories, or when investigating drift between those sources.
+description: Use when syncing OpenKruise Agents controller, sandbox-manager, or sandbox-gateway manifests from config/ into the openkruise/charts next directories, or when investigating drift between those sources.
 ---
 
 # Sync Agents Charts
@@ -71,6 +71,50 @@ python3 .qoder/skills/sync-charts/scripts/chart_drift.py \
 python3 .qoder/skills/sync-charts/scripts/chart_drift.py \
   --charts-repo "$CHARTS_REPO" --aspect crd
 ```
+
+## Deployment Manifests
+
+Run the read-only manifests checker. There is no apply mode for manifests; chart templates are always edited by hand:
+
+```bash
+python3 .qoder/skills/sync-charts/scripts/chart_drift.py \
+  --charts-repo "$CHARTS_REPO" --aspect manifests --component all
+```
+
+Narrow the scope with `--component controller|manager|gateway` or with `--kinds`, a comma-separated subset of `Service,ConfigMap,Ingress,Secret`:
+
+```bash
+python3 .qoder/skills/sync-charts/scripts/chart_drift.py \
+  --charts-repo "$CHARTS_REPO" --aspect manifests --component gateway
+python3 .qoder/skills/sync-charts/scripts/chart_drift.py \
+  --charts-repo "$CHARTS_REPO" --aspect manifests --kinds Service,ConfigMap
+```
+
+The checker renders each source overlay with kustomize (`./bin/kustomize`, falling back to `kubectl kustomize` when the binary is absent) and each mapped chart template with `helm template <release> <chart-dir> --namespace sandbox-system -s templates/<file>.yaml`; the manager chart additionally renders with `--set ingress.className=nginx --set e2b.adminApiKey=x`. The manager chart hosts both manager and gateway resources, and its `templates/service.yaml` is multi-document: document 0 is the manager Service and document 1 is the gateway Service.
+
+| Component | Source overlay | Kind | Source name | Chart template |
+| --- | --- | --- | --- | --- |
+| controller | `config/manager` | Service | `controller-manager-webhook-service` | controller `templates/service.yaml` |
+| manager | `config/sandbox-manager` | Service | `sandbox-manager` | manager `templates/service.yaml` |
+| manager | `config/sandbox-manager` | Ingress | `sandbox-manager` | manager `templates/ingress.yaml` |
+| manager | `config/sandbox-manager` | Secret | `e2b-key-store` | manager `templates/secret.yaml` |
+| manager | `config/sandbox-manager` | ConfigMap | `sandbox-manager-envoy-config` | manager `templates/envoy-config.yaml` |
+| gateway | `config/sandbox-gateway` | Service | `sandbox-gateway` | manager `templates/service.yaml` (document 1) |
+| gateway | `config/sandbox-gateway` | ConfigMap | `envoy-config` | manager `templates/gateway-envoy-config.yaml` |
+
+The comparison never checks `metadata.name` or `metadata.namespace`, and it ignores chart-managed metadata (`helm.sh/chart`, `helm.sh/resource-policy`, and the `app.kubernetes.io/{managed-by,instance,version,part-of,component}` labels); differences in those show up as `HELM_ONLY`. Deployment manifests, Namespace templates, and the controller's `configuration` ConfigMap are out of scope by design: Deployments are not synchronized by this checker, the controller chart provides no configmap template, and namespaces belong to the deployment environment. RBAC, ServiceAccount, and webhook documents from the same overlays are handled by the webhook, RBAC, and identity sections instead and are silently skipped here.
+
+Output categories:
+
+- `OK` — every compared field is source-equivalent.
+- `DRIFT` — source-defined behavior is missing or different in the chart; hand-splice it into the template.
+- `HELM_ONLY` — chart-only content driven by chart values or Helm rendering (extra ports, extra labels); usually retain it.
+- `MISSING` — a mapped chart template file does not exist.
+- `UNMAPPED` — a source manifest of a managed kind in a rendered overlay has no mapping entry.
+
+Exit codes match the CRD aspect: `0` clean, `1` drift or missing, `2` configuration or render error, `3` unmapped source manifest.
+
+Fix every `DRIFT` by hand-editing the mapped chart template: add or correct only the source-defined fields the finding names while preserving `{{ ... }}`, chart helpers, conditionals, and chart-only additions. `HELM_ONLY` findings describe intentional chart behavior; review them but do not delete chart content to silence them. `MISSING` and `UNMAPPED` are blockers, exactly like the CRD unmapped block: ask the user whether the charts should ship the affected resource, and add the explicit `MANIFEST_SPEC` mapping plus its test coverage in a separate reviewed skill change rather than deciding policy inside a chart-sync PR.
 
 ## Webhook and RBAC Splices
 
@@ -164,6 +208,6 @@ yamllint -c "$CHARTS_REPO/.github/configs/lintconf.yaml" \
 git -C "$CHARTS_REPO" status --short
 ```
 
-The checker verifies CRDs only; webhook parity requires the rendered comparison above and RBAC splices require manual source-to-template review. Identity resources require manual source-to-rendered review. The final checker run must report no `DRIFT` and exit `0`, which requires every source CRD to be mapped and byte-identical; any `UNMAPPED` exit `3` marks a blocking unmapped resource, not a successful sync.
+The CRD and deployment-manifest checks are automated; webhook parity requires the rendered comparison above and RBAC splices require manual source-to-template review. Identity resources require manual source-to-rendered review. The final CRD checker run must report no `DRIFT` and exit `0`, which requires every source CRD to be mapped and byte-identical; any `UNMAPPED` exit `3` marks a blocking unmapped resource, not a successful sync. The final manifests run must report no `DRIFT`, `MISSING`, or `UNMAPPED`; `HELM_ONLY` findings may legitimately remain.
 
 Commit with sign-off and create a charts PR that states the agents source SHA, the initial/final drift output, and CRD-upgrade impact. Do not change chart versions or release pointers in this PR.

--- a/.qoder/skills/sync-charts/SKILL.md
+++ b/.qoder/skills/sync-charts/SKILL.md
@@ -117,8 +117,7 @@ Exit codes match the CRD aspect: `0` clean, `1` drift or missing, `2` configurat
 Sync policy when splicing a `DRIFT` finding into a chart template:
 
 - **Do not modify resource metadata.** `metadata.labels`, `metadata.annotations`, and every other metadata field are left as the chart renders them; do not copy source metadata into the template.
-- **Spec: append only.** On `spec` (and on `data` / `stringData` for ConfigMap and Secret), only add a new field or append a new entry to a list or map. Do not change the value of an existing field.
-- **Never replace a `{{ ... }}` template with a concrete source value.** When the chart already renders a field through a template expression, keep the template even when the source carries a concrete value; do not substitute the source literal in its place.
+- **Never replace a `{{ ... }}` template with a concrete source value.** When the chart already renders a `spec`, `data`, or `stringData` field through a template expression, keep the template even when the source carries a concrete value; do not substitute the source literal in its place.
 
 Preserve every `{{ ... }}`, chart helper, conditional, and chart-only addition while applying a fix. `HELM_ONLY` findings describe intentional chart behavior; review them but do not delete chart content to silence them. `MISSING` and `UNMAPPED` are blockers, exactly like the CRD unmapped block: ask the user whether the charts should ship the affected resource, and add the explicit `MANIFEST_SPEC` mapping plus its test coverage in a separate reviewed skill change rather than deciding policy inside a chart-sync PR.
 

--- a/.qoder/skills/sync-charts/scripts/chart_drift.py
+++ b/.qoder/skills/sync-charts/scripts/chart_drift.py
@@ -1,14 +1,28 @@
 #!/usr/bin/env python3
-"""Check and optionally copy CRDs listed in config/crd/kustomization.yaml."""
+"""Check CRD and deployment-manifest drift between config/ and the charts checkout."""
 
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import shutil
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+
+import yaml
+
+
+CONTROLLER_OVERLAY = Path("config/manager")
+MANAGER_OVERLAY = Path("config/sandbox-manager")
+GATEWAY_OVERLAY = Path("config/sandbox-gateway")
+
+CONTROLLER_CHART = "kruise-agents-sandbox-controller"
+MANAGER_CHART = "kruise-agents-sandbox-manager"
+
+CHART_NAMESPACE = "sandbox-system"
 
 
 @dataclass(frozen=True)
@@ -69,6 +83,54 @@ CHART_SPEC = {
 }
 
 
+@dataclass(frozen=True)
+class ManifestTarget:
+    component: str
+    overlay: Path
+    kind: str
+    name: str
+    chart: str
+    template: Path
+    doc_index: int
+
+
+MANIFEST_SPEC = (
+    ManifestTarget("controller", CONTROLLER_OVERLAY, "Service", "controller-manager-webhook-service", CONTROLLER_CHART, Path("templates/service.yaml"), 0),
+    ManifestTarget("manager", MANAGER_OVERLAY, "Service", "sandbox-manager", MANAGER_CHART, Path("templates/service.yaml"), 0),
+    ManifestTarget("manager", MANAGER_OVERLAY, "Ingress", "sandbox-manager", MANAGER_CHART, Path("templates/ingress.yaml"), 0),
+    ManifestTarget("manager", MANAGER_OVERLAY, "Secret", "e2b-key-store", MANAGER_CHART, Path("templates/secret.yaml"), 0),
+    ManifestTarget("manager", MANAGER_OVERLAY, "ConfigMap", "sandbox-manager-envoy-config", MANAGER_CHART, Path("templates/envoy-config.yaml"), 0),
+    ManifestTarget("gateway", GATEWAY_OVERLAY, "Service", "sandbox-gateway", MANAGER_CHART, Path("templates/service.yaml"), 1),
+    ManifestTarget("gateway", GATEWAY_OVERLAY, "ConfigMap", "envoy-config", MANAGER_CHART, Path("templates/gateway-envoy-config.yaml"), 0),
+)
+
+OVERLAY_COMPONENTS = {
+    CONTROLLER_OVERLAY: "controller",
+    MANAGER_OVERLAY: "manager",
+    GATEWAY_OVERLAY: "gateway",
+}
+
+MANAGED_KINDS = frozenset({"Service", "ConfigMap", "Ingress", "Secret"})
+EXCLUDED_SOURCES = frozenset({("controller", "ConfigMap", "configuration")})
+
+CHART_RELEASES = {
+    CONTROLLER_CHART: ("sandbox-controller", ()),
+    MANAGER_CHART: ("sandbox-manager", ("ingress.className=nginx", "e2b.adminApiKey=x")),
+}
+
+CHART_MANAGED_LABELS = frozenset(
+    {
+        "helm.sh/chart",
+        "app.kubernetes.io/managed-by",
+        "app.kubernetes.io/instance",
+        "app.kubernetes.io/version",
+        "app.kubernetes.io/part-of",
+        "app.kubernetes.io/component",
+    }
+)
+CHART_MANAGED_ANNOTATIONS = frozenset({"helm.sh/resource-policy"})
+
+
 class ConfigurationError(Exception):
     pass
 
@@ -97,6 +159,8 @@ def resources(kustomization: Path) -> list[Path]:
 
 
 def synchronize(args: argparse.Namespace) -> int:
+    if args.component == "gateway":
+        raise ConfigurationError("--component gateway is only valid with --aspect manifests")
     if not args.charts_repo.is_dir():
         raise ConfigurationError(f"missing charts checkout: {args.charts_repo}")
     if not (args.charts_repo / "versions").is_dir():
@@ -145,20 +209,432 @@ def synchronize(args: argparse.Namespace) -> int:
     return 1 if has_drift else 0
 
 
+def run_command(command: list[str], cwd: Path) -> str:
+    try:
+        result = subprocess.run(command, cwd=cwd, capture_output=True, text=True)
+    except OSError as error:
+        raise ConfigurationError(f"cannot execute {command[0]}: {error}") from error
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip().splitlines()
+        raise ConfigurationError(f"command failed: {' '.join(command)}: {detail[0] if detail else 'unknown error'}")
+    return result.stdout
+
+
+def parse_docs(text: str) -> list[dict]:
+    return [doc for doc in yaml.safe_load_all(text) if isinstance(doc, dict)]
+
+
+def render_source(agents_repo: Path, overlay: Path) -> list[dict]:
+    kustomize = agents_repo / "bin" / "kustomize"
+    if kustomize.is_file():
+        command = [str(kustomize), "build", str(overlay)]
+    else:
+        command = ["kubectl", "kustomize", str(overlay)]
+    return parse_docs(run_command(command, agents_repo))
+
+
+def render_chart(charts_repo: Path, chart: str, template: Path) -> list[dict]:
+    release, settings = CHART_RELEASES[chart]
+    chart_dir = charts_repo / "versions" / chart / "next"
+    command = ["helm", "template", release, str(chart_dir), "--namespace", CHART_NAMESPACE, "-s", str(template)]
+    for setting in settings:
+        command += ["--set", setting]
+    return parse_docs(run_command(command, charts_repo))
+
+
+def check_manifests(args: argparse.Namespace) -> int:
+    agents_repo = args.agents_repo.resolve()
+    charts_repo = args.charts_repo.resolve()
+    if not charts_repo.is_dir():
+        raise ConfigurationError(f"missing charts checkout: {charts_repo}")
+    for chart in (CONTROLLER_CHART, MANAGER_CHART):
+        chart_dir = charts_repo / "versions" / chart / "next"
+        if not chart_dir.is_dir():
+            raise ConfigurationError(f"missing chart directory: {chart_dir}")
+
+    components = {"controller", "manager", "gateway"} if args.component == "all" else {args.component}
+    kinds = args.kinds
+    targets = [
+        target
+        for target in MANIFEST_SPEC
+        if target.component in components and (kinds is None or target.kind in kinds)
+    ]
+
+    source_docs: dict[Path, dict[tuple[str, str], dict]] = {}
+    overlays = {target.overlay for target in MANIFEST_SPEC if OVERLAY_COMPONENTS[target.overlay] in components}
+    for overlay in overlays:
+        docs = render_source(agents_repo, overlay)
+        source_docs[overlay] = {(doc.get("kind"), (doc.get("metadata") or {}).get("name")): doc for doc in docs}
+
+    has_drift = False
+    has_unmapped = False
+    chart_renders: dict[tuple[str, Path], list[dict]] = {}
+
+    for target in targets:
+        source = source_docs[target.overlay].get((target.kind, target.name))
+        if source is None:
+            print(f"DRIFT manifests {target.component} {target.kind}/{target.name}: not found in rendered source {target.overlay}")
+            has_drift = True
+            continue
+        if not (charts_repo / "versions" / target.chart / "next" / target.template).is_file():
+            print(f"MISSING manifests {target.component} {target.kind}/{target.name}: {target.template} not found")
+            has_drift = True
+            continue
+        key = (target.chart, target.template)
+        if key not in chart_renders:
+            chart_renders[key] = render_chart(charts_repo, target.chart, target.template)
+        docs = chart_renders[key]
+        if target.doc_index >= len(docs):
+            print(
+                f"DRIFT manifests {target.component} {target.kind}/{target.name}: "
+                f"{target.template} renders {len(docs)} document(s), expected index {target.doc_index}"
+            )
+            has_drift = True
+            continue
+        chart = docs[target.doc_index]
+        if chart.get("kind") != target.kind:
+            print(
+                f"DRIFT manifests {target.component} {target.kind}/{target.name}: "
+                f"{target.template}[{target.doc_index}] renders {chart.get('kind')}"
+            )
+            has_drift = True
+            continue
+        findings = compare_manifest(source, chart)
+        if any(finding.category == "DRIFT" for finding in findings):
+            has_drift = True
+        if findings:
+            for finding in findings:
+                detail = shorten(f"{finding.path} {finding.detail}")
+                print(f"{finding.category} manifests {target.component} {target.kind}/{target.name}: {detail}")
+        else:
+            print(f"OK manifests {target.component} {target.kind}/{target.name}")
+
+    for component in sorted(components):
+        overlay = next(key for key, value in OVERLAY_COMPONENTS.items() if value == component)
+        for kind, name in source_docs[overlay]:
+            if kinds is not None and kind not in kinds:
+                continue
+            if kind not in MANAGED_KINDS:
+                continue
+            if (component, kind, name) in EXCLUDED_SOURCES:
+                continue
+            if not any(
+                target.component == component and target.kind == kind and target.name == name
+                for target in MANIFEST_SPEC
+            ):
+                print(f"UNMAPPED manifests {component} {kind}/{name}")
+                has_unmapped = True
+
+    if has_unmapped:
+        return 3
+    return 1 if has_drift else 0
+
+
+def shorten(detail: str, limit: int = 200) -> str:
+    detail = " ".join(detail.split())
+    return detail if len(detail) <= limit else detail[: limit - 3] + "..."
+
+
+@dataclass
+class Finding:
+    category: str
+    path: str
+    detail: str
+
+
+def compare_manifest(source: dict, chart: dict) -> list[Finding]:
+    findings: list[Finding] = []
+    compare_metadata(source, chart, findings)
+    comparators = {
+        "Service": compare_service,
+        "ConfigMap": compare_configmap,
+        "Ingress": compare_ingress,
+        "Secret": compare_secret,
+    }
+    comparators[source.get("kind", "")](source, chart, findings)
+    return findings
+
+
+def compare_metadata(source: dict, chart: dict, findings: list[Finding]) -> None:
+    source_meta = source.get("metadata") or {}
+    chart_meta = chart.get("metadata") or {}
+    for field, managed in (("labels", CHART_MANAGED_LABELS), ("annotations", CHART_MANAGED_ANNOTATIONS)):
+        source_map = {key: value for key, value in (source_meta.get(field) or {}).items() if key not in managed}
+        chart_map = {key: value for key, value in (chart_meta.get(field) or {}).items() if key not in managed}
+        compare_mapping(source_map, chart_map, f"metadata.{field}", findings)
+
+
+def compare_mapping(source_map: dict, chart_map: dict, path: str, findings: list[Finding]) -> None:
+    for key, value in source_map.items():
+        if key not in chart_map:
+            findings.append(Finding("DRIFT", f"{path}.{key}", "missing in chart"))
+        elif chart_map[key] != value:
+            findings.append(Finding("DRIFT", f"{path}.{key}", f"source {value!r} != chart {chart_map[key]!r}"))
+    for key in chart_map:
+        if key not in source_map:
+            findings.append(Finding("HELM_ONLY", f"{path}.{key}", "chart-only"))
+
+
+def compare_structured(source, chart, path: str, findings: list[Finding], helm_only_keys: frozenset[str] = frozenset()) -> None:
+    if isinstance(source, dict) and isinstance(chart, dict):
+        for key, value in source.items():
+            if key in helm_only_keys:
+                if key not in chart or chart[key] != value:
+                    findings.append(Finding("HELM_ONLY", f"{path}.{key}", "helm-managed field differs"))
+                continue
+            if key not in chart:
+                findings.append(Finding("DRIFT", f"{path}.{key}", "missing in chart"))
+            else:
+                compare_structured(value, chart[key], f"{path}.{key}", findings, helm_only_keys)
+        for key in chart:
+            if key not in source:
+                if key in helm_only_keys:
+                    findings.append(Finding("HELM_ONLY", f"{path}.{key}", "chart-only, helm-managed"))
+                else:
+                    findings.append(Finding("HELM_ONLY", f"{path}.{key}", "chart-only"))
+    elif isinstance(source, list) and isinstance(chart, list):
+        source_items = _named_items(source)
+        chart_items = _named_items(chart)
+        if source_items is not None and chart_items is not None:
+            for key, value in source_items.items():
+                if key not in chart_items:
+                    findings.append(Finding("DRIFT", f"{path}[name={key}]", "missing in chart"))
+                else:
+                    compare_structured(value, chart_items[key], f"{path}[name={key}]", findings, helm_only_keys)
+            for key in chart_items:
+                if key not in source_items:
+                    findings.append(Finding("HELM_ONLY", f"{path}[name={key}]", "chart-only"))
+        else:
+            source_values = [_canonical(item) for item in source]
+            chart_values = [_canonical(item) for item in chart]
+            for value in source_values:
+                if value not in chart_values:
+                    findings.append(Finding("DRIFT", path, f"source item {value} missing in chart"))
+            for value in chart_values:
+                if value not in source_values:
+                    findings.append(Finding("HELM_ONLY", path, f"chart-only item {value}"))
+    elif source != chart:
+        findings.append(Finding("DRIFT", path, f"source {source!r} != chart {chart!r}"))
+
+
+def _named_items(items: list) -> dict | None:
+    if not items or not all(isinstance(item, dict) and "name" in item for item in items):
+        return None
+    return {item["name"]: item for item in items}
+
+
+def _canonical(value) -> str:
+    return json.dumps(value, sort_keys=True, default=str)
+
+
+def compare_service(source: dict, chart: dict, findings: list[Finding]) -> None:
+    source_spec = source.get("spec") or {}
+    chart_spec = chart.get("spec") or {}
+    if "type" in source_spec and source_spec.get("type") != chart_spec.get("type"):
+        findings.append(
+            Finding("DRIFT", "spec.type", f"source {source_spec.get('type')!r} != chart {chart_spec.get('type')!r}")
+        )
+    source_ports = source_spec.get("ports") or []
+    chart_ports = {port.get("port"): port for port in (chart_spec.get("ports") or [])}
+    for port in source_ports:
+        number = port.get("port")
+        match = chart_ports.get(number)
+        if match is None:
+            findings.append(Finding("DRIFT", f"spec.ports[{number}]", "missing in chart"))
+            continue
+        if port.get("targetPort") is not None and match.get("targetPort") != port.get("targetPort"):
+            findings.append(
+                Finding(
+                    "DRIFT",
+                    f"spec.ports[{number}].targetPort",
+                    f"source {port.get('targetPort')!r} != chart {match.get('targetPort')!r}",
+                )
+            )
+        source_protocol = port.get("protocol") or "TCP"
+        chart_protocol = match.get("protocol") or "TCP"
+        if source_protocol != chart_protocol:
+            findings.append(
+                Finding(
+                    "DRIFT",
+                    f"spec.ports[{number}].protocol",
+                    f"source {source_protocol!r} != chart {chart_protocol!r}",
+                )
+            )
+    source_numbers = {port.get("port") for port in source_ports}
+    for number in chart_ports:
+        if number not in source_numbers:
+            findings.append(Finding("HELM_ONLY", f"spec.ports[{number}]", "chart-only port"))
+
+
+def compare_configmap(source: dict, chart: dict, findings: list[Finding]) -> None:
+    source_data = source.get("data") or {}
+    chart_data = chart.get("data") or {}
+    for key, value in source_data.items():
+        if key not in chart_data:
+            findings.append(Finding("DRIFT", f"data.{key}", "missing in chart"))
+            continue
+        compare_data_value(f"data.{key}", value, chart_data[key], findings)
+    for key in chart_data:
+        if key not in source_data:
+            findings.append(Finding("HELM_ONLY", f"data.{key}", "chart-only key"))
+
+
+def compare_data_value(path: str, source_value, chart_value, findings: list[Finding]) -> None:
+    if isinstance(source_value, str) and isinstance(chart_value, str):
+        source_parsed = _maybe_yaml(source_value)
+        chart_parsed = _maybe_yaml(chart_value)
+        if (
+            source_parsed is not None
+            and chart_parsed is not None
+            and not isinstance(source_parsed, str)
+            and not isinstance(chart_parsed, str)
+        ):
+            compare_structured(source_parsed, chart_parsed, path, findings)
+            return
+    if source_value != chart_value:
+        findings.append(Finding("DRIFT", path, "source and chart differ"))
+
+
+def _maybe_yaml(text: str):
+    try:
+        return yaml.safe_load(text)
+    except yaml.YAMLError:
+        return None
+
+
+def compare_ingress(source: dict, chart: dict, findings: list[Finding]) -> None:
+    source_spec = source.get("spec") or {}
+    chart_spec = chart.get("spec") or {}
+    if "ingressClassName" in source_spec and source_spec.get("ingressClassName") != chart_spec.get("ingressClassName"):
+        findings.append(
+            Finding(
+                "DRIFT",
+                "spec.ingressClassName",
+                f"source {source_spec.get('ingressClassName')!r} != chart {chart_spec.get('ingressClassName')!r}",
+            )
+        )
+    source_tls = source_spec.get("tls") or []
+    chart_tls = chart_spec.get("tls") or []
+    source_secret_names = {entry.get("secretName") for entry in source_tls if isinstance(entry, dict)}
+    chart_secret_names = {entry.get("secretName") for entry in chart_tls if isinstance(entry, dict)}
+    for secret_name in sorted(name for name in source_secret_names if name is not None):
+        if secret_name not in chart_secret_names:
+            findings.append(Finding("DRIFT", f"spec.tls[{secret_name}]", "missing in chart"))
+    for secret_name in sorted(name for name in chart_secret_names if name is not None):
+        if secret_name not in source_secret_names:
+            findings.append(Finding("HELM_ONLY", f"spec.tls[{secret_name}]", "chart-only"))
+
+    source_rules = source_spec.get("rules") or []
+    chart_rules = chart_spec.get("rules") or []
+    for index, rule in enumerate(source_rules):
+        if index >= len(chart_rules):
+            findings.append(Finding("DRIFT", f"spec.rules[{index}]", "missing in chart"))
+            break
+        source_paths = (rule.get("http") or {}).get("paths") or []
+        chart_paths = (chart_rules[index].get("http") or {}).get("paths") or []
+        for path_index, source_path in enumerate(source_paths):
+            if path_index >= len(chart_paths):
+                findings.append(Finding("DRIFT", f"spec.rules[{index}].http.paths[{path_index}]", "missing in chart"))
+                break
+            chart_path = chart_paths[path_index]
+            for field in ("path", "pathType"):
+                if source_path.get(field) is not None and source_path.get(field) != chart_path.get(field):
+                    findings.append(
+                        Finding(
+                            "DRIFT",
+                            f"spec.rules[{index}].http.paths[{path_index}].{field}",
+                            f"source {source_path.get(field)!r} != chart {chart_path.get(field)!r}",
+                        )
+                    )
+            source_backend = (source_path.get("backend") or {}).get("service") or {}
+            chart_backend = (chart_path.get("backend") or {}).get("service") or {}
+            source_port = (source_backend.get("port") or {}).get("number")
+            chart_port = (chart_backend.get("port") or {}).get("number")
+            if source_port is not None and source_port != chart_port:
+                findings.append(
+                    Finding(
+                        "DRIFT",
+                        f"spec.rules[{index}].http.paths[{path_index}].backend.service.port.number",
+                        f"source {source_port!r} != chart {chart_port!r}",
+                    )
+                )
+            if source_backend.get("name") is not None and source_backend.get("name") != chart_backend.get("name"):
+                findings.append(
+                    Finding(
+                        "DRIFT",
+                        f"spec.rules[{index}].http.paths[{path_index}].backend.service.name",
+                        f"source {source_backend.get('name')!r} != chart {chart_backend.get('name')!r}",
+                    )
+                )
+        for path_index in range(len(source_paths), len(chart_paths)):
+            findings.append(Finding("HELM_ONLY", f"spec.rules[{index}].http.paths[{path_index}]", "chart-only path"))
+    if len(chart_rules) > len(source_rules):
+        findings.append(
+            Finding("HELM_ONLY", f"spec.rules[{len(source_rules)}:]", f"{len(chart_rules) - len(source_rules)} chart-only rule(s)")
+        )
+
+
+def compare_secret(source: dict, chart: dict, findings: list[Finding]) -> None:
+    if source.get("type") is not None and source.get("type") != chart.get("type"):
+        findings.append(Finding("DRIFT", "type", f"source {source.get('type')!r} != chart {chart.get('type')!r}"))
+    source_data = source.get("data") or {}
+    chart_data = chart.get("data") or {}
+    source_string = source.get("stringData") or {}
+    chart_string = chart.get("stringData") or {}
+    if not source_data and not source_string:
+        if chart_data or chart_string:
+            findings.append(Finding("DRIFT", "data", "source secret is empty but chart renders data"))
+        return
+    for key, value in source_data.items():
+        if key not in chart_data:
+            findings.append(Finding("DRIFT", f"data.{key}", "missing in chart"))
+        elif chart_data[key] != value:
+            findings.append(Finding("DRIFT", f"data.{key}", "source and chart differ"))
+    for key in chart_data:
+        if key not in source_data:
+            findings.append(Finding("HELM_ONLY", f"data.{key}", "chart-only key"))
+    for key, value in source_string.items():
+        if key not in chart_string:
+            findings.append(Finding("DRIFT", f"stringData.{key}", "missing in chart"))
+        elif chart_string[key] != value:
+            findings.append(Finding("DRIFT", f"stringData.{key}", "source and chart differ"))
+    for key in chart_string:
+        if key not in source_string:
+            findings.append(Finding("HELM_ONLY", f"stringData.{key}", "chart-only key"))
+
+
+def parse_kinds(value: str) -> frozenset[str]:
+    kinds = frozenset(kind.strip() for kind in value.split(",") if kind.strip())
+    if not kinds:
+        raise argparse.ArgumentTypeError("no kinds provided")
+    unknown = kinds - MANAGED_KINDS
+    if unknown:
+        raise argparse.ArgumentTypeError(f"unsupported kinds: {', '.join(sorted(unknown))}")
+    return kinds
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--agents-repo", type=Path, default=Path.cwd())
     parser.add_argument("--charts-repo", type=Path, required=True)
-    parser.add_argument("--component", choices=("all", "controller", "manager"), default="all")
-    parser.add_argument("--aspect", choices=("crd",), default="crd")
+    parser.add_argument("--component", choices=("all", "controller", "manager", "gateway"), default="all")
+    parser.add_argument("--aspect", choices=("crd", "manifests"), default="crd")
+    parser.add_argument("--kinds", type=parse_kinds, default=None, help="comma-separated kinds to check (manifests aspect only)")
     parser.add_argument("--target", choices=("next",), default="next")
     parser.add_argument("--apply-crds", action="store_true")
     return parser.parse_args()
 
 
 def main() -> int:
+    args = parse_args()
     try:
-        return synchronize(parse_args())
+        if args.aspect == "manifests":
+            if args.apply_crds:
+                raise ConfigurationError("--apply-crds is only valid with --aspect crd")
+            return check_manifests(args)
+        if args.kinds is not None:
+            raise ConfigurationError("--kinds is only valid with --aspect manifests")
+        return synchronize(args)
     except ConfigurationError as error:
         print(f"ERROR {error}", file=sys.stderr)
         return 2

--- a/.qoder/skills/sync-charts/scripts/chart_drift.py
+++ b/.qoder/skills/sync-charts/scripts/chart_drift.py
@@ -269,6 +269,7 @@ def check_manifests(args: argparse.Namespace) -> int:
     has_drift = False
     has_unmapped = False
     chart_renders: dict[tuple[str, Path], list[dict]] = {}
+    template_texts: dict[tuple[str, Path], str] = {}
 
     for target in targets:
         source = source_docs[target.overlay].get((target.kind, target.name))
@@ -300,7 +301,12 @@ def check_manifests(args: argparse.Namespace) -> int:
             has_drift = True
             continue
         findings = compare_manifest(source, chart)
-        if any(finding.category == "DRIFT" for finding in findings):
+        if key not in template_texts:
+            template_texts[key] = (charts_repo / "versions" / target.chart / "next" / target.template).read_text(
+                encoding="utf-8"
+            )
+        mark_templated(findings, template_texts[key])
+        if any(finding.category in ("DRIFT", "TEMPLATED") for finding in findings):
             has_drift = True
         if findings:
             for finding in findings:
@@ -353,6 +359,32 @@ def compare_manifest(source: dict, chart: dict) -> list[Finding]:
     }
     comparators[source.get("kind", "")](source, chart, findings)
     return findings
+
+
+def leaf_key(path: str) -> str:
+    key = path.rsplit(".", 1)[-1]
+    return key.split("[", 1)[0].strip()
+
+
+def is_value_difference(detail: str) -> bool:
+    return " != chart " in detail or detail == "source and chart differ" or detail.startswith("source item ")
+
+
+def template_renders_key(template_text: str, key: str) -> bool:
+    direct = re.search(r"^[ \t]*" + re.escape(key) + r"[ \t]*:[^\n]*\{\{", template_text, re.MULTILINE)
+    if direct:
+        return True
+    return re.search(r"\{\{-?[ \t]*range[^\n]*\." + re.escape(key) + r"[ \t]*-?\}\}", template_text) is not None
+
+
+def mark_templated(findings: list[Finding], template_text: str) -> None:
+    for finding in findings:
+        if finding.category != "DRIFT" or not is_value_difference(finding.detail):
+            continue
+        if not template_renders_key(template_text, leaf_key(finding.path)):
+            continue
+        finding.category = "TEMPLATED"
+        finding.detail += "; chart renders this field through a template"
 
 
 def compare_metadata(source: dict, chart: dict, findings: list[Finding]) -> None:
@@ -435,35 +467,34 @@ def compare_service(source: dict, chart: dict, findings: list[Finding]) -> None:
             Finding("DRIFT", "spec.type", f"source {source_spec.get('type')!r} != chart {chart_spec.get('type')!r}")
         )
     source_ports = source_spec.get("ports") or []
-    chart_ports = {port.get("port"): port for port in (chart_spec.get("ports") or [])}
-    for port in source_ports:
-        number = port.get("port")
-        match = chart_ports.get(number)
-        if match is None:
-            findings.append(Finding("DRIFT", f"spec.ports[{number}]", "missing in chart"))
-            continue
-        if port.get("targetPort") is not None and match.get("targetPort") != port.get("targetPort"):
-            findings.append(
-                Finding(
-                    "DRIFT",
-                    f"spec.ports[{number}].targetPort",
-                    f"source {port.get('targetPort')!r} != chart {match.get('targetPort')!r}",
+    chart_ports = chart_spec.get("ports") or []
+    for index, port in enumerate(source_ports):
+        if index >= len(chart_ports):
+            findings.append(Finding("DRIFT", f"spec.ports[{index}]", "missing in chart"))
+            break
+        match = chart_ports[index]
+        for field in ("port", "targetPort"):
+            if port.get(field) is not None and port.get(field) != match.get(field):
+                findings.append(
+                    Finding(
+                        "DRIFT",
+                        f"spec.ports[{index}].{field}",
+                        f"source {port.get(field)!r} != chart {match.get(field)!r}",
+                    )
                 )
-            )
         source_protocol = port.get("protocol") or "TCP"
         chart_protocol = match.get("protocol") or "TCP"
         if source_protocol != chart_protocol:
             findings.append(
                 Finding(
                     "DRIFT",
-                    f"spec.ports[{number}].protocol",
+                    f"spec.ports[{index}].protocol",
                     f"source {source_protocol!r} != chart {chart_protocol!r}",
                 )
             )
-    source_numbers = {port.get("port") for port in source_ports}
-    for number in chart_ports:
-        if number not in source_numbers:
-            findings.append(Finding("HELM_ONLY", f"spec.ports[{number}]", "chart-only port"))
+    for index in range(len(source_ports), len(chart_ports)):
+        number = chart_ports[index].get("port")
+        findings.append(Finding("HELM_ONLY", f"spec.ports[{index}]", f"chart-only port {number}"))
 
 
 def compare_configmap(source: dict, chart: dict, findings: list[Finding]) -> None:

--- a/.qoder/skills/sync-charts/tests/test_chart_drift.py
+++ b/.qoder/skills/sync-charts/tests/test_chart_drift.py
@@ -3,11 +3,15 @@
 
 from __future__ import annotations
 
+import copy
+import os
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+
+import yaml
 
 
 SKILL_DIR = Path(__file__).resolve().parents[1]
@@ -468,6 +472,385 @@ class ChartDriftTest(unittest.TestCase):
         ):
             with self.subTest(source=source):
                 self.assertIn(source, content)
+
+
+FAKE_KUSTOMIZE = """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+overlay = Path(sys.argv[2]).name
+fixtures = Path(os.environ["FAKE_KUSTOMIZE_FIXTURES"])
+sys.stdout.write((fixtures / (overlay + ".yaml")).read_text(encoding="utf-8"))
+"""
+
+FAKE_HELM = """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+template = Path(args[args.index("-s") + 1]).name
+chart = Path(args[2]).parent.name
+fixtures = Path(os.environ["FAKE_HELM_FIXTURES"])
+sys.stdout.write((fixtures / chart / template).read_text(encoding="utf-8"))
+"""
+
+CHART_LABELS = {
+    "helm.sh/chart": "sandbox-0.1.0",
+    "app.kubernetes.io/managed-by": "Helm",
+    "app.kubernetes.io/instance": "sandbox",
+    "app.kubernetes.io/version": "0.1.0",
+}
+
+CONTROLLER_CHART_NAME = "kruise-agents-sandbox-controller"
+MANAGER_CHART_NAME = "kruise-agents-sandbox-manager"
+
+
+def controller_source_docs() -> list[dict]:
+    return [
+        {
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": {"name": "sandbox-system"},
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "configuration"},
+            "data": {"controller_manager_env.yaml": "ENABLE_WEBHOOKS: true"},
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "ServiceAccount",
+            "metadata": {"name": "controller-manager"},
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": "controller-manager-webhook-service",
+                "labels": {"control-plane": "controller-manager"},
+            },
+            "spec": {
+                "type": "ClusterIP",
+                "ports": [
+                    {"port": 443, "targetPort": 9443, "protocol": "TCP", "name": "webhook"}
+                ],
+            },
+        },
+    ]
+
+
+def manager_source_docs() -> list[dict]:
+    return [
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {"name": "sandbox-manager"},
+            "spec": {
+                "type": "ClusterIP",
+                "ports": [{"port": 7788, "targetPort": 7788, "name": "http-envoy"}],
+            },
+        },
+        {
+            "apiVersion": "networking.k8s.io/v1",
+            "kind": "Ingress",
+            "metadata": {"name": "sandbox-manager"},
+            "spec": {
+                "ingressClassName": "nginx",
+                "tls": [{"hosts": ["example.com"], "secretName": "sandbox-manager-tls"}],
+                "rules": [
+                    {
+                        "host": "example.com",
+                        "http": {
+                            "paths": [
+                                {
+                                    "path": "/",
+                                    "pathType": "Prefix",
+                                    "backend": {
+                                        "service": {
+                                            "name": "sandbox-manager",
+                                            "port": {"number": 7788},
+                                        }
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                ],
+            },
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {"name": "e2b-key-store"},
+            "type": "Opaque",
+            "data": {},
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "sandbox-manager-envoy-config"},
+            "data": {
+                "envoy.yaml": (
+                    "admin:\n"
+                    "  address:\n"
+                    "    socket_address:\n"
+                    "      port_value: 9901\n"
+                )
+            },
+        },
+    ]
+
+
+def gateway_source_docs() -> list[dict]:
+    return [
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {"name": "sandbox-gateway"},
+            "spec": {
+                "type": "ClusterIP",
+                "ports": [{"port": 80, "targetPort": 8081, "name": "http"}],
+            },
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "envoy-config"},
+            "data": {
+                "envoy.yaml": "static_resources:\n  listeners:\n    - name: http\n"
+            },
+        },
+    ]
+
+
+def default_source_docs() -> dict[str, list[dict]]:
+    return {
+        "manager": controller_source_docs(),
+        "sandbox-manager": manager_source_docs(),
+        "sandbox-gateway": gateway_source_docs(),
+    }
+
+
+def chart_doc(source_doc: dict) -> dict:
+    doc = copy.deepcopy(source_doc)
+    metadata = dict(doc.get("metadata") or {})
+    metadata["labels"] = {**(metadata.get("labels") or {}), **CHART_LABELS}
+    if doc.get("kind") == "Secret":
+        metadata["annotations"] = {
+            **(metadata.get("annotations") or {}),
+            "helm.sh/resource-policy": "keep",
+        }
+    doc["metadata"] = metadata
+    return doc
+
+
+def default_chart_docs() -> dict[tuple[str, str], list[dict]]:
+    controller = {doc["kind"]: doc for doc in controller_source_docs()}
+    manager = {doc["kind"]: doc for doc in manager_source_docs()}
+    gateway = {doc["kind"]: doc for doc in gateway_source_docs()}
+    return {
+        (CONTROLLER_CHART_NAME, "service.yaml"): [chart_doc(controller["Service"])],
+        (MANAGER_CHART_NAME, "service.yaml"): [
+            chart_doc(manager["Service"]),
+            chart_doc(gateway["Service"]),
+        ],
+        (MANAGER_CHART_NAME, "ingress.yaml"): [chart_doc(manager["Ingress"])],
+        (MANAGER_CHART_NAME, "secret.yaml"): [chart_doc(manager["Secret"])],
+        (MANAGER_CHART_NAME, "envoy-config.yaml"): [chart_doc(manager["ConfigMap"])],
+        (MANAGER_CHART_NAME, "gateway-envoy-config.yaml"): [chart_doc(gateway["ConfigMap"])],
+    }
+
+
+def dump_docs(docs: list[dict]) -> str:
+    return yaml.safe_dump_all(docs, sort_keys=False, default_flow_style=False)
+
+
+class ManifestDriftTest(unittest.TestCase):
+    def setUp(self) -> None:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        self.root = Path(temp.name)
+        self.agents_repo = self.root / "agents"
+        self.charts_repo = self.root / "charts"
+
+    def write_source_fixtures(self, overlay_docs: dict[str, list[dict]]) -> None:
+        fixtures = self.agents_repo / ".kustomize-fixtures"
+        for overlay, docs in overlay_docs.items():
+            fixtures.mkdir(parents=True, exist_ok=True)
+            (fixtures / f"{overlay}.yaml").write_text(dump_docs(docs), encoding="utf-8")
+        kustomize = self.agents_repo / "bin" / "kustomize"
+        kustomize.parent.mkdir(parents=True, exist_ok=True)
+        kustomize.write_text(FAKE_KUSTOMIZE, encoding="utf-8")
+        kustomize.chmod(0o755)
+
+    def write_chart_fixtures(self, chart_docs: dict[tuple[str, str], list[dict]]) -> None:
+        for (chart, template), docs in chart_docs.items():
+            fixture = self.root / ".helm-fixtures" / chart / template
+            fixture.parent.mkdir(parents=True, exist_ok=True)
+            fixture.write_text(dump_docs(docs), encoding="utf-8")
+            template_file = self.charts_repo / "versions" / chart / "next" / "templates" / template
+            template_file.parent.mkdir(parents=True, exist_ok=True)
+            template_file.write_text("# chart template source\n", encoding="utf-8")
+        helm = self.root / "fakebin" / "helm"
+        helm.parent.mkdir(parents=True, exist_ok=True)
+        helm.write_text(FAKE_HELM, encoding="utf-8")
+        helm.chmod(0o755)
+
+    def run_checker(self, *args: str) -> subprocess.CompletedProcess:
+        env = {
+            **os.environ,
+            "PATH": f"{self.root / 'fakebin'}{os.pathsep}{os.environ['PATH']}",
+            "FAKE_KUSTOMIZE_FIXTURES": str(self.agents_repo / ".kustomize-fixtures"),
+            "FAKE_HELM_FIXTURES": str(self.root / ".helm-fixtures"),
+        }
+        return subprocess.run(
+            [
+                sys.executable,
+                str(CHECKER),
+                "--agents-repo",
+                str(self.agents_repo),
+                "--charts-repo",
+                str(self.charts_repo),
+                *args,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def run_manifests_checker(self, *extra_args: str) -> subprocess.CompletedProcess:
+        return self.run_checker("--aspect", "manifests", *extra_args)
+
+    def test_reports_every_mapped_manifest_clean_ignoring_skipped_documents(self) -> None:
+        self.write_source_fixtures(default_source_docs())
+        self.write_chart_fixtures(default_chart_docs())
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for line in (
+            "OK manifests controller Service/controller-manager-webhook-service",
+            "OK manifests manager Service/sandbox-manager",
+            "OK manifests manager Ingress/sandbox-manager",
+            "OK manifests manager Secret/e2b-key-store",
+            "OK manifests manager ConfigMap/sandbox-manager-envoy-config",
+            "OK manifests gateway Service/sandbox-gateway",
+            "OK manifests gateway ConfigMap/envoy-config",
+        ):
+            with self.subTest(line=line):
+                self.assertIn(line, result.stdout)
+        self.assertNotIn("UNMAPPED", result.stdout)
+        self.assertNotIn("Namespace", result.stdout)
+        self.assertNotIn("configuration", result.stdout)
+
+    def test_reports_missing_chart_template(self) -> None:
+        chart_docs = default_chart_docs()
+        del chart_docs[(MANAGER_CHART_NAME, "secret.yaml")]
+        self.write_source_fixtures(default_source_docs())
+        self.write_chart_fixtures(chart_docs)
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertIn(
+            "MISSING manifests manager Secret/e2b-key-store: templates/secret.yaml not found",
+            result.stdout,
+        )
+
+    def test_reports_unmapped_source_manifest(self) -> None:
+        source_docs = default_source_docs()
+        source_docs["sandbox-manager"].append(
+            {"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "sandbox-manager-extra"}}
+        )
+        self.write_source_fixtures(source_docs)
+        self.write_chart_fixtures(default_chart_docs())
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 3, result.stderr)
+        self.assertIn("UNMAPPED manifests manager ConfigMap/sandbox-manager-extra", result.stdout)
+
+    def test_reports_chart_only_port_as_helm_only(self) -> None:
+        chart_docs = default_chart_docs()
+        manager_service = chart_docs[(MANAGER_CHART_NAME, "service.yaml")][0]
+        manager_service["spec"]["ports"].append(
+            {"port": 9002, "targetPort": 9002, "name": "grpc-extproc", "protocol": "TCP"}
+        )
+        self.write_source_fixtures(default_source_docs())
+        self.write_chart_fixtures(chart_docs)
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "HELM_ONLY manifests manager Service/sandbox-manager: spec.ports[9002] chart-only port",
+            result.stdout,
+        )
+        self.assertNotIn("DRIFT manifests", result.stdout)
+
+    def test_component_gateway_checks_only_gateway(self) -> None:
+        self.write_source_fixtures(default_source_docs())
+        self.write_chart_fixtures(default_chart_docs())
+
+        result = self.run_manifests_checker("--component", "gateway")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("OK manifests gateway Service/sandbox-gateway", result.stdout)
+        self.assertIn("OK manifests gateway ConfigMap/envoy-config", result.stdout)
+        self.assertNotIn(" manifests controller ", result.stdout)
+        self.assertNotIn(" manifests manager ", result.stdout)
+
+    def test_rejects_invalid_aspect_flag_combinations(self) -> None:
+        for extra_args, message in (
+            (
+                ("--aspect", "manifests", "--apply-crds"),
+                "--apply-crds is only valid with --aspect crd",
+            ),
+            (
+                ("--aspect", "crd", "--kinds", "Service"),
+                "--kinds is only valid with --aspect manifests",
+            ),
+            (
+                ("--aspect", "crd", "--component", "gateway"),
+                "--component gateway is only valid with --aspect manifests",
+            ),
+        ):
+            with self.subTest(extra_args=extra_args):
+                result = self.run_checker(*extra_args)
+
+                self.assertEqual(result.returncode, 2, result.stderr)
+                self.assertIn(message, result.stderr)
+
+    def test_documents_deployment_manifest_synchronization(self) -> None:
+        content = SKILL.read_text(encoding="utf-8")
+
+        self.assertIn("## Deployment Manifests", content)
+        for requirement in (
+            "--aspect manifests --component all",
+            "--aspect manifests --component gateway",
+            "--aspect manifests --kinds Service,ConfigMap",
+            "controller-manager-webhook-service",
+            "sandbox-manager-envoy-config",
+            "e2b-key-store",
+            "envoy-config",
+            "templates/gateway-envoy-config.yaml",
+            "(document 1)",
+            "config/manager",
+            "config/sandbox-manager",
+            "config/sandbox-gateway",
+            "read-only manifests checker",
+            "`HELM_ONLY` — chart-only content",
+            "`MISSING` — a mapped chart template file does not exist",
+            "`UNMAPPED` — a source manifest of a managed kind",
+            "Deployments are not synchronized by this checker",
+            "`MANIFEST_SPEC` mapping",
+        ):
+            with self.subTest(requirement=requirement):
+                self.assertIn(requirement, content)
 
 
 if __name__ == "__main__":

--- a/.qoder/skills/sync-charts/tests/test_chart_drift.py
+++ b/.qoder/skills/sync-charts/tests/test_chart_drift.py
@@ -686,14 +686,19 @@ class ManifestDriftTest(unittest.TestCase):
         kustomize.write_text(FAKE_KUSTOMIZE, encoding="utf-8")
         kustomize.chmod(0o755)
 
-    def write_chart_fixtures(self, chart_docs: dict[tuple[str, str], list[dict]]) -> None:
+    def write_chart_fixtures(
+        self,
+        chart_docs: dict[tuple[str, str], list[dict]],
+        template_sources: dict[tuple[str, str], str] | None = None,
+    ) -> None:
         for (chart, template), docs in chart_docs.items():
             fixture = self.root / ".helm-fixtures" / chart / template
             fixture.parent.mkdir(parents=True, exist_ok=True)
             fixture.write_text(dump_docs(docs), encoding="utf-8")
             template_file = self.charts_repo / "versions" / chart / "next" / "templates" / template
             template_file.parent.mkdir(parents=True, exist_ok=True)
-            template_file.write_text("# chart template source\n", encoding="utf-8")
+            content = (template_sources or {}).get((chart, template), "# chart template source\n")
+            template_file.write_text(content, encoding="utf-8")
         helm = self.root / "fakebin" / "helm"
         helm.parent.mkdir(parents=True, exist_ok=True)
         helm.write_text(FAKE_HELM, encoding="utf-8")
@@ -787,9 +792,146 @@ class ManifestDriftTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn(
-            "HELM_ONLY manifests manager Service/sandbox-manager: spec.ports[9002] chart-only port",
+            "HELM_ONLY manifests manager Service/sandbox-manager: spec.ports[1] chart-only port 9002",
             result.stdout,
         )
+        self.assertNotIn("DRIFT manifests", result.stdout)
+
+    def test_marks_value_difference_on_templated_field_as_templated(self) -> None:
+        chart_docs = default_chart_docs()
+        manager_envoy = chart_docs[(MANAGER_CHART_NAME, "envoy-config.yaml")][0]
+        manager_envoy["data"]["envoy.yaml"] = (
+            "admin:\n"
+            "  address:\n"
+            "    socket_address:\n"
+            "      port_value: 9902\n"
+        )
+        template_sources = {
+            (
+                MANAGER_CHART_NAME,
+                "envoy-config.yaml",
+            ): "admin:\n  address:\n    socket_address:\n      port_value: {{ .Values.envoy.adminPort }}\n"
+        }
+        self.write_source_fixtures(default_source_docs())
+        self.write_chart_fixtures(chart_docs, template_sources)
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertIn(
+            "TEMPLATED manifests manager ConfigMap/sandbox-manager-envoy-config: "
+            "data.envoy.yaml.admin.address.socket_address.port_value source 9901 != chart 9902",
+            result.stdout,
+        )
+        self.assertIn("chart renders this field through a template", result.stdout)
+        self.assertNotIn("DRIFT manifests", result.stdout)
+
+    def test_keeps_plain_drift_when_template_is_literal(self) -> None:
+        chart_docs = default_chart_docs()
+        manager_envoy = chart_docs[(MANAGER_CHART_NAME, "envoy-config.yaml")][0]
+        manager_envoy["data"]["envoy.yaml"] = (
+            "admin:\n"
+            "  address:\n"
+            "    socket_address:\n"
+            "      port_value: 9902\n"
+        )
+        template_sources = {
+            (
+                MANAGER_CHART_NAME,
+                "envoy-config.yaml",
+            ): "admin:\n  address:\n    socket_address:\n      port_value: 9902\n"
+        }
+        self.write_source_fixtures(default_source_docs())
+        self.write_chart_fixtures(chart_docs, template_sources)
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertIn(
+            "DRIFT manifests manager ConfigMap/sandbox-manager-envoy-config: "
+            "data.envoy.yaml.admin.address.socket_address.port_value source 9901 != chart 9902",
+            result.stdout,
+        )
+        self.assertNotIn("TEMPLATED", result.stdout)
+        self.assertNotIn("chart renders this field through a template", result.stdout)
+
+    def test_keeps_missing_field_as_drift_even_when_templated(self) -> None:
+        chart_docs = default_chart_docs()
+        manager_envoy = chart_docs[(MANAGER_CHART_NAME, "envoy-config.yaml")][0]
+        manager_envoy["data"]["envoy.yaml"] = "admin:\n  address:\n    socket_address: {}\n"
+        template_sources = {
+            (
+                MANAGER_CHART_NAME,
+                "envoy-config.yaml",
+            ): "admin:\n  address:\n    socket_address:\n      port_value: {{ .Values.envoy.adminPort }}\n"
+        }
+        self.write_source_fixtures(default_source_docs())
+        self.write_chart_fixtures(chart_docs, template_sources)
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertIn(
+            "DRIFT manifests manager ConfigMap/sandbox-manager-envoy-config: "
+            "data.envoy.yaml.admin.address.socket_address.port_value missing in chart",
+            result.stdout,
+        )
+        self.assertNotIn("TEMPLATED", result.stdout)
+
+    def test_marks_range_templated_list_difference_as_templated(self) -> None:
+        source_docs = default_source_docs()
+        gateway_envoy = next(
+            doc
+            for doc in source_docs["sandbox-gateway"]
+            if doc.get("metadata", {}).get("name") == "envoy-config"
+        )
+        gateway_envoy["data"]["envoy.yaml"] = (
+            "static_resources:\n"
+            "  listeners:\n"
+            "    - name: http\n"
+            "  thresholds:\n"
+            "    - max_connections: 80000\n"
+            "      priority: DEFAULT\n"
+            "    - max_connections: 100\n"
+            "      priority: HIGH\n"
+        )
+        chart_docs = default_chart_docs()
+        chart_gateway_envoy = chart_docs[(MANAGER_CHART_NAME, "gateway-envoy-config.yaml")][0]
+        chart_gateway_envoy["data"]["envoy.yaml"] = (
+            "static_resources:\n"
+            "  listeners:\n"
+            "    - name: http\n"
+            "  thresholds:\n"
+            "    - max_connections: 80000\n"
+            "      priority: DEFAULT\n"
+        )
+        template_sources = {
+            (
+                MANAGER_CHART_NAME,
+                "gateway-envoy-config.yaml",
+            ): (
+                "static_resources:\n"
+                "  listeners:\n"
+                "    - name: http\n"
+                "  thresholds:\n"
+                "{{- range .Values.gateway.envoy.circuitBreakers.thresholds }}\n"
+                "    - max_connections: {{ .maxConnections }}\n"
+                "      priority: {{ .priority }}\n"
+                "{{- end }}\n"
+            )
+        }
+        self.write_source_fixtures(source_docs)
+        self.write_chart_fixtures(chart_docs, template_sources)
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertIn(
+            "TEMPLATED manifests gateway ConfigMap/envoy-config: "
+            "data.envoy.yaml.static_resources.thresholds source item",
+            result.stdout,
+        )
+        self.assertIn("missing in chart; chart renders this field through a template", result.stdout)
         self.assertNotIn("DRIFT manifests", result.stdout)
 
     def test_component_gateway_checks_only_gateway(self) -> None:
@@ -846,10 +988,14 @@ class ManifestDriftTest(unittest.TestCase):
             "`HELM_ONLY` — chart-only content",
             "`MISSING` — a mapped chart template file does not exist",
             "`UNMAPPED` — a source manifest of a managed kind",
+            "`TEMPLATED` — a value difference on a field the chart renders",
+            "`0` clean, `1` drift (including `TEMPLATED`) or missing",
             "Deployments are not synchronized by this checker",
             "`MANIFEST_SPEC` mapping",
-            "Do not modify resource metadata",
-            "Never replace a `{{ ... }}` template with a concrete source value",
+            "Preserve chart-managed metadata",
+            "fix values-driven drift by updating `values.yaml` defaults first",
+            "Match source order for indexed lists",
+            "template regressions",
         ):
             with self.subTest(requirement=requirement):
                 self.assertIn(requirement, content)

--- a/.qoder/skills/sync-charts/tests/test_chart_drift.py
+++ b/.qoder/skills/sync-charts/tests/test_chart_drift.py
@@ -848,6 +848,9 @@ class ManifestDriftTest(unittest.TestCase):
             "`UNMAPPED` — a source manifest of a managed kind",
             "Deployments are not synchronized by this checker",
             "`MANIFEST_SPEC` mapping",
+            "Do not modify resource metadata",
+            "append only",
+            "Never replace a `{{ ... }}` template with a concrete source value",
         ):
             with self.subTest(requirement=requirement):
                 self.assertIn(requirement, content)

--- a/.qoder/skills/sync-charts/tests/test_chart_drift.py
+++ b/.qoder/skills/sync-charts/tests/test_chart_drift.py
@@ -849,7 +849,6 @@ class ManifestDriftTest(unittest.TestCase):
             "Deployments are not synchronized by this checker",
             "`MANIFEST_SPEC` mapping",
             "Do not modify resource metadata",
-            "append only",
             "Never replace a `{{ ... }}` template with a concrete source value",
         ):
             with self.subTest(requirement=requirement):


### PR DESCRIPTION
## Summary

- Remove Deployment from the manifests drift checker scope; the checker now covers only **Service, ConfigMap, Ingress, and Secret** across controller, manager, and gateway components.
- Simplify `MANIFEST_SPEC` from 10 entries to 7 (drop 3 Deployment entries), remove Deployment-only comparison functions (`compare_deployment`, `compare_volumes`, `compare_containers`, `compare_container`, `compare_env`), and drop dead constants (`EXCLUDED_CONFIGMAP_REFS`, `PROBE_TIMING_FIELDS`).
- Update `SKILL.md` mapping table, `--kinds` subset description, out-of-scope paragraph, and `HELM_ONLY` bullet to reflect the narrower scope.
- Prune test suite: remove Deployment-specific tests and assertions; add new coverage for the narrowed scope (16 tests, all green).

## Test plan

- [x] `python3 .qoder/skills/sync-charts/tests/test_chart_drift.py -v` — 16/16 tests pass
- [x] Smoke run against a real charts checkout exits 0 with no Deployment in output (only Service/ConfigMap/Ingress/Secret findings)