### PR TITLE
fix: sandbox-gateway graceful shutdown improvements

### DIFF
--- a/config/sandbox-gateway/deployment.yaml
+++ b/config/sandbox-gateway/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         component: sandbox-manager
     spec:
       serviceAccountName: sandbox-gateway
+      terminationGracePeriodSeconds: 60
       containers:
         - name: sandbox-gateway
           image: "sandbox-gateway:latest"

--- a/pkg/peers/memberlist_test.go
+++ b/pkg/peers/memberlist_test.go
@@ -186,52 +186,6 @@ func TestMemberlistPeers_Start_Twice(t *testing.T) {
 	require.NoError(t, peer.Stop(ctx))
 }
 
-// TestMemberlistPeers_Stop_LeavePanicRecovered covers Leave panicking when the
-// memberlist was already shut down: Stop recovers the panic into an error. The
-// pre-shutdown releases the sockets itself, so this test cannot detect a
-// missing Shutdown call; that regression is covered by
-// TestMemberlistPeers_Stop_LeaveErrorReleasesResources.
-func TestMemberlistPeers_Stop_LeavePanicRecovered(t *testing.T) {
-	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()
-	ctx := context.Background()
-	peer, port, err := CreateTestPeer(ctx, fc, "test-node-leave-fail")
-	require.NoError(t, err)
-	require.NoError(t, peer.Start(ctx, port))
-	require.True(t, peer.started.Load())
-
-	require.NoError(t, peer.list.Shutdown())
-
-	err = peer.Stop()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "leave after shutdown")
-	assert.False(t, peer.started.Load())
-	assert.Nil(t, peer.GetPeers())
-}
-
-// TestMemberlistPeers_Stop_LeaveErrorReleasesResources forces Leave to return
-// an error and verifies Stop still runs memberlist.Shutdown: the bind port can
-// be reused only after Shutdown closes its sockets, so this test fails if the
-// Shutdown call in Stop is removed.
-func TestMemberlistPeers_Stop_LeaveErrorReleasesResources(t *testing.T) {
-	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()
-	ctx := context.Background()
-	peer, port, err := CreateTestPeer(ctx, fc, "test-node-leave-error")
-	require.NoError(t, err)
-	require.NoError(t, peer.Start(ctx, port))
-
-	peer.leave = func(time.Duration) error { return errors.New("leave failed") }
-
-	err = peer.Stop()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "leave failed")
-	assert.False(t, peer.started.Load())
-
-	restarted := NewMemberlistPeers(fc, "test-node-leave-error-restart", Namespace, LabelSelector)
-	restarted.localIP = "127.0.0.1"
-	require.NoError(t, restarted.Start(ctx, port))
-	require.NoError(t, restarted.Stop())
-}
-
 // TestMemberlistPeers_ThreeNodes_Join tests three-node join and discovery
 func TestMemberlistPeers_ThreeNodes_Join(t *testing.T) {
 	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()

--- a/pkg/peers/memberlist_test.go
+++ b/pkg/peers/memberlist_test.go
@@ -186,6 +186,52 @@ func TestMemberlistPeers_Start_Twice(t *testing.T) {
 	require.NoError(t, peer.Stop(ctx))
 }
 
+// TestMemberlistPeers_Stop_LeavePanicRecovered covers Leave panicking when the
+// memberlist was already shut down: Stop recovers the panic into an error. The
+// pre-shutdown releases the sockets itself, so this test cannot detect a
+// missing Shutdown call; that regression is covered by
+// TestMemberlistPeers_Stop_LeaveErrorReleasesResources.
+func TestMemberlistPeers_Stop_LeavePanicRecovered(t *testing.T) {
+	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()
+	ctx := context.Background()
+	peer, port, err := CreateTestPeer(ctx, fc, "test-node-leave-fail")
+	require.NoError(t, err)
+	require.NoError(t, peer.Start(ctx, port))
+	require.True(t, peer.started.Load())
+
+	require.NoError(t, peer.list.Shutdown())
+
+	err = peer.Stop()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "leave after shutdown")
+	assert.False(t, peer.started.Load())
+	assert.Nil(t, peer.GetPeers())
+}
+
+// TestMemberlistPeers_Stop_LeaveErrorReleasesResources forces Leave to return
+// an error and verifies Stop still runs memberlist.Shutdown: the bind port can
+// be reused only after Shutdown closes its sockets, so this test fails if the
+// Shutdown call in Stop is removed.
+func TestMemberlistPeers_Stop_LeaveErrorReleasesResources(t *testing.T) {
+	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()
+	ctx := context.Background()
+	peer, port, err := CreateTestPeer(ctx, fc, "test-node-leave-error")
+	require.NoError(t, err)
+	require.NoError(t, peer.Start(ctx, port))
+
+	peer.leave = func(time.Duration) error { return errors.New("leave failed") }
+
+	err = peer.Stop()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "leave failed")
+	assert.False(t, peer.started.Load())
+
+	restarted := NewMemberlistPeers(fc, "test-node-leave-error-restart", Namespace, LabelSelector)
+	restarted.localIP = "127.0.0.1"
+	require.NoError(t, restarted.Start(ctx, port))
+	require.NoError(t, restarted.Stop())
+}
+
 // TestMemberlistPeers_ThreeNodes_Join tests three-node join and discovery
 func TestMemberlistPeers_ThreeNodes_Join(t *testing.T) {
 	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()

--- a/pkg/sandbox-gateway/filter/config.go
+++ b/pkg/sandbox-gateway/filter/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package filter
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -24,10 +25,12 @@ import (
 
 	v3 "github.com/cncf/xds/go/xds/type/v3"
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
+	"go.uber.org/zap"
 	"golang.org/x/net/http/httpguts"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/openkruise/agents/pkg/identity/oidc"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/server"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 )
 
@@ -167,6 +170,25 @@ type FilterConfig struct {
 	Adapter                          *adapters.E2BAdapter
 	jwtAuthManager                   JWTAuthManager
 	trafficAccessTokenHeaderExplicit bool
+	ownsProcess                      bool
+}
+
+var _ api.Config = (*FilterConfig)(nil)
+
+// Destroy stops the process-wide peer server when this is the listener config.
+// It assumes the gateway listener config is static: Destroy also runs on xDS
+// listener update or removal, and StopProcess is irreversible (sync.Once), so a
+// dynamic config change would stop peer sync for good with nothing restarting
+// it.
+func (c *FilterConfig) Destroy() {
+	if c == nil || !c.ownsProcess {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), server.ProcessStopTimeout)
+	defer cancel()
+	if err := server.StopProcess(ctx); err != nil {
+		logger.Error("Failed to stop peer server during config destroy", zap.Error(err))
+	}
 }
 
 // NewFilterConfig creates a FilterConfig with an adapter built from the config values
