### PR TITLE
feat(sandboxclaim): support claim-time auto-pause policy and probes

### DIFF
--- a/api/v1alpha1/sandboxclaim_types.go
+++ b/api/v1alpha1/sandboxclaim_types.go
@@ -36,10 +36,40 @@ type SandboxClaimSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="replicas is immutable"
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// ShutdownTime specifies the absolute time when the sandbox should be shut down
-	// This will be set as spec.shutdownTime (absolute time) on the Sandbox
+	// ShutdownTime specifies the absolute time when the sandbox should be shut down.
+	// This is written to spec.shutdownTime on the Sandbox at claim time.
+	// If either pauseTime or shutdownTime is set, both Sandbox deadline fields are
+	// written from this Claim: a nil side clears that Sandbox field.
 	// +optional
 	ShutdownTime *metav1.Time `json:"shutdownTime,omitempty"`
+
+	// PauseTime specifies the absolute time when the sandbox should be paused.
+	// This is written to spec.pauseTime on the Sandbox at claim time.
+	// If either pauseTime or shutdownTime is set, both Sandbox deadline fields are
+	// written from this Claim: a nil side clears that Sandbox field.
+	// +optional
+	PauseTime *metav1.Time `json:"pauseTime,omitempty"`
+
+	// AutoPausePolicy is copied onto the claimed Sandbox at claim time, replacing
+	// any pool default. Probe-driven rules must name probes declared on the
+	// target SandboxSet or in probes below. Omitted or nil leaves the Sandbox
+	// autoPausePolicy unchanged.
+	// +optional
+	AutoPausePolicy *AutoPausePolicy `json:"autoPausePolicy,omitempty"`
+
+	// Probes are merged by name onto the claimed Sandbox at claim time: a
+	// probe with the same name replaces the version carried by the pool
+	// candidate, new names are appended. AutoPausePolicy rules may therefore
+	// reference probes declared here instead of on the target SandboxSet. The
+	// merged set must pass the same validation as SandboxSet probes and stay
+	// within the Sandbox probes limit, otherwise the claim completes with
+	// reason InvalidClaimSpec. Omitted or empty leaves the Sandbox probes
+	// unchanged.
+	// +optional
+	// +listType=map
+	// +listMapKey=name
+	// +kubebuilder:validation:MaxItems=16
+	Probes []Probe `json:"probes,omitempty"`
 
 	// ClaimTimeout specifies the maximum duration to wait for claiming sandboxes
 	// If the timeout is reached, the claim will be marked as Completed regardless of

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1511,6 +1511,22 @@ func (in *SandboxClaimSpec) DeepCopyInto(out *SandboxClaimSpec) {
 		in, out := &in.ShutdownTime, &out.ShutdownTime
 		*out = (*in).DeepCopy()
 	}
