### PR TITLE
[Docs/Test] Clarify PoolAutoscaler maxUnavailable startup-budget behavior

### DIFF
--- a/docs/proposals/20260827-sandboxset-scale-up-execution-coordination.md
+++ b/docs/proposals/20260827-sandboxset-scale-up-execution-coordination.md
@@ -220,6 +220,34 @@ createHeadroom = max(maxConcurrent - charged, 0)
 SandboxSet creates toward `spec.replicas` while `createHeadroom > 0`. Reaching the limit stops new
 create requests until a slot opens, but it is normal flow control rather than a startup failure.
 
+#### User guidance for `maxUnavailable`
+
+`spec.scaleStrategy.maxUnavailable` is the user-facing control for the trade-off between startup
+throughput and runaway scale-up protection. It is not a maximum replica count and it does not mean
+that every non-Available Sandbox immediately consumes the budget.
+
+The effective startup budget is resolved from the observed SandboxSet replica count:
+
+| Configuration | Startup budget behavior | Recommended use |
+| --- | --- | --- |
+| omitted | Uses the observed replica count, equivalent to 100% of the observed pool | Resource-rich clusters with reliable scheduling |
+| absolute, for example `2` | Allows two observed Failed/TimedOut startups | Resource-constrained clusters or strict protection |
+| percentage, for example `50%` | Resolves against observed replicas and rounds up | A proportional throughput/protection trade-off |
+
+For example, with `maxUnavailable: 2`, `status.replicas: 4`, and two observed startup blockers,
+SandboxSet publishes `ScalingLimited=True/StartupBudgetExhausted`. PoolAutoscaler then keeps the
+current target instead of publishing another Capacity-driven scale-up. With one blocker, the
+condition remains `False/StartupBudgetAvailable` and another target increase remains permitted.
+
+The budget counts only recognized startup failures and Pending Sandboxes past the effective
+`max-pending-timeout`. Healthy observed Creating Sandboxes do not immediately consume it, and
+Claimed/Used Sandboxes are not startup blockers for the warm pool. A Pending Sandbox may therefore
+remain below the budget until its timeout or failure classification is observed.
+
+Leaving `maxUnavailable` unset favors the fastest scale-up and allows the budget to grow with the
+observed pool. Users operating with tight scheduling or resource limits should set an explicit
+absolute or percentage value and monitor `ScalingLimited` before increasing `maxReplicas`.
+
 ### Scale-Up Cooldown and Sandbox Pending Timeout
 
 Sandbox controller owns the process-wide `--max-pending-timeout` setting. The controller registration

--- a/pkg/controller/sandboxset/scaling_limited_test.go
+++ b/pkg/controller/sandboxset/scaling_limited_test.go
@@ -98,6 +98,14 @@ func TestCalculateScalingLimited(t *testing.T) {
 			expectTimedOut:   1,
 		},
 		{
+			name:             "claimed sandboxes do not consume startup budget",
+			observedReplicas: 2,
+			groups:           GroupedSandboxes{Used: []*agentsv1alpha1.Sandbox{{ObjectMeta: metav1.ObjectMeta{Name: "claimed"}}}},
+			expectStatus:     metav1.ConditionFalse,
+			expectReason:     scalingLimitedReasonBudgetAvailable,
+			expectMessage:    "Timeout=0, Failed=0",
+		},
+		{
 			name:           "timeout exhausts budget",
 			maxUnavailable: intOrStringPtr(intstr.FromInt(1)),
 			groups:         GroupedSandboxes{Creating: []*agentsv1alpha1.Sandbox{newPending("timeout", 61*time.Second)}},


### PR DESCRIPTION
## Summary

Document the intended `SandboxSet.spec.scaleStrategy.maxUnavailable` control for PoolAutoscaler startup-budget protection and add a boundary test for Claimed/Used sandboxes.

## Changes

- Clarify in the scale-up coordination proposal that `maxUnavailable` is a startup budget, not a maximum replica count.
- Document omitted, absolute, and percentage `maxUnavailable` behavior and the trade-off between scale-up throughput and runaway protection.
- Clarify that only recognized Failed and timed-out ResourcePending sandboxes consume the startup budget; healthy Creating and Claimed/Used sandboxes do not immediately consume it.
- Add a SandboxSet boundary test proving Claimed/Used sandboxes do not consume startup budget.

## Scope

- No production logic changes.
- No CRD schema changes.
- The local `crd/` directory is intentionally not included.

## Validation

```text
548 tests passed in the affected sandboxset, poolautoscaler, and validating webhook packages.
```

Related context: #945, #895, #852.