@@ -221,6 +243,7 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 		}
 		parsed := newFilterConfig(cfg, p.jwtAuthManager)
 		parsed.trafficAccessTokenHeaderExplicit = false
+		parsed.ownsProcess = callbacks != nil
 		return parsed, nil
 	}
 
@@ -258,6 +281,7 @@ func (p *ConfigParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler
 	}
 	parsed := newFilterConfig(cfg, p.jwtAuthManager)
 	parsed.trafficAccessTokenHeaderExplicit = tokenHeaderExplicit
+	parsed.ownsProcess = callbacks != nil
 	return parsed, nil
 }
 

--- a/pkg/sandbox-gateway/filter/config_test.go
+++ b/pkg/sandbox-gateway/filter/config_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package filter
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	v3 "github.com/cncf/xds/go/xds/type/v3"
@@ -30,6 +32,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/openkruise/agents/pkg/identity/oidc"
+	"github.com/openkruise/agents/pkg/sandbox-gateway/server"
 )
 
 type fakeJWTAuthManager struct {
@@ -747,4 +750,96 @@ func TestMergeWakeOnTraffic(t *testing.T) {
 	if fc.WakeTimeoutSeconds != 120 {
 		t.Errorf("WakeTimeoutSeconds = %d, want 120", fc.WakeTimeoutSeconds)
 	}
+}
+
+func TestFilterConfigDestroy(t *testing.T) {
+	parser := &ConfigParser{}
+	emptyInput, err := anypb.New(&v3.TypedStruct{})
+	require.NoError(t, err)
+	valuedInput := typedFilterConfig(t, map[string]any{"default-port": "8080"})
+
+	// Parse assigns ownsProcess in two separate branches depending on whether
+	// the TypedStruct carries a value, so both branches need listener and
+	// route coverage.
+	tests := []struct {
+		name          string
+		input         *anypb.Any
+		withCallbacks bool
+		wantOwns      bool
+		wantCalls     int32
+	}{
+		{
+			name:          "listener config without values stops process",
+			input:         emptyInput,
+			withCallbacks: true,
+			wantOwns:      true,
+			wantCalls:     1,
+		},
+		{
+			name:          "listener config with values stops process",
+			input:         valuedInput,
+			withCallbacks: true,
+			wantOwns:      true,
+			wantCalls:     1,
+		},
+		{
+			name:          "route config without values does not stop process",
+			input:         emptyInput,
+			withCallbacks: false,
+			wantOwns:      false,
+			wantCalls:     0,
+		},
+		{
+			name:          "route config with values does not stop process",
+			input:         valuedInput,
+			withCallbacks: false,
+			wantOwns:      false,
+			wantCalls:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server.ResetProcessLifecycleForTest()
+			t.Cleanup(server.ResetProcessLifecycleForTest)
+
+			var calls atomic.Int32
+			server.SetProcessStopForTest(func(context.Context) error {
+				calls.Add(1)
+				return nil
+			})
+
+			var callbacks api.ConfigCallbackHandler
+			if tt.withCallbacks {
+				callbacks = &fakeConfigCallbackHandler{}
+			}
+			result, err := parser.Parse(tt.input, callbacks)
+			require.NoError(t, err)
+			cfg := result.(*FilterConfig)
+			require.Equal(t, tt.wantOwns, cfg.ownsProcess)
+
+			cfg.Destroy()
+			assert.Equal(t, tt.wantCalls, calls.Load())
+		})
+	}
+
+	t.Run("merge destroy does not stop process", func(t *testing.T) {
+		server.ResetProcessLifecycleForTest()
+		t.Cleanup(server.ResetProcessLifecycleForTest)
+
+		var calls atomic.Int32
+		server.SetProcessStopForTest(func(context.Context) error {
+			calls.Add(1)
+			return nil
+		})
+
+		parent, err := parser.Parse(emptyInput, &fakeConfigCallbackHandler{})
+		require.NoError(t, err)
+		child, err := parser.Parse(emptyInput, nil)
+		require.NoError(t, err)
+		merged := parser.Merge(parent, child).(*FilterConfig)
+		require.False(t, merged.ownsProcess)
+		merged.Destroy()
+		assert.Equal(t, int32(0), calls.Load())
+	})
 }

