### PR TITLE
feat(okactl): add version command and multi-arch release workflow

### DIFF
--- a/.github/workflows/e2e-okactl.yaml
+++ b/.github/workflows/e2e-okactl.yaml
@@ -13,7 +13,7 @@ permissions: read-all
 
 env:
   # Common versions
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.25'
   KIND_VERSION: 'v0.22.0'
   KIND_IMAGE: 'kindest/node:v1.32.0'
   KIND_CLUSTER_NAME: 'ci-testing'

--- a/.github/workflows/release-okactl.yml
+++ b/.github/workflows/release-okactl.yml
@@ -1,0 +1,82 @@
+name: Release okactl
+
+on:
+  push:
+    tags:
+      - 'okactl-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing okactl-v* tag to release (required for workflow_dispatch)'
+        required: true
+        type: string
+
+# Declare default permissions as read only.
+permissions: read-all
+
+env:
+  GO_VERSION: '1.25'
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          case "$TAG" in
+            okactl-v*) ;;
+            *)
+              echo "Tag must match okactl-v* (got: $TAG)" >&2
+              exit 1
+              ;;
+          esac
+          VERSION="${TAG#okactl-}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Setup Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build release binaries
+        run: make release-okactl
+        env:
+          OKACTL_VERSION: ${{ steps.tag.outputs.version }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: okactl ${{ steps.tag.outputs.version }}
+          body: |
+            ## okactl ${{ steps.tag.outputs.version }}
+
+            Download the binary for your platform from the assets below, verify the checksum, then install it on your `PATH`.
+
+            Example (linux/amd64):
+
+            ```bash
+            curl -L -o okactl https://github.com/openkruise/agents/releases/download/${{ steps.tag.outputs.tag }}/okactl-${{ steps.tag.outputs.version }}-linux-amd64
+            chmod +x okactl
+            sudo mv okactl /usr/local/bin/okactl
+            okactl version
+            ```
+          files: bin/release/*
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -81,9 +81,41 @@ vet: ## Run go vet against code.
 build: generate fmt vet manifests ## Build manager binary.
 	go build -o bin/agent-sandbox-controller ./cmd/agent-sandbox-controller
 
+# OKACTL_VERSION is derived from the nearest okactl-v* tag (prefix stripped); falls back to "dev".
+OKACTL_VERSION_RAW ?= $(shell git describe --tags --always --dirty --match 'okactl-v*' 2>/dev/null || echo "dev")
+OKACTL_VERSION ?= $(patsubst okactl-%,%,$(OKACTL_VERSION_RAW))
+OKACTL_GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "")
+OKACTL_BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+OKACTL_LDFLAGS = -s -w \
+	-X github.com/openkruise/agents/pkg/cli.Version=$(OKACTL_VERSION) \
+	-X github.com/openkruise/agents/pkg/cli.GitCommit=$(OKACTL_GIT_COMMIT) \
+	-X github.com/openkruise/agents/pkg/cli.BuildDate=$(OKACTL_BUILD_DATE)
+OKACTL_RELEASE_PLATFORMS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64
+
 .PHONY: build-okactl
 build-okactl: ## Build okactl CLI binary.
-	go build -o bin/okactl ./cmd/okactl
+	go build -trimpath -ldflags="$(OKACTL_LDFLAGS)" -o bin/okactl ./cmd/okactl
+
+.PHONY: release-okactl
+release-okactl: ## Cross-compile okactl for release platforms into bin/release/.
+	@mkdir -p bin/release
+	@rm -f bin/release/SHA256SUMS
+	@for platform in $(OKACTL_RELEASE_PLATFORMS); do \
+		os=$${platform%/*}; \
+		arch=$${platform#*/}; \
+		ext=""; \
+		if [ "$$os" = "windows" ]; then ext=".exe"; fi; \
+		out="bin/release/okactl-$(OKACTL_VERSION)-$$os-$$arch$$ext"; \
+		echo "Building $$out"; \
+		CGO_ENABLED=0 GOOS=$$os GOARCH=$$arch go build -trimpath -ldflags="$(OKACTL_LDFLAGS)" -o "$$out" ./cmd/okactl; \
+	done
+	@cd bin/release && \
+		if command -v sha256sum >/dev/null 2>&1; then \
+			sha256sum okactl-$(OKACTL_VERSION)-* > SHA256SUMS; \
+		else \
+			shasum -a 256 okactl-$(OKACTL_VERSION)-* > SHA256SUMS; \
+		fi
+	@echo "Release artifacts written to bin/release/"
 
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.

