### PR TITLE
docs: align Browser Use desktop example with installed SDK and template

### DIFF
--- a/examples/desktop/README-zh_CN.md
+++ b/examples/desktop/README-zh_CN.md
@@ -96,7 +96,7 @@ import time
 
 from browser_use import Agent, BrowserSession
 from browser_use.llm import ChatOpenAI
-from e2b_code_interpreter import Sandbox
+from e2b_desktop import Sandbox
 
 async def screenshot(agent: Agent):
     try:
@@ -114,7 +114,7 @@ async def screenshot(agent: Agent):
 
 async def main():
     # 创建 E2B 沙箱实例
-    sandbox = Sandbox.create(template="browser") # 一个已经运行 Chrome 的容器
+    sandbox = Sandbox.create(template="desktop") # 一个已经运行 Chrome 的容器
     try:
         # 创建 Browser-use 会话
         browser_session = BrowserSession(cdp_url=f"https://api.{sandbox.sandbox_domain}/browser/{sandbox.sandbox_id}") # 使用 cdp 协议连接远程沙箱中的浏览器

--- a/examples/desktop/README.md
+++ b/examples/desktop/README.md
@@ -100,7 +100,7 @@ import time
 
 from browser_use import Agent, BrowserSession
 from browser_use.llm import ChatOpenAI
-from e2b_code_interpreter import Sandbox
+from e2b_desktop import Sandbox
 
 async def screenshot(agent: Agent):
     try:
@@ -118,7 +118,7 @@ async def screenshot(agent: Agent):
 
 async def main():
     # Create E2B sandbox instance
-    sandbox = Sandbox.create(template="browser") # A container with Chrome already running
+    sandbox = Sandbox.create(template="desktop") # A container with Chrome already running
     try:
         # Create Browser-use session
         browser_session = BrowserSession(cdp_url=f"https://api.{sandbox.sandbox_domain}/browser/{sandbox.sandbox_id}") # Connect to the browser in the remote sandbox using the cdp protocol


### PR DESCRIPTION
The Browser Use blocks install e2b-desktop but import e2b_code_interpreter and request template="browser". The checked-in SandboxSet is named desktop.

This changes the SDK import and template name in the English and Chinese desktop READMEs. The Browser Use session code and cluster configuration are unchanged.

Validated locally with e2b-desktop 2.4.4 and browser-use 0.13.10: Python blocks compile, Sandbox exposes the referenced API, and BrowserSession accepts cdp_url. Network access was disabled. No live cluster, sandbox, remote CDP handshake, or model-backed task was run.

Disclosure: I work on Browser Use. Source: https://github.com/browser-use/browser-use