### PR TITLE
Tracing user operation

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -160,13 +160,13 @@ func main() {
 	// the calling site, so that structured logs (which by default omit it) are as
 	// locatable as klog-native logs.
 	//
-	// The explicit Encoder fixes the format to one JSON object per line with the
-	// trace ID as its first field (see tracing.NewTraceFirstJSONEncoder). It
-	// takes precedence over --zap-encoder, which therefore no longer switches
-	// the format; other zap flags (level, stacktrace) keep working.
+	// The explicit Encoder fixes the format to one JSON object per line with
+	// the trace ID first and ISO8601 timestamps (see tracing.NewTraceFirstJSONEncoder).
+	// Both --zap-encoder and --zap-time-encoding are overridden and have no effect;
+	// --zap-log-level and --zap-stacktrace-level remain effective.
 	opts.Encoder = tracing.NewTraceFirstJSONEncoder()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts), zap.RawZapOpts(gozap.AddCaller())))
-	setupLog.Info("controller logger initialized with trace-first JSON encoder; --zap-encoder is overridden and has no effect")
+	setupLog.Info("controller logger initialized with trace-first JSON encoder and ISO8601 timestamps; --zap-encoder and --zap-time-encoding are overridden and have no effect")
 
 	if metricLabelsAllowlist != "" {
 		keys := strings.Split(metricLabelsAllowlist, ",")

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -28,6 +28,7 @@ import (
 	_ "time/tzdata" // Embed timezone database for scratch-based container images
 
 	"github.com/spf13/pflag"
+	gozap "go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -155,7 +156,17 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	// AddCaller annotates each log line with the source file and line number of
+	// the calling site, so that structured logs (which by default omit it) are as
+	// locatable as klog-native logs.
+	//
+	// The explicit Encoder fixes the format to one JSON object per line with the
+	// trace ID as its first field (see tracing.NewTraceFirstJSONEncoder). It
+	// takes precedence over --zap-encoder, which therefore no longer switches
+	// the format; other zap flags (level, stacktrace) keep working.
+	opts.Encoder = tracing.NewTraceFirstJSONEncoder()
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts), zap.RawZapOpts(gozap.AddCaller())))
+	setupLog.Info("controller logger initialized with trace-first JSON encoder; --zap-encoder is overridden and has no effect")
 
 	if metricLabelsAllowlist != "" {
 		keys := strings.Split(metricLabelsAllowlist, ",")

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -298,6 +298,15 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 	// span this early does not produce noise.
 	ctx, reconcileSpan := tracing.StartReconcileSpan(ctx, box)
 	reconcileSpan.SetAttributes(attribute.String(tracing.AttrSandboxPhase, string(box.Status.Phase)))
+	// Record condition values at the start of this Reconcile iteration so
+	// the before->after transition is visible when comparing this span with
+	// the child updateSandboxStatus span.
+	for _, cond := range box.Status.Conditions {
+		reconcileSpan.SetAttributes(attribute.String(
+			tracing.AttrConditionPrefix+cond.Type,
+			fmt.Sprintf("%s:%s", cond.Status, cond.Reason),
+		))
+	}
 	if traceID := tracing.TraceIDFromContext(ctx); traceID != "" {
 		ctx = klog.NewContext(ctx, klog.FromContext(ctx).WithValues("traceID", traceID))
 	}
@@ -619,9 +628,16 @@ func (r *SandboxReconciler) updateSandboxStatus(ctx context.Context, newStatus a
 	// independent value on the shouldRequeue early-return path, where the
 	// Reconcile span's phase attribute has not been refreshed; the full
 	// before->after transition is recorded in logs and K8s Events.
-	ctx, span := tracing.StartControllerSpan(ctx, tracing.SpanControllerUpdateStatus,
+	statusAttrs := []attribute.KeyValue{
 		attribute.String(tracing.AttrPhaseAfter, string(newStatus.Phase)),
-	)
+	}
+	for _, cond := range newStatus.Conditions {
+		statusAttrs = append(statusAttrs, attribute.String(
+			tracing.AttrConditionPrefix+cond.Type,
+			fmt.Sprintf("%s:%s", cond.Status, cond.Reason),
+		))
+	}
+	ctx, span := tracing.StartControllerSpan(ctx, tracing.SpanControllerUpdateStatus, statusAttrs...)
 
 	by, _ := json.Marshal(newStatus)
 	patchStatus := fmt.Sprintf(`{"status":%s}`, string(by))

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -308,7 +308,13 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 		))
 	}
 	if traceID := tracing.TraceIDFromContext(ctx); traceID != "" {
-		ctx = klog.NewContext(ctx, klog.FromContext(ctx).WithValues("traceID", traceID))
+		logValues := []any{tracing.TraceIDLogKey, traceID}
+		// Surface the user operation that started this trace (propagated via
+		// baggage in the CR annotation) so logs can be filtered by operation.
+		if op := tracing.TraceOperationFromContext(ctx); op != "" {
+			logValues = append(logValues, tracing.TraceOperationLogKey, op)
+		}
+		ctx = klog.NewContext(ctx, klog.FromContext(ctx).WithValues(logValues...))
 	}
 	// End the Reconcile span with the final Reconcile error via defer: a
 	// failing iteration is marked failed and always retained even when the

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -34,7 +34,6 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
-	"github.com/openkruise/agents/pkg/tracing"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/timeout"
 )
