### PR TITLE
Fix G112: configure ReadHeaderTimeout to prevent Slowloris attacks

### DIFF
--- a/test/e2b/assets/runtime-mtls-server/main.go
+++ b/test/e2b/assets/runtime-mtls-server/main.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 )
 
 func main() {
@@ -37,7 +38,8 @@ func main() {
 
 	go func() {
 		plaintextServer := &http.Server{
-			Addr: ":8080",
+			Addr:              ":8080",
+			ReadHeaderTimeout: 3 * time.Second,
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				if _, err := fmt.Fprint(w, "runtime-plaintext-ok"); err != nil {
 					log.Printf("write plaintext response: %v", err)
@@ -48,7 +50,8 @@ func main() {
 	}()
 
 	server := &http.Server{
-		Addr: ":49983",
+		Addr:              ":49983",
+		ReadHeaderTimeout: 3 * time.Second,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			if _, err := fmt.Fprint(w, "runtime-mtls-ok"); err != nil {
 				log.Printf("write mTLS response: %v", err)


### PR DESCRIPTION
I. Describe what this PR does
Fixes G112 by configuring ReadHeaderTimeout in the test servers to prevent Slowloris attacks.

II. Does this pull request fix one issue?
fixes #961

III. Describe how to verify it
Run make lint and see no G112 errors for the test servers.

IV. Special notes for reviews
None
