### PR TITLE
fix(proxy): redact credential headers in ext_proc logs

### DIFF
--- a/pkg/proxy/ext_proc.go
+++ b/pkg/proxy/ext_proc.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -104,7 +105,7 @@ func (s *Server) handleRequestHeaders(requestHeaders *extProcPb.ProcessingReques
 	scheme, authority, path := parsed.Scheme, parsed.Authority, parsed.Path
 
 	log = log.WithValues("requestID", headers["x-request-id"])
-	log.Info("envoy ext processor parsed request", "scheme", scheme, "authority", authority, "path", path, "port", parsed.Port, "headers", headers)
+	log.Info("envoy ext processor parsed request", "scheme", scheme, "authority", authority, "path", path, "port", parsed.Port, "headers", sanitizedHeaders(headers))
 	if !s.adapter.IsSandboxRequest(authority, path, parsed.Port) {
 		return s.logAndCreateDstResponse(requestHeaders.RequestHeaders, map[string]string{
 			OrigDstHeader: s.LBEntry,
@@ -121,7 +122,7 @@ func (s *Server) handleRequestHeaders(requestHeaders *extProcPb.ProcessingReques
 		errorMsg := fmt.Sprintf("invalid sandbox port: %d", sandboxPort)
 		return s.logAndCreateErrorResponse(http.StatusBadRequest, errorMsg, log)
 	}
-	log.Info("request mapped", "sandboxID", sandboxID, "sandboxPort", sandboxPort, "extraHeaders", extraHeaders)
+	log.Info("request mapped", "sandboxID", sandboxID, "sandboxPort", sandboxPort, "extraHeaders", sanitizedHeaders(extraHeaders))
 
 	errorMsg := fmt.Sprintf("healthy sandbox %s not found", sandboxID)
 	route, ok := s.LoadRoute(sandboxID)
@@ -146,7 +147,7 @@ func (s *Server) handleRequestHeaders(requestHeaders *extProcPb.ProcessingReques
 
 func (s *Server) logAndCreateDstResponse(requestHeaders *extProcPb.HttpHeaders,
 	extraHeaders map[string]string, log logr.Logger) *extProcPb.ProcessingResponse {
-	log.Info("will modify request headers", "headers", extraHeaders)
+	log.Info("will modify request headers", "headers", sanitizedHeaders(extraHeaders))
 	setHeaders := make([]*configPb.HeaderValueOption, 0, len(extraHeaders))
 	for k, v := range extraHeaders {
 		setHeaders = append(setHeaders, &configPb.HeaderValueOption{
@@ -198,6 +199,61 @@ func extProcHeadersToMap(httpHeaders *extProcPb.HttpHeaders) map[string]string {
 	return headers
 }
 
+// redactedHeaderValue replaces a credential-bearing header value in log output.
+const redactedHeaderValue = "[REDACTED]"
+
+// sensitiveHeaderFragments are lowercase substrings that mark a header name as
+// credential-bearing. Matching on fragments rather than exact names keeps
+// configurable and deployment-specific headers covered, such as the traffic
+// access token header whose name comes from gateway configuration. Redacting a
+// header that turns out to be harmless costs nothing; missing one leaks a
+// credential into the log stream.
+//
+// The fragment is "authorization" rather than "auth" so the ":authority"
+// pseudo-header, which carries the request host and is needed to debug routing,
+// stays readable.
+var sensitiveHeaderFragments = []string{
+	"authorization",
+	"token",
+	"secret",
+	"cookie",
+	"api-key",
+	"apikey",
+	"password",
+	"credential",
+}
+
+// sanitizedHeaders wraps a header map so its credential-bearing values are
+// redacted before they reach the log stream, as required by the package rule
+// against logging access tokens and authorization headers.
+//
+// It implements logr.Marshaler instead of redacting eagerly so that a disabled
+// log level costs nothing: handleRequestHeaders runs on every proxied request,
+// and logr skips argument marshalling when the entry is not emitted.
+type sanitizedHeaders map[string]string
+
+func (h sanitizedHeaders) MarshalLog() any {
+	redacted := make(map[string]string, len(h))
+	for name, value := range h {
+		if isSensitiveHeader(name) {
+			redacted[name] = redactedHeaderValue
+			continue
+		}
+		redacted[name] = value
+	}
+	return redacted
+}
+
+func isSensitiveHeader(name string) bool {
+	lower := strings.ToLower(name)
+	for _, fragment := range sensitiveHeaderFragments {
+		if strings.Contains(lower, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
 func headerModifiers(key string, in *extProcPb.HttpHeaders, log logr.Logger) []*configPb.HeaderValueOption {
 	var modifiers []*configPb.HeaderValueOption
 	value := ""
@@ -210,7 +266,9 @@ func headerModifiers(key string, in *extProcPb.HttpHeaders, log logr.Logger) []*
 	if value != "" {
 		unmarshalled := map[string]string{}
 		if err := json.Unmarshal([]byte(value), &unmarshalled); err != nil {
-			log.Error(err, "failed to unmarshall header-modifier", "value", value)
+			// The modifier carries headers to set upstream and can therefore hold
+			// credentials, so only its size is safe to report alongside the error.
+			log.Error(err, "failed to unmarshall header-modifier", "valueLength", len(value))
 			return modifiers
 		}
 		for k, v := range unmarshalled {

--- a/pkg/proxy/ext_proc_test.go
+++ b/pkg/proxy/ext_proc_test.go
@@ -677,6 +677,105 @@ func TestServer_Process(t *testing.T) {
 	}
 }
 
+func TestSanitizedHeaders_MarshalLog(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    map[string]string
+	}{
+		{
+			name:    "nil map",
+			headers: nil,
+			want:    map[string]string{},
+		},
+		{
+			name: "routing headers are preserved",
+			headers: map[string]string{
+				":authority":                "8000-sandbox1.e2b.app",
+				":path":                     "/health",
+				"e2b-sandbox-id":            "sandbox1",
+				"e2b-sandbox-port":          "8000",
+				"x-request-id":              "req-1",
+				"x-envoy-original-dst-host": "192.168.1.10:8000",
+			},
+			want: map[string]string{
+				":authority":                "8000-sandbox1.e2b.app",
+				":path":                     "/health",
+				"e2b-sandbox-id":            "sandbox1",
+				"e2b-sandbox-port":          "8000",
+				"x-request-id":              "req-1",
+				"x-envoy-original-dst-host": "192.168.1.10:8000",
+			},
+		},
+		{
+			name: "credential headers are redacted",
+			headers: map[string]string{
+				"authorization":            "Bearer secret-jwt",
+				"proxy-authorization":      "Basic dXNlcjpwYXNz",
+				"x-backend-authorization":  "Bearer backend-jwt",
+				"x-access-token":           "raw-access-token",
+				"e2b-traffic-access-token": "traffic-jwt",
+				"x-api-key":                "e2b-api-key",
+				"cookie":                   "session=abc",
+			},
+			want: map[string]string{
+				"authorization":            redactedHeaderValue,
+				"proxy-authorization":      redactedHeaderValue,
+				"x-backend-authorization":  redactedHeaderValue,
+				"x-access-token":           redactedHeaderValue,
+				"e2b-traffic-access-token": redactedHeaderValue,
+				"x-api-key":                redactedHeaderValue,
+				"cookie":                   redactedHeaderValue,
+			},
+		},
+		{
+			name: "matching is case insensitive",
+			headers: map[string]string{
+				"Authorization":  "Bearer secret-jwt",
+				"X-API-Key":      "e2b-api-key",
+				"E2B-Sandbox-ID": "sandbox1",
+			},
+			want: map[string]string{
+				"Authorization":  redactedHeaderValue,
+				"X-API-Key":      redactedHeaderValue,
+				"E2B-Sandbox-ID": "sandbox1",
+			},
+		},
+		{
+			name: "credentials are redacted alongside routing headers",
+			headers: map[string]string{
+				":path":          "/files",
+				"e2b-sandbox-id": "sandbox1",
+				"authorization":  "Bearer secret-jwt",
+			},
+			want: map[string]string{
+				":path":          "/files",
+				"e2b-sandbox-id": "sandbox1",
+				"authorization":  redactedHeaderValue,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var original map[string]string
+			if tt.headers != nil {
+				original = make(map[string]string, len(tt.headers))
+				for name, value := range tt.headers {
+					original[name] = value
+				}
+			}
+
+			got := sanitizedHeaders(tt.headers).MarshalLog()
+			assert.Equal(t, tt.want, got)
+
+			// Redaction must not touch the caller's map: the same map keeps
+			// feeding the header mutation sent back to envoy.
+			assert.Equal(t, original, tt.headers)
+		})
+	}
+}
+
 // TestServer_RunLifecycle binds the fixed route-refresh and ext-proc ports;
 // `make test` runs packages serially so it cannot collide with the e2b
 // controller tests that bind the same ports.


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Fixes #941.

`handleRequestHeaders` logged the full parsed header map on every proxied request, so authorization headers, API keys and traffic access tokens were written to the log stream continuously. `pkg/proxy/AGENTS.md` explicitly forbids logging credentials in request data.

Header maps now go through a `sanitizedHeaders` wrapper that redacts values whose name looks like it carries a credential. It implements `logr.Marshaler` rather than redacting eagerly, so a disabled log level costs nothing on the request path.

Four log sites are covered. Two were named in the issue: the parsed request headers in `handleRequestHeaders` and the header mutation in `logAndCreateDstResponse`. The `request mapped` line logs the same `extraHeaders` map and would otherwise stay open, so it is included too. Finally, `headerModifiers` logged its raw value on an unmarshal failure. That value is untrusted request input whose purpose is to set upstream headers, so it can carry credentials, and it now reports only the length alongside the error.

### Ⅱ. Note on the matched fragments

Matching is on lowercase name fragments so configurable header names stay covered, for example the traffic access token header whose name comes from gateway config.

The fragment is `authorization` and not `auth` on purpose. `:authority` contains `auth`, and redacting it would hide the request host that routing issues are debugged with. A test case pins this behaviour.

Redacted: `authorization`, `proxy-authorization`, `x-backend-authorization`, `x-access-token`, `e2b-traffic-access-token`, `x-api-key`, `cookie`.

Preserved: `:authority`, `:path`, `e2b-sandbox-id`, `e2b-sandbox-port`, `x-request-id`, `x-envoy-original-dst-host`.

### Ⅲ. Testing

Added a table driven `TestSanitizedHeaders_MarshalLog` covering redaction, preserved routing headers, case insensitive matching, a nil map, and that the caller's map is not mutated, since the same map keeps feeding the header mutation sent back to envoy.

`go test ./pkg/proxy/...` and `go vet ./pkg/proxy/...` pass.