+	if in.PauseTime != nil {
+		in, out := &in.PauseTime, &out.PauseTime
+		*out = (*in).DeepCopy()
+	}
+	if in.AutoPausePolicy != nil {
+		in, out := &in.AutoPausePolicy, &out.AutoPausePolicy
+		*out = new(AutoPausePolicy)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Probes != nil {
+		in, out := &in.Probes, &out.Probes
+		*out = make([]Probe, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.ClaimTimeout != nil {
 		in, out := &in.ClaimTimeout, &out.ClaimTimeout
 		*out = new(v1.Duration)

--- a/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxclaims.yaml
@@ -65,6 +65,115 @@ spec:
                   to claimed Sandbox resources
                 type: object
                 x-kubernetes-map-type: granular
+              autoPausePolicy:
+                description: |-
+                  AutoPausePolicy is copied onto the claimed Sandbox at claim time, replacing
+                  any pool default. Probe-driven rules must name probes declared on the
+                  target SandboxSet or in probes below. Omitted or nil leaves the Sandbox
+                  autoPausePolicy unchanged.
+                properties:
+                  pause:
+                    description: Pause defines the pause policy for the sandbox.
+                    properties:
+                      whenProbedIdleState:
+                        description: |-
+                          WhenProbedIdleState pauses the sandbox when a probe's Condition message
+                          matches MessageRegex for at least ThresholdDuration.
+                        properties:
+                          messageRegex:
+                            description: |-
+                              MessageRegex is a regular expression matched against the probe's
+                              Condition message (stdout). When the message matches, the Agent is
+                              considered inactive. When it does not match, the Agent is considered
+                              active and the sandbox stays Running.
+                            maxLength: 512
+                            type: string
+                          probe:
+                            description: |-
+                              Probe is the name of the probe to evaluate for pause decisions.
+                              Must match a probe name in Spec.Probes.
+                            type: string
+                          thresholdDuration:
+                            description: |-
+                              ThresholdDuration is the minimum time the probe's Condition message
+                              must continuously match MessageRegex before the sandbox is paused.
+                              Measured from the Condition's lastTransitionTime.
+
+                              It is required: pausing as soon as a single probe report matches would
+                              drop the smoothing this rule exists for, so there is no meaningful
+                              default and an unset value is a misconfiguration rather than
+                              "pause immediately".
+                            type: string
+                        required:
+                        - messageRegex
+                        - probe
+                        - thresholdDuration
+                        type: object
+                    type: object
+                  resume:
+                    description: Resume defines the resume policy for the sandbox.
+                    properties:
+                      onIngressTraffic:
+                        description: |-
+                          OnIngressTraffic resumes the sandbox when the sandbox-gateway receives
+                          inbound traffic addressed to it while it is paused. Unlike the probed
+                          rules this one is event-driven: it needs no probe, it produces no
+                          Status.Schedules entry, and it is executed by the sandbox-gateway rather
+                          than by the sandbox controller.
+                        properties:
+                          pauseTimeout:
+                            description: |-
+                              PauseTimeout is the auto-pause timeout re-armed by a traffic wake: the
+                              gateway writes Spec.PauseTime = now + PauseTimeout atomically with
+                              Spec.Paused = false, so the woken sandbox has running time before its
+                              next auto-pause. It applies only to auto-pause sandboxes (those that
+                              already carry Spec.PauseTime); never-timeout and shutdown-only
+                              sandboxes keep their timeout mode unchanged.
+                              When absent or non-positive, a traffic wake does not re-arm auto-pause:
+                              the woken sandbox keeps running until it is paused or deleted again.
+                              A positive value is subject to the resume timeout floor
+                              (timeout.DefaultMinResumeTimeoutSeconds, currently 300s): values below
+                              the floor are raised to it so the fresh PauseTime cannot expire while
+                              the sandbox is still resuming.
+                            type: string
+                        type: object
+                      whenProbedScheduleTime:
+                        description: |-
+                          WhenProbedScheduleTime resumes the sandbox before a scheduled task
+                          by parsing the probe's Condition message as a timestamp.
+                        properties:
+                          leadTime:
+                            default: 5m
+                            description: |-
+                              LeadTime is the duration before the parsed timestamp at which the
+                              sandbox should be resumed. For example, if the probe reports the
+                              next scheduled task at time T and LeadTime is 5m, the sandbox is
+                              resumed at T - 5m.
+                            type: string
+                          probe:
+                            description: |-
+                              Probe is the name of the probe to evaluate for resume decisions.
+                              Must match a probe name in Spec.Probes.
+                            type: string
+                          timeFormat:
+                            default: unix
+                            description: |-
+                              TimeFormat indicates the format of the probe's Condition message for
+                              parsing as a timestamp, and defaults to "unix":
+
+                                unix     - seconds since epoch, e.g. "1787040000"
+                                datetime - RFC3339 with offset, e.g. "2026-08-29T08:00:00+08:00"
+
+                              NextResumeTime is set to the parsed timestamp minus LeadTime.
+                            enum:
+                            - unix
+                            - datetime
+                            type: string
+                        required:
+                        - probe
+                        type: object
+                    type: object
+                type: object
               claimTimeout:
                 default: 1m
                 description: |-
@@ -170,6 +279,199 @@ spec:
                   to claimed Sandbox resources and synced to sandbox template labels.
                 type: object
                 x-kubernetes-map-type: granular
+              pauseTime:
+                description: |-
+                  PauseTime specifies the absolute time when the sandbox should be paused.
+                  This is written to spec.pauseTime on the Sandbox at claim time.
+                  If either pauseTime or shutdownTime is set, both Sandbox deadline fields are
+                  written from this Claim: a nil side clears that Sandbox field.
+                format: date-time
+                type: string
+              probes:
+                description: |-
+                  Probes are merged by name onto the claimed Sandbox at claim time: a
+                  probe with the same name replaces the version carried by the pool
+                  candidate, new names are appended. AutoPausePolicy rules may therefore
+                  reference probes declared here instead of on the target SandboxSet. The
+                  merged set must pass the same validation as SandboxSet probes and stay
+                  within the Sandbox probes limit, otherwise the claim completes with
+                  reason InvalidClaimSpec. Omitted or empty leaves the Sandbox probes
+                  unchanged.
+                items:
+                  description: |-
+                    Probe defines a named probe that writes its result to a Pod Condition.
+                    Embeds corev1.Probe inline so that exec/periodSeconds/timeoutSeconds/etc.
+                    are directly accessible. Currently only exec probes are supported;
+                    other corev1.Probe fields (httpGet, tcpSocket, grpc) may be supported
+                    in the future as needed.
+                  properties:
+                    containerName:
+                      description: |-
+                        ContainerName specifies which container to execute the probe in.
+                        If empty, defaults to the first container in the pod spec.
+                      type: string
+                    exec:
+                      description: Exec specifies a command to execute in the container.
+                      properties:
+                        command:
+                          description: |-
+                            Command is the command line to execute inside the container, the working directory for the
+                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                            a shell, you need to explicitly call out to that shell.
+                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    failureThreshold:
+                      description: |-
+                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                        Defaults to 3. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    grpc:
+                      description: GRPC specifies a GRPC HealthCheckRequest.
+                      properties:
+                        port:
+                          description: Port number of the gRPC service. Number must
+                            be in the range 1 to 65535.
+                          format: int32
+                          type: integer
+                        service:
+                          default: ""
+                          description: |-
+                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                            If this is not specified, the default behavior is defined by gRPC.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    httpGet:
+                      description: HTTPGet specifies an HTTP GET request to perform.
+                      properties:
+                        host:
+                          description: |-
+                            Host name to connect to, defaults to the pod IP. You probably want to set
+                            "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            properties:
+                              name:
+                                description: |-
+                                  The header field name.
+                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Name or number of the port to access on the container.
+                            Number must be in the range 1 to 65535.
+                            Name must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: |-
+                            Scheme to use for connecting to the host.
+                            Defaults to HTTP.
+                          type: string
+                      required:
+                      - port
+                      type: object
+                    initialDelaySeconds:
+                      description: |-
+                        Number of seconds after the container has started before liveness probes are initiated.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                      format: int32
+                      type: integer
+                    name:
+                      description: |-
+                        Name is the unique identifier for this probe within the sandbox.
+                        Probe results are written to a Condition with type "agents.kruise.io/<Name>".
+                      maxLength: 299
+                      pattern: ^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$
+                      type: string
+                    periodSeconds:
+                      description: |-
+                        How often (in seconds) to perform the probe.
+                        Default to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: |-
+                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    tcpSocket:
+                      description: TCPSocket specifies a connection to a TCP port.
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Number or name of the port to access on the container.
+                            Number must be in the range 1 to 65535.
+                            Name must be an IANA_SVC_NAME.
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    terminationGracePeriodSeconds:
+                      description: |-
+                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                        The grace period is the duration in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                        Set this value longer than the expected cleanup time for your process.
+                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                        value overrides the value provided by the pod spec.
+                        Value must be non-negative integer. The value zero indicates stop immediately via
+                        the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: |-
+                        Number of seconds after which the probe times out.
+                        Defaults to 1 second. Minimum value is 1.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               replicas:
                 default: 1
                 description: |-
@@ -198,8 +500,10 @@ spec:
                 x-kubernetes-list-type: atomic
               shutdownTime:
                 description: |-
-                  ShutdownTime specifies the absolute time when the sandbox should be shut down
-                  This will be set as spec.shutdownTime (absolute time) on the Sandbox
+                  ShutdownTime specifies the absolute time when the sandbox should be shut down.
+                  This is written to spec.shutdownTime on the Sandbox at claim time.
+                  If either pauseTime or shutdownTime is set, both Sandbox deadline fields are
+                  written from this Claim: a nil side clears that Sandbox field.
                 format: date-time
                 type: string
               skipInitRuntime:

--- a/config/samples/agents_v1alpha1_sandboxclaim.yaml
+++ b/config/samples/agents_v1alpha1_sandboxclaim.yaml
@@ -23,6 +23,27 @@ spec:
   # ShutdownTime specifies the absolute time when the sandbox should be shut down
   # This will be set as spec.shutdownTime (absolute time) on the Sandbox
   # shutdownTime: "2025-12-30T12:00:00Z"
+
+  # PauseTime specifies the absolute time when the sandbox should be paused
+  # This will be set as spec.pauseTime on the Sandbox at claim time
+  # pauseTime: "2025-12-30T11:00:00Z"
+
+  # AutoPausePolicy is copied onto the claimed Sandbox, replacing any pool default.
+  # Probe-driven rules must name probes declared on the target SandboxSet
+  # or in probes below.
+  # autoPausePolicy:
+  #   resume:
+  #     onIngressTraffic: {}
+
+  # Probes are merged by name onto the claimed Sandbox at claim time: a probe
+  # with the same name replaces the version carried by the pool candidate,
+  # new names are appended. AutoPausePolicy rules may reference probes
+  # declared here instead of on the target SandboxSet.
+  # probes:
+  #   - name: Active
+  #     exec:
+  #       command: ["sh", "-c", "cat /tmp/activity"]
+  #     periodSeconds: 30
   
   # Labels contains key-value pairs to be added as labels to claimed Sandbox resources
   labels:

--- a/docs/proposals/20251229-sandbox-claim-crd.md
+++ b/docs/proposals/20251229-sandbox-claim-crd.md
@@ -192,7 +192,8 @@ The SandboxClaim CRD is designed to align with the E2B HTTP API's `NewSandboxReq
 | `templateID` | `templateName` |  implementable | Maps to SandboxSet pool name |
 | `timeout` | `shutdownTime` |  implementable | Absolute shutdown time |
 | `envVars` | `envVars` | implementable | Environment variables for envd init |
-| `autoPause` | N/A |  Future Work | Not implemented in E2B Api |
+| `autoPause` | `pauseTime` | implementable | Absolute pause time; see `/docs/proposals/20260909-sandboxclaim-auto-pause-policy-CN.md` |
+| `autoResume` | `autoPausePolicy.resume.onIngressTraffic` | implementable | Full `autoPausePolicy` overlay; see the same proposal |
 | `secure` | N/A |  Future Work | Not implemented in E2B Api |
 
 

--- a/docs/proposals/20260909-sandboxclaim-auto-pause-policy-CN.md
+++ b/docs/proposals/20260909-sandboxclaim-auto-pause-policy-CN.md
@@ -1,0 +1,198 @@
+---
+title: SandboxClaim 自动暂停 overlay
+authors:
+  - "@sophon"
+reviewers:
+  - "@TBD"
+creation-date: 2026-09-09
+last-updated: 2026-09-10
+status: implementable
+see-also:
+  - "/docs/proposals/20260626-sandbox-auto-pause.md"
+  - "/docs/proposals/20260627-wake-on-traffic-via-spec-patch.md"
+  - "/docs/proposals/20251229-sandbox-claim-crd.md"
+---
+
+# SandboxClaim 自动暂停 overlay
+
+## 摘要
+
+Sandbox 已能按 `spec.pauseTime` 做一次性定时暂停，并按 `spec.autoPausePolicy` 做 probe 驱动暂停/恢复与入站流量唤醒。SandboxClaim 目前只能 overlay `shutdownTime`，调用方无法在 claim 时指定这两种暂停。终态：Claim 增加三个可选字段 `spec.pauseTime`、`spec.autoPausePolicy` 与 `spec.probes`，在 claim 落盘前一次性写到 Sandbox；策略与 deadline 缺省继承池配置；probes 按名合并到候选已有的探测集（同名覆盖、新名追加）；非法配置使 Claim 以 `InvalidClaimSpec` 完成且不再重试。不改暂停运行时。
+
+## 背景
+
+池 Sandbox 在创建时从 SandboxSet 复制 `probes` 与 `autoPausePolicy`。Claim 之后，未 claim 成员才进入 auto-pause 决策；recycle 会清掉 `pauseTime`/`shutdownTime` 并从 SandboxSet 恢复策略。E2B create 已能用 `autoPause` 写 `PauseTime`，用 `autoResume` 局部写入 `OnIngressTraffic`。Claim CR 作为声明式对象，缺的是与 `shutdownTime` 同形态的 overlay，而不是再引入一套 E2B 相对秒数与 bool。
+
+没有 Claim 级 overlay 时，每租户无法覆盖池默认策略，也无法声明「到点暂停」；只能改 SandboxSet（影响整池）或绕开 Claim 直接改 Sandbox。
+
+## 设计终态
+
+### 范围与非目标
+
+范围内：
+
+- `SandboxClaim.spec.pauseTime`：绝对时间，写入 `Sandbox.spec.pauseTime`
+- `SandboxClaim.spec.autoPausePolicy`：复用现有 `AutoPausePolicy` 类型，整份写到 `Sandbox.spec.autoPausePolicy`
+- `SandboxClaim.spec.probes`：复用现有 `Probe` 类型，按名合并到候选的 `Sandbox.spec.probes`（同名覆盖、新名追加）
+- Claim 控制器在每次 claim 尝试前校验并 overlay；与现有 labels、annotations、`shutdownTime` 同一时机
+
+范围外：
+
+- 不增加 `autoPause` bool、相对 timeout、paused-retention 注解，也不从 `pauseTime` 推导 `shutdownTime`
+- 不增加独立的 `autoResume` 字段；流量唤醒通过 `autoPausePolicy.resume.onIngressTraffic` 表达
+- 不新建 SandboxClaim webhook；不改 sandbox 控制器、gateway、recycle、E2B HTTP（E2B 不暴露 probe 配置，保持 SandboxClaim 独有能力）
+- 不把 Claim 变成持续控制器：Completed 之后仍不回写已 claim 的 Sandbox
+
+### 所有权与数据流
+
+```
+SandboxClaim spec --> SandboxClaim 控制器 --claim 时 overlay--> claimed Sandbox
+SandboxSet probes 与 autoPausePolicy --> 池 Sandbox --> claimed Sandbox
+claimed Sandbox --> checkTimers（pauseTime）
+claimed Sandbox --> handleAutoPause（autoPausePolicy）
+claimed Sandbox --> gateway（OnIngressTraffic）
+claimed Sandbox --recycle--> 池 Sandbox
+```
+
+- Claim 只负责把调用方意图写进 Sandbox spec
+- 暂停与恢复的执行仍完全属于现有 Sandbox 控制器与 gateway
+- 池默认仍由 SandboxSet 声明；recycle 仍从 SandboxSet 恢复策略并清空 deadline
+
+### 可见接口
+
+`SandboxClaimSpec` 增加两个可选指针字段，语义对齐已有 `shutdownTime`：
+
+- `pauseTime *metav1.Time`：省略或 nil 表示不 overlay `Sandbox.spec.pauseTime`
+- `autoPausePolicy *AutoPausePolicy`：省略或 nil 表示不 overlay，保留池上已有策略
+
+不引入新的策略类型。`AutoPausePolicy` 的字段、默认值与跨字段规则与 Sandbox / SandboxSet 相同。
+
+### 写入规则
+
+对每一次成功 claim 的 Sandbox：
+
+1. **一次性。** overlay 只发生在该 Sandbox 被 claim 成功的那一次更新里。Claim 进入 Completed 后，再改 Claim spec 不会修改已 claim 的 Sandbox。
+2. **缺省继承。** 两个字段均为 nil 时，Sandbox 保留 claim 前状态：池成员的 `autoPausePolicy` 来自 SandboxSet，`pauseTime` 在池上本为空。
+3. **整份替换。** `autoPausePolicy` 非 nil 时，用 Claim 中的整份策略替换 Sandbox 上的策略，不做字段级 merge。只想打开 `OnIngressTraffic` 且保留池里的 idle/cron 规则时，调用方必须在 Claim 中写出完整策略。
+4. **deadline 成对写入。** 若 Claim 指定了 `pauseTime` 或 `shutdownTime` 中的任一个，则按 Claim 当前值同时设置 Sandbox 的这两个字段：Claim 上为 nil 的那一侧在 Sandbox 上为清空。两个都不指定则不改 Sandbox 的 deadline。
+5. **不推导删除时间。** `pauseTime` 到期只暂停；是否删除仍只看 `shutdownTime`。需要「暂停后再删除」时，调用方同时给出两个绝对时间。
+6. **批次一致。** 同一 Claim 一次 reconcile 中成功 claim 的多个副本带上相同的 overlay。
+7. **probes 按名合并。** claim `probes` 非 nil 时，与候选 Sandbox 上的 `spec.probes` 按名合并：同名项以 claim 版本替换（池序位置不变），新名追加在池序之后；claim 未带 probes 则不动。合并后的集合不得超过 Sandbox 的 probes 上限（16）。与单值字段 `autoPausePolicy` 的整份替换不同，probes 是集合类配置，与 labels/annotations 一样按 key 合并；取舍见「Claim 自带 probes」。
+
+### 校验与失败
+
+Claim 在构建 claim 选项时校验 `autoPausePolicy` 与 `probes`：
+
+- 使用与 SandboxSet admission 相同的校验规则
+- claim `probes` 列表自身需通过 `ValidateProbes`（名字唯一、exec-only、name 可作 condition type，与 SandboxSet 相同）
+- 被引用的 probe 名以「当前 SandboxSet.spec.probes 与 claim.probes 按名合并后的集合」为准（模板上的 probes 对运行中的池成员无效，与现有复制规则一致）；claim 未带 policy 时无需重校验池策略——合并只会增加 probe 名，池策略的引用不会失效
+- 合并后的集合超过 16 时，Claim 以 `InvalidClaimSpec` 完成：提前给出清晰错误，而不是等到 sandbox update 被 apiserver 拒绝
+- 通过 Claim 级校验后，领取时仍按每个候选 Sandbox 自身的 `spec.probes` 复核，但扣除 claim 自带的 probe 名：claim 自带的 probe 不要求候选预先声明，领取时合并写入；滚动更新中的旧候选若缺少其余被引用的 probe，会留在池中并等待兼容候选，不会写入无法执行的策略
+- 仅含 `OnIngressTraffic`、不含 probe 规则的策略合法
+- 空策略（没有任何 pause/resume 规则）、无法编译的 `messageRegex`、引用不存在的 probe 等均非法
+
+非法时的可观察结果与现有保留身份键校验相同：
+
+- 不再继续 claim
+- Claim 进入 Completed
+- `status.conditions[type=Completed].reason` 为 `InvalidClaimSpec`
+- 发出 Warning 事件 `InvalidClaimSpec`
+- 本轮之前已经 claim 成功的 Sandbox 保持已写入状态，不会回滚
+
+候选缺少当前合法策略所引用的 probe 是池容量暂时不匹配，不是 Claim spec 非法：本轮不领取该候选，并按现有无可用 Sandbox 路径重试；`createOnNoStock` 开启时可从当前 SandboxSet 创建兼容实例。
+
+apiserver 仍接受字段形状合法的对象；交叉规则不靠新 webhook。若非法策略被绕过写到了 Sandbox，Sandbox 侧既有 `ProbeValid=False` 仍会拒绝 probe 驱动暂停，但这不是 Claim 的主路径。
+
+### 与现有暂停机制的关系
+
+写入完成后，Sandbox 上的行为与今天直接编辑 Sandbox spec 相同：
+
+- `pauseTime` 由 `checkTimers` 无条件执行，不依赖 `AutoPauseController`
+- probe 驱动的 pause/resume 仍要求该 gate 打开，且规则引用的 probe 实际存在于 Sandbox spec（本设计下即合并后的 probes；sandbox 控制器对运行中的 Pod patch `kruise.io/podprobe`，`spec.probes` 变化在 Running 状态即生效）
+- `OnIngressTraffic` 仍由 gateway 执行，不打开 probe 决策循环
+- `pauseTime` 与 `autoPausePolicy` 并存：谁先到期谁暂停；probe 仍报 active 时 `pauseTime` 仍会暂停。需要 probe 最终裁决的调用方不要设 `pauseTime`
+
+Claim 写入策略不打开 feature gate。gate 关闭时，策略仍出现在 Sandbox spec 上，但 probe 注入与 probe 决策不运行；`pauseTime` 仍然生效。
+
+### 兼容与升级
+
+- 既有 Claim 不写这两个字段：行为与现在完全相同
+- 已 claim、且调用方未 overlay 策略的 Sandbox 继续使用池策略
+- recycle 后的池成员恢复为 SandboxSet 上的 `probes` 与 `autoPausePolicy`，`pauseTime` 被清空；下一次 claim 再按新 Claim overlay
+- 不改变 E2B HTTP；E2B 继续用 bool + 相对秒数，Claim 使用绝对时间
+
+### 可观察例子
+
+**继承池策略。** Claim 省略两个新字段。claim 后的 Sandbox 带有 SandboxSet 的 `autoPausePolicy`，`pauseTime` 为空。若池策略含 idle probe 且 gate 打开，idle 计时从 `claim-timestamp` 起算，不会因预热期间的 idle 立刻暂停。
+
+**仅定时暂停。** Claim 只设 `pauseTime`，不设 `autoPausePolicy` 与 `shutdownTime`。Sandbox 得到该 `pauseTime`，保留池策略，`shutdownTime` 仍为空。到期后暂停且不被删除。
+
+**仅覆盖策略。** 池有 idle 规则。Claim 给出只含 `resume.onIngressTraffic` 的 `autoPausePolicy`。Sandbox 上的 idle 规则被替换掉，只留下流量唤醒。调用方若还要 idle 规则，必须在 Claim 策略里一并写出。
+
+**非法引用。** SandboxSet 没有名为 `Active` 的 probe，Claim 的 pause 规则引用 `Active`。Claim 完成，reason=`InvalidClaimSpec`，没有任何新的 Sandbox 被这次失败的选项构建 claim 出来。
+
+**需要 probe 最终裁决。** Claim 只设 `autoPausePolicy.pause.whenProbedIdleState`，不设 `pauseTime`。到期行为只由 probe 决定。
+
+**两种触发都设。** Claim 同时设 `pauseTime` 与 idle 策略。Sandbox 在 probe 仍为 active 时若已过 `pauseTime`，仍会暂停。
+
+## 备选与取舍
+
+- **Claim 上使用 E2B 的 `autoPause` bool。** 与已有绝对时间 `shutdownTime` 不一致，还要把相对秒数和 retention 算术搬进 Claim。放弃。
+- **对 `OnIngressTraffic` 做字段级 merge。** 对「只开唤醒」更省事，但声明式 CR 无法看出最终策略，且与 SandboxSet 整份复制不一致。放弃；完整策略由调用方写出。
+- **Claim 自带 `probes`。** 已实现，按名合并语义与取舍见「Claim 自带 probes」。
+- **新建 Claim webhook。** Sandbox 本身也没有 webhook；交叉校验依赖 SandboxSet，适合走已有 claim 控制器失败路径。
+
+## 风险
+
+- 整份替换会清掉调用方没抄上来的池规则。这是刻意的可见性，不是静默 merge。
+- `pauseTime` 与 probe 策略并存时，定时器可以打断仍在工作的 Agent。与现行 Sandbox 提案一致，由调用方选择不要同时设置。
+- `AutoPauseController` 默认关闭：只 overlay 策略而不开 gate 时，probe 路径不会运行，容易被理解成「Claim 没生效」。probe 路径看 gate，`pauseTime` 不看 gate。
+
+## Claim 自带 probes
+
+已随本设计实现：`SandboxClaim.spec.probes` 可选，按名合并到候选 Sandbox 的 `spec.probes`。
+
+### 动机
+
+probe 驱动策略要求被引用的 probe 预先声明在目标 SandboxSet 上。当不同租户需要不同的探测逻辑（不同 exec 命令、不同探测周期）时，SandboxSet 必须枚举全部 probe 变体（`MaxItems=16`），且所有池成员无差别执行全部 probes——绝大多数 claim 用不到也在消耗资源。Claim 自带 probes 可让每个 claim 只声明并执行自己需要的探测。
+
+### 技术基础（当前代码已具备的支撑）
+
+- sandbox 控制器的 `EnsureProbe` 对运行中的 Pod patch `kruise.io/podprobe` annotation，`spec.probes` 变化在 Running 状态即生效；probe 结果按 `spec.probes` 同步增删，上一个 claim 遗留的 probe condition 会被移除
+- recycle 的 `resetSandboxForPool` 已将 `spec.probes` 与 `spec.autoPausePolicy` 从 SandboxSet 原样还原，claim 写入的 probes 不会泄漏给下一个租户
+
+### 实现：按名合并（merge），不整份替换
+
+与 SandboxSet 复制到候选上的 probes **按名合并**（`+listType=map` 的天然语义）：
+
+- Claim 同名 probe 覆盖池版本：租户可定制探测参数（命令、周期），池序位置不变
+- Claim 新名 probe 追加在池序之后
+- 合并后的最终集合需通过 `ValidateProbes` 且不超过 `MaxItems=16`
+
+最终组合自洽校验（控制器 claim 时已持有 SandboxSet）：
+
+- `finalProbes = merge(sandboxSet.spec.probes, claim.probes)`（Claim 侧同名优先）
+- `ValidateProbes(claim.probes)` + `ValidateAutoPausePolicy(claim.autoPausePolicy, finalProbes)`
+- 合并超限以 `InvalidClaimSpec` 完成
+
+领取过滤沿用现有机制，从策略派生并扣除 Claim 自带项：`required = PolicyProbeNames(finalPolicy) − names(claim.probes)`，即 claim 自带的 probe 不要求候选预先声明。落盘前由 `modifyPickedSandbox` 深拷贝合并到 `spec.probes`（含 `createOnNoStock` 新建路径），无持久化中间态，合并结果不 alias claim 或池的 spec。
+
+### merge 与 replace 的取舍
+
+备选的整份替换语义（claim.probes 非 nil 时全量覆盖 Sandbox probes）被放弃：
+
+- **管理员预配 + 使用方追加是预期形态。** SandboxSet 的 probes 由平台管理员声明（安全审计、合规探测等平台级配置），claim 的使用方在其上追加自己的探测。整份替换会让租户的 claim 移除平台探测直到 recycle 还原——claim 期间形成检测盲区，等于使用方决定了平台配置的命运
+- **probe 是通用机制而非 policy 的附属品。** `Probe` 的契约是「probe 本身不定义语义，消费者定义」；第二个消费者已存在（probe 结果 mirror 到 `SandboxStatus.Conditions` 供可观测），未来可能有更多。整份替换的「探测集随 policy 整体切换」只在「policy 是唯一消费者」时成立
+- **与 claim 的 metadata 语义一致。** claim 的 labels/annotations 是按 key 合并（`MergePodLabels`/`MergePodAnnotations`）而非全量替换，因为对象上已有其他来源的数据；probes 同属集合类配置。`autoPausePolicy` 是单值语义才整份替换——单值与集合天然不同的合并规则
+
+merge 的代价及对策：
+
+- **最终探测集需合并后才可推断**：claim 单边不可见。通过校验报错/事件列出合并结果弥补；且「引用池 probe」本来就是运行时依赖（池策略改引用别的 probe 名，claim 会失效重试，与现状语义一致）
+- **同名覆盖可能遮蔽池探测**：claim 校验可对「覆盖了哪些池 probe 名」发出事件，保持可见性
+- **合并叠加可能超限**：合并后统一校验 `MaxItems=16`
+
+### 已关闭的开放问题
+
+- claim 完成时新 probe 尚未产出首次结果，`thresholdDuration` 从首次结果起算：与现有 Sandbox probe 语义一致，WaitReady 不额外涵盖 probe 就绪
+- `createOnNoStock` 路径：合并在 claim 落盘前于内存完成（`modifyPickedSandbox`），不存在「复制池 probes 再合并」的持久化中间态
+- E2B HTTP：不暴露 probe 配置，保持 SandboxClaim 独有能力

--- a/docs/proposals/20260909-sandboxclaim-auto-pause-policy-CN.md
+++ b/docs/proposals/20260909-sandboxclaim-auto-pause-policy-CN.md
@@ -5,7 +5,7 @@ authors:
 reviewers:
   - "@TBD"
 creation-date: 2026-09-09
-last-updated: 2026-09-10
+last-updated: 2026-09-11
 status: implementable
 see-also:
   - "/docs/proposals/20260626-sandbox-auto-pause.md"
@@ -21,7 +21,7 @@ Sandbox 已能按 `spec.pauseTime` 做一次性定时暂停，并按 `spec.autoP
 
 ## 背景
 
-池 Sandbox 在创建时从 SandboxSet 复制 `probes` 与 `autoPausePolicy`。Claim 之后，未 claim 成员才进入 auto-pause 决策；recycle 会清掉 `pauseTime`/`shutdownTime` 并从 SandboxSet 恢复策略。E2B create 已能用 `autoPause` 写 `PauseTime`，用 `autoResume` 局部写入 `OnIngressTraffic`。Claim CR 作为声明式对象，缺的是与 `shutdownTime` 同形态的 overlay，而不是再引入一套 E2B 相对秒数与 bool。
+池 Sandbox 在创建时从 SandboxSet 复制 `probes` 与 `autoPausePolicy`。Claim 之后，只有已 claim 成员才进入 auto-pause 决策，未 claim 的池成员会被跳过；recycle 会清掉 `pauseTime`/`shutdownTime` 并从 SandboxSet 恢复策略。E2B create 已能用 `autoPause` 写 `PauseTime`，用 `autoResume` 局部写入 `OnIngressTraffic`。Claim CR 作为声明式对象，缺的是与 `shutdownTime` 同形态的 overlay，而不是再引入一套 E2B 相对秒数与 bool。
 
 没有 Claim 级 overlay 时，每租户无法覆盖池默认策略，也无法声明「到点暂停」；只能改 SandboxSet（影响整池）或绕开 Claim 直接改 Sandbox。
 
@@ -77,7 +77,7 @@ claimed Sandbox --recycle--> 池 Sandbox
 4. **deadline 成对写入。** 若 Claim 指定了 `pauseTime` 或 `shutdownTime` 中的任一个，则按 Claim 当前值同时设置 Sandbox 的这两个字段：Claim 上为 nil 的那一侧在 Sandbox 上为清空。两个都不指定则不改 Sandbox 的 deadline。
 5. **不推导删除时间。** `pauseTime` 到期只暂停；是否删除仍只看 `shutdownTime`。需要「暂停后再删除」时，调用方同时给出两个绝对时间。
 6. **批次一致。** 同一 Claim 一次 reconcile 中成功 claim 的多个副本带上相同的 overlay。
-7. **probes 按名合并。** claim `probes` 非 nil 时，与候选 Sandbox 上的 `spec.probes` 按名合并：同名项以 claim 版本替换（池序位置不变），新名追加在池序之后；claim 未带 probes 则不动。合并后的集合不得超过 Sandbox 的 probes 上限（16）。与单值字段 `autoPausePolicy` 的整份替换不同，probes 是集合类配置，与 labels/annotations 一样按 key 合并；取舍见「Claim 自带 probes」。
+7. **probes 按名合并。** claim `probes` 非 nil 时，与候选 Sandbox 上的 `spec.probes` 按名合并：同名项以 claim 版本替换（池序位置不变），新名追加在池序之后；claim 未带 probes 则不动。每个候选 Sandbox 的合并集合不得超过 Sandbox 的 probes 上限（16）；Claim 级合并超限与候选兼容性检查见「校验与失败」。与单值字段 `autoPausePolicy` 的整份替换不同，probes 是集合类配置，与 labels/annotations 一样按 key 合并；取舍见「Claim 自带 probes」。
 
 ### 校验与失败
 
@@ -86,8 +86,9 @@ Claim 在构建 claim 选项时校验 `autoPausePolicy` 与 `probes`：
 - 使用与 SandboxSet admission 相同的校验规则
 - claim `probes` 列表自身需通过 `ValidateProbes`（名字唯一、exec-only、name 可作 condition type，与 SandboxSet 相同）
 - 被引用的 probe 名以「当前 SandboxSet.spec.probes 与 claim.probes 按名合并后的集合」为准（模板上的 probes 对运行中的池成员无效，与现有复制规则一致）；claim 未带 policy 时无需重校验池策略——合并只会增加 probe 名，池策略的引用不会失效
-- 合并后的集合超过 16 时，Claim 以 `InvalidClaimSpec` 完成：提前给出清晰错误，而不是等到 sandbox update 被 apiserver 拒绝
+- 当前 `SandboxSet.spec.probes` 与 `claim.probes` 按名合并后的集合超过 16 时，Claim 以 `InvalidClaimSpec` 完成：提前给出清晰错误，而不是等到 sandbox update 被 apiserver 拒绝
 - 通过 Claim 级校验后，领取时仍按每个候选 Sandbox 自身的 `spec.probes` 复核，但扣除 claim 自带的 probe 名：claim 自带的 probe 不要求候选预先声明，领取时合并写入；滚动更新中的旧候选若缺少其余被引用的 probe，会留在池中并等待兼容候选，不会写入无法执行的策略
+- 候选 Sandbox 自身已有的 probes 与 claim probes 合并后超过 16 时，该候选会被跳过并按无可用 Sandbox 重试；`createOnNoStock` 的新建路径也将此情况作为可重试的 `NoAvailableError`，不将候选级超限归为 `InvalidClaimSpec`
 - 仅含 `OnIngressTraffic`、不含 probe 规则的策略合法
 - 空策略（没有任何 pause/resume 规则）、无法编译的 `messageRegex`、引用不存在的 probe 等均非法
 
@@ -99,7 +100,7 @@ Claim 在构建 claim 选项时校验 `autoPausePolicy` 与 `probes`：
 - 发出 Warning 事件 `InvalidClaimSpec`
 - 本轮之前已经 claim 成功的 Sandbox 保持已写入状态，不会回滚
 
-候选缺少当前合法策略所引用的 probe 是池容量暂时不匹配，不是 Claim spec 非法：本轮不领取该候选，并按现有无可用 Sandbox 路径重试；`createOnNoStock` 开启时可从当前 SandboxSet 创建兼容实例。
+候选缺少当前合法策略所引用的 probe，或候选与 claim probes 合并后超过 16，都是池容量暂时不匹配，不是 Claim spec 非法：本轮不领取该候选，并按现有无可用 Sandbox 路径重试；`createOnNoStock` 开启时，若当前 SandboxSet 能形成兼容集合，可从其中创建兼容实例。
 
 apiserver 仍接受字段形状合法的对象；交叉规则不靠新 webhook。若非法策略被绕过写到了 Sandbox，Sandbox 侧既有 `ProbeValid=False` 仍会拒绝 probe 驱动暂停，但这不是 Claim 的主路径。
 
@@ -167,7 +168,7 @@ probe 驱动策略要求被引用的 probe 预先声明在目标 SandboxSet 上�
 
 - Claim 同名 probe 覆盖池版本：租户可定制探测参数（命令、周期），池序位置不变
 - Claim 新名 probe 追加在池序之后
-- 合并后的最终集合需通过 `ValidateProbes` 且不超过 `MaxItems=16`
+- Claim 自带的 probes 需通过 `ValidateProbes`；SandboxSet 的 probes 已在 admission 时按同一规则校验，合并后的集合再检查 `MaxItems=16`
 
 最终组合自洽校验（控制器 claim 时已持有 SandboxSet）：
 
@@ -187,9 +188,9 @@ probe 驱动策略要求被引用的 probe 预先声明在目标 SandboxSet 上�
 
 merge 的代价及对策：
 
-- **最终探测集需合并后才可推断**：claim 单边不可见。通过校验报错/事件列出合并结果弥补；且「引用池 probe」本来就是运行时依赖（池策略改引用别的 probe 名，claim 会失效重试，与现状语义一致）
-- **同名覆盖可能遮蔽池探测**：claim 校验可对「覆盖了哪些池 probe 名」发出事件，保持可见性
-- **合并叠加可能超限**：合并后统一校验 `MaxItems=16`
+- **最终探测集需合并后才可推断**：claim 单边不可见。当前校验错误和 `InvalidClaimSpec` 事件只报告具体校验错误或上限，不列出完整合并结果；且「引用池 probe」本来就是运行时依赖（Claim 策略引用的 probe 名不在当前 SandboxSet 与 Claim 合并后的集合中时，以 `InvalidClaimSpec` 完成；仅候选不兼容时才重试）
+- **同名覆盖可能遮蔽池探测**：当前 claim 校验不会为被覆盖的池 probe 名单独发事件，覆盖关系需从 Claim 与池配置的内容推断
+- **合并叠加可能超限**：Claim 级与候选级都对合并结果检查 `MaxItems=16`
 
 ### 已关闭的开放问题
 

--- a/docs/proposals/20260909-sandboxclaim-auto-pause-policy-EN.md
+++ b/docs/proposals/20260909-sandboxclaim-auto-pause-policy-EN.md
@@ -1,0 +1,199 @@
+---
+title: SandboxClaim Auto-Pause Overlay
+authors:
+  - "@sophon"
+reviewers:
+  - "@TBD"
+creation-date: 2026-09-09
+last-updated: 2026-09-11
+status: implementable
+see-also:
+  - "/docs/proposals/20260626-sandbox-auto-pause.md"
+  - "/docs/proposals/20260627-wake-on-traffic-via-spec-patch.md"
+  - "/docs/proposals/20251229-sandbox-claim-crd.md"
+---
+
+# SandboxClaim Auto-Pause Overlay
+
+## Summary
+
+Sandbox can already perform a one-shot scheduled pause via `spec.pauseTime`, and probe-driven pause/resume and inbound-traffic wake-up via `spec.autoPausePolicy`. SandboxClaim currently only overlays `shutdownTime`, so callers cannot specify either kind of pause when claiming. The final state is: Claim adds three optional fields, `spec.pauseTime`, `spec.autoPausePolicy`, and `spec.probes`, and writes them to the Sandbox in one operation before the claim is persisted; the policy and deadline inherit the pool configuration when omitted; probes are merged by name into the candidate's existing probe set (same-name entries are replaced and new names are appended); invalid configuration completes the Claim with `InvalidClaimSpec` and is not retried. The pause runtime is unchanged.
+
+## Background
+
+Pool Sandboxes copy `probes` and `autoPausePolicy` from the SandboxSet when they are created. After a Claim, only claimed members enter the auto-pause decision, while unclaimed pool members are skipped; recycle clears `pauseTime`/`shutdownTime` and restores the policy from the SandboxSet. E2B create can already use `autoPause` to write `PauseTime`, and use `autoResume` to partially write `OnIngressTraffic`. As a declarative object, the Claim CR is missing an overlay with the same shape as `shutdownTime`; it does not need another set of E2B relative seconds and a bool.
+
+Without a Claim-level overlay, each tenant cannot override the pool's default policy or declare “pause at a specific time”; it can only modify the SandboxSet (affecting the entire pool) or bypass Claim and modify the Sandbox directly.
+
+## Final Design
+
+### Scope and Non-Goals
+
+In scope:
+
+- `SandboxClaim.spec.pauseTime`: an absolute time, written to `Sandbox.spec.pauseTime`
+- `SandboxClaim.spec.autoPausePolicy`: reuses the existing `AutoPausePolicy` type and writes the entire value to `Sandbox.spec.autoPausePolicy`
+- `SandboxClaim.spec.probes`: reuses the existing `Probe` type and merges by name into the candidate's `Sandbox.spec.probes` (same-name entries are replaced and new names are appended)
+- The Claim controller validates and overlays these fields before every claim attempt, at the same time as the existing labels, annotations, and `shutdownTime`
+
+Out of scope:
+
+- Do not add an `autoPause` bool, relative timeout, or paused-retention annotation, and do not derive `shutdownTime` from `pauseTime`
+- Do not add an independent `autoResume` field; traffic wake-up is expressed through `autoPausePolicy.resume.onIngressTraffic`
+- Do not create a new SandboxClaim webhook; do not change the sandbox controller, gateway, recycle, or E2B HTTP (E2B does not expose probe configuration, keeping this capability exclusive to SandboxClaim)
+- Do not turn Claim into a continuous controller: after Completed, it still does not write back to already claimed Sandboxes
+
+### Ownership and Data Flow
+
+```
+SandboxClaim spec --> SandboxClaim controller --overlay at claim time--> claimed Sandbox
+SandboxSet probes and autoPausePolicy --> pool Sandbox --> claimed Sandbox
+claimed Sandbox --> checkTimers (pauseTime)
+claimed Sandbox --> handleAutoPause (autoPausePolicy)
+claimed Sandbox --> gateway (OnIngressTraffic)
+claimed Sandbox --recycle--> pool Sandbox
+```
+
+- Claim is responsible only for writing the caller's intent into the Sandbox spec
+- Pause and resume execution remains entirely owned by the existing Sandbox controller and gateway
+- The pool default is still declared by the SandboxSet; recycle still restores policy from the SandboxSet and clears deadlines
+
+### Exposed Interface
+
+`SandboxClaimSpec` adds two optional pointer fields, with semantics aligned with the existing `shutdownTime`:
+
+- `pauseTime *metav1.Time`: omitted or nil means do not overlay `Sandbox.spec.pauseTime`
+- `autoPausePolicy *AutoPausePolicy`: omitted or nil means do not overlay the policy, preserving the policy already on the pool Sandbox
+
+No new policy type is introduced. The fields, defaults, and cross-field rules of `AutoPausePolicy` are the same as for Sandbox / SandboxSet.
+
+### Write Rules
+
+For every Sandbox claimed successfully:
+
+1. **One-time application.** The overlay occurs only in the update that successfully claims that Sandbox. After the Claim enters Completed, later changes to the Claim spec do not modify an already claimed Sandbox.
+2. **Inherit when omitted.** When both fields are nil, the Sandbox preserves its pre-claim state: a pool member's `autoPausePolicy` comes from the SandboxSet, and `pauseTime` is already empty on the pool.
+3. **Whole-value replacement.** When `autoPausePolicy` is non-nil, the entire policy in the Claim replaces the policy on the Sandbox; no field-level merge is performed. If the caller only wants to enable `OnIngressTraffic` while retaining the pool's idle/cron rules, it must write the complete policy in the Claim.
+4. **Paired deadline write.** If the Claim specifies either `pauseTime` or `shutdownTime`, set both corresponding Sandbox fields to the Claim's current values: the side that is nil on the Claim is cleared on the Sandbox. If neither is specified, do not modify the Sandbox deadlines.
+5. **Do not derive deletion time.** Expiration of `pauseTime` only pauses; deletion is still controlled solely by `shutdownTime`. To “pause and then delete,” the caller must provide both absolute times.
+6. **Batch consistency.** Multiple replicas successfully claimed by the same Claim in one reconcile carry the same overlay.
+7. **Merge probes by name.** When claim `probes` is non-nil, merge it by name with the candidate Sandbox's `spec.probes`: a same-name item is replaced by the Claim version (the pool position is preserved), and a new name is appended after the pool sequence; when the Claim does not include probes, leave them unchanged. The merged set for each candidate Sandbox must not exceed the Sandbox probe limit (16); see “Validation and Failure” for Claim-level merge limits and candidate compatibility checks. Unlike the single-value `autoPausePolicy`, which is replaced in full, probes are collection configuration and are merged by key like labels/annotations; see “Claim-Supplied Probes” for the trade-off.
+
+### Validation and Failure
+
+The Claim validates `autoPausePolicy` and `probes` when building the claim options:
+
+- Use the same validation rules as SandboxSet admission
+- The Claim's `probes` list itself must pass `ValidateProbes` (unique names, exec-only, and names usable as condition types, as with SandboxSet)
+- Referenced probe names are evaluated against the set obtained by merging the current `SandboxSet.spec.probes` and `claim.probes` by name (template probes are ineffective for running pool members, consistent with the existing copy rules); when the Claim has no policy, the pool policy does not need to be revalidated—the merge can only add probe names, so references in the pool policy cannot become invalid
+- When the set obtained by merging the current `SandboxSet.spec.probes` and `claim.probes` by name exceeds 16, complete the Claim with `InvalidClaimSpec`: provide a clear error early instead of waiting for the apiserver to reject the Sandbox update
+- After Claim-level validation passes, recheck each candidate Sandbox's own `spec.probes` at claim time, excluding names supplied by the Claim: a Claim-supplied probe need not be declared by the candidate in advance and is merged in at claim time; an old candidate during a rolling update that lacks another referenced probe remains in the pool and waits for a compatible candidate, rather than receiving a policy it cannot execute
+- If merging a candidate Sandbox's existing probes with the Claim probes exceeds 16, skip that candidate and retry through the no-available-Sandbox path; the `createOnNoStock` creation path also treats this as a retryable `NoAvailableError`, rather than classifying a candidate-level limit violation as `InvalidClaimSpec`
+- A policy containing only `OnIngressTraffic` and no probe rules is valid
+- An empty policy (with no pause/resume rules), a `messageRegex` that cannot be compiled, and a reference to a nonexistent probe are all invalid
+
+The observable results for invalid input are the same as for the existing reserved identity-key validation:
+
+- Do not continue claiming
+- Complete the Claim
+- Set `status.conditions[type=Completed].reason` to `InvalidClaimSpec`
+- Emit a Warning event, `InvalidClaimSpec`
+- Sandboxes successfully claimed before this reconcile retain their written state; they are not rolled back
+
+A candidate that lacks a probe referenced by the current valid policy, or whose probes exceed 16 after merging with the Claim probes, represents temporarily incompatible pool capacity, not an invalid Claim spec: do not claim that candidate in this round and retry through the existing no-available-Sandbox path; when `createOnNoStock` is enabled, a compatible instance can be created from the current SandboxSet if it can yield a compatible probe set.
+
+The apiserver still accepts objects whose field shapes are valid; cross-field rules do not rely on a new webhook. If an invalid policy is written to a Sandbox by bypassing validation, the existing Sandbox-side `ProbeValid=False` still rejects probe-driven pause, but that is not the primary Claim path.
+
+### Relationship to Existing Pause Mechanisms
+
+After the write completes, the Sandbox behaves as it does today when its spec is edited directly:
+
+- `pauseTime` is unconditionally executed by `checkTimers` and does not depend on `AutoPauseController`
+- Probe-driven pause/resume still requires that gate to be enabled, and the probe referenced by the rule must actually exist in the Sandbox spec (under this design, in the merged probes; the sandbox controller patches `kruise.io/podprobe` on the running Pod, and changes to `spec.probes` take effect while it is Running)
+- `OnIngressTraffic` is still executed by the gateway and does not enable the probe decision loop
+- `pauseTime` and `autoPausePolicy` coexist: whichever expires first pauses the Sandbox; even while a probe reports active, `pauseTime` still pauses it. Callers that need the probe to be the final authority should not set `pauseTime`
+
+Writing a policy from a Claim does not enable the feature gate. When the gate is disabled, the policy still appears in the Sandbox spec, but probe injection and probe decisions do not run; `pauseTime` still takes effect.
+
+### Compatibility and Upgrade
+
+- Existing Claims that do not write these two fields behave exactly as they do now
+- A claimed Sandbox for which the caller did not overlay a policy continues to use the pool policy
+- After recycle, a pool member is restored to the SandboxSet's `probes` and `autoPausePolicy`, and `pauseTime` is cleared; the next Claim applies its new overlay
+- E2B HTTP is unchanged; E2B continues to use a bool plus relative seconds, while Claim uses absolute times
+
+### Observable Examples
+
+**Inherit the pool policy.** The Claim omits the two new fields. After claiming, the Sandbox has the SandboxSet's `autoPausePolicy`, and `pauseTime` is empty. If the pool policy contains an idle probe and the gate is enabled, idle timing starts at `claim-timestamp` and does not immediately pause because of idle time accumulated during warm-up.
+
+**Scheduled pause only.** The Claim sets only `pauseTime`, without `autoPausePolicy` or `shutdownTime`. The Sandbox receives that `pauseTime`, retains the pool policy, and still has an empty `shutdownTime`. It pauses on expiration and is not deleted.
+
+**Policy override only.** The pool has an idle rule. The Claim provides an `autoPausePolicy` containing only `resume.onIngressTraffic`. The idle rule on the Sandbox is replaced, leaving only traffic wake-up. If the caller also wants the idle rule, it must include it in the Claim policy.
+
+**Invalid reference.** The SandboxSet has no probe named `Active`, while the Claim's pause rule references `Active`. The Claim completes with reason=`InvalidClaimSpec`, and no new Sandbox is claimed by this failed options build.
+
+**Probe as the final authority.** The Claim sets only `autoPausePolicy.pause.whenProbedIdleState`, without `pauseTime`. Expiration behavior is determined only by the probe.
+
+**Both triggers set.** The Claim sets both `pauseTime` and an idle policy. If `pauseTime` has passed while the probe still reports active, the Sandbox still pauses.
+
+## Alternatives and Trade-offs
+
+- **Use E2B's `autoPause` bool on Claim.** This is inconsistent with the existing absolute `shutdownTime` and would also move relative seconds and retention arithmetic into Claim. Rejected.
+- **Merge `OnIngressTraffic` at the field level.** This is more convenient for “enable wake-up only,” but a declarative CR would not reveal the final policy, and it would be inconsistent with whole-value copying from SandboxSet. Rejected; the caller writes the complete policy.
+- **Claim-supplied `probes`.** Implemented; the merge semantics and trade-offs are described in “Claim-Supplied Probes.”
+- **Create a Claim webhook.** Sandbox itself has no webhook either; cross-validation depends on SandboxSet and is suitable for the existing Claim controller failure path.
+
+## Risks
+
+- Whole-value replacement removes pool rules that the caller did not copy. This is deliberate visibility, rather than a silent merge.
+- When `pauseTime` and a probe policy coexist, the timer can interrupt an Agent that is still working. This is consistent with the current Sandbox proposal; the caller chooses not to set both.
+- `AutoPauseController` is disabled by default: overlaying only the policy without enabling the gate means the probe path does not run, which can make it appear that “the Claim did not take effect.” The probe path checks the gate; `pauseTime` does not.
+
+## Claim-Supplied Probes
+
+Implemented as part of this design: `SandboxClaim.spec.probes` is optional and is merged by name into the candidate Sandbox's `spec.probes`.
+
+### Motivation
+
+A probe-driven policy requires referenced probes to be declared in advance on the target SandboxSet. When different tenants need different probing logic (different exec commands or probe intervals), the SandboxSet must enumerate all probe variants (`MaxItems=16`), and every pool member executes all probes indiscriminately—even though most Claims do not use them and still consume resources. Claim-supplied probes allow each Claim to declare and execute only the probes it needs.
+
+### Technical Foundation (Already Supported by the Current Code)
+
+- The sandbox controller's `EnsureProbe` patches the `kruise.io/podprobe` annotation on a running Pod, so changes to `spec.probes` take effect while it is Running; probe results are added and removed in sync with `spec.probes`, and a probe condition left by the previous Claim is removed
+- Recycle's `resetSandboxForPool` already restores `spec.probes` and `spec.autoPausePolicy` from the SandboxSet verbatim, so probes written by a Claim do not leak to the next tenant
+
+### Implementation: Merge by Name, Not Whole-Value Replacement
+
+Probes copied from the SandboxSet to a candidate are **merged by name** (`+listType=map`'s natural semantics):
+
+- A Claim probe with the same name replaces the pool version, allowing the tenant to customize probe parameters (command and interval), while preserving the pool position
+- A Claim probe with a new name is appended after the pool sequence
+- Claim-supplied probes must pass `ValidateProbes`; SandboxSet probes have already been validated against the same rules at admission, and the merged set is then checked against `MaxItems=16`
+
+Final self-consistency validation (the controller holds the SandboxSet during claim):
+
+- `finalProbes = merge(sandboxSet.spec.probes, claim.probes)` (the Claim side wins for same names)
+- `ValidateProbes(claim.probes)` + `ValidateAutoPausePolicy(claim.autoPausePolicy, finalProbes)`
+- Complete with `InvalidClaimSpec` when the merged set exceeds the limit
+
+Candidate filtering retains the existing mechanism and derives required probes from the policy while subtracting Claim-supplied names: `required = PolicyProbeNames(finalPolicy) − names(claim.probes)`. In other words, a Claim-supplied probe need not be declared by a candidate in advance. Before persistence, `modifyPickedSandbox` deep-copies the merged result into `spec.probes` (including the `createOnNoStock` creation path); there is no persisted intermediate state, and the merged result does not alias the Claim or pool spec.
+
+### Merge vs. Replace Trade-off
+
+The alternative whole-value replacement semantics (when claim.probes is non-nil, replace all Sandbox probes) was rejected:
+
+- **Administrator preconfiguration plus caller addition is the expected shape.** SandboxSet probes are declared by platform administrators (platform-level security audits and compliance checks), and the Claim caller adds its own probes on top. Whole-value replacement would let a tenant's Claim remove platform probes until recycle restores them—creating a detection blind spot during the Claim and effectively letting the caller decide the fate of platform configuration
+- **A probe is a general mechanism, not an attachment of the policy.** The `Probe` contract is that “the probe itself defines no semantics; the consumer does”; a second consumer already exists (mirroring probe results to `SandboxStatus.Conditions` for observability), and more may appear in the future. Whole-value replacement's “the probe set switches together with the policy” only works when the policy is the sole consumer
+- **Consistent with Claim metadata semantics.** Claim labels/annotations are merged by key (`MergePodLabels`/`MergePodAnnotations`) rather than replaced wholesale because the object already has data from other sources; probes are also collection configuration. `autoPausePolicy` has single-value semantics and is therefore replaced in full—the merge rules are naturally different for a single value and a collection
+
+Costs of merging and mitigations:
+
+- **The final probe set can be inferred only after merging:** the Claim alone does not show it. Current validation errors and `InvalidClaimSpec` events report only the specific validation error or limit, not the complete merged result; moreover, “referencing a pool probe” is already a runtime dependency (if a probe name referenced by the Claim policy is absent from the merged set of the current SandboxSet and Claim, the Claim completes with `InvalidClaimSpec`; retries apply only when a candidate is incompatible)
+- **Same-name replacement can obscure a pool probe:** current Claim validation does not emit a separate event identifying overridden pool probe names; overrides must be inferred from the Claim and pool configurations
+- **Accumulated merges can exceed the limit:** both Claim-level and candidate-level checks enforce `MaxItems=16` on the merged result
+
+### Closed Open Questions
+
+- When a Claim completes before a new probe has produced its first result, `thresholdDuration` starts from the first result: this is consistent with existing Sandbox probe semantics, and WaitReady does not additionally cover probe readiness
+- `createOnNoStock` path: merging completes in memory before the Claim is persisted (`modifyPickedSandbox`), so there is no persisted intermediate state in which pool probes are copied and then merged
+- E2B HTTP: does not expose probe configuration, keeping this capability exclusive to SandboxClaim

--- a/pkg/autopause/probes.go
+++ b/pkg/autopause/probes.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autopause
+
+import (
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+// PolicyProbeNames returns the deduplicated names of the probes the policy
+// rules reference, in declaration order. A nil policy references none.
+func PolicyProbeNames(policy *agentsv1alpha1.AutoPausePolicy) []string {
+	if policy == nil {
+		return nil
+	}
+	var names []string
+	seen := map[string]struct{}{}
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	if policy.Pause != nil && policy.Pause.WhenProbedIdleState != nil {
+		add(policy.Pause.WhenProbedIdleState.Probe)
+	}
+	if policy.Resume != nil && policy.Resume.WhenProbedScheduleTime != nil {
+		add(policy.Resume.WhenProbedScheduleTime.Probe)
+	}
+	return names
+}
+
+// RequiredProbeNames returns the probe names a pool candidate must already
+// declare: the names referenced by the policy minus the ones carried by the
+// claim itself, because claim probes are merged onto the picked sandbox at
+// claim time. A nil policy references none.
+func RequiredProbeNames(policy *agentsv1alpha1.AutoPausePolicy, claimProbes []agentsv1alpha1.Probe) []string {
+	names := PolicyProbeNames(policy)
+	if len(names) == 0 || len(claimProbes) == 0 {
+		return names
+	}
+	carried := make(map[string]struct{}, len(claimProbes))
+	for i := range claimProbes {
+		carried[claimProbes[i].Name] = struct{}{}
+	}
+	var required []string
+	for _, name := range names {
+		if _, ok := carried[name]; !ok {
+			required = append(required, name)
+		}
+	}
+	return required
+}
+
+// MaxSandboxProbes mirrors the +kubebuilder:validation:MaxItems=16 limit on
+// Sandbox.spec.probes. The merged claim + pool set must stay within it, or
+// the apiserver would reject the sandbox update with a less clear error.
+const MaxSandboxProbes = 16
+
+// MergeProbes merges claim probes into pool probes by name: a claim probe
+// replaces the pool probe with the same name, new names are appended in
+// claim order. Every returned probe is a deep copy, so the result never
+// aliases the SandboxClaim spec or the informer-cached pool spec.
+func MergeProbes(poolProbes, claimProbes []agentsv1alpha1.Probe) []agentsv1alpha1.Probe {
+	var merged []agentsv1alpha1.Probe
+	claimByName := make(map[string]int, len(claimProbes))
+	for i := range claimProbes {
+		claimByName[claimProbes[i].Name] = i
+	}
+	for i := range poolProbes {
+		if j, ok := claimByName[poolProbes[i].Name]; ok {
+			merged = append(merged, *claimProbes[j].DeepCopy())
+		} else {
+			merged = append(merged, *poolProbes[i].DeepCopy())
+		}
+	}
+	poolNames := make(map[string]struct{}, len(poolProbes))
+	for i := range poolProbes {
+		poolNames[poolProbes[i].Name] = struct{}{}
+	}
+	for i := range claimProbes {
+		if _, ok := poolNames[claimProbes[i].Name]; !ok {
+			merged = append(merged, *claimProbes[i].DeepCopy())
+		}
+	}
+	return merged
+}

--- a/pkg/autopause/probes_test.go
+++ b/pkg/autopause/probes_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autopause
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+)
+
+func TestPolicyProbeNames(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy *agentsv1alpha1.AutoPausePolicy
+		want   []string
+	}{
+		{name: "nil policy"},
+		{name: "no rules", policy: &agentsv1alpha1.AutoPausePolicy{}},
+		{
+			name: "ingress traffic rule references no probe",
+			policy: &agentsv1alpha1.AutoPausePolicy{
+				Resume: &agentsv1alpha1.ResumePolicy{OnIngressTraffic: &agentsv1alpha1.IngressTrafficRule{}},
+			},
+		},
+		{
+			name: "pause rule",
+			policy: &agentsv1alpha1.AutoPausePolicy{
+				Pause: &agentsv1alpha1.PausePolicy{WhenProbedIdleState: &agentsv1alpha1.ProbedIdleStateRule{Probe: "idle"}},
+			},
+			want: []string{"idle"},
+		},
+		{
+			name: "pause and distinct resume rules",
+			policy: &agentsv1alpha1.AutoPausePolicy{
+				Pause:  &agentsv1alpha1.PausePolicy{WhenProbedIdleState: &agentsv1alpha1.ProbedIdleStateRule{Probe: "idle"}},
+				Resume: &agentsv1alpha1.ResumePolicy{WhenProbedScheduleTime: &agentsv1alpha1.ProbedScheduleTimeRule{Probe: "schedule"}},
+			},
+			want: []string{"idle", "schedule"},
+		},
+		{
+			name: "both rules reference the same probe",
+			policy: &agentsv1alpha1.AutoPausePolicy{
+				Pause:  &agentsv1alpha1.PausePolicy{WhenProbedIdleState: &agentsv1alpha1.ProbedIdleStateRule{Probe: "active"}},
+				Resume: &agentsv1alpha1.ResumePolicy{WhenProbedScheduleTime: &agentsv1alpha1.ProbedScheduleTimeRule{Probe: "active"}},
+			},
+			want: []string{"active"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PolicyProbeNames(tt.policy); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PolicyProbeNames() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequiredProbeNames(t *testing.T) {
+	idleAndCron := &agentsv1alpha1.AutoPausePolicy{
+		Pause:  &agentsv1alpha1.PausePolicy{WhenProbedIdleState: &agentsv1alpha1.ProbedIdleStateRule{Probe: "Active"}},
+		Resume: &agentsv1alpha1.ResumePolicy{WhenProbedScheduleTime: &agentsv1alpha1.ProbedScheduleTimeRule{Probe: "Cron"}},
+	}
+	tests := []struct {
+		name        string
+		policy      *agentsv1alpha1.AutoPausePolicy
+		claimProbes []agentsv1alpha1.Probe
+		want        []string
+	}{
+		{name: "nil policy", claimProbes: []agentsv1alpha1.Probe{{Name: "Active"}}},
+		{
+			name:   "no claim probes keeps the policy names",
+			policy: idleAndCron,
+			want:   []string{"Active", "Cron"},
+		},
+		{
+			name:        "claim-carried names are subtracted",
+			policy:      idleAndCron,
+			claimProbes: []agentsv1alpha1.Probe{{Name: "Active"}},
+			want:        []string{"Cron"},
+		},
+		{
+			name:        "fully carried policy requires nothing",
+			policy:      idleAndCron,
+			claimProbes: []agentsv1alpha1.Probe{{Name: "Active"}, {Name: "Cron"}},
+		},
+		{
+			name:        "unrelated claim probes change nothing",
+			policy:      idleAndCron,
+			claimProbes: []agentsv1alpha1.Probe{{Name: "Other"}},
+			want:        []string{"Active", "Cron"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RequiredProbeNames(tt.policy, tt.claimProbes); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RequiredProbeNames() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeProbes(t *testing.T) {
+	probe := func(name, command string) agentsv1alpha1.Probe {
+		return agentsv1alpha1.Probe{
+			Name: name,
+			Probe: corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					Exec: &corev1.ExecAction{Command: []string{command}},
+				},
+			},
+		}
+	}
+	tests := []struct {
+		name  string
+		pool  []agentsv1alpha1.Probe
+		claim []agentsv1alpha1.Probe
+		want  []agentsv1alpha1.Probe
+	}{
+		{name: "both empty"},
+		{
+			name: "empty claim returns the pool probes",
+			pool: []agentsv1alpha1.Probe{probe("Active", "pool-cmd")},
+			want: []agentsv1alpha1.Probe{probe("Active", "pool-cmd")},
+		},
+		{
+			name:  "same-name claim probe replaces the pool version in place",
+			pool:  []agentsv1alpha1.Probe{probe("Active", "pool-cmd"), probe("Audit", "audit-cmd")},
+			claim: []agentsv1alpha1.Probe{probe("Active", "claim-cmd")},
+			want:  []agentsv1alpha1.Probe{probe("Active", "claim-cmd"), probe("Audit", "audit-cmd")},
+		},
+		{
+			name:  "new-name claim probes append in claim order",
+			pool:  []agentsv1alpha1.Probe{probe("Active", "pool-cmd")},
+			claim: []agentsv1alpha1.Probe{probe("Cron", "cron-cmd"), probe("Audit", "audit-cmd")},
+			want:  []agentsv1alpha1.Probe{probe("Active", "pool-cmd"), probe("Cron", "cron-cmd"), probe("Audit", "audit-cmd")},
+		},
+		{
+			name:  "empty pool takes the claim probes as-is",
+			claim: []agentsv1alpha1.Probe{probe("Cron", "cron-cmd")},
+			want:  []agentsv1alpha1.Probe{probe("Cron", "cron-cmd")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MergeProbes(tt.pool, tt.claim)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MergeProbes() = %v, want %v", got, tt.want)
+			}
+			// The result must never alias the inputs: mutating it cannot leak
+			// back into the pool or claim specs.
+			for i := range got {
+				got[i].Name = "mutated"
+			}
+			for _, src := range [][]agentsv1alpha1.Probe{tt.pool, tt.claim} {
+				for i := range src {
+					if src[i].Name == "mutated" {
+						t.Fatalf("merged result aliases the input probe %v", src[i])
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/autopause/probes_test.go
+++ b/pkg/autopause/probes_test.go
@@ -20,8 +20,6 @@ import (
 	"reflect"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 )
 
@@ -117,16 +115,6 @@ func TestRequiredProbeNames(t *testing.T) {
 }
 
 func TestMergeProbes(t *testing.T) {
-	probe := func(name, command string) agentsv1alpha1.Probe {
-		return agentsv1alpha1.Probe{
-			Name: name,
-			Probe: corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					Exec: &corev1.ExecAction{Command: []string{command}},
-				},
-			},
-		}
-	}
 	tests := []struct {
 		name  string
 		pool  []agentsv1alpha1.Probe
@@ -136,41 +124,36 @@ func TestMergeProbes(t *testing.T) {
 		{name: "both empty"},
 		{
 			name: "empty claim returns the pool probes",
-			pool: []agentsv1alpha1.Probe{probe("Active", "pool-cmd")},
-			want: []agentsv1alpha1.Probe{probe("Active", "pool-cmd")},
+			pool: []agentsv1alpha1.Probe{execProbe("Active", "pool-cmd")},
+			want: []agentsv1alpha1.Probe{execProbe("Active", "pool-cmd")},
 		},
 		{
-			name:  "same-name claim probe replaces the pool version in place",
-			pool:  []agentsv1alpha1.Probe{probe("Active", "pool-cmd"), probe("Audit", "audit-cmd")},
-			claim: []agentsv1alpha1.Probe{probe("Active", "claim-cmd")},
-			want:  []agentsv1alpha1.Probe{probe("Active", "claim-cmd"), probe("Audit", "audit-cmd")},
-		},
-		{
-			name:  "new-name claim probes append in claim order",
-			pool:  []agentsv1alpha1.Probe{probe("Active", "pool-cmd")},
-			claim: []agentsv1alpha1.Probe{probe("Cron", "cron-cmd"), probe("Audit", "audit-cmd")},
-			want:  []agentsv1alpha1.Probe{probe("Active", "pool-cmd"), probe("Cron", "cron-cmd"), probe("Audit", "audit-cmd")},
+			name:  "claim probes replace in pool order and append in claim order",
+			pool:  []agentsv1alpha1.Probe{execProbe("Active", "pool-cmd"), execProbe("Audit", "audit-cmd")},
+			claim: []agentsv1alpha1.Probe{execProbe("Cron", "cron-cmd"), execProbe("Active", "claim-cmd"), execProbe("Extra", "extra-cmd")},
+			want:  []agentsv1alpha1.Probe{execProbe("Active", "claim-cmd"), execProbe("Audit", "audit-cmd"), execProbe("Cron", "cron-cmd"), execProbe("Extra", "extra-cmd")},
 		},
 		{
 			name:  "empty pool takes the claim probes as-is",
-			claim: []agentsv1alpha1.Probe{probe("Cron", "cron-cmd")},
-			want:  []agentsv1alpha1.Probe{probe("Cron", "cron-cmd")},
+			claim: []agentsv1alpha1.Probe{execProbe("Cron", "cron-cmd")},
+			want:  []agentsv1alpha1.Probe{execProbe("Cron", "cron-cmd")},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := MergeProbes(tt.pool, tt.claim)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("MergeProbes() = %v, want %v", got, tt.want)
+				t.Fatalf("MergeProbes() = %v, want %v", got, tt.want)
 			}
 			// The result must never alias the inputs: mutating it cannot leak
 			// back into the pool or claim specs.
 			for i := range got {
 				got[i].Name = "mutated"
+				got[i].Exec.Command[0] = "mutated"
 			}
 			for _, src := range [][]agentsv1alpha1.Probe{tt.pool, tt.claim} {
 				for i := range src {
-					if src[i].Name == "mutated" {
+					if src[i].Name == "mutated" || src[i].Exec.Command[0] == "mutated" {
 						t.Fatalf("merged result aliases the input probe %v", src[i])
 					}
 				}

--- a/pkg/autopause/validation.go
+++ b/pkg/autopause/validation.go
@@ -14,17 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package autopause validates the probe and auto-pause configuration shared by
-// Sandbox, SandboxSet and SandboxTemplate. The generated CRD schema constrains
-// field types and ranges, but the cross-field rules this package enforces -
-// unique probe names, exec-only handlers, and policy rules that must reference
-// a defined probe - can only be checked by webhooks and the controller.
+// Package autopause owns the probe and auto-pause configuration shared by
+// Sandbox, SandboxSet, SandboxTemplate and SandboxClaim.
 //
-// Admission covers SandboxSet and SandboxTemplate only, so the controller runs
-// the same rules on every Sandbox and reports the outcome on the ProbeValid
-// condition. The rules must therefore agree with what the reconciler actually
-// does: rejecting a configuration the reconciler would have handled would make
-// the same object valid for a Sandbox and invalid for a SandboxSet.
+// The generated CRD schema constrains field types and ranges, but the
+// cross-field rules this package enforces - unique probe names, exec-only
+// handlers, and policy rules that must reference a defined probe - can only be
+// checked by webhooks and the controller. The package also composes the
+// claim-time probe set: MergeProbes merges the SandboxClaim probes onto the
+// pool probes, and PolicyProbeNames / RequiredProbeNames derive which probes a
+// claim candidate must already declare. The merged set is checked against
+// ValidateProbes and MaxSandboxProbes before it is written.
+//
+// Admission covers SandboxSet and SandboxTemplate only. The SandboxClaim
+// controller applies the same AutoPausePolicy rules against the target
+// SandboxSet probes at claim time. The sandbox controller runs the same rules
+// on every Sandbox and reports the outcome on the ProbeValid condition. The
+// rules must therefore agree with what the reconciler actually does: rejecting
+// a configuration the reconciler would have handled would make the same object
+// valid for a Sandbox and invalid for a SandboxSet.
 package autopause
 
 import (

--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -34,6 +35,7 @@ import (
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/agent-runtime/common"
 	"github.com/openkruise/agents/pkg/agent-runtime/storages"
+	"github.com/openkruise/agents/pkg/autopause"
 	"github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/controller/sandboxset"
 	"github.com/openkruise/agents/pkg/features"
@@ -313,6 +315,25 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 	if err := validateClaimReservedIdentityKeys(claim); err != nil {
 		return infra.ClaimSandboxOptions{}, err
 	}
+	// finalProbes is the effective probe set the policy is validated against:
+	// the pool probes when the claim carries none, otherwise the merged set.
+	finalProbes := sandboxSet.Spec.Probes
+	if len(claim.Spec.Probes) > 0 {
+		if errs := autopause.ValidateProbes(claim.Spec.Probes, field.NewPath("spec", "probes")); len(errs) > 0 {
+			return infra.ClaimSandboxOptions{}, fmt.Errorf("%w: %v", ErrInvalidClaimSpec, errs.ToAggregate())
+		}
+		finalProbes = autopause.MergeProbes(sandboxSet.Spec.Probes, claim.Spec.Probes)
+		if len(finalProbes) > autopause.MaxSandboxProbes {
+			return infra.ClaimSandboxOptions{}, fmt.Errorf("%w: merged probes exceed the Sandbox limit of %d", ErrInvalidClaimSpec, autopause.MaxSandboxProbes)
+		}
+	}
+	if claim.Spec.AutoPausePolicy != nil {
+		// A policy may reference probes the claim itself carries, so validate
+		// it against the merged set rather than the pool probes alone.
+		if errs := autopause.ValidateAutoPausePolicy(claim.Spec.AutoPausePolicy, finalProbes, field.NewPath("spec", "autoPausePolicy")); len(errs) > 0 {
+			return infra.ClaimSandboxOptions{}, fmt.Errorf("%w: %v", ErrInvalidClaimSpec, errs.ToAggregate())
+		}
+	}
 	var reserveFailedSandboxFor *time.Duration
 	if claim.Spec.ReserveFailedSandbox {
 		reserveFailedSandboxFor = ptr.To(consts.ReserveFailedSandboxForever)
@@ -378,14 +399,20 @@ func (c *commonControl) buildClaimOptions(ctx context.Context, claim *agentsv1al
 			// controller itself.
 			infra.MergePodAnnotations(sbx, annotationutils.FilterBlackListed(claim.Spec.Annotations))
 
-			// apply shutdownTime
-			if claim.Spec.ShutdownTime != nil {
-				sbx.SetTimeout(timeout.Options{
-					ShutdownTime: claim.Spec.ShutdownTime.Time,
-				})
+			if claim.Spec.PauseTime != nil || claim.Spec.ShutdownTime != nil {
+				to := timeout.Options{}
+				if claim.Spec.PauseTime != nil {
+					to.PauseTime = claim.Spec.PauseTime.Time
+				}
+				if claim.Spec.ShutdownTime != nil {
+					to.ShutdownTime = claim.Spec.ShutdownTime.Time
+				}
+				sbx.SetTimeout(to)
 			}
 			return nil
 		},
+		AutoPausePolicy:         claim.Spec.AutoPausePolicy,
+		Probes:                  claim.Spec.Probes,
 		ReserveFailedSandboxFor: reserveFailedSandboxFor,
 		CreateOnNoStock:         claim.Spec.CreateOnNoStock,
 		UserMetadataKeys:        sandboxcr.BuildUserMetadataKeys(claim.Spec.Labels, claim.Spec.Annotations),

--- a/pkg/controller/sandboxclaim/core/common_control.go
+++ b/pkg/controller/sandboxclaim/core/common_control.go
@@ -263,6 +263,11 @@ func (c *commonControl) EnsureClaimCompleted(ctx context.Context, args ClaimArgs
 }
 
 // claimSandboxes attempts to claim up to batchSize sandboxes from the pool
+//
+// TODO: Move TryClaimSandbox orchestration into SandboxClaim core and put any
+// primitives shared with sandbox-manager in a neutral package.
+// known-limit: This controller still depends on sandbox-manager's claim flow
+// and options until that refactor removes the reverse dependency.
 func (c *commonControl) claimSandboxes(ctx context.Context, claim *agentsv1alpha1.SandboxClaim, sandboxSet *agentsv1alpha1.SandboxSet, batchSize int) (int, error) {
 	log := logf.FromContext(ctx)
 

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -19,6 +19,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/agent-runtime/storages"
+	"github.com/openkruise/agents/pkg/autopause"
 	"github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/cache/cachetest"
 	"github.com/openkruise/agents/pkg/features"
@@ -204,6 +206,7 @@ func TestCommonControl_EnsureClaimClaiming(t *testing.T) {
 		setupSandboxes   func(*testing.T) []*agentsv1alpha1.Sandbox
 		expectedStrategy RequeueStrategy
 		expectError      bool
+		expectEvent      string
 		checkStatus      func(*testing.T, *agentsv1alpha1.SandboxClaimStatus)
 	}{
 		{
@@ -278,6 +281,37 @@ func TestCommonControl_EnsureClaimClaiming(t *testing.T) {
 				assert.Equal(t, "InvalidClaimSpec", condition.Reason)
 				assert.Contains(t, condition.Message, agentsv1alpha1.LabelSandboxID)
 				assert.NotContains(t, condition.Message, "failed to build claim options")
+			},
+		},
+		{
+			name: "invalid auto-pause policy completes without claiming or retry",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim-invalid-policy",
+					Namespace: "default",
+					UID:       "test-uid-invalid-policy",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    "test-template",
+					Replicas:        int32Ptr(1),
+					AutoPausePolicy: &agentsv1alpha1.AutoPausePolicy{},
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+			},
+			newStatus: &agentsv1alpha1.SandboxClaimStatus{
+				Phase: agentsv1alpha1.SandboxClaimPhaseClaiming,
+			},
+			expectedStrategy: NoRequeue(),
+			expectEvent:      "Warning InvalidClaimSpec",
+			checkStatus: func(t *testing.T, status *agentsv1alpha1.SandboxClaimStatus) {
+				assert.Equal(t, agentsv1alpha1.SandboxClaimPhaseCompleted, status.Phase)
+				assert.Zero(t, status.ClaimedReplicas)
+				condition := GetClaimCondition(status, string(agentsv1alpha1.SandboxClaimConditionCompleted))
+				require.NotNil(t, condition)
+				assert.Equal(t, "InvalidClaimSpec", condition.Reason)
+				assert.Contains(t, condition.Message, "at least one of pause.whenProbedIdleState")
 			},
 		},
 		{
@@ -545,6 +579,14 @@ func TestCommonControl_EnsureClaimClaiming(t *testing.T) {
 			// Check status updates
 			if tt.checkStatus != nil && !tt.expectError {
 				tt.checkStatus(t, tt.newStatus)
+			}
+			if tt.expectEvent != "" {
+				select {
+				case event := <-fakeRecorder.Events:
+					assert.Contains(t, event, tt.expectEvent)
+				default:
+					t.Fatalf("expected event containing %q", tt.expectEvent)
+				}
 			}
 		})
 	}
@@ -1068,7 +1110,42 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 
 	ctx := context.Background()
 	shutdownTime := metav1.Now()
+	pauseTime := metav1.NewTime(shutdownTime.Time.Add(time.Hour))
 	timeoutDuration := metav1.Duration{Duration: 3 * time.Minute}
+	idlePolicy := &agentsv1alpha1.AutoPausePolicy{
+		Pause: &agentsv1alpha1.PausePolicy{
+			WhenProbedIdleState: &agentsv1alpha1.ProbedIdleStateRule{
+				Probe:             "Active",
+				MessageRegex:      "^inactive$",
+				ThresholdDuration: &metav1.Duration{Duration: time.Minute},
+			},
+		},
+	}
+	wakePolicy := &agentsv1alpha1.AutoPausePolicy{
+		Resume: &agentsv1alpha1.ResumePolicy{
+			OnIngressTraffic: &agentsv1alpha1.IngressTrafficRule{},
+		},
+	}
+	activeProbe := agentsv1alpha1.Probe{
+		Name: "Active",
+		Probe: corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{Command: []string{"true"}},
+			},
+		},
+	}
+	extraProbe := agentsv1alpha1.Probe{
+		Name: "Extra",
+		Probe: corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{Command: []string{"true"}},
+			},
+		},
+	}
+	maxPoolProbes := make([]agentsv1alpha1.Probe, 0, autopause.MaxSandboxProbes)
+	for i := range autopause.MaxSandboxProbes {
+		maxPoolProbes = append(maxPoolProbes, agentsv1alpha1.Probe{Name: fmt.Sprintf("pool-%d", i)})
+	}
 
 	tests := []struct {
 		name                string
@@ -1218,6 +1295,260 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 				expectedShutdownTime := shutdownTime.Time.Round(0).Truncate(time.Second).UTC()
 				assert.Equal(t, expectedShutdownTime, mockSandbox.Spec.ShutdownTime.Time, "ShutdownTime mismatch")
 			},
+		},
+		{
+			name: "nil pause overlay leaves pool autoPausePolicy and pauseTime",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim",
+					Namespace: "default",
+					UID:       "test-uid-inherit",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "test-template",
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Probes:          []agentsv1alpha1.Probe{activeProbe},
+					AutoPausePolicy: idlePolicy,
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				assert.Nil(t, opts.AutoPausePolicy, "nil claim overlay must not replace the pool policy")
+				mockSandbox := &sandboxcr.Sandbox{
+					Sandbox: &agentsv1alpha1.Sandbox{
+						Spec: agentsv1alpha1.SandboxSpec{AutoPausePolicy: idlePolicy.DeepCopy()},
+					},
+				}
+				require.NoError(t, opts.Modifier(mockSandbox))
+				assert.Equal(t, idlePolicy, mockSandbox.Spec.AutoPausePolicy)
+				assert.Nil(t, mockSandbox.Spec.PauseTime)
+				assert.Nil(t, mockSandbox.Spec.ShutdownTime)
+			},
+		},
+		{
+			name: "claim with pauseTime only",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim",
+					Namespace: "default",
+					UID:       "test-uid-pause",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "test-template",
+					PauseTime:    &pauseTime,
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+			},
+			expectError: false,
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				mockSandbox := &sandboxcr.Sandbox{
+					Sandbox: &agentsv1alpha1.Sandbox{
+						Spec: agentsv1alpha1.SandboxSpec{AutoPausePolicy: idlePolicy.DeepCopy()},
+					},
+				}
+				require.NoError(t, opts.Modifier(mockSandbox))
+				require.NotNil(t, mockSandbox.Spec.PauseTime)
+				assert.Equal(t, pauseTime.Time.Round(0).Truncate(time.Second).UTC(), mockSandbox.Spec.PauseTime.Time)
+				assert.Nil(t, mockSandbox.Spec.ShutdownTime)
+				assert.Equal(t, idlePolicy, mockSandbox.Spec.AutoPausePolicy)
+			},
+		},
+		{
+			name: "claim with pauseTime and shutdownTime",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim",
+					Namespace: "default",
+					UID:       "test-uid-both-deadlines",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "test-template",
+					PauseTime:    &pauseTime,
+					ShutdownTime: &shutdownTime,
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+			},
+			expectError: false,
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				mockSandbox := &sandboxcr.Sandbox{
+					Sandbox: &agentsv1alpha1.Sandbox{},
+				}
+				require.NoError(t, opts.Modifier(mockSandbox))
+				require.NotNil(t, mockSandbox.Spec.PauseTime)
+				require.NotNil(t, mockSandbox.Spec.ShutdownTime)
+				assert.Equal(t, pauseTime.Time.Round(0).Truncate(time.Second).UTC(), mockSandbox.Spec.PauseTime.Time)
+				assert.Equal(t, shutdownTime.Time.Round(0).Truncate(time.Second).UTC(), mockSandbox.Spec.ShutdownTime.Time)
+			},
+		},
+		{
+			name: "claim autoPausePolicy replaces pool policy",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim",
+					Namespace: "default",
+					UID:       "test-uid-policy",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    "test-template",
+					AutoPausePolicy: wakePolicy,
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Probes:          []agentsv1alpha1.Probe{activeProbe},
+					AutoPausePolicy: idlePolicy,
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				assert.Equal(t, wakePolicy, opts.AutoPausePolicy)
+			},
+		},
+		{
+			name: "onIngressTraffic policy is valid without sandboxset probes",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim",
+					Namespace: "default",
+					UID:       "test-uid-wake",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    "test-template",
+					AutoPausePolicy: wakePolicy,
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+			},
+			expectError: false,
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				assert.Equal(t, wakePolicy, opts.AutoPausePolicy)
+			},
+		},
+		{
+			name: "idle autoPausePolicy is valid when sandboxset defines the probe",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim",
+					Namespace: "default",
+					UID:       "test-uid-idle",
+				},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    "test-template",
+					AutoPausePolicy: idlePolicy,
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+				Spec: agentsv1alpha1.SandboxSetSpec{
+					Probes: []agentsv1alpha1.Probe{activeProbe},
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				assert.Equal(t, idlePolicy, opts.AutoPausePolicy)
+			},
+		},
+		{
+			name: "autoPausePolicy referencing missing probe is rejected",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "claim", Namespace: "default"},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    "pool",
+					AutoPausePolicy: idlePolicy,
+				},
+			},
+			sandboxSet:          &agentsv1alpha1.SandboxSet{ObjectMeta: metav1.ObjectMeta{Name: "pool", Namespace: "default"}},
+			expectError:         true,
+			expectErrorContains: "must reference a probe name defined in spec.probes",
+		},
+		{
+			name: "empty autoPausePolicy is rejected",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "claim", Namespace: "default"},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    "pool",
+					AutoPausePolicy: &agentsv1alpha1.AutoPausePolicy{},
+				},
+			},
+			sandboxSet:          &agentsv1alpha1.SandboxSet{ObjectMeta: metav1.ObjectMeta{Name: "pool", Namespace: "default"}},
+			expectError:         true,
+			expectErrorContains: "at least one of pause.whenProbedIdleState",
+		},
+		{
+			name: "claim probes pass through and may satisfy the policy",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "claim", Namespace: "default", UID: "test-uid-probes"},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName:    "pool",
+					AutoPausePolicy: idlePolicy,
+					Probes:          []agentsv1alpha1.Probe{activeProbe},
+				},
+			},
+			// The policy references "Active" and the claim itself carries it,
+			// so no pool probe is needed.
+			sandboxSet:  &agentsv1alpha1.SandboxSet{ObjectMeta: metav1.ObjectMeta{Name: "pool", Namespace: "default"}},
+			expectError: false,
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				assert.Equal(t, []agentsv1alpha1.Probe{activeProbe}, opts.Probes)
+				assert.Equal(t, idlePolicy, opts.AutoPausePolicy)
+			},
+		},
+		{
+			name: "claim probes without policy pass through",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "claim", Namespace: "default", UID: "test-uid-probes"},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "pool",
+					Probes:       []agentsv1alpha1.Probe{activeProbe},
+				},
+			},
+			sandboxSet:  &agentsv1alpha1.SandboxSet{ObjectMeta: metav1.ObjectMeta{Name: "pool", Namespace: "default"}},
+			expectError: false,
+			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
+				assert.Equal(t, []agentsv1alpha1.Probe{activeProbe}, opts.Probes)
+				assert.Nil(t, opts.AutoPausePolicy)
+			},
+		},
+		{
+			name: "duplicate claim probe names are rejected",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "claim", Namespace: "default", UID: "test-uid-probes"},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "pool",
+					Probes:       []agentsv1alpha1.Probe{activeProbe, activeProbe},
+				},
+			},
+			sandboxSet:          &agentsv1alpha1.SandboxSet{ObjectMeta: metav1.ObjectMeta{Name: "pool", Namespace: "default"}},
+			expectError:         true,
+			expectErrorContains: "Duplicate value",
+		},
+		{
+			name: "merged probes exceeding the sandbox limit are rejected",
+			claim: &agentsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "claim", Namespace: "default", UID: "test-uid-probes"},
+				Spec: agentsv1alpha1.SandboxClaimSpec{
+					TemplateName: "pool",
+					// "Extra" does not clash with any pool name, so the merged
+					// set has MaxSandboxProbes+1 entries.
+					Probes: []agentsv1alpha1.Probe{extraProbe},
+				},
+			},
+			sandboxSet: &agentsv1alpha1.SandboxSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "pool", Namespace: "default"},
+				Spec:       agentsv1alpha1.SandboxSetSpec{Probes: maxPoolProbes},
+			},
+			expectError:         true,
+			expectErrorContains: "exceed the Sandbox limit",
 		},
 		{
 			name: "claim with inplaceUpdate - image only",
@@ -1996,6 +2327,7 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 			}
 			if tt.expectErrorContains != "" {
 				assert.Contains(t, err.Error(), tt.expectErrorContains)
+				assert.ErrorIs(t, err, ErrInvalidClaimSpec)
 				assert.Nil(t, opts.Modifier)
 			}
 			if !tt.expectError && tt.validate != nil {

--- a/pkg/controller/sandboxclaim/core/common_control_test.go
+++ b/pkg/controller/sandboxclaim/core/common_control_test.go
@@ -570,10 +570,7 @@ func TestCommonControl_EnsureClaimClaiming(t *testing.T) {
 
 			// Check requeue strategy
 			if !tt.expectError {
-				assert.Equal(t, tt.expectedStrategy.Immediate, strategy.Immediate, "Immediate mismatch")
-				if tt.expectedStrategy.After > 0 {
-					assert.Equal(t, tt.expectedStrategy.After, strategy.After, "After mismatch")
-				}
+				assert.Equal(t, tt.expectedStrategy, strategy)
 			}
 
 			// Check status updates
@@ -1111,6 +1108,7 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 	ctx := context.Background()
 	shutdownTime := metav1.Now()
 	pauseTime := metav1.NewTime(shutdownTime.Time.Add(time.Hour))
+	oldDeadline := metav1.NewTime(shutdownTime.Time.Add(-time.Hour))
 	timeoutDuration := metav1.Duration{Duration: 3 * time.Minute}
 	idlePolicy := &agentsv1alpha1.AutoPausePolicy{
 		Pause: &agentsv1alpha1.PausePolicy{
@@ -1286,6 +1284,7 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 							Name:      "test-sandbox",
 							Namespace: "default",
 						},
+						Spec: agentsv1alpha1.SandboxSpec{PauseTime: oldDeadline.DeepCopy(), ShutdownTime: oldDeadline.DeepCopy()},
 					},
 				}
 				require.NoError(t, opts.Modifier(mockSandbox))
@@ -1294,10 +1293,11 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 				assert.Equal(t, "test-claim", mockSandbox.Labels[agentsv1alpha1.LabelSandboxClaimName], "LabelSandboxClaimName mismatch")
 				expectedShutdownTime := shutdownTime.Time.Round(0).Truncate(time.Second).UTC()
 				assert.Equal(t, expectedShutdownTime, mockSandbox.Spec.ShutdownTime.Time, "ShutdownTime mismatch")
+				assert.Nil(t, mockSandbox.Spec.PauseTime)
 			},
 		},
 		{
-			name: "nil pause overlay leaves pool autoPausePolicy and pauseTime",
+			name: "nil pause overlay preserves pool policy and both deadlines",
 			claim: &agentsv1alpha1.SandboxClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-claim",
@@ -1320,13 +1320,17 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 				assert.Nil(t, opts.AutoPausePolicy, "nil claim overlay must not replace the pool policy")
 				mockSandbox := &sandboxcr.Sandbox{
 					Sandbox: &agentsv1alpha1.Sandbox{
-						Spec: agentsv1alpha1.SandboxSpec{AutoPausePolicy: idlePolicy.DeepCopy()},
+						Spec: agentsv1alpha1.SandboxSpec{
+							AutoPausePolicy: idlePolicy.DeepCopy(),
+							PauseTime:       oldDeadline.DeepCopy(),
+							ShutdownTime:    oldDeadline.DeepCopy(),
+						},
 					},
 				}
 				require.NoError(t, opts.Modifier(mockSandbox))
 				assert.Equal(t, idlePolicy, mockSandbox.Spec.AutoPausePolicy)
-				assert.Nil(t, mockSandbox.Spec.PauseTime)
-				assert.Nil(t, mockSandbox.Spec.ShutdownTime)
+				assert.Equal(t, &oldDeadline, mockSandbox.Spec.PauseTime)
+				assert.Equal(t, &oldDeadline, mockSandbox.Spec.ShutdownTime)
 			},
 		},
 		{
@@ -1349,7 +1353,11 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
 				mockSandbox := &sandboxcr.Sandbox{
 					Sandbox: &agentsv1alpha1.Sandbox{
-						Spec: agentsv1alpha1.SandboxSpec{AutoPausePolicy: idlePolicy.DeepCopy()},
+						Spec: agentsv1alpha1.SandboxSpec{
+							AutoPausePolicy: idlePolicy.DeepCopy(),
+							PauseTime:       oldDeadline.DeepCopy(),
+							ShutdownTime:    oldDeadline.DeepCopy(),
+						},
 					},
 				}
 				require.NoError(t, opts.Modifier(mockSandbox))
@@ -1379,38 +1387,15 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 			expectError: false,
 			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
 				mockSandbox := &sandboxcr.Sandbox{
-					Sandbox: &agentsv1alpha1.Sandbox{},
+					Sandbox: &agentsv1alpha1.Sandbox{
+						Spec: agentsv1alpha1.SandboxSpec{PauseTime: oldDeadline.DeepCopy(), ShutdownTime: oldDeadline.DeepCopy()},
+					},
 				}
 				require.NoError(t, opts.Modifier(mockSandbox))
 				require.NotNil(t, mockSandbox.Spec.PauseTime)
 				require.NotNil(t, mockSandbox.Spec.ShutdownTime)
 				assert.Equal(t, pauseTime.Time.Round(0).Truncate(time.Second).UTC(), mockSandbox.Spec.PauseTime.Time)
 				assert.Equal(t, shutdownTime.Time.Round(0).Truncate(time.Second).UTC(), mockSandbox.Spec.ShutdownTime.Time)
-			},
-		},
-		{
-			name: "claim autoPausePolicy replaces pool policy",
-			claim: &agentsv1alpha1.SandboxClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-claim",
-					Namespace: "default",
-					UID:       "test-uid-policy",
-				},
-				Spec: agentsv1alpha1.SandboxClaimSpec{
-					TemplateName:    "test-template",
-					AutoPausePolicy: wakePolicy,
-				},
-			},
-			sandboxSet: &agentsv1alpha1.SandboxSet{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
-				Spec: agentsv1alpha1.SandboxSetSpec{
-					Probes:          []agentsv1alpha1.Probe{activeProbe},
-					AutoPausePolicy: idlePolicy,
-				},
-			},
-			expectError: false,
-			validate: func(t *testing.T, opts infra.ClaimSandboxOptions) {
-				assert.Equal(t, wakePolicy, opts.AutoPausePolicy)
 			},
 		},
 		{
@@ -1470,19 +1455,6 @@ func TestCommonControl_buildClaimOptions(t *testing.T) {
 			sandboxSet:          &agentsv1alpha1.SandboxSet{ObjectMeta: metav1.ObjectMeta{Name: "pool", Namespace: "default"}},
 			expectError:         true,
 			expectErrorContains: "must reference a probe name defined in spec.probes",
-		},
-		{
-			name: "empty autoPausePolicy is rejected",
-			claim: &agentsv1alpha1.SandboxClaim{
-				ObjectMeta: metav1.ObjectMeta{Name: "claim", Namespace: "default"},
-				Spec: agentsv1alpha1.SandboxClaimSpec{
-					TemplateName:    "pool",
-					AutoPausePolicy: &agentsv1alpha1.AutoPausePolicy{},
-				},
-			},
-			sandboxSet:          &agentsv1alpha1.SandboxSet{ObjectMeta: metav1.ObjectMeta{Name: "pool", Namespace: "default"}},
-			expectError:         true,
-			expectErrorContains: "at least one of pause.whenProbedIdleState",
 		},
 		{
 			name: "claim probes pass through and may satisfy the policy",

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/autopause"
 	infracache "github.com/openkruise/agents/pkg/cache"
 	cacheutils "github.com/openkruise/agents/pkg/cache/utils"
 	"github.com/openkruise/agents/pkg/controller/sandboxset"
@@ -55,8 +57,6 @@ import (
 	"github.com/openkruise/agents/pkg/utils/inplaceupdate"
 	"github.com/openkruise/agents/pkg/utils/runtime"
 	timeoututils "github.com/openkruise/agents/pkg/utils/timeout"
-
-	"go.opentelemetry.io/otel/attribute"
 )
 
 var DefaultCleanupTimeout = 30 * time.Second
@@ -602,6 +602,11 @@ func pickAnAvailableSandbox(ctx context.Context, opts infra.ClaimSandboxOptions,
 	availableCandidates := make([]*v1alpha1.Sandbox, 0, cnt)
 	speculatingCandidates := make([]*v1alpha1.Sandbox, 0, cnt)
 	var resizeSkipReason error
+	// The claim-required probes derive from the claim's auto-pause policy minus
+	// the probes the claim itself carries: candidates do not need to pre-declare
+	// those, they are merged onto the picked sandbox at claim time.
+	requiredProbeNames := autopause.RequiredProbeNames(opts.AutoPausePolicy, opts.Probes)
+	var missingProbeNames []string
 	for _, obj := range objects {
 		if len(availableCandidates) >= cnt {
 			if opts.SpeculateCreatingDuration == 0 || len(speculatingCandidates) >= cnt {
@@ -618,6 +623,11 @@ func pickAnAvailableSandbox(ctx context.Context, opts infra.ClaimSandboxOptions,
 			if errors.As(checkErr, &resizeIncompatible) {
 				resizeSkipReason = checkErr
 			}
+			continue
+		}
+		if missing := missingRequiredProbeNames(obj.Spec.Probes, requiredProbeNames); len(missing) > 0 {
+			missingProbeNames = missing
+			log.Info("skip sandbox without claim-required probes", "sandbox", klog.KObj(obj), "missingProbes", missing)
 			continue
 		}
 		state, _ := utils.GetSandboxState(obj)
@@ -694,7 +704,27 @@ func pickAnAvailableSandbox(ctx context.Context, opts infra.ClaimSandboxOptions,
 		log.Info("no candidate compatible with inplace resize", "reason", resizeSkipReason)
 		return nil, "", NoAvailableError(template, fmt.Sprintf("no candidate compatible with inplace resize: %v", resizeSkipReason))
 	}
+	if len(missingProbeNames) > 0 && len(availableCandidates) == 0 && len(speculatingCandidates) == 0 {
+		return nil, "", NoAvailableError(template, fmt.Sprintf("no candidate declares required probes %v", missingProbeNames))
+	}
 	return nil, "", NoAvailableError(template, pickErr.Error())
+}
+
+func missingRequiredProbeNames(probes []v1alpha1.Probe, required []string) []string {
+	if len(required) == 0 {
+		return nil
+	}
+	defined := make(map[string]struct{}, len(probes))
+	for i := range probes {
+		defined[probes[i].Name] = struct{}{}
+	}
+	missing := make([]string, 0, len(required))
+	for _, name := range required {
+		if _, ok := defined[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	return missing
 }
 
 func pickFromCandidates(ctx context.Context, candidates []*v1alpha1.Sandbox, pickCache *sync.Map) (*v1alpha1.Sandbox, error) {
@@ -756,6 +786,9 @@ func newSandboxFromSandboxSet(ctx context.Context, opts infra.ClaimSandboxOption
 		}
 	}
 	sbx := sandboxset.NewSandboxFromSandboxSet(sbs, refTemplate)
+	if missing := missingRequiredProbeNames(sbx.Spec.Probes, autopause.RequiredProbeNames(opts.AutoPausePolicy, opts.Probes)); len(missing) > 0 {
+		return nil, "", NoAvailableError(opts.Template, fmt.Sprintf("new sandbox does not declare required probes %v", missing))
+	}
 	// sandbox manager creates high-priority sandbox
 	sbx.Annotations[v1alpha1.SandboxAnnotationPriority] = "100"
 	for _, anno := range FilteredAnnotationsOnCreation {
@@ -816,15 +849,27 @@ func checkCandidateResize(sbx *v1alpha1.Sandbox, requests, limits corev1.Resourc
 	return nil
 }
 
+// modifyPickedSandbox applies the claim-time mutations to a sandbox returned by
+// pickAnAvailableSandbox. It must not be called directly.
 func modifyPickedSandbox(sbx *Sandbox, lockType infra.LockType, opts infra.ClaimSandboxOptions) error {
 	if lockType != infra.LockTypeCreate {
 		sbx.Sandbox = sbx.Sandbox.DeepCopy()
 	}
-
+	// Merge the claim probes before the modifier below so every later step
+	// sees the final probe set: a policy rule may reference a probe the claim
+	// itself carries.
+	if len(opts.Probes) > 0 {
+		sbx.Spec.Probes = autopause.MergeProbes(sbx.Spec.Probes, opts.Probes)
+	}
 	if opts.Modifier != nil {
 		if err := opts.Modifier(sbx); err != nil {
 			return terminalMutationError{stage: "modifier", err: err}
 		}
+	}
+	// Deep-copy the claim's policy so the sandbox spec never aliases the
+	// SandboxClaim spec.
+	if opts.AutoPausePolicy != nil {
+		sbx.Spec.AutoPausePolicy = opts.AutoPausePolicy.DeepCopy()
 	}
 	if opts.InplaceUpdate != nil {
 		if opts.InplaceUpdate.Image != "" {

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -630,6 +630,12 @@ func pickAnAvailableSandbox(ctx context.Context, opts infra.ClaimSandboxOptions,
 			log.Info("skip sandbox without claim-required probes", "sandbox", klog.KObj(obj), "missingProbes", missing)
 			continue
 		}
+		// Old candidates may have more probes than the current SandboxSet.
+		// Only merge to count when the combined lengths could exceed the limit.
+		if len(obj.Spec.Probes)+len(opts.Probes) > autopause.MaxSandboxProbes && len(autopause.MergeProbes(obj.Spec.Probes, opts.Probes)) > autopause.MaxSandboxProbes {
+			log.Info("skip sandbox whose merged probes exceed the limit", "sandbox", klog.KObj(obj))
+			continue
+		}
 		state, _ := utils.GetSandboxState(obj)
 		switch state {
 		case v1alpha1.SandboxStateAvailable:
@@ -786,6 +792,10 @@ func newSandboxFromSandboxSet(ctx context.Context, opts infra.ClaimSandboxOption
 		}
 	}
 	sbx := sandboxset.NewSandboxFromSandboxSet(sbs, refTemplate)
+	if mergedCount := len(autopause.MergeProbes(sbx.Spec.Probes, opts.Probes)); mergedCount > autopause.MaxSandboxProbes {
+		return nil, "", NoAvailableError(opts.Template,
+			fmt.Sprintf("new sandbox merged probes exceed the Sandbox limit of %d (%d probes)", autopause.MaxSandboxProbes, mergedCount))
+	}
 	if missing := missingRequiredProbeNames(sbx.Spec.Probes, autopause.RequiredProbeNames(opts.AutoPausePolicy, opts.Probes)); len(missing) > 0 {
 		return nil, "", NoAvailableError(opts.Template, fmt.Sprintf("new sandbox does not declare required probes %v", missing))
 	}

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -4270,7 +4270,7 @@ func TestPreCheckCandidateResizeCompatibility(t *testing.T) {
 	}
 }
 
-func TestPickAnAvailableSandbox_ResizeCompatibilityUsesCandidateResources(t *testing.T) {
+func TestPickAnAvailableSandbox_CandidateCompatibilityUsesCandidateSpec(t *testing.T) {
 	utestutils.InitLogOutput()
 
 	template := "test-resize-compat-template"
@@ -4311,6 +4311,14 @@ func TestPickAnAvailableSandbox_ResizeCompatibilityUsesCandidateResources(t *tes
 				PodInfo:    v1alpha1.PodInfo{PodIP: "1.2.3.4"},
 			},
 		}
+	}
+
+	// requiresActiveProbe is the minimal claim policy whose idle rule references
+	// the "Active" probe, standing in for the former RequiredProbeNames option.
+	requiresActiveProbe := &v1alpha1.AutoPausePolicy{
+		Pause: &v1alpha1.PausePolicy{
+			WhenProbedIdleState: &v1alpha1.ProbedIdleStateRule{Probe: "Active"},
+		},
 	}
 
 	setup := func(t *testing.T) (*Infra, client.Client) {
@@ -4393,6 +4401,78 @@ func TestPickAnAvailableSandbox_ResizeCompatibilityUsesCandidateResources(t *tes
 		assert.Contains(t, err.Error(), "inplace resize")
 		var retriable retriableError
 		assert.True(t, errors.As(err, &retriable), "resize-incompatible pool must stay retriable")
+	})
+
+	t.Run("old revision without a claim-required probe stays unclaimed", func(t *testing.T) {
+		testInfra, c := setup(t)
+		CreateSandboxWithStatus(t, c, newCandidate("old-without-probe", oldRevision, "512Mi"))
+		waitPool(t, testInfra, 1)
+
+		opts, err := ValidateAndInitClaimOptions(infra.ClaimSandboxOptions{
+			Namespace:       "default",
+			User:            "test-user",
+			Template:        template,
+			AutoPausePolicy: requiresActiveProbe,
+		})
+		require.NoError(t, err)
+
+		claimed, _, err := TryClaimSandbox(t.Context(), opts, &testInfra.pickCache, testInfra.Cache, make(chan struct{}, 1), nil)
+		require.Error(t, err)
+		assert.Nil(t, claimed)
+		assert.Contains(t, err.Error(), "required probes [Active]")
+		var retriable retriableError
+		assert.True(t, errors.As(err, &retriable), "probe-incompatible pool must stay retriable")
+
+		unchanged := &v1alpha1.Sandbox{}
+		require.NoError(t, c.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "old-without-probe"}, unchanged))
+		assert.Equal(t, "false", unchanged.Labels[v1alpha1.LabelSandboxIsClaimed])
+		assert.Nil(t, unchanged.Spec.AutoPausePolicy)
+	})
+
+	t.Run("updated candidate with required probe is preferred over incompatible old revision", func(t *testing.T) {
+		testInfra, c := setup(t)
+		oldCandidate := newCandidate("old-without-probe", oldRevision, "512Mi")
+		updatedCandidate := newCandidate("updated-with-probe", newRevision, "1Gi")
+		updatedCandidate.Spec.Probes = []v1alpha1.Probe{{Name: "Active"}}
+		CreateSandboxWithStatus(t, c, oldCandidate)
+		CreateSandboxWithStatus(t, c, updatedCandidate)
+		waitPool(t, testInfra, 2)
+
+		opts, err := ValidateAndInitClaimOptions(infra.ClaimSandboxOptions{
+			Namespace:       "default",
+			User:            "test-user",
+			Template:        template,
+			AutoPausePolicy: requiresActiveProbe,
+		})
+		require.NoError(t, err)
+
+		sbx, lockType, err := pickAnAvailableSandbox(t.Context(), opts, &testInfra.pickCache, testInfra.Cache)
+		require.NoError(t, err)
+		assert.Equal(t, infra.LockTypeUpdate, lockType)
+		assert.Equal(t, "updated-with-probe", sbx.GetName())
+	})
+
+	t.Run("claim-carried probe does not require pool pre-declaration", func(t *testing.T) {
+		testInfra, c := setup(t)
+		candidate := newCandidate("carried-probe-candidate", newRevision, "1Gi")
+		CreateSandboxWithStatus(t, c, candidate)
+		waitPool(t, testInfra, 1)
+
+		opts, err := ValidateAndInitClaimOptions(infra.ClaimSandboxOptions{
+			Namespace:       "default",
+			User:            "test-user",
+			Template:        template,
+			AutoPausePolicy: requiresActiveProbe,
+			// The claim carries the "Active" probe itself, so candidates
+			// without it stay eligible: it is merged on at claim time.
+			Probes: []v1alpha1.Probe{{Name: "Active"}},
+		})
+		require.NoError(t, err)
+
+		sbx, lockType, err := pickAnAvailableSandbox(t.Context(), opts, &testInfra.pickCache, testInfra.Cache)
+		require.NoError(t, err)
+		assert.Equal(t, infra.LockTypeUpdate, lockType)
+		assert.Equal(t, "carried-probe-candidate", sbx.GetName())
 	})
 
 	t.Run("locked candidates keep the generic no-available path", func(t *testing.T) {
@@ -4508,6 +4588,112 @@ func TestModifyPickedSandbox_InitRuntime(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestModifyPickedSandbox_AutoPausePolicy covers the claim-time auto-pause
+// policy overlay: a nil overlay keeps the policy the pool sandbox already
+// carries, while a claim policy replaces it with a deep copy so the sandbox
+// spec never aliases the SandboxClaim spec.
+func TestModifyPickedSandbox_AutoPausePolicy(t *testing.T) {
+	poolPolicy := &v1alpha1.AutoPausePolicy{
+		Pause: &v1alpha1.PausePolicy{
+			WhenProbedIdleState: &v1alpha1.ProbedIdleStateRule{Probe: "Active"},
+		},
+	}
+	claimPolicy := &v1alpha1.AutoPausePolicy{
+		Resume: &v1alpha1.ResumePolicy{
+			OnIngressTraffic: &v1alpha1.IngressTrafficRule{},
+		},
+	}
+
+	newSandbox := func() *Sandbox {
+		return &Sandbox{Sandbox: &v1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-sandbox",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+			Spec: v1alpha1.SandboxSpec{AutoPausePolicy: poolPolicy.DeepCopy()},
+		}}
+	}
+
+	t.Run("nil overlay keeps the pool policy", func(t *testing.T) {
+		sbx := newSandbox()
+		require.NoError(t, modifyPickedSandbox(sbx, infra.LockTypeUpdate, infra.ClaimSandboxOptions{}))
+		assert.Equal(t, poolPolicy, sbx.Spec.AutoPausePolicy)
+	})
+
+	t.Run("claim policy replaces the pool policy and is deep-copied", func(t *testing.T) {
+		sbx := newSandbox()
+		require.NoError(t, modifyPickedSandbox(sbx, infra.LockTypeUpdate, infra.ClaimSandboxOptions{
+			AutoPausePolicy: claimPolicy,
+		}))
+		assert.Equal(t, claimPolicy, sbx.Spec.AutoPausePolicy)
+		assert.NotSame(t, claimPolicy, sbx.Spec.AutoPausePolicy)
+	})
+}
+
+// TestModifyPickedSandbox_Probes covers the claim-time probe merge: claim
+// probes replace same-name pool probes and append new ones, the result is a
+// deep copy so the sandbox spec never aliases the SandboxClaim spec, and a
+// policy rule may reference a probe the claim itself carries.
+func TestModifyPickedSandbox_Probes(t *testing.T) {
+	probe := func(name, command string) v1alpha1.Probe {
+		return v1alpha1.Probe{
+			Name: name,
+			Probe: corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					Exec: &corev1.ExecAction{Command: []string{command}},
+				},
+			},
+		}
+	}
+	requiresActiveProbe := &v1alpha1.AutoPausePolicy{
+		Pause: &v1alpha1.PausePolicy{
+			WhenProbedIdleState: &v1alpha1.ProbedIdleStateRule{Probe: "Active"},
+		},
+	}
+
+	newSandbox := func(probes ...v1alpha1.Probe) *Sandbox {
+		return &Sandbox{Sandbox: &v1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-sandbox",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+			Spec: v1alpha1.SandboxSpec{Probes: probes},
+		}}
+	}
+
+	t.Run("empty claim probes keep the pool probes", func(t *testing.T) {
+		sbx := newSandbox(probe("Active", "pool-cmd"))
+		require.NoError(t, modifyPickedSandbox(sbx, infra.LockTypeUpdate, infra.ClaimSandboxOptions{}))
+		assert.Equal(t, []v1alpha1.Probe{probe("Active", "pool-cmd")}, sbx.Spec.Probes)
+	})
+
+	t.Run("claim probes replace by name and append new ones", func(t *testing.T) {
+		sbx := newSandbox(probe("Active", "pool-cmd"), probe("Audit", "audit-cmd"))
+		claimProbes := []v1alpha1.Probe{probe("Active", "claim-cmd"), probe("Cron", "cron-cmd")}
+		require.NoError(t, modifyPickedSandbox(sbx, infra.LockTypeUpdate, infra.ClaimSandboxOptions{
+			Probes: claimProbes,
+		}))
+		// Pool order first with the claim version of "Active", then new names.
+		assert.Equal(t, []v1alpha1.Probe{probe("Active", "claim-cmd"), probe("Audit", "audit-cmd"), probe("Cron", "cron-cmd")}, sbx.Spec.Probes)
+		// Deep copy: the merged entry never aliases the claim probes.
+		assert.NotSame(t, &claimProbes[0], &sbx.Spec.Probes[0])
+	})
+
+	t.Run("policy may reference a claim-carried probe", func(t *testing.T) {
+		// The pool only declares "Cron"; the policy references "Active",
+		// which the claim itself carries and the merge appends.
+		sbx := newSandbox(probe("Cron", "cron-cmd"))
+		require.NoError(t, modifyPickedSandbox(sbx, infra.LockTypeUpdate, infra.ClaimSandboxOptions{
+			AutoPausePolicy: requiresActiveProbe,
+			Probes:          []v1alpha1.Probe{probe("Active", "claim-cmd")},
+		}))
+		assert.Equal(t, []v1alpha1.Probe{probe("Cron", "cron-cmd"), probe("Active", "claim-cmd")}, sbx.Spec.Probes)
+		assert.Equal(t, requiresActiveProbe, sbx.Spec.AutoPausePolicy)
+	})
 }
 
 // TestNewSandboxFromSandboxSet_TemplateRef covers the SandboxTemplate

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -52,6 +52,7 @@ import (
 
 	"github.com/openkruise/agents/api/v1alpha1"
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
+	"github.com/openkruise/agents/pkg/autopause"
 	infracache "github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/cache/controllers"
 	"github.com/openkruise/agents/pkg/identity"
@@ -4312,6 +4313,18 @@ func TestPickAnAvailableSandbox_CandidateCompatibilityUsesCandidateSpec(t *testi
 			},
 		}
 	}
+	newProbes := func(prefix string, count int) []v1alpha1.Probe {
+		probes := make([]v1alpha1.Probe, 0, count)
+		for i := range count {
+			probes = append(probes, v1alpha1.Probe{
+				Name: fmt.Sprintf("%s-%d", prefix, i),
+				Probe: corev1.Probe{ProbeHandler: corev1.ProbeHandler{
+					Exec: &corev1.ExecAction{Command: []string{"true"}},
+				}},
+			})
+		}
+		return probes
+	}
 
 	// requiresActiveProbe is the minimal claim policy whose idle rule references
 	// the "Active" probe, standing in for the former RequiredProbeNames option.
@@ -4473,6 +4486,54 @@ func TestPickAnAvailableSandbox_CandidateCompatibilityUsesCandidateSpec(t *testi
 		require.NoError(t, err)
 		assert.Equal(t, infra.LockTypeUpdate, lockType)
 		assert.Equal(t, "carried-probe-candidate", sbx.GetName())
+	})
+
+	t.Run("old revision exceeding the merged probe limit falls back to creation", func(t *testing.T) {
+		testInfra, c := setup(t)
+		candidate := newCandidate("old-at-probe-limit", oldRevision, "512Mi")
+		candidate.Spec.Probes = newProbes("old", autopause.MaxSandboxProbes)
+		CreateSandboxWithStatus(t, c, candidate)
+		waitPool(t, testInfra, 1)
+
+		opts, err := ValidateAndInitClaimOptions(infra.ClaimSandboxOptions{
+			Namespace:       "default",
+			User:            "test-user",
+			Template:        template,
+			Probes:          newProbes("claim", 1),
+			CreateOnNoStock: true,
+		})
+		require.NoError(t, err)
+
+		sbx, lockType, err := pickAnAvailableSandbox(t.Context(), opts, &testInfra.pickCache, testInfra.Cache)
+		require.NoError(t, err)
+		assert.Equal(t, infra.LockTypeCreate, lockType)
+		assert.NotEqual(t, candidate.Name, sbx.GetName())
+	})
+
+	t.Run("same-name probe replacement stays within the exact limit", func(t *testing.T) {
+		testInfra, c := setup(t)
+		candidate := newCandidate("old-at-exact-probe-limit", oldRevision, "512Mi")
+		candidate.Spec.Probes = newProbes("pool", autopause.MaxSandboxProbes)
+		CreateSandboxWithStatus(t, c, candidate)
+		waitPool(t, testInfra, 1)
+
+		replacement := candidate.Spec.Probes[0].DeepCopy()
+		replacement.Exec.Command = []string{"replacement"}
+		opts, err := ValidateAndInitClaimOptions(infra.ClaimSandboxOptions{
+			Namespace: "default",
+			User:      "test-user",
+			Template:  template,
+			Probes:    []v1alpha1.Probe{*replacement},
+		})
+		require.NoError(t, err)
+
+		sbx, lockType, err := pickAnAvailableSandbox(t.Context(), opts, &testInfra.pickCache, testInfra.Cache)
+		require.NoError(t, err)
+		assert.Equal(t, infra.LockTypeUpdate, lockType)
+		assert.Equal(t, candidate.Name, sbx.GetName())
+		require.NoError(t, modifyPickedSandbox(sbx, lockType, opts))
+		assert.Len(t, sbx.Spec.Probes, autopause.MaxSandboxProbes)
+		assert.Equal(t, []string{"replacement"}, sbx.Spec.Probes[0].Exec.Command)
 	})
 
 	t.Run("locked candidates keep the generic no-available path", func(t *testing.T) {
@@ -4704,11 +4765,21 @@ func TestNewSandboxFromSandboxSet_TemplateRef(t *testing.T) {
 			WhenProbedIdleState: &v1alpha1.ProbedIdleStateRule{Probe: "Active"},
 		},
 	}
+	maxPoolProbes := make([]v1alpha1.Probe, 0, autopause.MaxSandboxProbes)
+	for i := range autopause.MaxSandboxProbes {
+		maxPoolProbes = append(maxPoolProbes, v1alpha1.Probe{
+			Name: fmt.Sprintf("pool-%d", i),
+			Probe: corev1.Probe{ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{Command: []string{"true"}},
+			}},
+		})
+	}
 
 	tests := []struct {
 		name       string
 		createSBT  bool
 		policy     *v1alpha1.AutoPausePolicy
+		poolProbes []v1alpha1.Probe
 		probes     []v1alpha1.Probe
 		wantErr    string
 		wantLabels map[string]string
@@ -4745,6 +4816,18 @@ func TestNewSandboxFromSandboxSet_TemplateRef(t *testing.T) {
 			policy:    requiresActiveProbe,
 			probes:    []v1alpha1.Probe{{Name: "Active"}},
 		},
+		{
+			name:       "current sandboxset merged probes over the limit is rejected",
+			createSBT:  true,
+			poolProbes: maxPoolProbes,
+			probes: []v1alpha1.Probe{{
+				Name: "claim-extra",
+				Probe: corev1.Probe{ProbeHandler: corev1.ProbeHandler{
+					Exec: &corev1.ExecAction{Command: []string{"true"}},
+				}},
+			}},
+			wantErr: "new sandbox merged probes exceed the Sandbox limit of 16 (17 probes)",
+		},
 	}
 
 	for _, tt := range tests {
@@ -4759,6 +4842,7 @@ func TestNewSandboxFromSandboxSet_TemplateRef(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: v1alpha1.SandboxSetSpec{
+					Probes: tt.poolProbes,
 					EmbeddedSandboxTemplate: v1alpha1.EmbeddedSandboxTemplate{
 						TemplateRef: &v1alpha1.SandboxTemplateRef{Name: refName},
 					},

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -4429,11 +4429,11 @@ func TestPickAnAvailableSandbox_CandidateCompatibilityUsesCandidateSpec(t *testi
 		assert.Nil(t, unchanged.Spec.AutoPausePolicy)
 	})
 
-	t.Run("updated candidate with required probe is preferred over incompatible old revision", func(t *testing.T) {
+	t.Run("new revision candidate without required probe falls back to old compatible revision", func(t *testing.T) {
 		testInfra, c := setup(t)
-		oldCandidate := newCandidate("old-without-probe", oldRevision, "512Mi")
-		updatedCandidate := newCandidate("updated-with-probe", newRevision, "1Gi")
-		updatedCandidate.Spec.Probes = []v1alpha1.Probe{{Name: "Active"}}
+		oldCandidate := newCandidate("old-with-probe", oldRevision, "512Mi")
+		oldCandidate.Spec.Probes = []v1alpha1.Probe{{Name: "Active"}}
+		updatedCandidate := newCandidate("updated-without-probe", newRevision, "1Gi")
 		CreateSandboxWithStatus(t, c, oldCandidate)
 		CreateSandboxWithStatus(t, c, updatedCandidate)
 		waitPool(t, testInfra, 2)
@@ -4449,7 +4449,7 @@ func TestPickAnAvailableSandbox_CandidateCompatibilityUsesCandidateSpec(t *testi
 		sbx, lockType, err := pickAnAvailableSandbox(t.Context(), opts, &testInfra.pickCache, testInfra.Cache)
 		require.NoError(t, err)
 		assert.Equal(t, infra.LockTypeUpdate, lockType)
-		assert.Equal(t, "updated-with-probe", sbx.GetName())
+		assert.Equal(t, "old-with-probe", sbx.GetName())
 	})
 
 	t.Run("claim-carried probe does not require pool pre-declaration", func(t *testing.T) {
@@ -4629,7 +4629,8 @@ func TestModifyPickedSandbox_AutoPausePolicy(t *testing.T) {
 			AutoPausePolicy: claimPolicy,
 		}))
 		assert.Equal(t, claimPolicy, sbx.Spec.AutoPausePolicy)
-		assert.NotSame(t, claimPolicy, sbx.Spec.AutoPausePolicy)
+		sbx.Spec.AutoPausePolicy.Resume.OnIngressTraffic.PauseTimeout = &metav1.Duration{Duration: time.Minute}
+		assert.Nil(t, claimPolicy.Resume.OnIngressTraffic.PauseTimeout)
 	})
 }
 
@@ -4648,9 +4649,9 @@ func TestModifyPickedSandbox_Probes(t *testing.T) {
 			},
 		}
 	}
-	requiresActiveProbe := &v1alpha1.AutoPausePolicy{
+	requiresCronProbe := &v1alpha1.AutoPausePolicy{
 		Pause: &v1alpha1.PausePolicy{
-			WhenProbedIdleState: &v1alpha1.ProbedIdleStateRule{Probe: "Active"},
+			WhenProbedIdleState: &v1alpha1.ProbedIdleStateRule{Probe: "Cron"},
 		},
 	}
 
@@ -4675,24 +4676,15 @@ func TestModifyPickedSandbox_Probes(t *testing.T) {
 		sbx := newSandbox(probe("Active", "pool-cmd"), probe("Audit", "audit-cmd"))
 		claimProbes := []v1alpha1.Probe{probe("Active", "claim-cmd"), probe("Cron", "cron-cmd")}
 		require.NoError(t, modifyPickedSandbox(sbx, infra.LockTypeUpdate, infra.ClaimSandboxOptions{
-			Probes: claimProbes,
+			AutoPausePolicy: requiresCronProbe,
+			Probes:          claimProbes,
 		}))
 		// Pool order first with the claim version of "Active", then new names.
 		assert.Equal(t, []v1alpha1.Probe{probe("Active", "claim-cmd"), probe("Audit", "audit-cmd"), probe("Cron", "cron-cmd")}, sbx.Spec.Probes)
-		// Deep copy: the merged entry never aliases the claim probes.
-		assert.NotSame(t, &claimProbes[0], &sbx.Spec.Probes[0])
-	})
-
-	t.Run("policy may reference a claim-carried probe", func(t *testing.T) {
-		// The pool only declares "Cron"; the policy references "Active",
-		// which the claim itself carries and the merge appends.
-		sbx := newSandbox(probe("Cron", "cron-cmd"))
-		require.NoError(t, modifyPickedSandbox(sbx, infra.LockTypeUpdate, infra.ClaimSandboxOptions{
-			AutoPausePolicy: requiresActiveProbe,
-			Probes:          []v1alpha1.Probe{probe("Active", "claim-cmd")},
-		}))
-		assert.Equal(t, []v1alpha1.Probe{probe("Cron", "cron-cmd"), probe("Active", "claim-cmd")}, sbx.Spec.Probes)
-		assert.Equal(t, requiresActiveProbe, sbx.Spec.AutoPausePolicy)
+		assert.Equal(t, requiresCronProbe, sbx.Spec.AutoPausePolicy)
+		// Deep copy: changing the merged nested command never changes the claim.
+		sbx.Spec.Probes[0].Probe.Exec.Command[0] = "modified"
+		assert.Equal(t, "claim-cmd", claimProbes[0].Probe.Exec.Command[0])
 	})
 }
 
@@ -4707,10 +4699,17 @@ func TestNewSandboxFromSandboxSet_TemplateRef(t *testing.T) {
 
 	const templateName = "ref-sbs"
 	const refName = "my-sbt"
+	requiresActiveProbe := &v1alpha1.AutoPausePolicy{
+		Pause: &v1alpha1.PausePolicy{
+			WhenProbedIdleState: &v1alpha1.ProbedIdleStateRule{Probe: "Active"},
+		},
+	}
 
 	tests := []struct {
 		name       string
 		createSBT  bool
+		policy     *v1alpha1.AutoPausePolicy
+		probes     []v1alpha1.Probe
 		wantErr    string
 		wantLabels map[string]string
 		wantAnnos  map[string]string
@@ -4733,6 +4732,18 @@ func TestNewSandboxFromSandboxSet_TemplateRef(t *testing.T) {
 			name:      "templateRef not found returns NoAvailable error",
 			createSBT: false,
 			wantErr:   "cannot resolve sandbox template",
+		},
+		{
+			name:      "templateRef sandbox missing required probe is rejected",
+			createSBT: true,
+			policy:    requiresActiveProbe,
+			wantErr:   "new sandbox does not declare required probes [Active]",
+		},
+		{
+			name:      "claim-carried probe satisfies templateRef policy",
+			createSBT: true,
+			policy:    requiresActiveProbe,
+			probes:    []v1alpha1.Probe{{Name: "Active"}},
 		},
 	}
 
@@ -4790,14 +4801,18 @@ func TestNewSandboxFromSandboxSet_TemplateRef(t *testing.T) {
 			}
 
 			opts := infra.ClaimSandboxOptions{
-				Template: templateName,
-				User:     "test-user",
+				Template:        templateName,
+				User:            "test-user",
+				AutoPausePolicy: tt.policy,
+				Probes:          tt.probes,
 			}
 			sbx, _, err := newSandboxFromSandboxSet(t.Context(), opts, infraInstance.Cache)
 
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
+				var retriable retriableError
+				require.ErrorAs(t, err, &retriable)
 				assert.Nil(t, sbx)
 				return
 			}

--- a/pkg/sandbox-manager/infra/types.go
+++ b/pkg/sandbox-manager/infra/types.go
@@ -55,6 +55,18 @@ type ClaimSandboxOptions struct {
 	Admission  *SandboxAdmission `json:"-"`
 	// Set Modifier to modify the Sandbox before it is updated. Returning an error aborts persistence.
 	Modifier func(sandbox Sandbox) error `json:"-"`
+	// AutoPausePolicy replaces the complete auto-pause policy of the claimed
+	// sandbox. It is Sandbox CR infra specific: only the sandboxcr claim flow
+	// applies it (deep-copied onto Spec.AutoPausePolicy); other Infrastructure
+	// implementations ignore it. A nil value keeps the policy the picked
+	// sandbox already carries.
+	AutoPausePolicy *v1alpha1.AutoPausePolicy `json:"-"`
+	// Probes are merged by name into the claimed sandbox's probe list: same-name
+	// entries replace the pool version, new names are appended. It is Sandbox CR
+	// infra specific: only the sandboxcr claim flow applies it (deep-copied onto
+	// Spec.Probes); other Infrastructure implementations ignore it. A nil value
+	// keeps the probes the picked sandbox already carries.
+	Probes []v1alpha1.Probe `json:"-"`
 	// ReserveFailedSandboxFor controls how long failed sandboxes are kept for debugging.
 	//   nil                          — backend default (DefaultReserveFailedSandboxFor)
 	//   ReserveFailedSandboxNever    — delete immediately


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Allow SandboxClaim to configure absolute `pauseTime`, a complete `autoPausePolicy`, and named `probes` when claiming a Sandbox.

- Omitted fields inherit the existing Sandbox configuration. When either deadline is supplied, write `pauseTime` and `shutdownTime` together, clearing the omitted side.
- Replace an explicitly supplied auto-pause policy and merge probes by name, overriding matching probes and appending new ones with deep copies.
- Validate Claim configuration using the existing probe/policy rules and complete invalid Claims with `InvalidClaimSpec`.
- Check the actual candidate's probe compatibility during pool rollouts, including the merged 16-probe limit. Skip incompatible candidates so `createOnNoStock` can create a compatible Sandbox; recheck the limit on the creation path.
- Update the API, generated schema/deepcopy code, example, proposal, and focused tests.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

The final candidate-limit fix passes:

```sh
go test -mod=readonly ./pkg/sandbox-manager/infra/sandboxcr \
  -run 'TestPickAnAvailableSandbox_CandidateCompatibilityUsesCandidateSpec|TestNewSandboxFromSandboxSet_TemplateRef' \
  -count=1
```

The regression cases cover oversized old candidates falling back to creation, same-name replacement at exactly 16 probes, and rejection of an oversized newly constructed Sandbox. Running the two rejection/fallback cases against the pre-fix implementation with a disposable Go overlay fails as expected.

Targeted auto-pause validation/merge, Claim option/completion, and Sandbox probe/pause tests also passed. `git diff --check` passes. The new Claim field schemas match the corresponding Sandbox schemas apart from their top-level descriptions.

### Ⅳ. Special notes for reviews

This is a one-time claim overlay; completed Claims do not manage their delivered Sandboxes. Existing pause/resume execution and its feature-gate behavior are unchanged, and E2B HTTP does not expose Claim probes.

The existing controller-to-sandbox-manager dependency is intentionally deferred, with a TODO to move claim orchestration into SandboxClaim core and keep shared primitives in a neutral package.