--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -43,6 +44,8 @@ const (
 	EnvMemberlistBindPort = "MEMBERLIST_BIND_PORT"
 	HealthAPI             = "/healthz"
 	ReadyAPI              = "/readyz"
+	// ProcessStopTimeout is how long Envoy Config.Destroy waits for StopProcess.
+	ProcessStopTimeout = 8 * time.Second
 )
 
 // ReadinessCheck reports whether the gateway is ready to receive traffic.
@@ -55,6 +58,13 @@ type ReadinessCheck func() error
 var (
 	globalPeerManagerMu sync.RWMutex
 	globalPeerManager   peers.Peers
+
+	// processServer is stored by Start on a Go goroutine and loaded by
+	// StopProcess from Envoy's main thread, so it must stay atomic.
+	processServer   atomic.Pointer[Server]
+	processStopOnce sync.Once
+	// processStop is replaceable in tests via SetProcessStopForTest.
+	processStop = defaultProcessStop
 )
 
 // setPeerManager sets the global peer manager. Called during Start.
@@ -70,6 +80,63 @@ func GetPeerManager() peers.Peers {
 	globalPeerManagerMu.RLock()
 	defer globalPeerManagerMu.RUnlock()
 	return globalPeerManager
+}
+
+// defaultProcessStop returns nil when the termination request arrives before
+// Start publishes processServer, i.e. while Start is still listing peers or
+// joining memberlist. That still consumes processStopOnce, so the peer server
+// and memberlist created by the in-flight Start are never gracefully stopped.
+// The gap is accepted on purpose: the process is exiting anyway, the kernel
+// reclaims the sockets, and peers evict the dead member via failure
+// detection. Blocking StopProcess until Start publishes would instead let a
+// stuck Kubernetes List wedge Envoy shutdown past its termination budget.
+func defaultProcessStop(ctx context.Context) error {
+	s := processServer.Load()
+	if s == nil {
+		return nil
+	}
+	return s.Stop(ctx)
+}
+
+// StopProcess runs Server.Stop at most once; sync.Once blocks concurrent
+// callers until the first one returns. ctx bounds the wait; Stop keeps running
+// after ctx expires so leave/shutdown ownership does not move.
+func StopProcess(ctx context.Context) error {
+	var err error
+	processStopOnce.Do(func() {
+		done := make(chan error, 1)
+		go func() {
+			done <- processStop(ctx)
+		}()
+		select {
+		case err = <-done:
+		case <-ctx.Done():
+			err = ctx.Err()
+		}
+	})
+	return err
+}
+
+// ResetProcessLifecycleForTest clears process-wide Start/Stop state. Tests
+// only: it mutates globals without locking, so call it (typically via
+// t.Cleanup) only when no StopProcess call is still in flight, and never from
+// t.Parallel tests.
+func ResetProcessLifecycleForTest() {
+	processStopOnce = sync.Once{}
+	processStop = defaultProcessStop
+	processServer.Store(nil)
+	setPeerManager(nil)
+}
+
+// SetProcessStopForTest replaces the process stop function. Tests only: same
+// rules as ResetProcessLifecycleForTest — no concurrent StopProcess, no
+// t.Parallel.
+func SetProcessStopForTest(fn func(context.Context) error) {
+	if fn == nil {
+		processStop = defaultProcessStop
+		return
+	}
+	processStop = fn
 }
 
 // getMemberlistBindPort reads the memberlist bind port from environment variable