--- a/cmd/okactl/main.go
+++ b/cmd/okactl/main.go
@@ -98,8 +98,10 @@ func main() {
 	createCmd.GroupID = groupResource
 	statusCmd := cli.NewStatusCommand(globalOpts)
 	statusCmd.GroupID = groupResource
+	versionCmd := cli.NewVersionCommand()
+	versionCmd.GroupID = groupOther
 
-	root.AddCommand(scaleCmd, setCmd, restartCmd, createCmd, statusCmd)
+	root.AddCommand(scaleCmd, setCmd, restartCmd, createCmd, statusCmd, versionCmd)
 
 	// Assign group ID to auto-generated commands (completion, help)
 	for _, cmd := range root.Commands() {

--- a/docs/developer-manuals/okactl.md
+++ b/docs/developer-manuals/okactl.md
@@ -8,7 +8,7 @@ All commands support resource short names: `sandboxset` → `sbs`, `sandboxupdat
 
 ## Installation
 
-### Build from source (requires Go 1.24+)
+### Build from source (requires Go 1.25+; see `go.mod`)
 
 ```bash
 make build-okactl
@@ -18,16 +18,37 @@ The binary will be output to `bin/okactl`. You can move it to your `$PATH`:
 
 ```bash
 mv bin/okactl /usr/local/bin/okactl
+okactl version
 ```
 
 ### Download pre-built binary
 
-Alternatively, you can download a pre-built binary from [GitHub Releases](https://github.com/Liquorice-Ma/agents/releases):
+Pre-built multi-arch binaries are published on
+[GitHub Releases](https://github.com/openkruise/agents/releases) for tags matching
+`okactl-v*` (for example `okactl-v0.1.0`). Asset names look like:
+
+- `okactl-v0.1.0-linux-amd64`
+- `okactl-v0.1.0-linux-arm64`
+- `okactl-v0.1.0-darwin-amd64`
+- `okactl-v0.1.0-darwin-arm64`
+- `okactl-v0.1.0-windows-amd64.exe`
+- `SHA256SUMS`
+
+Example (linux/amd64):
 
 ```bash
-curl -L -o /usr/local/bin/okactl https://github.com/Liquorice-Ma/agents/releases/download/v0.1.0/okactl
-chmod +x /usr/local/bin/okactl
+TAG=okactl-v0.1.0
+VERSION=v0.1.0
+curl -L -o okactl "https://github.com/openkruise/agents/releases/download/${TAG}/okactl-${VERSION}-linux-amd64"
+curl -L -o SHA256SUMS "https://github.com/openkruise/agents/releases/download/${TAG}/SHA256SUMS"
+sha256sum -c --ignore-missing SHA256SUMS
+chmod +x okactl
+sudo mv okactl /usr/local/bin/okactl
+okactl version
 ```
+
+To publish a release from this repository, push an `okactl-v*` tag (or run the
+`Release okactl` workflow via `workflow_dispatch`).
 
 ---
 
@@ -315,10 +336,16 @@ pkg/cli/
   status.go              # status sbs (SandboxSet) and status suo (SandboxUpdateOps) commands
   restart.go             # restart sandbox implementation (creates CRR)
   create.go              # create suo implementation
+  version.go             # version command (ldflags-injected Version/GitCommit/BuildDate)
   *_test.go              # Table-driven unit tests for each command
 ```
 
-### Run Unit Tests
+### Check version
+
+```bash
+make build-okactl
+./bin/okactl version
+```
 
 ```bash
 go test ./pkg/cli/... -v

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// Version metadata set via -ldflags at build time.
+var (
+	Version   = "dev"
+	GitCommit = ""
+	BuildDate = ""
+)
+
+// NewVersionCommand returns the "version" command.
+func NewVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the okactl version",
+		Long:  `Print the okactl client version information.`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return printVersion(cmd.OutOrStdout())
+		},
+	}
+}
+
+func printVersion(w io.Writer) error {
+	_, err := fmt.Fprintln(w, formatVersion())
+	return err
+}
+
+func formatVersion() string {
+	var b strings.Builder
+	b.WriteString("okactl version ")
+	b.WriteString(Version)
+	if GitCommit != "" {
+		b.WriteString("  git:")
+		b.WriteString(GitCommit)
+	}
+	if BuildDate != "" {
+		b.WriteString("  built:")
+		b.WriteString(BuildDate)
+	}
+	return b.String()
+}

--- a/pkg/cli/version_test.go
+++ b/pkg/cli/version_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewVersionCommand(t *testing.T) {
+	cmd := NewVersionCommand()
+	assert.Equal(t, "version", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.False(t, cmd.HasSubCommands())
+}
+
+func TestFormatVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		gitCommit string
+		buildDate string
+		want      string
+	}{
+		{
+			name:    "version only",
+			version: "v0.1.0",
+			want:    "okactl version v0.1.0",
+		},
+		{
+			name:      "version with commit and date",
+			version:   "v0.1.0",
+			gitCommit: "abc1234",
+			buildDate: "2026-09-12T00:00:00Z",
+			want:      "okactl version v0.1.0  git:abc1234  built:2026-09-12T00:00:00Z",
+		},
+		{
+			name:      "version with commit only",
+			version:   "dev",
+			gitCommit: "deadbeef",
+			want:      "okactl version dev  git:deadbeef",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origVersion, origCommit, origDate := Version, GitCommit, BuildDate
+			t.Cleanup(func() {
+				Version, GitCommit, BuildDate = origVersion, origCommit, origDate
+			})
+			Version = tt.version
+			GitCommit = tt.gitCommit
+			BuildDate = tt.buildDate
+			assert.Equal(t, tt.want, formatVersion())
+		})
+	}
+}
+
+func TestVersionCommandPrintsInjectedVersion(t *testing.T) {
+	origVersion, origCommit, origDate := Version, GitCommit, BuildDate
+	t.Cleanup(func() {
+		Version, GitCommit, BuildDate = origVersion, origCommit, origDate
+	})
+	Version = "v9.9.9"
+	GitCommit = ""
+	BuildDate = ""
+
+	cmd := NewVersionCommand()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetArgs(nil)
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "okactl version v9.9.9\n", buf.String())
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Ship stamped multi-arch `okactl` binaries via GitHub Releases (`okactl-v*` tags).

- Add `okactl version` (ldflags)
- Add `make release-okactl` + release workflow
- Fix install docs; bump e2e Go to 1.25

### Ⅱ. Does this pull request fix one issue?
fix #444

### Ⅲ. Describe how to verify it

```bash
go test ./pkg/cli/ -run Version -count=1
make build-okactl && ./bin/okactl version
make release-okactl OKACTL_VERSION=v0.0.0-test && ls bin/release/
```

Or push `okactl-v0.1.0` and check the GitHub Release assets.

### Ⅳ. Special notes for reviews

Distribution only — no new CLI resource commands.