@@ -301,12 +300,6 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 	// placeholder timeout for timed sandboxes.
 	statusCode := http.StatusOK
 	if paused {
-		// This connect actually resumes the sandbox: relabel the trace
-		// operation so every CR write in this request (the resume itself and
-		// the follow-up timeout update) propagates "resume" instead of the
-		// connect route pattern. Connecting to a running sandbox keeps the
-		// default pattern because nothing is resumed.
-		ctx = tracing.WithTraceOperation(ctx, traceOpResume)
 		log.Info("sandbox is paused, will resume it", "reason", pauseResumeReason)
 		resumeOpts := sc.buildResumeOpts(ctx, sbx, autoPause, time.Now(), effectiveTimeout, !currentEndAt.IsZero())
 		if err := sc.manager.ResumeSandbox(ctx, sbx, resumeOpts); err != nil {

--- a/pkg/servers/e2b/pause_resume.go
+++ b/pkg/servers/e2b/pause_resume.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
+	"github.com/openkruise/agents/pkg/tracing"
 	"github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/timeout"
 )
@@ -300,6 +301,12 @@ func (sc *Controller) ConnectSandbox(r *http.Request) (web.ApiResponse[*models.S
 	// placeholder timeout for timed sandboxes.
 	statusCode := http.StatusOK
 	if paused {
+		// This connect actually resumes the sandbox: relabel the trace
+		// operation so every CR write in this request (the resume itself and
+		// the follow-up timeout update) propagates "resume" instead of the
+		// connect route pattern. Connecting to a running sandbox keeps the
+		// default pattern because nothing is resumed.
+		ctx = tracing.WithTraceOperation(ctx, traceOpResume)
 		log.Info("sandbox is paused, will resume it", "reason", pauseResumeReason)
 		resumeOpts := sc.buildResumeOpts(ctx, sbx, autoPause, time.Now(), effectiveTimeout, !currentEndAt.IsZero())
 		if err := sc.manager.ResumeSandbox(ctx, sbx, resumeOpts); err != nil {

--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
+	"github.com/openkruise/agents/pkg/tracing"
 	"github.com/openkruise/agents/pkg/utils"
 )
 
@@ -52,13 +53,16 @@ func (sc *Controller) registerRoutes() {
 	sc.mux.HandleFunc("GET "+adapters.CustomPrefix+"/api/health", healthHandler)
 
 	// Sandbox management endpoints
-	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes", sc.CreateSandbox, sc.CheckApiKey)
+	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes", sc.CreateSandbox, traceOperation(traceOpCreate), sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodGet, "/v2/sandboxes", sc.ListSandboxes, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodGet, "/sandboxes/{sandboxID}", sc.DescribeSandbox, sc.CheckApiKey)
-	RegisterE2BRoute(sc.mux, http.MethodDelete, "/sandboxes/{sandboxID}", sc.DeleteSandbox, sc.CheckApiKey)
+	RegisterE2BRoute(sc.mux, http.MethodDelete, "/sandboxes/{sandboxID}", sc.DeleteSandbox, traceOperation(traceOpKill), sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodPut, "/sandboxes/{sandboxID}/network", sc.UpdateSandboxNetwork, sc.CheckApiKey)
-	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/pause", sc.PauseSandbox, sc.CheckApiKey)
-	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/resume", sc.ResumeSandbox, sc.CheckApiKey)
+	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/pause", sc.PauseSandbox, traceOperation(traceOpPause), sc.CheckApiKey)
+	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/resume", sc.ResumeSandbox, traceOperation(traceOpResume), sc.CheckApiKey)
+	// Connect is labeled dynamically inside ConnectSandbox: it records
+	// "resume" only when it actually resumes a paused sandbox; connecting to
+	// a running sandbox keeps the default route pattern.
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/connect", sc.ConnectSandbox, sc.CheckApiKey)
 	web.RegisterRoute(sc.mux, http.MethodPost, adapters.CustomPrefix+"/api/sandboxes/{sandboxID}/traffic-access-token", sc.RefreshTrafficAccessToken, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/timeout", sc.SetSandboxTimeout, sc.CheckApiKey)
@@ -96,6 +100,30 @@ func RegisterE2BRoute[T any](mux *http.ServeMux, method, path string, handler we
 func registerObservabilityRoutes(mux *http.ServeMux) {
 	// Prometheus metrics endpoint for exporting metrics
 	mux.Handle("GET /metrics", promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{}))
+}
+
+// User-facing trace operation verbs recorded in baggage and surfaced as the
+// "traceOperation" field in cross-component logs. Users think in terms of
+// create/pause/resume/kill regardless of which HTTP route triggered the
+// operation. The verb is bound once per HTTP request at the entry point, so
+// internal sub-operations (e.g. anything a delete does under the hood) always
+// inherit the entry verb.
+const (
+	traceOpCreate = "create"
+	traceOpPause  = "pause"
+	traceOpResume = "resume"
+	traceOpKill   = "kill"
+)
+
+// traceOperation returns a middleware that overrides the trace operation
+// recorded in baggage with a short user-facing verb (e.g. "create", "kill")
+// instead of the default "METHOD /route" pattern set by the web framework.
+// The verb propagates to the controller via the trace-baggage CR annotation
+// and surfaces as the "traceOperation" field in cross-component logs.
+func traceOperation(operation string) web.MiddleWare {
+	return func(ctx context.Context, _ *http.Request) (context.Context, *web.ApiError) {
+		return tracing.WithTraceOperation(ctx, operation), nil
+	}
 }
 
 // AnonymousUser owns resources created while authentication is disabled. Reusing AdminKeyID

--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -60,10 +60,7 @@ func (sc *Controller) registerRoutes() {
 	RegisterE2BRoute(sc.mux, http.MethodPut, "/sandboxes/{sandboxID}/network", sc.UpdateSandboxNetwork, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/pause", sc.PauseSandbox, traceOperation(traceOpPause), sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/resume", sc.ResumeSandbox, traceOperation(traceOpResume), sc.CheckApiKey)
-	// Connect is labeled dynamically inside ConnectSandbox: it records
-	// "resume" only when it actually resumes a paused sandbox; connecting to
-	// a running sandbox keeps the default route pattern.
-	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/connect", sc.ConnectSandbox, sc.CheckApiKey)
+	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/connect", sc.ConnectSandbox, traceOperation(traceOpResume), sc.CheckApiKey)
 	web.RegisterRoute(sc.mux, http.MethodPost, adapters.CustomPrefix+"/api/sandboxes/{sandboxID}/traffic-access-token", sc.RefreshTrafficAccessToken, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/timeout", sc.SetSandboxTimeout, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/snapshots", sc.CreateSnapshot, sc.CheckApiKey)

--- a/pkg/servers/e2b/routes_test.go
+++ b/pkg/servers/e2b/routes_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -37,21 +38,25 @@ import (
 
 	infracache "github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/sandbox-manager/logs"
+	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/openkruise/agents/pkg/tracing"
 )
 
 type lookupKeyStorage struct {
-	byKey map[string]*models.CreatedTeamAPIKey
-	calls []string
+	byKey      map[string]*models.CreatedTeamAPIKey
+	calls      []string
+	operations []string
 }
 
 func (s *lookupKeyStorage) Init(context.Context) error { return nil }
 func (s *lookupKeyStorage) Run()                       {}
 func (s *lookupKeyStorage) Stop()                      {}
 
-func (s *lookupKeyStorage) LoadByKey(_ context.Context, key string) (*models.CreatedTeamAPIKey, bool) {
+func (s *lookupKeyStorage) LoadByKey(ctx context.Context, key string) (*models.CreatedTeamAPIKey, bool) {
 	s.calls = append(s.calls, key)
+	s.operations = append(s.operations, tracing.TraceOperationFromContext(ctx))
 	user, ok := s.byKey[key]
 	return user, ok
 }
@@ -87,6 +92,27 @@ func (s *lookupKeyStorage) ListTeams(context.Context, *models.CreatedTeamAPIKey)
 
 func (s *lookupKeyStorage) FindTeamByName(context.Context, string) (*models.Team, bool, error) {
 	return nil, false, nil
+}
+
+func TestConnectRouteTraceOperation(t *testing.T) {
+	for _, prefix := range []string{"", adapters.CustomPrefix + "/api"} {
+		path := prefix + "/sandboxes/test-sandbox/connect"
+		t.Run(path, func(t *testing.T) {
+			storage := &lookupKeyStorage{}
+			controller := &Controller{mux: http.NewServeMux(), keys: storage}
+			controller.registerRoutes()
+
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			req.Header.Set(models.HeaderApiKey, "invalid-key")
+			rec := httptest.NewRecorder()
+			controller.mux.ServeHTTP(rec, req)
+
+			// 在鉴权阶段检查标签，确保尚未查询 Sandbox 状态时就已统一标记。
+			require.Equal(t, http.StatusUnauthorized, rec.Code)
+			assert.Equal(t, []string{"invalid-key"}, storage.calls)
+			assert.Equal(t, []string{traceOpResume}, storage.operations)
+		})
+	}
 }
 
 // TestCheckApiKey_WithRealSetup tests CheckApiKey with full Setup

--- a/pkg/servers/web/framework.go
+++ b/pkg/servers/web/framework.go
@@ -127,6 +127,10 @@ func RegisterRoute[T any](mux *http.ServeMux, method, path string, handler Handl
 		// Store root span context so that InjectTraceContext uses the root span's SpanID
 		// when propagating trace context to the controller via CR annotations.
 		ctx = tracing.WithRootSpanContext(ctx)
+		// Record the user-facing operation (method + route pattern) in baggage
+		// so cross-component logs (e.g. controller Reconcile) can attribute
+		// the trace to this API call. Propagates alongside the trace context.
+		ctx = tracing.WithTraceOperation(ctx, pattern)
 
 		defer func() {
 			if rec := recover(); rec != nil {

--- a/pkg/tracing/propagator.go
+++ b/pkg/tracing/propagator.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -27,9 +28,26 @@ import (
 // W3C Trace Context across components via Kubernetes CRD annotations.
 const TraceContextAnnotationKey = "agents.kruise.io/trace-context"
 
+// TraceBaggageAnnotationKey is the annotation key used to propagate
+// W3C Baggage across components via Kubernetes CRD annotations. It carries
+// trace-scoped metadata such as the user operation that started the trace.
+const TraceBaggageAnnotationKey = "agents.kruise.io/trace-baggage"
+
 // traceParentKey is the standard W3C Trace Context header key used by the
 // OTel propagator (https://www.w3.org/TR/trace-context/#traceparent-header).
 const traceParentKey = "traceparent"
+
+// baggageKey is the standard W3C Baggage header key used by the OTel
+// propagator (https://www.w3.org/TR/baggage/#baggage-http-header-format).
+const baggageKey = "baggage"
+
+// operationBaggageMember is the baggage member name carrying the user
+// operation (HTTP method + route pattern) that started the trace.
+const operationBaggageMember = "operation"
+
+// TraceOperationLogKey is the structured-logging key for the user operation
+// that started the trace (e.g. "POST /sandboxes/{sandboxID}/pause").
+const TraceOperationLogKey = "traceOperation"
 
 // annotationCarrier implements propagation.TextMapCarrier over a map[string]string.
 type annotationCarrier struct {
@@ -37,21 +55,28 @@ type annotationCarrier struct {
 }
 
 // Get returns the value for the given OTel propagator key.
-// The standard W3C "traceparent" key is mapped to TraceContextAnnotationKey
-// so that the annotation key follows Kubernetes naming conventions.
+// The standard W3C "traceparent" and "baggage" keys are mapped to
+// Kubernetes-convention annotation keys.
 func (c *annotationCarrier) Get(key string) string {
-	if key == traceParentKey {
+	switch key {
+	case traceParentKey:
 		return c.annotations[TraceContextAnnotationKey]
+	case baggageKey:
+		return c.annotations[TraceBaggageAnnotationKey]
 	}
 	return c.annotations[key]
 }
 
 // Set stores the value for the given OTel propagator key.
-// The standard W3C "traceparent" key is mapped to TraceContextAnnotationKey
-// so that the annotation key follows Kubernetes naming conventions.
+// The standard W3C "traceparent" and "baggage" keys are mapped to
+// Kubernetes-convention annotation keys.
 func (c *annotationCarrier) Set(key, value string) {
-	if key == traceParentKey {
+	switch key {
+	case traceParentKey:
 		c.annotations[TraceContextAnnotationKey] = value
+		return
+	case baggageKey:
+		c.annotations[TraceBaggageAnnotationKey] = value
 		return
 	}
 	c.annotations[key] = value
@@ -129,6 +154,34 @@ func InjectTraceContext(ctx context.Context, annotations map[string]string) map[
 	carrier := &annotationCarrier{annotations: annotations}
 	otel.GetTextMapPropagator().Inject(ctx, carrier)
 	return annotations
+}
+
+// WithTraceOperation records the user operation (e.g. the HTTP method and
+// route pattern) that started the trace as an OTel Baggage member, so it
+// propagates across components together with the trace context (both via
+// HTTP headers and via CR annotations through InjectTraceContext). A raw
+// member is used so values may contain spaces; serialization percent-encodes
+// them. An invalid operation value leaves ctx unchanged.
+func WithTraceOperation(ctx context.Context, operation string) context.Context {
+	if operation == "" {
+		return ctx
+	}
+	member, err := baggage.NewMemberRaw(operationBaggageMember, operation)
+	if err != nil {
+		return ctx
+	}
+	bag, err := baggage.FromContext(ctx).SetMember(member)
+	if err != nil {
+		return ctx
+	}
+	return baggage.ContextWithBaggage(ctx, bag)
+}
+
+// TraceOperationFromContext returns the user operation stored by
+// WithTraceOperation, or extracted from propagated baggage (HTTP headers or
+// CR annotations via ExtractTraceContext). Returns "" when absent.
+func TraceOperationFromContext(ctx context.Context) string {
+	return baggage.FromContext(ctx).Member(operationBaggageMember).Value()
 }
 
 // ExtractTraceContext extracts trace context from annotations and returns a context

--- a/pkg/tracing/propagator.go
+++ b/pkg/tracing/propagator.go
@@ -151,6 +151,9 @@ func InjectTraceContext(ctx context.Context, annotations map[string]string) map[
 	if annotations == nil {
 		annotations = make(map[string]string, 1)
 	}
+	// Empty baggage does not trigger a carrier write. Clear the previous value
+	// before injection so the new trace context cannot inherit a stale operation.
+	delete(annotations, TraceBaggageAnnotationKey)
 	carrier := &annotationCarrier{annotations: annotations}
 	otel.GetTextMapPropagator().Inject(ctx, carrier)
 	return annotations

--- a/pkg/tracing/propagator_test.go
+++ b/pkg/tracing/propagator_test.go
@@ -18,10 +18,13 @@ package tracing
 
 import (
 	"context"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
@@ -83,6 +86,11 @@ func TestInjectTraceContext_NilAnnotations(t *testing.T) {
 			hasSpan: true,
 			wantNil: false,
 		},
+		{
+			name:    "baggage without an active span does not allocate annotations",
+			ctx:     WithTraceOperation(context.Background(), "resume"),
+			wantNil: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -111,11 +119,21 @@ func TestInjectTraceContext_NilAnnotations(t *testing.T) {
 }
 
 func TestInjectTraceContext_WithExistingAnnotations(t *testing.T) {
+	const staleBaggage = "operation=pause,tenant=old"
+	staleAnnotations := map[string]string{
+		"existing":                "value",
+		TraceContextAnnotationKey: "00-11111111111111111111111111111111-2222222222222222-01",
+		TraceBaggageAnnotationKey: staleBaggage,
+	}
+	otherBaggage, err := baggage.Parse("tenant=current")
+	require.NoError(t, err)
+
 	tests := []struct {
 		name        string
 		ctx         context.Context
 		annotations map[string]string
 		hasSpan     bool
+		wantBaggage string
 	}{
 		{
 			name:        "existing annotations with no active span",
@@ -129,6 +147,38 @@ func TestInjectTraceContext_WithExistingAnnotations(t *testing.T) {
 			annotations: map[string]string{"existing": "value"},
 			hasSpan:     true,
 		},
+		{
+			name:        "empty baggage clears the previous operation",
+			ctx:         context.Background(),
+			annotations: staleAnnotations,
+			hasSpan:     true,
+		},
+		{
+			name:        "current operation replaces stale baggage",
+			ctx:         WithTraceOperation(context.Background(), "resume"),
+			annotations: staleAnnotations,
+			hasSpan:     true,
+			wantBaggage: "operation=resume",
+		},
+		{
+			name:        "other baggage is preserved without an operation",
+			ctx:         baggage.ContextWithBaggage(context.Background(), otherBaggage),
+			annotations: staleAnnotations,
+			hasSpan:     true,
+			wantBaggage: "tenant=current",
+		},
+		{
+			name:        "no active span leaves stale annotations untouched",
+			ctx:         context.Background(),
+			annotations: staleAnnotations,
+			wantBaggage: staleBaggage,
+		},
+		{
+			name:        "baggage alone leaves stale annotations untouched",
+			ctx:         WithTraceOperation(context.Background(), "resume"),
+			annotations: staleAnnotations,
+			wantBaggage: staleBaggage,
+		},
 	}
 
 	for _, tt := range tests {
@@ -137,15 +187,43 @@ func TestInjectTraceContext_WithExistingAnnotations(t *testing.T) {
 				cleanup := initTestTracer()
 				defer cleanup()
 				tracer := Tracer("test")
-				tt.ctx, _ = tracer.Start(tt.ctx, "test-span")
+				var span trace.Span
+				tt.ctx, span = tracer.Start(tt.ctx, "test-span")
+				defer span.End()
 			} else {
 				cleanup := initNoopTracer()
 				defer cleanup()
 			}
 
-			result := InjectTraceContext(tt.ctx, tt.annotations)
-			assert.NotNil(t, result, "should return non-nil annotations")
-			assert.Equal(t, "value", result["existing"], "existing annotation should be preserved")
+			// Keep input and expected maps independent so in-place mutations
+			// cannot hide stale annotations.
+			annotations := maps.Clone(tt.annotations)
+			want := maps.Clone(tt.annotations)
+			if tt.hasSpan {
+				sc := trace.SpanContextFromContext(tt.ctx)
+				want[TraceContextAnnotationKey] = "00-" + sc.TraceID().String() + "-" + sc.SpanID().String() + "-" + sc.TraceFlags().String()
+			}
+			if tt.wantBaggage == "" {
+				delete(want, TraceBaggageAnnotationKey)
+			} else {
+				want[TraceBaggageAnnotationKey] = tt.wantBaggage
+			}
+
+			result := InjectTraceContext(tt.ctx, annotations)
+			assert.Equal(t, want, result)
+			assert.Equal(t, want, annotations, "existing annotations must be updated in place")
+			if tt.hasSpan {
+				extracted := ExtractTraceContext(context.Background(), result)
+				assert.Equal(t, TraceOperationFromContext(tt.ctx), TraceOperationFromContext(extracted))
+				assert.Equal(t, baggage.FromContext(tt.ctx).String(), baggage.FromContext(extracted).String())
+			}
+			if tt.hasSpan && tt.wantBaggage != "" {
+				// Reusing the same map without baggage must clear the previous injection.
+				ctx := baggage.ContextWithBaggage(tt.ctx, baggage.Baggage{})
+				delete(want, TraceBaggageAnnotationKey)
+				assert.Equal(t, want, InjectTraceContext(ctx, result))
+				assert.Equal(t, want, annotations)
+			}
 		})
 	}
 }
@@ -216,8 +294,11 @@ func TestInjectTraceContext_NoActiveSpanWithNoopTracer(t *testing.T) {
 
 func TestWithRootSpanContext_InjectUsesRootSpanID(t *testing.T) {
 	tests := []struct {
-		name           string
-		useRootSpanCtx bool
+		name             string
+		useRootSpanCtx   bool
+		operation        string
+		clearCurrentSpan bool
+		unsampled        bool
 	}{
 		{
 			name:           "WithRootSpanContext: injected SpanID is root span's SpanID",
@@ -226,6 +307,21 @@ func TestWithRootSpanContext_InjectUsesRootSpanID(t *testing.T) {
 		{
 			name:           "without WithRootSpanContext: injected SpanID is child span's SpanID",
 			useRootSpanCtx: false,
+		},
+		{
+			name:           "operation added after saving root context is injected",
+			useRootSpanCtx: true,
+			operation:      "resume",
+		},
+		{
+			name:             "stored root clears stale baggage without a valid current span",
+			useRootSpanCtx:   true,
+			clearCurrentSpan: true,
+		},
+		{
+			name:           "valid unsampled root clears stale baggage",
+			useRootSpanCtx: true,
+			unsampled:      true,
 		},
 	}
 
@@ -238,17 +334,28 @@ func TestWithRootSpanContext_InjectUsesRootSpanID(t *testing.T) {
 
 			// Create root span (simulates HTTP middleware root span).
 			ctx, rootSpan := tracer.Start(context.Background(), "root-span")
+			rootSpanCtx := rootSpan.SpanContext()
+			if tt.unsampled {
+				rootSpanCtx = rootSpanCtx.WithTraceFlags(0)
+				ctx = trace.ContextWithSpanContext(ctx, rootSpanCtx)
+			}
 
 			// Optionally capture root span context before creating child spans.
 			if tt.useRootSpanCtx {
 				ctx = WithRootSpanContext(ctx)
 			}
+			ctx = WithTraceOperation(ctx, tt.operation)
 
 			// Create child span (simulates manager/infra span).
 			childCtx, childSpan := tracer.Start(ctx, "child-span")
+			if tt.clearCurrentSpan {
+				childCtx = trace.ContextWithSpanContext(childCtx, trace.SpanContext{})
+			}
 
 			// Inject trace context from child ctx.
-			annotations := InjectTraceContext(childCtx, nil)
+			annotations := InjectTraceContext(childCtx, map[string]string{
+				TraceBaggageAnnotationKey: "operation=pause",
+			})
 
 			// Verify trace-context annotation was injected.
 			traceparent, ok := annotations[TraceContextAnnotationKey]
@@ -257,9 +364,18 @@ func TestWithRootSpanContext_InjectUsesRootSpanID(t *testing.T) {
 
 			// Extract context from annotations (simulates controller Reconcile).
 			extractedCtx := ExtractTraceContext(context.Background(), annotations)
-			extractedSpanID := trace.SpanFromContext(extractedCtx).SpanContext().SpanID()
+			extractedSpanCtx := trace.SpanContextFromContext(extractedCtx)
+			extractedSpanID := extractedSpanCtx.SpanID()
+			assert.Equal(t, rootSpanCtx.TraceID(), extractedSpanCtx.TraceID())
+			assert.Equal(t, tt.operation, TraceOperationFromContext(extractedCtx))
+			if tt.operation == "" {
+				assert.NotContains(t, annotations, TraceBaggageAnnotationKey)
+			} else {
+				assert.Equal(t, "operation="+tt.operation, annotations[TraceBaggageAnnotationKey])
+			}
 
 			if tt.useRootSpanCtx {
+				assert.Equal(t, rootSpanCtx.TraceFlags(), extractedSpanCtx.TraceFlags())
 				assert.Equal(t, rootSpan.SpanContext().SpanID(), extractedSpanID,
 					"extracted SpanID should be root span's SpanID")
 				assert.NotEqual(t, childSpan.SpanContext().SpanID(), extractedSpanID,

--- a/pkg/tracing/provider.go
+++ b/pkg/tracing/provider.go
@@ -128,8 +128,11 @@ func InitTracerProvider(ctx context.Context, cfg Config) (func(context.Context) 
 	var err error
 	switch cfg.Mode {
 	case TracingModeStd:
-		// Export spans to standard output for local debugging.
-		exporter, err = stdouttrace.New(stdouttrace.WithPrettyPrint())
+		// Export spans to standard output as single-line JSON so that log
+		// collectors treat each span as one log entry. Pretty-print
+		// (multi-line JSON) is intentionally avoided because newline-based
+		// collectors split a single span into many fragments.
+		exporter, err = stdouttrace.New()
 		if err != nil {
 			return nil, fmt.Errorf("failed to create stdout exporter: %w", err)
 		}

--- a/pkg/tracing/span.go
+++ b/pkg/tracing/span.go
@@ -90,8 +90,12 @@ const (
 	AttrCheckpointName   = "checkpoint.name"
 	// AttrCheckpointRejected records whether AssumePodCheckpointed rejected the
 	// pause (validation failed or checkpoint not yet complete).
-	AttrCheckpointRejected  = "checkpoint.rejected"
-	AttrPhaseAfter          = "phase.after"
+	AttrCheckpointRejected = "checkpoint.rejected"
+	AttrPhaseAfter         = "phase.after"
+	// AttrConditionPrefix is the prefix for span attributes that record
+	// individual Sandbox condition values as "Status:Reason", e.g.
+	// "condition.RuntimeInitialized" = "False:Pending".
+	AttrConditionPrefix     = "condition."
 	AttrClaimLockType       = "claim.lock_type"
 	AttrClaimRetries        = "claim.retries"
 	AttrClaimDuration       = "claim.duration"

--- a/pkg/tracing/zap_encoder.go
+++ b/pkg/tracing/zap_encoder.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tracing
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"go.uber.org/zap"
@@ -153,7 +154,12 @@ func (e *traceFirstEncoder) EncodeEntry(entry zapcore.Entry, fields []zapcore.Fi
 	spliced.AppendByte('{')
 	spliced.AppendString(`"` + TraceIDLogKey + `":`)
 	spliced.AppendBytes(quoted)
-	spliced.AppendByte(',')
+	// Empty objects may include a line ending. Add a comma only when the
+	// original object has fields, and preserve its unmodified suffix.
+	body := bytes.TrimSpace(encoded.Bytes()[1:])
+	if len(body) > 0 && body[0] != '}' {
+		spliced.AppendByte(',')
+	}
 	spliced.AppendBytes(encoded.Bytes()[1:])
 	encoded.Free()
 	return spliced, nil

--- a/pkg/tracing/zap_encoder.go
+++ b/pkg/tracing/zap_encoder.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"encoding/json"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/buffer"
+	"go.uber.org/zap/zapcore"
+)
+
+// TraceIDLogKey is the structured-log field key carrying the trace ID that
+// controller code injects into its logger after StartReconcileSpan (see
+// TraceIDFromContext). Encoders and call sites must share this constant so
+// the key never drifts.
+const TraceIDLogKey = "traceID"
+
+// splicePool recycles the buffers returned by the splicing encoder below.
+var splicePool = buffer.NewPool()
+
+// NewTraceFirstJSONEncoder returns a JSON encoder that emits every log line
+// as one JSON object with the trace ID, when present, as its first field:
+//
+//	{"traceID":"...","level":"INFO","ts":"...","msg":"...",...}
+//
+// It builds on the zap production encoder config with ISO8601 timestamps and
+// capitalized levels so lines stay as readable as the previous console
+// format.
+func NewTraceFirstJSONEncoder() zapcore.Encoder {
+	cfg := zap.NewProductionEncoderConfig()
+	cfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	cfg.EncodeLevel = zapcore.CapitalLevelEncoder
+	return NewTraceFirstEncoder(zapcore.NewJSONEncoder(cfg))
+}
+
+// NewTraceFirstEncoder wraps base so that the TraceIDLogKey field, when
+// present, is emitted as the first key of each encoded entry instead of its
+// natural position at the end of the accumulated logger context. This keeps
+// the trace ID at a fixed leading position for log collectors that index the
+// first field of JSON log lines.
+func NewTraceFirstEncoder(base zapcore.Encoder) zapcore.Encoder {
+	return &traceFirstEncoder{Encoder: base}
+}
+
+// traceFirstEncoder implements zapcore.Encoder by delegation (embedding) and
+// overrides AddString and EncodeEntry to promote the trace ID field.
+//
+// It must intercept AddString because zap never delivers logger context
+// fields (With/WithValues) to EncodeEntry's fields slice: ioCore.With writes
+// them straight into the encoder via its ObjectEncoder methods. The wrapper
+// therefore swallows the trace ID AddString call, remembers the value, and
+// re-emits it during EncodeEntry ahead of everything else.
+//
+// Pointer receivers are required because AddString mutates the captured
+// trace ID; NewTraceFirstEncoder and Clone must both return pointers so the
+// mutation is visible to ioCore.Write.
+type traceFirstEncoder struct {
+	zapcore.Encoder
+
+	// traceID is captured from AddString calls made by ioCore.With while
+	// the logger accumulates context fields (e.g. klog WithValues chains).
+	traceID string
+}
+
+// Clone keeps the wrapper around the cloned base encoder and carries over
+// the captured trace ID: zap clones the encoder on every Logger.With, so a
+// value captured by an earlier With would otherwise be lost.
+func (e *traceFirstEncoder) Clone() zapcore.Encoder {
+	return &traceFirstEncoder{Encoder: e.Encoder.Clone(), traceID: e.traceID}
+}
+
+// AddString captures the trace ID instead of letting it flow into the base
+// encoder's field namespace; every other key is forwarded unchanged.
+func (e *traceFirstEncoder) AddString(key, val string) {
+	if key == TraceIDLogKey {
+		e.traceID = val
+		return
+	}
+	e.Encoder.AddString(key, val)
+}
+
+// EncodeEntry encodes the entry without the trace ID field and splices the
+// captured value right after the leading '{' of the base encoding, making it
+// the first key of the JSON object. Entries without a trace ID (startup
+// logs, paths outside a Reconcile) are encoded unchanged.
+func (e *traceFirstEncoder) EncodeEntry(entry zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
+	// Prefer the value captured from With/WithValues; a trace ID supplied as
+	// a per-call field (when callers log directly with the encoder) is used
+	// as a fallback. The per-call copy is dropped so the ID is never emitted
+	// twice.
+	traceID := e.traceID
+	idx := -1
+	for i := range fields {
+		if fields[i].Key == TraceIDLogKey && fields[i].Type == zapcore.StringType {
+			idx = i
+			if traceID == "" {
+				traceID = fields[i].String
+			}
+			break
+		}
+	}
+	if idx < 0 && traceID == "" {
+		return e.Encoder.EncodeEntry(entry, fields)
+	}
+
+	rest := make([]zapcore.Field, 0, len(fields))
+	for i := range fields {
+		if i == idx {
+			continue
+		}
+		rest = append(rest, fields[i])
+	}
+
+	encoded, err := e.Encoder.EncodeEntry(entry, rest)
+	if err != nil {
+		return nil, err
+	}
+
+	// A string always marshals; the error branch only satisfies the linter.
+	quoted, err := json.Marshal(traceID)
+	if err != nil {
+		encoded.Free()
+		return nil, err
+	}
+
+	if encoded.Len() == 0 || encoded.Bytes()[0] != '{' {
+		// base does not emit a JSON object (e.g. a console encoder): splice
+		// is impossible, so re-encode with the trace ID moved to the front
+		// of the field list instead.
+		encoded.Free()
+		promoted := make([]zapcore.Field, 0, len(fields)+1)
+		promoted = append(promoted, zap.String(TraceIDLogKey, traceID))
+		promoted = append(promoted, rest...)
+		return e.Encoder.EncodeEntry(entry, promoted)
+	}
+
+	spliced := splicePool.Get()
+	spliced.AppendByte('{')
+	spliced.AppendString(`"` + TraceIDLogKey + `":`)
+	spliced.AppendBytes(quoted)
+	spliced.AppendByte(',')
+	spliced.AppendBytes(encoded.Bytes()[1:])
+	encoded.Free()
+	return spliced, nil
+}

--- a/pkg/tracing/zap_encoder_test.go
+++ b/pkg/tracing/zap_encoder_test.go
@@ -67,12 +67,16 @@ var testTime = time.Date(2026, 8, 11, 11, 46, 3, 0, time.Local)
 func TestTraceFirstEncoderEncodeEntry(t *testing.T) {
 	entry := zapcore.Entry{Level: zapcore.InfoLevel, Message: "update sandbox status success", Time: testTime}
 
-	cases := []struct {
-		name        string
-		fields      []zapcore.Field
-		wantKeys    []string
-		wantTraceID any
-	}{
+	type testCase struct {
+		name           string
+		fields         []zapcore.Field
+		encoderConfig  *zapcore.EncoderConfig
+		contextTraceID string
+		wantKeys       []string
+		wantTraceID    any
+		wantLine       string
+	}
+	cases := []testCase{
 		{
 			name: "trace id in the middle is promoted to the first key",
 			fields: []zapcore.Field{
@@ -126,9 +130,56 @@ func TestTraceFirstEncoderEncodeEntry(t *testing.T) {
 		},
 	}
 
+	for _, ending := range []struct {
+		name   string
+		config zapcore.EncoderConfig
+		suffix string
+	}{
+		{name: "no line ending", config: zapcore.EncoderConfig{SkipLineEnding: true}},
+		{name: "default LF", suffix: "\n"},
+		{name: "CRLF", config: zapcore.EncoderConfig{LineEnding: "\r\n"}, suffix: "\r\n"},
+	} {
+		// Disabling built-in fields makes the real Zap encoder emit an empty object.
+		emptyCase := testCase{
+			name:          "empty object with per-call trace id/" + ending.name,
+			fields:        []zapcore.Field{zap.String(TraceIDLogKey, "tid")},
+			encoderConfig: &ending.config,
+			wantKeys:      []string{TraceIDLogKey},
+			wantTraceID:   "tid",
+			wantLine:      `{"traceID":"tid"}` + ending.suffix,
+		}
+		cases = append(cases, emptyCase)
+
+		emptyCase.name = "empty object with context trace id/" + ending.name
+		emptyCase.fields = nil
+		emptyCase.contextTraceID = "tid"
+		cases = append(cases, emptyCase)
+
+		emptyCase.name = "empty config with remaining field/" + ending.name
+		emptyCase.fields = []zapcore.Field{zap.String("controller", "c")}
+		emptyCase.wantKeys = []string{TraceIDLogKey, "controller"}
+		emptyCase.wantLine = `{"traceID":"tid","controller":"c"}` + ending.suffix
+		cases = append(cases, emptyCase)
+
+		emptyCase.name = "empty object without trace id is unchanged/" + ending.name
+		emptyCase.fields = nil
+		emptyCase.contextTraceID = ""
+		emptyCase.wantKeys = nil
+		emptyCase.wantTraceID = nil
+		emptyCase.wantLine = "{}" + ending.suffix
+		cases = append(cases, emptyCase)
+	}
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			enc := NewTraceFirstEncoder(testJSONEncoder())
+			base := testJSONEncoder()
+			if tc.encoderConfig != nil {
+				base = zapcore.NewJSONEncoder(*tc.encoderConfig)
+			}
+			enc := NewTraceFirstEncoder(base)
+			if tc.contextTraceID != "" {
+				enc.AddString(TraceIDLogKey, tc.contextTraceID)
+			}
 			buf, err := enc.EncodeEntry(entry, tc.fields)
 			require.NoError(t, err)
 			line := buf.String()
@@ -136,6 +187,9 @@ func TestTraceFirstEncoderEncodeEntry(t *testing.T) {
 
 			assert.True(t, json.Valid([]byte(line)), "output must be valid JSON: %s", line)
 			assert.Equal(t, tc.wantKeys, topLevelKeys(t, line))
+			if tc.wantLine != "" {
+				assert.Equal(t, tc.wantLine, line, "output must preserve the original line ending")
+			}
 
 			var decoded map[string]any
 			require.NoError(t, json.Unmarshal([]byte(line), &decoded))

--- a/pkg/tracing/zap_encoder_test.go
+++ b/pkg/tracing/zap_encoder_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// testJSONEncoder builds a base JSON encoder equivalent to the one used by
+// NewTraceFirstJSONEncoder.
+func testJSONEncoder() zapcore.Encoder {
+	cfg := zap.NewProductionEncoderConfig()
+	cfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	return zapcore.NewJSONEncoder(cfg)
+}
+
+// topLevelKeys decodes a single-line JSON object and returns its top-level
+// keys in encoding order.
+func topLevelKeys(t *testing.T, line string) []string {
+	t.Helper()
+	dec := json.NewDecoder(strings.NewReader(line))
+	tok, err := dec.Token()
+	require.NoError(t, err)
+	require.Equal(t, json.Delim('{'), tok, "line must be a JSON object: %s", line)
+
+	var keys []string
+	for dec.More() {
+		keyTok, err := dec.Token()
+		require.NoError(t, err)
+		key, ok := keyTok.(string)
+		require.True(t, ok, "object key must be a string: %s", line)
+		keys = append(keys, key)
+
+		var raw json.RawMessage
+		require.NoError(t, dec.Decode(&raw), "failed to skip value of %q", key)
+	}
+	return keys
+}
+
+// testTime fills Entry.Time so the "ts" key is emitted; zap omits the
+// timestamp for a zero entry time.
+var testTime = time.Date(2026, 8, 11, 11, 46, 3, 0, time.Local)
+
+func TestTraceFirstEncoderEncodeEntry(t *testing.T) {
+	entry := zapcore.Entry{Level: zapcore.InfoLevel, Message: "update sandbox status success", Time: testTime}
+
+	cases := []struct {
+		name        string
+		fields      []zapcore.Field
+		wantKeys    []string
+		wantTraceID any
+	}{
+		{
+			name: "trace id in the middle is promoted to the first key",
+			fields: []zapcore.Field{
+				zap.String("controller", "sandbox-controller"),
+				zap.String("reconcileID", "1011dda1"),
+				zap.String(TraceIDLogKey, "dce858203322f71c3598d87c81e88a5b"),
+				zap.String("sandbox", "box"),
+				zap.String("status", "{}"),
+			},
+			wantKeys: []string{
+				TraceIDLogKey, "level", "ts", "msg",
+				"controller", "reconcileID", "sandbox", "status",
+			},
+			wantTraceID: "dce858203322f71c3598d87c81e88a5b",
+		},
+		{
+			name: "trace id as the last context field is promoted",
+			fields: []zapcore.Field{
+				zap.String("controller", "sandbox-controller"),
+				zap.String(TraceIDLogKey, "tid"),
+			},
+			wantKeys:    []string{TraceIDLogKey, "level", "ts", "msg", "controller"},
+			wantTraceID: "tid",
+		},
+		{
+			name: "trace id already first keeps field order",
+			fields: []zapcore.Field{
+				zap.String(TraceIDLogKey, "tid"),
+				zap.String("controller", "sandbox-controller"),
+			},
+			wantKeys:    []string{TraceIDLogKey, "level", "ts", "msg", "controller"},
+			wantTraceID: "tid",
+		},
+		{
+			name: "no trace id encodes unchanged",
+			fields: []zapcore.Field{
+				zap.String("controller", "sandbox-controller"),
+				zap.String("status", "running"),
+			},
+			wantKeys:    []string{"level", "ts", "msg", "controller", "status"},
+			wantTraceID: nil, // key absent
+		},
+		{
+			name: "non string trace id field is not promoted",
+			fields: []zapcore.Field{
+				zap.Int32(TraceIDLogKey, 7),
+				zap.String("controller", "sandbox-controller"),
+			},
+			wantKeys:    []string{"level", "ts", "msg", TraceIDLogKey, "controller"},
+			wantTraceID: float64(7),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			enc := NewTraceFirstEncoder(testJSONEncoder())
+			buf, err := enc.EncodeEntry(entry, tc.fields)
+			require.NoError(t, err)
+			line := buf.String()
+			buf.Free()
+
+			assert.True(t, json.Valid([]byte(line)), "output must be valid JSON: %s", line)
+			assert.Equal(t, tc.wantKeys, topLevelKeys(t, line))
+
+			var decoded map[string]any
+			require.NoError(t, json.Unmarshal([]byte(line), &decoded))
+			assert.Equal(t, tc.wantTraceID, decoded[TraceIDLogKey])
+		})
+	}
+}
+
+func TestTraceFirstJSONEncoderPromotesTraceID(t *testing.T) {
+	enc := NewTraceFirstJSONEncoder()
+	buf, err := enc.EncodeEntry(
+		zapcore.Entry{Level: zapcore.InfoLevel, Message: "m", Time: testTime},
+		[]zapcore.Field{
+			zap.String("controller", "sandbox-controller"),
+			zap.String(TraceIDLogKey, "dce858203322f71c3598d87c81e88a5b"),
+		},
+	)
+	require.NoError(t, err)
+	line := buf.String()
+	buf.Free()
+
+	assert.True(t, strings.HasPrefix(line,
+		`{"traceID":"dce858203322f71c3598d87c81e88a5b","level":"INFO"`), "got: %s", line)
+}
+
+// TestTraceFirstEncoderWithZapLogger exercises the real write path: logger
+// context fields (controller-runtime's WithValues chain plus the trace ID)
+// are accumulated before the per-call fields, exactly like the klog-to-zapr
+// bridging used by the controller.
+func TestTraceFirstEncoderWithZapLogger(t *testing.T) {
+	var out bytes.Buffer
+	core := zapcore.NewCore(NewTraceFirstEncoder(testJSONEncoder()), zapcore.AddSync(&out), zapcore.InfoLevel)
+	logger := zap.New(core)
+
+	logger.
+		With(zap.String("controller", "sandbox-controller"), zap.String("reconcileID", "1011dda1")).
+		With(zap.String(TraceIDLogKey, "dce858203322f71c3598d87c81e88a5b")).
+		Info("update sandbox status success", zap.String("sandbox", "box"), zap.String("status", "{\"phase\":\"Running\"}"))
+
+	line := strings.TrimSpace(out.String())
+	assert.Equal(t, []string{
+		TraceIDLogKey, "level", "ts", "msg",
+		"controller", "reconcileID", "sandbox", "status",
+	}, topLevelKeys(t, line))
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &decoded))
+	assert.Equal(t, "dce858203322f71c3598d87c81e88a5b", decoded[TraceIDLogKey])
+	assert.Equal(t, "{\"phase\":\"Running\"}", decoded["status"])
+}
+
+func TestTraceFirstEncoderClone(t *testing.T) {
+	enc := NewTraceFirstEncoder(testJSONEncoder())
+	cloned, ok := enc.Clone().(*traceFirstEncoder)
+	require.True(t, ok, "Clone must keep the wrapper")
+
+	buf, err := cloned.EncodeEntry(
+		zapcore.Entry{Level: zapcore.InfoLevel, Message: "m", Time: testTime},
+		[]zapcore.Field{zap.String("controller", "c"), zap.String(TraceIDLogKey, "tid")},
+	)
+	require.NoError(t, err)
+	line := buf.String()
+	buf.Free()
+
+	assert.Equal(t, []string{TraceIDLogKey, "level", "ts", "msg", "controller"}, topLevelKeys(t, line))
+}
+
+// TestTraceFirstEncoderConsoleFallback covers a non-object base encoder: the
+// splice is impossible, so the trace ID is moved to the front of the field
+// list instead of being dropped.
+func TestTraceFirstEncoderConsoleFallback(t *testing.T) {
+	cfg := zap.NewDevelopmentEncoderConfig()
+	enc := NewTraceFirstEncoder(zapcore.NewConsoleEncoder(cfg))
+
+	buf, err := enc.EncodeEntry(
+		zapcore.Entry{Level: zapcore.InfoLevel, Message: "m", Time: testTime},
+		[]zapcore.Field{zap.String("controller", "c"), zap.String(TraceIDLogKey, "tid")},
+	)
+	require.NoError(t, err)
+	line := buf.String()
+	buf.Free()
+
+	assert.NotEmpty(t, line)
+	// The console encoder separates fields with ", " after the colon.
+	assert.Contains(t, line, `"traceID": "tid"`)
+	assert.Contains(t, line, `"controller": "c"`)
+}

--- a/test/e2e/tracing_chain_test.go
+++ b/test/e2e/tracing_chain_test.go
@@ -191,16 +191,16 @@ var _ = Describe("Tracing Full Chain", func() {
 		By("Verifying manager stdout exports the request root span with TraceID == request ID")
 		Eventually(func(g Gomega) {
 			logs := podLogs(ctx, managerNamespace, managerPodSelector, managerContainerName)
-			g.Expect(logs).To(ContainSubstring(`"Name": "POST /sandboxes"`))
-			g.Expect(logs).To(ContainSubstring(`"TraceID": "` + requestID + `"`))
+			spans := spansForTrace(logs, requestID)
+			g.Expect(spans).To(ContainElement("POST /sandboxes"), "request trace %s", requestID)
 		}, time.Minute*2, time.Second*5).Should(Succeed())
 
 		By("Verifying controller stdout exports spans joined to the same trace")
 		Eventually(func(g Gomega) {
 			logs := podLogs(ctx, controllerNamespace, controllerPodSelector, controllerContainerName)
-			g.Expect(logs).To(ContainSubstring(`"Name": "` + tracing.SpanControllerReconcile + `"`))
-			g.Expect(logs).To(ContainSubstring(`"Name": "` + tracing.SpanControllerCreatePod + `"`))
-			g.Expect(logs).To(ContainSubstring(`"TraceID": "` + requestID + `"`))
+			spans := spansForTrace(logs, requestID)
+			g.Expect(spans).To(ContainElement(tracing.SpanControllerReconcile), "request trace %s", requestID)
+			g.Expect(spans).To(ContainElement(tracing.SpanControllerCreatePod), "request trace %s", requestID)
 		}, time.Minute*2, time.Second*5).Should(Succeed())
 	})
 })
@@ -222,6 +222,7 @@ func podLogs(ctx context.Context, namespace, selector, container string) string 
 			DoRaw(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		sb.Write(raw)
+		sb.WriteByte('\n')
 	}
 	return sb.String()
 }

--- a/test/e2e/tracing_logs_test.go
+++ b/test/e2e/tracing_logs_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// spansForTrace 从混合日志中解析指定 trace 的 span，返回 SpanID 到名称的映射。
+// 同时支持紧凑和多行 JSON；按 SpanID 去重，且只检查 SpanContext.TraceID。
+// 本文件可通过 go test test/e2e/tracing_logs_test.go 独立验证，不加载集群初始化。
+func spansForTrace(logs, traceID string) map[string]string {
+	spans := make(map[string]string)
+	if traceID == "" {
+		return spans
+	}
+	for logs != "" {
+		line, rest, _ := strings.Cut(logs, "\n")
+		if !strings.HasPrefix(strings.TrimSpace(line), "{") {
+			logs = rest
+			continue
+		}
+		var span struct {
+			Name        string
+			SpanContext struct {
+				TraceID string
+				SpanID  string
+			}
+		}
+		decoder := json.NewDecoder(strings.NewReader(logs))
+		if err := decoder.Decode(&span); err != nil {
+			// 日志可能含非 JSON 内容或尚未写完的记录，跳过当前行后继续解析。
+			logs = rest
+			continue
+		}
+		logs = logs[decoder.InputOffset():]
+		if span.Name != "" && span.SpanContext.TraceID == traceID && span.SpanContext.SpanID != "" {
+			spans[span.SpanContext.SpanID] = span.Name
+		}
+	}
+	return spans
+}
+
+func TestSpansForTrace(t *testing.T) {
+	const (
+		traceID      = "50293b018bb7d1f4e75518d2ba6feb0e"
+		otherTraceID = "11111111111111111111111111111111"
+		spanID       = "5bffabc97d55aa1a"
+		otherSpanID  = "b66efda2b875d73a"
+	)
+	spanJSON := func(name, tid, id string) string {
+		return fmt.Sprintf(`{"Name":%q,"SpanContext":{"TraceID":%q,"SpanID":%q},"Parent":{"TraceID":%q,"SpanID":"0123456789abcdef"}}`, name, tid, id, tid)
+	}
+	compact := spanJSON("POST /sandboxes", traceID, spanID)
+	var pretty bytes.Buffer
+	require.NoError(t, json.Indent(&pretty, []byte(compact), "", "\t"))
+	wantSpan := map[string]string{spanID: "POST /sandboxes"}
+
+	tests := []struct {
+		name string
+		logs string
+		want map[string]string
+	}{
+		{
+			name: "compact JSON without final newline",
+			logs: compact,
+			want: wantSpan,
+		},
+		{
+			name: "pretty JSON with surrounding whitespace",
+			logs: " \n\t" + pretty.String() + "\r\n",
+			want: wantSpan,
+		},
+		{
+			name: "mixed application logs and spans",
+			logs: "I0910 startup completed\n{\"level\":\"info\",\"msg\":\"ready\"}\n" + compact + "\nI0910 request completed\n",
+			want: wantSpan,
+		},
+		{
+			name: "duplicate records and parent trace ID count once",
+			logs: compact + "\n" + pretty.String(),
+			want: wantSpan,
+		},
+		{
+			name: "distinct spans with the same name count separately",
+			logs: compact + "\n" + spanJSON("POST /sandboxes", traceID, otherSpanID),
+			want: map[string]string{spanID: "POST /sandboxes", otherSpanID: "POST /sandboxes"},
+		},
+		{
+			name: "name from another trace does not match",
+			logs: spanJSON("POST /sandboxes", otherTraceID, spanID) + "\n" + spanJSON("unrelated", traceID, otherSpanID),
+			want: map[string]string{otherSpanID: "unrelated"},
+		},
+		{
+			name: "parent trace ID alone does not match",
+			logs: strings.Replace(compact, traceID, otherTraceID, 1),
+			want: map[string]string{},
+		},
+		{
+			name: "missing span ID is not a span",
+			logs: spanJSON("POST /sandboxes", traceID, ""),
+			want: map[string]string{},
+		},
+		{
+			name: "missing name is not a span",
+			logs: spanJSON("", traceID, spanID),
+			want: map[string]string{},
+		},
+		{
+			name: "JSON embedded in an application message is not a span",
+			logs: fmt.Sprintf(`{"level":"info","msg":%q}`, compact),
+			want: map[string]string{},
+		},
+		{
+			name: "malformed record does not hide the next span",
+			logs: "{invalid JSON}\n{\"Name\":\n" + compact,
+			want: wantSpan,
+		},
+		{
+			name: "truncated final record is ignored",
+			logs: compact + "\n{\"Name\":\"unfinished\"",
+			want: wantSpan,
+		},
+		{
+			name: "span larger than scanner default token limit",
+			logs: strings.TrimSuffix(compact, "}") + fmt.Sprintf(",\"Extra\":%q}", strings.Repeat("x", 128*1024)),
+			want: wantSpan,
+		},
+		{
+			name: "empty logs",
+			want: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, spansForTrace(tt.logs, traceID))
+		})
+	}
+	t.Run("empty trace ID does not match incomplete records", func(t *testing.T) {
+		assert.Empty(t, spansForTrace(spanJSON("POST /sandboxes", "", spanID), ""))
+	})
+}
+
+func TestSpansForTraceStdoutExporter(t *testing.T) {
+	for _, pretty := range []bool{false, true} {
+		t.Run(fmt.Sprintf("pretty=%t", pretty), func(t *testing.T) {
+			var output bytes.Buffer
+			opts := []stdouttrace.Option{stdouttrace.WithWriter(&output)}
+			if pretty {
+				opts = append(opts, stdouttrace.WithPrettyPrint())
+			}
+			exporter, err := stdouttrace.New(opts...)
+			require.NoError(t, err)
+			provider := sdktrace.NewTracerProvider(
+				sdktrace.WithSyncer(exporter),
+				sdktrace.WithSampler(sdktrace.AlwaysSample()),
+			)
+			t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+			tracer := provider.Tracer("stdout-parser-test")
+			ctx, root := tracer.Start(t.Context(), "POST /sandboxes")
+			_, child := tracer.Start(ctx, "controller.Reconcile")
+			child.End()
+			root.End()
+			_, unrelated := tracer.Start(t.Context(), "controller.CreatePod")
+			unrelated.End()
+
+			got := spansForTrace(output.String(), root.SpanContext().TraceID().String())
+			assert.Equal(t, map[string]string{
+				root.SpanContext().SpanID().String():  "POST /sandboxes",
+				child.SpanContext().SpanID().String(): "controller.Reconcile",
+			}, got)
+		})
+	}
+}

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -21,7 +21,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"strings"
+	"maps"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -120,31 +120,25 @@ var _ = Describe("Tracing Stdout", func() {
 		}, time.Minute*5, time.Millisecond*500).Should(Equal(agentsv1alpha1.SandboxRunning))
 
 		By("Verifying spans show up on controller stdout with the propagated trace ID")
-		// The BatchSpanProcessor exports in batches (up to a few seconds of
-		// delay), so poll the logs instead of reading them once. The stdout
-		// exporter pretty-prints spans as JSON, hence the `"Name": "..."`
-		// assertions below cannot collide with regular klog output.
-		traceMarker := `"TraceID": "` + traceID + `"`
+		// BatchSpanProcessor 会延迟批量导出，因此需要轮询日志。
+		// 按 JSON 字段筛选同一 trace 下的 span，不依赖空格或换行格式，
+		// 也不允许其他请求的 span 名称满足本次请求的断言。
 		Eventually(func(g Gomega) {
 			logs := podLogs(ctx, controllerNamespace, controllerPodSelector, controllerContainerName)
-			g.Expect(logs).To(ContainSubstring(`"Name": "` + tracing.SpanControllerReconcile + `"`))
-			g.Expect(logs).To(ContainSubstring(`"Name": "` + tracing.SpanControllerCreatePod + `"`))
-			g.Expect(logs).To(ContainSubstring(`"Name": "` + tracing.SpanControllerUpdateStatus + `"`))
-			// Spans triggered by this sandbox must carry the trace ID extracted
-			// from the annotation, proving controller-side trace-context
-			// extraction works.
-			g.Expect(logs).To(ContainSubstring(traceMarker))
+			spans := spansForTrace(logs, traceID)
+			g.Expect(spans).To(ContainElement(tracing.SpanControllerReconcile), "controller trace %s", traceID)
+			g.Expect(spans).To(ContainElement(tracing.SpanControllerCreatePod), "controller trace %s", traceID)
+			g.Expect(spans).To(ContainElement(tracing.SpanControllerUpdateStatus), "controller trace %s", traceID)
 		}, time.Minute*2, time.Second*5).Should(Succeed())
 
 		By("Waiting for span exports of this trace to settle")
-		// The create flow may still be flushing through the BatchSpanProcessor;
-		// wait until two consecutive polls observe the same span count for this
-		// trace before asserting nothing new joins it.
-		prev := -1
+		// 等待连续两次轮询得到相同且非空的 SpanID 集合，
+		// 避免把 Parent.TraceID 的重复出现误计为额外的 span。
+		var prev map[string]string
 		Eventually(func() bool {
-			n := strings.Count(podLogs(ctx, controllerNamespace, controllerPodSelector, controllerContainerName), traceMarker)
-			settled := n == prev
-			prev = n
+			spans := spansForTrace(podLogs(ctx, controllerNamespace, controllerPodSelector, controllerContainerName), traceID)
+			settled := len(spans) > 0 && maps.Equal(spans, prev)
+			prev = spans
 			return settled
 		}, time.Minute*2, time.Second*5).Should(BeTrue(), "span exports for the trace did not settle")
 
@@ -162,8 +156,8 @@ var _ = Describe("Tracing Stdout", func() {
 		Expect(k8sClient.Patch(ctx, sandbox, client.MergeFrom(orig))).To(Succeed())
 
 		By("Verifying the read-only Reconcile exports no new spans for this trace")
-		Consistently(func() int {
-			return strings.Count(podLogs(ctx, controllerNamespace, controllerPodSelector, controllerContainerName), traceMarker)
+		Consistently(func() map[string]string {
+			return spansForTrace(podLogs(ctx, controllerNamespace, controllerPodSelector, controllerContainerName), traceID)
 		}, time.Second*30, time.Second*5).Should(Equal(prev),
 			"read-only Reconcile iterations must be filtered out and never export spans")
 	})


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/openkruise/kruise/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

Improve tracing observability across sandbox-manager and the controller to correlate user operations, controller logs, and Sandbox state transitions.

- **Trace-first logging:** Use single-line JSON controller logs with `traceID` as the first field when present, and include caller information.
- **Condition visibility:** Record `condition.<Type>=Status:Reason` attributes on Reconcile and updateSandboxStatus spans to help diagnose lifecycle delays and compare condition changes.
- **Operation propagation:** Carry user operations through OTel Baggage and CR annotations, exposing them as `traceOperation` in controller logs. Lifecycle endpoints use `create`, `pause`, `resume`, and `kill`; other endpoints default to the HTTP method and route pattern.
- **Single-line stdout spans:** Disable pretty-printing in std mode so newline-based log collectors do not split a span into multiple records.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

The following build and unit tests passed:

```bash
go build ./...
go test ./pkg/tracing ./pkg/servers/web ./pkg/servers/e2b/... -count=1
```

New encoder tests cover field ordering, missing trace IDs, chained Logger.With context, cloning, and console fallback.

Suggested runtime verification with tracing enabled:
1. Perform create/pause/resume/kill operations and verify the corresponding controller logs contain a leading `traceID` field and the expected `traceOperation`.
2. Compare `condition.*` attributes on Reconcile and updateSandboxStatus spans.
3. Verify each span exported in std mode occupies a single JSON line.

### Ⅳ. Special notes for reviews

- **Logging compatibility:** The controller explicitly selects the JSON encoder, so `--zap-encoder` no longer changes the output format. Log parsers relying on the previous console format may need adjustment.
- Connect is labeled `resume` only when it triggers recovery of a paused Sandbox; connecting to a running Sandbox retains the default route pattern.
- Baggage is propagated through the new `agents.kruise.io/trace-baggage` annotation without changing the CRD schema.
- Only std mode disables pretty-printing; file mode remains unchanged.
- No new tracing backend or cloud-provider-specific configuration is introduced.