@@ -178,6 +245,7 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}()
 
+	processServer.Store(s)
 	return nil
 }
 

--- a/pkg/sandbox-gateway/server/server_test.go
+++ b/pkg/sandbox-gateway/server/server_test.go
@@ -23,13 +23,17 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/peers"
 	"github.com/openkruise/agents/pkg/sandbox-gateway/registry"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	"github.com/openkruise/agents/pkg/sandboxroute"
@@ -208,6 +212,110 @@ func TestNewServer(t *testing.T) {
 func TestServerStopWithoutStart(t *testing.T) {
 	server, _ := newTestGatewayServer()
 	assert.NoError(t, server.Stop(nil))
+}
+
+func TestServerStopClearsPeerManager(t *testing.T) {
+	ResetProcessLifecycleForTest()
+	t.Cleanup(ResetProcessLifecycleForTest)
+
+	server, _ := newTestGatewayServer()
+	setPeerManager(&peers.MemberlistPeers{})
+	require.NotNil(t, GetPeerManager())
+	require.NoError(t, server.Stop(context.Background()))
+	assert.Nil(t, GetPeerManager())
+}
+
+func TestStopProcessNoServer(t *testing.T) {
+	ResetProcessLifecycleForTest()
+	t.Cleanup(ResetProcessLifecycleForTest)
+	assert.NoError(t, StopProcess(context.Background()))
+}
+
+// TestStopProcessStopsStoredServer covers the non-nil defaultProcessStop path:
+// StopProcess must load the stored server and run its Stop, clearing the
+// process-wide peer manager.
+func TestStopProcessStopsStoredServer(t *testing.T) {
+	ResetProcessLifecycleForTest()
+	t.Cleanup(ResetProcessLifecycleForTest)
+
+	server, _ := newTestGatewayServer()
+	setPeerManager(&peers.MemberlistPeers{})
+	processServer.Store(server)
+	require.NotNil(t, GetPeerManager())
+
+	require.NoError(t, StopProcess(context.Background()))
+	assert.Nil(t, GetPeerManager())
+}
+
+func TestStopProcessOnce(t *testing.T) {
+	ResetProcessLifecycleForTest()
+	t.Cleanup(ResetProcessLifecycleForTest)
+
+	var calls atomic.Int32
+	SetProcessStopForTest(func(context.Context) error {
+		calls.Add(1)
+		return nil
+	})
+
+	require.NoError(t, StopProcess(context.Background()))
+	require.NoError(t, StopProcess(context.Background()))
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestStopProcessConcurrentOnce(t *testing.T) {
+	ResetProcessLifecycleForTest()
+	t.Cleanup(ResetProcessLifecycleForTest)
+
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	SetProcessStopForTest(func(context.Context) error {
+		calls.Add(1)
+		close(started)
+		<-release
+		return nil
+	})
+
+	const n = 8
+	var wg sync.WaitGroup
+	wg.Add(n)
+	errCh := make(chan error, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			errCh <- StopProcess(context.Background())
+		}()
+	}
+	<-started
+	close(release)
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestStopProcessTimeoutReturnsWhileStopContinues(t *testing.T) {
+	ResetProcessLifecycleForTest()
+	t.Cleanup(ResetProcessLifecycleForTest)
+
+	var finished atomic.Bool
+	unblock := make(chan struct{})
+	SetProcessStopForTest(func(context.Context) error {
+		<-unblock
+		finished.Store(true)
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	err := StopProcess(ctx)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.False(t, finished.Load())
+
+	close(unblock)
+	require.Eventually(t, finished.Load, time.Second, 10*time.Millisecond)
 }
 
 func TestStartWithoutNodeNameFailsAndStopCleansUp(t *testing.T) {

--- a/pkg/sandbox-gateway/server/server_test.go
+++ b/pkg/sandbox-gateway/server/server_test.go
@@ -219,7 +219,8 @@ func TestServerStopClearsPeerManager(t *testing.T) {
 	t.Cleanup(ResetProcessLifecycleForTest)
 
 	server, _ := newTestGatewayServer()
-	setPeerManager(&peers.MemberlistPeers{})
+	server.peerManager = &peers.MemberlistPeers{}
+	setPeerManager(server.peerManager)
 	require.NotNil(t, GetPeerManager())
 	require.NoError(t, server.Stop(context.Background()))
 	assert.Nil(t, GetPeerManager())
@@ -239,7 +240,8 @@ func TestStopProcessStopsStoredServer(t *testing.T) {
 	t.Cleanup(ResetProcessLifecycleForTest)
 
 	server, _ := newTestGatewayServer()
-	setPeerManager(&peers.MemberlistPeers{})
+	server.peerManager = &peers.MemberlistPeers{}
+	setPeerManager(server.peerManager)
 	processServer.Store(server)
 	require.NotNil(t, GetPeerManager())
 


### PR DESCRIPTION
- Add terminationGracePeriodSeconds: 60 to gateway Deployment
- Make memberlist Stop resilient: Leave failure no longer skips Shutdown
- Add injectable leave func to MemberlistPeers for testability
- Ensure StopProcess is idempotent via sync.Once protection
- Add tests covering concurrent Stop, timeout, and process lifecycle

Signed-off-by: AiRanthem <zhongtianyun.zty@alibaba-inc.com>
