### PR TITLE
chore(release): sync master into release-v0.6 (13 commits)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL'
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: 'trivy-results.sarif'
 

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -85,7 +85,7 @@ jobs:
           always() &&
           (github.event_name != 'pull_request' ||
            github.event.pull_request.head.repo.full_name == github.repository)
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: govulncheck.sarif
           category: govulncheck

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -58,7 +58,7 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif
           category: scorecard

--- a/.qoder/skills/sync-charts/SKILL.md
+++ b/.qoder/skills/sync-charts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-charts
-description: Use when syncing OpenKruise Agents controller or sandbox-manager manifests from config/ into the openkruise/charts next directories, or when investigating drift between those sources.
+description: Use when syncing OpenKruise Agents controller, sandbox-manager, or sandbox-gateway manifests from config/ into the openkruise/charts next directories, or when investigating drift between those sources.
 ---
 
 # Sync Agents Charts
@@ -10,7 +10,7 @@ Keep `config/` as the source of truth, but preserve Helm-only logic in the chart
 ## Boundaries
 
 - Work in a clean agents checkout and a clean charts checkout. Modify only `versions/kruise-agents-sandbox-{controller,manager}/next/**` in charts.
-- Do not edit `config/crd/`, `templates/agentio/crds.yaml`, a released version directory, `Chart.yaml`, `values.yaml`, or `charts/` pointer files.
+- Do not edit `config/crd/`, `templates/agentio/crds.yaml`, a released version directory, `Chart.yaml`, or `charts/` pointer files. Edit `values.yaml` only to update existing default values so source-defined behavior renders correctly; do not add new value keys or restructure values.
 - Copy CRDs byte-for-byte only. Splice RBAC and webhook entries into the existing Helm templates; preserve every `{{ ... }}`, conditional, chart-only resource, and extra permission unless the user approves its removal.
 - Manager has no webhook template. Do not create one.
 
@@ -71,6 +71,57 @@ python3 .qoder/skills/sync-charts/scripts/chart_drift.py \
 python3 .qoder/skills/sync-charts/scripts/chart_drift.py \
   --charts-repo "$CHARTS_REPO" --aspect crd
 ```
+
+## Deployment Manifests
+
+Run the read-only manifests checker. There is no apply mode for manifests; chart templates are always edited by hand:
+
+```bash
+python3 .qoder/skills/sync-charts/scripts/chart_drift.py \
+  --charts-repo "$CHARTS_REPO" --aspect manifests --component all
+```
+
+Narrow the scope with `--component controller|manager|gateway` or with `--kinds`, a comma-separated subset of `Service,ConfigMap,Ingress,Secret`:
+
+```bash
+python3 .qoder/skills/sync-charts/scripts/chart_drift.py \
+  --charts-repo "$CHARTS_REPO" --aspect manifests --component gateway
+python3 .qoder/skills/sync-charts/scripts/chart_drift.py \
+  --charts-repo "$CHARTS_REPO" --aspect manifests --kinds Service,ConfigMap
+```
+
+The checker renders each source overlay with kustomize (`./bin/kustomize`, falling back to `kubectl kustomize` when the binary is absent) and each mapped chart template with `helm template <release> <chart-dir> --namespace sandbox-system -s templates/<file>.yaml`; the manager chart additionally renders with `--set ingress.className=nginx --set e2b.adminApiKey=x`. The manager chart hosts both manager and gateway resources, and its `templates/service.yaml` is multi-document: document 0 is the manager Service and document 1 is the gateway Service.
+
+| Component | Source overlay | Kind | Source name | Chart template |
+| --- | --- | --- | --- | --- |
+| controller | `config/manager` | Service | `controller-manager-webhook-service` | controller `templates/service.yaml` |
+| manager | `config/sandbox-manager` | Service | `sandbox-manager` | manager `templates/service.yaml` |
+| manager | `config/sandbox-manager` | Ingress | `sandbox-manager` | manager `templates/ingress.yaml` |
+| manager | `config/sandbox-manager` | Secret | `e2b-key-store` | manager `templates/secret.yaml` |
+| manager | `config/sandbox-manager` | ConfigMap | `sandbox-manager-envoy-config` | manager `templates/envoy-config.yaml` |
+| gateway | `config/sandbox-gateway` | Service | `sandbox-gateway` | manager `templates/service.yaml` (document 1) |
+| gateway | `config/sandbox-gateway` | ConfigMap | `envoy-config` | manager `templates/gateway-envoy-config.yaml` |
+
+The comparison never checks `metadata.name` or `metadata.namespace`, and it ignores chart-managed metadata (`helm.sh/chart`, `helm.sh/resource-policy`, and the `app.kubernetes.io/{managed-by,instance,version,part-of,component}` labels). For value differences the checker also reads the raw chart template file and reports the finding as `TEMPLATED` when the affected field is rendered through a `{{ ... }}` expression or a `{{- range ... }}` block. Deployment manifests, Namespace templates, and the controller's `configuration` ConfigMap are out of scope by design: Deployments are not synchronized by this checker, the controller chart provides no configmap template, and namespaces belong to the deployment environment. RBAC, ServiceAccount, and webhook documents from the same overlays are handled by the webhook, RBAC, and identity sections instead and are silently skipped here.
+
+Output categories:
+
+- `OK` — every compared field is source-equivalent.
+- `DRIFT` — source-defined behavior is missing or different in the chart; hand-splice it into the template.
+- `TEMPLATED` — a value difference on a field the chart renders through a `{{ ... }}` template; resolve it by updating the existing `values.yaml` default so the template stays in place.
+- `HELM_ONLY` — chart-only content driven by chart values or Helm rendering (extra ports, extra labels); usually retain it.
+- `MISSING` — a mapped chart template file does not exist.
+- `UNMAPPED` — a source manifest of a managed kind in a rendered overlay has no mapping entry.
+
+Exit codes match the CRD aspect: `0` clean, `1` drift (including `TEMPLATED`) or missing, `2` configuration or render error, `3` unmapped source manifest.
+
+Sync policy when resolving a `DRIFT` or `TEMPLATED` finding in a chart template:
+
+- **Preserve chart-managed metadata, but add source-defined labels/annotations the chart does not already generate.** The checker ignores chart-managed labels/annotations (`helm.sh/chart`, `helm.sh/resource-policy`, and the `app.kubernetes.io/{managed-by,instance,version,part-of,component}` labels); every other source label/annotation must be present in the rendered chart. Add them after the chart helper block (for example, after `{{- include "sandbox-controller.labels" . | nindent 4 }}`) instead of replacing chart-generated labels. Do not copy `metadata.name`, `metadata.namespace`, or any chart-managed field.
+- **Keep `{{ ... }}` templates; fix values-driven drift by updating `values.yaml` defaults first.** When a DRIFT is caused by a chart value (for example, `.Values.controller.extProcMaxConcurrency`) rendering to a different value than the source, update the existing default in `values.yaml` so the template stays in place. Replace a template with a concrete source value only when no value-driven path exists and the source requires a specific literal.
+- **Match source order for indexed lists; append chart-only entries at the end.** The checker compares `Ingress` rules and `Service` ports by index. Reorder source-derived entries in the template to match the rendered source order, then append chart-only entries after them.
+
+Preserve every `{{ ... }}`, chart helper, conditional, and chart-only addition while applying a fix. `HELM_ONLY` findings describe intentional chart behavior; review them but do not delete chart content to silence them. `MISSING` and `UNMAPPED` are blockers, exactly like the CRD unmapped block: ask the user whether the charts should ship the affected resource, and add the explicit `MANIFEST_SPEC` mapping plus its test coverage in a separate reviewed skill change rather than deciding policy inside a chart-sync PR.
 
 ## Webhook and RBAC Splices
 
@@ -164,6 +215,8 @@ yamllint -c "$CHARTS_REPO/.github/configs/lintconf.yaml" \
 git -C "$CHARTS_REPO" status --short
 ```
 
-The checker verifies CRDs only; webhook parity requires the rendered comparison above and RBAC splices require manual source-to-template review. Identity resources require manual source-to-rendered review. The final checker run must report no `DRIFT` and exit `0`, which requires every source CRD to be mapped and byte-identical; any `UNMAPPED` exit `3` marks a blocking unmapped resource, not a successful sync.
+Before committing, review `git -C "$CHARTS_REPO" diff` for template regressions: a hunk that removes a `{{ ... }}` expression or a `{{- range ... }}` block and replaces it with literals violates the sync policy unless no value-driven path exists and the source requires a specific literal; restore the template and update the `values.yaml` default instead. The checker cannot catch this retroactively, because a hardcoded value that matches the source renders identically.
+
+The CRD and deployment-manifest checks are automated; webhook parity requires the rendered comparison above and RBAC splices require manual source-to-template review. Identity resources require manual source-to-rendered review. The final CRD checker run must report no `DRIFT` and exit `0`, which requires every source CRD to be mapped and byte-identical; any `UNMAPPED` exit `3` marks a blocking unmapped resource, not a successful sync. The final manifests run must report no `DRIFT`, `TEMPLATED`, `MISSING`, or `UNMAPPED`; `HELM_ONLY` findings may legitimately remain.
 
 Commit with sign-off and create a charts PR that states the agents source SHA, the initial/final drift output, and CRD-upgrade impact. Do not change chart versions or release pointers in this PR.

--- a/.qoder/skills/sync-charts/scripts/chart_drift.py
+++ b/.qoder/skills/sync-charts/scripts/chart_drift.py
@@ -1,14 +1,28 @@
 #!/usr/bin/env python3
-"""Check and optionally copy CRDs listed in config/crd/kustomization.yaml."""
+"""Check CRD and deployment-manifest drift between config/ and the charts checkout."""
 
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import shutil
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+
+import yaml
+
+
+CONTROLLER_OVERLAY = Path("config/manager")
+MANAGER_OVERLAY = Path("config/sandbox-manager")
+GATEWAY_OVERLAY = Path("config/sandbox-gateway")
+
+CONTROLLER_CHART = "kruise-agents-sandbox-controller"
+MANAGER_CHART = "kruise-agents-sandbox-manager"
+
+CHART_NAMESPACE = "sandbox-system"
 
 
 @dataclass(frozen=True)
@@ -69,6 +83,54 @@ CHART_SPEC = {
 }
 
 
+@dataclass(frozen=True)
+class ManifestTarget:
+    component: str
+    overlay: Path
+    kind: str
+    name: str
+    chart: str
+    template: Path
+    doc_index: int
+
+
+MANIFEST_SPEC = (
+    ManifestTarget("controller", CONTROLLER_OVERLAY, "Service", "controller-manager-webhook-service", CONTROLLER_CHART, Path("templates/service.yaml"), 0),
+    ManifestTarget("manager", MANAGER_OVERLAY, "Service", "sandbox-manager", MANAGER_CHART, Path("templates/service.yaml"), 0),
+    ManifestTarget("manager", MANAGER_OVERLAY, "Ingress", "sandbox-manager", MANAGER_CHART, Path("templates/ingress.yaml"), 0),
+    ManifestTarget("manager", MANAGER_OVERLAY, "Secret", "e2b-key-store", MANAGER_CHART, Path("templates/secret.yaml"), 0),
+    ManifestTarget("manager", MANAGER_OVERLAY, "ConfigMap", "sandbox-manager-envoy-config", MANAGER_CHART, Path("templates/envoy-config.yaml"), 0),
+    ManifestTarget("gateway", GATEWAY_OVERLAY, "Service", "sandbox-gateway", MANAGER_CHART, Path("templates/service.yaml"), 1),
+    ManifestTarget("gateway", GATEWAY_OVERLAY, "ConfigMap", "envoy-config", MANAGER_CHART, Path("templates/gateway-envoy-config.yaml"), 0),
+)
+
+OVERLAY_COMPONENTS = {
+    CONTROLLER_OVERLAY: "controller",
+    MANAGER_OVERLAY: "manager",
+    GATEWAY_OVERLAY: "gateway",
+}
+
+MANAGED_KINDS = frozenset({"Service", "ConfigMap", "Ingress", "Secret"})
+EXCLUDED_SOURCES = frozenset({("controller", "ConfigMap", "configuration")})
+
+CHART_RELEASES = {
+    CONTROLLER_CHART: ("sandbox-controller", ()),
+    MANAGER_CHART: ("sandbox-manager", ("ingress.className=nginx", "e2b.adminApiKey=x")),
+}
+
+CHART_MANAGED_LABELS = frozenset(
+    {
+        "helm.sh/chart",
+        "app.kubernetes.io/managed-by",
+        "app.kubernetes.io/instance",
+        "app.kubernetes.io/version",
+        "app.kubernetes.io/part-of",
+        "app.kubernetes.io/component",
+    }
+)
+CHART_MANAGED_ANNOTATIONS = frozenset({"helm.sh/resource-policy"})
+
+
 class ConfigurationError(Exception):
     pass
 
@@ -97,6 +159,8 @@ def resources(kustomization: Path) -> list[Path]:
 
 
 def synchronize(args: argparse.Namespace) -> int:
+    if args.component == "gateway":
+        raise ConfigurationError("--component gateway is only valid with --aspect manifests")
     if not args.charts_repo.is_dir():
         raise ConfigurationError(f"missing charts checkout: {args.charts_repo}")
     if not (args.charts_repo / "versions").is_dir():
@@ -145,20 +209,463 @@ def synchronize(args: argparse.Namespace) -> int:
     return 1 if has_drift else 0
 
 
+def run_command(command: list[str], cwd: Path) -> str:
+    try:
+        result = subprocess.run(command, cwd=cwd, capture_output=True, text=True)
+    except OSError as error:
+        raise ConfigurationError(f"cannot execute {command[0]}: {error}") from error
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip().splitlines()
+        raise ConfigurationError(f"command failed: {' '.join(command)}: {detail[0] if detail else 'unknown error'}")
+    return result.stdout
+
+
+def parse_docs(text: str) -> list[dict]:
+    return [doc for doc in yaml.safe_load_all(text) if isinstance(doc, dict)]
+
+
+def render_source(agents_repo: Path, overlay: Path) -> list[dict]:
+    kustomize = agents_repo / "bin" / "kustomize"
+    if kustomize.is_file():
+        command = [str(kustomize), "build", str(overlay)]
+    else:
+        command = ["kubectl", "kustomize", str(overlay)]
+    return parse_docs(run_command(command, agents_repo))
+
+
+def render_chart(charts_repo: Path, chart: str, template: Path) -> list[dict]:
+    release, settings = CHART_RELEASES[chart]
+    chart_dir = charts_repo / "versions" / chart / "next"
+    command = ["helm", "template", release, str(chart_dir), "--namespace", CHART_NAMESPACE, "-s", str(template)]
+    for setting in settings:
+        command += ["--set", setting]
+    return parse_docs(run_command(command, charts_repo))
+
+
+def check_manifests(args: argparse.Namespace) -> int:
+    agents_repo = args.agents_repo.resolve()
+    charts_repo = args.charts_repo.resolve()
+    if not charts_repo.is_dir():
+        raise ConfigurationError(f"missing charts checkout: {charts_repo}")
+    for chart in (CONTROLLER_CHART, MANAGER_CHART):
+        chart_dir = charts_repo / "versions" / chart / "next"
+        if not chart_dir.is_dir():
+            raise ConfigurationError(f"missing chart directory: {chart_dir}")
+
+    components = {"controller", "manager", "gateway"} if args.component == "all" else {args.component}
+    kinds = args.kinds
+    targets = [
+        target
+        for target in MANIFEST_SPEC
+        if target.component in components and (kinds is None or target.kind in kinds)
+    ]
+
+    source_docs: dict[Path, dict[tuple[str, str], dict]] = {}
+    overlays = {target.overlay for target in MANIFEST_SPEC if OVERLAY_COMPONENTS[target.overlay] in components}
+    for overlay in overlays:
+        docs = render_source(agents_repo, overlay)
+        source_docs[overlay] = {(doc.get("kind"), (doc.get("metadata") or {}).get("name")): doc for doc in docs}
+
+    has_drift = False
+    has_unmapped = False
+    chart_renders: dict[tuple[str, Path], list[dict]] = {}
+    template_texts: dict[tuple[str, Path], str] = {}
+
+    for target in targets:
+        source = source_docs[target.overlay].get((target.kind, target.name))
+        if source is None:
+            print(f"DRIFT manifests {target.component} {target.kind}/{target.name}: not found in rendered source {target.overlay}")
+            has_drift = True
+            continue
+        if not (charts_repo / "versions" / target.chart / "next" / target.template).is_file():
+            print(f"MISSING manifests {target.component} {target.kind}/{target.name}: {target.template} not found")
+            has_drift = True
+            continue
+        key = (target.chart, target.template)
+        if key not in chart_renders:
+            chart_renders[key] = render_chart(charts_repo, target.chart, target.template)
+        docs = chart_renders[key]
+        if target.doc_index >= len(docs):
+            print(
+                f"DRIFT manifests {target.component} {target.kind}/{target.name}: "
+                f"{target.template} renders {len(docs)} document(s), expected index {target.doc_index}"
+            )
+            has_drift = True
+            continue
+        chart = docs[target.doc_index]
+        if chart.get("kind") != target.kind:
+            print(
+                f"DRIFT manifests {target.component} {target.kind}/{target.name}: "
+                f"{target.template}[{target.doc_index}] renders {chart.get('kind')}"
+            )
+            has_drift = True
+            continue
+        findings = compare_manifest(source, chart)
+        if key not in template_texts:
+            template_texts[key] = (charts_repo / "versions" / target.chart / "next" / target.template).read_text(
+                encoding="utf-8"
+            )
+        mark_templated(findings, template_texts[key])
+        if any(finding.category in ("DRIFT", "TEMPLATED") for finding in findings):
+            has_drift = True
+        if findings:
+            for finding in findings:
+                detail = shorten(f"{finding.path} {finding.detail}")
+                print(f"{finding.category} manifests {target.component} {target.kind}/{target.name}: {detail}")
+        else:
+            print(f"OK manifests {target.component} {target.kind}/{target.name}")
+
+    for component in sorted(components):
+        overlay = next(key for key, value in OVERLAY_COMPONENTS.items() if value == component)
+        for kind, name in source_docs[overlay]:
+            if kinds is not None and kind not in kinds:
+                continue
+            if kind not in MANAGED_KINDS:
+                continue
+            if (component, kind, name) in EXCLUDED_SOURCES:
+                continue
+            if not any(
+                target.component == component and target.kind == kind and target.name == name
+                for target in MANIFEST_SPEC
+            ):
+                print(f"UNMAPPED manifests {component} {kind}/{name}")
+                has_unmapped = True
+
+    if has_unmapped:
+        return 3
+    return 1 if has_drift else 0
+
+
+def shorten(detail: str, limit: int = 200) -> str:
+    detail = " ".join(detail.split())
+    return detail if len(detail) <= limit else detail[: limit - 3] + "..."
+
+
+@dataclass
+class Finding:
+    category: str
+    path: str
+    detail: str
+
+
+def compare_manifest(source: dict, chart: dict) -> list[Finding]:
+    findings: list[Finding] = []
+    compare_metadata(source, chart, findings)
+    comparators = {
+        "Service": compare_service,
+        "ConfigMap": compare_configmap,
+        "Ingress": compare_ingress,
+        "Secret": compare_secret,
+    }
+    comparators[source.get("kind", "")](source, chart, findings)
+    return findings
+
+
+def leaf_key(path: str) -> str:
+    key = path.rsplit(".", 1)[-1]
+    return key.split("[", 1)[0].strip()
+
+
+def is_value_difference(detail: str) -> bool:
+    return " != chart " in detail or detail == "source and chart differ" or detail.startswith("source item ")
+
+
+def template_renders_key(template_text: str, key: str) -> bool:
+    direct = re.search(r"^[ \t]*" + re.escape(key) + r"[ \t]*:[^\n]*\{\{", template_text, re.MULTILINE)
+    if direct:
+        return True
+    return re.search(r"\{\{-?[ \t]*range[^\n]*\." + re.escape(key) + r"[ \t]*-?\}\}", template_text) is not None
+
+
+def mark_templated(findings: list[Finding], template_text: str) -> None:
+    for finding in findings:
+        if finding.category != "DRIFT" or not is_value_difference(finding.detail):
+            continue
+        if not template_renders_key(template_text, leaf_key(finding.path)):
+            continue
+        finding.category = "TEMPLATED"
+        finding.detail += "; chart renders this field through a template"
+
+
+def compare_metadata(source: dict, chart: dict, findings: list[Finding]) -> None:
+    source_meta = source.get("metadata") or {}
+    chart_meta = chart.get("metadata") or {}
+    for field, managed in (("labels", CHART_MANAGED_LABELS), ("annotations", CHART_MANAGED_ANNOTATIONS)):
+        source_map = {key: value for key, value in (source_meta.get(field) or {}).items() if key not in managed}
+        chart_map = {key: value for key, value in (chart_meta.get(field) or {}).items() if key not in managed}
+        compare_mapping(source_map, chart_map, f"metadata.{field}", findings)
+
+
+def compare_mapping(source_map: dict, chart_map: dict, path: str, findings: list[Finding]) -> None:
+    for key, value in source_map.items():
+        if key not in chart_map:
+            findings.append(Finding("DRIFT", f"{path}.{key}", "missing in chart"))
+        elif chart_map[key] != value:
+            findings.append(Finding("DRIFT", f"{path}.{key}", f"source {value!r} != chart {chart_map[key]!r}"))
+    for key in chart_map:
+        if key not in source_map:
+            findings.append(Finding("HELM_ONLY", f"{path}.{key}", "chart-only"))
+
+
+def compare_structured(source, chart, path: str, findings: list[Finding], helm_only_keys: frozenset[str] = frozenset()) -> None:
+    if isinstance(source, dict) and isinstance(chart, dict):
+        for key, value in source.items():
+            if key in helm_only_keys:
+                if key not in chart or chart[key] != value:
+                    findings.append(Finding("HELM_ONLY", f"{path}.{key}", "helm-managed field differs"))
+                continue
+            if key not in chart:
+                findings.append(Finding("DRIFT", f"{path}.{key}", "missing in chart"))
+            else:
+                compare_structured(value, chart[key], f"{path}.{key}", findings, helm_only_keys)
+        for key in chart:
+            if key not in source:
+                if key in helm_only_keys:
+                    findings.append(Finding("HELM_ONLY", f"{path}.{key}", "chart-only, helm-managed"))
+                else:
+                    findings.append(Finding("HELM_ONLY", f"{path}.{key}", "chart-only"))
+    elif isinstance(source, list) and isinstance(chart, list):
+        source_items = _named_items(source)
+        chart_items = _named_items(chart)
+        if source_items is not None and chart_items is not None:
+            for key, value in source_items.items():
+                if key not in chart_items:
+                    findings.append(Finding("DRIFT", f"{path}[name={key}]", "missing in chart"))
+                else:
+                    compare_structured(value, chart_items[key], f"{path}[name={key}]", findings, helm_only_keys)
+            for key in chart_items:
+                if key not in source_items:
+                    findings.append(Finding("HELM_ONLY", f"{path}[name={key}]", "chart-only"))
+        else:
+            source_values = [_canonical(item) for item in source]
+            chart_values = [_canonical(item) for item in chart]
+            for value in source_values:
+                if value not in chart_values:
+                    findings.append(Finding("DRIFT", path, f"source item {value} missing in chart"))
+            for value in chart_values:
+                if value not in source_values:
+                    findings.append(Finding("HELM_ONLY", path, f"chart-only item {value}"))
+    elif source != chart:
+        findings.append(Finding("DRIFT", path, f"source {source!r} != chart {chart!r}"))
+
+
+def _named_items(items: list) -> dict | None:
+    if not items or not all(isinstance(item, dict) and "name" in item for item in items):
+        return None
+    return {item["name"]: item for item in items}
+
+
+def _canonical(value) -> str:
+    return json.dumps(value, sort_keys=True, default=str)
+
+
+def compare_service(source: dict, chart: dict, findings: list[Finding]) -> None:
+    source_spec = source.get("spec") or {}
+    chart_spec = chart.get("spec") or {}
+    if "type" in source_spec and source_spec.get("type") != chart_spec.get("type"):
+        findings.append(
+            Finding("DRIFT", "spec.type", f"source {source_spec.get('type')!r} != chart {chart_spec.get('type')!r}")
+        )
+    source_ports = source_spec.get("ports") or []
+    chart_ports = chart_spec.get("ports") or []
+    for index, port in enumerate(source_ports):
+        if index >= len(chart_ports):
+            findings.append(Finding("DRIFT", f"spec.ports[{index}]", "missing in chart"))
+            break
+        match = chart_ports[index]
+        for field in ("port", "targetPort"):
+            if port.get(field) is not None and port.get(field) != match.get(field):
+                findings.append(
+                    Finding(
+                        "DRIFT",
+                        f"spec.ports[{index}].{field}",
+                        f"source {port.get(field)!r} != chart {match.get(field)!r}",
+                    )
+                )
+        source_protocol = port.get("protocol") or "TCP"
+        chart_protocol = match.get("protocol") or "TCP"
+        if source_protocol != chart_protocol:
+            findings.append(
+                Finding(
+                    "DRIFT",
+                    f"spec.ports[{index}].protocol",
+                    f"source {source_protocol!r} != chart {chart_protocol!r}",
+                )
+            )
+    for index in range(len(source_ports), len(chart_ports)):
+        number = chart_ports[index].get("port")
+        findings.append(Finding("HELM_ONLY", f"spec.ports[{index}]", f"chart-only port {number}"))
+
+
+def compare_configmap(source: dict, chart: dict, findings: list[Finding]) -> None:
+    source_data = source.get("data") or {}
+    chart_data = chart.get("data") or {}
+    for key, value in source_data.items():
+        if key not in chart_data:
+            findings.append(Finding("DRIFT", f"data.{key}", "missing in chart"))
+            continue
+        compare_data_value(f"data.{key}", value, chart_data[key], findings)
+    for key in chart_data:
+        if key not in source_data:
+            findings.append(Finding("HELM_ONLY", f"data.{key}", "chart-only key"))
+
+
+def compare_data_value(path: str, source_value, chart_value, findings: list[Finding]) -> None:
+    if isinstance(source_value, str) and isinstance(chart_value, str):
+        source_parsed = _maybe_yaml(source_value)
+        chart_parsed = _maybe_yaml(chart_value)
+        if (
+            source_parsed is not None
+            and chart_parsed is not None
+            and not isinstance(source_parsed, str)
+            and not isinstance(chart_parsed, str)
+        ):
+            compare_structured(source_parsed, chart_parsed, path, findings)
+            return
+    if source_value != chart_value:
+        findings.append(Finding("DRIFT", path, "source and chart differ"))
+
+
+def _maybe_yaml(text: str):
+    try:
+        return yaml.safe_load(text)
+    except yaml.YAMLError:
+        return None
+
+
+def compare_ingress(source: dict, chart: dict, findings: list[Finding]) -> None:
+    source_spec = source.get("spec") or {}
+    chart_spec = chart.get("spec") or {}
+    if "ingressClassName" in source_spec and source_spec.get("ingressClassName") != chart_spec.get("ingressClassName"):
+        findings.append(
+            Finding(
+                "DRIFT",
+                "spec.ingressClassName",
+                f"source {source_spec.get('ingressClassName')!r} != chart {chart_spec.get('ingressClassName')!r}",
+            )
+        )
+    source_tls = source_spec.get("tls") or []
+    chart_tls = chart_spec.get("tls") or []
+    source_secret_names = {entry.get("secretName") for entry in source_tls if isinstance(entry, dict)}
+    chart_secret_names = {entry.get("secretName") for entry in chart_tls if isinstance(entry, dict)}
+    for secret_name in sorted(name for name in source_secret_names if name is not None):
+        if secret_name not in chart_secret_names:
+            findings.append(Finding("DRIFT", f"spec.tls[{secret_name}]", "missing in chart"))
+    for secret_name in sorted(name for name in chart_secret_names if name is not None):
+        if secret_name not in source_secret_names:
+            findings.append(Finding("HELM_ONLY", f"spec.tls[{secret_name}]", "chart-only"))
+
+    source_rules = source_spec.get("rules") or []
+    chart_rules = chart_spec.get("rules") or []
+    for index, rule in enumerate(source_rules):
+        if index >= len(chart_rules):
+            findings.append(Finding("DRIFT", f"spec.rules[{index}]", "missing in chart"))
+            break
+        source_paths = (rule.get("http") or {}).get("paths") or []
+        chart_paths = (chart_rules[index].get("http") or {}).get("paths") or []
+        for path_index, source_path in enumerate(source_paths):
+            if path_index >= len(chart_paths):
+                findings.append(Finding("DRIFT", f"spec.rules[{index}].http.paths[{path_index}]", "missing in chart"))
+                break
+            chart_path = chart_paths[path_index]
+            for field in ("path", "pathType"):
+                if source_path.get(field) is not None and source_path.get(field) != chart_path.get(field):
+                    findings.append(
+                        Finding(
+                            "DRIFT",
+                            f"spec.rules[{index}].http.paths[{path_index}].{field}",
+                            f"source {source_path.get(field)!r} != chart {chart_path.get(field)!r}",
+                        )
+                    )
+            source_backend = (source_path.get("backend") or {}).get("service") or {}
+            chart_backend = (chart_path.get("backend") or {}).get("service") or {}
+            source_port = (source_backend.get("port") or {}).get("number")
+            chart_port = (chart_backend.get("port") or {}).get("number")
+            if source_port is not None and source_port != chart_port:
+                findings.append(
+                    Finding(
+                        "DRIFT",
+                        f"spec.rules[{index}].http.paths[{path_index}].backend.service.port.number",
+                        f"source {source_port!r} != chart {chart_port!r}",
+                    )
+                )
+            if source_backend.get("name") is not None and source_backend.get("name") != chart_backend.get("name"):
+                findings.append(
+                    Finding(
+                        "DRIFT",
+                        f"spec.rules[{index}].http.paths[{path_index}].backend.service.name",
+                        f"source {source_backend.get('name')!r} != chart {chart_backend.get('name')!r}",
+                    )
+                )
+        for path_index in range(len(source_paths), len(chart_paths)):
+            findings.append(Finding("HELM_ONLY", f"spec.rules[{index}].http.paths[{path_index}]", "chart-only path"))
+    if len(chart_rules) > len(source_rules):
+        findings.append(
+            Finding("HELM_ONLY", f"spec.rules[{len(source_rules)}:]", f"{len(chart_rules) - len(source_rules)} chart-only rule(s)")
+        )
+
+
+def compare_secret(source: dict, chart: dict, findings: list[Finding]) -> None:
+    if source.get("type") is not None and source.get("type") != chart.get("type"):
+        findings.append(Finding("DRIFT", "type", f"source {source.get('type')!r} != chart {chart.get('type')!r}"))
+    source_data = source.get("data") or {}
+    chart_data = chart.get("data") or {}
+    source_string = source.get("stringData") or {}
+    chart_string = chart.get("stringData") or {}
+    if not source_data and not source_string:
+        if chart_data or chart_string:
+            findings.append(Finding("DRIFT", "data", "source secret is empty but chart renders data"))
+        return
+    for key, value in source_data.items():
+        if key not in chart_data:
+            findings.append(Finding("DRIFT", f"data.{key}", "missing in chart"))
+        elif chart_data[key] != value:
+            findings.append(Finding("DRIFT", f"data.{key}", "source and chart differ"))
+    for key in chart_data:
+        if key not in source_data:
+            findings.append(Finding("HELM_ONLY", f"data.{key}", "chart-only key"))
+    for key, value in source_string.items():
+        if key not in chart_string:
+            findings.append(Finding("DRIFT", f"stringData.{key}", "missing in chart"))
+        elif chart_string[key] != value:
+            findings.append(Finding("DRIFT", f"stringData.{key}", "source and chart differ"))
+    for key in chart_string:
+        if key not in source_string:
+            findings.append(Finding("HELM_ONLY", f"stringData.{key}", "chart-only key"))
+
+
+def parse_kinds(value: str) -> frozenset[str]:
+    kinds = frozenset(kind.strip() for kind in value.split(",") if kind.strip())
+    if not kinds:
+        raise argparse.ArgumentTypeError("no kinds provided")
+    unknown = kinds - MANAGED_KINDS
+    if unknown:
+        raise argparse.ArgumentTypeError(f"unsupported kinds: {', '.join(sorted(unknown))}")
+    return kinds
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--agents-repo", type=Path, default=Path.cwd())
     parser.add_argument("--charts-repo", type=Path, required=True)
-    parser.add_argument("--component", choices=("all", "controller", "manager"), default="all")
-    parser.add_argument("--aspect", choices=("crd",), default="crd")
+    parser.add_argument("--component", choices=("all", "controller", "manager", "gateway"), default="all")
+    parser.add_argument("--aspect", choices=("crd", "manifests"), default="crd")
+    parser.add_argument("--kinds", type=parse_kinds, default=None, help="comma-separated kinds to check (manifests aspect only)")
     parser.add_argument("--target", choices=("next",), default="next")
     parser.add_argument("--apply-crds", action="store_true")
     return parser.parse_args()
 
 
 def main() -> int:
+    args = parse_args()
     try:
-        return synchronize(parse_args())
+        if args.aspect == "manifests":
+            if args.apply_crds:
+                raise ConfigurationError("--apply-crds is only valid with --aspect crd")
+            return check_manifests(args)
+        if args.kinds is not None:
+            raise ConfigurationError("--kinds is only valid with --aspect manifests")
+        return synchronize(args)
     except ConfigurationError as error:
         print(f"ERROR {error}", file=sys.stderr)
         return 2

--- a/.qoder/skills/sync-charts/tests/test_chart_drift.py
+++ b/.qoder/skills/sync-charts/tests/test_chart_drift.py
@@ -3,11 +3,15 @@
 
 from __future__ import annotations
 
+import copy
+import os
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+
+import yaml
 
 
 SKILL_DIR = Path(__file__).resolve().parents[1]
@@ -468,6 +472,533 @@ class ChartDriftTest(unittest.TestCase):
         ):
             with self.subTest(source=source):
                 self.assertIn(source, content)
+
+
+FAKE_KUSTOMIZE = """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+overlay = Path(sys.argv[2]).name
+fixtures = Path(os.environ["FAKE_KUSTOMIZE_FIXTURES"])
+sys.stdout.write((fixtures / (overlay + ".yaml")).read_text(encoding="utf-8"))
+"""
+
+FAKE_HELM = """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+template = Path(args[args.index("-s") + 1]).name
+chart = Path(args[2]).parent.name
+fixtures = Path(os.environ["FAKE_HELM_FIXTURES"])
+sys.stdout.write((fixtures / chart / template).read_text(encoding="utf-8"))
+"""
+
+CHART_LABELS = {
+    "helm.sh/chart": "sandbox-0.1.0",
+    "app.kubernetes.io/managed-by": "Helm",
+    "app.kubernetes.io/instance": "sandbox",
+    "app.kubernetes.io/version": "0.1.0",
+}
+
+CONTROLLER_CHART_NAME = "kruise-agents-sandbox-controller"
+MANAGER_CHART_NAME = "kruise-agents-sandbox-manager"
+
+
+def controller_source_docs() -> list[dict]:
+    return [
+        {
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": {"name": "sandbox-system"},
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "configuration"},
+            "data": {"controller_manager_env.yaml": "ENABLE_WEBHOOKS: true"},
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "ServiceAccount",
+            "metadata": {"name": "controller-manager"},
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": "controller-manager-webhook-service",
+                "labels": {"control-plane": "controller-manager"},
+            },
+            "spec": {
+                "type": "ClusterIP",
+                "ports": [
+                    {"port": 443, "targetPort": 9443, "protocol": "TCP", "name": "webhook"}
+                ],
+            },
+        },
+    ]
+
+
+def manager_source_docs() -> list[dict]:
+    return [
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {"name": "sandbox-manager"},
+            "spec": {
+                "type": "ClusterIP",
+                "ports": [{"port": 7788, "targetPort": 7788, "name": "http-envoy"}],
+            },
+        },
+        {
+            "apiVersion": "networking.k8s.io/v1",
+            "kind": "Ingress",
+            "metadata": {"name": "sandbox-manager"},
+            "spec": {
+                "ingressClassName": "nginx",
+                "tls": [{"hosts": ["example.com"], "secretName": "sandbox-manager-tls"}],
+                "rules": [
+                    {
+                        "host": "example.com",
+                        "http": {
+                            "paths": [
+                                {
+                                    "path": "/",
+                                    "pathType": "Prefix",
+                                    "backend": {
+                                        "service": {
+                                            "name": "sandbox-manager",
+                                            "port": {"number": 7788},
+                                        }
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                ],
+            },
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {"name": "e2b-key-store"},
+            "type": "Opaque",
+            "data": {},
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "sandbox-manager-envoy-config"},
+            "data": {
+                "envoy.yaml": (
+                    "admin:\n"
+                    "  address:\n"
+                    "    socket_address:\n"
+                    "      port_value: 9901\n"
+                )
+            },
+        },
+    ]
+
+
+def gateway_source_docs() -> list[dict]:
+    return [
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {"name": "sandbox-gateway"},
+            "spec": {
+                "type": "ClusterIP",
+                "ports": [{"port": 80, "targetPort": 8081, "name": "http"}],
+            },
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "envoy-config"},
+            "data": {
+                "envoy.yaml": "static_resources:\n  listeners:\n    - name: http\n"
+            },
+        },
+    ]
+
+
+def default_source_docs() -> dict[str, list[dict]]:
+    return {
+        "manager": controller_source_docs(),
+        "sandbox-manager": manager_source_docs(),
+        "sandbox-gateway": gateway_source_docs(),
+    }
+
+
+def chart_doc(source_doc: dict) -> dict:
+    doc = copy.deepcopy(source_doc)
+    metadata = dict(doc.get("metadata") or {})
+    metadata["labels"] = {**(metadata.get("labels") or {}), **CHART_LABELS}
+    if doc.get("kind") == "Secret":
+        metadata["annotations"] = {
+            **(metadata.get("annotations") or {}),
+            "helm.sh/resource-policy": "keep",
+        }
+    doc["metadata"] = metadata
+    return doc
+
+
+def default_chart_docs() -> dict[tuple[str, str], list[dict]]:
+    controller = {doc["kind"]: doc for doc in controller_source_docs()}
+    manager = {doc["kind"]: doc for doc in manager_source_docs()}
+    gateway = {doc["kind"]: doc for doc in gateway_source_docs()}
+    return {
+        (CONTROLLER_CHART_NAME, "service.yaml"): [chart_doc(controller["Service"])],
+        (MANAGER_CHART_NAME, "service.yaml"): [
+            chart_doc(manager["Service"]),
+            chart_doc(gateway["Service"]),
+        ],
+        (MANAGER_CHART_NAME, "ingress.yaml"): [chart_doc(manager["Ingress"])],
+        (MANAGER_CHART_NAME, "secret.yaml"): [chart_doc(manager["Secret"])],
+        (MANAGER_CHART_NAME, "envoy-config.yaml"): [chart_doc(manager["ConfigMap"])],
+        (MANAGER_CHART_NAME, "gateway-envoy-config.yaml"): [chart_doc(gateway["ConfigMap"])],
+    }
+
+
+def dump_docs(docs: list[dict]) -> str:
+    return yaml.safe_dump_all(docs, sort_keys=False, default_flow_style=False)
+
+
+class ManifestDriftTest(unittest.TestCase):
+    def setUp(self) -> None:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        self.root = Path(temp.name)
+        self.agents_repo = self.root / "agents"
+        self.charts_repo = self.root / "charts"
+
+    def write_source_fixtures(self, overlay_docs: dict[str, list[dict]]) -> None:
+        fixtures = self.agents_repo / ".kustomize-fixtures"
+        for overlay, docs in overlay_docs.items():
+            fixtures.mkdir(parents=True, exist_ok=True)
+            (fixtures / f"{overlay}.yaml").write_text(dump_docs(docs), encoding="utf-8")
+        kustomize = self.agents_repo / "bin" / "kustomize"
+        kustomize.parent.mkdir(parents=True, exist_ok=True)
+        kustomize.write_text(FAKE_KUSTOMIZE, encoding="utf-8")
+        kustomize.chmod(0o755)
+
+    def write_chart_fixtures(
+        self,
+        chart_docs: dict[tuple[str, str], list[dict]],
+        template_sources: dict[tuple[str, str], str] | None = None,
+    ) -> None:
+        for (chart, template), docs in chart_docs.items():
+            fixture = self.root / ".helm-fixtures" / chart / template
+            fixture.parent.mkdir(parents=True, exist_ok=True)
+            fixture.write_text(dump_docs(docs), encoding="utf-8")
+            template_file = self.charts_repo / "versions" / chart / "next" / "templates" / template
+            template_file.parent.mkdir(parents=True, exist_ok=True)
+            content = (template_sources or {}).get((chart, template), "# chart template source\n")
+            template_file.write_text(content, encoding="utf-8")
+        helm = self.root / "fakebin" / "helm"
+        helm.parent.mkdir(parents=True, exist_ok=True)
+        helm.write_text(FAKE_HELM, encoding="utf-8")
+        helm.chmod(0o755)
+
+    def run_checker(self, *args: str) -> subprocess.CompletedProcess:
+        env = {
+            **os.environ,
+            "PATH": f"{self.root / 'fakebin'}{os.pathsep}{os.environ['PATH']}",
+            "FAKE_KUSTOMIZE_FIXTURES": str(self.agents_repo / ".kustomize-fixtures"),
+            "FAKE_HELM_FIXTURES": str(self.root / ".helm-fixtures"),
+        }
+        return subprocess.run(
+            [
+                sys.executable,
+                str(CHECKER),
+                "--agents-repo",
+                str(self.agents_repo),
+                "--charts-repo",
+                str(self.charts_repo),
+                *args,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def run_manifests_checker(self, *extra_args: str) -> subprocess.CompletedProcess:
+        return self.run_checker("--aspect", "manifests", *extra_args)
+
+    def test_reports_every_mapped_manifest_clean_ignoring_skipped_documents(self) -> None:
+        self.write_source_fixtures(default_source_docs())
+        self.write_chart_fixtures(default_chart_docs())
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for line in (
+            "OK manifests controller Service/controller-manager-webhook-service",
+            "OK manifests manager Service/sandbox-manager",
+            "OK manifests manager Ingress/sandbox-manager",
+            "OK manifests manager Secret/e2b-key-store",
+            "OK manifests manager ConfigMap/sandbox-manager-envoy-config",
+            "OK manifests gateway Service/sandbox-gateway",
+            "OK manifests gateway ConfigMap/envoy-config",
+        ):
+            with self.subTest(line=line):
+                self.assertIn(line, result.stdout)
+        self.assertNotIn("UNMAPPED", result.stdout)
+        self.assertNotIn("Namespace", result.stdout)
+        self.assertNotIn("configuration", result.stdout)
+
+    def test_reports_missing_chart_template(self) -> None:
+        chart_docs = default_chart_docs()
+        del chart_docs[(MANAGER_CHART_NAME, "secret.yaml")]
+        self.write_source_fixtures(default_source_docs())
+        self.write_chart_fixtures(chart_docs)
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertIn(
+            "MISSING manifests manager Secret/e2b-key-store: templates/secret.yaml not found",
+            result.stdout,
+        )
+
+    def test_reports_unmapped_source_manifest(self) -> None:
+        source_docs = default_source_docs()
+        source_docs["sandbox-manager"].append(
+            {"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "sandbox-manager-extra"}}
+        )
+        self.write_source_fixtures(source_docs)
+        self.write_chart_fixtures(default_chart_docs())
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 3, result.stderr)
+        self.assertIn("UNMAPPED manifests manager ConfigMap/sandbox-manager-extra", result.stdout)
+
+    def test_reports_chart_only_port_as_helm_only(self) -> None:
+        chart_docs = default_chart_docs()
+        manager_service = chart_docs[(MANAGER_CHART_NAME, "service.yaml")][0]
+        manager_service["spec"]["ports"].append(
+            {"port": 9002, "targetPort": 9002, "name": "grpc-extproc", "protocol": "TCP"}
+        )
+        self.write_source_fixtures(default_source_docs())
+        self.write_chart_fixtures(chart_docs)
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "HELM_ONLY manifests manager Service/sandbox-manager: spec.ports[1] chart-only port 9002",
+            result.stdout,
+        )
+        self.assertNotIn("DRIFT manifests", result.stdout)
+
+    def test_marks_value_difference_on_templated_field_as_templated(self) -> None:
+        chart_docs = default_chart_docs()
+        manager_envoy = chart_docs[(MANAGER_CHART_NAME, "envoy-config.yaml")][0]
+        manager_envoy["data"]["envoy.yaml"] = (
+            "admin:\n"
+            "  address:\n"
+            "    socket_address:\n"
+            "      port_value: 9902\n"
+        )
+        template_sources = {
+            (
+                MANAGER_CHART_NAME,
+                "envoy-config.yaml",
+            ): "admin:\n  address:\n    socket_address:\n      port_value: {{ .Values.envoy.adminPort }}\n"
+        }
+        self.write_source_fixtures(default_source_docs())
+        self.write_chart_fixtures(chart_docs, template_sources)
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertIn(
+            "TEMPLATED manifests manager ConfigMap/sandbox-manager-envoy-config: "
+            "data.envoy.yaml.admin.address.socket_address.port_value source 9901 != chart 9902",
+            result.stdout,
+        )
+        self.assertIn("chart renders this field through a template", result.stdout)
+        self.assertNotIn("DRIFT manifests", result.stdout)
+
+    def test_keeps_plain_drift_when_template_is_literal(self) -> None:
+        chart_docs = default_chart_docs()
+        manager_envoy = chart_docs[(MANAGER_CHART_NAME, "envoy-config.yaml")][0]
+        manager_envoy["data"]["envoy.yaml"] = (
+            "admin:\n"
+            "  address:\n"
+            "    socket_address:\n"
+            "      port_value: 9902\n"
+        )
+        template_sources = {
+            (
+                MANAGER_CHART_NAME,
+                "envoy-config.yaml",
+            ): "admin:\n  address:\n    socket_address:\n      port_value: 9902\n"
+        }
+        self.write_source_fixtures(default_source_docs())
+        self.write_chart_fixtures(chart_docs, template_sources)
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertIn(
+            "DRIFT manifests manager ConfigMap/sandbox-manager-envoy-config: "
+            "data.envoy.yaml.admin.address.socket_address.port_value source 9901 != chart 9902",
+            result.stdout,
+        )
+        self.assertNotIn("TEMPLATED", result.stdout)
+        self.assertNotIn("chart renders this field through a template", result.stdout)
+
+    def test_keeps_missing_field_as_drift_even_when_templated(self) -> None:
+        chart_docs = default_chart_docs()
+        manager_envoy = chart_docs[(MANAGER_CHART_NAME, "envoy-config.yaml")][0]
+        manager_envoy["data"]["envoy.yaml"] = "admin:\n  address:\n    socket_address: {}\n"
+        template_sources = {
+            (
+                MANAGER_CHART_NAME,
+                "envoy-config.yaml",
+            ): "admin:\n  address:\n    socket_address:\n      port_value: {{ .Values.envoy.adminPort }}\n"
+        }
+        self.write_source_fixtures(default_source_docs())
+        self.write_chart_fixtures(chart_docs, template_sources)
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertIn(
+            "DRIFT manifests manager ConfigMap/sandbox-manager-envoy-config: "
+            "data.envoy.yaml.admin.address.socket_address.port_value missing in chart",
+            result.stdout,
+        )
+        self.assertNotIn("TEMPLATED", result.stdout)
+
+    def test_marks_range_templated_list_difference_as_templated(self) -> None:
+        source_docs = default_source_docs()
+        gateway_envoy = next(
+            doc
+            for doc in source_docs["sandbox-gateway"]
+            if doc.get("metadata", {}).get("name") == "envoy-config"
+        )
+        gateway_envoy["data"]["envoy.yaml"] = (
+            "static_resources:\n"
+            "  listeners:\n"
+            "    - name: http\n"
+            "  thresholds:\n"
+            "    - max_connections: 80000\n"
+            "      priority: DEFAULT\n"
+            "    - max_connections: 100\n"
+            "      priority: HIGH\n"
+        )
+        chart_docs = default_chart_docs()
+        chart_gateway_envoy = chart_docs[(MANAGER_CHART_NAME, "gateway-envoy-config.yaml")][0]
+        chart_gateway_envoy["data"]["envoy.yaml"] = (
+            "static_resources:\n"
+            "  listeners:\n"
+            "    - name: http\n"
+            "  thresholds:\n"
+            "    - max_connections: 80000\n"
+            "      priority: DEFAULT\n"
+        )
+        template_sources = {
+            (
+                MANAGER_CHART_NAME,
+                "gateway-envoy-config.yaml",
+            ): (
+                "static_resources:\n"
+                "  listeners:\n"
+                "    - name: http\n"
+                "  thresholds:\n"
+                "{{- range .Values.gateway.envoy.circuitBreakers.thresholds }}\n"
+                "    - max_connections: {{ .maxConnections }}\n"
+                "      priority: {{ .priority }}\n"
+                "{{- end }}\n"
+            )
+        }
+        self.write_source_fixtures(source_docs)
+        self.write_chart_fixtures(chart_docs, template_sources)
+
+        result = self.run_manifests_checker()
+
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertIn(
+            "TEMPLATED manifests gateway ConfigMap/envoy-config: "
+            "data.envoy.yaml.static_resources.thresholds source item",
+            result.stdout,
+        )
+        self.assertIn("missing in chart; chart renders this field through a template", result.stdout)
+        self.assertNotIn("DRIFT manifests", result.stdout)
+
+    def test_component_gateway_checks_only_gateway(self) -> None:
+        self.write_source_fixtures(default_source_docs())
+        self.write_chart_fixtures(default_chart_docs())
+
+        result = self.run_manifests_checker("--component", "gateway")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("OK manifests gateway Service/sandbox-gateway", result.stdout)
+        self.assertIn("OK manifests gateway ConfigMap/envoy-config", result.stdout)
+        self.assertNotIn(" manifests controller ", result.stdout)
+        self.assertNotIn(" manifests manager ", result.stdout)
+
+    def test_rejects_invalid_aspect_flag_combinations(self) -> None:
+        for extra_args, message in (
+            (
+                ("--aspect", "manifests", "--apply-crds"),
+                "--apply-crds is only valid with --aspect crd",
+            ),
+            (
+                ("--aspect", "crd", "--kinds", "Service"),
+                "--kinds is only valid with --aspect manifests",
+            ),
+            (
+                ("--aspect", "crd", "--component", "gateway"),
+                "--component gateway is only valid with --aspect manifests",
+            ),
+        ):
+            with self.subTest(extra_args=extra_args):
+                result = self.run_checker(*extra_args)
+
+                self.assertEqual(result.returncode, 2, result.stderr)
+                self.assertIn(message, result.stderr)
+
+    def test_documents_deployment_manifest_synchronization(self) -> None:
+        content = SKILL.read_text(encoding="utf-8")
+
+        self.assertIn("## Deployment Manifests", content)
+        for requirement in (
+            "--aspect manifests --component all",
+            "--aspect manifests --component gateway",
+            "--aspect manifests --kinds Service,ConfigMap",
+            "controller-manager-webhook-service",
+            "sandbox-manager-envoy-config",
+            "e2b-key-store",
+            "envoy-config",
+            "templates/gateway-envoy-config.yaml",
+            "(document 1)",
+            "config/manager",
+            "config/sandbox-manager",
+            "config/sandbox-gateway",
+            "read-only manifests checker",
+            "`HELM_ONLY` — chart-only content",
+            "`MISSING` — a mapped chart template file does not exist",
+            "`UNMAPPED` — a source manifest of a managed kind",
+            "`TEMPLATED` — a value difference on a field the chart renders",
+            "`0` clean, `1` drift (including `TEMPLATED`) or missing",
+            "Deployments are not synchronized by this checker",
+            "`MANIFEST_SPEC` mapping",
+            "Preserve chart-managed metadata",
+            "fix values-driven drift by updating `values.yaml` defaults first",
+            "Match source order for indexed lists",
+            "template regressions",
+        ):
+            with self.subTest(requirement=requirement):
+                self.assertIn(requirement, content)
 
 
 if __name__ == "__main__":

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,178 @@
 # Change Log
 
+## v0.6.0-alpha1
+> Change log since v0.3.0
+
+Version range: v0.3.0 → v0.6.0-alpha1
+
+---
+
+## 1. Features
+
+### 1.1 Security Enhancement
+
+**Ingress & Egress Control**
+- Introduced TrafficPolicy, GlobalTrafficPolicy, and SecurityProfile CRDs to drive sandbox egress control (#397, #433, #445, #448, #483, #494, #521, #588, #610, #615, #745, #746), including protocol fields, scheme matching, CRD registration in kustomization (#915), and restored API definitions (#521).
+- SecurityProfile gained MCP tool access-control (#614), `headerManipulation` actions (#829), token-transformation headers (#859), and inline E2B L7 network rules (#838).
+- CRD admission validation (#919) and validation/status alignment (#930) were hardened.
+- Gateway now supports JWT verification with optional Runtime mTLS (#648, #561), keeps the UUID baseline when JWT is enabled (#885), aligns the traffic token header with the E2B SDK (#689), and rotates traffic access tokens (#742).
+- AccessToken is masked in route log output and the debug endpoint (#607).
+
+**Identity & Token Framework**
+- Introduced a FeatureGate-controlled Security Identity Provider that issues and propagates tokens across the sandbox lifecycle (#324, #450, #460, #463, #469).
+- Token issuance is gated on the `agent-name` label (#488) and deferred until the sandbox reaches Ready (#642); tokens are re-issued after resume and before CSI re-mount (#638).
+- Access tokens are now issued at claim time by TokenKind (#671) and on clone (#633), with identity annotations propagated to checkpoints (#637) and storage-auth annotations injected into the clone path (#639).
+- Added a SecurityTokenRefreshReconciler for proactive rotation (#475), and refactored `IssueToken` so each provider builds its own request (#632).
+
+**TLS & Runtime Transport**
+- Added a gateway CA bundle injection framework (#478) and extended `InjectAllCAIntoContainers` to cover InitContainers (#552).
+- TLS-capable sandboxes now route CSI mounts (#720) and the `/init` handshake (#700) over HTTPS; a TLS runtime client wired with Secret-based material is used on claim/clone paths (#702), and the claim path is supplied with the runtime TLS bundle (#729).
+- Security tokens are delivered over the resolved runtime transport (#734), and every runtime API call logs the resolved transport (#752). Upgrade hooks use TLS (#886), and self-signed leaf certificates now include SKI/AKI for Python 3.13+ compatibility (#797).
+
+
+### 1.2 Operations Enhancement
+
+**Checkpoint, Pause/Resume & Commit**
+- Introduced `CheckpointControl` for the checkpoint lifecycle (#508) with a `CheckpointRestore` upgrade strategy (#670), `PersistentContents` filesystem checkpoints (#674), selectable checkpoint labels (#712, #714), and a pause path that waits for active checkpoints (#913).
+- Added a `Commit` CRD (#502), a Commit controller with registry auth and job orchestration (#533), and a nerdctl commit/push execution layer (#608); commits without a CommitID skip provider deletion and pod deletion is rejected (#595).
+- Resume became atomic with a placeholder pause time and a minimum timeout floor (#435), with clearer errors on client cancellation (#424). Post-resume re-runtime-init and CSI re-mount are surfaced via events and conditions (#416).
+- A `PauseStrategy` (Stop / Snapshot / CloudDisk) was introduced (#713, #774) and exposed on `SandboxSet` (#839).
+- Paused retention timeout handling was refined (#566), and the default failed-sandbox reserve TTL reduced to 30 minutes (#457).
+
+**Upgrade & In-Place Update**
+- Paused sandboxes can now be upgraded via `SandboxUpdateOps` (#710) using a two-phase upgrade flow (#750), with upgrade policy cleared on success (#785). The filter was relaxed to accept non-SandboxSet-controlled sandboxes (#482) and the `SandboxHashImmutablePart` check is skipped when the annotation is missing (#531). Only Running/Upgrading sandboxes are eligible candidates (#553), and sandboxes whose template already matches the patch target are skipped (#511).
+- Sandbox memory now can be resized during sandbox claims (#519)
+- Init-container image consistency is verified before post-resume initialization (#538); resume upgrades continue from the previous failed step (#447); init-container injection order was stabilized for backward compatibility (#513); and injected resources are preserved across resize (#462, #537).
+- In-place update false-positives were fixed (#420, #557), and `ResourcesEqual` was renamed to `IsResourceSatisfied` with a relaxed comparison (#716). `SandboxInPlaceResourceResizeGate` was removed from the sandbox-manager layer (#470).
+
+**Observability, Events & Lifecycle Tracing**
+- New metrics: `sandbox_runtime_container_abnormal` (#452), `_time` metrics for abnormal states with stale-condition fixes (#591), and metric cleanup moved off the reconcile hot path via an async pool (#461).
+- Events and conditions were added for pod creation failures (#626), k8s lifecycle events (#603), and controller/manager lifecycle tracing (#658).
+- Proxy and infra reconciler log volume was reduced (#579), and E2B gained an optional dedicated observability listener with the empty debug endpoint removed (#858).
+
+**Controller & SandboxSet**
+- `SandboxSet` now auto-creates `SandboxTemplate` (#396), uses a legacy revision hash to prevent sandbox recreation on upgrade (#514), scopes `maxUnavailable` to a startup-failure budget (#910), and sorts scale-down candidates by priority (#803).
+- Sandbox finalizer became lazy — added on pause, removed on resume (#646), and leftover pods from a previous same-name sandbox are rejected (#757).
+- Status is persisted during the Pending phase (#455), and a batch claim size flag was made effective (#656) with claims scoped to namespace (#824).
+- The `okactl` CLI was added for sandbox operations (#497), and multi-arch image publishing was enabled (#545).
+
+**Cache, Informer & Performance**
+- Secret-backed key storage switched from a ticker to informer-driven refresh (#421); claim hot path uses `CountActiveSandboxes` (#517); `APIReader` fallbacks were added for claimed-sandbox lookup (#423) and checkpoint wait (#522); `SandboxTemplateRef` is supported in runtime checks (#442); cache misses are returned definitively (#751); and the TrafficPolicy cache is skipped when the CRD is absent (#730).
+- Gateway informer cache memory usage was reduced (#724).
+
+**E2B Compatibility**
+- Added Claude Code support (#415), pod-IP metadata (#436), E2B ≥v2.25.0 SDK-compatible API key encoding (#473), named cloned sandboxes via metadata extensions (#385), dynamically resolved sandbox domains (#649), and an unlimited default create-server timeout (#484).
+- Volume API (#580, #596), Network API (#616), dimension-aware API key quota (#565), a secret-to-MySQL API key migration script (#309), and egress control injection (#397) were added.
+- The E2B Volume management endpoints were temporarily disabled (#744).
+
+**Storage & Runtime**
+- RRSA-based storage authentication for on-demand CSI mounts (#568), an agent-runtime client with CSI mount API (#685), atomic `ListDir`/`Remove` filesystem operations (#723), and a storage CLI binary (#539).
+
+**Short & Stable Sandbox IDs**
+- Implemented short and stable sandbox IDs to reduce identifier length while preserving uniqueness across lifecycle operations (#686).
+- Added an atomic `max` helper to support lock-free ID generation utilities (#766).
+
+**Miscellaneous**
+- Clone failures are retried (#437, #530, #542); sidecar injection moved into `PodGenerateFunc` (#520); postStart hooks are merged using a `--` separator (#555); the security metadata source was moved to sandbox annotations (#630); and a sync-charts skill was added for CRD/webhook/RBAC/identity synchronization (#916).
+
+### 1.3 Cost Optimization
+
+- **Sandbox recycle / return-to-pool** (#548, #609, #569) — reuse released sandboxes to avoid cold starts.
+- **CheckpointRestore upgrade strategy** (#670, #674) — upgrade sandboxes via filesystem checkpoints instead of rebuilds.
+- **Auto-pause and resume** (#612, #899) with probe-driven `AutoPausePolicy` (#899) and an `OnIngressTraffic` wake-on-traffic resume rule (#900, #586).
+- **PoolAutoscaler** (#625) — capacity-based and cron-driven pool autoscaling with coordinated scale-up execution (#895) and a patched webhook service (#917).
+- **Paused retention refinement** (#566) and **DefaultReserveFailedSandboxFor reduced to 30 minutes** (#457).
+- **Reconcile hot-path async pool** for metric cleanup (#461) and **CountActiveSandboxes** for the claim hot path (#517).
+
+---
+
+## 2. Bug Fixes
+
+**Core Logic**
+- Prevented `ClaimSandbox` from returning `(nil, nil)` on context cancellation (#399); removed `UnsafeDisableDeepCopy` in `groupAllSandboxes` to avoid informer cache corruption (#387).
+- Fixed false-positive resource change detection in in-place update (#420, #557), preserved system-injected resource fields during resize (#462, #537), and fixed TTL leak by letting Checkpoint own SandboxTemplate (#419).
+- Resume during pausing is rejected with 400 (#404); pausing sandboxes are now allowed to pause (#422); `SandboxSet` legacy revision hash prevents sandbox recreation on upgrade (#514); internal labels no longer leak into sandbox pod templates (#911); invalid `SandboxClaim` retry loops are fixed (#840); sandbox cleanup uses `SandboxManager` on network-policy failures (#707).
+
+**Lifecycle & Status**
+- Sandbox status is persisted during the Pending phase (#455); resume flow decouples phase transition from pod readiness (#529); checkpoint delete expectation settles when the checkpoint is already gone (#812); pause conditions for checkpoint-disabled and pod-deleted paths are corrected (#524); pod status is synced before upgrade initialization (#912); pause waits for active checkpoints (#913); `SecurityTokenRefresh` treats absent `RuntimeInitialized` as serving (#675); clone honors request CSI mount config over checkpoint annotation (#641).
+
+**E2B Compatibility**
+- Dead sandboxes return 404 from `DescribeSandbox` to avoid SDK `ValueError` (#636, #692); `is_running` is polled after kill to avoid an async-deletion race (#645); pagination is stabilized for duplicate timestamps (#563); reserved failed-sandbox cleanup is fixed (#589); E2B traffic policy precedence is corrected (#740); Volume management endpoints are temporarily disabled (#744); resource ownership and key storage validation are hardened (#835); the configured admin key is persisted and unreadable Secret entries are skipped (#854).
+
+**API Keys & Quota**
+- Invalid API key creation returns 400 (#449); the quota anti-drift primary-loss test is stabilized under `-race` (#617); API key persistence and owner labels are hardened (#677); registry secret lookup errors are propagated (#584); the claim batch size flag now takes effect (#656); claims are scoped to namespace (#824).
+
+**Controller / Webhook / CRD**
+- Webhook controller queue bootstrap and server CertDir alignment (#654); TrafficPolicy cache setup skipped when the CRD is absent (#730); `SandboxTemplate` webhook registration fixed (#820); `PoolAutoscaler` webhook service patched (#917); `SecurityProfiles`, `GlobalSecurityProfiles`, `GlobalTrafficPolicies` registered in kustomization (#915); ops-template patch sanitization and checkpoint resume selection fixed (#793); `SandboxSet` reconcile is skipped while deleting (#856).
+
+**Gateway & Transport**
+- Traffic token header aligned with the E2B SDK (#689); traffic tokens are issued for cloned sandboxes (#728); UUID baseline preserved when JWT auth is enabled (#885); upgrade hooks use TLS (#886); self-signed leaf certificates include SKI/AKI for Python 3.13+ (#797).
+
+**HTTP / Resource Leaks**
+- Fixed an unclosed `http.Response` body in the BrowserUse endpoint handler that caused a socket leak (#708).
+
+**Tests / CI Fixes**
+- Sandbox connection method in resume (#476); checkpoint condition stabilized with `Eventually` (#592); quota fail-open and resume timeout checks hardened (#884); envoy ext_proc timeout raised and transient 504s tolerated (#906); Redis/CR state dumped on quota rebuild E2E failure (#816); E2B Build Image steps retried on runner resource failures (#647); free-disk-space step added to the e2e-e2b-mysql-latest workflow (#643); flaky background-command kill test stabilized (#651); `TestSandboxManager_DebugMaskAccessToken` stabilized (#634).
+
+---
+
+## 3. Chores
+
+**Dependabot Bumps**
+- `aquasecurity/trivy-action` 0.35.0 → 0.36.0 (#294); `github/codeql-action` 4.35.4 → 4.37.8 (#429, #466, #499, #527, #621, #680, #878); `ruby/setup-ruby` 1.307.0 → 1.321.0 (#430, #599, #619, #652, #681); `crate-ci/typos` 1.46.1 → 1.48.0 (#431, #464, #498, #602); `codecov/codecov-action` 6.0.0 → 7.0.0 (#432, #526); `golangci/golangci-lint-action` 9.2.0 → 9.3.0 (#465, #601); `actions/checkout` 6.0.1 → 7.0.1 (#500, #578, #624, #683); `actions/cache` 5.0.5 → 6.1.0 (#575, #600); `docker/setup-qemu-action` 3 → 4 (#622); `spf13/cobra` 1.10.0 → 1.10.2 (#873); `container-storage-interface/spec` 1.9.0 → 1.13.0 (#876); `google.golang.org/protobuf` 1.36.11 → 1.36.12 (#869); `golang-x` group (#868); `otel` group (#867); `zizmorcore/zizmor-action` 0.6.1 → 0.6.2 (#877).
+
+**Documentation & Proposals**
+- v0.3.0 changelog (#383); multi-agent development limits in AGENTS.md (#438); pause/resume checkpoint design (#467); sandbox reuse & return-to-pool design (#547); CSI mount proposal (#536); short and stable Sandbox IDs proposal (#635); OpenTelemetry distributed tracing proposal (#604); agent guidance hierarchy refined (#655); proposal authors and image reference (#673).
+
+**CI / Test Infrastructure**
+- E2E coverage expanded: fixed E2B 2.24.0 tests (#471), sandbox-manager E2E (#518), E2B create-with-labels and command execution (#582); pytest plugin architecture rewrite and CI updates (#594).
+- Envoy base image updated to v1.37.3 (#509).
+
+**Refactors**
+- Dependency cleanup breaking circular and layer-violating references (#474); `doSidecarInjection` takes `*Sandbox` (#480); `syncStatusFromPod` extracted as a struct field (#672); sandbox reuse terminology renamed to "recycle" (#609); E2B request context values use an unexported key type (#902); security metadata consumed from sandbox annotations (#630); `IssueToken` no longer takes a request parameter (#632).
+
+**Scripts & Runtime Utilities**
+- `run_envd.sh` / `envd-run.sh` updates (#516, #541); `chmod` in runtime function (#486); `RunCommandWithRuntime` timeout (#503).
+
+**Supply-Chain Security**
+- CI now runs govulncheck, zizmor, and OpenSSF Scorecard, with gosec enabled (#836), and GitHub Actions hardened against zizmor/Scorecard findings (#921). Tier-1 code-scanning findings (command injection, CVEs, dependabot cooldown) were addressed (#918), gosec warnings were fixed (#587), and a SECURITY.md policy was added (#606).
+
+**Generated Code**
+- Generated client update (#417); security-related file relocations (#456).
+
+**Open-Source Storage Tests**
+- Added `AgenticBucket` and `BucketSpace` test coverage for open-source storage components (#817).
+
+
+## New Contributors
+* @Kuromesi made their first contribution in https://github.com/openkruise/agents/pull/397
+* @oindrilakha12-ui made their first contribution in https://github.com/openkruise/agents/pull/387
+* @l1b0k made their first contribution in https://github.com/openkruise/agents/pull/433
+* @rakshaak29 made their first contribution in https://github.com/openkruise/agents/pull/442
+* @delavet made their first contribution in https://github.com/openkruise/agents/pull/483
+* @zyl1121 made their first contribution in https://github.com/openkruise/agents/pull/447
+* @Jayant-kernel made their first contribution in https://github.com/openkruise/agents/pull/558
+* @denverdino made their first contribution in https://github.com/openkruise/agents/pull/587
+* @chacha923 made their first contribution in https://github.com/openkruise/agents/pull/563
+* @yanghanlin made their first contribution in https://github.com/openkruise/agents/pull/594
+* @Liquorice-Ma made their first contribution in https://github.com/openkruise/agents/pull/497
+* @googs1025 made their first contribution in https://github.com/openkruise/agents/pull/545
+* @singhsrijan46 made their first contribution in https://github.com/openkruise/agents/pull/613
+* @ashnaaseth2325-oss made their first contribution in https://github.com/openkruise/agents/pull/584
+* @ZeroCoder-dot made their first contribution in https://github.com/openkruise/agents/pull/673
+* @AlbeeSo made their first contribution in https://github.com/openkruise/agents/pull/676
+* @vishalmore90 made their first contribution in https://github.com/openkruise/agents/pull/708
+* @silver-chard made their first contribution in https://github.com/openkruise/agents/pull/537
+* @nishantbkl3345-ship-it made their first contribution in https://github.com/openkruise/agents/pull/798
+* @HARSHRAJ2789 made their first contribution in https://github.com/openkruise/agents/pull/790
+* @DahuK made their first contribution in https://github.com/openkruise/agents/pull/836
+* @chrisliu1995 made their first contribution in https://github.com/openkruise/agents/pull/625
+* @omlahore made their first contribution in https://github.com/openkruise/agents/pull/902
+* @RedZapdos123 made their first contribution in https://github.com/openkruise/agents/pull/886
+* @ywExcellent made their first contribution in https://github.com/openkruise/agents/pull/895
+
+**Full Changelog**: https://github.com/openkruise/agents/compare/v0.3.0...v0.6.0-alpha1
+
 ## v0.3.0
 > Change log since v0.2.0
 

--- a/Makefile
+++ b/Makefile
@@ -264,9 +264,13 @@ ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -
 GOLANGCI_LINT_VERSION ?= v2.3.0
 
 # Run tests
+# -p 1 runs test binaries serially: pkg/proxy, pkg/sandbox-manager and
+# pkg/servers/e2b bind the fixed route-refresh (7789) and ext-proc (9002)
+# ports, and a bind failure is now a hard test failure. Drop it once those
+# listeners take injectable ports.
 .PHONY: test
 test:
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -race ./pkg/... -coverprofile raw-cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -race -p 1 ./pkg/... -coverprofile raw-cover.out
 	grep -v "pkg/client" raw-cover.out > cover.out
 
 .PHONY: kustomize

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 build: generate fmt vet manifests ## Build manager binary.
-	go build -o bin/agent-sandbox-controller cmd/agent-sandbox-controller/main.go
+	go build -o bin/agent-sandbox-controller ./cmd/agent-sandbox-controller
 
 .PHONY: build-okactl
 build-okactl: ## Build okactl CLI binary.

--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -605,6 +605,7 @@ const (
 	SandboxReadyReasonUpgrading            = "Upgrading"
 	SandboxReadyReasonStartContainerFailed = "StartContainerFailed"
 	SandboxReadyReasonPodCreateFailed      = "PodCreateFailed"
+	SandboxReadyReasonUnschedulable        = "Unschedulable"
 
 	// SandboxConditionInplaceUpdate Reason
 	SandboxInplaceUpdateReasonInplaceUpdating = "InplaceUpdating"

--- a/api/v1alpha1/sandboxset_types.go
+++ b/api/v1alpha1/sandboxset_types.go
@@ -145,10 +145,10 @@ type SandboxSetScaleStrategy struct {
 	// the base (equivalent to 100%, i.e. no cap). Scale-down is unaffected.
 	//
 	// The physical scale-up budget is charged by startup blockers: sandboxes
-	// whose Ready condition is False with reason PodCreateFailed or
-	// StartContainerFailed, sandboxes stuck in Creating/ResourcePending past the
-	// configured --max-pending-timeout, and sandbox creations that have been
-	// issued but are not yet observed by the controller (they release their slot
+	// whose Ready condition is False with reason PodCreateFailed,
+	// StartContainerFailed, or Unschedulable, sandboxes stuck in
+	// Creating/ResourcePending past the configured --max-pending-timeout, and
+	// sandbox creations that have been issued but are not yet observed by the controller (they release their slot
 	// once observed as healthy Creating sandboxes). Healthy observed Creating
 	// sandboxes do NOT count against the budget.
 	//

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -28,6 +28,7 @@ import (
 	_ "time/tzdata" // Embed timezone database for scratch-based container images
 
 	"github.com/spf13/pflag"
+	gozap "go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -155,7 +156,17 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	// AddCaller annotates each log line with the source file and line number of
+	// the calling site, so that structured logs (which by default omit it) are as
+	// locatable as klog-native logs.
+	//
+	// The explicit Encoder fixes the format to one JSON object per line with
+	// the trace ID first and ISO8601 timestamps (see tracing.NewTraceFirstJSONEncoder).
+	// Both --zap-encoder and --zap-time-encoding are overridden and have no effect;
+	// --zap-log-level and --zap-stacktrace-level remain effective.
+	opts.Encoder = tracing.NewTraceFirstJSONEncoder()
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts), zap.RawZapOpts(gozap.AddCaller())))
+	setupLog.Info("controller logger initialized with trace-first JSON encoder and ISO8601 timestamps; --zap-encoder and --zap-time-encoding are overridden and have no effect")
 
 	if metricLabelsAllowlist != "" {
 		keys := strings.Split(metricLabelsAllowlist, ",")

--- a/cmd/sandbox-gateway-cert-init/main.go
+++ b/cmd/sandbox-gateway-cert-init/main.go
@@ -27,11 +27,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openkruise/agents/pkg/sandbox-gateway/runtimecredentials"
+	"github.com/openkruise/agents/pkg/utils/logs"
 )
 
 func main() {
 	if err := run(context.Background()); err != nil {
-		klog.Fatalf("initialize runtime mTLS credentials: %v", err)
+		klog.Fatalf("initialize runtime mTLS credentials: %v", logs.SanitizeValue(err.Error()))
 	}
 }
 

--- a/cmd/sandbox-manager/hook.go
+++ b/cmd/sandbox-manager/hook.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+
+	"k8s.io/client-go/rest"
+)
+
+// defaultStartupHook is the community no-op startup extension point. Internal
+// builds override startupHook (same package) via init() to install bootstrap
+// logic such as the hosted IdP client; this build keeps it a no-op.
+func defaultStartupHook(context.Context, *rest.Config) error { return nil }
+
+// startupHook runs once after the user-cluster rest.Config is established and
+// the optional secret config has been overlaid onto process settings,
+// but before the e2b controller or any listener starts.
+var startupHook = defaultStartupHook

--- a/cmd/sandbox-manager/hook_test.go
+++ b/cmd/sandbox-manager/hook_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func TestDefaultStartupHook(t *testing.T) {
+	require.NoError(t, defaultStartupHook(context.Background(), &rest.Config{}))
+}

--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/pflag"
 	zapRaw "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -46,11 +47,15 @@ import (
 	utilruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
+// These identifiers name both the process environment variables read at startup
+// and the data keys of the Secret referenced by --secret-config. The two sources
+// are intentionally spelled the same so operators can move a value between them.
 const (
-	E2BKeyStorageDSNEnvVar   = "E2B_KEY_STORAGE_DSN"
-	E2BKeyHashPepperEnvVar   = "E2B_KEY_HASH_PEPPER"
-	QuotaRedisUsernameEnvVar = "QUOTA_REDIS_USERNAME"
-	QuotaRedisPasswordEnvVar = "QUOTA_REDIS_PASSWORD"
+	E2BAdminKeySecretKey        = "E2B_ADMIN_KEY"        // #nosec G101 -- env-var/Secret data key name, not a credential
+	E2BKeyStorageDSNSecretKey   = "E2B_KEY_STORAGE_DSN"  // #nosec G101 -- env-var/Secret data key name, not a credential
+	E2BKeyHashPepperSecretKey   = "E2B_KEY_HASH_PEPPER"  // #nosec G101 -- env-var/Secret data key name, not a credential
+	QuotaRedisUsernameSecretKey = "QUOTA_REDIS_USERNAME" // #nosec G101 -- env-var/Secret data key name, not a credential
+	QuotaRedisPasswordSecretKey = "QUOTA_REDIS_PASSWORD" // #nosec G101 -- env-var/Secret data key name, not a credential
 )
 
 // validateE2BTimeoutFlags rejects a non-positive E2B max timeout, which would
@@ -77,6 +82,30 @@ func validateMetricsPort(metricsPort, controlPort, memberlistBindPort int) error
 		return fmt.Errorf("--metrics-port (%d) must differ from --memberlist-bind-port (%d) when using a dedicated metrics listener", metricsPort, memberlistBindPort)
 	}
 	return nil
+}
+
+// newStartupSecretClient builds a client only when startup needs to read Secrets.
+// It returns a nil Reader exactly when no startup Secret is referenced; callers
+// must not pass a non-empty ref to resolveSecretSettings with a nil reader.
+func newStartupSecretClient(clientConfig *rest.Config, runtimeClientCertSecret, secretConfigRef string) (ctrlclient.Client, error) {
+	if runtimeClientCertSecret == "" && secretConfigRef == "" {
+		return nil, nil
+	}
+	return ctrlclient.New(clientConfig, ctrlclient.Options{})
+}
+
+// resolveSecretSettings leaves flag/env values unchanged when --secret-config is
+// empty. When set, the Secret values overlay those settings, including empty ones.
+func resolveSecretSettings(reader ctrlclient.Reader, ref, sysNs string, current secretConfig) (secretConfig, error) {
+	if ref == "" {
+		return current, nil
+	}
+	cfg, err := loadSecretConfig(reader, ref, sysNs)
+	if err != nil {
+		return secretConfig{}, err
+	}
+	klog.InfoS("secret config loaded", "secret", ref)
+	return cfg, nil
 }
 
 func main() {
@@ -116,6 +145,7 @@ func main() {
 	var trafficTokenValidity time.Duration
 	var trafficTokenMinValidity time.Duration
 	var trafficTokenMaxValidity time.Duration
+	var secretConfigRef string
 
 	utilfeature.DefaultMutableFeatureGate.AddFlag(pflag.CommandLine)
 
@@ -154,8 +184,9 @@ func main() {
 	pflag.IntVar(&memberlistBindPort, "memberlist-bind-port", 7946, "Port for memberlist gossip (default 7946)")
 	pflag.StringVar(&e2bKeyStorage, "e2b-key-storage", "secret",
 		"Storage backend for E2B API keys. Valid values: 'secret' (K8s Secret, default), 'mysql' (MySQL via GORM). "+
-			"When --e2b-key-storage=mysql and auth is enabled, both the MySQL DSN (env "+E2BKeyStorageDSNEnvVar+
-			") and the HMAC key-hash pepper (env "+E2BKeyHashPepperEnvVar+") are required; secret mode does not use either.")
+			"When --e2b-key-storage=mysql and auth is enabled, both the MySQL DSN (env "+E2BKeyStorageDSNSecretKey+
+			" or the corresponding key of the Secret named by --secret-config) and the HMAC key-hash pepper (env "+
+			E2BKeyHashPepperSecretKey+" or the corresponding key of that Secret) are required; secret mode does not use either.")
 	pflag.BoolVar(&e2bKeyStorageDisableAutoMigrate, "e2b-key-storage-disable-schema-auto-update", false,
 		"Disable schema auto-migration for DB-Based key storage like mysql; when enabled, schema changes are skipped but admin team/key bootstrap still runs")
 	pflag.StringVar(&quotaRedisAddr, "quota-redis-addr", "", "Redis address for sandbox-manager quota enforcement. Empty disables enforcement and fails open.")
@@ -170,6 +201,12 @@ func main() {
 	pflag.DurationVar(&trafficTokenValidity, "traffic-access-token-validity", config.DefaultTrafficAccessTokenValidity, "Validity requested for traffic access tokens.")
 	pflag.DurationVar(&trafficTokenMinValidity, "traffic-access-token-min-validity", config.DefaultTrafficAccessTokenMinValidity, "Minimum allowed traffic access token validity.")
 	pflag.DurationVar(&trafficTokenMaxValidity, "traffic-access-token-max-validity", config.DefaultTrafficAccessTokenMaxValidity, "Maximum allowed traffic access token validity.")
+	pflag.StringVar(&secretConfigRef, "secret-config", "",
+		"name or namespace/name of the Secret that provides the five secret values "+E2BAdminKeySecretKey+", "+E2BKeyStorageDSNSecretKey+", "+
+			E2BKeyHashPepperSecretKey+", "+QuotaRedisUsernameSecretKey+", "+QuotaRedisPasswordSecretKey+". "+
+			"When the namespace is omitted, --system-namespace is used. "+
+			"When set, the Secret is read once at startup and overrides those values (all five keys must be present); "+
+			"changes take effect only on restart. Leave it empty to keep flag and env values.")
 
 	// Tracing flags (definitions shared with agent-sandbox-controller via
 	// tracing.Config.BindFlags; pulled into pflag by AddGoFlagSet below)
@@ -210,10 +247,6 @@ func main() {
 		klog.Fatalf("--peer-selector is required")
 	}
 
-	if e2bEnableAuth && e2bAdminKey == "" {
-		klog.Fatalf("--e2b-admin-key is required when --e2b-enable-auth is true")
-	}
-
 	// Validate timeout flags.
 	if err := validateE2BTimeoutFlags(e2bMaxTimeout); err != nil {
 		klog.Fatalf("invalid e2b timeout flags: %v", err)
@@ -248,10 +281,39 @@ func main() {
 		klog.Fatalf("--kube-client-burst must be greater than 0")
 	}
 
-	e2bKeyStorageDSN := strings.TrimSpace(os.Getenv(E2BKeyStorageDSNEnvVar))
-	e2bKeyStoragePepper := strings.TrimSpace(os.Getenv(E2BKeyHashPepperEnvVar))
-	quotaRedisUsername := strings.TrimSpace(os.Getenv(QuotaRedisUsernameEnvVar))
-	quotaRedisPassword := strings.TrimSpace(os.Getenv(QuotaRedisPasswordEnvVar))
+	e2bKeyStorageDSN := strings.TrimSpace(os.Getenv(E2BKeyStorageDSNSecretKey))
+	e2bKeyStoragePepper := strings.TrimSpace(os.Getenv(E2BKeyHashPepperSecretKey))
+	quotaRedisUsername := strings.TrimSpace(os.Getenv(QuotaRedisUsernameSecretKey))
+	quotaRedisPassword := strings.TrimSpace(os.Getenv(QuotaRedisPasswordSecretKey))
+
+	clientConfig, err := clients.NewRestConfig(float32(kubeClientQPS), kubeClientBurst)
+	if err != nil {
+		klog.Fatalf("Failed to initialize Kubernetes client: %v", err)
+	}
+
+	startupReader, err := newStartupSecretClient(clientConfig, runtimeClientCertSecret, secretConfigRef)
+	if err != nil {
+		klog.Fatalf("Failed to create client for startup Secrets: %v", err)
+	}
+	secretSettings, err := resolveSecretSettings(startupReader, secretConfigRef, sysNs, secretConfig{
+		AdminKey:      e2bAdminKey,
+		KeyStorageDSN: e2bKeyStorageDSN,
+		KeyHashPepper: e2bKeyStoragePepper,
+		RedisUsername: quotaRedisUsername,
+		RedisPassword: quotaRedisPassword,
+	})
+	if err != nil {
+		klog.Fatalf("Failed to load secret config: %v", err)
+	}
+	e2bAdminKey = secretSettings.AdminKey
+	e2bKeyStorageDSN = secretSettings.KeyStorageDSN
+	e2bKeyStoragePepper = secretSettings.KeyHashPepper
+	quotaRedisUsername = secretSettings.RedisUsername
+	quotaRedisPassword = secretSettings.RedisPassword
+
+	if e2bEnableAuth && e2bAdminKey == "" {
+		klog.Fatalf("E2B admin key is required when --e2b-enable-auth is true; provide it via --e2b-admin-key or the %q key of the Secret named by --secret-config", E2BAdminKeySecretKey)
+	}
 
 	quotaOpts := config.QuotaOptions{
 		RedisAddr:         quotaRedisAddr,
@@ -263,12 +325,6 @@ func main() {
 		BreakerD:          quotaRedisBreakerD,
 		AntiDriftInterval: quotaAntiDriftInterval,
 		AntiDriftGrace:    quotaAntiDriftGrace,
-	}
-
-	// Initialize Kubernetes client and config
-	clientConfig, err := clients.NewRestConfig(float32(kubeClientQPS), kubeClientBurst)
-	if err != nil {
-		klog.Fatalf("Failed to initialize Kubernetes client: %v", err)
 	}
 
 	// Initialize tracing
@@ -300,12 +356,8 @@ func main() {
 		if !found || secretNamespace == "" || secretName == "" {
 			klog.Fatalf("--runtime-client-cert-secret must be in namespace/name form, got %q", runtimeClientCertSecret)
 		}
-		secretReader, err := ctrlclient.New(clientConfig, ctrlclient.Options{})
-		if err != nil {
-			klog.Fatalf("Failed to create client for the runtime client TLS bundle: %v", err)
-		}
 		loadCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		runtimeTLSBundle, err = utilruntime.NewTLSBundleFromSecret(loadCtx, secretReader, secretNamespace, secretName)
+		runtimeTLSBundle, err = utilruntime.NewTLSBundleFromSecret(loadCtx, startupReader, secretNamespace, secretName)
 		cancel()
 		if err != nil {
 			klog.Fatalf("Failed to load the runtime client TLS bundle: %v", err)
@@ -325,6 +377,17 @@ func main() {
 			DisableAutoMigrate: e2bKeyStorageDisableAutoMigrate,
 			Pepper:             e2bKeyStoragePepper,
 		}
+	}
+
+	// hookCtx is a cancelable context for the startup hook and any background
+	// work it starts. A signal handler is not registered here: doing so before
+	// the controller registers its own in Run would suppress the default process
+	// exit for a SIGTERM during controller Init. Cancellation runs on main
+	// return via defer; klog.Fatalf skips that defer, and the hook is not waited.
+	hookCtx, hookCancel := context.WithCancel(context.Background())
+	defer hookCancel()
+	if err := startupHook(hookCtx, clientConfig); err != nil {
+		klog.Fatalf("startup hook failed: %v", err)
 	}
 
 	sandboxController := e2b.NewController(e2b.ControllerOptions{

--- a/cmd/sandbox-manager/main.go
+++ b/cmd/sandbox-manager/main.go
@@ -23,7 +23,9 @@ import (
 	"net/http"         // Added for pprof server
 	_ "net/http/pprof" // #nosec -- intentional pprof endpoint for diagnostics
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -44,6 +46,7 @@ import (
 	"github.com/openkruise/agents/pkg/tracing"
 	"github.com/openkruise/agents/pkg/utils"
 	utilfeature "github.com/openkruise/agents/pkg/utils/feature"
+	"github.com/openkruise/agents/pkg/utils/network"
 	utilruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
@@ -124,11 +127,13 @@ func main() {
 	var shortSandboxIDPrefix string
 	var sysNs string
 	var peerSelector string
+	var networkInterface string
 	var sandboxNamespace string
 	var sandboxLabelSelector string
 	var maxClaimWorkers int
 	var maxCreateQPS int
 	var extProcMaxConcurrency int
+	var disableEnvoyExtProc bool
 	var kubeClientQPS float64
 	var kubeClientBurst int
 	var memberlistBindPort int
@@ -174,11 +179,13 @@ func main() {
 			"use the same value on every sandbox-manager replica")
 	pflag.StringVar(&sysNs, "system-namespace", utils.DefaultSandboxDeployNamespace, "The namespace where the sandbox manager is running (required)")
 	pflag.StringVar(&peerSelector, "peer-selector", "", "Peer selector for sandbox manager (required)")
+	pflag.StringVar(&networkInterface, "network-interface", "", "Network interface whose single global-unicast address (IPv4 preferred, IPv6 otherwise) serves sandbox-cluster traffic")
 	pflag.StringVar(&sandboxNamespace, "sandbox-namespace", "", "Namespace to filter sandbox-related custom resources (Sandbox, SandboxSet, Checkpoint, SandboxTemplate, TrafficPolicy). Defaults to all.")
 	pflag.StringVar(&sandboxLabelSelector, "sandbox-label-selector", "", "Label selector to filter sandbox-related custom resources (Sandbox, SandboxSet, Checkpoint, SandboxTemplate, TrafficPolicy). Defaults to all.")
 	pflag.IntVar(&maxClaimWorkers, "max-claim-workers", consts.DefaultClaimWorkers, "Maximum number of claim workers (0 uses default)")
 	pflag.IntVar(&maxCreateQPS, "max-create-qps", consts.DefaultCreateQPS, "Maximum QPS for sandbox creation (0 uses default)")
 	pflag.IntVar(&extProcMaxConcurrency, "ext-proc-max-concurrency", consts.DefaultExtProcConcurrency, "Maximum concurrency for external processor (0 uses default)")
+	pflag.BoolVar(&disableEnvoyExtProc, "disable-envoy-ext-proc", false, "Disable the Envoy ext-proc gRPC listener (port 9002). HTTP route refresh still starts.")
 	pflag.Float64Var(&kubeClientQPS, "kube-client-qps", 500, "QPS for Kubernetes client")
 	pflag.IntVar(&kubeClientBurst, "kube-client-burst", 1000, "Burst for Kubernetes client")
 	pflag.IntVar(&memberlistBindPort, "memberlist-bind-port", 7946, "Port for memberlist gossip (default 7946)")
@@ -245,6 +252,10 @@ func main() {
 
 	if peerSelector == "" {
 		klog.Fatalf("--peer-selector is required")
+	}
+	bindAddress, err := network.ResolveNetworkInterfaceAddress(networkInterface)
+	if err != nil {
+		klog.Fatalf("Invalid --network-interface: %v", err)
 	}
 
 	// Validate timeout flags.
@@ -399,11 +410,13 @@ func main() {
 		Manager: config.SandboxManagerOptions{
 			SystemNamespace:       sysNs,
 			PeerSelector:          peerSelector,
+			BindAddress:           bindAddress,
 			SandboxNamespace:      sandboxNamespace,
 			SandboxLabelSelector:  sandboxLabelSelector,
 			MaxClaimWorkers:       maxClaimWorkers,
 			MaxCreateQPS:          maxCreateQPS,
 			ExtProcMaxConcurrency: uint32(extProcMaxConcurrency),
+			DisableEnvoyExtProc:   disableEnvoyExtProc,
 			MemberlistBindPort:    memberlistBindPort,
 			EnableShortSandboxID:  enableShortSandboxID,
 			ShortSandboxIDPrefix:  shortSandboxIDPrefix,
@@ -419,7 +432,9 @@ func main() {
 	}
 
 	// Start HTTP Server
-	sandboxCtx, err := sandboxController.Run()
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+	sandboxCtx, err := sandboxController.Run(stop)
 	if err != nil {
 		klog.Fatalf("Failed to start sandbox controller: %v", err)
 	}

--- a/cmd/sandbox-manager/secretconfig.go
+++ b/cmd/sandbox-manager/secretconfig.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// secretConfig holds the five secret values loaded from --secret-config.
+// It does not validate them against auth or key-storage mode; the caller overlays
+// these onto the corresponding process settings. Emptiness against auth and
+// key-storage mode is checked later by keys.Config.validate when key storage is constructed.
+type secretConfig struct {
+	AdminKey      string
+	KeyStorageDSN string
+	KeyHashPepper string
+	RedisUsername string
+	RedisPassword string
+}
+
+// secretConfigLoadTimeout bounds the single startup Get so a broken reference
+// or unreachable API server fails fast instead of hanging boot.
+const secretConfigLoadTimeout = 30 * time.Second
+
+// parseSecretConfig requires all five keys to be present and returns the values.
+// Errors mention only key names, never their values. The admin key is used
+// verbatim (matching the flag semantics); the other four are whitespace-trimmed
+// (matching the env-var semantics) so an accidental trailing newline in Secret
+// data does not leak in.
+func parseSecretConfig(data map[string][]byte) (secretConfig, error) {
+	for _, key := range []string{
+		E2BAdminKeySecretKey,
+		E2BKeyStorageDSNSecretKey,
+		E2BKeyHashPepperSecretKey,
+		QuotaRedisUsernameSecretKey,
+		QuotaRedisPasswordSecretKey,
+	} {
+		if _, ok := data[key]; !ok {
+			return secretConfig{}, fmt.Errorf("missing required key %q", key)
+		}
+	}
+	return secretConfig{
+		AdminKey:      string(data[E2BAdminKeySecretKey]),
+		KeyStorageDSN: strings.TrimSpace(string(data[E2BKeyStorageDSNSecretKey])),
+		KeyHashPepper: strings.TrimSpace(string(data[E2BKeyHashPepperSecretKey])),
+		RedisUsername: strings.TrimSpace(string(data[QuotaRedisUsernameSecretKey])),
+		RedisPassword: strings.TrimSpace(string(data[QuotaRedisPasswordSecretKey])),
+	}, nil
+}
+
+// parseSecretRef accepts "name" or "namespace/name". A missing namespace uses
+// defaultNamespace.
+func parseSecretRef(ref, defaultNamespace string) (string, string, error) {
+	err := fmt.Errorf("--secret-config must be a Secret name or namespace/name, got %q", ref)
+	switch strings.Count(ref, "/") {
+	case 0: // name only
+		if defaultNamespace == "" || ref == "" {
+			return "", "", err
+		}
+		return defaultNamespace, ref, nil
+	case 1: // namespace/name
+		namespace, name, _ := strings.Cut(ref, "/")
+		if namespace == "" {
+			namespace = defaultNamespace
+		}
+		if namespace == "" || name == "" {
+			return "", "", err
+		}
+		return namespace, name, nil
+	default:
+		return "", "", err
+	}
+}
+
+// loadSecretConfig parses ref, then performs exactly one precise Get. It never
+// lists, watches, caches, or falls back to any other source.
+func loadSecretConfig(reader ctrlclient.Reader, ref, defaultNamespace string) (secretConfig, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), secretConfigLoadTimeout)
+	defer cancel()
+	namespace, name, err := parseSecretRef(ref, defaultNamespace)
+	if err != nil {
+		return secretConfig{}, err
+	}
+	secret := &corev1.Secret{}
+	if err := reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, secret); err != nil {
+		return secretConfig{}, fmt.Errorf("failed to get secret config %s/%s: %w", namespace, name, err)
+	}
+	cfg, err := parseSecretConfig(secret.Data)
+	if err != nil {
+		return secretConfig{}, fmt.Errorf("invalid secret config %s/%s: %w", namespace, name, err)
+	}
+	return cfg, nil
+}

--- a/cmd/sandbox-manager/secretconfig_test.go
+++ b/cmd/sandbox-manager/secretconfig_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func fullSecretData() map[string][]byte {
+	return map[string][]byte{
+		E2BAdminKeySecretKey:        []byte("admin"),
+		E2BKeyStorageDSNSecretKey:   []byte("dsn"),
+		E2BKeyHashPepperSecretKey:   []byte("pepper"),
+		QuotaRedisUsernameSecretKey: []byte("user"),
+		QuotaRedisPasswordSecretKey: []byte("pass"),
+	}
+}
+
+func secretWith(data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "cfg"},
+		Data:       data,
+	}
+}
+
+func TestParseSecretConfig(t *testing.T) {
+	missing := fullSecretData()
+	delete(missing, E2BAdminKeySecretKey)
+
+	cases := []struct {
+		name        string
+		data        map[string][]byte
+		errContains string
+		want        secretConfig
+	}{
+		{
+			name: "all-empty-ok",
+			data: map[string][]byte{E2BAdminKeySecretKey: {}, E2BKeyStorageDSNSecretKey: {}, E2BKeyHashPepperSecretKey: {}, QuotaRedisUsernameSecretKey: {}, QuotaRedisPasswordSecretKey: {}},
+		},
+		{
+			name:        "missing-key",
+			data:        missing,
+			errContains: E2BAdminKeySecretKey,
+		},
+		{
+			name: "values-present",
+			data: fullSecretData(),
+			want: secretConfig{AdminKey: "admin", KeyStorageDSN: "dsn", KeyHashPepper: "pepper", RedisUsername: "user", RedisPassword: "pass"},
+		},
+		{
+			name: "admin-not-trimmed-others-trimmed",
+			data: map[string][]byte{E2BAdminKeySecretKey: []byte(" x "), E2BKeyStorageDSNSecretKey: []byte("  d  "), E2BKeyHashPepperSecretKey: []byte("\tp\n"), QuotaRedisUsernameSecretKey: []byte(" u "), QuotaRedisPasswordSecretKey: []byte(" w ")},
+			want: secretConfig{AdminKey: " x ", KeyStorageDSN: "d", KeyHashPepper: "p", RedisUsername: "u", RedisPassword: "w"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := parseSecretConfig(tc.data)
+			if tc.errContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, cfg)
+		})
+	}
+}
+
+func TestLoadSecretConfig(t *testing.T) {
+	t.Run("ref", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithObjects(secretWith(fullSecretData())).Build()
+		cases := []struct {
+			name      string
+			ref       string
+			defaultNs string
+			wantErr   string
+		}{
+			{name: "ns-name", ref: "ns/cfg", defaultNs: "sys"},
+			{name: "name-only-uses-default-ns", ref: "cfg", defaultNs: "ns"},
+			{name: "empty-namespace-uses-default-ns", ref: "/cfg", defaultNs: "ns"},
+			{name: "empty-name", ref: "ns/", defaultNs: "sys", wantErr: "Secret name or namespace/name"},
+			{name: "empty", ref: "", defaultNs: "sys", wantErr: "Secret name or namespace/name"},
+			{name: "extra-slash", ref: "ns/cfg/extra", defaultNs: "sys", wantErr: "Secret name or namespace/name"},
+			{name: "name-only-empty-default-ns", ref: "cfg", defaultNs: "", wantErr: "Secret name or namespace/name"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				cfg, err := loadSecretConfig(c, tc.ref, tc.defaultNs)
+				if tc.wantErr != "" {
+					require.Error(t, err)
+					assert.Contains(t, err.Error(), tc.wantErr)
+					return
+				}
+				require.NoError(t, err)
+				assert.Equal(t, "admin", cfg.AdminKey)
+			})
+		}
+	})
+
+	t.Run("not-found", func(t *testing.T) {
+		c := fake.NewClientBuilder().Build()
+		_, err := loadSecretConfig(c, "ns/cfg", "sys")
+		require.Error(t, err)
+		assert.True(t, apierrors.IsNotFound(err))
+		assert.Contains(t, err.Error(), "ns/cfg")
+	})
+	t.Run("missing-key-wrapped-with-ref", func(t *testing.T) {
+		data := fullSecretData()
+		delete(data, E2BKeyHashPepperSecretKey)
+		c := fake.NewClientBuilder().WithObjects(secretWith(data)).Build()
+		_, err := loadSecretConfig(c, "ns/cfg", "sys")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), E2BKeyHashPepperSecretKey)
+		assert.Contains(t, err.Error(), "ns/cfg")
+	})
+}
+
+func TestSecretConfigErrorsDoNotLeakValues(t *testing.T) {
+	const sentinel = "SUPER_SECRET_SENTINEL"
+	data := fullSecretData()
+	for k := range data {
+		data[k] = []byte(sentinel)
+	}
+	delete(data, E2BKeyStorageDSNSecretKey)
+	_, err := parseSecretConfig(data)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), sentinel)
+}
+
+func TestResolveSecretSettings(t *testing.T) {
+	current := secretConfig{
+		AdminKey:      "flag-admin",
+		KeyStorageDSN: "flag-dsn",
+		KeyHashPepper: "flag-pepper",
+		RedisUsername: "flag-user",
+		RedisPassword: "flag-pass",
+	}
+
+	t.Run("empty-ref-passthrough", func(t *testing.T) {
+		got, err := resolveSecretSettings(nil, "", "sys", current)
+		require.NoError(t, err)
+		assert.Equal(t, current, got)
+	})
+
+	t.Run("secret-overlays-current", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithObjects(secretWith(fullSecretData())).Build()
+		got, err := resolveSecretSettings(c, "ns/cfg", "sys", current)
+		require.NoError(t, err)
+		assert.Equal(t, secretConfig{
+			AdminKey:      "admin",
+			KeyStorageDSN: "dsn",
+			KeyHashPepper: "pepper",
+			RedisUsername: "user",
+			RedisPassword: "pass",
+		}, got)
+	})
+
+	t.Run("empty-secret-values-overlay-current", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithObjects(secretWith(map[string][]byte{
+			E2BAdminKeySecretKey:        {},
+			E2BKeyStorageDSNSecretKey:   {},
+			E2BKeyHashPepperSecretKey:   {},
+			QuotaRedisUsernameSecretKey: {},
+			QuotaRedisPasswordSecretKey: {},
+		})).Build()
+		got, err := resolveSecretSettings(c, "ns/cfg", "sys", current)
+		require.NoError(t, err)
+		assert.Equal(t, secretConfig{}, got)
+	})
+
+	t.Run("load-error-wraps-ref", func(t *testing.T) {
+		c := fake.NewClientBuilder().Build()
+		_, err := resolveSecretSettings(c, "ns/cfg", "sys", current)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsNotFound(err))
+	})
+}

--- a/config/crd/bases/agents.kruise.io_sandboxsets.yaml
+++ b/config/crd/bases/agents.kruise.io_sandboxsets.yaml
@@ -418,10 +418,10 @@ spec:
                       the base (equivalent to 100%, i.e. no cap). Scale-down is unaffected.
 
                       The physical scale-up budget is charged by startup blockers: sandboxes
-                      whose Ready condition is False with reason PodCreateFailed or
-                      StartContainerFailed, sandboxes stuck in Creating/ResourcePending past the
-                      configured --max-pending-timeout, and sandbox creations that have been
-                      issued but are not yet observed by the controller (they release their slot
+                      whose Ready condition is False with reason PodCreateFailed,
+                      StartContainerFailed, or Unschedulable, sandboxes stuck in
+                      Creating/ResourcePending past the configured --max-pending-timeout, and
+                      sandbox creations that have been issued but are not yet observed by the controller (they release their slot
                       once observed as healthy Creating sandboxes). Healthy observed Creating
                       sandboxes do NOT count against the budget.
 

--- a/docs/proposals/20260824-sandbox-manager-network-interface-peer-discovery.md
+++ b/docs/proposals/20260824-sandbox-manager-network-interface-peer-discovery.md
@@ -1,0 +1,385 @@
+---
+title: Sandbox Manager Network Interface Binding and Reliable Peer Discovery
+authors:
+  - "@AiRanthem"
+reviewers: []
+creation-date: 2026-08-24
+last-updated: 2026-09-09
+status: implementable
+---
+
+# Sandbox Manager Network Interface Binding and Reliable Peer Discovery
+
+## Summary
+
+Sandbox Manager accepts an optional `--network-interface` flag. When it is set,
+one validated global-unicast address from that interface, preferring IPv4 over
+IPv6, becomes the process-wide sandbox-cluster address for the control API,
+peer route service, memberlist, and the local return entry used by non-Sandbox
+proxy requests. When it is empty, the
+existing non-hosted network behavior is preserved. A second optional flag,
+`--disable-envoy-ext-proc`, skips the Envoy ext-proc gRPC listener on port
+`9002` for deployments whose data plane does not consume ext-proc; the peer
+route service starts regardless.
+
+Peer discovery lists selector-matching Pods through a live, uncached Kubernetes
+client built from the process `rest.Config`. Sandbox Manager and Sandbox Gateway
+share that bounded listing contract: namespace and selector are required at
+startup, each retry cycle performs at most one List while unjoined, and listing
+stops after a successful join. After memberlist begins listening, seed
+discovery and joining run in the background with retry. Shutdown stops new
+discovery and retries; an active join returns under its network deadlines. One
+lifecycle owner runs Leave and Shutdown exactly once. This keeps temporary peer
+absence from blocking the control API without creating competing cleanup paths.
+
+## Background
+
+A hosted Sandbox Manager is a Sandbox Manager deployed outside the sandbox
+cluster, meaning the cluster that runs sandbox orchestration. That Pod has both
+a platform network and a sandbox-cluster network. Endpoints that serve or
+advertise sandbox-cluster traffic must consistently use the sandbox-cluster
+network; selecting different local addresses can make a process reachable
+through one protocol but isolated through another.
+
+Peer Pods also start and stop independently. A one-time Kubernetes list or a
+single synchronous join turns ordinary startup ordering into permanent
+isolation. Reliable discovery therefore retries a namespace- and
+selector-scoped live Pod list until a join succeeds, then hands membership to
+memberlist. That retry is independent of API readiness.
+
+## Target Design
+
+### One sandbox-cluster address
+
+`--network-interface` has the following contract:
+
+- An empty value preserves the established non-hosted behavior. The control
+  API and peer route service listen on all local addresses. Memberlist uses
+  `POD_IP` when present, otherwise the first non-loopback IPv4 address. The
+  non-Sandbox proxy return entry remains on loopback.
+- A non-empty value is an exact operating-system interface name. The interface
+  must exist, be up, and have exactly one global-unicast address in the
+  preferred family: IPv4 when the interface has any global-unicast IPv4
+  address, otherwise IPv6. Missing, down, addressless, or multiple addresses
+  in the preferred family make startup fail. The process never falls back to
+  another interface.
+- The address is resolved and validated once during startup. Address changes
+  take effect after a process restart.
+- The same address is used by the control API listener, the peer route listener
+  on port `7789`, and memberlist's bind and advertised address. The non-Sandbox
+  proxy return entry uses this address as well, so return traffic does not
+  silently switch to loopback after the listeners move to the sandbox-cluster
+  network.
+- Interface selection controls local listeners and advertised peer identity. It
+  does not use `SO_BINDTODEVICE`, select outbound routes, or change DNS policy.
+
+The ext-proc listener on port `9002`, pprof, metrics, and other observability
+listeners are outside this address contract. Their exposure is a separate
+concern; only ext-proc enablement is covered below.
+
+```mermaid
+flowchart LR
+    Flag["--network-interface"] --> Resolve[Resolve and validate one address]
+    Resolve --> API[Control API]
+    Resolve --> Route[Peer route :7789]
+    Resolve --> Gossip[Memberlist bind and advertise]
+    Resolve --> Return[Non-Sandbox proxy return entry]
+```
+
+### Optional ext-proc listener
+
+`--disable-envoy-ext-proc` has the following contract:
+
+- The default keeps the established behavior: the Envoy ext-proc gRPC server
+  and its gRPC health service listen on port `9002` on all local addresses.
+- When set, neither the port `9002` listener nor the gRPC server is created.
+  The peer route service on port `7789`, route ingestion, and route
+  distribution are unaffected, so the replica still participates in route
+  synchronization.
+- The flag does not change the ext-proc address or protocol. An Envoy that is
+  configured to call ext-proc must not target a replica started with this
+  flag; that pairing is a deployment configuration error.
+- Both listeners bind synchronously during startup. A bind failure of either
+  enabled listener fails startup before the process serves requests.
+
+### Bounded peer listing
+
+The Sandbox Manager builder constructs an uncached controller-runtime client
+from the same `rest.Config` already supplied to the process. It does not add a
+Pod informer to the shared sandbox cache, and it does not list through
+`APIReader`. Peer code receives that client as a reader; it does not import or
+read the cache, and it does not read through Infra.
+
+Listing is restricted by both of these required inputs:
+
+- a non-empty system namespace; and
+- a non-empty, syntactically valid peer label selector.
+
+Invalid or absent scope is a startup error rather than an unfiltered Pod list.
+Sandbox Manager also requires a non-nil `rest.Config` so assembly can build the
+live client.
+
+Sandbox Manager and Sandbox Gateway share this listing contract. Gateway builds
+the same kind of live client from in-cluster configuration. While unjoined,
+each retry cycle performs at most one live Pod list and stops listing after a
+successful join. API availability therefore affects peer convergence, not
+control-API or Gateway readiness.
+
+### Trusted seed addresses
+
+Each listed, selector-matching Pod can contribute at most one seed:
+
+- Without a `memberlist-url` annotation, the seed is the Pod's `status.podIP`
+  plus the configured memberlist port. IPv4 and IPv6 PodIPs are both eligible;
+  IPv6 seeds use the bracketed host:port form.
+- With the annotation, its host must be the same valid IP as
+  `status.podIP`; only the port may differ. An annotation cannot redirect peer
+  traffic to another Pod, tenant, or external address.
+- Pods with an empty or invalid PodIP, invalid annotated address, the local
+  memberlist address, or a duplicate address are excluded.
+- Pods in the terminal `Succeeded` or `Failed` phase are excluded: no container
+  remains to accept memberlist traffic, so each would only cost a dial timeout
+  per retry cycle.
+
+**Warning:** A Sandbox Manager started with `--network-interface` must not be a
+memberlist seed. Seed addresses are always derived from `status.podIP`, which
+can differ from the selected interface address that memberlist actually binds
+and advertises. If the peer selector matches that Manager Pod, other members
+join `status.podIP` and never reach the listener. The peer selector must not
+select those Pods.
+
+This constraint belongs to the deployment that owns the peer selector. Sandbox
+Manager deliberately adds no in-process guard: the process knows only its own
+flag value and bound address, while the unreachable join happens in other
+members, so a local check could pass while the topology stays wrong. A
+misconfigured selector therefore keeps this process starting normally and
+surfaces as the affected members repeatedly logging join failures against the
+hosted Manager's PodIP. Correcting it is an orchestration change to the peer
+selector, not a code change.
+
+Those Managers still join memberlist by contacting a seed that listens on its
+PodIP, typically a Sandbox Gateway or a Sandbox Manager started without
+`--network-interface`. After a successful join, gossip advertises the selected
+interface address, so later members discover the hosted Manager that way
+rather than through Kubernetes seed listing.
+
+The Kubernetes seed set is therefore only the selector-matching Pods that
+listen on `status.podIP`. Sandbox Gateway and non-hosted Sandbox Manager
+replicas remain valid seeds. Hosted Managers may appear in memberlist
+membership after they join, but they are not seed sources. The local member is
+excluded. A Kubernetes Service and its mirrored or selected backends are
+routing objects, not peer membership or seed sources.
+
+Pod readiness and non-terminal phases do not filter the seed set. They are not
+reliable membership signals: a newly starting peer may already accept
+memberlist traffic, while memberlist itself owns ongoing liveness after a join.
+
+Seeds are sorted into a stable order, and every seed is joined, one Join call
+per seed, without stopping at the first success. Per-seed calls keep each
+failure attributable, because a bulk Join discards errors once any seed
+succeeds, and honor cancellation between dials.
+
+### Non-blocking join lifecycle
+
+The peer route listener on port `7789` starts before memberlist begins
+listening, so a replica never advertises itself to peers before it can accept
+their route refreshes. Memberlist then begins listening before seed discovery
+starts, and Sandbox Manager runs the following lifecycle in the background:
+
+1. List eligible peer Pods from the API server and derive trusted seed
+   addresses.
+2. Join every seed in stable order, one Join call per seed, without stopping
+   at the first success.
+3. Stop discovery after a cycle in which any join reports `joined > 0`.
+4. If the list fails, no seeds exist, or every join fails, wait 10 seconds
+   after the attempt finishes and retry.
+
+Joining is not a readiness condition and does not delay control API startup. A
+replica may temporarily operate as a single member; successful joining hands
+ongoing membership changes to memberlist, so periodic Kubernetes rediscovery is
+unnecessary. A replica whose selector never yields a seed, such as a
+single-replica deployment, keeps listing once per retry interval for the life
+of the process; the empty seed set is logged at the default verbosity on the
+first cycle and at verbosity 2 afterwards, while list failures are logged as
+errors on every cycle.
+
+Kubernetes listing and the 10-second retry wait stop immediately when the peer
+lifecycle context is canceled. Memberlist's join API has no context parameter,
+so an already-started join returns under memberlist's existing network
+deadlines rather than being interrupted by cancellation. Its default connection
+and stream deadlines are each 10 seconds, and a complete push/pull can cross
+more than one deadline window. No new join or retry starts after cancellation.
+
+Known limit: there is no single 10-second upper bound for a complete in-flight
+join. If shutdown must interrupt that work immediately or enforce one overall
+deadline, the upgrade path is a context-aware memberlist transport that
+preserves memberlist's dynamic-port and cleanup semantics. That transport is
+not part of this proposal.
+
+```mermaid
+flowchart LR
+    Listener[Memberlist listening] --> Worker[Background join worker]
+    Worker --> List[List peer Pods from APIServer]
+    List --> Seeds[Validate, deduplicate, and sort seeds]
+    Seeds --> Join[Join one seed]
+    Join -->|joined > 0| Done[Memberlist maintains membership]
+    Join -->|all fail| Wait[Wait 10 seconds]
+    List -->|error or empty| Wait
+    Wait --> List
+    Stop[Stop request or parent cancellation] --> Worker
+    Worker -->|active join returned| Leave[Best-effort Leave]
+    Leave --> Shutdown[Mandatory Shutdown while process is alive]
+```
+
+### Startup and shutdown boundary
+
+Startup fails before serving requests when the selected interface, resolved
+address, namespace, selector, peer client, control API listener,
+peer route listener, or memberlist listener is invalid. The initial seed set
+and join result are deliberately not startup requirements. This startup and
+shutdown contract applies to the Sandbox Manager process. Sandbox Gateway
+process lifecycle is outside this proposal.
+
+Each peer instance establishes one lifecycle owner when memberlist starts. That
+owner remains until cleanup finishes, including after seed discovery succeeds.
+An explicit stop request or parent-context cancellation cancels the peer
+lifecycle context; the owner then runs Leave and Shutdown exactly once. The
+peer's Start is called exactly once and its Stop at most once, after Start has
+returned, by the component that owns it; a second Start is rejected, and
+concurrent or repeated Stop calls are outside the contract. A caller's wait
+deadline does not transfer cleanup ownership or create a competing close path:
+when Stop returns because its context expired, the owner still completes Leave
+and Shutdown. Stop on a peer whose Start never succeeded is a no-op, so a
+component can run its shutdown sequence after a failed Start without special
+cases.
+
+Sandbox cache synchronization completes before the process serves requests. A
+termination signal that arrives while startup is still running follows the
+crash model described below rather than the graceful Stop path: the process
+exits immediately without waiting for startup to finish and without
+per-component cleanup, so memberlist Leave and primary lease release are
+skipped. Other members remove the stale entry through failure detection and
+the lease expires through its TTL; both self-heal without operator action. A
+signal that arrives once startup has completed, including one observed
+together with the completion, runs the graceful Stop path. Running the
+graceful chain for an interrupted startup is the upgrade path if graceful
+cleanup during startup ever becomes a requirement.
+
+The lifecycle owner prevents new discovery work, allows an in-flight join to
+return under the network-deadline boundary described above, and then attempts
+`Leave` before `Shutdown`. `Leave` is best effort and has a five-second limit;
+its failure is reported but never prevents `Shutdown` while the process remains
+alive. No code path calls `Leave` after `Shutdown`, and the join worker never
+races a separate stop caller for ownership of memberlist cleanup.
+
+If the process is forcibly terminated before the active join returns or the
+leave message is delivered, other members temporarily retain a stale active
+member and remove it through memberlist's normal failure detection. This is the
+same cluster-level failure model as a process crash, OOM, node loss, or network
+partition. Peer membership is not a quorum or authorization source. A stale
+peer may add only bounded per-peer fanout delay or error: it must not roll back
+local route state, change the outcome of an authoritative Sandbox mutation, or
+prevent parallel synchronization to other live peers.
+
+Failure detection removes an unreachable member from the surviving members'
+view. It does not promise that two isolated memberlist partitions will merge
+again without an external seed after connectivity returns; successful seed
+discovery intentionally stops its Kubernetes retry loop.
+
+### Compatibility and ownership
+
+This proposal adds two optional CLI flags, `--network-interface` and
+`--disable-envoy-ext-proc`. It does not change CRDs, HTTP models, Secrets, or
+the memberlist wire protocol. Both in-cluster configuration and `KUBECONFIG`
+continue to supply the sandbox-cluster Kubernetes client.
+
+Process peer discovery and peer lifecycle belong to the Manager layer because
+they coordinate Sandbox Manager processes rather than implement a Sandbox
+backend. Interface address resolution is a policy-neutral helper in
+`pkg/utils/network`. Command entrypoints only accept the flags, resolve the
+interface address once, and assemble these capabilities; the Manager builder
+constructs the live peer client from the supplied `rest.Config`. API protocol
+behavior and Infra backend behavior remain unchanged.
+
+Sandbox Gateway now requires non-empty `PEER_NAMESPACE` and
+`PEER_LABEL_SELECTOR`; an empty value fails peer startup instead of listing
+Pods across all namespaces. The reference manifest under
+`config/sandbox-gateway` already sets both. Self-authored Gateway manifests
+must set them before upgrading, and the release notes for the first release
+containing this change must call this out.
+
+The following are outside this proposal:
+
+- memberlist encryption and peer-route mTLS;
+- changing the address or port of the `9002` ext-proc listener;
+- metrics, pprof, or observability listener isolation;
+- Deployment, RBAC, KDM, or rollout configuration;
+- Sandbox Gateway process lifecycle, including SIGTERM handling and peer-route
+  listener bind sequencing;
+- an informer refactor for Sandbox Gateway;
+- address hot reload or periodic seed reconciliation.
+
+No RBAC change is required for Sandbox Manager: its existing Pod permissions
+already include `get`, `list`, and `watch`. Peer discovery treats listed Pods as
+read-only objects and never mutates them.
+
+Deployment changes remain outside this proposal, but hosted activation depends
+on them. Kubernetes TCP probes without an explicit host target the Pod IP; when
+the control API and peer route bind only to a different sandbox-cluster
+address, those probes cannot reach the listeners and can restart the Pod.
+Hosted rollout configuration must make the `8080` and `7789` probes reach the
+selected sandbox-cluster address before enabling `--network-interface`.
+
+Hosted activation also depends on seed topology. The peer selector must not
+match Sandbox Manager Pods started with `--network-interface`. At least one
+PodIP-reachable seed must remain in that selector, and the selected interface
+must be able to reach that seed's memberlist address. New hosted replicas
+cannot join if every such seed is gone, because Kubernetes listing stops after
+the first successful join.
+
+## Risks
+
+- Live Pod listing during retry depends on APIServer availability. Namespace and
+  label filtering bound each list to the peer Pods for one Sandbox Manager
+  scope, and listing stops after the first successful join. A replica that
+  never finds a seed keeps issuing one bounded list per retry interval.
+- A canceled process can remain in a memberlist join across multiple 10-second
+  network-deadline windows. An immediate-cancellation requirement has a defined
+  transport-based upgrade path.
+- Forced termination, or a termination signal during startup, can skip Leave
+  and temporarily retain a stale member. Memberlist failure detection removes
+  it; the stale entry may add bounded per-peer fanout failure but cannot change
+  authoritative Sandbox state. A primary lease acquired during startup is held
+  until its TTL expires.
+- An interface address can change while the process is running. Resolving once
+  avoids split listener identity; operational recovery is a restart.
+- The API may become ready while the replica is still a single member. This is
+  intentional: background retry repairs startup races without making peer
+  availability a control-plane availability dependency.
+- A hosted Manager whose Pod is still selected as a seed will advertise one
+  address and be joined at another. Peer selector configuration must exclude
+  those Pods.
+- After the first successful join, a new hosted replica cannot join unless a
+  PodIP-reachable seed is still available.
+
+## Alternatives
+
+- A shared Pod informer on the sandbox cache is rejected because seed discovery
+  lists a handful of process Pods until join succeeds, then stops. A
+  process-lifetime watch expands cache filters, startup registration, and tests,
+  and makes memberlist wait on informer sync.
+- Listing through the manager `APIReader` is rejected. That reader is the
+  cache-bypass Get fallback, not a substitute for informers. Assembly constructs
+  a dedicated uncached client from `rest.Config`, matching Gateway.
+- Picking the first address from a multi-address interface is rejected because
+  address ordering is not a stable network identity.
+- Trusting an arbitrary `memberlist-url` host is rejected because Pod metadata
+  must not redirect peer traffic outside the selected Pod identity.
+- Publishing the selected interface address as a Kubernetes seed is rejected.
+  Hosted Managers join through a PodIP-reachable seed and then rely on
+  memberlist gossip; the peer selector must not list them as seeds.
+- A custom cancellable memberlist transport is deferred because this scope
+  accepts memberlist's existing network-deadline behavior, and a correct
+  transport must preserve more than dialing alone.
+- Continuous Kubernetes seed reconciliation after a successful join is
+  rejected because memberlist already owns membership convergence.

--- a/pkg/agent-runtime/storage-cli/link/symlink.go
+++ b/pkg/agent-runtime/storage-cli/link/symlink.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/openkruise/agents/pkg/utils/pathutils"
 )
 
 // CreateSymlink creates a symlink so that the user-facing mount path inside
@@ -34,9 +36,12 @@ func CreateSymlink(target, link string) error {
 	// Normalize link path: remove trailing slash if present
 	link = strings.TrimRight(link, "/")
 
-	// Validate link path is not empty after trimming
-	if link == "" {
-		return fmt.Errorf("link path cannot be empty")
+	// Reject unsafe paths before any filesystem operation.
+	if err := pathutils.ValidateSafePath(target); err != nil {
+		return fmt.Errorf("invalid target path: %w", err)
+	}
+	if err := pathutils.ValidateSafePath(link); err != nil {
+		return fmt.Errorf("invalid link path: %w", err)
 	}
 
 	// Check if target exists and is a directory

--- a/pkg/agent-runtime/storage-cli/link/symlink_test.go
+++ b/pkg/agent-runtime/storage-cli/link/symlink_test.go
@@ -54,7 +54,7 @@ func TestCreateSymlinkBranches(t *testing.T) {
 				// trailing slash will be trimmed to empty string.
 				return tgt, "/"
 			},
-			expectError: "link path cannot be empty",
+			expectError: "invalid link path: path must not be empty",
 		},
 		{
 			name: "target does not exist returns error",

--- a/pkg/agent-runtime/storage-cli/main.go
+++ b/pkg/agent-runtime/storage-cli/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openkruise/agents/pkg/agent-runtime/storage-cli/link"
 	"github.com/openkruise/agents/pkg/agent-runtime/storage-cli/mountfinder"
 	"github.com/openkruise/agents/pkg/agent-runtime/storage-cli/storage"
+	"github.com/openkruise/agents/pkg/utils/logs"
 	"github.com/spf13/cobra"
 )
 
@@ -112,7 +113,7 @@ func runMount(cmd *cobra.Command) error {
 
 	originDirectory := csiReq.TargetPath
 	originDirectoryMd5 := getMD5String(csiReq.TargetPath)
-	log.Printf("Origin directory: %s, md5: %s", originDirectory, originDirectoryMd5)
+	log.Printf("Origin directory: %s, md5: %s", logs.SanitizeValue(originDirectory), originDirectoryMd5)
 
 	mountRootPath, err := mountFinderFn(mountName, debugMode)
 	if err != nil {
@@ -132,7 +133,7 @@ func runMount(cmd *cobra.Command) error {
 	}
 
 	toMountTargetPath := path.Join(mountRootPath, provider.SubDir(), originDirectoryMd5)
-	log.Printf("Real mount target path: %s", toMountTargetPath)
+	log.Printf("Real mount target path: %s", logs.SanitizeValue(toMountTargetPath))
 	csiReq.TargetPath = toMountTargetPath
 
 	if err = provider.Mount(context.Background(), csiReq, debugMode); err != nil {
@@ -149,7 +150,7 @@ func mountRun(cmd *cobra.Command, args []string) {
 	startTime := time.Now()
 	log.Printf("Received mount request: driver=%s mountName=%s", driver, mountName)
 	if err := runMount(cmd); err != nil {
-		log.Printf("Mount failed (costMs=%d): %v", time.Since(startTime).Milliseconds(), err)
+		log.Printf("Mount failed (costMs=%d): %v", time.Since(startTime).Milliseconds(), logs.SanitizeValue(err.Error()))
 		os.Exit(1)
 	}
 	log.Printf("Mount succeeded (costMs=%d)", time.Since(startTime).Milliseconds())

--- a/pkg/agent-runtime/storage-cli/main.go
+++ b/pkg/agent-runtime/storage-cli/main.go
@@ -88,8 +88,8 @@ func runMount(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to decode CSI request config: %w", err)
 	}
 
-	csiReq := csi.NodePublishVolumeRequest{}
-	if err := proto.Unmarshal(configRaw, &csiReq); err != nil {
+	csiReq := &csi.NodePublishVolumeRequest{}
+	if err := proto.Unmarshal(configRaw, csiReq); err != nil {
 		cmd.Help() // #nosec G104 -- help output error is non-actionable
 		return fmt.Errorf("failed to unmarshal CSI request: %w", err)
 	}
@@ -195,7 +195,7 @@ func main() {
 	}
 }
 
-func validateGeneralParams(csiReq csi.NodePublishVolumeRequest) error {
+func validateGeneralParams(csiReq *csi.NodePublishVolumeRequest) error {
 	if strings.TrimSpace(csiReq.VolumeContext["csi.storage.k8s.io/pod.uid"]) == "" {
 		return fmt.Errorf("Pod UID is required. Use csi.storage.k8s.io/pod.uid setting")
 	}

--- a/pkg/agent-runtime/storage-cli/main_test.go
+++ b/pkg/agent-runtime/storage-cli/main_test.go
@@ -283,8 +283,8 @@ func TestRootCmdExecute_VersionSubcommand(t *testing.T) {
 
 // newCSIRequestWithVolumeContext builds a minimal NodePublishVolumeRequest
 // with the provided volume context; used to drive validateGeneralParams.
-func newCSIRequestWithVolumeContext(ctx map[string]string) csi.NodePublishVolumeRequest {
-	return csi.NodePublishVolumeRequest{VolumeContext: ctx}
+func newCSIRequestWithVolumeContext(ctx map[string]string) *csi.NodePublishVolumeRequest {
+	return &csi.NodePublishVolumeRequest{VolumeContext: ctx}
 }
 
 // captureStdout swaps os.Stdout for the duration of fn and returns the
@@ -348,8 +348,8 @@ func ensureSubcommand(t *testing.T, parent, child *cobra.Command) {
 type fakeProvider struct {
 	driverName string
 	subDir     string
-	validateFn func(csi.NodePublishVolumeRequest) error
-	mountFn    func(context.Context, csi.NodePublishVolumeRequest) error
+	validateFn func(*csi.NodePublishVolumeRequest) error
+	mountFn    func(context.Context, *csi.NodePublishVolumeRequest) error
 }
 
 func (f *fakeProvider) Driver() string { return f.driverName }
@@ -359,19 +359,19 @@ func (f *fakeProvider) SubDir() string {
 	}
 	return "fake"
 }
-func (f *fakeProvider) Validate(req csi.NodePublishVolumeRequest) error {
+func (f *fakeProvider) Validate(req *csi.NodePublishVolumeRequest) error {
 	if f.validateFn != nil {
 		return f.validateFn(req)
 	}
 	return nil
 }
-func (f *fakeProvider) Mount(ctx context.Context, req csi.NodePublishVolumeRequest, debug bool) error {
+func (f *fakeProvider) Mount(ctx context.Context, req *csi.NodePublishVolumeRequest, debug bool) error {
 	if f.mountFn != nil {
 		return f.mountFn(ctx, req)
 	}
 	return nil
 }
-func (f *fakeProvider) Unmount(_ context.Context, _ csi.NodePublishVolumeRequest) error {
+func (f *fakeProvider) Unmount(_ context.Context, _ *csi.NodePublishVolumeRequest) error {
 	return nil
 }
 
@@ -444,7 +444,7 @@ func TestRunMount(t *testing.T) {
 	lookupValidateErr := func(_ string) (storage.Provider, bool) {
 		return &fakeProvider{
 			driverName: fakeDriver,
-			validateFn: func(_ csi.NodePublishVolumeRequest) error {
+			validateFn: func(_ *csi.NodePublishVolumeRequest) error {
 				return fmt.Errorf("validate: secret key missing")
 			},
 		}, true
@@ -452,7 +452,7 @@ func TestRunMount(t *testing.T) {
 	lookupMountErr := func(_ string) (storage.Provider, bool) {
 		return &fakeProvider{
 			driverName: fakeDriver,
-			mountFn: func(_ context.Context, _ csi.NodePublishVolumeRequest) error {
+			mountFn: func(_ context.Context, _ *csi.NodePublishVolumeRequest) error {
 				return fmt.Errorf("mount: socket not found")
 			},
 		}, true
@@ -613,5 +613,3 @@ func TestRunMount_PodUIDFromEnv(t *testing.T) {
 	// POD_UID env fills the missing pod uid so validateGeneralParams passes.
 	assert.NoError(t, runMount(silentCmd()))
 }
-
-

--- a/pkg/agent-runtime/storage-cli/mountfinder/root_mount_helper.go
+++ b/pkg/agent-runtime/storage-cli/mountfinder/root_mount_helper.go
@@ -7,6 +7,9 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/openkruise/agents/pkg/utils/logs"
+	"github.com/openkruise/agents/pkg/utils/pathutils"
 )
 
 type MountReader interface {
@@ -105,11 +108,15 @@ func FindMountPath(mountName string, debug bool) (string, error) {
 		}
 	}
 
+	if err := pathutils.ValidateSafePath(mountPath); err != nil {
+		return "", fmt.Errorf("invalid mount path: %w", err)
+	}
+
 	if !checkMountPathExists(mountPath) {
 		return "", fmt.Errorf("mount path %s is not accessible", mountPath)
 	}
 	if debug {
-		log.Printf("[DEBUG] Mount path %s exists and is accessible\n", mountPath)
+		log.Printf("[DEBUG] Mount path %s exists and is accessible\n", logs.SanitizeValue(mountPath))
 	}
 	return mountPath, nil
 }

--- a/pkg/agent-runtime/storage-cli/storage/csi_runner.go
+++ b/pkg/agent-runtime/storage-cli/storage/csi_runner.go
@@ -49,7 +49,7 @@ var newClientFn = func(socketPath string) (csi.NodeClient, io.Closer, error) {
 // debug controls whether the full PublishContext (which may contain credentials
 // such as AK/SK or tokens) is included in the log output. Pass true only in
 // non-production environments for troubleshooting.
-func RunNodePublishVolume(ctx context.Context, driver string, req csi.NodePublishVolumeRequest, debug bool) error {
+func RunNodePublishVolume(ctx context.Context, driver string, req *csi.NodePublishVolumeRequest, debug bool) error {
 	socketPath := path.Join(CsiSocketDir, driver, CsiSocketFile)
 	client, closer, err := newClientFn(socketPath)
 	if err != nil {
@@ -71,7 +71,7 @@ func RunNodePublishVolume(ctx context.Context, driver string, req csi.NodePublis
 	defer cancel()
 
 	start := time.Now()
-	resp, err := client.NodePublishVolume(callCtx, &req, grpc.WaitForReady(true))
+	resp, err := client.NodePublishVolume(callCtx, req, grpc.WaitForReady(true))
 	if err != nil {
 		return fmt.Errorf("NodePublishVolume failed for driver %q: %w", driver, err)
 	}

--- a/pkg/agent-runtime/storage-cli/storage/csi_runner_test.go
+++ b/pkg/agent-runtime/storage-cli/storage/csi_runner_test.go
@@ -52,12 +52,12 @@ func (c *nopCloser) Close() error {
 type fakeNodeClient struct {
 	csi.NodeClient
 
-	gotReq  *csi.NodePublishVolumeRequest
-	gotCtx  context.Context
-	resp    *csi.NodePublishVolumeResponse
-	err     error
-	calls   atomic.Int32
-	onCall  func(ctx context.Context)
+	gotReq *csi.NodePublishVolumeRequest
+	gotCtx context.Context
+	resp   *csi.NodePublishVolumeResponse
+	err    error
+	calls  atomic.Int32
+	onCall func(ctx context.Context)
 }
 
 func (f *fakeNodeClient) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest, _ ...grpc.CallOption) (*csi.NodePublishVolumeResponse, error) {
@@ -154,7 +154,7 @@ func TestRunNodePublishVolume(t *testing.T) {
 			ctx, cancel := tt.ctx()
 			defer cancel()
 
-			err := RunNodePublishVolume(ctx, driver, csi.NodePublishVolumeRequest{VolumeId: "vol-1"}, false)
+			err := RunNodePublishVolume(ctx, driver, &csi.NodePublishVolumeRequest{VolumeId: "vol-1"}, false)
 
 			if tt.expectError == "" {
 				assert.NoError(t, err)
@@ -184,7 +184,7 @@ func TestRunNodePublishVolumeAppliesTimeout(t *testing.T) {
 		return fake, &nopCloser{}, nil
 	})
 
-	err := RunNodePublishVolume(context.Background(), "fake.csi.example.com", csi.NodePublishVolumeRequest{}, false)
+	err := RunNodePublishVolume(context.Background(), "fake.csi.example.com", &csi.NodePublishVolumeRequest{}, false)
 	assert.NoError(t, err)
 	assert.Equal(t, int32(1), fake.calls.Load())
 }
@@ -330,7 +330,7 @@ func TestRunNodePublishVolumeBuildsSocketPath(t *testing.T) {
 				return &fakeNodeClient{resp: &csi.NodePublishVolumeResponse{}}, &nopCloser{}, nil
 			})
 
-			err := RunNodePublishVolume(context.Background(), tt.driver, csi.NodePublishVolumeRequest{}, false)
+			err := RunNodePublishVolume(context.Background(), tt.driver, &csi.NodePublishVolumeRequest{}, false)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, seenPath)
 			// Sanity-check the layout: the socket must live under CsiSocketDir.

--- a/pkg/agent-runtime/storage-cli/storage/provider.go
+++ b/pkg/agent-runtime/storage-cli/storage/provider.go
@@ -39,7 +39,7 @@ type Provider interface {
 
 	// Validate checks driver-specific fields on the CSI request before
 	// the mount is attempted. It MUST NOT mutate the request.
-	Validate(req csi.NodePublishVolumeRequest) error
+	Validate(req *csi.NodePublishVolumeRequest) error
 
 	// Mount performs the driver-specific mount. The default open-source
 	// implementation forwards to the CSI plugin via NodePublishVolume; see
@@ -47,9 +47,9 @@ type Provider interface {
 	//
 	// debug controls whether sensitive fields (e.g. PublishContext) are included
 	// in log output. Pass true only in non-production environments.
-	Mount(ctx context.Context, req csi.NodePublishVolumeRequest, debug bool) error
+	Mount(ctx context.Context, req *csi.NodePublishVolumeRequest, debug bool) error
 
 	// Unmount performs the driver-specific unmount. Drivers that have not
 	// implemented unmount yet may return nil.
-	Unmount(ctx context.Context, req csi.NodePublishVolumeRequest) error
+	Unmount(ctx context.Context, req *csi.NodePublishVolumeRequest) error
 }

--- a/pkg/agent-runtime/storage-cli/storage/registry_test.go
+++ b/pkg/agent-runtime/storage-cli/storage/registry_test.go
@@ -31,13 +31,13 @@ type fakeProvider struct {
 	subDir string
 }
 
-func (f *fakeProvider) Driver() string                                          { return f.driver }
-func (f *fakeProvider) SubDir() string                                          { return f.subDir }
-func (f *fakeProvider) Validate(_ csi.NodePublishVolumeRequest) error           { return nil }
-func (f *fakeProvider) Mount(_ context.Context, _ csi.NodePublishVolumeRequest, _ bool) error {
+func (f *fakeProvider) Driver() string                                 { return f.driver }
+func (f *fakeProvider) SubDir() string                                 { return f.subDir }
+func (f *fakeProvider) Validate(_ *csi.NodePublishVolumeRequest) error { return nil }
+func (f *fakeProvider) Mount(_ context.Context, _ *csi.NodePublishVolumeRequest, _ bool) error {
 	return nil
 }
-func (f *fakeProvider) Unmount(_ context.Context, _ csi.NodePublishVolumeRequest) error {
+func (f *fakeProvider) Unmount(_ context.Context, _ *csi.NodePublishVolumeRequest) error {
 	return nil
 }
 

--- a/pkg/agent-runtime/storage-cli/validation_test.go
+++ b/pkg/agent-runtime/storage-cli/validation_test.go
@@ -25,12 +25,12 @@ import (
 func TestValidateGeneralParams(t *testing.T) {
 	tests := []struct {
 		name    string
-		csiReq  csi.NodePublishVolumeRequest
+		csiReq  *csi.NodePublishVolumeRequest
 		wantErr bool
 	}{
 		{
 			name: "valid request with pod uid",
-			csiReq: csi.NodePublishVolumeRequest{
+			csiReq: &csi.NodePublishVolumeRequest{
 				VolumeContext: map[string]string{
 					"csi.storage.k8s.io/pod.uid": "test-pod-uid",
 				},
@@ -39,7 +39,7 @@ func TestValidateGeneralParams(t *testing.T) {
 		},
 		{
 			name: "request without pod uid",
-			csiReq: csi.NodePublishVolumeRequest{
+			csiReq: &csi.NodePublishVolumeRequest{
 				VolumeContext: map[string]string{
 					"csi.storage.k8s.io/pod.uid": "",
 				},
@@ -48,14 +48,14 @@ func TestValidateGeneralParams(t *testing.T) {
 		},
 		{
 			name: "request without pod uid key",
-			csiReq: csi.NodePublishVolumeRequest{
+			csiReq: &csi.NodePublishVolumeRequest{
 				VolumeContext: map[string]string{},
 			},
 			wantErr: true,
 		},
 		{
 			name:    "nil volume context",
-			csiReq:  csi.NodePublishVolumeRequest{},
+			csiReq:  &csi.NodePublishVolumeRequest{},
 			wantErr: true,
 		},
 	}

--- a/pkg/cache/tasks.go
+++ b/pkg/cache/tasks.go
@@ -117,8 +117,8 @@ func (c *Cache) NewSandboxWaitReadyTask(ctx context.Context, sbx *agentsv1alpha1
 			return false, nil
 		}
 		readyCond := utils.GetSandboxCondition(&s.Status, string(agentsv1alpha1.SandboxConditionReady))
-		if readyCond != nil && readyCond.Reason == agentsv1alpha1.SandboxReadyReasonStartContainerFailed {
-			return false, fmt.Errorf("sandbox start container failed: %s", readyCond.Message)
+		if readyCond != nil && utils.IsSandboxStartupFailureReason(readyCond.Reason) {
+			return false, fmt.Errorf("sandbox startup failed (reason=%s): %s", readyCond.Reason, readyCond.Message)
 		}
 		inplaceCond := utils.GetSandboxCondition(&s.Status, string(agentsv1alpha1.SandboxConditionInplaceUpdate))
 		if inplaceCond != nil && inplaceCond.Reason == agentsv1alpha1.SandboxInplaceUpdateReasonInplaceUpdating {

--- a/pkg/cache/tasks_test.go
+++ b/pkg/cache/tasks_test.go
@@ -144,7 +144,31 @@ func TestNewSandboxWaitReadyTask_StartContainerFailed_ReturnsError(t *testing.T)
 	task := c.NewSandboxWaitReadyTask(context.Background(), sbx)
 	err = task.Wait(100 * time.Millisecond)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "start container failed")
+	assert.Contains(t, err.Error(), agentsv1alpha1.SandboxReadyReasonStartContainerFailed)
+}
+
+func TestNewSandboxWaitReadyTask_PodCreateFailed_ReturnsError(t *testing.T) {
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sbx-wait-3", Generation: 1},
+		Status: agentsv1alpha1.SandboxStatus{
+			ObservedGeneration: 1,
+			Conditions: []metav1.Condition{
+				{
+					Type:    string(agentsv1alpha1.SandboxConditionReady),
+					Status:  metav1.ConditionFalse,
+					Reason:  agentsv1alpha1.SandboxReadyReasonPodCreateFailed,
+					Message: "ResourceQuotaExceeded: quota exhausted",
+				},
+			},
+		},
+	}
+	c, _, err := cachetest.NewTestCache(t, sbx)
+	require.NoError(t, err)
+	task := c.NewSandboxWaitReadyTask(context.Background(), sbx)
+	err = task.Wait(100 * time.Millisecond)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), agentsv1alpha1.SandboxReadyReasonPodCreateFailed)
+	assert.Contains(t, err.Error(), "ResourceQuotaExceeded: quota exhausted")
 }
 
 func TestNewCheckpointTask_Succeeded(t *testing.T) {

--- a/pkg/cache/tasks_test.go
+++ b/pkg/cache/tasks_test.go
@@ -147,6 +147,29 @@ func TestNewSandboxWaitReadyTask_StartContainerFailed_ReturnsError(t *testing.T)
 	assert.Contains(t, err.Error(), agentsv1alpha1.SandboxReadyReasonStartContainerFailed)
 }
 
+func TestNewSandboxWaitReadyTask_Unschedulable_ReturnsError(t *testing.T) {
+	sbx := &agentsv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sbx-wait-unschedulable", Generation: 1},
+		Status: agentsv1alpha1.SandboxStatus{
+			ObservedGeneration: 1,
+			Conditions: []metav1.Condition{
+				{
+					Type:    string(agentsv1alpha1.SandboxConditionReady),
+					Status:  metav1.ConditionFalse,
+					Reason:  agentsv1alpha1.SandboxReadyReasonUnschedulable,
+					Message: "insufficient CPU",
+				},
+			},
+		},
+	}
+	c, _, err := cachetest.NewTestCache(t, sbx)
+	require.NoError(t, err)
+	task := c.NewSandboxWaitReadyTask(context.Background(), sbx)
+	err = task.Wait(100 * time.Millisecond)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), agentsv1alpha1.SandboxReadyReasonUnschedulable)
+}
+
 func TestNewSandboxWaitReadyTask_PodCreateFailed_ReturnsError(t *testing.T) {
 	sbx := &agentsv1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sbx-wait-3", Generation: 1},

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -103,7 +103,9 @@ func NewCommonControl(args SandboxControlArgs) SandboxControl {
 		lifecycleHookFunc:    lifecycleHookFunc,
 		initializer:          initializer,
 		recycleControl:       NewSandboxRecycleControl(args.Client, args.Recorder, args.RecycleConfig),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
+		syncStatusFromPod: func(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool) {
+			defaultSyncStatusFromPod(pod, newStatus, syncReadyCondition, classifyStartupFailure)
+		},
 	}
 	control.upgradeControl = NewUpgradeControl(args.Client, args.CheckpointControl, args.PodControl, args.Recorder, lifecycleHookFunc, initializer, control.syncStatusFromPod, control.handleResume)
 	return control
@@ -138,10 +140,9 @@ func (r *commonControl) EnsureSandboxRunning(ctx context.Context, args EnsureFun
 		return 0, nil
 	}
 
-	// pod status running
+	r.syncStatusFromPod(pod, newStatus, true)
 	if pod.Status.Phase == corev1.PodRunning {
 		newStatus.Phase = agentsv1alpha1.SandboxRunning
-		r.syncStatusFromPod(pod, newStatus, true)
 		return 0, nil
 	}
 
@@ -203,9 +204,14 @@ func (r *commonControl) EnsureSandboxUpdated(ctx context.Context, args EnsureFun
 }
 
 // defaultSyncStatusFromPod is the default implementation of syncStatusFromPod.
-// It syncs sandbox status from pod info and, when syncReadyCondition is true, also
-// syncs the Ready condition and detects container startup failures.
-func defaultSyncStatusFromPod(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool) {
+// It synchronizes Pod identity and, when requested, normalizes Ready failures
+// through the controller-specific startup failure normalizer.
+func defaultSyncStatusFromPod(
+	pod *corev1.Pod,
+	newStatus *agentsv1alpha1.SandboxStatus,
+	syncReadyCondition bool,
+	normalizePodStartupFailure func(*corev1.Pod) (reason, message string, failed bool),
+) {
 	newStatus.NodeName = pod.Spec.NodeName
 	newStatus.SandboxIp = pod.Status.PodIP
 	newStatus.PodInfo = agentsv1alpha1.PodInfo{
@@ -218,6 +224,15 @@ func defaultSyncStatusFromPod(pod *corev1.Pod, newStatus *agentsv1alpha1.Sandbox
 	}
 	pCond := utils.GetPodCondition(&pod.Status, corev1.PodReady)
 	cond := utils.GetSandboxCondition(newStatus, string(agentsv1alpha1.SandboxConditionReady))
+	reason, message, failed := "", "", false
+	if normalizePodStartupFailure != nil {
+		reason, message, failed = normalizePodStartupFailure(pod)
+	}
+	// Keep ordinary Pending Pods condition-free. Unclassified startup delays
+	// remain governed by the SandboxSet ResourcePending timeout.
+	if cond == nil && pCond == nil && !failed {
+		return
+	}
 	if cond == nil {
 		cond = &metav1.Condition{
 			Type:               string(agentsv1alpha1.SandboxConditionReady),
@@ -234,23 +249,19 @@ func defaultSyncStatusFromPod(pod *corev1.Pod, newStatus *agentsv1alpha1.Sandbox
 			cond.Reason = agentsv1alpha1.SandboxReadyReasonPodReady
 			cond.Message = ""
 		} else {
-			// Still not Ready: keep any previously recorded Reason so we do
-			// not erase a classification that has not been superseded. Sync
-			// the latest kubelet-level message for operator visibility, and
-			// classifyStartupFailure below may overwrite Reason if it now
-			// matches a definitive failure.
+			// Preserve non-startup failure reasons until they are superseded by
+			// the normalizer or the Pod becomes Ready.
 			cond.Message = pCond.Message
 		}
 	}
-	// Only classify explicit container startup failures. Other Waiting reasons
-	// are left to kubelet retries and the SandboxSet ResourcePending timeout.
-	// A previously recorded failure reason is kept until the Ready status
-	// flips to True (handled above), so we do not erase the classification
-	// speculatively while the pod is still not Ready.
 	if cond.Status == metav1.ConditionFalse {
-		if reason, message, failed := classifyStartupFailure(pod); failed {
+		if failed {
 			cond.Reason = reason
 			cond.Message = message
+		} else if cond.Reason == agentsv1alpha1.SandboxReadyReasonStartContainerFailed {
+			// Only the normalizer-owned startup failure is cleared on recovery.
+			cond.Reason = agentsv1alpha1.SandboxReadyReasonPodReady
+			cond.Message = ""
 		}
 	}
 	utils.SetSandboxCondition(newStatus, *cond)

--- a/pkg/controller/sandbox/core/common_control.go
+++ b/pkg/controller/sandbox/core/common_control.go
@@ -254,12 +254,17 @@ func defaultSyncStatusFromPod(
 			cond.Message = pCond.Message
 		}
 	}
+	if failed && cond.Status != metav1.ConditionFalse {
+		cond.Status = metav1.ConditionFalse
+		cond.LastTransitionTime = metav1.Now()
+	}
 	if cond.Status == metav1.ConditionFalse {
 		if failed {
 			cond.Reason = reason
 			cond.Message = message
-		} else if cond.Reason == agentsv1alpha1.SandboxReadyReasonStartContainerFailed {
-			// Only the normalizer-owned startup failure is cleared on recovery.
+		} else if cond.Reason == agentsv1alpha1.SandboxReadyReasonStartContainerFailed ||
+			cond.Reason == agentsv1alpha1.SandboxReadyReasonUnschedulable {
+			// Only normalizer-owned startup failures are cleared on recovery.
 			cond.Reason = agentsv1alpha1.SandboxReadyReasonPodReady
 			cond.Message = ""
 		}

--- a/pkg/controller/sandbox/core/common_control_test.go
+++ b/pkg/controller/sandbox/core/common_control_test.go
@@ -42,6 +42,10 @@ import (
 	"github.com/openkruise/agents/pkg/utils/sidecarutils"
 )
 
+func defaultCommonSyncStatusFromPod(pod *corev1.Pod, newStatus *agentsv1alpha1.SandboxStatus, syncReadyCondition bool) {
+	defaultSyncStatusFromPod(pod, newStatus, syncReadyCondition, classifyStartupFailure)
+}
+
 func TestCommonControl_EnsureSandboxRunning(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
@@ -331,7 +335,7 @@ func TestCommonControl_EnsureSandboxRunning(t *testing.T) {
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				rateLimiter:          rl,
 				podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-				syncStatusFromPod:    defaultSyncStatusFromPod,
+				syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 			}
 
 			requeue, err := control.EnsureSandboxRunning(context.TODO(), tt.args)
@@ -526,7 +530,7 @@ func TestCommonControl_EnsureSandboxUpdated(t *testing.T) {
 				recorder:             record.NewFakeRecorder(10),
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fc, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-				syncStatusFromPod:    defaultSyncStatusFromPod,
+				syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 			}
 
 			err := control.EnsureSandboxUpdated(context.TODO(), tt.args)
@@ -721,7 +725,7 @@ func TestCommonControl_EnsureSandboxUpdated_InitializePath(t *testing.T) {
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fc, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				initializer:          tt.initializer,
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-				syncStatusFromPod:    defaultSyncStatusFromPod,
+				syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 			}
 
 			newStatus := &agentsv1alpha1.SandboxStatus{
@@ -957,7 +961,7 @@ func TestCommonControl_EnsureSandboxPaused(t *testing.T) {
 				recorder:             record.NewFakeRecorder(10),
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fc, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-				syncStatusFromPod:    defaultSyncStatusFromPod,
+				syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 				checkpointControl:    NewCheckpointControl(fc, record.NewFakeRecorder(10)),
 			}
 
@@ -1420,7 +1424,7 @@ func TestCommonControl_EnsureSandboxResumed(t *testing.T) {
 				initializer:          init,
 				checkpointControl:    NewCheckpointControl(fc, record.NewFakeRecorder(10)),
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-				syncStatusFromPod:    defaultSyncStatusFromPod,
+				syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 			}
 
 			err := control.EnsureSandboxResumed(context.TODO(), tt.args)
@@ -1547,7 +1551,7 @@ func TestCommonControl_EnsureSandboxTerminated(t *testing.T) {
 				recorder:             record.NewFakeRecorder(10),
 				inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fc, inplaceupdate.DefaultGeneratePatchBodyFunc),
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-				syncStatusFromPod:    defaultSyncStatusFromPod,
+				syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 			}
 
 			err := control.EnsureSandboxTerminated(context.TODO(), tt.args)
@@ -2427,7 +2431,7 @@ func TestCommonControl_EnsureSandboxUpdated_InplaceNotDone(t *testing.T) {
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
+		syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2475,7 +2479,7 @@ func TestCommonControl_EnsureSandboxResumed_TerminatingPod(t *testing.T) {
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
+		syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2517,7 +2521,7 @@ func TestCommonControl_EnsureSandboxResumed_SetResumedCondition(t *testing.T) {
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
+		syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2569,7 +2573,7 @@ func TestCommonControl_EnsureSandboxResumed_LegacyBackfill(t *testing.T) {
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
 		checkpointControl:    NewCheckpointControl(fakeClient, record.NewFakeRecorder(10)),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
+		syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 	}
 
 	tests := []struct {
@@ -2732,7 +2736,7 @@ func TestCommonControl_EnsureSandboxTerminated_PodNotExist_NoFinalizer(t *testin
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
+		syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 	}
 
 	err := control.EnsureSandboxTerminated(context.TODO(), EnsureFuncArgs{Pod: nil, Box: box, NewStatus: &agentsv1alpha1.SandboxStatus{}})
@@ -2760,7 +2764,7 @@ func TestCommonControl_EnsureSandboxPaused_AlreadyPaused(t *testing.T) {
 		recorder:             record.NewFakeRecorder(10),
 		inplaceUpdateControl: inplaceupdate.NewInPlaceUpdateControl(fakeClient, inplaceupdate.DefaultGeneratePatchBodyFunc),
 		podControl:           NewPodControl(fakeClient, record.NewFakeRecorder(10), GeneratePodFromSandbox),
-		syncStatusFromPod:    defaultSyncStatusFromPod,
+		syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2831,7 +2835,7 @@ func TestCommonControl_performRecreateUpgrade_PodTerminating(t *testing.T) {
 		podControl:           podCtrl,
 		checkpointControl:    checkpointCtrl,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultSyncStatusFromPod, nil),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultCommonSyncStatusFromPod, nil),
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -2892,7 +2896,7 @@ func TestCommonControl_performRecreateUpgrade_NewPodNotReady(t *testing.T) {
 		podControl:           podCtrl,
 		checkpointControl:    checkpointCtrl,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultSyncStatusFromPod, nil),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultCommonSyncStatusFromPod, nil),
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -3137,7 +3141,7 @@ func TestCommonControl_performRecreateUpgrade_PodReadyFalse(t *testing.T) {
 		podControl:           podCtrl,
 		checkpointControl:    checkpointCtrl,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultSyncStatusFromPod, nil),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultCommonSyncStatusFromPod, nil),
 	}
 
 	newStatus := &agentsv1alpha1.SandboxStatus{
@@ -3440,7 +3444,7 @@ func TestCommonControl_EnsureSandboxResumed_InitContainerInconsistent(t *testing
 				initializer:          &mockSandboxInitializer{err: nil},
 				podControl:           NewPodControl(fc, record.NewFakeRecorder(10), GeneratePodFromSandbox),
 				checkpointControl:    NewCheckpointControl(fc, record.NewFakeRecorder(10)),
-				syncStatusFromPod:    defaultSyncStatusFromPod,
+				syncStatusFromPod:    defaultCommonSyncStatusFromPod,
 			}
 
 			newStatus := &agentsv1alpha1.SandboxStatus{
@@ -3590,7 +3594,7 @@ func TestCommonControl_performRecreateUpgrade_InitializerPath(t *testing.T) {
 				podControl:           podCtrl,
 				checkpointControl:    checkpointCtrl,
 				initializer:          initializer,
-				upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultSyncStatusFromPod, nil),
+				upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(10), NewLifecycleHookFunc(nil), initializer, defaultCommonSyncStatusFromPod, nil),
 			}
 
 			newStatus := &agentsv1alpha1.SandboxStatus{

--- a/pkg/controller/sandbox/core/pod_failure.go
+++ b/pkg/controller/sandbox/core/pod_failure.go
@@ -54,10 +54,10 @@ const (
 //
 // The first hit wins, and init containers are checked before app containers
 // since they run first and block the app containers just as definitively.
-// The returned reason is always SandboxReadyReasonStartContainerFailed to
-// preserve the existing downstream contract (SandboxSet ScalingLimited,
-// wait-ready task, claim short-circuit all key off this single reason). The
-// returned message carries the originating pod- or container-level detail
+// Container startup failures return SandboxReadyReasonStartContainerFailed,
+// while scheduler capacity failures return SandboxReadyReasonUnschedulable.
+// Both reasons are recognized as startup failures by downstream consumers.
+// The returned message carries the originating pod- or container-level detail
 // for diagnostics.
 //
 // If no definitive failure is present, failed is false and callers must leave
@@ -82,7 +82,7 @@ func classifyStartupFailure(pod *corev1.Pod) (reason, message string, failed boo
 			continue
 		}
 		if c.Status == corev1.ConditionFalse && c.Reason == corev1.PodReasonUnschedulable {
-			return agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
+			return agentsv1alpha1.SandboxReadyReasonUnschedulable,
 				c.Message,
 				true
 		}

--- a/pkg/controller/sandbox/core/pod_failure_test.go
+++ b/pkg/controller/sandbox/core/pod_failure_test.go
@@ -167,11 +167,11 @@ func TestDefaultSyncStatusFromPodStartupFailure(t *testing.T) {
 			expectMessage: "kubelet message",
 		},
 		{
-			name:           "transient reason keeps prior startup failure",
+			name:           "transient reason clears prior startup failure",
 			waitingReason:  "ContainerCreating",
 			previousReason: agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
-			expectReason:   agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
-			expectMessage:  "previous failure",
+			expectReason:   agentsv1alpha1.SandboxReadyReasonPodReady,
+			expectMessage:  "",
 		},
 		{
 			name:           "existing pod keeps prior pod create failure",
@@ -227,7 +227,7 @@ func TestDefaultSyncStatusFromPodStartupFailure(t *testing.T) {
 				Message: "previous failure",
 			}}}
 
-			defaultSyncStatusFromPod(pod, status, true)
+			defaultSyncStatusFromPod(pod, status, true, classifyStartupFailure)
 
 			condition := utils.GetSandboxCondition(status, string(agentsv1alpha1.SandboxConditionReady))
 			assert.Equal(t, tt.expectReason, condition.Reason)

--- a/pkg/controller/sandbox/core/pod_failure_test.go
+++ b/pkg/controller/sandbox/core/pod_failure_test.go
@@ -42,6 +42,7 @@ func TestClassifyStartupFailure(t *testing.T) {
 		name          string
 		pod           *corev1.Pod
 		failed        bool
+		expectReason  string
 		expectMessage string
 	}{
 		{name: "nil pod"},
@@ -102,7 +103,8 @@ func TestClassifyStartupFailure(t *testing.T) {
 				Reason:  corev1.PodReasonUnschedulable,
 				Message: "kubelet message",
 			}}}},
-			failed: true,
+			failed:       true,
+			expectReason: agentsv1alpha1.SandboxReadyReasonUnschedulable,
 		},
 		{
 			name: "scheduler error is transient",
@@ -136,7 +138,11 @@ func TestClassifyStartupFailure(t *testing.T) {
 			reason, message, failed := classifyStartupFailure(tt.pod)
 			assert.Equal(t, tt.failed, failed)
 			if tt.failed {
-				assert.Equal(t, agentsv1alpha1.SandboxReadyReasonStartContainerFailed, reason)
+				expectReason := tt.expectReason
+				if expectReason == "" {
+					expectReason = agentsv1alpha1.SandboxReadyReasonStartContainerFailed
+				}
+				assert.Equal(t, expectReason, reason)
 				if tt.expectMessage != "" {
 					assert.Equal(t, tt.expectMessage, message)
 				} else {
@@ -170,6 +176,13 @@ func TestDefaultSyncStatusFromPodStartupFailure(t *testing.T) {
 			name:           "transient reason clears prior startup failure",
 			waitingReason:  "ContainerCreating",
 			previousReason: agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
+			expectReason:   agentsv1alpha1.SandboxReadyReasonPodReady,
+			expectMessage:  "",
+		},
+		{
+			name:           "transient reason clears prior unschedulable failure",
+			waitingReason:  "ContainerCreating",
+			previousReason: agentsv1alpha1.SandboxReadyReasonUnschedulable,
 			expectReason:   agentsv1alpha1.SandboxReadyReasonPodReady,
 			expectMessage:  "",
 		},

--- a/pkg/controller/sandbox/core/upgrade_control_test.go
+++ b/pkg/controller/sandbox/core/upgrade_control_test.go
@@ -126,7 +126,7 @@ func newTestCommonControl(hookFunc LifecycleHookFunc, objects ...client.Object) 
 		podControl:           podCtrl,
 		lifecycleHookFunc:    hookFunc,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(100), hookFunc, initializer, defaultSyncStatusFromPod, nil),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(100), hookFunc, initializer, defaultCommonSyncStatusFromPod, nil),
 	}
 }
 
@@ -897,7 +897,7 @@ func newTestCommonControlWithCheckpointIndex(hookFunc LifecycleHookFunc, objects
 		podControl:           podCtrl,
 		lifecycleHookFunc:    hookFunc,
 		initializer:          initializer,
-		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(100), hookFunc, initializer, defaultSyncStatusFromPod, nil),
+		upgradeControl:       NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(100), hookFunc, initializer, defaultCommonSyncStatusFromPod, nil),
 	}
 }
 
@@ -1717,7 +1717,7 @@ func TestEnsureSandboxUpgraded_Resuming(t *testing.T) {
 			}
 			return nil
 		}
-		return NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(100), mockLifecycleHookFunc(0, "", "", nil), initializer, defaultSyncStatusFromPod, resumeFn), initializer
+		return NewUpgradeControl(fakeClient, checkpointCtrl, podCtrl, record.NewFakeRecorder(100), mockLifecycleHookFunc(0, "", "", nil), initializer, defaultCommonSyncStatusFromPod, resumeFn), initializer
 	}
 
 	tests := []struct {

--- a/pkg/controller/sandbox/pod_event_handler.go
+++ b/pkg/controller/sandbox/pod_event_handler.go
@@ -95,6 +95,13 @@ func isActivePodUpdate(oldObj, newObj *corev1.Pod) bool {
 	if !isPodConditionEqual(rCond1, rCond2) {
 		return true
 	}
+	// PodScheduled drives the shared startup-failure normalizer. Observe both
+	// failure and recovery so the Sandbox Ready condition stays current.
+	sCond1 := utils.GetPodCondition(&oldObj.Status, corev1.PodScheduled)
+	sCond2 := utils.GetPodCondition(&newObj.Status, corev1.PodScheduled)
+	if !isPodConditionEqual(sCond1, sCond2) {
+		return true
+	}
 	pCond1 := utils.GetPodCondition(&oldObj.Status, core.PodConditionContainersPaused)
 	pCond2 := utils.GetPodCondition(&newObj.Status, core.PodConditionContainersPaused)
 	if !isPodConditionEqual(pCond1, pCond2) {

--- a/pkg/controller/sandbox/pod_event_handler_test.go
+++ b/pkg/controller/sandbox/pod_event_handler_test.go
@@ -113,6 +113,52 @@ func TestIsActivePodUpdate(t *testing.T) {
 			description: "should return true when pod IP is assigned",
 		},
 		{
+			name: "PodScheduled condition reports unschedulable",
+			oldPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			newPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:    corev1.PodScheduled,
+						Status:  corev1.ConditionFalse,
+						Reason:  corev1.PodReasonUnschedulable,
+						Message: "insufficient CPU",
+					}},
+				},
+			},
+			expected:    true,
+			description: "should return true when PodScheduled reports Unschedulable",
+		},
+		{
+			name: "PodScheduled condition recovers from unschedulable",
+			oldPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:    corev1.PodScheduled,
+						Status:  corev1.ConditionFalse,
+						Reason:  corev1.PodReasonUnschedulable,
+						Message: "insufficient CPU",
+					}},
+				},
+			},
+			newPod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			expected:    true,
+			description: "should return true when PodScheduled recovers so the startup failure is cleared",
+		},
+		{
 			name: "PodReady condition status changed from False to True",
 			oldPod: &corev1.Pod{
 				Status: corev1.PodStatus{
@@ -545,7 +591,7 @@ func TestIsActivePodUpdate(t *testing.T) {
 			description: "should return false when all tracked conditions are identical",
 		},
 		{
-			name: "Untracked condition changed - should not trigger update",
+			name: "PodScheduled condition changed - should trigger update",
 			oldPod: &corev1.Pod{
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
@@ -573,13 +619,13 @@ func TestIsActivePodUpdate(t *testing.T) {
 						},
 						{
 							Type:   corev1.PodScheduled,
-							Status: corev1.ConditionFalse, // Changed but not tracked
+							Status: corev1.ConditionFalse,
 						},
 					},
 				},
 			},
-			expected:    false,
-			description: "should return false when only untracked conditions change",
+			expected:    true,
+			description: "should return true when PodScheduled changes",
 		},
 		{
 			name: "Multiple conditions but only tracked ones matter",

--- a/pkg/controller/sandbox/sandbox_controller.go
+++ b/pkg/controller/sandbox/sandbox_controller.go
@@ -298,8 +298,23 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (cr
 	// span this early does not produce noise.
 	ctx, reconcileSpan := tracing.StartReconcileSpan(ctx, box)
 	reconcileSpan.SetAttributes(attribute.String(tracing.AttrSandboxPhase, string(box.Status.Phase)))
+	// Record condition values at the start of this Reconcile iteration so
+	// the before->after transition is visible when comparing this span with
+	// the child updateSandboxStatus span.
+	for _, cond := range box.Status.Conditions {
+		reconcileSpan.SetAttributes(attribute.String(
+			tracing.AttrConditionPrefix+cond.Type,
+			fmt.Sprintf("%s:%s", cond.Status, cond.Reason),
+		))
+	}
 	if traceID := tracing.TraceIDFromContext(ctx); traceID != "" {
-		ctx = klog.NewContext(ctx, klog.FromContext(ctx).WithValues("traceID", traceID))
+		logValues := []any{tracing.TraceIDLogKey, traceID}
+		// Surface the user operation that started this trace (propagated via
+		// baggage in the CR annotation) so logs can be filtered by operation.
+		if op := tracing.TraceOperationFromContext(ctx); op != "" {
+			logValues = append(logValues, tracing.TraceOperationLogKey, op)
+		}
+		ctx = klog.NewContext(ctx, klog.FromContext(ctx).WithValues(logValues...))
 	}
 	// End the Reconcile span with the final Reconcile error via defer: a
 	// failing iteration is marked failed and always retained even when the
@@ -619,9 +634,16 @@ func (r *SandboxReconciler) updateSandboxStatus(ctx context.Context, newStatus a
 	// independent value on the shouldRequeue early-return path, where the
 	// Reconcile span's phase attribute has not been refreshed; the full
 	// before->after transition is recorded in logs and K8s Events.
-	ctx, span := tracing.StartControllerSpan(ctx, tracing.SpanControllerUpdateStatus,
+	statusAttrs := []attribute.KeyValue{
 		attribute.String(tracing.AttrPhaseAfter, string(newStatus.Phase)),
-	)
+	}
+	for _, cond := range newStatus.Conditions {
+		statusAttrs = append(statusAttrs, attribute.String(
+			tracing.AttrConditionPrefix+cond.Type,
+			fmt.Sprintf("%s:%s", cond.Status, cond.Reason),
+		))
+	}
+	ctx, span := tracing.StartControllerSpan(ctx, tracing.SpanControllerUpdateStatus, statusAttrs...)
 
 	by, _ := json.Marshal(newStatus)
 	patchStatus := fmt.Sprintf(`{"status":%s}`, string(by))

--- a/pkg/controller/sandboxset/event_handler.go
+++ b/pkg/controller/sandboxset/event_handler.go
@@ -62,7 +62,7 @@ func (e *SandboxEventHandler) Update(ctx context.Context, evt event.TypedUpdateE
 	}
 	oldState, _ := utils.GetSandboxState(oldSbx)
 	newState, _ := utils.GetSandboxState(newSbx)
-	if oldState != newState {
+	if oldState != newState || isStartupFailure(oldSbx) != isStartupFailure(newSbx) {
 		w.Add(req)
 	}
 	if oldState == agentsv1alpha1.SandboxStateCreating && newState == agentsv1alpha1.SandboxStateAvailable {

--- a/pkg/controller/sandboxset/event_handler_test.go
+++ b/pkg/controller/sandboxset/event_handler_test.go
@@ -162,6 +162,94 @@ func TestSandboxEventHandler_Create(t *testing.T) {
 	}
 }
 
+func TestSandboxEventHandler_Update(t *testing.T) {
+	sbs := &agentsv1alpha1.SandboxSet{ObjectMeta: metav1.ObjectMeta{
+		Name: "test-sandboxset", Namespace: "default", UID: "123456789",
+	}}
+	newSandbox := func(phase agentsv1alpha1.SandboxPhase, conditions []metav1.Condition) *agentsv1alpha1.Sandbox {
+		return &agentsv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sandbox",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: agentsv1alpha1.SandboxSetControllerKind.GroupVersion().String(),
+					Kind:       agentsv1alpha1.SandboxSetControllerKind.Kind,
+					Name:       sbs.Name,
+					UID:        sbs.UID,
+					Controller: ptr.To(true),
+				}},
+			},
+			Status: agentsv1alpha1.SandboxStatus{Phase: phase, Conditions: conditions},
+		}
+	}
+	readyFailure := []metav1.Condition{{
+		Type:   string(agentsv1alpha1.SandboxConditionReady),
+		Status: metav1.ConditionFalse,
+		Reason: agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
+	}}
+	readyPending := []metav1.Condition{{
+		Type:   string(agentsv1alpha1.SandboxConditionReady),
+		Status: metav1.ConditionFalse,
+		Reason: agentsv1alpha1.SandboxReadyReasonPodReady,
+	}}
+	readyPodCreateFailed := []metav1.Condition{{
+		Type:   string(agentsv1alpha1.SandboxConditionReady),
+		Status: metav1.ConditionFalse,
+		Reason: agentsv1alpha1.SandboxReadyReasonPodCreateFailed,
+	}}
+	tests := []struct {
+		name          string
+		oldSandbox    *agentsv1alpha1.Sandbox
+		newSandbox    *agentsv1alpha1.Sandbox
+		shouldEnqueue bool
+	}{
+		{
+			name:          "startup failure enters while sandbox remains creating",
+			oldSandbox:    newSandbox(agentsv1alpha1.SandboxPending, readyPending),
+			newSandbox:    newSandbox(agentsv1alpha1.SandboxPending, readyFailure),
+			shouldEnqueue: true,
+		},
+		{
+			name:          "pod create failure enters while sandbox remains creating",
+			oldSandbox:    newSandbox(agentsv1alpha1.SandboxPending, readyPending),
+			newSandbox:    newSandbox(agentsv1alpha1.SandboxPending, readyPodCreateFailed),
+			shouldEnqueue: true,
+		},
+		{
+			name:          "startup failure clears while sandbox remains creating",
+			oldSandbox:    newSandbox(agentsv1alpha1.SandboxPending, readyFailure),
+			newSandbox:    newSandbox(agentsv1alpha1.SandboxPending, readyPending),
+			shouldEnqueue: true,
+		},
+		{
+			name:       "unrelated pending update is ignored",
+			oldSandbox: newSandbox(agentsv1alpha1.SandboxPending, readyPending),
+			newSandbox: newSandbox(agentsv1alpha1.SandboxPending, readyPending),
+		},
+		{
+			name:          "sandbox state change remains enqueued",
+			oldSandbox:    newSandbox(agentsv1alpha1.SandboxPending, nil),
+			newSandbox:    newSandbox(agentsv1alpha1.SandboxFailed, nil),
+			shouldEnqueue: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queue := &fakePriorityQueue{}
+			(&SandboxEventHandler{}).Update(t.Context(), event.TypedUpdateEvent[client.Object]{
+				ObjectOld: tt.oldSandbox,
+				ObjectNew: tt.newSandbox,
+			}, queue)
+			if tt.shouldEnqueue {
+				assert.Equal(t, GetControllerKey(sbs), queue.request.String())
+			} else {
+				assert.Equal(t, "/", queue.request.String())
+			}
+		})
+	}
+}
+
 func TestSandboxEventHandler_Delete(t *testing.T) {
 	sbs := &agentsv1alpha1.SandboxSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/sandboxset/scaling_limited.go
+++ b/pkg/controller/sandboxset/scaling_limited.go
@@ -139,8 +139,7 @@ func isStartupFailure(sandbox *agentsv1alpha1.Sandbox) bool {
 	if condition == nil || condition.Status != metav1.ConditionFalse {
 		return false
 	}
-	return condition.Reason == agentsv1alpha1.SandboxReadyReasonStartContainerFailed ||
-		condition.Reason == agentsv1alpha1.SandboxReadyReasonPodCreateFailed
+	return utils.IsSandboxStartupFailureReason(condition.Reason)
 }
 
 // resolveStartupBudget computes the startup budget used by the

--- a/pkg/controller/sandboxset/scaling_limited_test.go
+++ b/pkg/controller/sandboxset/scaling_limited_test.go
@@ -131,6 +131,17 @@ func TestCalculateScalingLimited(t *testing.T) {
 			expectFailed:  1,
 		},
 		{
+			name:           "unschedulable exhausts budget",
+			maxUnavailable: intOrStringPtr(intstr.FromInt(1)),
+			groups: GroupedSandboxes{Creating: []*agentsv1alpha1.Sandbox{
+				newFailed("failed", agentsv1alpha1.SandboxReadyReasonUnschedulable),
+			}},
+			expectStatus:  metav1.ConditionTrue,
+			expectReason:  scalingLimitedReasonBudgetExhausted,
+			expectMessage: "Timeout=0, Failed=1",
+			expectFailed:  1,
+		},
+		{
 			name:                 "configured pending timeout is used",
 			maxUnavailable:       intOrStringPtr(intstr.FromInt(1)),
 			sbxMaxPendingTimeout: 25 * time.Second,

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -95,7 +95,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	SecurityIdentityProviderGate:           {Default: false, PreRelease: featuregate.Alpha},
 	SandboxPauseCheckpointGate:             {Default: false, PreRelease: featuregate.Alpha},
 	CommitGate:                             {Default: false, PreRelease: featuregate.Alpha},
-	PoolAutoscalerGate:                     {Default: false, PreRelease: featuregate.Alpha},
+	PoolAutoscalerGate:                     {Default: true, PreRelease: featuregate.Alpha},
 	AutoPauseControllerGate:                {Default: false, PreRelease: featuregate.Alpha},
 }
 

--- a/pkg/peers/helpers.go
+++ b/pkg/peers/helpers.go
@@ -74,6 +74,5 @@ func CreateTestPeer(ctx context.Context, c client.Client, nodeName string) (*Mem
 	}
 
 	peer := NewMemberlistPeers(c, nodeName, Namespace, LabelSelector)
-	peer.localIP = "127.0.0.1"
 	return peer, port, nil
 }

--- a/pkg/peers/memberlist.go
+++ b/pkg/peers/memberlist.go
@@ -18,9 +18,13 @@ package peers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
+	"sort"
+	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -47,8 +51,25 @@ const (
 	DefaultSuspicionMult = 4
 	// DefaultRetransmitMult is the multiplier for the number of retransmissions
 	DefaultRetransmitMult = 4
+	// DefaultJoinRetryInterval is the delay between peer discovery attempts.
+	DefaultJoinRetryInterval = 10 * time.Second
+	// DefaultLeaveTimeout bounds graceful memberlist departure.
+	DefaultLeaveTimeout = 5 * time.Second
 )
 
+type memberlistHandle interface {
+	Join(existing []string) (int, error)
+	Leave(timeout time.Duration) error
+	Shutdown() error
+	Members() []*memberlist.Node
+	LocalNode() *memberlist.Node
+}
+
+// MemberlistPeers discovers peers through hashicorp memberlist.
+//
+// Lifecycle contract: one owner calls Start exactly once and Stop at most
+// once, after Start has returned; the two never run concurrently. Stop on a
+// peer whose Start never succeeded is a no-op.
 type MemberlistPeers struct {
 	apiReader ctrlclient.Reader
 
@@ -56,22 +77,33 @@ type MemberlistPeers struct {
 	peerSelector string
 	sysNs        string
 
-	list    *memberlist.Memberlist
-	config  *memberlist.Config
-	localIP string
+	retryInterval time.Duration
 
-	started atomic.Bool
-	stopCh  chan struct{}
+	// list is assigned once in Start, before started is stored, and stays
+	// read-only afterwards, so getters gate on started instead of taking mu;
+	// the lifecycle goroutine inherits the same write from the go statement.
+	list memberlistHandle
+
+	// mu serializes Start and Stop and guards the lifecycle fields below.
+	mu              sync.Mutex
+	started         atomic.Bool
+	lifecycleCancel context.CancelFunc
+	// lifecycleDone carries the cleanup result; buffered so the lifecycle
+	// goroutine never blocks on delivery when Stop gives up waiting.
+	// Nil means Start never succeeded.
+	lifecycleDone chan error
 }
 
-// NewMemberlistPeers creates a new MemberlistPeers instance
+// NewMemberlistPeers returns a peer that, once started, lists selector-matching
+// seed Pods in namespace through apiReader until a join succeeds. Production
+// passes a live uncached client; tests may pass a fake.
 func NewMemberlistPeers(apiReader ctrlclient.Reader, nodeName string, namespace, peerSelector string) *MemberlistPeers {
 	return &MemberlistPeers{
-		apiReader:    apiReader,
-		sysNs:        namespace,
-		peerSelector: peerSelector,
-		localName:    nodeName,
-		stopCh:       make(chan struct{}),
+		apiReader:     apiReader,
+		sysNs:         namespace,
+		peerSelector:  peerSelector,
+		localName:     nodeName,
+		retryInterval: DefaultJoinRetryInterval,
 	}
 }
 
@@ -86,71 +118,50 @@ func FindPodIP() (string, error) {
 	return podIP, nil
 }
 
-// Start initializes and starts the memberlist
-func (m *MemberlistPeers) Start(ctx context.Context, bindPort int) error {
-	log := klog.FromContext(ctx)
-	var err error
+// Start creates the memberlist listener and starts peer discovery in the
+// background. It must be called exactly once.
+func (m *MemberlistPeers) Start(ctx context.Context, bindAddress string, bindPort int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.started.Load() {
-		return fmt.Errorf("memberlist already started")
+		return errors.New("memberlist already started")
+	}
+	log := klog.FromContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if m.apiReader == nil {
+		return fmt.Errorf("peer reader is not configured")
+	}
+	if m.sysNs == "" {
+		return fmt.Errorf("peer namespace is empty")
+	}
+	if m.peerSelector == "" {
+		return fmt.Errorf("peer selector is empty")
+	}
+	selector, err := labels.Parse(m.peerSelector)
+	if err != nil {
+		return fmt.Errorf("failed to parse peer selector: %w", err)
 	}
 
-	// Get pod IP for memberlist binding
-	localIP := m.localIP
+	localIP := bindAddress
 	if localIP == "" {
 		localIP, err = FindPodIP()
 		if err != nil {
 			return fmt.Errorf("failed to determine local IP for memberlist: %w", err)
 		}
 	}
-	localURL := fmt.Sprintf("%s:%d", localIP, bindPort)
 
-	// Get existing peers from Kubernetes API for initial join
-	log.Info("discovering existing peers for memberlist join", "localURL", localURL)
-	apiReader := m.apiReader
-	selector, err := labels.Parse(m.peerSelector)
-	if err != nil {
-		return fmt.Errorf("failed to parse peer selector: %w", err)
-	}
-	peerList := &corev1.PodList{}
-	if err := apiReader.List(ctx, peerList, &ctrlclient.ListOptions{
-		Namespace:     m.sysNs,
-		LabelSelector: selector,
-	}); err != nil {
-		return fmt.Errorf("failed to list peer pods: %w", err)
-	}
-	log.Info("listed peers for memberlist join", "count", len(peerList.Items))
-
-	// Build list of existing peer IPs for initial join
-	existingPeers := make([]string, 0)
-	for _, peer := range peerList.Items {
-		// AnnotationMemberlistURL is generally not needed in production when all replicas use the same memberlist port.
-		// In scenarios like unit tests or single-host multi-replica deployments where a fixed port cannot be guaranteed
-		// for all replicas, this annotation can be used as a way to specify a custom address.
-		memberlistURL := peer.Annotations[agentsv1alpha1.AnnotationMemberlistURL]
-		if memberlistURL == "" {
-			ip := peer.Status.PodIP
-			if ip == "" {
-				log.Info("ignoring peer with empty IP", "ip", ip, "peer", klog.KObj(&peer))
-				continue
-			}
-			memberlistURL = fmt.Sprintf("%s:%d", ip, bindPort)
-		}
-		if memberlistURL == localURL {
-			continue
-		}
-		// Memberlist uses the bind port for gossip
-		existingPeers = append(existingPeers, memberlistURL)
-		log.Info("adding peer for memberlist join", "memberlistURL", memberlistURL, "pod", klog.KObj(&peer))
-	}
-	log.Info("found existing peers for memberlist join", "count", len(existingPeers))
-
-	bindAddr := localIP
+	localURL := net.JoinHostPort(localIP, strconv.Itoa(bindPort))
 
 	// Create memberlist config
 	config := memberlist.DefaultLANConfig()
 	config.Name = m.localName
-	config.BindAddr = bindAddr
+	config.BindAddr = localIP
 	config.BindPort = bindPort
+	// Advertise exactly the bound address so peers reach the listener that
+	// this process actually owns.
+	config.AdvertiseAddr = localIP
 	config.AdvertisePort = bindPort
 
 	// Tuning for faster failure detection and convergence
@@ -171,57 +182,196 @@ func (m *MemberlistPeers) Start(ctx context.Context, bindPort int) error {
 	config.LogOutput = nil
 	config.Logger = nil
 
-	m.config = config
-
 	// Create the memberlist
 	list, err := memberlist.Create(config)
 	if err != nil {
 		return fmt.Errorf("failed to create memberlist: %w", err)
 	}
-	m.list = list
-
-	// Join existing peers if provided
-	if len(existingPeers) > 0 {
-		log.Info("attempting to join existing peers", "peers", existingPeers)
-		joined, err := list.Join(existingPeers)
-		if err != nil {
-			log.Error(err, "failed to join some peers", "joined", joined)
-			// Don't return error - we can still operate as a single node
-		} else {
-			log.Info("successfully joined peers", "count", joined)
-		}
-	}
-
-	m.started.Store(true)
-	log.Info("memberlist started", "addr", bindAddr, "port", bindPort, "name", m.localName)
+	m.startLifecycle(ctx, list, selector, bindPort, localURL)
+	log.Info("memberlist started", "addr", localIP, "port", bindPort, "name", m.localName)
 
 	return nil
 }
 
-// Stop gracefully leaves the cluster and shuts down
-func (m *MemberlistPeers) Stop() error {
-	if !m.started.Load() || m.list == nil {
+// startLifecycle publishes list to the getters and launches the background
+// discovery owner. It is the tail of Start, shared with tests that inject a
+// fake memberlist, so both paths wire the lifecycle identically.
+func (m *MemberlistPeers) startLifecycle(ctx context.Context, list memberlistHandle, selector labels.Selector, bindPort int, localURL string) {
+	m.list = list
+	m.started.Store(true)
+	lifecycleCtx, cancel := context.WithCancel(ctx)
+	m.lifecycleCancel = cancel
+	m.lifecycleDone = make(chan error, 1)
+	go m.runLifecycle(lifecycleCtx, selector, bindPort, localURL)
+}
+
+func (m *MemberlistPeers) runLifecycle(ctx context.Context, selector labels.Selector, bindPort int, localURL string) {
+	for attempt := 1; ctx.Err() == nil; attempt++ {
+		if m.tryJoin(ctx, selector, bindPort, localURL, attempt) {
+			break
+		}
+		// Wait a full interval after each failed attempt, however long the
+		// attempt itself took.
+		retry := time.NewTimer(m.retryInterval)
+		select {
+		case <-ctx.Done():
+			retry.Stop()
+		case <-retry.C:
+		}
+	}
+	// After a successful join, ctx is still active; wait for cancellation so
+	// Leave/Shutdown still run from this owner.
+	<-ctx.Done()
+	m.lifecycleDone <- m.cleanup()
+}
+
+// tryJoin lists candidate seed Pods once and joins every seed in stable
+// order, one Join call per seed. It reports whether any join succeeded.
+// attempt is the 1-based discovery cycle, used to keep steady-state retries
+// quiet in the logs.
+func (m *MemberlistPeers) tryJoin(ctx context.Context, selector labels.Selector, bindPort int, localURL string, attempt int) bool {
+	log := klog.FromContext(ctx)
+	peerList := &corev1.PodList{}
+	err := m.apiReader.List(ctx, peerList, &ctrlclient.ListOptions{
+		Namespace:     m.sysNs,
+		LabelSelector: selector,
+	})
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Error(err, "failed to list peer pods")
+		}
+		return false
+	}
+	seeds := trustedSeedAddresses(peerList.Items, localURL, bindPort)
+	if len(seeds) == 0 {
+		// A single-replica deployment lands here on every cycle for the
+		// lifetime of the process, so only the first report is visible at
+		// the default verbosity.
+		seedLog := log.V(2)
+		if attempt == 1 {
+			seedLog = log
+		}
+		seedLog.Info("no eligible peer seeds, retrying discovery",
+			"pods", len(peerList.Items), "namespace", m.sysNs, "selector", m.peerSelector, "retryInterval", m.retryInterval)
+		return false
+	}
+	// Join every seed, one Join call per seed: both styles probe every
+	// address serially, but per-seed calls keep each failure attributable
+	// (bulk Join discards errors once any seed succeeds) and honor
+	// cancellation between dials.
+	joined := false
+	for _, seed := range seeds {
+		if ctx.Err() != nil {
+			return joined
+		}
+		count, joinErr := m.list.Join([]string{seed})
+		if joinErr != nil {
+			log.Error(joinErr, "failed to join peer", "peer", seed, "joined", count)
+		}
+		if count > 0 {
+			log.Info("successfully joined peer", "peer", seed, "count", count)
+			joined = true
+		}
+	}
+	return joined
+}
+
+// trustedSeedAddresses derives at most one seed address per Pod. Readiness
+// and non-terminal phases are not filters, but a Pod in the terminal
+// Succeeded or Failed phase has no container left to accept memberlist
+// traffic, so it is excluded rather than costing a dial timeout per cycle.
+func trustedSeedAddresses(pods []corev1.Pod, localURL string, bindPort int) []string {
+	seen := make(map[string]struct{}, len(pods))
+	seeds := make([]string, 0, len(pods))
+	for i := range pods {
+		if phase := pods[i].Status.Phase; phase == corev1.PodSucceeded || phase == corev1.PodFailed {
+			continue
+		}
+		podIP := net.ParseIP(pods[i].Status.PodIP)
+		if podIP == nil {
+			continue
+		}
+		// String canonicalizes 4-in-6 to dotted quad; JoinHostPort brackets
+		// IPv6. One path covers both families.
+		seed := net.JoinHostPort(podIP.String(), strconv.Itoa(bindPort))
+		if annotated := pods[i].Annotations[agentsv1alpha1.AnnotationMemberlistURL]; annotated != "" {
+			override, ok := parseMemberlistURL(annotated, podIP)
+			if !ok {
+				continue
+			}
+			seed = override
+		}
+		if seed == localURL {
+			continue
+		}
+		if _, exists := seen[seed]; exists {
+			continue
+		}
+		seen[seed] = struct{}{}
+		seeds = append(seeds, seed)
+	}
+	sort.Strings(seeds)
+	return seeds
+}
+
+// parseMemberlistURL parses the memberlist-url annotation into a seed address
+// for the peer with the given Pod IP. The annotation may only override the
+// port: its host must equal the Pod's status.podIP, so an annotation cannot
+// redirect peer traffic outside the selected Pod identity. It returns false
+// when the annotated address is invalid.
+func parseMemberlistURL(annotated string, podIP net.IP) (string, bool) {
+	host, port, err := net.SplitHostPort(annotated)
+	if err != nil {
+		return "", false
+	}
+	annotatedIP := net.ParseIP(host)
+	if annotatedIP == nil || !annotatedIP.Equal(podIP) {
+		return "", false
+	}
+	portNumber, err := strconv.Atoi(port)
+	if err != nil || portNumber < 1 || portNumber > 65535 {
+		return "", false
+	}
+	return net.JoinHostPort(podIP.String(), strconv.Itoa(portNumber)), true
+}
+
+// cleanup leaves and then shuts down the memberlist. Leave is best effort and
+// never prevents Shutdown; the two run exactly once, from the lifecycle owner.
+func (m *MemberlistPeers) cleanup() error {
+	var errs []error
+	if err := m.list.Leave(DefaultLeaveTimeout); err != nil {
+		errs = append(errs, fmt.Errorf("failed to leave memberlist: %w", err))
+	}
+	if err := m.list.Shutdown(); err != nil {
+		errs = append(errs, fmt.Errorf("failed to shutdown memberlist: %w", err))
+	}
+	return errors.Join(errs...)
+}
+
+// Stop cancels peer discovery and waits for its cleanup result. It is called
+// at most once, after Start has returned. When ctx expires first, Stop
+// returns ctx.Err() while the lifecycle owner still completes Leave and
+// Shutdown. Stopping a peer that never started returns nil: callers shut
+// down whole components even when startup failed before Start.
+func (m *MemberlistPeers) Stop(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Nil lifecycleDone means Start never succeeded.
+	if m.lifecycleDone == nil {
 		return nil
 	}
-
-	close(m.stopCh)
-
-	// Gracefully leave the cluster
-	if err := m.list.Leave(5 * time.Second); err != nil {
-		return fmt.Errorf("failed to leave memberlist: %w", err)
+	m.lifecycleCancel()
+	select {
+	case err := <-m.lifecycleDone:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-
-	if err := m.list.Shutdown(); err != nil {
-		return fmt.Errorf("failed to shutdown memberlist: %w", err)
-	}
-
-	m.started.Store(false)
-	return nil
 }
 
 // GetPeers returns the current list of alive peers (excluding self)
 func (m *MemberlistPeers) GetPeers() []Peer {
-	if !m.started.Load() || m.list == nil {
+	if !m.started.Load() {
 		return nil
 	}
 
@@ -242,7 +392,7 @@ func (m *MemberlistPeers) GetPeers() []Peer {
 
 // GetAllMembers returns all members including self
 func (m *MemberlistPeers) GetAllMembers() []Peer {
-	if !m.started.Load() || m.list == nil {
+	if !m.started.Load() {
 		return nil
 	}
 
@@ -256,34 +406,9 @@ func (m *MemberlistPeers) GetAllMembers() []Peer {
 	return members
 }
 
-// WaitForPeers blocks until at least minPeers are discovered or context is canceled
-func (m *MemberlistPeers) WaitForPeers(ctx context.Context, minPeers int) error {
-	log := klog.FromContext(ctx)
-	log.Info("waiting for peers", "minPeers", minPeers)
-
-	ticker := time.NewTicker(100 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-m.stopCh:
-			return fmt.Errorf("memberlist stopped")
-		case <-ticker.C:
-			peers := m.GetPeers()
-			if len(peers) >= minPeers {
-				log.Info("minimum peers reached", "count", len(peers))
-				return nil
-			}
-			log.V(4).Info("waiting for more peers", "current", len(peers), "min", minPeers)
-		}
-	}
-}
-
 // LocalAddr returns the local node's address
 func (m *MemberlistPeers) LocalAddr() net.IP {
-	if !m.started.Load() || m.list == nil {
+	if !m.started.Load() {
 		return nil
 	}
 	return m.list.LocalNode().Addr
@@ -291,7 +416,7 @@ func (m *MemberlistPeers) LocalAddr() net.IP {
 
 // LocalPort returns the local node's port
 func (m *MemberlistPeers) LocalPort() int {
-	if !m.started.Load() || m.list == nil {
+	if !m.started.Load() {
 		return 0
 	}
 	return int(m.list.LocalNode().Port)

--- a/pkg/peers/memberlist_test.go
+++ b/pkg/peers/memberlist_test.go
@@ -18,14 +18,97 @@ package peers
 
 import (
 	"context"
+	"errors"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/memberlist"
+	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
+
+func interceptList(list func(context.Context, ctrlclient.ObjectList, ...ctrlclient.ListOption) error) ctrlclient.Client {
+	return interceptor.NewClient(fake.NewClientBuilder().Build(), interceptor.Funcs{
+		List: func(ctx context.Context, _ ctrlclient.WithWatch, obj ctrlclient.ObjectList, opts ...ctrlclient.ListOption) error {
+			return list(ctx, obj, opts...)
+		},
+	})
+}
+
+// fakeMemberlistHandle records every memberlist call in order; counts and
+// ordering assertions both derive from recordedCalls.
+type fakeMemberlistHandle struct {
+	join     func([]string) (int, error)
+	leaveErr error
+	mu       sync.Mutex
+	calls    []string
+}
+
+func (f *fakeMemberlistHandle) Join(seeds []string) (int, error) {
+	f.record("join:" + strings.Join(seeds, ","))
+	if f.join != nil {
+		return f.join(seeds)
+	}
+	return 0, nil
+}
+
+func (f *fakeMemberlistHandle) Leave(time.Duration) error {
+	f.record("leave")
+	return f.leaveErr
+}
+
+func (f *fakeMemberlistHandle) Shutdown() error {
+	f.record("shutdown")
+	return nil
+}
+
+func (*fakeMemberlistHandle) Members() []*memberlist.Node { return nil }
+
+func (*fakeMemberlistHandle) LocalNode() *memberlist.Node {
+	return &memberlist.Node{Addr: net.ParseIP("127.0.0.1")}
+}
+
+func (f *fakeMemberlistHandle) record(call string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, call)
+}
+
+func (f *fakeMemberlistHandle) recordedCalls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
+
+func (f *fakeMemberlistHandle) callCount(call string) int {
+	count := 0
+	for _, recorded := range f.recordedCalls() {
+		if recorded == call {
+			count++
+		}
+	}
+	return count
+}
+
+// startFakeLifecycle wires handle through the same startLifecycle tail that
+// Start uses, so these tests exercise the production lifecycle wiring.
+func startFakeLifecycle(ctx context.Context, reader ctrlclient.Reader, handle memberlistHandle, retry time.Duration) *MemberlistPeers {
+	peer := NewMemberlistPeers(reader, "test-node", Namespace, LabelSelector)
+	peer.retryInterval = retry
+	peer.startLifecycle(ctx, handle, labels.SelectorFromSet(labels.Set{LabelSelectorKey: LabelSelectorValue}), 7946, "127.0.0.1:7946")
+	return peer
+}
 
 // TestMemberlistPeers_Start_Stop tests basic start and stop functionality
 func TestMemberlistPeers_Start_Stop(t *testing.T) {
@@ -34,9 +117,9 @@ func TestMemberlistPeers_Start_Stop(t *testing.T) {
 	peer, port, err := CreateTestPeer(ctx, fc, "test-node-1")
 	require.NoError(t, err)
 
-	err = peer.Start(ctx, port)
+	err = peer.Start(ctx, "127.0.0.1", port)
 	require.NoError(t, err)
-	assert.True(t, peer.started.Load())
+	assert.NotNil(t, peer.list)
 
 	// Verify LocalAddr and LocalPort
 	assert.NotNil(t, peer.LocalAddr())
@@ -51,26 +134,32 @@ func TestMemberlistPeers_Start_Stop(t *testing.T) {
 	assert.Len(t, members, 1)
 	assert.Equal(t, "test-node-1", members[0].Name)
 
-	err = peer.Stop()
+	err = peer.Stop(ctx)
 	require.NoError(t, err)
-	assert.False(t, peer.started.Load())
 }
 
-// TestMemberlistPeers_Start_Twice tests that starting twice should return an error
-func TestMemberlistPeers_Start_Twice(t *testing.T) {
-	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()
-	ctx := context.Background()
-	peer, port, err := CreateTestPeer(ctx, fc, "test-node-2")
+func TestMemberlistPeers_StartDoesNotWaitForDiscovery(t *testing.T) {
+	t.Setenv("POD_IP", "127.0.0.1")
+	listStarted := make(chan struct{})
+	reader := interceptList(func(ctx context.Context, _ ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+		close(listStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	port, err := getFreePort()
 	require.NoError(t, err)
+	parent, cancel := context.WithCancel(t.Context())
+	peer := NewMemberlistPeers(reader, "non-blocking-node", Namespace, LabelSelector)
 
-	err = peer.Start(ctx, port)
-	require.NoError(t, err)
-
-	err = peer.Start(ctx, port)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already started")
-
-	_ = peer.Stop()
+	require.NoError(t, peer.Start(parent, "", port))
+	assert.Equal(t, "127.0.0.1", peer.LocalAddr().String())
+	select {
+	case <-listStarted:
+	case <-time.After(time.Second):
+		t.Fatal("background discovery did not start")
+	}
+	cancel()
+	require.NoError(t, peer.Stop(t.Context()))
 }
 
 // TestMemberlistPeers_Stop_NotStarted tests that stopping when not started does not return an error
@@ -78,8 +167,23 @@ func TestMemberlistPeers_Stop_NotStarted(t *testing.T) {
 	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()
 	peer := NewMemberlistPeers(fc, "test-node-not-started", Namespace, LabelSelector)
 
-	err := peer.Stop()
-	assert.NoError(t, err)
+	assert.NoError(t, peer.Stop(t.Context()))
+}
+
+// TestMemberlistPeers_Start_Twice tests that a second Start is rejected
+// instead of replacing the running memberlist.
+func TestMemberlistPeers_Start_Twice(t *testing.T) {
+	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()
+	ctx := t.Context()
+	peer, port, err := CreateTestPeer(ctx, fc, "test-node-2")
+	require.NoError(t, err)
+
+	require.NoError(t, peer.Start(ctx, "127.0.0.1", port))
+	first := peer.list
+
+	assert.ErrorContains(t, peer.Start(ctx, "127.0.0.1", port), "already started")
+	assert.Same(t, first, peer.list)
+	require.NoError(t, peer.Stop(ctx))
 }
 
 // TestMemberlistPeers_ThreeNodes_Join tests three-node join and discovery
@@ -96,19 +200,19 @@ func TestMemberlistPeers_ThreeNodes_Join(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start first node (seed node)
-	err = peer1.Start(ctx, port1)
+	err = peer1.Start(ctx, "127.0.0.1", port1)
 	require.NoError(t, err)
-	defer func() { _ = peer1.Stop() }()
+	defer func() { _ = peer1.Stop(ctx) }()
 
 	// Start second node, join first
-	err = peer2.Start(ctx, port2)
+	err = peer2.Start(ctx, "127.0.0.1", port2)
 	require.NoError(t, err)
-	defer func() { _ = peer2.Stop() }()
+	defer func() { _ = peer2.Stop(ctx) }()
 
 	// Start third node, join first two
-	err = peer3.Start(ctx, port3)
+	err = peer3.Start(ctx, "127.0.0.1", port3)
 	require.NoError(t, err)
-	defer func() { _ = peer3.Stop() }()
+	defer func() { _ = peer3.Stop(ctx) }()
 
 	// Wait for gossip propagation
 	assert.Eventually(t, func() bool {
@@ -137,82 +241,6 @@ func TestMemberlistPeers_ThreeNodes_Join(t *testing.T) {
 	assert.True(t, peerNames["node-3"], "peer1 should discover node-3")
 }
 
-// TestMemberlistPeers_WaitForPeers tests waiting for peers functionality
-func TestMemberlistPeers_WaitForPeers(t *testing.T) {
-	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()
-	ctx := t.Context()
-
-	peer1, port1, err := CreateTestPeer(ctx, fc, "wait-node-1")
-	require.NoError(t, err)
-	peer2, port2, err := CreateTestPeer(ctx, fc, "wait-node-2")
-	require.NoError(t, err)
-
-	// Start first node
-	err = peer1.Start(ctx, port1)
-	require.NoError(t, err)
-	defer func() { _ = peer1.Stop() }()
-
-	// Start second node asynchronously (delay 200ms)
-	go func() {
-		time.Sleep(200 * time.Millisecond)
-		_ = peer2.Start(ctx, port2)
-	}()
-	defer func() { _ = peer2.Stop() }()
-
-	// Wait for at least 1 peer
-	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	err = peer1.WaitForPeers(waitCtx, 1)
-	assert.NoError(t, err)
-
-	// Verify peer was indeed discovered
-	assert.Len(t, peer1.GetPeers(), 1)
-}
-
-// TestMemberlistPeers_WaitForPeers_Timeout tests waiting timeout
-func TestMemberlistPeers_WaitForPeers_Timeout(t *testing.T) {
-	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()
-	ctx := t.Context()
-	peer, port, err := CreateTestPeer(ctx, fc, "timeout-node")
-	require.NoError(t, err)
-
-	err = peer.Start(ctx, port)
-	require.NoError(t, err)
-	defer func() { _ = peer.Stop() }()
-
-	// Set very short timeout
-	waitCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-	defer cancel()
-
-	// Wait for 1 peer, should timeout
-	err = peer.WaitForPeers(waitCtx, 1)
-	assert.Error(t, err)
-	assert.Equal(t, context.DeadlineExceeded, err)
-}
-
-// TestMemberlistPeers_WaitForPeers_Stopped tests that WaitForPeers returns error after stopped
-func TestMemberlistPeers_WaitForPeers_Stopped(t *testing.T) {
-	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()
-	ctx := t.Context()
-	peer, port, err := CreateTestPeer(ctx, fc, "stopped-node")
-	require.NoError(t, err)
-
-	err = peer.Start(ctx, port)
-	require.NoError(t, err)
-
-	// Stop asynchronously
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		_ = peer.Stop()
-	}()
-
-	// Wait should return stopped error
-	err = peer.WaitForPeers(ctx, 1)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "stopped")
-}
-
 // TestMemberlistPeers_NodeLeave tests that node is removed from peers list after leaving
 func TestMemberlistPeers_NodeLeave(t *testing.T) {
 	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()
@@ -224,11 +252,11 @@ func TestMemberlistPeers_NodeLeave(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start two nodes
-	err = peer1.Start(ctx, port1)
+	err = peer1.Start(ctx, "127.0.0.1", port1)
 	require.NoError(t, err)
-	defer func() { _ = peer1.Stop() }()
+	defer func() { _ = peer1.Stop(ctx) }()
 
-	err = peer2.Start(ctx, port2)
+	err = peer2.Start(ctx, "127.0.0.1", port2)
 	require.NoError(t, err)
 
 	// Wait for peer2 to be discovered
@@ -237,7 +265,7 @@ func TestMemberlistPeers_NodeLeave(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond)
 
 	// Gracefully stop peer2
-	err = peer2.Stop()
+	err = peer2.Stop(ctx)
 	require.NoError(t, err)
 
 	// Wait for peer2 to be removed from peer1's list
@@ -257,6 +285,39 @@ func TestMemberlistPeers_GetPeers_NotStarted(t *testing.T) {
 	assert.Equal(t, 0, peer.LocalPort())
 }
 
+// TestMemberlistPeers_GettersRaceWithStart fails under -race when a getter
+// reads list without waiting on the started barrier.
+func TestMemberlistPeers_GettersRaceWithStart(t *testing.T) {
+	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()
+	peer, port, err := CreateTestPeer(t.Context(), fc, "race-node")
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = peer.GetPeers()
+					_ = peer.GetAllMembers()
+					_ = peer.LocalAddr()
+					_ = peer.LocalPort()
+				}
+			}
+		}()
+	}
+
+	require.NoError(t, peer.Start(t.Context(), "127.0.0.1", port))
+	close(stop)
+	wg.Wait()
+	require.NoError(t, peer.Stop(t.Context()))
+}
+
 // TestMemberlistPeers_Join_PartialFailure tests that partial join failure does not affect startup
 func TestMemberlistPeers_Join_PartialFailure(t *testing.T) {
 	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).Build()
@@ -265,9 +326,220 @@ func TestMemberlistPeers_Join_PartialFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try to join a non-existent node and seed node
-	err = peer.Start(ctx, port)
+	err = peer.Start(ctx, "127.0.0.1", port)
 	require.NoError(t, err) // Should not fail because single node operation is allowed
-	defer func() { _ = peer.Stop() }()
+	defer func() { _ = peer.Stop(ctx) }()
 
-	assert.True(t, peer.started.Load())
+	assert.NotNil(t, peer.list)
+}
+
+func TestTrustedSeedAddresses(t *testing.T) {
+	pod := func(ip, annotation string, phase v1.PodPhase) v1.Pod {
+		annotations := map[string]string{}
+		if annotation != "" {
+			annotations[agentsv1alpha1.AnnotationMemberlistURL] = annotation
+		}
+		return v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Annotations: annotations},
+			Status:     v1.PodStatus{PodIP: ip, Phase: phase},
+		}
+	}
+	tests := []struct {
+		name     string
+		pods     []v1.Pod
+		localURL string // empty means the default local URL below
+		want     []string
+	}{
+		{name: "pod ip with the bind port", pods: []v1.Pod{pod("10.0.0.3", "", v1.PodRunning)}, want: []string{"10.0.0.3:7946"}},
+		{name: "annotation overrides only the port", pods: []v1.Pod{pod("10.0.0.2", "10.0.0.2:9000", v1.PodRunning)}, want: []string{"10.0.0.2:9000"}},
+		{name: "annotation redirecting to another ip is dropped", pods: []v1.Pod{pod("10.0.0.4", "10.0.0.99:9000", v1.PodRunning)}, want: []string{}},
+		{name: "annotation with a hostname is dropped", pods: []v1.Pod{pod("10.0.0.6", "evil.example:9000", v1.PodRunning)}, want: []string{}},
+		{name: "annotation with an invalid port is dropped", pods: []v1.Pod{pod("10.0.0.5", "10.0.0.5:70000", v1.PodRunning)}, want: []string{}},
+		{name: "invalid pod ip is skipped", pods: []v1.Pod{pod("not-an-ip", "", v1.PodRunning)}, want: []string{}},
+		{name: "local address is excluded", pods: []v1.Pod{pod("127.0.0.1", "127.0.0.1:7946", v1.PodRunning)}, want: []string{}},
+		{name: "ipv6 pod ip is bracketed", pods: []v1.Pod{pod("fd00::3", "", v1.PodRunning)}, want: []string{"[fd00::3]:7946"}},
+		{name: "ipv6 annotation overrides only the port", pods: []v1.Pod{pod("fd00::2", "[fd00::2]:9000", v1.PodRunning)}, want: []string{"[fd00::2]:9000"}},
+		{name: "unbracketed ipv6 annotation is dropped", pods: []v1.Pod{pod("fd00::4", "fd00::4:9000", v1.PodRunning)}, want: []string{}},
+		{name: "ipv4-mapped pod ip stays a dotted quad", pods: []v1.Pod{pod("::ffff:10.0.0.3", "", v1.PodRunning)}, want: []string{"10.0.0.3:7946"}},
+		{name: "ipv6 local address is excluded", pods: []v1.Pod{pod("fd00::9", "", v1.PodRunning)}, localURL: "[fd00::9]:7946", want: []string{}},
+		{name: "pending and unready pods stay eligible", pods: []v1.Pod{pod("10.0.0.7", "", v1.PodPending), pod("10.0.0.8", "", "")}, want: []string{"10.0.0.7:7946", "10.0.0.8:7946"}},
+		{name: "terminal pods are excluded", pods: []v1.Pod{pod("10.0.0.9", "", v1.PodSucceeded), pod("10.0.0.10", "", v1.PodFailed)}, want: []string{}},
+		{name: "duplicates collapse", pods: []v1.Pod{pod("10.0.0.3", "", v1.PodRunning), pod("10.0.0.3", "", v1.PodRunning)}, want: []string{"10.0.0.3:7946"}},
+		{name: "seeds are sorted", pods: []v1.Pod{pod("10.0.0.3", "", v1.PodRunning), pod("10.0.0.2", "10.0.0.2:9000", v1.PodRunning)}, want: []string{"10.0.0.2:9000", "10.0.0.3:7946"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			localURL := tt.localURL
+			if localURL == "" {
+				localURL = "127.0.0.1:7946"
+			}
+			assert.Equal(t, tt.want, trustedSeedAddresses(tt.pods, localURL, 7946))
+		})
+	}
+}
+
+// The fake client itself filters by namespace and label selector, so the
+// joined seeds prove the discovery list carries both.
+func TestMemberlistPeers_SeedListUsesNamespaceAndSelector(t *testing.T) {
+	matching := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "matching", Namespace: Namespace, Labels: map[string]string{LabelSelectorKey: LabelSelectorValue}},
+		Status:     v1.PodStatus{PodIP: "10.0.0.2"},
+	}
+	otherNamespace := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-ns", Namespace: "other", Labels: map[string]string{LabelSelectorKey: LabelSelectorValue}},
+		Status:     v1.PodStatus{PodIP: "10.0.0.3"},
+	}
+	otherLabel := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-label", Namespace: Namespace, Labels: map[string]string{"app": "other"}},
+		Status:     v1.PodStatus{PodIP: "10.0.0.4"},
+	}
+	fc := fake.NewClientBuilder().WithStatusSubresource(&v1.Pod{}).WithObjects(matching, otherNamespace, otherLabel).Build()
+	handle := &fakeMemberlistHandle{join: func([]string) (int, error) { return 1, nil }}
+	peer := startFakeLifecycle(t.Context(), fc, handle, time.Hour)
+
+	require.Eventually(t, func() bool {
+		return len(handle.recordedCalls()) > 0
+	}, time.Second, time.Millisecond)
+	require.NoError(t, peer.Stop(t.Context()))
+	assert.Equal(t, []string{"join:10.0.0.2:7946", "leave", "shutdown"}, handle.recordedCalls())
+}
+
+func TestMemberlistPeers_RetriesUntilJoinSucceeds(t *testing.T) {
+	var listCalls atomic.Int32
+	reader := interceptList(func(_ context.Context, list ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+		call := listCalls.Add(1)
+		if call == 1 {
+			return assert.AnError
+		}
+		pods := list.(*v1.PodList)
+		if call > 2 {
+			pods.Items = []v1.Pod{{Status: v1.PodStatus{PodIP: "10.0.0.2"}}}
+		}
+		return nil
+	})
+	var joinCalls atomic.Int32
+	handle := &fakeMemberlistHandle{join: func([]string) (int, error) {
+		if joinCalls.Add(1) == 1 {
+			return 0, assert.AnError
+		}
+		return 1, nil
+	}}
+	peer := startFakeLifecycle(t.Context(), reader, handle, 5*time.Millisecond)
+
+	require.Eventually(t, func() bool { return listCalls.Load() >= 4 }, time.Second, time.Millisecond)
+	require.Eventually(t, func() bool { return joinCalls.Load() == 2 }, time.Second, time.Millisecond)
+	listCount := listCalls.Load()
+	assert.Never(t, func() bool { return listCalls.Load() != listCount }, 20*time.Millisecond, time.Millisecond,
+		"successful join must stop Kubernetes discovery")
+	require.NoError(t, peer.Stop(t.Context()))
+	assert.Equal(t, []string{"join:10.0.0.2:7946", "join:10.0.0.2:7946", "leave", "shutdown"}, handle.recordedCalls())
+}
+
+func TestMemberlistPeers_JoinsAllSeedsIndividuallyInStableOrder(t *testing.T) {
+	reader := interceptList(func(_ context.Context, list ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+		list.(*v1.PodList).Items = []v1.Pod{
+			{Status: v1.PodStatus{PodIP: "10.0.0.4"}},
+			{Status: v1.PodStatus{PodIP: "10.0.0.3"}},
+			{Status: v1.PodStatus{PodIP: "10.0.0.2"}},
+		}
+		return nil
+	})
+	var joinCalls atomic.Int32
+	handle := &fakeMemberlistHandle{join: func(seeds []string) (int, error) {
+		if len(seeds) != 1 {
+			t.Errorf("Join seeds = %v, want exactly one seed", seeds)
+			return 0, assert.AnError
+		}
+		if joinCalls.Add(1) == 1 {
+			return 0, assert.AnError
+		}
+		return 1, nil
+	}}
+	peer := startFakeLifecycle(t.Context(), reader, handle, time.Hour)
+
+	require.Eventually(t, func() bool { return joinCalls.Load() == 3 }, time.Second, time.Millisecond)
+	require.NoError(t, peer.Stop(t.Context()))
+	assert.Equal(t, []string{
+		"join:10.0.0.2:7946", // first dial fails
+		"join:10.0.0.3:7946", // first success must not stop the loop
+		"join:10.0.0.4:7946",
+		"leave", "shutdown",
+	}, handle.recordedCalls())
+}
+
+// startBlockedJoin starts a peer whose first Join call blocks until the
+// returned release function runs.
+func startBlockedJoin(t *testing.T) (*MemberlistPeers, *fakeMemberlistHandle, func()) {
+	t.Helper()
+	joinStarted := make(chan struct{})
+	releaseJoin := make(chan struct{})
+	reader := interceptList(func(_ context.Context, list ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+		list.(*v1.PodList).Items = []v1.Pod{{Status: v1.PodStatus{PodIP: "10.0.0.2"}}}
+		return nil
+	})
+	handle := &fakeMemberlistHandle{join: func([]string) (int, error) {
+		close(joinStarted)
+		<-releaseJoin
+		return 0, nil
+	}}
+	peer := startFakeLifecycle(t.Context(), reader, handle, time.Hour)
+	<-joinStarted
+	return peer, handle, func() { close(releaseJoin) }
+}
+
+func TestMemberlistPeers_StopWaitsForActiveJoin(t *testing.T) {
+	peer, handle, release := startBlockedJoin(t)
+
+	stopResult := make(chan error, 1)
+	go func() { stopResult <- peer.Stop(t.Context()) }()
+	assert.Never(t, func() bool { return handle.callCount("leave") != 0 }, 20*time.Millisecond, time.Millisecond)
+	release()
+	require.NoError(t, <-stopResult)
+	assert.Equal(t, []string{"join:10.0.0.2:7946", "leave", "shutdown"}, handle.recordedCalls())
+}
+
+func TestMemberlistPeers_StopDeadlineDoesNotTakeCleanupOwnership(t *testing.T) {
+	peer, handle, release := startBlockedJoin(t)
+
+	waitCtx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+	assert.ErrorIs(t, peer.Stop(waitCtx), context.DeadlineExceeded)
+	assert.Zero(t, handle.callCount("leave"))
+	release()
+	select {
+	case err := <-peer.lifecycleDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("lifecycle cleanup did not finish")
+	}
+	assert.Equal(t, []string{"join:10.0.0.2:7946", "leave", "shutdown"}, handle.recordedCalls())
+}
+
+func TestMemberlistPeers_StopReturnsCleanupError(t *testing.T) {
+	leaveErr := errors.New("leave failed")
+	reader := interceptList(func(context.Context, ctrlclient.ObjectList, ...ctrlclient.ListOption) error {
+		return nil
+	})
+	handle := &fakeMemberlistHandle{leaveErr: leaveErr}
+	peer := startFakeLifecycle(t.Context(), reader, handle, time.Hour)
+
+	err := peer.Stop(t.Context())
+	assert.ErrorIs(t, err, leaveErr)
+	assert.Equal(t, []string{"leave", "shutdown"}, handle.recordedCalls(), "Leave failure must not skip Shutdown")
+}
+
+func TestMemberlistPeers_ParentCancellationOwnsCleanup(t *testing.T) {
+	parent, cancel := context.WithCancel(t.Context())
+	reader := interceptList(func(context.Context, ctrlclient.ObjectList, ...ctrlclient.ListOption) error {
+		return nil
+	})
+	handle := &fakeMemberlistHandle{}
+	peer := startFakeLifecycle(parent, reader, handle, time.Hour)
+	cancel()
+
+	require.Eventually(t, func() bool {
+		return handle.callCount("leave") == 1
+	}, time.Second, time.Millisecond, "parent cancellation must trigger cleanup")
+	require.NoError(t, peer.Stop(t.Context()))
+	assert.Equal(t, []string{"leave", "shutdown"}, handle.recordedCalls())
 }

--- a/pkg/peers/peers.go
+++ b/pkg/peers/peers.go
@@ -30,20 +30,20 @@ type Peer struct {
 // Peers defines the interface for peer discovery and management
 // It abstracts the underlying implementation (memberlist) from the consumers
 type Peers interface {
-	// Start initializes and starts the peer discovery mechanism
-	Start(ctx context.Context, bindPort int) error
+	// Start initializes and starts the peer discovery mechanism. Must be
+	// called exactly once.
+	Start(ctx context.Context, bindAddress string, bindPort int) error
 
-	// Stop gracefully shuts down the peer discovery
-	Stop() error
+	// Stop gracefully shuts down the peer discovery. Must be called at most
+	// once, after Start returns. Stopping a peer that never started is a
+	// no-op.
+	Stop(ctx context.Context) error
 
 	// GetPeers returns the current list of alive peers (excluding self)
 	GetPeers() []Peer
 
 	// GetAllMembers returns all members including self
 	GetAllMembers() []Peer
-
-	// WaitForPeers blocks until at least minPeers are discovered or context is cancelled
-	WaitForPeers(ctx context.Context, minPeers int) error
 
 	// LocalAddr returns the local node's address
 	LocalAddr() net.IP

--- a/pkg/proxy/ext_proc.go
+++ b/pkg/proxy/ext_proc.go
@@ -22,7 +22,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -136,7 +138,7 @@ func (s *Server) handleRequestHeaders(requestHeaders *extProcPb.ProcessingReques
 	}
 	// An adapter can set "x-envoy-original-dst-host" header to force route the request to a specific destination
 	if _, ok := extraHeaders[OrigDstHeader]; !ok {
-		extraHeaders[OrigDstHeader] = fmt.Sprintf("%s:%d", route.IP, sandboxPort)
+		extraHeaders[OrigDstHeader] = net.JoinHostPort(route.IP, strconv.Itoa(sandboxPort))
 	}
 
 	return s.logAndCreateDstResponse(requestHeaders.RequestHeaders, extraHeaders, log)

--- a/pkg/proxy/ext_proc_test.go
+++ b/pkg/proxy/ext_proc_test.go
@@ -19,6 +19,7 @@ package proxy
 import (
 	"context"
 	"io"
+	"net"
 	"sort"
 	"testing"
 	"time"
@@ -27,14 +28,18 @@ import (
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	types "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/sandboxroute"
+	"github.com/openkruise/agents/pkg/sandboxroute/refresh"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
+	"github.com/openkruise/agents/pkg/utils/network"
 )
 
 // testRequestAdapter is a RequestAdapter implementation for testing
@@ -65,7 +70,7 @@ func (t *testRequestAdapter) Entry() string {
 
 func (t *testRequestAdapter) ParseRequest(headers map[string]string) *adapters.ParsedRequest {
 	// Use a real E2BAdapter to parse, so tests exercise the real parsing logic
-	a := adapters.NewE2BAdapter(0)
+	a := adapters.NewE2BAdapter(0, "")
 	return a.ParseRequest(headers)
 }
 
@@ -622,26 +627,74 @@ func TestServer_Process(t *testing.T) {
 	}
 }
 
-// TestServer_Run_Stop tests server start and stop
-func TestServer_Run_Stop(t *testing.T) {
-	// Create test adapter
-	adapter := &testRequestAdapter{
-		entry: "127.0.0.1:8080",
+// TestServer_RunLifecycle binds the fixed route-refresh and ext-proc ports;
+// `make test` runs packages serially so it cannot collide with the e2b
+// controller tests that bind the same ports.
+func TestServer_RunLifecycle(t *testing.T) {
+	tests := []struct {
+		name         string
+		options      config.SandboxManagerOptions
+		occupyGRPC   bool
+		wantRunErr   string
+		wantGRPC     bool
+		wantReleased []string
+	}{
+		{
+			name:         "ext-proc bind failure returns synchronously",
+			options:      config.SandboxManagerOptions{ExtProcMaxConcurrency: 1000},
+			occupyGRPC:   true,
+			wantRunErr:   "listen for envoy ext-proc",
+			wantReleased: []string{network.ListenAddress("", refresh.DefaultPort)},
+		},
+		{
+			name:         "run then stop releases both listeners",
+			options:      config.SandboxManagerOptions{ExtProcMaxConcurrency: 1000},
+			wantGRPC:     true,
+			wantReleased: []string{network.ListenAddress("", refresh.DefaultPort), network.ListenAddress("", consts.ExtProcPort)},
+		},
+		{
+			name:         "grpc listener skipped when ext-proc disabled",
+			options:      config.SandboxManagerOptions{DisableEnvoyExtProc: true},
+			occupyGRPC:   true,
+			wantReleased: []string{network.ListenAddress("", refresh.DefaultPort)},
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.occupyGRPC {
+				occupied, err := net.Listen("tcp", network.ListenAddress("", consts.ExtProcPort))
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = occupied.Close() })
+			}
 
-	// Create server
-	server := NewServer(config.SandboxManagerOptions{ExtProcMaxConcurrency: 1000})
-	server.SetRequestAdapter(adapter)
-
-	// Start server in background
-	go func() {
-		// This will fail due to port occupation, but we only care about API calls
-		_ = server.Run()
-	}()
-
-	// Wait a bit for goroutine to start
-	time.Sleep(10 * time.Millisecond)
-
-	// Stop server
-	server.Stop(t.Context())
+			server := NewServer(tt.options)
+			err := server.Run()
+			if tt.wantRunErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantRunErr)
+				assert.Nil(t, server.httpSrv)
+				assert.Nil(t, server.grpcSrv)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, server.httpSrv)
+				if tt.wantGRPC {
+					require.NotNil(t, server.grpcSrv)
+				} else {
+					assert.Nil(t, server.grpcSrv)
+				}
+				server.Stop(t.Context())
+			}
+			// Serve may still be entering when Stop runs; it then closes the
+			// listener itself, so release is prompt but not synchronous.
+			for _, addr := range tt.wantReleased {
+				require.Eventuallyf(t, func() bool {
+					listener, err := net.Listen("tcp", addr)
+					if err != nil {
+						return false
+					}
+					return assert.NoError(t, listener.Close())
+				}, time.Second, 5*time.Millisecond, "listener on %s must be released", addr)
+			}
+		})
+	}
 }

--- a/pkg/proxy/ext_proc_test.go
+++ b/pkg/proxy/ext_proc_test.go
@@ -174,6 +174,56 @@ func TestServer_Process(t *testing.T) {
 			},
 		},
 		{
+			name: "IPv6 sandbox upstream uses bracketed host port",
+			setupRoutes: []sandboxroute.Route{
+				{ID: "sandbox-ipv6", IP: "2001:db8::1", Owner: "user1"},
+			},
+			adapter: &testRequestAdapter{
+				isSandboxRequest: true,
+				mapResult: mapResult{
+					sandboxID:   "sandbox-ipv6",
+					sandboxPort: 49999,
+				},
+				entry: "127.0.0.1:8080",
+			},
+			requests: []*extProcPb.ProcessingRequest{
+				{
+					Request: &extProcPb.ProcessingRequest_RequestHeaders{
+						RequestHeaders: &extProcPb.HttpHeaders{
+							Headers: &corev3.HeaderMap{
+								Headers: []*corev3.HeaderValue{
+									{Key: ":scheme", RawValue: []byte("http")},
+									{Key: ":authority", RawValue: []byte("localhost:9002")},
+									{Key: ":path", RawValue: []byte("/sandbox")},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+			expectResp: []*extProcPb.ProcessingResponse{
+				{
+					Response: &extProcPb.ProcessingResponse_RequestHeaders{
+						RequestHeaders: &extProcPb.HeadersResponse{
+							Response: &extProcPb.CommonResponse{
+								HeaderMutation: &extProcPb.HeaderMutation{
+									SetHeaders: []*corev3.HeaderValueOption{
+										{
+											Header: &corev3.HeaderValue{
+												Key:      "x-envoy-original-dst-host",
+												RawValue: []byte("[2001:db8::1]:49999"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:        "non-sandbox",
 			setupRoutes: []sandboxroute.Route{},
 			adapter: &testRequestAdapter{

--- a/pkg/proxy/routes_test.go
+++ b/pkg/proxy/routes_test.go
@@ -51,8 +51,8 @@ func newMockPeers(members ...peers.Peer) *mockPeers {
 	return &mockPeers{members: members}
 }
 
-func (m *mockPeers) Start(_ context.Context, _ int) error { return nil }
-func (m *mockPeers) Stop() error                          { return nil }
+func (m *mockPeers) Start(_ context.Context, _ string, _ int) error { return nil }
+func (m *mockPeers) Stop(context.Context) error                     { return nil }
 func (m *mockPeers) GetPeers() []peers.Peer {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -60,10 +60,9 @@ func (m *mockPeers) GetPeers() []peers.Peer {
 	copy(result, m.members)
 	return result
 }
-func (m *mockPeers) GetAllMembers() []peers.Peer                 { return m.GetPeers() }
-func (m *mockPeers) WaitForPeers(_ context.Context, _ int) error { return nil }
-func (m *mockPeers) LocalAddr() net.IP                           { return net.ParseIP("127.0.0.1") }
-func (m *mockPeers) LocalPort() int                              { return 0 }
+func (m *mockPeers) GetAllMembers() []peers.Peer { return m.GetPeers() }
+func (m *mockPeers) LocalAddr() net.IP           { return net.ParseIP("127.0.0.1") }
+func (m *mockPeers) LocalPort() int              { return 0 }
 
 func (m *mockPeers) SetMembers(members ...peers.Peer) {
 	m.mu.Lock()
@@ -491,12 +490,12 @@ func TestSyncRouteWithPeers_TwoNodes_Memberlist(t *testing.T) {
 	ctx := context.Background()
 	port1, port2 := ml1.port, ml2.port
 
-	require.NoError(t, ml1.peer.Start(ctx, port1))
-	require.NoError(t, ml2.peer.Start(ctx, port2))
+	require.NoError(t, ml1.peer.Start(ctx, "127.0.0.1", port1))
+	require.NoError(t, ml2.peer.Start(ctx, "127.0.0.1", port2))
 
 	defer func() {
-		_ = ml1.peer.Stop()
-		_ = ml2.peer.Stop()
+		_ = ml1.peer.Stop(ctx)
+		_ = ml2.peer.Stop(ctx)
 	}()
 
 	// Wait for mutual discovery

--- a/pkg/proxy/routes_test.go
+++ b/pkg/proxy/routes_test.go
@@ -344,6 +344,25 @@ func TestSyncRouteWithPeers_TwoNodes_Success(t *testing.T) {
 	assert.Equal(t, route.ID, peer2.getReceived()[0].ID)
 }
 
+func TestSyncRouteWithPeers_IPv6Peer(t *testing.T) {
+	peer := newRecordingPeer()
+	defer peer.close()
+
+	const peerIP = "fd11:1111:1111::10"
+	overridePeerTransport(t, map[string]string{
+		net.JoinHostPort(peerIP, fmt.Sprint(refresh.DefaultPort)): peer.server.URL[7:],
+	}, 5*time.Second)
+
+	s := newTestServer(newMockPeers(peers.Peer{IP: peerIP, Name: "node-v6"}))
+	route := testProxyRoute("sb-v6", "fd11:1111:1111::20", "1")
+	require.NoError(t, s.SyncRouteWithPeers(t.Context(), route))
+
+	require.Eventually(t, func() bool {
+		return len(peer.getReceived()) == 1
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, route.ID, peer.getReceived()[0].ID)
+}
+
 func TestSyncRouteWithPeers_TwoNodes_OneFails(t *testing.T) {
 	// peer1 is a real server; peer2 points to a non-existent address
 	peer1 := newRecordingPeer()

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/consts"
 	"github.com/openkruise/agents/pkg/sandboxroute"
 	"github.com/openkruise/agents/pkg/sandboxroute/refresh"
+	"github.com/openkruise/agents/pkg/utils/network"
 )
 
 type healthServer struct{}
@@ -67,6 +68,7 @@ type Server struct {
 	// grpc
 	grpcSrv                     *grpc.Server
 	extProcMaxConcurrentStreams uint32
+	disableEnvoyExtProc         bool
 	// http
 	httpSrv *http.Server
 	// internal
@@ -75,7 +77,8 @@ type Server struct {
 	LBEntry string // entry of load balancer, usually a service
 	// peers - now managed by Peers
 	peersManager peers.Peers
-	// lifecycle
+	bindAddress  string
+	// lifecycle: Run is called once and Stop at most once, after Run.
 	mu sync.Mutex
 }
 
@@ -83,7 +86,9 @@ func NewServer(opts config.SandboxManagerOptions) *Server {
 	store := sandboxroute.NewStore()
 	return &Server{
 		extProcMaxConcurrentStreams: opts.ExtProcMaxConcurrency,
+		disableEnvoyExtProc:         opts.DisableEnvoyExtProc,
 		store:                       store,
+		bindAddress:                 opts.BindAddress,
 	}
 }
 
@@ -96,41 +101,60 @@ func (s *Server) SetPeersManager(p peers.Peers) {
 	s.peersManager = p
 }
 
+// Run binds the route-refresh HTTP listener and, unless disabled, the Envoy
+// ext-proc gRPC listener, then serves both in the background. Bind failures
+// are returned synchronously. Listeners are owned by their servers: Shutdown
+// and Stop close them, as does Serve when it observes a stopped server.
 func (s *Server) Run() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// HTTP
-	s.httpSrv = &http.Server{
-		Addr:              fmt.Sprintf(":%d", refresh.DefaultPort),
+	httpSrv := &http.Server{
+		Addr:              network.ListenAddress(s.bindAddress, refresh.DefaultPort),
 		Handler:           s.newServeMux(),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
-
-	// GRPC
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", consts.ExtProcPort))
+	httpLis, err := net.Listen("tcp", httpSrv.Addr)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to listen for proxy route updates on %s: %w", httpSrv.Addr, err)
 	}
-	s.grpcSrv = grpc.NewServer(grpc.MaxConcurrentStreams(s.extProcMaxConcurrentStreams))
-	extProcPb.RegisterExternalProcessorServer(s.grpcSrv, s)
-	grpc_health_v1.RegisterHealthServer(s.grpcSrv, &healthServer{})
-	klog.InfoS("Starting envoy ext-proc gRPC server", "address", lis.Addr())
 
-	// Start servers
-	go func() {
-		klog.InfoS("Starting proxy system server", "address", s.httpSrv.Addr)
-		if err := s.httpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+	var grpcSrv *grpc.Server
+	var grpcLis net.Listener
+	if s.disableEnvoyExtProc {
+		klog.InfoS("Envoy ext-proc gRPC listener disabled")
+	} else {
+		extProcAddr := network.ListenAddress("", consts.ExtProcPort)
+		grpcLis, err = net.Listen("tcp", extProcAddr)
+		if err != nil {
+			if closeErr := httpLis.Close(); closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
+				err = errors.Join(err, fmt.Errorf("close proxy route listener: %w", closeErr))
+			}
+			return fmt.Errorf("failed to listen for envoy ext-proc on %s: %w", extProcAddr, err)
+		}
+		grpcSrv = grpc.NewServer(grpc.MaxConcurrentStreams(s.extProcMaxConcurrentStreams))
+		extProcPb.RegisterExternalProcessorServer(grpcSrv, s)
+		grpc_health_v1.RegisterHealthServer(grpcSrv, &healthServer{})
+	}
+
+	s.httpSrv = httpSrv
+	s.grpcSrv = grpcSrv
+
+	go func(srv *http.Server, lis net.Listener) {
+		klog.InfoS("Starting proxy system server", "address", lis.Addr())
+		if err := srv.Serve(lis); err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, net.ErrClosed) {
 			klog.Fatalf("HTTP server failed to start: %v", err)
 		}
-	}()
+	}(httpSrv, httpLis)
 
-	go func() {
-		klog.InfoS("Starting proxy gRPC server", "address", lis.Addr())
-		if err := s.grpcSrv.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
-			klog.Fatalf("gRPC server failed to start: %v", err)
-		}
-	}()
+	if grpcSrv != nil {
+		go func(srv *grpc.Server, lis net.Listener) {
+			klog.InfoS("Starting proxy gRPC server", "address", lis.Addr())
+			if err := srv.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) && !errors.Is(err, net.ErrClosed) {
+				klog.Fatalf("gRPC server failed to start: %v", err)
+			}
+		}(grpcSrv, grpcLis)
+	}
 
 	return nil
 }
@@ -156,7 +180,9 @@ func (s *Server) Stop(ctx context.Context) {
 		s.grpcSrv.Stop()
 	}
 	if s.httpSrv != nil {
-		_ = s.httpSrv.Shutdown(ctx)
+		if err := s.httpSrv.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, net.ErrClosed) {
+			klog.ErrorS(err, "Failed to shut down proxy system server")
+		}
 	}
 }
 

--- a/pkg/proxy/utils.go
+++ b/pkg/proxy/utils.go
@@ -22,7 +22,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/openkruise/agents/pkg/sandboxroute/refresh"
@@ -49,7 +51,8 @@ func requestPeer(ctx context.Context, method, ip, path string, body []byte) erro
 	if len(body) > 0 {
 		buf = bytes.NewReader(body)
 	}
-	request, err := http.NewRequestWithContext(ctx, method, fmt.Sprintf("http://%s:%d%s", ip, refresh.DefaultPort, path), buf)
+	peerAddress := net.JoinHostPort(ip, strconv.Itoa(refresh.DefaultPort))
+	request, err := http.NewRequestWithContext(ctx, method, fmt.Sprintf("http://%s%s", peerAddress, path), buf)
 	if err != nil {
 		return err
 	}

--- a/pkg/sandbox-gateway/filter/filter.go
+++ b/pkg/sandbox-gateway/filter/filter.go
@@ -20,7 +20,8 @@ import (
 	"context"
 	"crypto/subtle"
 	"errors"
-	"fmt"
+	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -198,7 +199,7 @@ func (f *sandboxFilter) DecodeHeaders(header api.RequestHeaderMap, endStream boo
 // apply identical overrides so a request that triggered a wake continues
 // exactly like a request that arrived on a Running sandbox.
 func (f *sandboxFilter) applyUpstreamOverrides(route sandboxroute.Route, sandboxPort int) {
-	upstreamHost := fmt.Sprintf("%s:%d", route.IP, sandboxPort)
+	upstreamHost := net.JoinHostPort(route.IP, strconv.Itoa(sandboxPort))
 	f.callbacks.StreamInfo().DynamicMetadata().Set("envoy.lb.original_dst", "host", upstreamHost)
 	if f.config.EnableRuntimeMTLS && sandboxPort == utils.RuntimePort {
 		f.callbacks.StreamInfo().DynamicMetadata().Set(runtimeMTLSMetadataNamespace, runtimeMTLSMetadataKey, true)

--- a/pkg/sandbox-gateway/filter/filter_test.go
+++ b/pkg/sandbox-gateway/filter/filter_test.go
@@ -503,7 +503,7 @@ func TestDecodeHeadersExtractionVectors(t *testing.T) {
 				return newSandboxHeader("default--ipv6-sandbox")
 			},
 			endStream: true,
-			wantHost:  "2001:db8::1:49983",
+			wantHost:  "[2001:db8::1]:49983",
 		},
 		{
 			name:   "IPv6 upstream via host header",
@@ -512,7 +512,7 @@ func TestDecodeHeadersExtractionVectors(t *testing.T) {
 				return newHostHeader("8080-default--ipv6-sandbox.example.com")
 			},
 			endStream: true,
-			wantHost:  "2001:db8::1:8080",
+			wantHost:  "[2001:db8::1]:8080",
 		},
 		{
 			name:   "kruise custom protocol rewrites the path",

--- a/pkg/sandbox-gateway/server/server.go
+++ b/pkg/sandbox-gateway/server/server.go
@@ -167,7 +167,7 @@ func (s *Server) Start(ctx context.Context) error {
 	s.peerManager = peers.NewMemberlistPeers(s.client, peers.NodePrefixSandboxGateway+nodeName, namespace, labelSelector)
 	setPeerManager(s.peerManager)
 
-	if err := s.peerManager.Start(ctx, s.memberlistBindPort); err != nil {
+	if err := s.peerManager.Start(ctx, "", s.memberlistBindPort); err != nil {
 		return err
 	}
 
@@ -222,7 +222,7 @@ func (s *Server) Stop(ctx context.Context) error {
 		}
 	}
 	if s.peerManager != nil {
-		if err := s.peerManager.Stop(); err != nil {
+		if err := s.peerManager.Stop(ctx); err != nil {
 			errs = append(errs, err)
 		}
 		setPeerManager(nil)

--- a/pkg/sandbox-manager/api_test.go
+++ b/pkg/sandbox-manager/api_test.go
@@ -2521,16 +2521,26 @@ func TestSandboxManager_DeleteSandboxRecycle(t *testing.T) {
 
 // staticPeers is a fixed-membership peers stub for peer-sync failure tests.
 type staticPeers struct {
-	members []peers.Peer
+	members     []peers.Peer
+	events      *[]string
+	bindAddress string
+	bindPort    int
+	startErr    error
 }
 
-func (s *staticPeers) Start(context.Context, int) error        { return nil }
-func (s *staticPeers) Stop() error                             { return nil }
-func (s *staticPeers) GetPeers() []peers.Peer                  { return s.members }
-func (s *staticPeers) GetAllMembers() []peers.Peer             { return s.members }
-func (s *staticPeers) WaitForPeers(context.Context, int) error { return nil }
-func (s *staticPeers) LocalAddr() net.IP                       { return nil }
-func (s *staticPeers) LocalPort() int                          { return 0 }
+func (s *staticPeers) Start(_ context.Context, bindAddress string, bindPort int) error {
+	s.bindAddress = bindAddress
+	s.bindPort = bindPort
+	if s.events != nil {
+		*s.events = append(*s.events, "peers")
+	}
+	return s.startErr
+}
+func (s *staticPeers) Stop(context.Context) error  { return nil }
+func (s *staticPeers) GetPeers() []peers.Peer      { return s.members }
+func (s *staticPeers) GetAllMembers() []peers.Peer { return s.members }
+func (s *staticPeers) LocalAddr() net.IP           { return nil }
+func (s *staticPeers) LocalPort() int              { return 0 }
 
 func TestSandboxManagerSyncRouteErrors(t *testing.T) {
 	t.Run("projection error is returned", func(t *testing.T) {

--- a/pkg/sandbox-manager/config/manager.go
+++ b/pkg/sandbox-manager/config/manager.go
@@ -62,11 +62,13 @@ type QuotaOptions struct {
 type SandboxManagerOptions struct {
 	SystemNamespace       string
 	PeerSelector          string
+	BindAddress           string
 	SandboxNamespace      string
 	SandboxLabelSelector  string
 	MaxClaimWorkers       int
 	MaxCreateQPS          int
 	ExtProcMaxConcurrency uint32
+	DisableEnvoyExtProc   bool
 	MemberlistBindPort    int
 	EnableShortSandboxID  bool
 	ShortSandboxIDPrefix  string

--- a/pkg/sandbox-manager/core.go
+++ b/pkg/sandbox-manager/core.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"k8s.io/apimachinery/pkg/api/validate/content"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -56,10 +57,7 @@ type RedisClient interface {
 
 type GetInfraBuilderFunc func() (infra.Builder, error)
 
-type NewPeerArgs struct {
-	apiReader client.Reader
-}
-type GetPeersFunc func(args NewPeerArgs) (peers.Peers, error)
+type GetPeersFunc func() (peers.Peers, error)
 
 type SandboxManagerBuilder struct {
 	instance       *SandboxManager
@@ -81,6 +79,7 @@ func NewSandboxManagerBuilder(opts config.SandboxManagerOptions) *SandboxManager
 		instance: &SandboxManager{
 			proxy:                    proxy.NewServer(opts),
 			memberlistBindPort:       opts.MemberlistBindPort,
+			bindAddress:              opts.BindAddress,
 			systemNamespace:          opts.SystemNamespace,
 			enableShortID:            opts.EnableShortSandboxID,
 			shortIDPrefix:            opts.ShortSandboxIDPrefix,
@@ -127,9 +126,22 @@ func (b *SandboxManagerBuilder) WithCustomInfra(builderFunc GetInfraBuilderFunc)
 }
 
 func (b *SandboxManagerBuilder) WithMemberlistPeers() *SandboxManagerBuilder {
-	b.getPeersFunc = func(args NewPeerArgs) (peers.Peers, error) {
+	b.getPeersFunc = func() (peers.Peers, error) {
+		if b.opts.SystemNamespace == "" {
+			return nil, fmt.Errorf("system namespace is empty")
+		}
 		if b.opts.PeerSelector == "" {
 			return nil, fmt.Errorf("peer selector is empty")
+		}
+		if _, err := labels.Parse(b.opts.PeerSelector); err != nil {
+			return nil, fmt.Errorf("invalid peer selector: %w", err)
+		}
+		if b.opts.RestConfig == nil {
+			return nil, fmt.Errorf("rest config is required for peer discovery")
+		}
+		peerClient, err := client.New(b.opts.RestConfig, client.Options{})
+		if err != nil {
+			return nil, fmt.Errorf("create peer client: %w", err)
 		}
 		// build node name of sandbox-manager
 		nodeName := os.Getenv("HOSTNAME")
@@ -139,12 +151,11 @@ func (b *SandboxManagerBuilder) WithMemberlistPeers() *SandboxManagerBuilder {
 		if nodeName == "" {
 			nodeName = uuid.NewString()[:8]
 		}
-		peersManager := peers.NewMemberlistPeers(
-			args.apiReader,
+		return peers.NewMemberlistPeers(
+			peerClient,
 			peers.NodePrefixSandboxManager+nodeName,
 			b.opts.SystemNamespace,
-			b.opts.PeerSelector)
-		return peersManager, nil
+			b.opts.PeerSelector), nil
 	}
 
 	return b
@@ -194,10 +205,9 @@ func (b *SandboxManagerBuilder) Build() (*SandboxManager, error) {
 	}
 	b.instance.routeSource = routeSource
 
-	// Build peers manager
+	// Build peers from RestConfig, not from the sandbox cache or Infra.
 	if b.getPeersFunc != nil {
-		reader := b.instance.infra.GetCache().GetAPIReader()
-		peersManager, err := b.getPeersFunc(NewPeerArgs{apiReader: reader})
+		peersManager, err := b.getPeersFunc()
 		if err != nil {
 			return nil, errors.NewError(errors.ErrorInternal, "failed to get peers manager: %v", err)
 		}
@@ -226,6 +236,7 @@ func (b *SandboxManagerBuilder) Build() (*SandboxManager, error) {
 type SandboxManager struct {
 	peersManager       peers.Peers
 	memberlistBindPort int
+	bindAddress        string
 
 	infra infra.Infrastructure
 	proxy *proxy.Server
@@ -336,16 +347,6 @@ func (m *SandboxManager) Run(ctx context.Context) error {
 		m.primary.set(true)
 	}
 
-	// Start peers (optional - only if configured)
-	if m.peersManager != nil {
-		if err := m.peersManager.Start(ctx, m.memberlistBindPort); err != nil {
-			return fmt.Errorf("failed to start memberlist: %w", err)
-		}
-		log.Info("memberlist started successfully")
-	} else {
-		log.Info("peers manager not configured, skip starting memberlist")
-	}
-
 	if err := m.infra.Run(ctx); err != nil {
 		return err
 	}
@@ -356,13 +357,21 @@ func (m *SandboxManager) Run(ctx context.Context) error {
 		}
 	}
 
-	go func() {
-		klog.InfoS("starting proxy")
-		err := m.proxy.Run()
-		if err != nil {
-			klog.Error(err, "proxy stopped")
+	// The peer route listener must accept refreshes before memberlist
+	// advertises this replica; peers start syncing routes as soon as the
+	// background join succeeds.
+	klog.InfoS("starting proxy")
+	if err := m.proxy.Run(); err != nil {
+		return fmt.Errorf("failed to start proxy: %w", err)
+	}
+	if m.peersManager != nil {
+		if err := m.peersManager.Start(ctx, m.bindAddress, m.memberlistBindPort); err != nil {
+			return fmt.Errorf("failed to start memberlist: %w", err)
 		}
-	}()
+		log.Info("memberlist started successfully")
+	} else {
+		log.Info("peers manager not configured, skip starting memberlist")
+	}
 	if m.quotaAntiDrift != nil {
 		m.quotaAntiDrift.Run(ctx)
 	}
@@ -394,7 +403,7 @@ func (m *SandboxManager) Stop(ctx context.Context) {
 	m.proxy.Stop(ctx)
 	m.infra.Stop(ctx)
 	if m.peersManager != nil {
-		if err := m.peersManager.Stop(); err != nil {
+		if err := m.peersManager.Stop(ctx); err != nil {
 			log.Error(err, "failed to stop peers manager")
 		}
 	}

--- a/pkg/sandbox-manager/core_test.go
+++ b/pkg/sandbox-manager/core_test.go
@@ -19,11 +19,14 @@ package sandbox_manager
 import (
 	"context"
 	stderrors "errors"
+	"net"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
@@ -36,7 +39,9 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
+	"github.com/openkruise/agents/pkg/sandboxroute/refresh"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
+	"github.com/openkruise/agents/pkg/utils/network"
 )
 
 type routeSourceOverrideBuilder struct {
@@ -69,16 +74,22 @@ type failingSandboxRouteSource struct {
 	err error
 }
 
-type workerAllocationFailureInfra struct {
+// recordingInfra is an Infrastructure whose Run succeeds immediately, records
+// "infra" into events when set, and serves cache as its cache provider.
+type recordingInfra struct {
 	infra.Infrastructure
-	cache infracache.Provider
+	cache  infracache.Provider
+	events *[]string
 }
 
-func (workerAllocationFailureInfra) Run(context.Context) error {
+func (i recordingInfra) Run(context.Context) error {
+	if i.events != nil {
+		*i.events = append(*i.events, "infra")
+	}
 	return nil
 }
 
-func (i workerAllocationFailureInfra) GetCache() infracache.Provider {
+func (i recordingInfra) GetCache() infracache.Provider {
 	return i.cache
 }
 
@@ -139,7 +150,7 @@ func TestSandboxManagerRunFailsWhenWorkerAllocationFails(t *testing.T) {
 		},
 	})
 	manager := &SandboxManager{
-		infra: workerAllocationFailureInfra{cache: workerAllocationFailureCache{
+		infra: recordingInfra{cache: workerAllocationFailureCache{
 			Provider: cache,
 			reader:   failingReader,
 		}},
@@ -155,6 +166,70 @@ func TestSandboxManagerRunFailsWhenWorkerAllocationFails(t *testing.T) {
 	assert.Nil(t, manager.generateSandboxID)
 }
 
+// TestSandboxManagerRunStartupOrder pins infra -> proxy -> peers: the peer
+// route listener must be serving before memberlist can advertise this
+// replica, and a proxy bind failure must stop startup before peers start.
+// The proxy binds the fixed route-refresh port; `make test` runs packages
+// serially so this cannot collide with the proxy and e2b package tests.
+func TestSandboxManagerRunStartupOrder(t *testing.T) {
+	routeAddr := network.ListenAddress("", refresh.DefaultPort)
+	tests := []struct {
+		name            string
+		occupyRoutePort bool
+		wantErr         string
+		wantEvents      []string
+		wantBindAddress string
+	}{
+		{
+			name:            "proxy bind failure stops startup before peers",
+			occupyRoutePort: true,
+			wantErr:         "failed to start proxy",
+			wantEvents:      []string{"infra"},
+		},
+		{
+			name:            "peers start after infra and proxy with the bind address",
+			wantErr:         assert.AnError.Error(),
+			wantEvents:      []string{"infra", "peers"},
+			wantBindAddress: "10.0.0.8",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.occupyRoutePort {
+				occupied, err := net.Listen("tcp", routeAddr)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = occupied.Close() })
+			}
+			events := []string{}
+			recorded := &staticPeers{events: &events, startErr: assert.AnError}
+			proxyServer := proxy.NewServer(config.SandboxManagerOptions{DisableEnvoyExtProc: true})
+			t.Cleanup(func() { proxyServer.Stop(context.Background()) })
+			manager := &SandboxManager{
+				infra:              recordingInfra{events: &events},
+				proxy:              proxyServer,
+				peersManager:       recorded,
+				primary:            &primaryState{},
+				bindAddress:        "10.0.0.8",
+				memberlistBindPort: 9000,
+			}
+
+			err := manager.Run(t.Context())
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantErr)
+			assert.Equal(t, tt.wantEvents, events)
+			assert.Equal(t, tt.wantBindAddress, recorded.bindAddress)
+			if tt.wantBindAddress != "" {
+				assert.Equal(t, 9000, recorded.bindPort)
+				// Run returned from peers.Start, so a serving route listener
+				// proves the proxy came up before peers.
+				conn, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(refresh.DefaultPort)))
+				require.NoError(t, err, "peer route listener must serve before peers start")
+				require.NoError(t, conn.Close())
+			}
+		})
+	}
+}
+
 func TestNewSandboxManagerBuilder(t *testing.T) {
 	tests := []struct {
 		name                     string
@@ -164,6 +239,7 @@ func TestNewSandboxManagerBuilder(t *testing.T) {
 		expectExtProcConcurrency uint32
 		expectMaxCreateQPS       int
 		expectMemberlistBindPort int
+		expectBindAddress        string
 		expectShortIDPrefix      string
 	}{
 		{
@@ -179,6 +255,7 @@ func TestNewSandboxManagerBuilder(t *testing.T) {
 			name: "custom options should be preserved",
 			opts: config.SandboxManagerOptions{
 				SystemNamespace:       "custom-namespace",
+				BindAddress:           "10.0.0.8",
 				MaxClaimWorkers:       20,
 				ExtProcMaxConcurrency: 200,
 				MaxCreateQPS:          50,
@@ -186,6 +263,7 @@ func TestNewSandboxManagerBuilder(t *testing.T) {
 				ShortSandboxIDPrefix:  "prod-",
 			},
 			expectSystemNamespace:    "custom-namespace",
+			expectBindAddress:        "10.0.0.8",
 			expectMaxClaimWorkers:    20,
 			expectExtProcConcurrency: 200,
 			expectMaxCreateQPS:       50,
@@ -207,6 +285,8 @@ func TestNewSandboxManagerBuilder(t *testing.T) {
 			assert.Equal(t, tt.expectExtProcConcurrency, builder.opts.ExtProcMaxConcurrency)
 			assert.Equal(t, tt.expectMaxCreateQPS, builder.opts.MaxCreateQPS)
 			assert.Equal(t, tt.expectMemberlistBindPort, builder.opts.MemberlistBindPort)
+			assert.Equal(t, tt.expectMemberlistBindPort, builder.instance.memberlistBindPort)
+			assert.Equal(t, tt.expectBindAddress, builder.instance.bindAddress)
 			assert.Equal(t, tt.expectShortIDPrefix, builder.instance.shortIDPrefix)
 		})
 	}
@@ -306,6 +386,12 @@ func TestSandboxManagerBuilder_WithMemberlistPeers(t *testing.T) {
 			expectError:      "",
 			expectNodePrefix: peers.NodePrefixSandboxManager,
 		},
+		{
+			name:         "missing rest config should return error",
+			hostname:     "test-host",
+			peerSelector: "app=sandbox-manager",
+			expectError:  "rest config is required for peer discovery",
+		},
 	}
 
 	for _, tt := range tests {
@@ -317,6 +403,9 @@ func TestSandboxManagerBuilder_WithMemberlistPeers(t *testing.T) {
 			opts := config.SandboxManagerOptions{
 				PeerSelector:    tt.peerSelector,
 				SystemNamespace: "test-namespace",
+			}
+			if tt.expectError == "" {
+				opts.RestConfig = &rest.Config{Host: "https://127.0.0.1:1"}
 			}
 
 			builder := NewSandboxManagerBuilder(opts).
@@ -347,7 +436,7 @@ func TestSandboxManagerBuilder_WithMemberlistPeers(t *testing.T) {
 }
 
 func TestSandboxManagerBuilder_WithRequestAdapter(t *testing.T) {
-	adapter := adapters.NewE2BAdapter(0)
+	adapter := adapters.NewE2BAdapter(0, "")
 	builder := NewSandboxManagerBuilder(config.SandboxManagerOptions{}).
 		WithRequestAdapter(adapter)
 	assert.Same(t, adapter, builder.requestAdapter, "requestAdapter should be set")
@@ -362,7 +451,7 @@ func TestSandboxManagerBuilder_Build(t *testing.T) {
 
 		builder := NewSandboxManagerBuilder(opts).
 			WithCustomInfra(withTestInfra(t, opts)).
-			WithRequestAdapter(adapters.NewE2BAdapter(0))
+			WithRequestAdapter(adapters.NewE2BAdapter(0, ""))
 
 		manager, err := builder.Build()
 		require.NoError(t, err)
@@ -380,6 +469,7 @@ func TestSandboxManagerBuilder_Build(t *testing.T) {
 			SystemNamespace:  "test-namespace",
 			SandboxNamespace: "default",
 			PeerSelector:     "app=test",
+			RestConfig:       &rest.Config{Host: "https://127.0.0.1:1"},
 		}
 
 		builder := NewSandboxManagerBuilder(opts).
@@ -460,7 +550,7 @@ func TestSandboxManagerBuilder_Build(t *testing.T) {
 
 		builder := NewSandboxManagerBuilder(opts).
 			WithCustomInfra(withTestInfra(t, opts)).
-			WithCustomPeers(func(args NewPeerArgs) (peers.Peers, error) {
+			WithCustomPeers(func() (peers.Peers, error) {
 				return nil, assert.AnError
 			})
 
@@ -475,6 +565,7 @@ func TestSandboxManagerBuilder_Chaining(t *testing.T) {
 	opts := config.SandboxManagerOptions{
 		SystemNamespace: "test-namespace",
 		PeerSelector:    "app=test",
+		RestConfig:      &rest.Config{Host: "https://127.0.0.1:1"},
 	}
 
 	t.Setenv("HOSTNAME", "test-host-chain")
@@ -485,7 +576,7 @@ func TestSandboxManagerBuilder_Chaining(t *testing.T) {
 	assert.Same(t, builder, builder.WithSandboxInfra())
 	assert.Same(t, builder, builder.WithCustomInfra(withTestInfra(t, opts)))
 	assert.Same(t, builder, builder.WithMemberlistPeers())
-	assert.Same(t, builder, builder.WithRequestAdapter(adapters.NewE2BAdapter(0)))
+	assert.Same(t, builder, builder.WithRequestAdapter(adapters.NewE2BAdapter(0, "")))
 
 	// The fully chained builder must still build.
 	manager, err := builder.Build()

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -1097,35 +1097,3 @@ func sandboxReadyFailureReason(sbx *v1alpha1.Sandbox, state string, readyCond, i
 	}
 	return "sandbox ready condition is not satisfied"
 }
-
-func checkSandboxReady(ctx context.Context, sbx *v1alpha1.Sandbox) (bool, error) {
-	log := klog.FromContext(ctx).WithValues("sandbox", klog.KObj(sbx), "resourceVersion", sbx.GetResourceVersion()).V(utils.DebugLogLevel)
-	if sbx.Status.ObservedGeneration != sbx.Generation {
-		log.Info("watched sandbox not updated", "generation", sbx.Generation, "observedGeneration", sbx.Status.ObservedGeneration)
-		return false, nil
-	}
-	readyCond := GetSandboxCondition(sbx, v1alpha1.SandboxConditionReady)
-	if readyCond.Reason == v1alpha1.SandboxReadyReasonStartContainerFailed {
-		err := retriableError{Message: fmt.Sprintf("sandbox start container failed: %s", readyCond.Message)}
-		log.Error(err, "sandbox start container failed")
-		return false, err
-	}
-
-	// If an inplace update is still in progress, wait for it to reach a terminal
-	// state (Succeeded or Failed) before reporting ready
-	inplaceCond := GetSandboxCondition(sbx, v1alpha1.SandboxConditionInplaceUpdate)
-	if inplaceCond.Reason == v1alpha1.SandboxInplaceUpdateReasonInplaceUpdating {
-		log.Info("sandbox inplace update still in progress, waiting")
-		return false, nil
-	}
-
-	ip := sbx.Status.PodInfo.PodIP
-	state, reason := utils.GetSandboxState(sbx)
-	isReady := state == v1alpha1.SandboxStateRunning && ip != ""
-	log.Info("sandbox ready checked", "state", state, "reason", reason, "ip", ip, "isReady", isReady, "resourceVersion", sbx.GetResourceVersion())
-	if isReady {
-		// Expect the resourceVersion to ensure InplaceRefresh fetches the latest from API server
-		expectations.ResourceVersionExpectationExpect(sbx)
-	}
-	return isReady, nil
-}

--- a/pkg/sandbox-manager/infra/sandboxcr/claim.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim.go
@@ -1075,15 +1075,15 @@ func sandboxReadyFailureReason(sbx *v1alpha1.Sandbox, state string, readyCond, i
 	if inplaceCond.Reason == v1alpha1.SandboxInplaceUpdateReasonInplaceUpdating {
 		return "inplace update is still in progress"
 	}
-	if sbx.Status.PodInfo.PodIP == "" {
-		return "sandbox has no pod IP"
-	}
-	if readyCond.Reason == v1alpha1.SandboxReadyReasonStartContainerFailed {
+	if utils.IsSandboxStartupFailureReason(readyCond.Reason) {
 		reason := fmt.Sprintf("ready condition reports %s", readyCond.Reason)
 		if readyCond.Message != "" {
 			reason = fmt.Sprintf("%s: %s", reason, readyCond.Message)
 		}
 		return reason
+	}
+	if sbx.Status.PodInfo.PodIP == "" {
+		return "sandbox has no pod IP"
 	}
 	if state != v1alpha1.SandboxStateRunning {
 		return fmt.Sprintf("sandbox state is %s", state)

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -59,7 +59,6 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/config"
 	managererrors "github.com/openkruise/agents/pkg/sandbox-manager/errors"
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
-	"github.com/openkruise/agents/pkg/sandboxid"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	pkgutils "github.com/openkruise/agents/pkg/utils"
 	"github.com/openkruise/agents/pkg/utils/expectations"
@@ -817,7 +816,7 @@ func TestClaimSandboxFailed(t *testing.T) {
 					},
 				}
 			},
-			expectError: "sandbox start container failed",
+			expectError: "sandbox startup failed (reason=StartContainerFailed)",
 		},
 		{
 			name: "start container failed, reserved forever keeps existing shutdown time",
@@ -839,7 +838,7 @@ func TestClaimSandboxFailed(t *testing.T) {
 					},
 				}
 			},
-			expectError:            "sandbox start container failed",
+			expectError:            "sandbox startup failed (reason=StartContainerFailed)",
 			expectExistingShutdown: &existingShutdownTime,
 		},
 		{
@@ -861,7 +860,7 @@ func TestClaimSandboxFailed(t *testing.T) {
 					},
 				}
 			},
-			expectError:    "sandbox start container failed",
+			expectError:    "sandbox startup failed (reason=StartContainerFailed)",
 			expectShutdown: true,
 		},
 		{
@@ -883,7 +882,7 @@ func TestClaimSandboxFailed(t *testing.T) {
 					},
 				}
 			},
-			expectError:   "sandbox start container failed",
+			expectError:   "sandbox startup failed (reason=StartContainerFailed)",
 			expectDeleted: true,
 		},
 		{
@@ -1082,162 +1081,6 @@ func TestReserveFailedSandboxRejectsUnsupportedType(t *testing.T) {
 	err := reserveFailedSandbox(t.Context(), nil, timeoututils.Options{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported sandbox type")
-}
-
-func TestCheckSandboxInplaceUpdate(t *testing.T) {
-	utestutils.InitLogOutput()
-	tests := []struct {
-		name               string
-		generation         int64
-		observedGeneration int64
-		condStatus         metav1.ConditionStatus
-		condReason         string
-		condMessage        string
-		extraConditions    []metav1.Condition
-		expectResult       bool
-		expectError        error
-	}{
-		{
-			name:               "success",
-			generation:         1,
-			observedGeneration: 1,
-			condStatus:         metav1.ConditionTrue,
-			condReason:         v1alpha1.SandboxReadyReasonPodReady,
-			expectResult:       true,
-		},
-		{
-			name:               "not satisfied: out-dated cache",
-			generation:         2,
-			observedGeneration: 1,
-			condStatus:         metav1.ConditionTrue,
-			condReason:         v1alpha1.SandboxReadyReasonPodReady,
-			expectResult:       false,
-		},
-		{
-			name:               "not satisfied: inplace updating",
-			generation:         1,
-			observedGeneration: 1,
-			condStatus:         metav1.ConditionFalse,
-			condReason:         v1alpha1.SandboxReadyReasonUpgrading,
-			expectResult:       false,
-		},
-		{
-			name:               "not satisfied: inplace update condition in progress",
-			generation:         1,
-			observedGeneration: 1,
-			condStatus:         metav1.ConditionTrue,
-			condReason:         v1alpha1.SandboxReadyReasonPodReady,
-			extraConditions: []metav1.Condition{
-				{
-					Type:   string(v1alpha1.SandboxConditionInplaceUpdate),
-					Status: metav1.ConditionFalse,
-					Reason: v1alpha1.SandboxInplaceUpdateReasonInplaceUpdating,
-				},
-			},
-			expectResult: false,
-		},
-		{
-			name:               "ready after inplace update failed",
-			generation:         1,
-			observedGeneration: 1,
-			condStatus:         metav1.ConditionTrue,
-			condReason:         v1alpha1.SandboxReadyReasonPodReady,
-			extraConditions: []metav1.Condition{
-				{
-					Type:   string(v1alpha1.SandboxConditionInplaceUpdate),
-					Status: metav1.ConditionTrue,
-					Reason: v1alpha1.SandboxInplaceUpdateReasonFailed,
-				},
-			},
-			expectResult: true,
-		},
-		{
-			name:               "ready after inplace update succeeded",
-			generation:         1,
-			observedGeneration: 1,
-			condStatus:         metav1.ConditionTrue,
-			condReason:         v1alpha1.SandboxReadyReasonPodReady,
-			extraConditions: []metav1.Condition{
-				{
-					Type:   string(v1alpha1.SandboxConditionInplaceUpdate),
-					Status: metav1.ConditionTrue,
-					Reason: v1alpha1.SandboxInplaceUpdateReasonSucceeded,
-				},
-			},
-			expectResult: true,
-		},
-		{
-			name:               "not satisfied: start container failed, deleted",
-			generation:         1,
-			observedGeneration: 1,
-			condStatus:         metav1.ConditionFalse,
-			condReason:         v1alpha1.SandboxReadyReasonStartContainerFailed,
-			condMessage:        "by test",
-			expectResult:       false,
-			expectError:        retriableError{Message: "sandbox start container failed: by test"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			testInfra, fc := NewTestInfra(t)
-			template := "test-template"
-			sbs := &v1alpha1.SandboxSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      template,
-					Namespace: "default",
-				},
-			}
-			err := fc.Create(t.Context(), sbs)
-			require.NoError(t, err)
-			conditions := []metav1.Condition{
-				{
-					Type:    string(v1alpha1.SandboxConditionReady),
-					Status:  tt.condStatus,
-					Reason:  tt.condReason,
-					Message: tt.condMessage,
-				},
-			}
-			conditions = append(conditions, tt.extraConditions...)
-			sbx := &v1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "sbx-1",
-					Namespace: "default",
-					Labels: map[string]string{
-						v1alpha1.LabelSandboxTemplate:  template,
-						v1alpha1.LabelSandboxIsClaimed: "true",
-					},
-					Annotations: map[string]string{},
-					Generation:  tt.generation,
-				},
-				Status: v1alpha1.SandboxStatus{
-					Phase:      v1alpha1.SandboxRunning,
-					Conditions: conditions,
-					PodInfo: v1alpha1.PodInfo{
-						PodIP: "1.2.3.4",
-					},
-					ObservedGeneration: tt.observedGeneration,
-				},
-			}
-			CreateSandboxWithStatus(t, fc, sbx)
-
-			gotSbx, err := testInfra.Cache.GetClaimedSandbox(t.Context(), infracache.GetClaimedSandboxOptions{
-				SandboxID: sandboxid.Resolve(sbx),
-			})
-			assert.NoError(t, err)
-			if err != nil {
-				return
-			}
-			result, err := checkSandboxReady(t.Context(), gotSbx)
-			assert.Equal(t, tt.expectResult, result)
-			if tt.expectError != nil {
-				assert.Error(t, err)
-				assert.True(t, errors.Is(err, tt.expectError))
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
 }
 
 func TestSandboxReadyFailureMessage(t *testing.T) {
@@ -3095,9 +2938,9 @@ func TestTryClaimSandboxRecordsPickSandboxFailures(t *testing.T) {
 				})
 			},
 			want: []infra.PickSandboxFailure{
-				{Key: "default/test-sbx", Reason: "failed to wait for sandbox ready: sandbox start container failed: by test", Count: 1},
+				{Key: "default/test-sbx", Reason: "failed to wait for sandbox ready: sandbox startup failed (reason=StartContainerFailed): by test", Count: 1},
 			},
-			wantError: "sandbox start container failed",
+			wantError: "sandbox startup failed (reason=StartContainerFailed)",
 		},
 	}
 

--- a/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
+++ b/pkg/sandbox-manager/infra/sandboxcr/claim_test.go
@@ -1184,6 +1184,51 @@ func TestSandboxReadyFailureMessage(t *testing.T) {
 			},
 			want: "sandbox default/sbx-1 is not ready before wait timeout: reason=ready condition reports StartContainerFailed: process exited, state=dead, ready=StartContainerFailed",
 		},
+		{
+			name: "ready condition reports unschedulable with message",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "sbx-1",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase:              v1alpha1.SandboxRunning,
+					ObservedGeneration: 1,
+					Conditions: []metav1.Condition{
+						{
+							Type:    string(v1alpha1.SandboxConditionReady),
+							Reason:  v1alpha1.SandboxReadyReasonUnschedulable,
+							Message: "insufficient CPU",
+						},
+					},
+					PodInfo: v1alpha1.PodInfo{PodIP: "1.2.3.4"},
+				},
+			},
+			want: "sandbox default/sbx-1 is not ready before wait timeout: reason=ready condition reports Unschedulable: insufficient CPU, state=dead, ready=Unschedulable",
+		},
+		{
+			name: "unschedulable reason reported without pod ip",
+			sbx: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "sbx-1",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase:              v1alpha1.SandboxRunning,
+					ObservedGeneration: 1,
+					Conditions: []metav1.Condition{
+						{
+							Type:    string(v1alpha1.SandboxConditionReady),
+							Reason:  v1alpha1.SandboxReadyReasonUnschedulable,
+							Message: "insufficient CPU",
+						},
+					},
+				},
+			},
+			want: "sandbox default/sbx-1 is not ready before wait timeout: reason=ready condition reports Unschedulable: insufficient CPU, state=dead, ready=Unschedulable",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sandbox-manager/leader.go
+++ b/pkg/sandbox-manager/leader.go
@@ -112,10 +112,13 @@ type primaryElector struct {
 	elector leaderElectionRunner
 	state   *primaryState
 
-	runOnce  sync.Once
-	stopOnce sync.Once
-	stopCh   chan struct{}
-	done     chan struct{}
+	// runClaimed is set by whichever of Run and Stop comes first. Run owns
+	// closing done only when it wins; Stop closes done itself otherwise, so
+	// it never waits on a goroutine that will not exist.
+	runClaimed atomic.Bool
+	stopOnce   sync.Once
+	stopCh     chan struct{}
+	done       chan struct{}
 }
 
 func newPrimaryElector(opts config.SandboxManagerOptions, state *primaryState) (*primaryElector, error) {
@@ -190,33 +193,34 @@ func (e *primaryElector) Run(ctx context.Context) {
 		return
 	}
 
-	e.runOnce.Do(func() {
-		if e.stopCh == nil {
-			e.stopCh = make(chan struct{})
-		}
-		if e.done == nil {
-			e.done = make(chan struct{})
-		}
+	if !e.runClaimed.CompareAndSwap(false, true) {
+		return
+	}
+	if e.stopCh == nil {
+		e.stopCh = make(chan struct{})
+	}
+	if e.done == nil {
+		e.done = make(chan struct{})
+	}
 
-		runCtx, cancel := context.WithCancel(ctx)
-		defer func() {
+	runCtx, cancel := context.WithCancel(ctx)
+	defer func() {
+		cancel()
+		e.state.set(false)
+		close(e.done)
+	}()
+
+	go func() {
+		select {
+		case <-e.stopCh:
 			cancel()
-			e.state.set(false)
-			close(e.done)
-		}()
-
-		go func() {
-			select {
-			case <-e.stopCh:
-				cancel()
-			case <-runCtx.Done():
-			}
-		}()
-
-		for runCtx.Err() == nil {
-			e.elector.Run(runCtx)
+		case <-runCtx.Done():
 		}
-	})
+	}()
+
+	for runCtx.Err() == nil {
+		e.elector.Run(runCtx)
+	}
 }
 
 func (e *primaryElector) Stop(ctx context.Context) {
@@ -230,6 +234,13 @@ func (e *primaryElector) Stop(ctx context.Context) {
 	e.state.set(false)
 	if e.done == nil {
 		return
+	}
+
+	// If Run never claimed the lifecycle, close done here so Stop does not
+	// wait on a goroutine that will never exist. The swap is a plain atomic,
+	// so a running Run never blocks this path and ctx stays honored below.
+	if e.runClaimed.CompareAndSwap(false, true) {
+		close(e.done)
 	}
 
 	select {

--- a/pkg/sandbox-manager/leader_test.go
+++ b/pkg/sandbox-manager/leader_test.go
@@ -153,6 +153,26 @@ func TestPrimaryElectorStopLeadingClearsPrimary(t *testing.T) {
 	assert.False(t, state.IsPrimary())
 }
 
+func TestPrimaryElectorStopWithoutRunDoesNotBlock(t *testing.T) {
+	elector := &primaryElector{
+		state:  &primaryState{},
+		stopCh: make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		elector.Stop(context.Background())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Stop blocked when Run was never called")
+	}
+}
+
 func TestPrimaryElectorStopCancelsAndClearsPrimary(t *testing.T) {
 	state := &primaryState{}
 	state.set(true)

--- a/pkg/servers/e2b/adapters/domain_test.go
+++ b/pkg/servers/e2b/adapters/domain_test.go
@@ -90,7 +90,7 @@ func TestE2BAdapter_DomainDispatch(t *testing.T) {
 		{name: "customized path selects customized domain and address", path: "/kruise/api/sandboxes/sid/connect", expectDomain: "API.example.com", expectAddress: "API.example.com/kruise/sid/9222"},
 	}
 
-	adapter := NewE2BAdapter(8080)
+	adapter := NewE2BAdapter(8080, "")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			domain, err := adapter.GetDomain("API.example.com.", tt.path)

--- a/pkg/servers/e2b/adapters/unified_e2b.go
+++ b/pkg/servers/e2b/adapters/unified_e2b.go
@@ -17,7 +17,7 @@ limitations under the License.
 package adapters
 
 import (
-	"fmt"
+	"net"
 	"strconv"
 	"strings"
 )
@@ -35,13 +35,17 @@ var DefaultAdapterFactory = NewE2BAdapter
 
 type E2BAdapter struct {
 	Port       int
+	entryHost  string
 	native     *NativeE2BAdapter
 	customized *CustomizedE2BAdapter
 }
 
-func NewE2BAdapter(port int) *E2BAdapter {
+// NewE2BAdapter builds an adapter for one E2B API port.
+// An empty entryHost preserves the established loopback Entry() address.
+func NewE2BAdapter(port int, entryHost string) *E2BAdapter {
 	return &E2BAdapter{
 		Port:       port,
+		entryHost:  entryHost,
 		native:     &NativeE2BAdapter{},
 		customized: &CustomizedE2BAdapter{},
 	}
@@ -81,7 +85,11 @@ func (a *E2BAdapter) IsSandboxRequest(authority, path string, port int) bool {
 }
 
 func (a *E2BAdapter) Entry() string {
-	return fmt.Sprintf("127.0.0.1:%d", a.Port)
+	host := a.entryHost
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	return net.JoinHostPort(host, strconv.Itoa(a.Port))
 }
 
 func (a *E2BAdapter) ChooseAdapter(path string) E2BMapper {

--- a/pkg/servers/e2b/adapters/unified_e2b_test.go
+++ b/pkg/servers/e2b/adapters/unified_e2b_test.go
@@ -64,7 +64,24 @@ func SetUpE2BAdapter(t *testing.T) *E2BAdapter {
 	})
 	require.NoError(t, err)
 	assert.NoError(t, keyStore.Init(context.Background()))
-	return NewE2BAdapter(8080)
+	return NewE2BAdapter(8080, "")
+}
+
+func TestE2BAdapterEntry(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{name: "empty host preserves loopback", want: "127.0.0.1:8080"},
+		{name: "configured host", host: "10.0.0.2", want: "10.0.0.2:8080"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := NewE2BAdapter(8080, tt.host)
+			assert.Equal(t, tt.want, adapter.Entry())
+		})
+	}
 }
 
 func TestMap(t *testing.T) {
@@ -268,7 +285,7 @@ func TestIsSandboxRequest(t *testing.T) {
 }
 
 func TestParseRequest(t *testing.T) {
-	adapter := NewE2BAdapter(8080)
+	adapter := NewE2BAdapter(8080, "")
 
 	tests := []struct {
 		name            string

--- a/pkg/servers/e2b/core.go
+++ b/pkg/servers/e2b/core.go
@@ -20,11 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -37,6 +36,7 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/logs"
 	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
+	"github.com/openkruise/agents/pkg/utils/network"
 	utilruntime "github.com/openkruise/agents/pkg/utils/runtime"
 )
 
@@ -60,7 +60,6 @@ type Controller struct {
 	mux             *http.ServeMux
 	server          *http.Server
 	metricsServer   *http.Server
-	stop            chan os.Signal
 	cache           cache.Provider
 	storageRegistry storages.VolumeMountProviderRegistry
 	adapter         *adapters.E2BAdapter
@@ -100,7 +99,7 @@ func NewController(opts ControllerOptions) *Controller {
 	sc := &Controller{
 		mux:              http.NewServeMux(),
 		domain:           opts.Domain,
-		adapter:          adapters.DefaultAdapterFactory(opts.Port),
+		adapter:          adapters.DefaultAdapterFactory(opts.Port, opts.Manager.BindAddress),
 		maxTimeout:       opts.MaxTimeout,
 		keyCfg:           opts.KeyConfig,
 		mgrOpts:          opts.Manager,
@@ -108,7 +107,7 @@ func NewController(opts ControllerOptions) *Controller {
 	}
 
 	sc.server = &http.Server{
-		Addr:              fmt.Sprintf(":%d", opts.Port),
+		Addr:              network.ListenAddress(opts.Manager.BindAddress, opts.Port),
 		Handler:           sc.mux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
@@ -187,41 +186,127 @@ func (sc *Controller) initKeyStorage(ctx context.Context) error {
 	return nil
 }
 
-func (sc *Controller) Run() (context.Context, error) {
-	if sc.stop != nil {
-		return nil, errors.New("controller already started")
-	}
+// Run starts the controller in two phases.
+//
+// stop delivers the termination signal and must be buffered (capacity >= 1)
+// so a signal racing startup is not dropped by a non-blocking sender.
+//
+// The returned context is canceled when the controller is done: immediately
+// after an interrupted or failed startup, and only after the graceful
+// shutdown chain completes in steady state.
+//
+// An interrupted startup skips memberlist Leave and leader lease release;
+// peers converge through the memberlist suspicion timeout (a few seconds with
+// the tuned probe settings) and the lease expires via TTL. Both self-heal
+// without operator action. Upgrade path: run the shutdown chain in the
+// interrupted branch once graceful leaf cleanup during startup is required.
+func (sc *Controller) Run(stop <-chan os.Signal) (context.Context, error) {
 	ctx, cancel := context.WithCancel(logs.NewContext())
-	// Channel to listen for interrupt signal
-	sc.stop = make(chan os.Signal, 1)
-	signal.Notify(sc.stop, syscall.SIGINT, syscall.SIGTERM)
-	if err := sc.manager.Run(ctx); err != nil {
-		klog.Fatalf("Sandbox manager failed to start: %v", err)
-	}
 
-	// Run HTTP server in a goroutine
+	startupDone := make(chan error, 1)
 	go func() {
-		klog.InfoS("Starting Server", "address", sc.server.Addr)
-		if err := sc.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			klog.Fatalf("HTTP server failed to start: %v", err)
-		}
+		startupDone <- sc.startComponents(ctx)
 	}()
-	if sc.metricsServer != nil {
-		go serveMetrics(sc.metricsServer)
+
+	outcome, err := awaitStartup(startupDone, stop)
+	switch outcome {
+	case startupInterrupted:
+		klog.FromContext(ctx).Info("termination signal during startup, exiting without graceful cleanup")
+		cancel()
+		return ctx, nil
+	case startupFailed:
+		klog.FromContext(ctx).Error(err, "startup failed, exiting")
+		cancel()
+		return ctx, err
 	}
 
-	// stopper
+	// Steady state: a signal triggers the graceful shutdown chain. A signal
+	// that awaitStartup already consumed alongside a completed startup starts
+	// the chain right away.
 	go func() {
-		<-sc.stop
+		if outcome != startupSignaled {
+			<-stop
+		}
 		shutdownCtx, shutdownCancel := context.WithTimeout(logs.NewContext("action", "shutdown"), consts.ShutdownTimeout)
 		defer shutdownCancel()
 		sc.shutdown(shutdownCtx, cancel)
 	}()
+	return ctx, nil
+}
 
+// startComponents runs the sequential startup pipeline in the background so
+// Run can race it against termination signals. Key storage starts last: once
+// startComponents reports success, shutdown may assume keys.Run has run and
+// pair it with keys.Stop.
+func (sc *Controller) startComponents(ctx context.Context) error {
+	if err := sc.manager.Run(ctx); err != nil {
+		return fmt.Errorf("sandbox manager failed to start: %w", err)
+	}
+	if err := sc.startHTTPServer(); err != nil {
+		return err
+	}
+	if sc.metricsServer != nil {
+		go serveMetrics(sc.metricsServer)
+	}
 	if sc.keys != nil {
 		sc.keys.Run()
 	}
-	return ctx, nil
+	return nil
+}
+
+// startupOutcome classifies how controller startup ended.
+type startupOutcome int
+
+const (
+	// startupCompleted: startup succeeded and no termination signal was seen.
+	startupCompleted startupOutcome = iota
+	// startupSignaled: startup succeeded and a termination signal was
+	// consumed alongside it; the caller must start graceful shutdown itself.
+	startupSignaled
+	startupFailed
+	// startupInterrupted: a termination signal preempted an unfinished startup.
+	startupInterrupted
+)
+
+// awaitStartup races startup completion against a termination signal. A
+// startup result that is already available when the signal is observed still
+// wins, so a fully started controller is never torn down with crash
+// semantics; only an unfinished startup is interrupted.
+func awaitStartup(startupDone <-chan error, stop <-chan os.Signal) (startupOutcome, error) {
+	select {
+	case err := <-startupDone:
+		return classifyStartup(err, startupCompleted)
+	case <-stop:
+		select {
+		case err := <-startupDone:
+			return classifyStartup(err, startupSignaled)
+		default:
+			return startupInterrupted, nil
+		}
+	}
+}
+
+func classifyStartup(err error, success startupOutcome) (startupOutcome, error) {
+	if err != nil {
+		return startupFailed, err
+	}
+	return success, nil
+}
+
+func (sc *Controller) startHTTPServer() error {
+	listener, err := net.Listen("tcp", sc.server.Addr)
+	if err != nil {
+		return fmt.Errorf("listen for E2B API on %s: %w", sc.server.Addr, err)
+	}
+
+	go func() {
+		klog.InfoS("Starting Server", "address", listener.Addr().String())
+		if err := sc.server.Serve(listener); err != nil &&
+			!errors.Is(err, http.ErrServerClosed) && !errors.Is(err, net.ErrClosed) {
+			klog.Fatalf("HTTP server failed: %v", err)
+		}
+	}()
+	return nil
 }
 
 func serveMetrics(server *http.Server) {
@@ -261,6 +346,9 @@ func (sc *Controller) shutdown(ctx context.Context, cancel context.CancelFunc) {
 	if sc.manager != nil {
 		sc.manager.Stop(ctx)
 	}
+	// shutdown runs only after startup reported success, so keys.Run has been
+	// called and keys.Stop cannot block on a worker that never started
+	// (secretKeyStorage.Stop waits for its done channel).
 	if sc.keys != nil {
 		sc.keys.Stop()
 	}

--- a/pkg/servers/e2b/core_test.go
+++ b/pkg/servers/e2b/core_test.go
@@ -29,7 +29,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"os/signal"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -57,6 +56,7 @@ import (
 	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/openkruise/agents/pkg/utils/network"
 	utilruntime "github.com/openkruise/agents/pkg/utils/runtime"
 	"github.com/openkruise/agents/pkg/utils/testutils"
 )
@@ -106,6 +106,7 @@ func TestNewController(t *testing.T) {
 	mgrOpts := config.SandboxManagerOptions{
 		SystemNamespace:       "sandbox-system",
 		PeerSelector:          "component=sandbox-manager",
+		BindAddress:           "10.0.0.2",
 		SandboxNamespace:      "sandboxes",
 		SandboxLabelSelector:  "app=sandbox",
 		MaxClaimWorkers:       7,
@@ -165,7 +166,10 @@ func TestNewController(t *testing.T) {
 
 			// Port is not retained as a field; it only shapes the server address.
 			require.NotNil(t, sc.server)
-			assert.Equal(t, fmt.Sprintf(":%d", tt.opts.Port), sc.server.Addr)
+			assert.Equal(t, network.ListenAddress(tt.opts.Manager.BindAddress, tt.opts.Port), sc.server.Addr)
+			if tt.opts.Manager.BindAddress != "" {
+				assert.Equal(t, fmt.Sprintf("%s:%d", tt.opts.Manager.BindAddress, tt.opts.Port), sc.adapter.Entry())
+			}
 			assert.NotNil(t, sc.mux)
 			assert.NotNil(t, sc.adapter)
 
@@ -287,8 +291,6 @@ func setupWithQuota(t *testing.T, quotaEnforcer sandboxmanager.QuotaEnforcer) (*
 		}
 	}
 
-	controller.stop = make(chan os.Signal, 1)
-	signal.Notify(controller.stop, syscall.SIGINT, syscall.SIGTERM)
 	serverErr := make(chan error, 1)
 	go func() {
 		if err := controller.server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -300,7 +302,6 @@ func setupWithQuota(t *testing.T, quotaEnforcer sandboxmanager.QuotaEnforcer) (*
 
 	return controller, fc, func() {
 		t.Helper()
-		signal.Stop(controller.stop)
 		_ = controller.server.Close()
 		require.NoError(t, <-serverErr)
 	}
@@ -331,27 +332,41 @@ func TestNewControllerPropagatesShortSandboxIDOption(t *testing.T) {
 	}
 }
 
-type stopProbeInfraBuilder struct {
+// hookInfraBuilder builds hookInfra around a real sandboxcr infra.
+type hookInfraBuilder struct {
 	base infra.Builder
+	run  func(context.Context) error
 	stop func()
 }
 
-func (b stopProbeInfraBuilder) Build() infra.Infrastructure {
-	return stopProbeInfra{Infrastructure: b.base.Build(), stop: b.stop}
+func (b hookInfraBuilder) Build() infra.Infrastructure {
+	return hookInfra{Infrastructure: b.base.Build(), run: b.run, stop: b.stop}
 }
 
-type stopProbeInfra struct {
+// hookInfra lets tests replace Run and observe Stop on an otherwise real
+// Infrastructure; its route source never emits events.
+type hookInfra struct {
 	infra.Infrastructure
+	run  func(context.Context) error
 	stop func()
 }
 
-func (stopProbeInfra) GetSandboxRouteSource() infra.SandboxRouteSource {
-	return noOpSandboxRouteSource{}
+func (i hookInfra) Run(ctx context.Context) error {
+	if i.run != nil {
+		return i.run(ctx)
+	}
+	return i.Infrastructure.Run(ctx)
 }
 
-func (i stopProbeInfra) Stop(ctx context.Context) {
-	i.stop()
+func (i hookInfra) Stop(ctx context.Context) {
+	if i.stop != nil {
+		i.stop()
+	}
 	i.Infrastructure.Stop(ctx)
+}
+
+func (hookInfra) GetSandboxRouteSource() infra.SandboxRouteSource {
+	return noOpSandboxRouteSource{}
 }
 
 type noOpSandboxRouteSource struct{}
@@ -371,7 +386,7 @@ func newStopProbeManager(t *testing.T, stop func()) *sandboxmanager.SandboxManag
 	proxyServer := proxy.NewServer(opts)
 	mgr, err := sandboxmanager.NewSandboxManagerBuilder(opts).
 		WithCustomInfra(func() (infra.Builder, error) {
-			return stopProbeInfraBuilder{
+			return hookInfraBuilder{
 				base: sandboxcr.NewInfraBuilder(opts).
 					WithCache(fakeCache).
 					WithAPIReader(fc).
@@ -402,11 +417,12 @@ func TestControllerRunStartsDedicatedObservabilityListener(t *testing.T) {
 		return context.Background()
 	}
 
-	runCtx, err := sc.Run()
+	stop := make(chan os.Signal, 1)
+	runCtx, err := sc.Run(stop)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		select {
-		case sc.stop <- syscall.SIGTERM:
+		case stop <- syscall.SIGTERM:
 		case <-runCtx.Done():
 		}
 		select {
@@ -414,7 +430,6 @@ func TestControllerRunStartsDedicatedObservabilityListener(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			t.Error("timed out waiting for controller shutdown")
 		}
-		signal.Stop(sc.stop)
 	})
 
 	waitAddr := func(name string, ch <-chan string) string {
@@ -552,6 +567,7 @@ func TestControllerShutdownStopsManagerAfterHTTPShutdown(t *testing.T) {
 				t.Fatal("shutdown completed before the active request drained")
 			case <-time.After(50 * time.Millisecond):
 			}
+			assert.False(t, cancelCalled.Load(), "server context must remain active while HTTP requests drain")
 
 			close(servers[len(servers)-1].release)
 			select {

--- a/pkg/servers/e2b/routes.go
+++ b/pkg/servers/e2b/routes.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
 	"github.com/openkruise/agents/pkg/servers/web"
+	"github.com/openkruise/agents/pkg/tracing"
 	"github.com/openkruise/agents/pkg/utils"
 )
 
@@ -52,14 +53,14 @@ func (sc *Controller) registerRoutes() {
 	sc.mux.HandleFunc("GET "+adapters.CustomPrefix+"/api/health", healthHandler)
 
 	// Sandbox management endpoints
-	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes", sc.CreateSandbox, sc.CheckApiKey)
+	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes", sc.CreateSandbox, traceOperation(traceOpCreate), sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodGet, "/v2/sandboxes", sc.ListSandboxes, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodGet, "/sandboxes/{sandboxID}", sc.DescribeSandbox, sc.CheckApiKey)
-	RegisterE2BRoute(sc.mux, http.MethodDelete, "/sandboxes/{sandboxID}", sc.DeleteSandbox, sc.CheckApiKey)
+	RegisterE2BRoute(sc.mux, http.MethodDelete, "/sandboxes/{sandboxID}", sc.DeleteSandbox, traceOperation(traceOpKill), sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodPut, "/sandboxes/{sandboxID}/network", sc.UpdateSandboxNetwork, sc.CheckApiKey)
-	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/pause", sc.PauseSandbox, sc.CheckApiKey)
-	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/resume", sc.ResumeSandbox, sc.CheckApiKey)
-	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/connect", sc.ConnectSandbox, sc.CheckApiKey)
+	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/pause", sc.PauseSandbox, traceOperation(traceOpPause), sc.CheckApiKey)
+	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/resume", sc.ResumeSandbox, traceOperation(traceOpResume), sc.CheckApiKey)
+	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/connect", sc.ConnectSandbox, traceOperation(traceOpResume), sc.CheckApiKey)
 	web.RegisterRoute(sc.mux, http.MethodPost, adapters.CustomPrefix+"/api/sandboxes/{sandboxID}/traffic-access-token", sc.RefreshTrafficAccessToken, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/timeout", sc.SetSandboxTimeout, sc.CheckApiKey)
 	RegisterE2BRoute(sc.mux, http.MethodPost, "/sandboxes/{sandboxID}/snapshots", sc.CreateSnapshot, sc.CheckApiKey)
@@ -96,6 +97,30 @@ func RegisterE2BRoute[T any](mux *http.ServeMux, method, path string, handler we
 func registerObservabilityRoutes(mux *http.ServeMux) {
 	// Prometheus metrics endpoint for exporting metrics
 	mux.Handle("GET /metrics", promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{}))
+}
+
+// User-facing trace operation verbs recorded in baggage and surfaced as the
+// "traceOperation" field in cross-component logs. Users think in terms of
+// create/pause/resume/kill regardless of which HTTP route triggered the
+// operation. The verb is bound once per HTTP request at the entry point, so
+// internal sub-operations (e.g. anything a delete does under the hood) always
+// inherit the entry verb.
+const (
+	traceOpCreate = "create"
+	traceOpPause  = "pause"
+	traceOpResume = "resume"
+	traceOpKill   = "kill"
+)
+
+// traceOperation returns a middleware that overrides the trace operation
+// recorded in baggage with a short user-facing verb (e.g. "create", "kill")
+// instead of the default "METHOD /route" pattern set by the web framework.
+// The verb propagates to the controller via the trace-baggage CR annotation
+// and surfaces as the "traceOperation" field in cross-component logs.
+func traceOperation(operation string) web.MiddleWare {
+	return func(ctx context.Context, _ *http.Request) (context.Context, *web.ApiError) {
+		return tracing.WithTraceOperation(ctx, operation), nil
+	}
 }
 
 // AnonymousUser owns resources created while authentication is disabled. Reusing AdminKeyID

--- a/pkg/servers/e2b/routes_test.go
+++ b/pkg/servers/e2b/routes_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -37,21 +38,25 @@ import (
 
 	infracache "github.com/openkruise/agents/pkg/cache"
 	"github.com/openkruise/agents/pkg/sandbox-manager/logs"
+	"github.com/openkruise/agents/pkg/servers/e2b/adapters"
 	"github.com/openkruise/agents/pkg/servers/e2b/keys"
 	"github.com/openkruise/agents/pkg/servers/e2b/models"
+	"github.com/openkruise/agents/pkg/tracing"
 )
 
 type lookupKeyStorage struct {
-	byKey map[string]*models.CreatedTeamAPIKey
-	calls []string
+	byKey      map[string]*models.CreatedTeamAPIKey
+	calls      []string
+	operations []string
 }
 
 func (s *lookupKeyStorage) Init(context.Context) error { return nil }
 func (s *lookupKeyStorage) Run()                       {}
 func (s *lookupKeyStorage) Stop()                      {}
 
-func (s *lookupKeyStorage) LoadByKey(_ context.Context, key string) (*models.CreatedTeamAPIKey, bool) {
+func (s *lookupKeyStorage) LoadByKey(ctx context.Context, key string) (*models.CreatedTeamAPIKey, bool) {
 	s.calls = append(s.calls, key)
+	s.operations = append(s.operations, tracing.TraceOperationFromContext(ctx))
 	user, ok := s.byKey[key]
 	return user, ok
 }
@@ -87,6 +92,27 @@ func (s *lookupKeyStorage) ListTeams(context.Context, *models.CreatedTeamAPIKey)
 
 func (s *lookupKeyStorage) FindTeamByName(context.Context, string) (*models.Team, bool, error) {
 	return nil, false, nil
+}
+
+func TestConnectRouteTraceOperation(t *testing.T) {
+	for _, prefix := range []string{"", adapters.CustomPrefix + "/api"} {
+		path := prefix + "/sandboxes/test-sandbox/connect"
+		t.Run(path, func(t *testing.T) {
+			storage := &lookupKeyStorage{}
+			controller := &Controller{mux: http.NewServeMux(), keys: storage}
+			controller.registerRoutes()
+
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			req.Header.Set(models.HeaderApiKey, "invalid-key")
+			rec := httptest.NewRecorder()
+			controller.mux.ServeHTTP(rec, req)
+
+			// 在鉴权阶段检查标签，确保尚未查询 Sandbox 状态时就已统一标记。
+			require.Equal(t, http.StatusUnauthorized, rec.Code)
+			assert.Equal(t, []string{"invalid-key"}, storage.calls)
+			assert.Equal(t, []string{traceOpResume}, storage.operations)
+		})
+	}
 }
 
 // TestCheckApiKey_WithRealSetup tests CheckApiKey with full Setup

--- a/pkg/servers/e2b/run_test.go
+++ b/pkg/servers/e2b/run_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2b
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkruise/agents/pkg/cache/cachetest"
+	"github.com/openkruise/agents/pkg/proxy"
+	sandboxmanager "github.com/openkruise/agents/pkg/sandbox-manager"
+	"github.com/openkruise/agents/pkg/sandbox-manager/config"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra"
+	"github.com/openkruise/agents/pkg/sandbox-manager/infra/sandboxcr"
+)
+
+// newStartupController builds a controller whose infra Run is replaced by
+// run, for exercising Controller.Run startup paths. The ext-proc listener is
+// disabled so only the route-refresh port would be bound if startup ever got
+// far enough to start the proxy.
+func newStartupController(t *testing.T, run func(context.Context) error) *Controller {
+	t.Helper()
+	opts := config.InitOptions(config.SandboxManagerOptions{DisableEnvoyExtProc: true})
+	fakeCache, fc, err := cachetest.NewTestCache(t)
+	require.NoError(t, err)
+	proxyServer := proxy.NewServer(opts)
+	manager, err := sandboxmanager.NewSandboxManagerBuilder(opts).
+		WithCustomInfra(func() (infra.Builder, error) {
+			return hookInfraBuilder{
+				base: sandboxcr.NewInfraBuilder(opts).
+					WithCache(fakeCache).
+					WithAPIReader(fc).
+					WithRouteReader(proxyServer),
+				run: run,
+			}, nil
+		}).
+		Build()
+	require.NoError(t, err)
+	return &Controller{
+		server:  &http.Server{Addr: "127.0.0.1:0"},
+		manager: manager,
+	}
+}
+
+// TestControllerSignalDuringStartupExitsCleanly pins the startup crash
+// semantics: a termination signal that lands while the manager is still
+// starting makes Run return a canceled context with no error, so main exits
+// zero without waiting for startup or running per-component cleanup.
+func TestControllerSignalDuringStartupExitsCleanly(t *testing.T) {
+	started := make(chan struct{})
+	controller := newStartupController(t, func(ctx context.Context) error {
+		close(started)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	type runResult struct {
+		ctx context.Context
+		err error
+	}
+	result := make(chan runResult, 1)
+	stop := make(chan os.Signal, 1)
+	go func() {
+		ctx, err := controller.Run(stop)
+		result <- runResult{ctx: ctx, err: err}
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for manager startup to block")
+	}
+	stop <- syscall.SIGTERM
+
+	select {
+	case got := <-result:
+		require.NoError(t, got.err)
+		require.ErrorIs(t, got.ctx.Err(), context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after SIGTERM during startup")
+	}
+}
+
+// TestControllerRunPropagatesStartupFailure pins that startup errors surface
+// synchronously from Run instead of crashing from a background goroutine.
+func TestControllerRunPropagatesStartupFailure(t *testing.T) {
+	controller := newStartupController(t, func(context.Context) error {
+		return errors.New("cache sync failed")
+	})
+
+	_, err := controller.Run(make(chan os.Signal, 1))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "sandbox manager failed to start")
+}
+
+func TestAwaitStartup(t *testing.T) {
+	tests := []struct {
+		name     string
+		startup  func(startupDone chan error, stop chan os.Signal)
+		expected []startupOutcome
+		errMsg   string
+	}{
+		{
+			name:     "startup succeeds",
+			startup:  func(startupDone chan error, _ chan os.Signal) { startupDone <- nil },
+			expected: []startupOutcome{startupCompleted},
+		},
+		{
+			name:     "startup fails",
+			startup:  func(startupDone chan error, _ chan os.Signal) { startupDone <- errors.New("boom") },
+			expected: []startupOutcome{startupFailed},
+			errMsg:   "boom",
+		},
+		{
+			name:     "signal interrupts startup",
+			startup:  func(_ chan error, stop chan os.Signal) { stop <- syscall.SIGTERM },
+			expected: []startupOutcome{startupInterrupted},
+		},
+		{
+			// The outer select picks either ready channel; both branches must
+			// report the completed startup so the caller shuts down gracefully.
+			name: "signal pending with completed startup is never an interruption",
+			startup: func(startupDone chan error, stop chan os.Signal) {
+				startupDone <- nil
+				stop <- syscall.SIGTERM
+			},
+			expected: []startupOutcome{startupCompleted, startupSignaled},
+		},
+		{
+			name: "signal pending with failed startup reports the failure",
+			startup: func(startupDone chan error, stop chan os.Signal) {
+				startupDone <- errors.New("boom")
+				stop <- syscall.SIGTERM
+			},
+			expected: []startupOutcome{startupFailed},
+			errMsg:   "boom",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Repeat so rows with two ready channels exercise both select
+			// branches in practice.
+			for range 32 {
+				startupDone := make(chan error, 1)
+				stop := make(chan os.Signal, 1)
+				tt.startup(startupDone, stop)
+
+				outcome, err := awaitStartup(startupDone, stop)
+				assert.Contains(t, tt.expected, outcome)
+				if tt.errMsg != "" {
+					assert.ErrorContains(t, err, tt.errMsg)
+				} else {
+					assert.NoError(t, err)
+				}
+			}
+		})
+	}
+}
+
+func TestControllerStartHTTPServerReportsBindFailure(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	controller := &Controller{server: &http.Server{Addr: listener.Addr().String()}}
+	err = controller.startHTTPServer()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "listen for E2B API")
+}

--- a/pkg/servers/e2b/sandbox_test.go
+++ b/pkg/servers/e2b/sandbox_test.go
@@ -68,7 +68,7 @@ func TestResolveSandboxDomain(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := &Controller{
 				domain:  tt.configuredDomain,
-				adapter: adapters.NewE2BAdapter(0),
+				adapter: adapters.NewE2BAdapter(0, ""),
 			}
 			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
 			req.Host = tt.host

--- a/pkg/servers/e2b/templates_test.go
+++ b/pkg/servers/e2b/templates_test.go
@@ -533,7 +533,7 @@ func TestListTemplatesUsesCacheProvider(t *testing.T) {
 		MemberlistBindPort: config.DefaultMemberlistBindPort,
 	})
 	manager, err := sandboxmanager.NewSandboxManagerBuilder(opts).
-		WithRequestAdapter(adapters.DefaultAdapterFactory(TestServerPort)).
+		WithRequestAdapter(adapters.DefaultAdapterFactory(TestServerPort, "")).
 		WithCustomInfra(func() (infra.Builder, error) {
 			return sandboxcr.NewInfraBuilder(opts).
 				WithCache(spyCache).

--- a/pkg/servers/web/framework.go
+++ b/pkg/servers/web/framework.go
@@ -127,6 +127,10 @@ func RegisterRoute[T any](mux *http.ServeMux, method, path string, handler Handl
 		// Store root span context so that InjectTraceContext uses the root span's SpanID
 		// when propagating trace context to the controller via CR annotations.
 		ctx = tracing.WithRootSpanContext(ctx)
+		// Record the user-facing operation (method + route pattern) in baggage
+		// so cross-component logs (e.g. controller Reconcile) can attribute
+		// the trace to this API call. Propagates alongside the trace context.
+		ctx = tracing.WithTraceOperation(ctx, pattern)
 
 		defer func() {
 			if rec := recover(); rec != nil {

--- a/pkg/tracing/propagator.go
+++ b/pkg/tracing/propagator.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -27,9 +28,26 @@ import (
 // W3C Trace Context across components via Kubernetes CRD annotations.
 const TraceContextAnnotationKey = "agents.kruise.io/trace-context"
 
+// TraceBaggageAnnotationKey is the annotation key used to propagate
+// W3C Baggage across components via Kubernetes CRD annotations. It carries
+// trace-scoped metadata such as the user operation that started the trace.
+const TraceBaggageAnnotationKey = "agents.kruise.io/trace-baggage"
+
 // traceParentKey is the standard W3C Trace Context header key used by the
 // OTel propagator (https://www.w3.org/TR/trace-context/#traceparent-header).
 const traceParentKey = "traceparent"
+
+// baggageKey is the standard W3C Baggage header key used by the OTel
+// propagator (https://www.w3.org/TR/baggage/#baggage-http-header-format).
+const baggageKey = "baggage"
+
+// operationBaggageMember is the baggage member name carrying the user
+// operation (HTTP method + route pattern) that started the trace.
+const operationBaggageMember = "operation"
+
+// TraceOperationLogKey is the structured-logging key for the user operation
+// that started the trace (e.g. "POST /sandboxes/{sandboxID}/pause").
+const TraceOperationLogKey = "traceOperation"
 
 // annotationCarrier implements propagation.TextMapCarrier over a map[string]string.
 type annotationCarrier struct {
@@ -37,21 +55,28 @@ type annotationCarrier struct {
 }
 
 // Get returns the value for the given OTel propagator key.
-// The standard W3C "traceparent" key is mapped to TraceContextAnnotationKey
-// so that the annotation key follows Kubernetes naming conventions.
+// The standard W3C "traceparent" and "baggage" keys are mapped to
+// Kubernetes-convention annotation keys.
 func (c *annotationCarrier) Get(key string) string {
-	if key == traceParentKey {
+	switch key {
+	case traceParentKey:
 		return c.annotations[TraceContextAnnotationKey]
+	case baggageKey:
+		return c.annotations[TraceBaggageAnnotationKey]
 	}
 	return c.annotations[key]
 }
 
 // Set stores the value for the given OTel propagator key.
-// The standard W3C "traceparent" key is mapped to TraceContextAnnotationKey
-// so that the annotation key follows Kubernetes naming conventions.
+// The standard W3C "traceparent" and "baggage" keys are mapped to
+// Kubernetes-convention annotation keys.
 func (c *annotationCarrier) Set(key, value string) {
-	if key == traceParentKey {
+	switch key {
+	case traceParentKey:
 		c.annotations[TraceContextAnnotationKey] = value
+		return
+	case baggageKey:
+		c.annotations[TraceBaggageAnnotationKey] = value
 		return
 	}
 	c.annotations[key] = value
@@ -126,9 +151,40 @@ func InjectTraceContext(ctx context.Context, annotations map[string]string) map[
 	if annotations == nil {
 		annotations = make(map[string]string, 1)
 	}
+	// Empty baggage does not trigger a carrier write. Clear the previous value
+	// before injection so the new trace context cannot inherit a stale operation.
+	delete(annotations, TraceBaggageAnnotationKey)
 	carrier := &annotationCarrier{annotations: annotations}
 	otel.GetTextMapPropagator().Inject(ctx, carrier)
 	return annotations
+}
+
+// WithTraceOperation records the user operation (e.g. the HTTP method and
+// route pattern) that started the trace as an OTel Baggage member, so it
+// propagates across components together with the trace context (both via
+// HTTP headers and via CR annotations through InjectTraceContext). A raw
+// member is used so values may contain spaces; serialization percent-encodes
+// them. An invalid operation value leaves ctx unchanged.
+func WithTraceOperation(ctx context.Context, operation string) context.Context {
+	if operation == "" {
+		return ctx
+	}
+	member, err := baggage.NewMemberRaw(operationBaggageMember, operation)
+	if err != nil {
+		return ctx
+	}
+	bag, err := baggage.FromContext(ctx).SetMember(member)
+	if err != nil {
+		return ctx
+	}
+	return baggage.ContextWithBaggage(ctx, bag)
+}
+
+// TraceOperationFromContext returns the user operation stored by
+// WithTraceOperation, or extracted from propagated baggage (HTTP headers or
+// CR annotations via ExtractTraceContext). Returns "" when absent.
+func TraceOperationFromContext(ctx context.Context) string {
+	return baggage.FromContext(ctx).Member(operationBaggageMember).Value()
 }
 
 // ExtractTraceContext extracts trace context from annotations and returns a context

--- a/pkg/tracing/propagator_test.go
+++ b/pkg/tracing/propagator_test.go
@@ -18,10 +18,13 @@ package tracing
 
 import (
 	"context"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
@@ -83,6 +86,11 @@ func TestInjectTraceContext_NilAnnotations(t *testing.T) {
 			hasSpan: true,
 			wantNil: false,
 		},
+		{
+			name:    "baggage without an active span does not allocate annotations",
+			ctx:     WithTraceOperation(context.Background(), "resume"),
+			wantNil: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -111,11 +119,21 @@ func TestInjectTraceContext_NilAnnotations(t *testing.T) {
 }
 
 func TestInjectTraceContext_WithExistingAnnotations(t *testing.T) {
+	const staleBaggage = "operation=pause,tenant=old"
+	staleAnnotations := map[string]string{
+		"existing":                "value",
+		TraceContextAnnotationKey: "00-11111111111111111111111111111111-2222222222222222-01",
+		TraceBaggageAnnotationKey: staleBaggage,
+	}
+	otherBaggage, err := baggage.Parse("tenant=current")
+	require.NoError(t, err)
+
 	tests := []struct {
 		name        string
 		ctx         context.Context
 		annotations map[string]string
 		hasSpan     bool
+		wantBaggage string
 	}{
 		{
 			name:        "existing annotations with no active span",
@@ -129,6 +147,38 @@ func TestInjectTraceContext_WithExistingAnnotations(t *testing.T) {
 			annotations: map[string]string{"existing": "value"},
 			hasSpan:     true,
 		},
+		{
+			name:        "empty baggage clears the previous operation",
+			ctx:         context.Background(),
+			annotations: staleAnnotations,
+			hasSpan:     true,
+		},
+		{
+			name:        "current operation replaces stale baggage",
+			ctx:         WithTraceOperation(context.Background(), "resume"),
+			annotations: staleAnnotations,
+			hasSpan:     true,
+			wantBaggage: "operation=resume",
+		},
+		{
+			name:        "other baggage is preserved without an operation",
+			ctx:         baggage.ContextWithBaggage(context.Background(), otherBaggage),
+			annotations: staleAnnotations,
+			hasSpan:     true,
+			wantBaggage: "tenant=current",
+		},
+		{
+			name:        "no active span leaves stale annotations untouched",
+			ctx:         context.Background(),
+			annotations: staleAnnotations,
+			wantBaggage: staleBaggage,
+		},
+		{
+			name:        "baggage alone leaves stale annotations untouched",
+			ctx:         WithTraceOperation(context.Background(), "resume"),
+			annotations: staleAnnotations,
+			wantBaggage: staleBaggage,
+		},
 	}
 
 	for _, tt := range tests {
@@ -137,15 +187,43 @@ func TestInjectTraceContext_WithExistingAnnotations(t *testing.T) {
 				cleanup := initTestTracer()
 				defer cleanup()
 				tracer := Tracer("test")
-				tt.ctx, _ = tracer.Start(tt.ctx, "test-span")
+				var span trace.Span
+				tt.ctx, span = tracer.Start(tt.ctx, "test-span")
+				defer span.End()
 			} else {
 				cleanup := initNoopTracer()
 				defer cleanup()
 			}
 
-			result := InjectTraceContext(tt.ctx, tt.annotations)
-			assert.NotNil(t, result, "should return non-nil annotations")
-			assert.Equal(t, "value", result["existing"], "existing annotation should be preserved")
+			// Keep input and expected maps independent so in-place mutations
+			// cannot hide stale annotations.
+			annotations := maps.Clone(tt.annotations)
+			want := maps.Clone(tt.annotations)
+			if tt.hasSpan {
+				sc := trace.SpanContextFromContext(tt.ctx)
+				want[TraceContextAnnotationKey] = "00-" + sc.TraceID().String() + "-" + sc.SpanID().String() + "-" + sc.TraceFlags().String()
+			}
+			if tt.wantBaggage == "" {
+				delete(want, TraceBaggageAnnotationKey)
+			} else {
+				want[TraceBaggageAnnotationKey] = tt.wantBaggage
+			}
+
+			result := InjectTraceContext(tt.ctx, annotations)
+			assert.Equal(t, want, result)
+			assert.Equal(t, want, annotations, "existing annotations must be updated in place")
+			if tt.hasSpan {
+				extracted := ExtractTraceContext(context.Background(), result)
+				assert.Equal(t, TraceOperationFromContext(tt.ctx), TraceOperationFromContext(extracted))
+				assert.Equal(t, baggage.FromContext(tt.ctx).String(), baggage.FromContext(extracted).String())
+			}
+			if tt.hasSpan && tt.wantBaggage != "" {
+				// Reusing the same map without baggage must clear the previous injection.
+				ctx := baggage.ContextWithBaggage(tt.ctx, baggage.Baggage{})
+				delete(want, TraceBaggageAnnotationKey)
+				assert.Equal(t, want, InjectTraceContext(ctx, result))
+				assert.Equal(t, want, annotations)
+			}
 		})
 	}
 }
@@ -216,8 +294,11 @@ func TestInjectTraceContext_NoActiveSpanWithNoopTracer(t *testing.T) {
 
 func TestWithRootSpanContext_InjectUsesRootSpanID(t *testing.T) {
 	tests := []struct {
-		name           string
-		useRootSpanCtx bool
+		name             string
+		useRootSpanCtx   bool
+		operation        string
+		clearCurrentSpan bool
+		unsampled        bool
 	}{
 		{
 			name:           "WithRootSpanContext: injected SpanID is root span's SpanID",
@@ -226,6 +307,21 @@ func TestWithRootSpanContext_InjectUsesRootSpanID(t *testing.T) {
 		{
 			name:           "without WithRootSpanContext: injected SpanID is child span's SpanID",
 			useRootSpanCtx: false,
+		},
+		{
+			name:           "operation added after saving root context is injected",
+			useRootSpanCtx: true,
+			operation:      "resume",
+		},
+		{
+			name:             "stored root clears stale baggage without a valid current span",
+			useRootSpanCtx:   true,
+			clearCurrentSpan: true,
+		},
+		{
+			name:           "valid unsampled root clears stale baggage",
+			useRootSpanCtx: true,
+			unsampled:      true,
 		},
 	}
 
@@ -238,17 +334,28 @@ func TestWithRootSpanContext_InjectUsesRootSpanID(t *testing.T) {
 
 			// Create root span (simulates HTTP middleware root span).
 			ctx, rootSpan := tracer.Start(context.Background(), "root-span")
+			rootSpanCtx := rootSpan.SpanContext()
+			if tt.unsampled {
+				rootSpanCtx = rootSpanCtx.WithTraceFlags(0)
+				ctx = trace.ContextWithSpanContext(ctx, rootSpanCtx)
+			}
 
 			// Optionally capture root span context before creating child spans.
 			if tt.useRootSpanCtx {
 				ctx = WithRootSpanContext(ctx)
 			}
+			ctx = WithTraceOperation(ctx, tt.operation)
 
 			// Create child span (simulates manager/infra span).
 			childCtx, childSpan := tracer.Start(ctx, "child-span")
+			if tt.clearCurrentSpan {
+				childCtx = trace.ContextWithSpanContext(childCtx, trace.SpanContext{})
+			}
 
 			// Inject trace context from child ctx.
-			annotations := InjectTraceContext(childCtx, nil)
+			annotations := InjectTraceContext(childCtx, map[string]string{
+				TraceBaggageAnnotationKey: "operation=pause",
+			})
 
 			// Verify trace-context annotation was injected.
 			traceparent, ok := annotations[TraceContextAnnotationKey]
@@ -257,9 +364,18 @@ func TestWithRootSpanContext_InjectUsesRootSpanID(t *testing.T) {
 
 			// Extract context from annotations (simulates controller Reconcile).
 			extractedCtx := ExtractTraceContext(context.Background(), annotations)
-			extractedSpanID := trace.SpanFromContext(extractedCtx).SpanContext().SpanID()
+			extractedSpanCtx := trace.SpanContextFromContext(extractedCtx)
+			extractedSpanID := extractedSpanCtx.SpanID()
+			assert.Equal(t, rootSpanCtx.TraceID(), extractedSpanCtx.TraceID())
+			assert.Equal(t, tt.operation, TraceOperationFromContext(extractedCtx))
+			if tt.operation == "" {
+				assert.NotContains(t, annotations, TraceBaggageAnnotationKey)
+			} else {
+				assert.Equal(t, "operation="+tt.operation, annotations[TraceBaggageAnnotationKey])
+			}
 
 			if tt.useRootSpanCtx {
+				assert.Equal(t, rootSpanCtx.TraceFlags(), extractedSpanCtx.TraceFlags())
 				assert.Equal(t, rootSpan.SpanContext().SpanID(), extractedSpanID,
 					"extracted SpanID should be root span's SpanID")
 				assert.NotEqual(t, childSpan.SpanContext().SpanID(), extractedSpanID,

--- a/pkg/tracing/provider.go
+++ b/pkg/tracing/provider.go
@@ -128,8 +128,11 @@ func InitTracerProvider(ctx context.Context, cfg Config) (func(context.Context) 
 	var err error
 	switch cfg.Mode {
 	case TracingModeStd:
-		// Export spans to standard output for local debugging.
-		exporter, err = stdouttrace.New(stdouttrace.WithPrettyPrint())
+		// Export spans to standard output as single-line JSON so that log
+		// collectors treat each span as one log entry. Pretty-print
+		// (multi-line JSON) is intentionally avoided because newline-based
+		// collectors split a single span into many fragments.
+		exporter, err = stdouttrace.New()
 		if err != nil {
 			return nil, fmt.Errorf("failed to create stdout exporter: %w", err)
 		}

--- a/pkg/tracing/span.go
+++ b/pkg/tracing/span.go
@@ -90,8 +90,12 @@ const (
 	AttrCheckpointName   = "checkpoint.name"
 	// AttrCheckpointRejected records whether AssumePodCheckpointed rejected the
 	// pause (validation failed or checkpoint not yet complete).
-	AttrCheckpointRejected  = "checkpoint.rejected"
-	AttrPhaseAfter          = "phase.after"
+	AttrCheckpointRejected = "checkpoint.rejected"
+	AttrPhaseAfter         = "phase.after"
+	// AttrConditionPrefix is the prefix for span attributes that record
+	// individual Sandbox condition values as "Status:Reason", e.g.
+	// "condition.RuntimeInitialized" = "False:Pending".
+	AttrConditionPrefix     = "condition."
 	AttrClaimLockType       = "claim.lock_type"
 	AttrClaimRetries        = "claim.retries"
 	AttrClaimDuration       = "claim.duration"

--- a/pkg/tracing/zap_encoder.go
+++ b/pkg/tracing/zap_encoder.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/buffer"
+	"go.uber.org/zap/zapcore"
+)
+
+// TraceIDLogKey is the structured-log field key carrying the trace ID that
+// controller code injects into its logger after StartReconcileSpan (see
+// TraceIDFromContext). Encoders and call sites must share this constant so
+// the key never drifts.
+const TraceIDLogKey = "traceID"
+
+// splicePool recycles the buffers returned by the splicing encoder below.
+var splicePool = buffer.NewPool()
+
+// NewTraceFirstJSONEncoder returns a JSON encoder that emits every log line
+// as one JSON object with the trace ID, when present, as its first field:
+//
+//	{"traceID":"...","level":"INFO","ts":"...","msg":"...",...}
+//
+// It builds on the zap production encoder config with ISO8601 timestamps and
+// capitalized levels so lines stay as readable as the previous console
+// format.
+func NewTraceFirstJSONEncoder() zapcore.Encoder {
+	cfg := zap.NewProductionEncoderConfig()
+	cfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	cfg.EncodeLevel = zapcore.CapitalLevelEncoder
+	return NewTraceFirstEncoder(zapcore.NewJSONEncoder(cfg))
+}
+
+// NewTraceFirstEncoder wraps base so that the TraceIDLogKey field, when
+// present, is emitted as the first key of each encoded entry instead of its
+// natural position at the end of the accumulated logger context. This keeps
+// the trace ID at a fixed leading position for log collectors that index the
+// first field of JSON log lines.
+func NewTraceFirstEncoder(base zapcore.Encoder) zapcore.Encoder {
+	return &traceFirstEncoder{Encoder: base}
+}
+
+// traceFirstEncoder implements zapcore.Encoder by delegation (embedding) and
+// overrides AddString and EncodeEntry to promote the trace ID field.
+//
+// It must intercept AddString because zap never delivers logger context
+// fields (With/WithValues) to EncodeEntry's fields slice: ioCore.With writes
+// them straight into the encoder via its ObjectEncoder methods. The wrapper
+// therefore swallows the trace ID AddString call, remembers the value, and
+// re-emits it during EncodeEntry ahead of everything else.
+//
+// Pointer receivers are required because AddString mutates the captured
+// trace ID; NewTraceFirstEncoder and Clone must both return pointers so the
+// mutation is visible to ioCore.Write.
+type traceFirstEncoder struct {
+	zapcore.Encoder
+
+	// traceID is captured from AddString calls made by ioCore.With while
+	// the logger accumulates context fields (e.g. klog WithValues chains).
+	traceID string
+}
+
+// Clone keeps the wrapper around the cloned base encoder and carries over
+// the captured trace ID: zap clones the encoder on every Logger.With, so a
+// value captured by an earlier With would otherwise be lost.
+func (e *traceFirstEncoder) Clone() zapcore.Encoder {
+	return &traceFirstEncoder{Encoder: e.Encoder.Clone(), traceID: e.traceID}
+}
+
+// AddString captures the trace ID instead of letting it flow into the base
+// encoder's field namespace; every other key is forwarded unchanged.
+func (e *traceFirstEncoder) AddString(key, val string) {
+	if key == TraceIDLogKey {
+		e.traceID = val
+		return
+	}
+	e.Encoder.AddString(key, val)
+}
+
+// EncodeEntry encodes the entry without the trace ID field and splices the
+// captured value right after the leading '{' of the base encoding, making it
+// the first key of the JSON object. Entries without a trace ID (startup
+// logs, paths outside a Reconcile) are encoded unchanged.
+func (e *traceFirstEncoder) EncodeEntry(entry zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
+	// Prefer the value captured from With/WithValues; a trace ID supplied as
+	// a per-call field (when callers log directly with the encoder) is used
+	// as a fallback. The per-call copy is dropped so the ID is never emitted
+	// twice.
+	traceID := e.traceID
+	idx := -1
+	for i := range fields {
+		if fields[i].Key == TraceIDLogKey && fields[i].Type == zapcore.StringType {
+			idx = i
+			if traceID == "" {
+				traceID = fields[i].String
+			}
+			break
+		}
+	}
+	if idx < 0 && traceID == "" {
+		return e.Encoder.EncodeEntry(entry, fields)
+	}
+
+	rest := make([]zapcore.Field, 0, len(fields))
+	for i := range fields {
+		if i == idx {
+			continue
+		}
+		rest = append(rest, fields[i])
+	}
+
+	encoded, err := e.Encoder.EncodeEntry(entry, rest)
+	if err != nil {
+		return nil, err
+	}
+
+	// A string always marshals; the error branch only satisfies the linter.
+	quoted, err := json.Marshal(traceID)
+	if err != nil {
+		encoded.Free()
+		return nil, err
+	}
+
+	if encoded.Len() == 0 || encoded.Bytes()[0] != '{' {
+		// base does not emit a JSON object (e.g. a console encoder): splice
+		// is impossible, so re-encode with the trace ID moved to the front
+		// of the field list instead.
+		encoded.Free()
+		promoted := make([]zapcore.Field, 0, len(fields)+1)
+		promoted = append(promoted, zap.String(TraceIDLogKey, traceID))
+		promoted = append(promoted, rest...)
+		return e.Encoder.EncodeEntry(entry, promoted)
+	}
+
+	spliced := splicePool.Get()
+	spliced.AppendByte('{')
+	spliced.AppendString(`"` + TraceIDLogKey + `":`)
+	spliced.AppendBytes(quoted)
+	// Empty objects may include a line ending. Add a comma only when the
+	// original object has fields, and preserve its unmodified suffix.
+	body := bytes.TrimSpace(encoded.Bytes()[1:])
+	if len(body) > 0 && body[0] != '}' {
+		spliced.AppendByte(',')
+	}
+	spliced.AppendBytes(encoded.Bytes()[1:])
+	encoded.Free()
+	return spliced, nil
+}

--- a/pkg/tracing/zap_encoder_test.go
+++ b/pkg/tracing/zap_encoder_test.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// testJSONEncoder builds a base JSON encoder equivalent to the one used by
+// NewTraceFirstJSONEncoder.
+func testJSONEncoder() zapcore.Encoder {
+	cfg := zap.NewProductionEncoderConfig()
+	cfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	return zapcore.NewJSONEncoder(cfg)
+}
+
+// topLevelKeys decodes a single-line JSON object and returns its top-level
+// keys in encoding order.
+func topLevelKeys(t *testing.T, line string) []string {
+	t.Helper()
+	dec := json.NewDecoder(strings.NewReader(line))
+	tok, err := dec.Token()
+	require.NoError(t, err)
+	require.Equal(t, json.Delim('{'), tok, "line must be a JSON object: %s", line)
+
+	var keys []string
+	for dec.More() {
+		keyTok, err := dec.Token()
+		require.NoError(t, err)
+		key, ok := keyTok.(string)
+		require.True(t, ok, "object key must be a string: %s", line)
+		keys = append(keys, key)
+
+		var raw json.RawMessage
+		require.NoError(t, dec.Decode(&raw), "failed to skip value of %q", key)
+	}
+	return keys
+}
+
+// testTime fills Entry.Time so the "ts" key is emitted; zap omits the
+// timestamp for a zero entry time.
+var testTime = time.Date(2026, 8, 11, 11, 46, 3, 0, time.Local)
+
+func TestTraceFirstEncoderEncodeEntry(t *testing.T) {
+	entry := zapcore.Entry{Level: zapcore.InfoLevel, Message: "update sandbox status success", Time: testTime}
+
+	type testCase struct {
+		name           string
+		fields         []zapcore.Field
+		encoderConfig  *zapcore.EncoderConfig
+		contextTraceID string
+		wantKeys       []string
+		wantTraceID    any
+		wantLine       string
+	}
+	cases := []testCase{
+		{
+			name: "trace id in the middle is promoted to the first key",
+			fields: []zapcore.Field{
+				zap.String("controller", "sandbox-controller"),
+				zap.String("reconcileID", "1011dda1"),
+				zap.String(TraceIDLogKey, "dce858203322f71c3598d87c81e88a5b"),
+				zap.String("sandbox", "box"),
+				zap.String("status", "{}"),
+			},
+			wantKeys: []string{
+				TraceIDLogKey, "level", "ts", "msg",
+				"controller", "reconcileID", "sandbox", "status",
+			},
+			wantTraceID: "dce858203322f71c3598d87c81e88a5b",
+		},
+		{
+			name: "trace id as the last context field is promoted",
+			fields: []zapcore.Field{
+				zap.String("controller", "sandbox-controller"),
+				zap.String(TraceIDLogKey, "tid"),
+			},
+			wantKeys:    []string{TraceIDLogKey, "level", "ts", "msg", "controller"},
+			wantTraceID: "tid",
+		},
+		{
+			name: "trace id already first keeps field order",
+			fields: []zapcore.Field{
+				zap.String(TraceIDLogKey, "tid"),
+				zap.String("controller", "sandbox-controller"),
+			},
+			wantKeys:    []string{TraceIDLogKey, "level", "ts", "msg", "controller"},
+			wantTraceID: "tid",
+		},
+		{
+			name: "no trace id encodes unchanged",
+			fields: []zapcore.Field{
+				zap.String("controller", "sandbox-controller"),
+				zap.String("status", "running"),
+			},
+			wantKeys:    []string{"level", "ts", "msg", "controller", "status"},
+			wantTraceID: nil, // key absent
+		},
+		{
+			name: "non string trace id field is not promoted",
+			fields: []zapcore.Field{
+				zap.Int32(TraceIDLogKey, 7),
+				zap.String("controller", "sandbox-controller"),
+			},
+			wantKeys:    []string{"level", "ts", "msg", TraceIDLogKey, "controller"},
+			wantTraceID: float64(7),
+		},
+	}
+
+	for _, ending := range []struct {
+		name   string
+		config zapcore.EncoderConfig
+		suffix string
+	}{
+		{name: "no line ending", config: zapcore.EncoderConfig{SkipLineEnding: true}},
+		{name: "default LF", suffix: "\n"},
+		{name: "CRLF", config: zapcore.EncoderConfig{LineEnding: "\r\n"}, suffix: "\r\n"},
+	} {
+		// Disabling built-in fields makes the real Zap encoder emit an empty object.
+		emptyCase := testCase{
+			name:          "empty object with per-call trace id/" + ending.name,
+			fields:        []zapcore.Field{zap.String(TraceIDLogKey, "tid")},
+			encoderConfig: &ending.config,
+			wantKeys:      []string{TraceIDLogKey},
+			wantTraceID:   "tid",
+			wantLine:      `{"traceID":"tid"}` + ending.suffix,
+		}
+		cases = append(cases, emptyCase)
+
+		emptyCase.name = "empty object with context trace id/" + ending.name
+		emptyCase.fields = nil
+		emptyCase.contextTraceID = "tid"
+		cases = append(cases, emptyCase)
+
+		emptyCase.name = "empty config with remaining field/" + ending.name
+		emptyCase.fields = []zapcore.Field{zap.String("controller", "c")}
+		emptyCase.wantKeys = []string{TraceIDLogKey, "controller"}
+		emptyCase.wantLine = `{"traceID":"tid","controller":"c"}` + ending.suffix
+		cases = append(cases, emptyCase)
+
+		emptyCase.name = "empty object without trace id is unchanged/" + ending.name
+		emptyCase.fields = nil
+		emptyCase.contextTraceID = ""
+		emptyCase.wantKeys = nil
+		emptyCase.wantTraceID = nil
+		emptyCase.wantLine = "{}" + ending.suffix
+		cases = append(cases, emptyCase)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := testJSONEncoder()
+			if tc.encoderConfig != nil {
+				base = zapcore.NewJSONEncoder(*tc.encoderConfig)
+			}
+			enc := NewTraceFirstEncoder(base)
+			if tc.contextTraceID != "" {
+				enc.AddString(TraceIDLogKey, tc.contextTraceID)
+			}
+			buf, err := enc.EncodeEntry(entry, tc.fields)
+			require.NoError(t, err)
+			line := buf.String()
+			buf.Free()
+
+			assert.True(t, json.Valid([]byte(line)), "output must be valid JSON: %s", line)
+			assert.Equal(t, tc.wantKeys, topLevelKeys(t, line))
+			if tc.wantLine != "" {
+				assert.Equal(t, tc.wantLine, line, "output must preserve the original line ending")
+			}
+
+			var decoded map[string]any
+			require.NoError(t, json.Unmarshal([]byte(line), &decoded))
+			assert.Equal(t, tc.wantTraceID, decoded[TraceIDLogKey])
+		})
+	}
+}
+
+func TestTraceFirstJSONEncoderPromotesTraceID(t *testing.T) {
+	enc := NewTraceFirstJSONEncoder()
+	buf, err := enc.EncodeEntry(
+		zapcore.Entry{Level: zapcore.InfoLevel, Message: "m", Time: testTime},
+		[]zapcore.Field{
+			zap.String("controller", "sandbox-controller"),
+			zap.String(TraceIDLogKey, "dce858203322f71c3598d87c81e88a5b"),
+		},
+	)
+	require.NoError(t, err)
+	line := buf.String()
+	buf.Free()
+
+	assert.True(t, strings.HasPrefix(line,
+		`{"traceID":"dce858203322f71c3598d87c81e88a5b","level":"INFO"`), "got: %s", line)
+}
+
+// TestTraceFirstEncoderWithZapLogger exercises the real write path: logger
+// context fields (controller-runtime's WithValues chain plus the trace ID)
+// are accumulated before the per-call fields, exactly like the klog-to-zapr
+// bridging used by the controller.
+func TestTraceFirstEncoderWithZapLogger(t *testing.T) {
+	var out bytes.Buffer
+	core := zapcore.NewCore(NewTraceFirstEncoder(testJSONEncoder()), zapcore.AddSync(&out), zapcore.InfoLevel)
+	logger := zap.New(core)
+
+	logger.
+		With(zap.String("controller", "sandbox-controller"), zap.String("reconcileID", "1011dda1")).
+		With(zap.String(TraceIDLogKey, "dce858203322f71c3598d87c81e88a5b")).
+		Info("update sandbox status success", zap.String("sandbox", "box"), zap.String("status", "{\"phase\":\"Running\"}"))
+
+	line := strings.TrimSpace(out.String())
+	assert.Equal(t, []string{
+		TraceIDLogKey, "level", "ts", "msg",
+		"controller", "reconcileID", "sandbox", "status",
+	}, topLevelKeys(t, line))
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &decoded))
+	assert.Equal(t, "dce858203322f71c3598d87c81e88a5b", decoded[TraceIDLogKey])
+	assert.Equal(t, "{\"phase\":\"Running\"}", decoded["status"])
+}
+
+func TestTraceFirstEncoderClone(t *testing.T) {
+	enc := NewTraceFirstEncoder(testJSONEncoder())
+	cloned, ok := enc.Clone().(*traceFirstEncoder)
+	require.True(t, ok, "Clone must keep the wrapper")
+
+	buf, err := cloned.EncodeEntry(
+		zapcore.Entry{Level: zapcore.InfoLevel, Message: "m", Time: testTime},
+		[]zapcore.Field{zap.String("controller", "c"), zap.String(TraceIDLogKey, "tid")},
+	)
+	require.NoError(t, err)
+	line := buf.String()
+	buf.Free()
+
+	assert.Equal(t, []string{TraceIDLogKey, "level", "ts", "msg", "controller"}, topLevelKeys(t, line))
+}
+
+// TestTraceFirstEncoderConsoleFallback covers a non-object base encoder: the
+// splice is impossible, so the trace ID is moved to the front of the field
+// list instead of being dropped.
+func TestTraceFirstEncoderConsoleFallback(t *testing.T) {
+	cfg := zap.NewDevelopmentEncoderConfig()
+	enc := NewTraceFirstEncoder(zapcore.NewConsoleEncoder(cfg))
+
+	buf, err := enc.EncodeEntry(
+		zapcore.Entry{Level: zapcore.InfoLevel, Message: "m", Time: testTime},
+		[]zapcore.Field{zap.String("controller", "c"), zap.String(TraceIDLogKey, "tid")},
+	)
+	require.NoError(t, err)
+	line := buf.String()
+	buf.Free()
+
+	assert.NotEmpty(t, line)
+	// The console encoder separates fields with ", " after the colon.
+	assert.Contains(t, line, `"traceID": "tid"`)
+	assert.Contains(t, line, `"controller": "c"`)
+}

--- a/pkg/utils/logs/sanitize.go
+++ b/pkg/utils/logs/sanitize.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import "strings"
+
+// SanitizeValue removes line delimiters before a value is written to a log.
+func SanitizeValue(s string) string {
+	s = strings.ReplaceAll(s, "\n", "")
+	s = strings.ReplaceAll(s, "\r", "")
+	return s
+}

--- a/pkg/utils/logs/sanitize_test.go
+++ b/pkg/utils/logs/sanitize_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import "testing"
+
+func TestSanitizeValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name: "empty value",
+		},
+		{
+			name:  "unchanged value",
+			value: "normal value",
+			want:  "normal value",
+		},
+		{
+			name:  "newline",
+			value: "before\nafter",
+			want:  "beforeafter",
+		},
+		{
+			name:  "carriage return",
+			value: "before\rafter",
+			want:  "beforeafter",
+		},
+		{
+			name:  "carriage return newline",
+			value: "before\r\nafter",
+			want:  "beforeafter",
+		},
+		{
+			name:  "multiple control characters",
+			value: "a\nb\rc\r\nd",
+			want:  "abcd",
+		},
+		{
+			name:  "tab and unicode remain",
+			value: "值\t保留",
+			want:  "值\t保留",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SanitizeValue(tt.value); got != tt.want {
+				t.Fatalf("SanitizeValue(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/network/network.go
+++ b/pkg/utils/network/network.go
@@ -14,15 +14,84 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package network provides shared utilities for network CIDR/IP validation
-// and normalization used by the e2b API layer and the sandbox-manager infra layer.
+// Package network provides shared address helpers for listen addresses,
+// interface resolution, and CIDR/FQDN classification.
 package network
 
 import (
+	"fmt"
 	"net"
 	"regexp"
+	"strconv"
 	"strings"
 )
+
+// ListenAddress returns a TCP listen address for host and port.
+// An empty host yields ":port", which listens on all local addresses.
+func ListenAddress(host string, port int) string {
+	return net.JoinHostPort(host, strconv.Itoa(port))
+}
+
+// ResolveNetworkInterfaceAddress returns a single global-unicast address on the
+// named interface, preferring IPv4 over IPv6. Multiple addresses in the preferred
+// available family are rejected. An empty name returns an empty address.
+func ResolveNetworkInterfaceAddress(name string) (string, error) {
+	if name == "" {
+		return "", nil
+	}
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return "", fmt.Errorf("find network interface %q: %w", name, err)
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return "", fmt.Errorf("list addresses for network interface %q: %w", name, err)
+	}
+	return chooseInterfaceAddress(name, iface.Flags, addrs)
+}
+
+// chooseInterfaceAddress selects a global-unicast address from an up interface.
+// IPv4 is preferred regardless of address order; IPv6 is used only when no IPv4
+// address qualifies. It rejects down interfaces, no qualifying addresses, and
+// multiple qualifying addresses in the preferred available family.
+func chooseInterfaceAddress(name string, flags net.Flags, addrs []net.Addr) (string, error) {
+	if flags&net.FlagUp == 0 {
+		return "", fmt.Errorf("network interface %q is down", name)
+	}
+	var selected net.IP
+	count := 0
+	for _, addr := range addrs {
+		var ip net.IP
+		switch value := addr.(type) {
+		case *net.IPNet:
+			ip = value.IP
+		case *net.IPAddr:
+			ip = value.IP
+		default:
+			continue
+		}
+		// Skip non-global-unicast addresses and, once IPv4 is selected, any IPv6 address.
+		if !ip.IsGlobalUnicast() || (selected.To4() != nil && ip.To4() == nil) {
+			continue
+		}
+		if selected.To4() == nil && ip.To4() != nil {
+			count = 0
+		}
+		selected = ip
+		count++
+	}
+	if count > 1 {
+		family := "IPv6"
+		if selected.To4() != nil {
+			family = "IPv4"
+		}
+		return "", fmt.Errorf("network interface %q has multiple global-unicast %s addresses", name, family)
+	}
+	if selected == nil {
+		return "", fmt.Errorf("network interface %q has no global-unicast IPv4 or IPv6 address", name)
+	}
+	return selected.String(), nil
+}
 
 // IsCIDROrIP returns true if the entry is a valid CIDR or bare IP address.
 func IsCIDROrIP(entry string) bool {

--- a/pkg/utils/network/network_test.go
+++ b/pkg/utils/network/network_test.go
@@ -17,10 +17,90 @@ limitations under the License.
 package network
 
 import (
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestListenAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		port int
+		want string
+	}{
+		{name: "empty host listens on all addresses", port: 8080, want: ":8080"},
+		{name: "configured host", host: "10.0.0.2", port: 8080, want: "10.0.0.2:8080"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ListenAddress(tt.host, tt.port))
+		})
+	}
+}
+
+func TestResolveNetworkInterfaceAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		iface   string
+		wantErr string
+	}{
+		{name: "empty interface name resolves to empty address"},
+		{name: "missing interface fails", iface: "definitely-missing-o1-interface", wantErr: "find network interface"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			address, err := ResolveNetworkInterfaceAddress(tt.iface)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Empty(t, address)
+		})
+	}
+}
+
+func TestChooseInterfaceAddress(t *testing.T) {
+	addr := func(value string) net.Addr {
+		ip, ipNet, err := net.ParseCIDR(value)
+		require.NoError(t, err)
+		ipNet.IP = ip
+		return ipNet
+	}
+	tests := []struct {
+		name      string
+		flags     net.Flags
+		addrs     []net.Addr
+		want      string
+		wantError string
+	}{
+		{name: "down interface", addrs: []net.Addr{addr("10.0.0.2/24")}, wantError: "is down"},
+		{name: "no address", flags: net.FlagUp, wantError: "has no global-unicast IPv4"},
+		{name: "loopback and link-local are excluded", flags: net.FlagUp, addrs: []net.Addr{addr("127.0.0.1/8"), addr("::1/128"), addr("fe80::1/64")}, wantError: "has no global-unicast IPv4 or IPv6"},
+		{name: "one IPv6 address", flags: net.FlagUp, addrs: []net.Addr{addr("fe80::1/64"), addr("2001:db8::1/64")}, want: "2001:db8::1"},
+		{name: "IPv6 IPAddr", flags: net.FlagUp, addrs: []net.Addr{&net.IPAddr{IP: net.ParseIP("fd00::1")}}, want: "fd00::1"},
+		{name: "multiple IPv6 addresses", flags: net.FlagUp, addrs: []net.Addr{addr("2001:db8::1/64"), addr("2001:db8::2/64")}, wantError: "has multiple global-unicast IPv6"},
+		{name: "IPv4 preferred after multiple IPv6 addresses", flags: net.FlagUp, addrs: []net.Addr{addr("2001:db8::1/64"), addr("2001:db8::2/64"), addr("10.0.0.2/24")}, want: "10.0.0.2"},
+		{name: "multiple IPv4 addresses", flags: net.FlagUp, addrs: []net.Addr{addr("10.0.0.2/24"), addr("192.168.1.2/24")}, wantError: "has multiple global-unicast IPv4"},
+		{name: "one IPv4 among ignored addresses", flags: net.FlagUp, addrs: []net.Addr{addr("127.0.0.1/8"), addr("10.0.0.2/24"), addr("2001:db8::1/64")}, want: "10.0.0.2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := chooseInterfaceAddress("user0", tt.flags, tt.addrs)
+			if tt.wantError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
 
 func TestIsCIDROrIP(t *testing.T) {
 	tests := []struct {

--- a/pkg/utils/pathutils/safepath.go
+++ b/pkg/utils/pathutils/safepath.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pathutils
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ValidateSafePath rejects empty paths and paths that retain ".." segments after cleaning.
+func ValidateSafePath(p string) error {
+	if p == "" {
+		return fmt.Errorf("path must not be empty")
+	}
+	clean := filepath.Clean(p)
+	for _, seg := range strings.Split(clean, string(filepath.Separator)) {
+		if seg == ".." {
+			return fmt.Errorf("path must not contain '..' segments: %s", p)
+		}
+	}
+	return nil
+}

--- a/pkg/utils/pathutils/safepath_test.go
+++ b/pkg/utils/pathutils/safepath_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pathutils
+
+import "testing"
+
+func TestValidateSafePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{
+			name:    "empty path",
+			path:    "",
+			wantErr: true,
+		},
+		{
+			name: "absolute path",
+			path: "/run/csi/mount-root/nas/hash",
+		},
+		{
+			name: "relative path",
+			path: "relative/path",
+		},
+		{
+			name: "dot dot within file name",
+			path: "a..b/file",
+		},
+		{
+			name:    "leading parent directory",
+			path:    "../etc/passwd",
+			wantErr: true,
+		},
+		{
+			name:    "multiple parent directories",
+			path:    "a/../../b",
+			wantErr: true,
+		},
+		{
+			name:    "parent directory only",
+			path:    "..",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSafePath(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateSafePath(%q) error = %v, wantErr %t", tt.path, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/utils/proxyutils/default.go
+++ b/pkg/utils/proxyutils/default.go
@@ -21,7 +21,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 
 	"k8s.io/klog/v2"
 
@@ -37,7 +39,8 @@ func requestSandbox(ctx context.Context, s *agentsv1alpha1.Sandbox, method, path
 	if s.Status.Phase != agentsv1alpha1.SandboxRunning {
 		return nil, errors.New("sandbox is not running")
 	}
-	url := fmt.Sprintf("http://%s:%d%s", s.Status.PodInfo.PodIP, port, path)
+	sandboxAddress := net.JoinHostPort(s.Status.PodInfo.PodIP, strconv.Itoa(port))
+	url := fmt.Sprintf("http://%s%s", sandboxAddress, path)
 	r, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)

--- a/pkg/utils/proxyutils/default_test.go
+++ b/pkg/utils/proxyutils/default_test.go
@@ -18,6 +18,8 @@ package proxyutils
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"testing"
@@ -43,13 +45,37 @@ func TestRequestSandbox(t *testing.T) {
 	require.NoError(t, err)
 	port, _ := strconv.Atoi(portStr)
 
+	var (
+		ipv6Port       int
+		ipv6SkipReason string
+	)
+	ipv6Listener, ipv6Err := net.Listen("tcp6", "[::1]:0")
+	if ipv6Err != nil {
+		ipv6SkipReason = "IPv6 loopback is unavailable: " + ipv6Err.Error()
+	} else {
+		ipv6Server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		ipv6Server.Listener = ipv6Listener
+		ipv6Server.Start()
+		defer ipv6Server.Close()
+
+		_, ipv6PortStr, splitErr := net.SplitHostPort(ipv6Server.Listener.Addr().String())
+		require.NoError(t, splitErr)
+		ipv6Port, err = strconv.Atoi(ipv6PortStr)
+		require.NoError(t, err)
+	}
+
 	tests := []struct {
-		name    string
-		sandbox *v1alpha1.Sandbox
-		wantErr bool
+		name       string
+		sandbox    *v1alpha1.Sandbox
+		port       int
+		skipReason string
+		wantErr    bool
 	}{
 		{
 			name: "running sandbox",
+			port: port,
 			sandbox: &v1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "running-sandbox",
@@ -70,7 +96,25 @@ func TestRequestSandbox(t *testing.T) {
 			},
 		},
 		{
+			name:       "running sandbox with IPv6 PodIP",
+			port:       ipv6Port,
+			skipReason: ipv6SkipReason,
+			sandbox: &v1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "running-ipv6-sandbox",
+					Namespace: "default",
+				},
+				Status: v1alpha1.SandboxStatus{
+					Phase: v1alpha1.SandboxRunning,
+					PodInfo: v1alpha1.PodInfo{
+						PodIP: "::1",
+					},
+				},
+			},
+		},
+		{
 			name: "paused sandbox",
+			port: port,
 			sandbox: &v1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "running-sandbox",
@@ -95,7 +139,10 @@ func TestRequestSandbox(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := requestSandbox(t.Context(), tt.sandbox, "GET", "/", port, nil)
+			if tt.skipReason != "" {
+				t.Skip(tt.skipReason)
+			}
+			_, err := requestSandbox(t.Context(), tt.sandbox, "GET", "/", tt.port, nil)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/utils/runtime/runtime.go
+++ b/pkg/utils/runtime/runtime.go
@@ -20,7 +20,8 @@ package runtime
 
 import (
 	"context"
-	"fmt"
+	"net"
+	"strconv"
 
 	agentsv1alpha1 "github.com/openkruise/agents/api/v1alpha1"
 	"github.com/openkruise/agents/pkg/utils"
@@ -56,5 +57,5 @@ func GetRuntimeURL(sbx *agentsv1alpha1.Sandbox) string {
 	if ip == "" {
 		return ""
 	}
-	return fmt.Sprintf("http://%s:%d", ip, utils.RuntimePort)
+	return "http://" + net.JoinHostPort(ip, strconv.Itoa(utils.RuntimePort))
 }

--- a/pkg/utils/runtime/runtime_test.go
+++ b/pkg/utils/runtime/runtime_test.go
@@ -1018,6 +1018,18 @@ func TestGetRuntimeURL(t *testing.T) {
 			expected: fmt.Sprintf("http://10.0.0.1:%d", utils.RuntimePort),
 		},
 		{
+			name: "no annotation but IPv6 PodIP present falls back to bracketed ip:port",
+			sandbox: &agentsv1alpha1.Sandbox{
+				Status: agentsv1alpha1.SandboxStatus{
+					Phase: agentsv1alpha1.SandboxRunning,
+					PodInfo: agentsv1alpha1.PodInfo{
+						PodIP: "2001:db8::1",
+					},
+				},
+			},
+			expected: fmt.Sprintf("http://[2001:db8::1]:%d", utils.RuntimePort),
+		},
+		{
 			name: "empty annotation value falls back to ip:port",
 			sandbox: &agentsv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -72,6 +72,21 @@ func GetSandboxCondition(status *agentsv1alpha1.SandboxStatus, condType string) 
 	}
 	return nil
 }
+
+// IsSandboxStartupFailureReason reports whether a Sandbox Ready condition
+// reason represents a definitive startup failure. Callers that gate on
+// startup failures (e.g. the SandboxSet startup budget and the cache
+// wait-ready task) share this single reason set.
+func IsSandboxStartupFailureReason(reason string) bool {
+	switch reason {
+	case agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
+		agentsv1alpha1.SandboxReadyReasonPodCreateFailed:
+		return true
+	default:
+		return false
+	}
+}
+
 func GetPodCondition(status *corev1.PodStatus, condType corev1.PodConditionType) *corev1.PodCondition {
 	for i := range status.Conditions {
 		c := &status.Conditions[i]

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -80,7 +80,8 @@ func GetSandboxCondition(status *agentsv1alpha1.SandboxStatus, condType string) 
 func IsSandboxStartupFailureReason(reason string) bool {
 	switch reason {
 	case agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
-		agentsv1alpha1.SandboxReadyReasonPodCreateFailed:
+		agentsv1alpha1.SandboxReadyReasonPodCreateFailed,
+		agentsv1alpha1.SandboxReadyReasonUnschedulable:
 		return true
 	default:
 		return false

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -2035,3 +2035,48 @@ func TestWakeOnIngressTraffic(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSandboxStartupFailureReason(t *testing.T) {
+	tests := []struct {
+		name        string
+		reason      string
+		wantFailure bool
+	}{
+		{
+			name:        "start container failed",
+			reason:      agentsv1alpha1.SandboxReadyReasonStartContainerFailed,
+			wantFailure: true,
+		},
+		{
+			name:        "pod create failed",
+			reason:      agentsv1alpha1.SandboxReadyReasonPodCreateFailed,
+			wantFailure: true,
+		},
+		{
+			name:        "pod ready",
+			reason:      agentsv1alpha1.SandboxReadyReasonPodReady,
+			wantFailure: false,
+		},
+		{
+			name:        "upgrading",
+			reason:      agentsv1alpha1.SandboxReadyReasonUpgrading,
+			wantFailure: false,
+		},
+		{
+			name:        "unknown reason",
+			reason:      "SomethingElse",
+			wantFailure: false,
+		},
+		{
+			name:        "empty reason",
+			reason:      "",
+			wantFailure: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantFailure, IsSandboxStartupFailureReason(tt.reason))
+		})
+	}
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -2053,6 +2053,11 @@ func TestIsSandboxStartupFailureReason(t *testing.T) {
 			wantFailure: true,
 		},
 		{
+			name:        "unschedulable",
+			reason:      agentsv1alpha1.SandboxReadyReasonUnschedulable,
+			wantFailure: true,
+		},
+		{
 			name:        "pod ready",
 			reason:      agentsv1alpha1.SandboxReadyReasonPodReady,
 			wantFailure: false,

--- a/pkg/utils/webhookutils/writer/atomic/atomic_writer.go
+++ b/pkg/utils/webhookutils/writer/atomic/atomic_writer.go
@@ -29,6 +29,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+
+	"github.com/openkruise/agents/pkg/utils/logs"
+	"github.com/openkruise/agents/pkg/utils/pathutils"
 )
 
 const (
@@ -67,6 +70,9 @@ type FileProjection struct {
 // NewAtomicWriter creates a new Writer configured to write to the given
 // target directory, or returns an error if the target directory does not exist.
 func NewAtomicWriter(targetDir string) (*Writer, error) {
+	if err := pathutils.ValidateSafePath(targetDir); err != nil {
+		return nil, fmt.Errorf("invalid target directory: %w", err)
+	}
 	_, err := os.Stat(targetDir)
 	if os.IsNotExist(err) {
 		return nil, err
@@ -143,6 +149,11 @@ func (w *Writer) Write(payload map[string]FileProjection) error {
 		// empty oldTsDir indicates that it didn't exist
 		oldTsDir = ""
 	}
+	if oldTsDir != "" {
+		if err := pathutils.ValidateSafePath(oldTsDir); err != nil {
+			return fmt.Errorf("unsafe data-directory symlink target: %w", err)
+		}
+	}
 	oldTsPath := path.Join(w.targetDir, oldTsDir)
 
 	var pathsToRemove sets.String
@@ -160,10 +171,10 @@ func (w *Writer) Write(payload map[string]FileProjection) error {
 			klog.Error(err, "unable to determine whether payload should be written to disk")
 			return err
 		} else if !should && len(pathsToRemove) == 0 {
-			klog.V(6).Info("no update required for target directory", "directory", w.targetDir)
+			klog.V(6).Info("no update required for target directory", "directory", logs.SanitizeValue(w.targetDir))
 			return nil
 		} else {
-			klog.V(1).Info("write required for target directory", "directory", w.targetDir)
+			klog.V(1).Info("write required for target directory", "directory", logs.SanitizeValue(w.targetDir))
 		}
 	}
 
@@ -184,7 +195,7 @@ func (w *Writer) Write(payload map[string]FileProjection) error {
 
 	// (7)
 	if err = w.createUserVisibleFiles(cleanPayload); err != nil {
-		klog.Error(err, "unable to create visible symlinks in target directory", "target directory", w.targetDir)
+		klog.Error(err, "unable to create visible symlinks in target directory", "target directory", logs.SanitizeValue(w.targetDir))
 		return err
 	}
 
@@ -207,7 +218,7 @@ func (w *Writer) Write(payload map[string]FileProjection) error {
 	if err != nil {
 		os.Remove(newDataDirPath) // #nosec -- best-effort cleanup
 		os.RemoveAll(tsDir)       // #nosec -- best-effort cleanup
-		klog.Error(err, "unable to rename symbolic link for data directory", "data directory", newDataDirPath)
+		klog.Error(err, "unable to rename symbolic link for data directory", "data directory", logs.SanitizeValue(newDataDirPath))
 		return err
 	}
 
@@ -349,7 +360,7 @@ func (w *Writer) pathsToRemove(payload map[string]FileProjection, oldTsDir strin
 
 	result := paths.Difference(newPaths)
 	if len(result) > 0 {
-		klog.V(1).Info("paths to remove", "target directory", w.targetDir, "paths", result)
+		klog.V(1).Info("paths to remove", "target directory", logs.SanitizeValue(w.targetDir), "paths", result.List())
 	}
 
 	return result, nil

--- a/pkg/utils/webhookutils/writer/fs.go
+++ b/pkg/utils/webhookutils/writer/fs.go
@@ -25,6 +25,8 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"github.com/openkruise/agents/pkg/utils/logs"
+	"github.com/openkruise/agents/pkg/utils/pathutils"
 	"github.com/openkruise/agents/pkg/utils/webhookutils/generator"
 	"github.com/openkruise/agents/pkg/utils/webhookutils/writer/atomic"
 )
@@ -60,6 +62,9 @@ func (ops *FSCertWriterOptions) setDefaults() {
 func (ops *FSCertWriterOptions) validate() error {
 	if len(ops.Path) == 0 {
 		return errors.New("path must be set in FSCertWriterOptions")
+	}
+	if err := pathutils.ValidateSafePath(ops.Path); err != nil {
+		return fmt.Errorf("invalid cert writer path: %w", err)
 	}
 	return nil
 }
@@ -104,6 +109,10 @@ func (f *fsCertWriter) doWrite() (*generator.Artifacts, error) {
 }
 
 func WriteCertsToDir(path string, certs *generator.Artifacts) error {
+	if err := pathutils.ValidateSafePath(path); err != nil {
+		return fmt.Errorf("invalid cert directory: %w", err)
+	}
+
 	// Writer's algorithm only manages files using symbolic link.
 	// If a file is not a symbolic link, will ignore the update for it.
 	// We want to cleanup for Writer by removing old files that are not symbolic links.
@@ -140,14 +149,14 @@ func prepareToWrite(dir string) error {
 		if os.IsNotExist(err) {
 			continue
 		} else if err != nil {
-			klog.Error(err, "unable to stat file", "file", abspath)
+			klog.Error(logs.SanitizeValue(err.Error()), "unable to stat file", "file", logs.SanitizeValue(abspath))
 		}
 		_, err = os.Readlink(abspath)
 		// if it's not a symbolic link
 		if err != nil {
 			err = os.Remove(abspath)
 			if err != nil {
-				klog.Error(err, "unable to remove old file", "file", abspath)
+				klog.Error(logs.SanitizeValue(err.Error()), "unable to remove old file", "file", logs.SanitizeValue(abspath))
 			}
 		}
 	}

--- a/pkg/utils/webhookutils/writer/fs_test.go
+++ b/pkg/utils/webhookutils/writer/fs_test.go
@@ -18,6 +18,7 @@ package writer
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/openkruise/agents/pkg/utils/webhookutils/generator"
@@ -47,6 +48,23 @@ func TestPrepareToWrite(t *testing.T) {
 	// Verify directory permissions (0755)
 	if mode := info.Mode().Perm(); mode != 0755 {
 		t.Errorf("Expected directory permissions 0755, got %o", mode)
+	}
+}
+
+func TestWriteCertsToDirRejectsUnsafePath(t *testing.T) {
+	rootDir := t.TempDir()
+	workDir := filepath.Join(rootDir, "work")
+	if err := os.Mkdir(workDir, 0755); err != nil {
+		t.Fatalf("create work directory: %v", err)
+	}
+	t.Chdir(workDir)
+
+	unsafeDir := filepath.Join(rootDir, "unsafe-cert-dir")
+	if err := WriteCertsToDir("../unsafe-cert-dir", nil); err == nil {
+		t.Fatal("WriteCertsToDir accepted an unsafe path")
+	}
+	if _, err := os.Stat(unsafeDir); !os.IsNotExist(err) {
+		t.Fatalf("unsafe directory was created before validation: %v", err)
 	}
 }
 

--- a/test/e2e/tracing_chain_test.go
+++ b/test/e2e/tracing_chain_test.go
@@ -191,16 +191,16 @@ var _ = Describe("Tracing Full Chain", func() {
 		By("Verifying manager stdout exports the request root span with TraceID == request ID")
 		Eventually(func(g Gomega) {
 			logs := podLogs(ctx, managerNamespace, managerPodSelector, managerContainerName)
-			g.Expect(logs).To(ContainSubstring(`"Name": "POST /sandboxes"`))
-			g.Expect(logs).To(ContainSubstring(`"TraceID": "` + requestID + `"`))
+			spans := spansForTrace(logs, requestID)
+			g.Expect(spans).To(ContainElement("POST /sandboxes"), "request trace %s", requestID)
 		}, time.Minute*2, time.Second*5).Should(Succeed())
 
 		By("Verifying controller stdout exports spans joined to the same trace")
 		Eventually(func(g Gomega) {
 			logs := podLogs(ctx, controllerNamespace, controllerPodSelector, controllerContainerName)
-			g.Expect(logs).To(ContainSubstring(`"Name": "` + tracing.SpanControllerReconcile + `"`))
-			g.Expect(logs).To(ContainSubstring(`"Name": "` + tracing.SpanControllerCreatePod + `"`))
-			g.Expect(logs).To(ContainSubstring(`"TraceID": "` + requestID + `"`))
+			spans := spansForTrace(logs, requestID)
+			g.Expect(spans).To(ContainElement(tracing.SpanControllerReconcile), "request trace %s", requestID)
+			g.Expect(spans).To(ContainElement(tracing.SpanControllerCreatePod), "request trace %s", requestID)
 		}, time.Minute*2, time.Second*5).Should(Succeed())
 	})
 })
@@ -222,6 +222,7 @@ func podLogs(ctx context.Context, namespace, selector, container string) string 
 			DoRaw(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		sb.Write(raw)
+		sb.WriteByte('\n')
 	}
 	return sb.String()
 }

--- a/test/e2e/tracing_logs_test.go
+++ b/test/e2e/tracing_logs_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// spansForTrace 从混合日志中解析指定 trace 的 span，返回 SpanID 到名称的映射。
+// 同时支持紧凑和多行 JSON；按 SpanID 去重，且只检查 SpanContext.TraceID。
+// 本文件可通过 go test test/e2e/tracing_logs_test.go 独立验证，不加载集群初始化。
+func spansForTrace(logs, traceID string) map[string]string {
+	spans := make(map[string]string)
+	if traceID == "" {
+		return spans
+	}
+	for logs != "" {
+		line, rest, _ := strings.Cut(logs, "\n")
+		if !strings.HasPrefix(strings.TrimSpace(line), "{") {
+			logs = rest
+			continue
+		}
+		var span struct {
+			Name        string
+			SpanContext struct {
+				TraceID string
+				SpanID  string
+			}
+		}
+		decoder := json.NewDecoder(strings.NewReader(logs))
+		if err := decoder.Decode(&span); err != nil {
+			// 日志可能含非 JSON 内容或尚未写完的记录，跳过当前行后继续解析。
+			logs = rest
+			continue
+		}
+		logs = logs[decoder.InputOffset():]
+		if span.Name != "" && span.SpanContext.TraceID == traceID && span.SpanContext.SpanID != "" {
+			spans[span.SpanContext.SpanID] = span.Name
+		}
+	}
+	return spans
+}
+
+func TestSpansForTrace(t *testing.T) {
+	const (
+		traceID      = "50293b018bb7d1f4e75518d2ba6feb0e"
+		otherTraceID = "11111111111111111111111111111111"
+		spanID       = "5bffabc97d55aa1a"
+		otherSpanID  = "b66efda2b875d73a"
+	)
+	spanJSON := func(name, tid, id string) string {
+		return fmt.Sprintf(`{"Name":%q,"SpanContext":{"TraceID":%q,"SpanID":%q},"Parent":{"TraceID":%q,"SpanID":"0123456789abcdef"}}`, name, tid, id, tid)
+	}
+	compact := spanJSON("POST /sandboxes", traceID, spanID)
+	var pretty bytes.Buffer
+	require.NoError(t, json.Indent(&pretty, []byte(compact), "", "\t"))
+	wantSpan := map[string]string{spanID: "POST /sandboxes"}
+
+	tests := []struct {
+		name string
+		logs string
+		want map[string]string
+	}{
+		{
+			name: "compact JSON without final newline",
+			logs: compact,
+			want: wantSpan,
+		},
+		{
+			name: "pretty JSON with surrounding whitespace",
+			logs: " \n\t" + pretty.String() + "\r\n",
+			want: wantSpan,
+		},
+		{
+			name: "mixed application logs and spans",
+			logs: "I0910 startup completed\n{\"level\":\"info\",\"msg\":\"ready\"}\n" + compact + "\nI0910 request completed\n",
+			want: wantSpan,
+		},
+		{
+			name: "duplicate records and parent trace ID count once",
+			logs: compact + "\n" + pretty.String(),
+			want: wantSpan,
+		},
+		{
+			name: "distinct spans with the same name count separately",
+			logs: compact + "\n" + spanJSON("POST /sandboxes", traceID, otherSpanID),
+			want: map[string]string{spanID: "POST /sandboxes", otherSpanID: "POST /sandboxes"},
+		},
+		{
+			name: "name from another trace does not match",
+			logs: spanJSON("POST /sandboxes", otherTraceID, spanID) + "\n" + spanJSON("unrelated", traceID, otherSpanID),
+			want: map[string]string{otherSpanID: "unrelated"},
+		},
+		{
+			name: "parent trace ID alone does not match",
+			logs: strings.Replace(compact, traceID, otherTraceID, 1),
+			want: map[string]string{},
+		},
+		{
+			name: "missing span ID is not a span",
+			logs: spanJSON("POST /sandboxes", traceID, ""),
+			want: map[string]string{},
+		},
+		{
+			name: "missing name is not a span",
+			logs: spanJSON("", traceID, spanID),
+			want: map[string]string{},
+		},
+		{
+			name: "JSON embedded in an application message is not a span",
+			logs: fmt.Sprintf(`{"level":"info","msg":%q}`, compact),
+			want: map[string]string{},
+		},
+		{
+			name: "malformed record does not hide the next span",
+			logs: "{invalid JSON}\n{\"Name\":\n" + compact,
+			want: wantSpan,
+		},
+		{
+			name: "truncated final record is ignored",
+			logs: compact + "\n{\"Name\":\"unfinished\"",
+			want: wantSpan,
+		},
+		{
+			name: "span larger than scanner default token limit",
+			logs: strings.TrimSuffix(compact, "}") + fmt.Sprintf(",\"Extra\":%q}", strings.Repeat("x", 128*1024)),
+			want: wantSpan,
+		},
+		{
+			name: "empty logs",
+			want: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, spansForTrace(tt.logs, traceID))
+		})
+	}
+	t.Run("empty trace ID does not match incomplete records", func(t *testing.T) {
+		assert.Empty(t, spansForTrace(spanJSON("POST /sandboxes", "", spanID), ""))
+	})
+}
+
+func TestSpansForTraceStdoutExporter(t *testing.T) {
+	for _, pretty := range []bool{false, true} {
+		t.Run(fmt.Sprintf("pretty=%t", pretty), func(t *testing.T) {
+			var output bytes.Buffer
+			opts := []stdouttrace.Option{stdouttrace.WithWriter(&output)}
+			if pretty {
+				opts = append(opts, stdouttrace.WithPrettyPrint())
+			}
+			exporter, err := stdouttrace.New(opts...)
+			require.NoError(t, err)
+			provider := sdktrace.NewTracerProvider(
+				sdktrace.WithSyncer(exporter),
+				sdktrace.WithSampler(sdktrace.AlwaysSample()),
+			)
+			t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+			tracer := provider.Tracer("stdout-parser-test")
+			ctx, root := tracer.Start(t.Context(), "POST /sandboxes")
+			_, child := tracer.Start(ctx, "controller.Reconcile")
+			child.End()
+			root.End()
+			_, unrelated := tracer.Start(t.Context(), "controller.CreatePod")
+			unrelated.End()
+
+			got := spansForTrace(output.String(), root.SpanContext().TraceID().String())
+			assert.Equal(t, map[string]string{
+				root.SpanContext().SpanID().String():  "POST /sandboxes",
+				child.SpanContext().SpanID().String(): "controller.Reconcile",
+			}, got)
+		})
+	}
+}

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -21,7 +21,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"strings"
+	"maps"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -120,31 +120,25 @@ var _ = Describe("Tracing Stdout", func() {
 		}, time.Minute*5, time.Millisecond*500).Should(Equal(agentsv1alpha1.SandboxRunning))
 
 		By("Verifying spans show up on controller stdout with the propagated trace ID")
-		// The BatchSpanProcessor exports in batches (up to a few seconds of
-		// delay), so poll the logs instead of reading them once. The stdout
-		// exporter pretty-prints spans as JSON, hence the `"Name": "..."`
-		// assertions below cannot collide with regular klog output.
-		traceMarker := `"TraceID": "` + traceID + `"`
+		// BatchSpanProcessor 会延迟批量导出，因此需要轮询日志。
+		// 按 JSON 字段筛选同一 trace 下的 span，不依赖空格或换行格式，
+		// 也不允许其他请求的 span 名称满足本次请求的断言。
 		Eventually(func(g Gomega) {
 			logs := podLogs(ctx, controllerNamespace, controllerPodSelector, controllerContainerName)
-			g.Expect(logs).To(ContainSubstring(`"Name": "` + tracing.SpanControllerReconcile + `"`))
-			g.Expect(logs).To(ContainSubstring(`"Name": "` + tracing.SpanControllerCreatePod + `"`))
-			g.Expect(logs).To(ContainSubstring(`"Name": "` + tracing.SpanControllerUpdateStatus + `"`))
-			// Spans triggered by this sandbox must carry the trace ID extracted
-			// from the annotation, proving controller-side trace-context
-			// extraction works.
-			g.Expect(logs).To(ContainSubstring(traceMarker))
+			spans := spansForTrace(logs, traceID)
+			g.Expect(spans).To(ContainElement(tracing.SpanControllerReconcile), "controller trace %s", traceID)
+			g.Expect(spans).To(ContainElement(tracing.SpanControllerCreatePod), "controller trace %s", traceID)
+			g.Expect(spans).To(ContainElement(tracing.SpanControllerUpdateStatus), "controller trace %s", traceID)
 		}, time.Minute*2, time.Second*5).Should(Succeed())
 
 		By("Waiting for span exports of this trace to settle")
-		// The create flow may still be flushing through the BatchSpanProcessor;
-		// wait until two consecutive polls observe the same span count for this
-		// trace before asserting nothing new joins it.
-		prev := -1
+		// 等待连续两次轮询得到相同且非空的 SpanID 集合，
+		// 避免把 Parent.TraceID 的重复出现误计为额外的 span。
+		var prev map[string]string
 		Eventually(func() bool {
-			n := strings.Count(podLogs(ctx, controllerNamespace, controllerPodSelector, controllerContainerName), traceMarker)
-			settled := n == prev
-			prev = n
+			spans := spansForTrace(podLogs(ctx, controllerNamespace, controllerPodSelector, controllerContainerName), traceID)
+			settled := len(spans) > 0 && maps.Equal(spans, prev)
+			prev = spans
 			return settled
 		}, time.Minute*2, time.Second*5).Should(BeTrue(), "span exports for the trace did not settle")
 
@@ -162,8 +156,8 @@ var _ = Describe("Tracing Stdout", func() {
 		Expect(k8sClient.Patch(ctx, sandbox, client.MergeFrom(orig))).To(Succeed())
 
 		By("Verifying the read-only Reconcile exports no new spans for this trace")
-		Consistently(func() int {
-			return strings.Count(podLogs(ctx, controllerNamespace, controllerPodSelector, controllerContainerName), traceMarker)
+		Consistently(func() map[string]string {
+			return spansForTrace(podLogs(ctx, controllerNamespace, controllerPodSelector, controllerContainerName), traceID)
 		}, time.Second*30, time.Second*5).Should(Equal(prev),
 			"read-only Reconcile iterations must be filtered out and never export spans")
 	})


### PR DESCRIPTION
## Summary

Cherry-pick the 13 commits that landed on `master` after `release-v0.6` (which is currently at tag `v0.6.0-alpha1`) into `release-v0.6`. All commits applied cleanly with no conflicts; the resulting tree is identical to `master`.

## Cherry-picked commits (oldest → newest)

- `fix(security): address CodeQL path-injection and log-injection alerts (#928)`
- `docs: add v0.6.0-alpha1 release notes (#932)`
- `fix(sandbox): propagate startup failures to wait-ready and ScalingLimited (#936)`
- `feat(poolautoscaler): enable feature gate by default (#938)`
- `refactor(controller): generalize Pod status synchronization (#939)`
- `feat(sandbox-manager): load secret config at startup and add startup hook (#857)`
- `fix(sandbox): classify unschedulable startup failures (#942)`
- `fix: unbreak go vet and make build on master (#940)`
- `feat(sandbox-manager): add network interface binding and reliable peer discovery (#920)`
- `fix(network): format IPv6 upstream addresses (#901)`
- `build(deps): bump github/codeql-action/upload-sarif (#949)`
- `chore(skill): drop Deployment from sync-charts manifests drift check (#944)`
- `Tracing user operation (#950)`

## Notes

- Each commit was cherry-picked with `-x`, so the original source commit is recorded in the message.
- No code changes beyond the cherry-picks; `git diff` against `master` is empty.